### PR TITLE
git_ui: Add option to skip Git commit hooks

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1709,6 +1709,8 @@
     "path_style": "file_name_first",
     // Whether to show the stage and restore buttons on diff hunks.
     "show_stage_restore_buttons": true,
+    // Whether to skip running Git hooks.
+    "skip_hooks": false,
     // Directory where git worktrees are created, relative to the repository
     // working directory.
     //

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -458,6 +458,7 @@ pub struct CommitOptions {
     pub amend: bool,
     pub signoff: bool,
     pub allow_empty: bool,
+    pub skip_hooks: bool,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -2559,6 +2560,10 @@ impl GitRepository for RealGitRepository {
 
             if options.allow_empty {
                 cmd.arg("--allow-empty");
+            }
+
+            if options.skip_hooks {
+                cmd.arg("--no-verify");
             }
 
             if let Some((name, email)) = name_and_email {
@@ -5013,11 +5018,29 @@ mod tests {
         .await
         .expect_err("failing pre-commit hook should abort the commit");
 
+        repo.commit(
+            "Commit bypassing hook".into(),
+            None,
+            CommitOptions {
+                skip_hooks: true,
+                ..CommitOptions::default()
+            },
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(test_commit_envs()),
+        )
+        .await
+        .expect("skip_hooks should bypass a failing pre-commit hook in a trusted repo");
+
         write_hook("pre-commit", "#!/bin/sh\nexit 0\n");
         write_hook(
             "commit-msg",
             "#!/bin/sh\necho 'rewritten by commit-msg hook' > \"$1\"\n",
         );
+
+        fs::write(repo_dir.path().join("file"), "three").unwrap();
+        repo.stage_paths(vec![repo_path("file")], Arc::new(HashMap::default()))
+            .await
+            .unwrap();
 
         repo.commit(
             "Original message".into(),

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -69,6 +69,7 @@ pub struct CommitModal {
     properties: ModalContainerProperties,
     branch_list_handle: PopoverMenuHandle<BranchList>,
     commit_menu_handle: PopoverMenuHandle<ContextMenu>,
+    _git_panel_subscription: Subscription,
 }
 
 impl Focusable for CommitModal {
@@ -219,6 +220,7 @@ impl CommitModal {
         .detach();
 
         let properties = ModalContainerProperties::new(window, 50);
+        let git_panel_subscription = cx.observe(&git_panel, |_, _, cx| cx.notify());
 
         Self {
             git_panel,
@@ -227,6 +229,7 @@ impl CommitModal {
             properties,
             branch_list_handle: PopoverMenuHandle::default(),
             commit_menu_handle: PopoverMenuHandle::default(),
+            _git_panel_subscription: git_panel_subscription,
         }
     }
 
@@ -287,6 +290,7 @@ impl CommitModal {
                     let git_panel = git_panel_entity.read(cx);
                     let amend_enabled = git_panel.amend_pending();
                     let signoff_enabled = git_panel.signoff_enabled();
+                    let skip_hooks = git_panel.skip_hooks_enabled(cx);
                     let has_previous_commit = git_panel.head_commit(cx).is_some();
 
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -326,6 +330,22 @@ impl CommitModal {
                                     }
                                 },
                             )
+                            .toggleable_entry(
+                                "Skip hooks",
+                                skip_hooks,
+                                IconPosition::Start,
+                                None,
+                                {
+                                    let git_panel = git_panel_entity.downgrade();
+                                    move |_, cx| {
+                                        git_panel
+                                            .update(cx, |git_panel, cx| {
+                                                git_panel.toggle_skip_hooks(cx);
+                                            })
+                                            .log_err();
+                                    }
+                                },
+                            )
                     }))
                 }
             })
