### PR TITLE
Rewatch a directory that was deleted and recreated

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -32,6 +32,15 @@ pub struct FsWatcher {
 struct FsWatcherRegistration {
     id: WatcherRegistrationId,
     mode: WatcherMode,
+    /// Inode of the path at the time it was registered. Used to detect when a
+    /// watched path has been replaced by a different file/directory (e.g. one
+    /// that was deleted and quickly recreated). On Linux, inotify silently
+    /// invalidates the kernel watch on the old inode when the directory is
+    /// removed, but this registration lingers; without re-registering, a later
+    /// `add` for the recreated path would be treated as already-watched and the
+    /// new inode would never be watched. `None` when the inode is unavailable
+    /// (non-Unix, or the stat failed), in which case the check is skipped.
+    inode: Option<u64>,
 }
 
 impl FsWatcher {
@@ -52,9 +61,28 @@ impl FsWatcher {
     fn add_existing_path(&self, path: Arc<Path>) -> anyhow::Result<()> {
         let case_insensitive = case_insensitive_path(&path);
         let key = WatchKey::for_registration(SanitizedPath::new(&path), case_insensitive);
-        if self.registrations.lock().contains_key(&key) {
-            log::trace!("path to watch is already watched: {path:?}");
-            return Ok(());
+        // Bind the lookup to a local so the registrations lock is released before
+        // the block below re-acquires it; `parking_lot::Mutex` is not reentrant.
+        let existing = self.registrations.lock().get(&key).copied();
+        if let Some(existing) = existing {
+            let current_inode = path_inode(&path);
+            // Treat the path as already watched unless the inode changed, which
+            // means the file/directory here was replaced (e.g. deleted and
+            // recreated). In that case inotify's watch on the old inode is dead,
+            // so drop the stale registration and fall through to register a
+            // fresh watch on the new inode. When either inode is unknown we can't
+            // tell, so conservatively keep the existing registration.
+            if current_inode.is_none() || existing.inode.is_none() || current_inode == existing.inode
+            {
+                log::trace!("path to watch is already watched: {path:?}");
+                return Ok(());
+            }
+            log::trace!(
+                "path {path:?} was recreated (inode {:?} -> {current_inode:?}); re-registering watch",
+                existing.inode,
+            );
+            self.registrations.lock().remove(&key);
+            global_watcher().remove(existing.id);
         }
         match register_existing_path(
             path.clone(),
@@ -210,12 +238,29 @@ pub fn requires_poll_watcher(path: &Path) -> bool {
     }
 }
 
+/// The inode of `path` itself (a final symlink is not followed), or `None` when
+/// the inode is unavailable (non-Unix platforms, or the stat failed). Used to
+/// detect a path replaced by a newly-created inode. See [`FsWatcherRegistration::inode`].
+fn path_inode(path: &Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::symlink_metadata(path).ok().map(|meta| meta.ino())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
 fn register_existing_path(
     path: Arc<Path>,
     case_insensitive: bool,
     tx: async_channel::Sender<()>,
     pending_path_events: Arc<Mutex<Vec<PathEvent>>>,
 ) -> anyhow::Result<Option<FsWatcherRegistration>> {
+    let inode = path_inode(path.as_ref());
     let mode = if requires_poll_watcher(path.as_ref()) {
         log::info!(
             "Using poll watcher ({}ms interval) for {}",
@@ -251,6 +296,7 @@ fn register_existing_path(
     Ok(Some(FsWatcherRegistration {
         id: registration_id,
         mode,
+        inode,
     }))
 }
 

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -72,7 +72,9 @@ impl FsWatcher {
             // so drop the stale registration and fall through to register a
             // fresh watch on the new inode. When either inode is unknown we can't
             // tell, so conservatively keep the existing registration.
-            if current_inode.is_none() || existing.inode.is_none() || current_inode == existing.inode
+            if current_inode.is_none()
+                || existing.inode.is_none()
+                || current_inode == existing.inode
             {
                 log::trace!("path to watch is already watched: {path:?}");
                 return Ok(());

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5207,6 +5207,31 @@ impl BackgroundScanner {
         let mut root_canonical_path = None;
         let mut new_entries: Vec<Entry> = Vec::new();
         let mut new_jobs: Vec<Option<ScanJob>> = Vec::new();
+
+        // Establish the watch on this directory *before* enumerating its
+        // contents, so that any child created after the enumeration but before
+        // the watch would otherwise be active still produces an FS event and is
+        // not silently lost. Without this ordering, a directory that is deleted
+        // and quickly recreated while it is being repopulated (e.g. a build or
+        // test step that clears then rewrites an output directory) only reflects
+        // the entries that happened to exist at the instant of enumeration. For
+        // external entries we watch the canonical (resolved) path, matching the
+        // bookkeeping recorded after `populate_dir` below. See zed#53901.
+        let watched_abs_path: Option<Arc<Path>> = if job.is_external {
+            self.fs
+                .canonicalize(job.abs_path.as_ref())
+                .await
+                .ok()
+                .map(|canonical| {
+                    let canonical: Arc<Path> = canonical.into();
+                    self.watcher.add(&canonical).log_err();
+                    canonical
+                })
+        } else {
+            self.watcher.add(job.abs_path.as_ref()).log_err();
+            Some(job.abs_path.clone())
+        };
+
         let mut child_paths = self
             .fs
             .read_dir(&job.abs_path)
@@ -5418,33 +5443,13 @@ impl BackgroundScanner {
         }
 
         state.populate_dir(job.path.clone(), new_entries, new_ignore);
-        // For external entries, watch the canonical (resolved) path so OS-level
-        // FS events on the real filesystem location are observed. The same
-        // canonical path is stored in both `external_canonical_to_relative`
-        // (for translating canonical-path FS events back to worktree-relative
-        // paths) and `watched_dir_abs_paths_by_entry_id` (used by `remove_path`
-        // to know which abs path to unwatch), so both cleanup paths agree on
-        // the path the watcher was actually registered on.
-        //
-        // `canonicalize` is an async filesystem operation that may suspend, so
-        // the lock must not be held across the await point below.
-        drop(state);
-        let watched_abs_path: Option<Arc<Path>> = if job.is_external {
-            self.fs
-                .canonicalize(job.abs_path.as_ref())
-                .await
-                .ok()
-                .map(|canonical| {
-                    let canonical: Arc<Path> = canonical.into();
-                    self.watcher.add(&canonical).log_err();
-                    canonical
-                })
-        } else {
-            self.watcher.add(job.abs_path.as_ref()).log_err();
-            Some(job.abs_path.clone())
-        };
-
-        let mut state = self.state.lock().await;
+        // The watch on this directory was already established before its
+        // contents were enumerated (see above). Record the bookkeeping that
+        // maps the watched abs path to this entry: `watched_dir_abs_paths_by_entry_id`
+        // is used by `remove_path` to know which abs path to unwatch, and (for
+        // external entries) `external_canonical_to_relative` translates
+        // canonical-path FS events back to worktree-relative paths. Both cleanup
+        // paths therefore agree on the path the watcher was registered on.
         if let Some(watched_abs_path) = &watched_abs_path {
             if job.is_external {
                 state

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4712,6 +4712,110 @@ fn drain_git_repo_updates(events: &mut futures::channel::mpsc::UnboundedReceiver
     found
 }
 
+// Regression test for https://github.com/zed-industries/zed/issues/53901 (the
+// delete-then-recreate cause, distinct from the macOS fd-saturation cause):
+// a directory that is removed and immediately recreated while its children are
+// still being written (e.g. a build/test step that clears then repopulates an
+// output directory) must end up with ALL of its children reflected in the
+// worktree - not just the handful that happened to exist at the instant the
+// recreated directory was rescanned.
+#[gpui::test]
+async fn test_rapid_delete_recreate_dir_shows_all_children(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    init_test(cx);
+
+    const COUNT: usize = 20;
+
+    let fs = Arc::new(RealFs::new(None, cx.executor()));
+    let temp_root = TempTree::new(json!({
+        "test_results": {},
+    }));
+    let results_dir = temp_root.path().join("test_results");
+
+    // Simulate the first run: populate `test_results` with COUNT files + COUNT dirs.
+    for i in 0..COUNT {
+        fs.create_file(
+            &results_dir.join(format!("file{i}.txt")),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        fs.create_dir(&results_dir.join(format!("dir{i}")))
+            .await
+            .unwrap();
+    }
+
+    let tree = Worktree::local(
+        temp_root.path(),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Second run: remove the directory and *immediately* recreate + repopulate it,
+    // with no delay between the removal and recreation (the trigger), and each child
+    // created ~10ms apart so the burst spans more than FS_WATCH_LATENCY (100ms).
+    fs.remove_dir(
+        &results_dir,
+        RemoveOptions {
+            recursive: true,
+            ignore_if_not_exists: true,
+        },
+    )
+    .await
+    .unwrap();
+    fs.create_dir(&results_dir).await.unwrap();
+    for i in 0..COUNT {
+        cx.background_executor
+            .timer(std::time::Duration::from_millis(10))
+            .await;
+        fs.create_file(
+            &results_dir.join(format!("file{i}.txt")),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        fs.create_dir(&results_dir.join(format!("dir{i}")))
+            .await
+            .unwrap();
+    }
+
+    tree.flush_fs_events(cx).await;
+
+    let missing = tree.read_with(cx, |tree, _| {
+        let mut missing = Vec::new();
+        for i in 0..COUNT {
+            for name in [
+                format!("test_results/file{i}.txt"),
+                format!("test_results/dir{i}"),
+            ] {
+                if tree
+                    .entry_for_path(RelPath::from_unix_str(&name).unwrap())
+                    .is_none()
+                {
+                    missing.push(name);
+                }
+            }
+        }
+        missing
+    });
+
+    assert!(
+        missing.is_empty(),
+        "{} of {} entries missing from the worktree after a rapid delete/recreate: {missing:?}",
+        missing.len(),
+        COUNT * 2,
+    );
+}
+
 fn init_test(cx: &mut gpui::TestAppContext) {
     zlog::init_test();
 


### PR DESCRIPTION
# Objective

Addresses the delete-then-recreate cause reported under #53901 (@Akizay's reproduction) — a different root cause from the macOS FSEvents fd-saturation case in #61072, so this intentionally does not use a closing keyword.

When a directory is deleted and quickly recreated while it is being repopulated — e.g. a build or test step that clears an output directory and then rewrites it — most of the newly-written files never appear in the project panel (nor do buffers/git status reflect them) until the workspace is reloaded. @Akizay reproduced this on Linux with a small Python script that `rmtree`s a directory and immediately recreates it with 20 files + 20 subdirectories; only the first one or two show up.

## Root cause

Proven empirically on Linux/inotify (see Testing): the failure is a stale watch registration in the `fs` crate, not fd budgets and not an LSP.

1. Each watched directory has its own inotify watch (inotify is not recursive). `FsWatcher` tracks these in a `registrations` map keyed by path.
2. When the directory is deleted, the kernel silently invalidates its inotify watch (`IN_IGNORED`), but `FsWatcher`'s `registrations` entry lingers, because the delete and the recreate coalesce within one `FS_WATCH_LATENCY` (100ms) debounce window, so the worktree processes the path as still-present (metadata exists again) and never unwatches it.
3. When the worktree rescans the recreated directory and calls `watcher.add(path)`, `add_existing_path` finds the lingering registration and short-circuits with "path to watch is already watched" — so the **new** inode is never watched. Every file written into it afterwards produces no FS event and is lost until an unrelated rescan.
4. Separately, `scan_dir` established the directory's watch only *after* enumerating its contents (`read_dir`), leaving a TOCTOU window even when a fresh watch is created.

This matches @Akizay's observation that inserting a `sleep` longer than `FS_WATCH_LATENCY` between the delete and the recreate fixes it: with the delete processed in its own window, the worktree unwatches the path, so the later `add` re-registers cleanly.

## Solution

- `fs`: record each registration's inode. In `add_existing_path`, only treat a path as already-watched when the inode is unchanged; if it changed (the directory was replaced), drop the stale registration and re-register a fresh watch on the new inode. Unix-only (inodes are unavailable elsewhere, and macOS/Windows use recursive watches so the recreated subdirectory is already covered by the root watch).
- `worktree`: in `scan_dir`, establish the directory's watch *before* `read_dir`, so a child created after enumeration but before the watch would otherwise be active is still delivered as an event rather than lost.

Known limitation: if the OS reuses the exact same inode number for the recreated directory, the inode comparison can't detect the replacement. In practice a freshly recreated directory gets a new inode (confirmed in the test), and this is strictly better than the previous behavior, which never recovered.

Disclosure per the AI policy: I investigated and developed this with an LLM agent (Claude Code / Opus 4.8), reviewing and directing each step; the measurements below are from real runs I can defend in review.

## Testing

New integration test `test_rapid_delete_recreate_dir_shows_all_children` (worktree, `RealFs`) reproduces @Akizay's scenario: populate `test_results` with 20 files + 20 dirs, then remove it and immediately recreate + repopulate it with each child ~10ms apart (so the burst spans more than `FS_WATCH_LATENCY`), and assert all 40 entries are present.

Run on real Linux inotify (Debian 12 aarch64, in Docker, since the bug can't reproduce on macOS FSEvents which is recursive):

- Before the fix: 38 of 40 entries missing (deterministic).
- After the fix: 0 missing; test passes in ~2.3s.
- `cargo test -p worktree -p fs`: 61 + 18 passed, 0 failed (no regressions).
- `cargo clippy -p fs -p worktree --tests` and `cargo fmt --check`: clean.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed files created in a directory that was deleted and immediately recreated (for example by a build or test step that clears and repopulates an output directory) not appearing until the workspace was reloaded
