### PR TITLE
vim: Fix tab/shift-tab in commit editor's vim normal mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1133,6 +1133,13 @@
     },
   },
   {
+    "context": "CommitEditor > Editor && VimControl && !menu",
+    "bindings": {
+      "tab": "git_panel::FocusChanges",
+      "shift-tab": "git_panel::FocusChanges",
+    },
+  },
+  {
     "context": "Editor && edit_prediction && edit_prediction_mode == eager && !showing_completions",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to


### PR DESCRIPTION
# Objective

Fix discrepancy where, while in `Insert` mode and focused on the commit editor, using `tab` or `shift-tab` would focus back on the changes list but, in `Normal` mode, it would not.

## Solution

Update vim's default keymap in order to properly support handling `tab` and `shift-tab` when focused on the commit editor and in `Normal` mode. While in `Insert` mode, using these bindings would focus back on the changes but, while in `Normal` mode that was not the case, so this change fixes that issue.

## Testing

Manually confirmed to be working as expected.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>

https://github.com/user-attachments/assets/5599d8a8-6451-428b-9a00-6a9ab348852c


</details>

<details>
  <summary>After</summary>

https://github.com/user-attachments/assets/2be0654c-ca22-48c6-96eb-5b497f90c3a1


</details>

---

Release Notes:

- Fixed `tab` and `shift-tab` behavior in git's commit editor while in Vim's `Normal` mode not focusing back on the changes list.