@@ -346,6 +366,7 @@ impl CommitModal {
             active_repo,
             is_amend_pending,
             is_signoff_enabled,
+            skip_hooks,
             workspace,
             is_generating,
         ) = self.git_panel.update(cx, |git_panel, cx| {
@@ -356,6 +377,7 @@ impl CommitModal {
             let active_repo = git_panel.active_repository.clone();
             let is_amend_pending = git_panel.amend_pending();
             let is_signoff_enabled = git_panel.signoff_enabled();
+            let skip_hooks = git_panel.skip_hooks_enabled(cx);
             let is_generating = git_panel.is_generating_commit_message();
             (
                 can_commit,
@@ -366,6 +388,7 @@ impl CommitModal {
                 active_repo,
                 is_amend_pending,
                 is_signoff_enabled,
+                skip_hooks,
                 git_panel.workspace.clone(),
                 is_generating,
             )
@@ -455,6 +478,7 @@ impl CommitModal {
                                             amend: is_amend_pending,
                                             signoff: is_signoff_enabled,
                                             allow_empty: false,
+                                            skip_hooks,
                                         },
                                         window,
                                         cx,
@@ -470,9 +494,10 @@ impl CommitModal {
                                             tooltip,
                                             Some(&git::Commit),
                                             format!(
-                                                "git commit{}{}",
+                                                "git commit{}{}{}",
                                                 if is_amend_pending { " --amend" } else { "" },
-                                                if is_signoff_enabled { " --signoff" } else { "" }
+                                                if is_signoff_enabled { " --signoff" } else { "" },
+                                                if skip_hooks { " --no-verify" } else { "" }
                                             ),
                                             &focus_handle.clone(),
                                             cx,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -930,6 +930,7 @@ pub struct GitPanel {
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
     signoff_enabled: bool,
+    skip_hooks_override: Option<bool>,
     pending_serialization: Task<()>,
     pub(crate) project: Entity<Project>,
     scroll_handle: UniformListScrollHandle,
@@ -1089,6 +1090,7 @@ impl GitPanel {
             let mut was_file_icons = GitPanelSettings::get_global(cx).file_icons;
             let mut was_folder_icons = GitPanelSettings::get_global(cx).folder_icons;
             let mut was_diff_stats = GitPanelSettings::get_global(cx).diff_stats;
+            let mut was_skip_hooks = ProjectSettings::get_global(cx).git.skip_hooks;
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
                 let settings = GitPanelSettings::get_global(cx);
                 let sort_by = settings.sort_by;
@@ -1097,6 +1099,7 @@ impl GitPanel {
                 let file_icons = settings.file_icons;
                 let folder_icons = settings.folder_icons;
                 let diff_stats = settings.diff_stats;
+                let skip_hooks = ProjectSettings::get_global(cx).git.skip_hooks;
                 if tree_view != was_tree_view {
                     match (&mut this.view_mode, tree_view) {
                         (GitPanelViewMode::Tree(state), false) => {
@@ -1125,12 +1128,16 @@ impl GitPanel {
                 if file_icons != was_file_icons || folder_icons != was_folder_icons {
                     cx.notify();
                 }
+                if skip_hooks != was_skip_hooks {
+                    cx.notify();
+                }
                 was_sort_by = sort_by;
                 was_group_by = group_by;
                 was_tree_view = tree_view;
                 was_file_icons = file_icons;
                 was_folder_icons = folder_icons;
                 was_diff_stats = diff_stats;
+                was_skip_hooks = skip_hooks;
             })
             .detach();
 
@@ -1231,6 +1238,7 @@ impl GitPanel {
                 original_commit_message,
                 pending_commit_message_restores,
                 signoff_enabled,
+                skip_hooks_override: None,
                 pending_serialization: Task::ready(()),
                 single_staged_entry: None,
                 single_tracked_entry: None,
@@ -2786,6 +2794,7 @@ impl GitPanel {
                     amend: self.amend_pending,
                     signoff: self.signoff_enabled,
                     allow_empty: false,
+                    skip_hooks: self.skip_hooks_enabled(cx),
                 },
                 window,
                 cx,
@@ -2950,6 +2959,7 @@ impl GitPanel {
             self.fill_co_authors(&mut message, cx);
         }
 
+        let submitted_skip_hooks_override = self.skip_hooks_override;
         let task = if self.has_staged_changes() {
             // Repository serializes all git operations, so we can just send a commit immediately
             let commit_task = active_repository.update(cx, |repo, cx| {
@@ -2985,6 +2995,9 @@ impl GitPanel {
 
                 match result {
                     Ok(()) => {
+                        if this.skip_hooks_override == submitted_skip_hooks_override {
+                            this.skip_hooks_override = None;
+                        }
                         if options.amend {
                             this.set_amend_pending(false, cx);
                         } else {
@@ -5367,6 +5380,7 @@ impl GitPanel {
                 let has_previous_commit = self.head_commit(cx).is_some();
                 let amend = self.amend_pending();
                 let signoff = self.signoff_enabled;
+                let skip_hooks = self.skip_hooks_enabled(cx);
 
                 move |window, cx| {
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -5398,6 +5412,22 @@ impl GitPanel {
                                 IconPosition::Start,
                                 Some(Box::new(Signoff)),
                                 move |window, cx| window.dispatch_action(Box::new(Signoff), cx),
+                            )
+                            .toggleable_entry(
+                                "Skip hooks",
+                                skip_hooks,
+                                IconPosition::Start,
+                                None,
+                                {
+                                    let git_panel = git_panel.downgrade();
+                                    move |_, cx| {
+                                        git_panel
+                                            .update(cx, |git_panel, cx| {
+                                                git_panel.toggle_skip_hooks(cx);
+                                            })
+                                            .log_err();
+                                    }
+                                },
                             )
                     }))
                 }
@@ -5843,6 +5873,7 @@ impl GitPanel {
         let commit_tooltip_focus_handle = self.commit_editor.focus_handle(cx);
         let amend = self.amend_pending();
         let signoff = self.signoff_enabled;
+        let skip_hooks = self.skip_hooks_enabled(cx);
 
         let label_color = if self.pending_commit.is_some() {
             Color::Disabled
@@ -5879,6 +5910,7 @@ impl GitPanel {
                                             amend,
                                             signoff,
                                             allow_empty: false,
+                                            skip_hooks,
                                         },
                                         window,
                                         cx,
@@ -5895,9 +5927,10 @@ impl GitPanel {
                                     tooltip,
                                     Some(&git::Commit),
                                     format!(
-                                        "git commit{}{}",
+                                        "git commit{}{}{}",
                                         if amend { " --amend" } else { "" },
-                                        if signoff { " --signoff" } else { "" }
+                                        if signoff { " --signoff" } else { "" },
+                                        if skip_hooks { " --no-verify" } else { "" }
                                     ),
                                     &handle.clone(),
                                     cx,
@@ -7774,6 +7807,17 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         self.set_signoff_enabled(!self.signoff_enabled, cx);
+    }
+
+    pub fn skip_hooks_enabled(&self, cx: &App) -> bool {
+        self.skip_hooks_override
+            .unwrap_or_else(|| ProjectSettings::get_global(cx).git.skip_hooks)
+    }
+
+    pub fn toggle_skip_hooks(&mut self, cx: &mut Context<Self>) {
+        let current_value = self.skip_hooks_enabled(cx);
+        self.skip_hooks_override = Some(!current_value);
+        cx.notify();
     }
 
     pub async fn load(

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3125,6 +3125,7 @@ impl GitStore {
                         amend: options.amend,
                         signoff: options.signoff,
                         allow_empty: options.allow_empty,
+                        skip_hooks: options.skip_hooks,
                     },
                     askpass,
                     cx,
@@ -7529,6 +7530,7 @@ impl Repository {
                                     amend: options.amend,
                                     signoff: options.signoff,
                                     allow_empty: options.allow_empty,
+                                    skip_hooks: options.skip_hooks,
                                 }),
                                 askpass_id,
                             })

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -487,6 +487,10 @@ pub struct GitSettings {
     ///
     /// Default: true
     pub show_stage_restore_buttons: bool,
+    /// Whether to skip running Git hooks.
+    ///
+    /// Default: false
+    pub skip_hooks: bool,
     /// Directory where git worktrees are created, relative to the repository
     /// working directory. When the resolved directory is outside the project
     /// root, the project's directory name is automatically appended so that
@@ -705,6 +709,7 @@ impl Settings for ProjectSettings {
             hunk_style: git.hunk_style.unwrap(),
             path_style: git.path_style.unwrap().into(),
             show_stage_restore_buttons: git.show_stage_restore_buttons.unwrap_or(true),
+            skip_hooks: git.skip_hooks.unwrap_or(false),
             worktree_directory: git
                 .worktree_directory
                 .clone()

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -413,6 +413,7 @@ message Commit {
     bool amend = 1;
     bool signoff = 2;
     bool allow_empty = 3;
+    bool skip_hooks = 4;
   }
 }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -554,6 +554,10 @@ pub struct GitSettings {
     ///
     /// Default: true
     pub show_stage_restore_buttons: Option<bool>,
+    /// Whether to skip running Git hooks.
+    ///
+    /// Default: false
+    pub skip_hooks: Option<bool>,
     /// Directory where git worktrees are created, relative to the repository
     /// working directory.
     ///
@@ -890,6 +894,17 @@ pub enum GitHostingProviderKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merge_from::MergeFrom as _;
+
+    fn default_git_settings() -> GitSettings {
+        let settings: crate::SettingsContent = settings_json::parse_json_with_comments(
+            include_str!("../../../assets/settings/default.json"),
+        )
+        .expect("default settings should parse");
+        settings
+            .git
+            .expect("default settings should include git settings")
+    }
 
     #[test]
     fn test_stdio_context_server_without_args() {
@@ -908,5 +923,23 @@ mod tests {
             panic!("expected Stdio variant, got {settings:?}");
         };
         assert_eq!(command.args, vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn git_skip_hooks_defaults_to_false() {
+        let settings = default_git_settings();
+        assert_eq!(settings.skip_hooks, Some(false));
+    }
+
+    #[test]
+    fn git_skip_hooks_is_overridden_when_merged() {
+        let mut settings = default_git_settings();
+        let project_settings = GitSettings {
+            skip_hooks: Some(true),
+            ..Default::default()
+        };
+        settings.merge_from(&project_settings);
+
+        assert_eq!(settings.skip_hooks, Some(true));
     }
 }

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7450,7 +7450,7 @@ fn terminal_page() -> SettingsPage {
 }
 
 fn version_control_page() -> SettingsPage {
-    fn git_integration_section() -> [SettingsPageItem; 2] {
+    fn git_integration_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Git Integration"),
             SettingsPageItem::DynamicItem(DynamicItem {
@@ -7550,6 +7550,20 @@ fn version_control_page() -> SettingsPage {
                         },
                     ],
                 ],
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Skip hooks",
+                description: "Whether to skip Git hooks when committing.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git.skip_hooks"),
+                    pick: |settings_content| settings_content.git.as_ref()?.skip_hooks.as_ref(),
+                    write: |settings_content, value, _| {
+                        settings_content.git.get_or_insert_default().skip_hooks = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
             }),
         ]
     }


### PR DESCRIPTION
# Objective

- Follow up on #59846 with a hook-skipping design compatible with Zed’s native Git hook execution.
- Provide an explicit escape hatch when verification hooks should not run for a commit, without changing default behavior.

## Solution

- Add a `git.skip_hooks` setting, disabled by default.
- Add a transient **Skip hooks** option to the Git panel and commit modal.
- The per-commit option overrides the setting for one commit, resets after success, and remains selected after failure.
- Pass `--no-verify` only when enabled, for both local and remote commits.

## Testing

Automated:

- `cargo check -p project -p git_ui -p settings_ui`
- `cargo test -p git commit_runs_git_hooks`
- `cargo test -p settings_content git_skip_hooks`
- `cargo fmt --all -- --check`
- `git diff --check`

Manual:

- Verified normal commits fail in a temporary repository with a failing `pre-commit` hook.
- Verified **Skip hooks** permits the commit.
- Verified `git.skip_hooks: true` permits commits without enabling the per-commit option.
- Verified normal hook behavior returns after disabling the option.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="1648" height="1208" alt="Screenshot 2026-07-20 at 21 20 45" src="https://github.com/user-attachments/assets/542e6c0d-2165-448b-abc1-b541026400cf" />


## Suggested .rules additions

- Commit options that affect Git command behavior must be propagated through `GitStore`'s remote request path and `git.proto`.

---

Release Notes:

- Added a `git.skip_hooks` setting and commit-menu option to skip Git hooks.