### PR TITLE
thread_view: Make thinking icon color consistent

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -5080,7 +5080,7 @@ impl ThreadView {
             (
                 "Disable Thinking Mode",
                 IconName::ThinkingMode,
-                Color::Muted,
+                Color::Accent,
             )
         } else {
             (
@@ -5226,7 +5226,7 @@ impl ThreadView {
                     .child(
                         Icon::new(IconName::ThinkingMode)
                             .size(IconSize::Small)
-                            .color(label_color),
+                            .color(Color::Accent),
                     )
                     .child(Label::new(label).size(LabelSize::Small).color(label_color))
                     .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted)),


### PR DESCRIPTION
Tiny tiny tweak just adjusting the thinking icon color so its consistent with the fast mode icon. Icons that are _toggled_ on and off should be displayed in a colorful way so its obvious in which state they're in.

---

Release Notes:

- N/A
