### PR TITLE
Set the default value of tsserver to 8 GiB instead of 7.9 GiB

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -281,7 +281,7 @@ impl LspAdapter for VtslsLspAdapter {
                 "showOnAllFunctions": true
             },
             "tsserver": {
-                "maxTsServerMemory": 8092
+                "maxTsServerMemory": 8192
             },
         });
 

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -80,7 +80,7 @@ To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS lan
 
 ## Large projects
 
-`vtsls` may run out of memory on very large projects. We default the limit to 8092 (8 GiB) vs. the default of 3072 but this may not be sufficient for you:
+`vtsls` may run out of memory on very large projects. We default the limit to 8192 (8 GiB) vs. the default of 3072 but this may not be sufficient for you:
 
 ```json [settings]
 {
@@ -88,9 +88,9 @@ To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS lan
     "vtsls": {
       "settings": {
         // For TypeScript:
-        "typescript": { "tsserver": { "maxTsServerMemory": 16184 } },
+        "typescript": { "tsserver": { "maxTsServerMemory": 16384 } },
         // For JavaScript:
-        "javascript": { "tsserver": { "maxTsServerMemory": 16184 } }
+        "javascript": { "tsserver": { "maxTsServerMemory": 16384 } }
       }
     }
   }


### PR DESCRIPTION
Correct memory values: 8 GiB limit (8192) and tsserver max memory set to 16384 for TypeScript and JavaScript examples.

# Objective

- Standardized memory values.

## Testing

- This commit not be tested.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A