### PR TITLE
Revert "gpui_web: Only cancel the native context menu when the app claims the right-click"

### DIFF
--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -151,21 +151,13 @@ impl WebWindowInner {
                 current_state.modifiers = modifiers;
             }
 
-            let result = this.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
+            this.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
                 button,
                 position,
                 modifiers,
                 click_count,
                 first_mouse: false,
             }));
-
-            // The browser fires `contextmenu` after this event; remember whether
-            // the app claimed the right-click (e.g. opened its own menu) so the
-            // contextmenu listener cancels the native menu only in that case.
-            if button == MouseButton::Right {
-                let claimed = result.is_some_and(|result| !result.propagate);
-                this.app_claimed_right_click.set(claimed);
-            }
         })
     }
 
@@ -279,12 +271,9 @@ impl WebWindowInner {
     }
 
     fn register_context_menu(self: &Rc<Self>) -> Closure<dyn FnMut(JsValue)> {
-        let this = Rc::clone(self);
         self.listen("contextmenu", move |event: JsValue| {
             let event: web_sys::Event = event.unchecked_into();
-            if this.app_claimed_right_click.replace(false) {
-                event.prevent_default();
-            }
+            event.prevent_default();
         })
     }
 

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -55,7 +55,6 @@ pub(crate) struct WebWindowInner {
     pub(crate) last_physical_size: Cell<(u32, u32)>,
     pub(crate) notify_scale: Cell<bool>,
     pub(crate) is_composing: Cell<bool>,
-    pub(crate) app_claimed_right_click: Cell<bool>,
     mql_handle: RefCell<Option<MqlHandle>>,
     pending_physical_size: Cell<Option<(u32, u32)>>,
 }
@@ -183,7 +182,6 @@ impl WebWindow {
             last_physical_size: Cell::new((0, 0)),
             notify_scale: Cell::new(false),
             is_composing: Cell::new(false),
-            app_claimed_right_click: Cell::new(false),
             mql_handle: RefCell::new(None),
             pending_physical_size: Cell::new(None),
         });


### PR DESCRIPTION
Reverts zed-industries/zed#60892

Realised this is probably not the desired behavior. Context menu is not really useful when the app is full canvas. I think it's better to not have the browser context menu on web at all. My bad and sorry for the hassle!