### PR TITLE
language_models: Don't require API keys for OpenAI/Anthropic-compatible providers

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -230,7 +230,7 @@ impl Model {
 pub async fn stream_completion(
     client: &dyn HttpClient,
     api_url: &str,
-    api_key: &str,
+    api_key: Option<&str>,
     request: Request,
     beta_headers: Option<String>,
     extra_headers: &CustomHeaders,
@@ -328,7 +328,7 @@ pub async fn non_streaming_completion(
     let (mut response, rate_limits) = send_request(
         client,
         api_url,
-        api_key,
+        Some(api_key),
         &request,
         beta_headers,
         extra_headers,
@@ -352,7 +352,7 @@ pub async fn non_streaming_completion(
 async fn send_request(
     client: &dyn HttpClient,
     api_url: &str,
-    api_key: &str,
+    api_key: Option<&str>,
     request: impl Serialize,
     beta_headers: Option<String>,
     extra_headers: &CustomHeaders,
@@ -363,8 +363,10 @@ async fn send_request(
         .method(Method::POST)
         .uri(uri)
         .header("Anthropic-Version", "2023-06-01")
-        .header("X-Api-Key", api_key.trim())
         .header("Content-Type", "application/json");
+    if let Some(api_key) = api_key {
+        request_builder = request_builder.header("X-Api-Key", api_key.trim());
+    }
 
     if let Some(beta_headers) = beta_headers {
         request_builder = request_builder.header("Anthropic-Beta", beta_headers);
@@ -510,7 +512,7 @@ fn get_header<'a>(key: &str, headers: &'a HeaderMap) -> anyhow::Result<&'a str> 
 pub async fn stream_completion_with_rate_limit_info(
     client: &dyn HttpClient,
     api_url: &str,
-    api_key: &str,
+    api_key: Option<&str>,
     request: Request,
     beta_headers: Option<String>,
     extra_headers: &CustomHeaders,

--- a/crates/edit_prediction_cli/src/anthropic_client.rs
+++ b/crates/edit_prediction_cli/src/anthropic_client.rs
@@ -104,7 +104,7 @@ impl PlainLlmClient {
         let mut stream = stream_completion(
             self.http_client.as_ref(),
             ANTHROPIC_API_URL,
-            &self.api_key,
+            Some(&self.api_key),
             request,
             None,
             &http_client::CustomHeaders::default(),

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -494,6 +494,39 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_compatible_providers_do_not_require_an_api_key(cx: &mut App) {
+        let (client, credentials_provider) = init_test(cx);
+        let registry = cx.new(|_| LanguageModelRegistry::default());
+
+        // Custom providers frequently point at local endpoints that don't
+        // authenticate requests, so having no API key must not make them
+        // unusable (issue #61371: a provider named after a hosted service
+        // appeared to require that service's API key).
+        let providers = update_compatible_provider_settings(&["mtplx"], &["acme"], cx);
+        registry.update(cx, |registry, cx| {
+            register_compatible_providers(
+                registry,
+                &CompatibleProviders::default(),
+                &providers,
+                &client,
+                &credentials_provider,
+                cx,
+            );
+        });
+
+        for id in ["mtplx", "acme"] {
+            let provider = registry
+                .read(cx)
+                .provider(&LanguageModelProviderId::from(Arc::<str>::from(id)))
+                .expect("provider should be registered");
+            assert!(
+                provider.is_authenticated(cx),
+                "provider `{id}` should be usable without an API key"
+            );
+        }
+    }
+
+    #[gpui::test]
     fn test_compatible_provider_changes_kind_and_unregisters(cx: &mut App) {
         let (client, credentials_provider) = init_test(cx);
         let registry = cx.new(|_| LanguageModelRegistry::default());

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -487,7 +487,7 @@ impl AnthropicModel {
             let request = anthropic::stream_completion(
                 http_client.as_ref(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 beta_headers,
                 &extra_headers,

--- a/crates/language_models/src/provider/anthropic_compatible.rs
+++ b/crates/language_models/src/provider/anthropic_compatible.rs
@@ -179,8 +179,11 @@ impl LanguageModelProvider for AnthropicCompatibleLanguageModelProvider {
             .collect()
     }
 
-    fn is_authenticated(&self, cx: &App) -> bool {
-        self.state.read(cx).is_authenticated()
+    fn is_authenticated(&self, _cx: &App) -> bool {
+        // An API key is not required: the provider may point at a local or
+        // self-hosted endpoint that doesn't authenticate requests. When a key
+        // is configured it is picked up in `stream_completion`.
+        true
     }
 
     fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
@@ -250,16 +253,12 @@ impl AnthropicCompatibleLanguageModel {
         let beta_headers = self.model.beta_headers();
 
         async move {
-            let Some(api_key) = api_key else {
-                return Err(LanguageModelCompletionError::NoApiKey {
-                    provider: provider_name,
-                });
-            };
-
+            // The API key is optional: custom providers often point at local
+            // or self-hosted endpoints that don't authenticate requests.
             let request = anthropic::stream_completion(
                 http_client.as_ref(),
                 &api_url,
-                &api_key,
+                api_key.as_deref(),
                 request,
                 beta_headers,
                 &extra_headers,

--- a/crates/language_models/src/provider/api_compatible.rs
+++ b/crates/language_models/src/provider/api_compatible.rs
@@ -211,7 +211,8 @@ impl<S: ApiCompatibleProviderSettings> Render for ApiCompatibleProviderConfigura
             v_flex()
                 .on_action(cx.listener(Self::save_api_key))
                 .child(Label::new(format!(
-                    "To use Zed's agent with an {provider_name}-compatible provider, you need to add an API key."
+                    "Add an API key if your {provider_name}-compatible provider requires one. \
+                     Local endpoints usually don't need an API key."
                 )))
                 .child(
                     div()

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -379,7 +379,7 @@ impl OpenAiLanguageModel {
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );
@@ -415,7 +415,7 @@ impl OpenAiLanguageModel {
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -136,8 +136,11 @@ impl LanguageModelProvider for OpenAiCompatibleLanguageModelProvider {
             .collect()
     }
 
-    fn is_authenticated(&self, cx: &App) -> bool {
-        self.state.read(cx).is_authenticated()
+    fn is_authenticated(&self, _cx: &App) -> bool {
+        // An API key is not required: the provider may point at a local or
+        // self-hosted endpoint that doesn't authenticate requests. When a key
+        // is configured it is picked up in `stream_completion`.
+        true
     }
 
     fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
@@ -203,14 +206,13 @@ impl OpenAiCompatibleLanguageModel {
 
         let provider = self.provider_name.clone();
         let future = self.request_limiter.stream(async move {
-            let Some(api_key) = api_key else {
-                return Err(LanguageModelCompletionError::NoApiKey { provider });
-            };
+            // The API key is optional: custom providers often point at local
+            // or self-hosted endpoints that don't authenticate requests.
             let request = stream_completion(
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                api_key.as_deref(),
                 request,
                 &extra_headers,
             );
@@ -240,14 +242,11 @@ impl OpenAiCompatibleLanguageModel {
 
         let provider = self.provider_name.clone();
         let future = self.request_limiter.stream(async move {
-            let Some(api_key) = api_key else {
-                return Err(LanguageModelCompletionError::NoApiKey { provider });
-            };
             let request = stream_response(
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                api_key.as_deref(),
                 request,
                 &extra_headers,
             );

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -581,7 +581,7 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
                         http_client.as_ref(),
                         PROVIDER_NAME.0.as_str(),
                         CODEX_BASE_URL,
-                        &access_token,
+                        Some(&access_token),
                         responses_request,
                         &extra_headers,
                     )

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -420,7 +420,7 @@ impl OpenCodeLanguageModel {
             let request = anthropic::stream_completion(
                 http_client.as_ref(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 None,
                 &extra_headers,
@@ -458,7 +458,7 @@ impl OpenCodeLanguageModel {
                 http_client.as_ref(),
                 &provider_name,
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );
@@ -495,7 +495,7 @@ impl OpenCodeLanguageModel {
                 http_client.as_ref(),
                 &provider_name,
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -299,7 +299,7 @@ impl VercelAiGatewayLanguageModel {
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -247,7 +247,7 @@ impl XAiLanguageModel {
                 http_client.as_ref(),
                 provider.0.as_str(),
                 &api_url,
-                &api_key,
+                Some(&api_key),
                 request,
                 &extra_headers,
             );

--- a/crates/open_ai/Cargo.toml
+++ b/crates/open_ai/Cargo.toml
@@ -30,4 +30,5 @@ strum.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+http_client = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -444,6 +444,77 @@ mod tests {
     use super::{Model, ReasoningEffort};
 
     #[test]
+    fn stream_completion_sends_authorization_header_only_with_api_key() {
+        use super::*;
+        use std::sync::{Arc, Mutex};
+
+        let auth_headers: Arc<Mutex<Vec<Option<String>>>> = Arc::default();
+        let client = http_client::FakeHttpClient::create({
+            let auth_headers = auth_headers.clone();
+            move |request| {
+                auth_headers.lock().unwrap().push(
+                    request
+                        .headers()
+                        .get("Authorization")
+                        .map(|value| value.to_str().unwrap().to_string()),
+                );
+                async move {
+                    Ok(http_client::http::Response::builder()
+                        .status(200)
+                        .body(AsyncBody::from("data: [DONE]\n".to_string()))
+                        .unwrap())
+                }
+            }
+        });
+
+        let request = || Request {
+            model: "test-model".into(),
+            messages: Vec::new(),
+            stream: true,
+            stream_options: None,
+            max_completion_tokens: None,
+            max_tokens: None,
+            stop: Vec::new(),
+            temperature: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            tools: Vec::new(),
+            prompt_cache_key: None,
+            reasoning_effort: None,
+            service_tier: None,
+        };
+
+        futures::executor::block_on(async {
+            stream_completion(
+                client.as_ref(),
+                "test",
+                "http://localhost:1234/v1",
+                None,
+                request(),
+                &CustomHeaders::default(),
+            )
+            .await
+            .unwrap();
+            stream_completion(
+                client.as_ref(),
+                "test",
+                "http://localhost:1234/v1",
+                Some("sk-test"),
+                request(),
+                &CustomHeaders::default(),
+            )
+            .await
+            .unwrap();
+        });
+
+        assert_eq!(
+            auth_headers.lock().unwrap().as_slice(),
+            [None, Some("Bearer sk-test".to_string())],
+            "requests without an API key must not send an Authorization header"
+        );
+    }
+
+    #[test]
     fn gpt_5_1_uses_none_reasoning_by_default() {
         let expected_efforts = [
             ReasoningEffort::None,
@@ -830,16 +901,20 @@ pub async fn stream_completion(
     client: &dyn HttpClient,
     provider_name: &str,
     api_url: &str,
-    api_key: &str,
+    api_key: Option<&str>,
     request: Request,
     extra_headers: &CustomHeaders,
 ) -> Result<BoxStream<'static, Result<ResponseStreamEvent>>, RequestError> {
     let uri = format!("{api_url}/chat/completions");
-    let request = HttpRequest::builder()
+    let mut request_builder = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", api_key.trim()))
+        .header("Content-Type", "application/json");
+    if let Some(api_key) = api_key {
+        request_builder =
+            request_builder.header("Authorization", format!("Bearer {}", api_key.trim()));
+    }
+    let request = request_builder
         .extra_headers(extra_headers)
         .body(AsyncBody::from(
             serde_json::to_string(&request).map_err(|e| RequestError::Other(e.into()))?,

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -550,17 +550,21 @@ pub async fn stream_response(
     client: &dyn HttpClient,
     provider_name: &str,
     api_url: &str,
-    api_key: &str,
+    api_key: Option<&str>,
     request: Request,
     extra_headers: &CustomHeaders,
 ) -> Result<BoxStream<'static, Result<StreamEvent>>, RequestError> {
     let uri = format!("{api_url}/responses");
     let is_streaming = request.stream;
-    let request = HttpRequest::builder()
+    let mut request_builder = HttpRequest::builder()
         .method(Method::POST)
         .uri(uri)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", api_key.trim()))
+        .header("Content-Type", "application/json");
+    if let Some(api_key) = api_key {
+        request_builder =
+            request_builder.header("Authorization", format!("Bearer {}", api_key.trim()));
+    }
+    let request = request_builder
         .extra_headers(extra_headers)
         .body(AsyncBody::from(
             serde_json::to_string(&request).map_err(|e| RequestError::Other(e.into()))?,

--- a/crates/settings_ui/src/pages/llm_providers_page.rs
+++ b/crates/settings_ui/src/pages/llm_providers_page.rs
@@ -677,7 +677,8 @@ fn render_llm_provider_form_page(
                 ))
                 .child(render_form_field(
                     "API Key",
-                    "Stored in the system keychain, not in settings.json.",
+                    "Stored in the system keychain, not in settings.json. \
+                     Leave empty if the endpoint doesn't require authentication.",
                     &form.api_key,
                     cx,
                 ))
@@ -1152,13 +1153,15 @@ fn save_llm_provider_form(
                 .await
                 .map_err(|_| anyhow::anyhow!("Settings update was canceled"))??;
 
-            let set_api_key = cx.update(|_window, cx| {
-                let provider = LanguageModelRegistry::read_global(cx)
-                    .provider(&provider_id)
-                    .ok_or_else(|| anyhow::anyhow!("Provider was not registered"))?;
-                anyhow::Ok(provider.set_api_key(Some(api_key), cx))
-            })??;
-            set_api_key.await?;
+            if !api_key.is_empty() {
+                let set_api_key = cx.update(|_window, cx| {
+                    let provider = LanguageModelRegistry::read_global(cx)
+                        .provider(&provider_id)
+                        .ok_or_else(|| anyhow::anyhow!("Provider was not registered"))?;
+                    anyhow::Ok(provider.set_api_key(Some(api_key), cx))
+                })??;
+                set_api_key.await?;
+            }
 
             cx.update(|window, cx| {
                 this.update(cx, |this, cx| {
@@ -1211,10 +1214,9 @@ fn validate_llm_provider_form(
         return Err("API URL cannot be empty".into());
     }
 
+    // An empty API key is allowed: local and self-hosted endpoints often
+    // don't authenticate requests.
     let api_key = values.api_key.clone();
-    if api_key.is_empty() {
-        return Err("API Key cannot be empty".into());
-    }
 
     let models = match values.kind {
         CompatibleProviderKind::OpenAi => ParsedModels::OpenAi(

--- a/docs/src/ai/use-api-access.md
+++ b/docs/src/ai/use-api-access.md
@@ -462,11 +462,11 @@ The optional `custom_headers` map adds extra headers to every request, which som
 
 Models also support the optional `default_temperature`, `extra_beta_headers` (sent as `anthropic-beta` headers), `mode`, and `tool_override` fields, which behave the same as in [Custom Anthropic Models](#anthropic-custom-models).
 
-Enter the API key in the provider settings UI or set the generated environment variable (`<PROVIDER_NAME>_API_KEY`; in the example above, `SOME_PROVIDER_API_KEY`). Do not put API keys in `settings.json`.
+Enter the API key in the provider settings UI or set the generated environment variable (`<PROVIDER_NAME>_API_KEY`; in the example above, `SOME_PROVIDER_API_KEY`). Do not put API keys in `settings.json`. If the endpoint doesn't require authentication, leave the API key empty.
 
 ### OpenAI-Compatible Endpoints {#openai-compatible}
 
-Use an OpenAI-compatible endpoint when you have a custom base URL, model ID, and API key.
+Use an OpenAI-compatible endpoint when you have a custom base URL and model ID. An API key is only needed if the endpoint requires one.
 
 You can add a custom OpenAI-compatible provider from Agent Settings with {#action agent::OpenSettings}. Look for `Add Provider` in the LLM Providers section and fill in the provider name, API URL, model ID, and context window.
 
@@ -568,4 +568,4 @@ For example, a chat-completions endpoint with the maximum OpenAI-style reasoning
 }
 ```
 
-Enter the API key in the provider settings UI or set the generated environment variable. Do not put API keys in `settings.json`.
+Enter the API key in the provider settings UI or set the generated environment variable. Do not put API keys in `settings.json`. If the endpoint doesn't require authentication — common for local and self-hosted servers — leave the API key empty and requests are sent without an `Authorization` header.


### PR DESCRIPTION
# Objective

Fixes #61371

A custom OpenAI-compatible provider pointing at a local endpoint fails every request with `missing <name> API key` until an API key is stored, even when the endpoint doesn't authenticate requests at all. The error wording makes it look like Zed confused the custom provider with a hosted service of the same name (in the issue: a local provider named MTPLX appearing to require a hosted MTPLX key). The actual problem is that `openai_compatible` and `anthropic_compatible` providers unconditionally require an API key, so a keyless local provider can never work no matter what it is called.

## Solution

Treat the API key as optional for user-defined compatible providers, the same way the LM Studio provider already does:

- `open_ai::stream_completion` / `open_ai::responses::stream_response` and the `anthropic` request helpers now take `Option<&str>` and only set the `Authorization` / `X-Api-Key` header when a key is present.
- The `openai_compatible` and `anthropic_compatible` providers no longer fail with `NoApiKey` when no key is stored, and report themselves as authenticated so their models stay selectable.
- The provider setup form no longer rejects an empty API key, and the configuration UI + docs now say a key is only needed if the endpoint requires one.

Hosted providers (OpenAI, Anthropic, xAI, Vercel AI Gateway, OpenCode, Codex) still require their keys exactly as before; their call sites just wrap the key in `Some(...)`.

## Testing

- `cargo test -p open_ai`: all pass, including a new test asserting the `Authorization` header is only sent when a key is present.
- Added a `language_models` test that a keyless `openai_compatible` / `anthropic_compatible` provider reports `is_authenticated() == true`. I couldn't run the full `language_models` suite on my Windows machine (no cmake for the wasmtime C API build), so I'm relying on CI for that crate.
- `cargo check -p anthropic -p open_ai` is clean.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed custom OpenAI-compatible and Anthropic-compatible providers requiring an API key even when the endpoint (for example a local server) doesn't authenticate requests ([#61371](https://github.com/zed-industries/zed/issues/61371)).
