### PR TITLE
Only install crash handler when a minidump endpoint is configured

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -95,6 +95,13 @@ pub static MINIDUMP_ENDPOINT: LazyLock<Option<String>> = LazyLock::new(|| {
         .or_else(|| env::var("ZED_MINIDUMP_ENDPOINT").ok())
 });
 
+pub fn should_install_crash_handler(channel: ReleaseChannel) -> bool {
+    matches!(
+        env::var("ZED_GENERATE_MINIDUMPS").as_deref(),
+        Ok("true" | "1")
+    ) || (channel != ReleaseChannel::Dev && MINIDUMP_ENDPOINT.is_some())
+}
+
 static DOTNET_PROJECT_FILES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(global\.json|Directory\.Build\.props|.*\.(csproj|fsproj|vbproj|sln))$").unwrap()
 });

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -47,7 +47,6 @@ use smol::{
     stream::StreamExt as _,
 };
 use std::{
-    env,
     ffi::OsStr,
     fs::File,
     io::Write,
@@ -571,10 +570,8 @@ pub fn execute_run(
     let app = gpui_platform::headless();
     let pid = std::process::id();
     let id = pid.to_string();
-    let should_install_crash_handler = matches!(
-        env::var("ZED_GENERATE_MINIDUMPS").as_deref(),
-        Ok("true" | "1")
-    ) || *RELEASE_CHANNEL != ReleaseChannel::Dev;
+    let should_install_crash_handler =
+        client::telemetry::should_install_crash_handler(*RELEASE_CHANNEL);
 
     let crash_handler = if should_install_crash_handler {
         Some(app.background_executor().spawn(crashes::init(
@@ -851,10 +848,8 @@ pub(crate) fn execute_proxy(
     let server_paths = ServerPaths::new(&identifier)?;
 
     let id = std::process::id().to_string();
-    let should_install_crash_handler = matches!(
-        env::var("ZED_GENERATE_MINIDUMPS").as_deref(),
-        Ok("true" | "1")
-    ) || *RELEASE_CHANNEL != ReleaseChannel::Dev;
+    let should_install_crash_handler =
+        client::telemetry::should_install_crash_handler(*RELEASE_CHANNEL);
 
     if should_install_crash_handler {
         smol::spawn(crashes::init(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -382,11 +382,8 @@ fn main() {
         return;
     }
 
-    let should_install_crash_handler = matches!(
-        env::var("ZED_GENERATE_MINIDUMPS").as_deref(),
-        Ok("true" | "1")
-    ) || *release_channel::RELEASE_CHANNEL
-        != ReleaseChannel::Dev;
+    let should_install_crash_handler =
+        client::telemetry::should_install_crash_handler(*release_channel::RELEASE_CHANNEL);
 
     let crash_handler = if should_install_crash_handler {
         Some(


### PR DESCRIPTION
Closes FR-130

Builds compiled from source at a release tag report a non-dev release channel, so they used to install the crash handler and write minidumps into the shared logs directory. An official Zed launched later would find and upload those dumps to Sentry, where they can never be symbolicated (their debug UUID matches no uploaded debug files).

Gate the crash handler on having somewhere to send the dumps: either the compile-time ZED_MINIDUMP_ENDPOINT baked into official builds, the runtime ZED_MINIDUMP_ENDPOINT override, or an explicit ZED_GENERATE_MINIDUMPS opt-in for debugging the crash pipeline locally.

Release Notes:

- N/A
