### PR TITLE
docs: Add PHPantom language server configuration

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2342,7 +2342,7 @@
       },
     },
     "PHP": {
-      "language_servers": ["phpactor", "!intelephense", "!phptools", "..."],
+      "language_servers": ["phpactor", "!intelephense", "!phptools", "!phpantom", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["@prettier/plugin-php"],
@@ -2693,7 +2693,7 @@
   "windows": {
     "languages": {
       "PHP": {
-        "language_servers": ["intelephense", "!phpactor", "!phptools", "..."],
+        "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."],
       },
     },
   },

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -115,7 +115,7 @@ You can specify your preference using the `language_servers` setting:
 ```json [settings]
   "languages": {
     "PHP": {
-      "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
+      "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."]
     }
   }
 ```
@@ -123,7 +123,7 @@ You can specify your preference using the `language_servers` setting:
 In this example:
 
 - `intelephense` is set as the primary language server.
-- `phpactor` and `phptools` are disabled (note the `!` prefix).
+- `phpactor`, `phptools` and `phpantom` are disabled (note the `!` prefix).
 - `"..."` expands to the rest of the language servers registered for PHP that are not already listed.
 
 The `"..."` entry acts as a wildcard that includes any registered language server you haven't explicitly mentioned. Servers you list by name keep their position, and `"..."` fills in the remaining ones at that point in the list. Servers prefixed with `!` are excluded entirely. This means that if a new language server extension is installed or a new server is registered for a language, `"..."` will automatically include it. If you want full control over which servers are enabled, omit `"..."` — only the servers you list by name will be used.

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -50,7 +50,13 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."]
+      "language_servers": [
+        "intelephense",
+        "!phpactor",
+        "!phptools",
+        "!phpantom",
+        "..."
+      ]
     }
   }
 }
@@ -82,7 +88,13 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phptools", "!intelephense", "!phpactor", "!phpantom", "..."]
+      "language_servers": [
+        "phptools",
+        "!intelephense",
+        "!phpactor",
+        "!phpantom",
+        "..."
+      ]
     }
   }
 }
@@ -118,7 +130,13 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phpactor", "!intelephense", "!phptools", "!phpantom", "..."]
+      "language_servers": [
+        "phpactor",
+        "!intelephense",
+        "!phptools",
+        "!phpantom",
+        "..."
+      ]
     }
   }
 }
@@ -132,7 +150,13 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phpantom", "!phpactor", "!intelephense", "!phptools", "..."]
+      "language_servers": [
+        "phpantom",
+        "!phpactor",
+        "!intelephense",
+        "!phptools",
+        "..."
+      ]
     }
   }
 }

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -38,7 +38,7 @@ where php
 
 ## Choosing a language server
 
-The PHP extension uses [LSP language servers](https://microsoft.github.io/language-server-protocol) with Phpactor as the default. If you want to use other language servers that support Zed (e.g. Intelephense or PHP Tools), make sure to follow the documentation on how to implement it.
+The PHP extension uses [LSP language servers](https://microsoft.github.io/language-server-protocol) with Phpactor as the default. If you want to use other language servers that support Zed (e.g. Intelephense, PHP Tools or PHPantom), make sure to follow the documentation on how to implement it.
 
 ### Intelephense
 
@@ -50,7 +50,7 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
+      "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."]
     }
   }
 }
@@ -82,7 +82,7 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phptools", "!intelephense", "!phpactor", "..."]
+      "language_servers": ["phptools", "!intelephense", "!phpactor", "!phpantom", "..."]
     }
   }
 }
@@ -118,7 +118,21 @@ Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages
 {
   "languages": {
     "PHP": {
-      "language_servers": ["phpactor", "!intelephense", "!phptools", "..."]
+      "language_servers": ["phpactor", "!intelephense", "!phptools", "!phpantom", "..."]
+    }
+  }
+}
+```
+
+### PHPantom
+
+Configure language servers in Settings ({#kb zed::OpenSettings}) under Languages > PHP, or add to your settings file:
+
+```json [settings]
+{
+  "languages": {
+    "PHP": {
+      "language_servers": ["phpantom", "!phpactor", "!intelephense", "!phptools", "..."]
     }
   }
 }


### PR DESCRIPTION
Adds documentation for **PHPantom**—a fast, Rust-based PHP language server—as a selectable language server alongside `PhpTools`, `Intelephense`, and `Phpactor`.

Release Notes:

- N/A