### PR TITLE
path: Normalize Windows paths independently of the host platform

### DIFF
--- a/crates/path/src/path.rs
+++ b/crates/path/src/path.rs
@@ -127,9 +127,68 @@ impl PathStyle {
 
     pub fn normalize(self, path_like: &str) -> String {
         match self {
-            PathStyle::Windows => crate::normalize_path(Path::new(path_like))
-                .to_string_lossy()
-                .into_owned(),
+            PathStyle::Windows => {
+                let drive_and_remainder = path_like.split_once(':').filter(|(drive, _)| {
+                    let mut characters = drive.chars();
+                    characters
+                        .next()
+                        .is_some_and(|character| character.is_ascii_alphabetic())
+                        && characters.next().is_none()
+                });
+                let unc_remainder = path_like
+                    .strip_prefix("\\\\")
+                    .or_else(|| path_like.strip_prefix("//"));
+
+                let (prefix, remainder) = if let Some((drive, remainder)) = drive_and_remainder {
+                    if let Some(remainder) = remainder
+                        .strip_prefix('\\')
+                        .or_else(|| remainder.strip_prefix('/'))
+                    {
+                        (format!("{drive}:\\"), remainder)
+                    } else {
+                        (format!("{drive}:"), remainder)
+                    }
+                } else if let Some(remainder) = unc_remainder {
+                    let (server, remainder) = match remainder.split_once(['\\', '/']) {
+                        Some(parts) => parts,
+                        None => return path_like.to_string(),
+                    };
+                    let (share, remainder) = match remainder.split_once(['\\', '/']) {
+                        Some(parts) => parts,
+                        None => return format!("\\\\{server}\\{remainder}"),
+                    };
+                    (format!("\\\\{server}\\{share}\\"), remainder)
+                } else if let Some(remainder) = path_like
+                    .strip_prefix('\\')
+                    .or_else(|| path_like.strip_prefix('/'))
+                {
+                    ("\\".to_string(), remainder)
+                } else {
+                    (String::new(), path_like)
+                };
+
+                let mut components: Vec<&str> = Vec::new();
+                for component in remainder.split(['\\', '/']) {
+                    match component {
+                        "" | "." => {}
+                        ".." => {
+                            if components.last().is_some_and(|c| *c != "..") {
+                                components.pop();
+                            } else if prefix.is_empty() {
+                                components.push(component);
+                            }
+                        }
+                        component => components.push(component),
+                    }
+                }
+
+                let normalized = components.join("\\");
+                if prefix.is_empty() {
+                    normalized
+                } else {
+                    format!("{prefix}{normalized}")
+                }
+            }
             PathStyle::Unix => {
                 let is_absolute = path_like.starts_with('/');
                 let remainder = if is_absolute {

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1510,6 +1510,54 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_normalize_windows_path_regardless_of_host_platform() {
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:\Users\user\dev\..\worktrees"),
+            r"C:\Users\user\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:\Users\.\worktrees"),
+            r"C:\Users\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:\Users\user\dev\sub\..\..\worktrees"),
+            r"C:\Users\user\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize("C:/Users/user/dev/../worktrees"),
+            r"C:\Users\user\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:/Users\user/dev\..\worktrees"),
+            r"C:\Users\user\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:\Users/user\.\worktrees"),
+            r"C:\Users\user\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"\\server\share\dev\..\worktrees"),
+            r"\\server\share\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"//server\share/dev\..\worktrees"),
+            r"\\server\share\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"\dev\..\worktrees"),
+            r"\worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"dev\..\worktrees"),
+            r"worktrees"
+        );
+        assert_eq!(
+            PathStyle::Windows.normalize(r"C:\..\worktrees"),
+            r"C:\worktrees"
+        );
+    }
+
     fn rel_path_entry(path: &'static str, is_file: bool) -> (&'static RelPath, bool) {
         (RelPath::from_unix_str(path).unwrap(), is_file)
     }


### PR DESCRIPTION
# Objective

Zed's `PathStyle` is designed to handle paths across platforms. Its behavior should depend only on the selected path style, not on the platform where Zed is running. This is essential for remote development, where the local and remote platforms may differ.

While fixing bugs involving Windows remote targets, I found that `PathStyle::normalize` does not behave consistently across host platforms. For `PathStyle::Windows`, it delegates to `crate::normalize_path`:

https://github.com/zed-industries/zed/blob/914e1c9873b6b85bfeedc5b58e8270885bdd532e/crates/path/src/path.rs#L237-L263

That function uses `Path::components()`, which interprets paths according to the host platform. As a result, when Zed runs on a Unix-like system and connects to a Windows remote, something maybe wrong here.

`PathStyle::normalize` should instead interpret paths according to the selected `PathStyle`, independently of the host platform.

## Solution

Implement Windows path normalization directly in `PathStyle::normalize` without relying on `std::path::Path` parsing.

The new implementation:

- Recognizes drive-letter, rooted, relative, and UNC paths.
- Treats both `\` and `/` as Windows path separators.
- Resolves `.` and `..` components lexically.
- Uses `\` as the normalized Windows path separator.
- Produces the same result regardless of the host platform.

## Testing

New test is added and tested with `cargo test -p util`, this test would fail on current main branch.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A or Added/Fixed/Improved ...
