### PR TITLE
Add reasoning effort support for Mistral models

### DIFF
--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -578,6 +578,11 @@ pub fn into_mistral(
                     })
                 })
                 .collect::<Result<_>>()?,
+            reasoning_effort: if model.supports_thinking() && request.thinking_allowed {
+                Some(mistral::ReasoningEffort::High)
+            } else {
+                None
+            },
         },
         request.thread_id,
     ))
@@ -884,6 +889,44 @@ mod tests {
         assert_eq!(mistral_request.messages.len(), 2);
         assert!(mistral_request.stream);
         assert_eq!(affinity, Some("abcdef".into()));
+    }
+
+    #[test]
+    fn test_into_mistral_reasoning_effort() {
+        let request = |thinking_allowed| LanguageModelRequest {
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".into())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            stop: vec![],
+            thinking_allowed,
+            thinking_effort: None,
+            speed: Default::default(),
+            compact_at_tokens: None,
+        };
+
+        let (mistral_request, _) =
+            into_mistral(request(true), mistral::Model::MistralMediumLatest, None).unwrap();
+        assert_eq!(
+            mistral_request.reasoning_effort,
+            Some(mistral::ReasoningEffort::High)
+        );
+
+        let (mistral_request, _) =
+            into_mistral(request(false), mistral::Model::MistralMediumLatest, None).unwrap();
+        assert_eq!(mistral_request.reasoning_effort, None);
+
+        let (mistral_request, _) =
+            into_mistral(request(true), mistral::Model::CodestralLatest, None).unwrap();
+        assert_eq!(mistral_request.reasoning_effort, None);
     }
 
     #[test]

--- a/crates/mistral/src/mistral.rs
+++ b/crates/mistral/src/mistral.rs
@@ -91,6 +91,9 @@ impl Model {
             "mistral-large-latest" => Ok(Self::MistralLargeLatest),
             "mistral-medium-latest" => Ok(Self::MistralMediumLatest),
             "mistral-small-latest" => Ok(Self::MistralSmallLatest),
+            "ministral-3b-latest" => Ok(Self::Ministral3bLatest),
+            "ministral-8b-latest" => Ok(Self::Ministral8bLatest),
+            "ministral-14b-latest" => Ok(Self::Ministral14bLatest),
             invalid_id => anyhow::bail!("invalid model id '{invalid_id}'"),
         }
     }
@@ -175,7 +178,7 @@ impl Model {
 
     pub fn supports_thinking(&self) -> bool {
         match self {
-            Self::MistralMediumLatest => true,
+            Self::MistralMediumLatest | Self::MistralSmallLatest => true,
             Self::Custom {
                 supports_thinking, ..
             } => supports_thinking.unwrap_or(false),
@@ -203,6 +206,15 @@ pub struct Request {
     pub parallel_tool_calls: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<ToolDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    None,
+    High,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
# Objective

Follow-up to #60898 (as suggested by @tomhoule ). That PR marked `mistral-medium-latest` as supporting thinking, but the flag is currently a no-op: unlike Magistral, whose reasoning was native, Mistral Medium 3.5 and Small 4 only emit thinking chunks when the request sets `reasoning_effort: "high"` (see [Mistral's reasoning docs](https://docs.mistral.ai/studio-api/conversations/reasoning)), and the `Request` struct had no such field.

Related: #57581

## Solution

- Add a `ReasoningEffort` enum and an optional `reasoning_effort` field to the Mistral `Request`. The field is skipped during serialization when `None`, so requests for non-reasoning models (Codestral, Large, Ministrals) are byte-identical to before.
- Set `reasoning_effort: "high"` in `into_mistral()` when the model supports thinking and the request allows it. The rest of the pipeline already works: `MistralEventMapper` handles `MessagePart::Thinking` deltas, and `into_mistral` replays thinking parts into history, matching Mistral's requirement to replay the reasoning trace across turns.
- Add `mistral-small-latest` to `supports_thinking()`: it now points to Mistral Small 4, a hybrid reasoning model like Medium 3.5.
- Cover the Ministral variants in `Model::from_id()`, which previously rejected `ministral-3b-latest` / `ministral-8b-latest` / `ministral-14b-latest` as invalid ids even though the enum defines them.

## Testing

- Added `test_into_mistral_reasoning_effort` covering the three cases: thinking model with thinking allowed (sends `high`), thinking model with thinking disallowed (omits the field), and non-thinking model (omits the field).
- Existing Mistral provider tests pass (`cargo test -p language_models mistral`); both touched crates are clippy-clean.
- Reviewers can test by configuring a Mistral API key, selecting `mistral-medium-latest` or `mistral-small-latest` in the agent panel, and confirming thinking blocks stream in; with a non-reasoning model like Codestral, requests are unchanged.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed thinking not being triggered for Mistral Medium 3.5 and Mistral Small 4, and fixed custom Mistral configurations rejecting Ministral model ids
