### PR TITLE
editor: Skip untitled buffers when saving a multi-buffer

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -964,7 +964,13 @@ impl Item for Editor {
         } else {
             buffers
                 .into_iter()
-                .filter(|buffer| buffer.read(cx).is_dirty())
+                // Skip untitled buffers: a multi-buffer (e.g. project search results) can
+                // excerpt a buffer with no file on disk, which can only be persisted via
+                // `save_as`. Trying to save it here errors and aborts the whole save.
+                .filter(|buffer| {
+                    let buffer = buffer.read(cx);
+                    buffer.is_dirty() && buffer.file().is_some()
+                })
                 .collect()
         };
 
@@ -3281,6 +3287,92 @@ mod tests {
             let r = ranges[0].start.to_point(text_snapshot)..ranges[0].end.to_point(text_snapshot);
             assert_eq!(r.start.row, 2, "merged range should start at row 2");
             assert_eq!(r.end.row, 3, "merged range should end at row 3");
+        });
+    }
+
+    // Regression test for a multi-buffer (e.g. project search results) that excerpts
+    // an untitled buffer alongside a file-backed one. Saving used to error out with
+    // "buffer doesn't have a file", which aborted `workspace: reload` and quit flows.
+    #[gpui::test]
+    async fn test_save_multi_buffer_with_untitled_buffer_skips_untitled(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx, |_| {});
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/dir"), json!({ "file.txt": "the cat sat" }))
+            .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+
+        let file_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let untitled_buffer = project.update(cx, |project, cx| {
+            project.create_local_buffer("the cat", None, false, cx)
+        });
+
+        // Make both buffers dirty so both are candidates to be saved.
+        file_buffer.update(cx, |buffer, cx| {
+            buffer.edit([(0..0, "X")], None, cx);
+        });
+        untitled_buffer.update(cx, |buffer, cx| {
+            buffer.edit([(0..0, "Y")], None, cx);
+        });
+
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::new(project.read(cx).capability());
+            multi_buffer.set_excerpts_for_path(
+                PathKey::sorted(0),
+                file_buffer.clone(),
+                [Point::new(0, 0)..Point::new(0, 3)],
+                0,
+                cx,
+            );
+            multi_buffer.set_excerpts_for_path(
+                PathKey::sorted(1),
+                untitled_buffer.clone(),
+                [Point::new(0, 0)..Point::new(0, 3)],
+                0,
+                cx,
+            );
+            multi_buffer
+        });
+        let editor = cx.new_window_entity(|window, cx| {
+            Editor::for_multibuffer(multi_buffer, Some(project.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        editor.update(cx, |editor, cx| {
+            assert!(!editor.buffer().read(cx).is_singleton());
+        });
+
+        let save = editor.update_in(cx, |editor, window, cx| {
+            editor.save(
+                SaveOptions {
+                    format: false,
+                    force_format: false,
+                    autosave: false,
+                },
+                project.clone(),
+                window,
+                cx,
+            )
+        });
+        save.await
+            .expect("saving a multi-buffer that excerpts an untitled buffer should not error");
+        cx.run_until_parked();
+
+        // The file-backed buffer is saved; the untitled buffer is skipped and stays dirty.
+        file_buffer.update(cx, |buffer, _| assert!(!buffer.is_dirty()));
+        untitled_buffer.update(cx, |buffer, _| {
+            assert!(buffer.file().is_none());
+            assert!(buffer.is_dirty());
         });
     }
 }


### PR DESCRIPTION
Closes #60041.

## Summary

When Project Search results contain both a saved file and an untitled buffer, running `workspace: reload` did nothing (quitting hit the same path). The log showed:

```
ERROR [.../workspace.rs] buffer doesn't have a file
```

## Root cause

The Project Search results view is an `Editor` over a multi-buffer, and its `Item::save` delegates to `Editor::save`. For a multi-buffer, `Editor::save` collects every dirty buffer and calls `Project::save_buffers`. An untitled excerpt has no file, so `BufferStore::save_buffer` returns `Err("buffer doesn't have a file")`. That error propagates through `Pane::save_item` → `save_all_internal` → `prepare_to_close`, which then reports the workspace as not ready to close, so `reload`/quit silently aborts.

A singleton untitled buffer avoids this because `Editor::can_save` returns `false` for it (the workspace routes it to `save_as`); for a multi-buffer, `can_save` is always `true`.

## Fix

Exclude file-less (untitled) buffers when collecting the buffers to save for a multi-buffer. Untitled buffers can only be written via `save_as`, so a bulk multi-buffer save now persists the file-backed excerpts and leaves untitled ones untouched. This also addresses the same latent issue in other multi-buffer views (diagnostics, find-all-references) that can excerpt an untitled buffer.

## Testing

- Added `test_save_multi_buffer_with_untitled_buffer_skips_untitled` in `crates/editor/src/items.rs`: it builds a multi-buffer over a file-backed buffer and an untitled buffer (both dirty), then asserts `save` succeeds, the file-backed buffer is persisted, and the untitled buffer stays dirty. Fails before this change (`buffer doesn't have a file`), passes after.
- `cargo test -p editor --lib save` (13 tests) and `cargo test -p search --lib project_search` (22 tests) pass.
- `./script/clippy -p editor` is clean.

Manual repro (before): new untitled buffer with text → Project Search for a term matching both it and a saved file → `workspace: reload` → no-op with `buffer doesn't have a file` in the log. After: reload proceeds.

Release Notes:

- Fixed `workspace: reload` and quitting silently doing nothing when Project Search results included an unsaved untitled buffer.
