### PR TITLE
thread_view: Only show thread controls at the end of the turn

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6442,9 +6442,11 @@ impl ThreadView {
             primary
         };
 
-        let primary = if matches!(entry, AgentThreadEntry::AssistantMessage(_))
-            && !assistant_message_is_blank
-        {
+        let is_generating = matches!(thread.read(cx).status(), ThreadStatus::Generating);
+        let is_turn_end =
+            Self::entry_is_finalized_turn_end(thread.read(cx).entries(), entry_ix, is_generating);
+
+        let primary = if is_turn_end && !assistant_message_is_blank {
             let user_message_index = thread
                 .read(cx)
                 .entries()
@@ -6660,6 +6662,35 @@ impl ThreadView {
             )
     }
 
+    /// A turn ends when no further assistant output (message
+    /// or tool call) follows before the next user message, and it's finalized
+    /// once a user message follows it or generation has stopped. This keeps
+    /// per-turn controls off the in-progress turn while streaming.
+    fn entry_is_finalized_turn_end(
+        entries: &[AgentThreadEntry],
+        entry_ix: usize,
+        is_generating: bool,
+    ) -> bool {
+        if !matches!(
+            entries.get(entry_ix),
+            Some(AgentThreadEntry::AssistantMessage(_))
+        ) {
+            return false;
+        }
+
+        for entry in &entries[entry_ix + 1..] {
+            match entry {
+                AgentThreadEntry::UserMessage(_) => return true,
+                AgentThreadEntry::AssistantMessage(_) | AgentThreadEntry::ToolCall(_) => {
+                    return false;
+                }
+                _ => {}
+            }
+        }
+
+        !is_generating
+    }
+
     fn render_thread_controls(
         &self,
         thread: &Entity<AcpThread>,
@@ -6702,13 +6733,15 @@ impl ThreadView {
             this.scroll_to_user_message_index(user_message_index, cx);
         }));
 
-        let scroll_to_top = IconButton::new(("scroll_to_top", entry_ix), IconName::ArrowUp)
-            .icon_size(IconSize::Small)
-            .icon_color(Color::Muted)
-            .tooltip(Tooltip::text("Scroll to Top"))
-            .on_click(cx.listener(move |this, _, _, cx| {
-                this.scroll_to_top(cx);
-            }));
+        let scroll_to_top = is_thread_bottom.then(|| {
+            IconButton::new(("scroll_to_top", entry_ix), IconName::ArrowUp)
+                .icon_size(IconSize::Small)
+                .icon_color(Color::Muted)
+                .tooltip(Tooltip::text("Scroll to Top"))
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.scroll_to_top(cx);
+                }))
+        });
 
         let show_stats = is_thread_bottom && AgentSettings::get_global(cx).show_turn_stats;
 
@@ -6797,6 +6830,13 @@ impl ThreadView {
             })
             .flatten();
 
+        let separator_dots = || {
+            Label::new("•")
+                .size(LabelSize::Small)
+                .color(Color::Muted)
+                .alpha(0.5)
+        };
+
         h_flex()
             .w_full()
             .py_1p5()
@@ -6812,21 +6852,18 @@ impl ThreadView {
                             .px_1()
                             .gap_1()
                             .when_some(last_turn_tokens_label, |this, label| {
-                                this.child(label).child(
-                                    Label::new("•")
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted)
-                                        .alpha(0.5),
-                                )
+                                this.child(label).child(separator_dots())
                             })
-                            .when_some(last_turn_clock, |this, label| this.child(label)),
+                            .when_some(last_turn_clock, |this, label| {
+                                this.child(label).child(separator_dots())
+                            }),
                     )
                 },
             )
             .when_some(feedback_buttons, |this, buttons| this.child(buttons))
             .when_some(copy_response_button, |this, button| this.child(button))
             .child(scroll_to_recent_user_prompt)
-            .child(scroll_to_top)
+            .when_some(scroll_to_top, |this, button| this.child(button))
             .into_any_element()
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6443,8 +6443,9 @@ impl ThreadView {
         };
 
         let is_generating = matches!(thread.read(cx).status(), ThreadStatus::Generating);
-        let is_turn_end =
-            Self::entry_is_finalized_turn_end(thread.read(cx).entries(), entry_ix, is_generating);
+
+        let is_turn_end = Self::entry_is_finalized_turn_end(thread.read(cx).entries(), entry_ix)
+            .unwrap_or(!is_generating);
 
         let primary = if is_turn_end && !assistant_message_is_blank {
             let user_message_index = thread
@@ -6662,33 +6663,28 @@ impl ThreadView {
             )
     }
 
-    /// A turn ends when no further assistant output (message
-    /// or tool call) follows before the next user message, and it's finalized
-    /// once a user message follows it or generation has stopped. This keeps
-    /// per-turn controls off the in-progress turn while streaming.
-    fn entry_is_finalized_turn_end(
-        entries: &[AgentThreadEntry],
-        entry_ix: usize,
-        is_generating: bool,
-    ) -> bool {
+    /// A turn ends when no further assistant output (message or tool call)
+    /// follows before the next user message, and it's finalized once a user
+    /// message follows it.
+    fn entry_is_finalized_turn_end(entries: &[AgentThreadEntry], entry_ix: usize) -> Option<bool> {
         if !matches!(
             entries.get(entry_ix),
             Some(AgentThreadEntry::AssistantMessage(_))
         ) {
-            return false;
+            return Some(false);
         }
 
         for entry in &entries[entry_ix + 1..] {
             match entry {
-                AgentThreadEntry::UserMessage(_) => return true,
+                AgentThreadEntry::UserMessage(_) => return Some(true),
                 AgentThreadEntry::AssistantMessage(_) | AgentThreadEntry::ToolCall(_) => {
-                    return false;
+                    return Some(false);
                 }
                 _ => {}
             }
         }
 
-        !is_generating
+        None
     }
 
     fn render_thread_controls(


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/61245. That PR introduced a bug where the thread controls would appear at seemingly random tool boundaries as opposed to only at the end of each turn. It caused this sort of behavior, where we'd have many instances of those buttons showing up:

<img width="500" alt="Screenshot 2026-07-20 at 4  03 2@2x" src="https://github.com/user-attachments/assets/6e6f716e-adb5-4532-9f89-e955398cda23" />

Alongside with fixing it, this PR is also making the "scroll to top" only show up only at the very last turn. I think that makes more sense given you'd be most likely interested to go to the top when you're at the bottom, rather than at every turn, but I could be persuaded otherwise; not holding that too strongly.

Release Notes:

- N/A
