### PR TITLE
gpui: Allow changing wayland layer-shell keyboard interactivity

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -880,6 +880,12 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn set_exclusive_zone(&self, _zone: Pixels) {}
     #[cfg(all(target_os = "linux", feature = "wayland"))]
     fn set_exclusive_edge(&self, _edge: layer_shell::Anchor) {}
+    #[cfg(all(target_os = "linux", feature = "wayland"))]
+    fn set_keyboard_interactivity(
+        &self,
+        _keyboard_interactivity: layer_shell::KeyboardInteractivity,
+    ) {
+    }
     fn set_input_region(&self, _region: Option<&[Bounds<Pixels>]>) {}
     fn window_decorations(&self) -> Decorations {
         Decorations::Server

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2015,6 +2015,18 @@ impl Window {
         self.platform_window.set_exclusive_edge(edge);
     }
 
+    /// Set how a layer-shell surface receives keyboard focus. Changes are committed
+    /// immediately. This is ignored for other window kinds. (Wayland layer-shell
+    /// windows only)
+    #[cfg(all(target_os = "linux", feature = "wayland"))]
+    pub fn set_keyboard_interactivity(
+        &self,
+        keyboard_interactivity: crate::layer_shell::KeyboardInteractivity,
+    ) {
+        self.platform_window
+            .set_keyboard_interactivity(keyboard_interactivity);
+    }
+
     /// Start a window resize operation (Wayland)
     pub fn start_window_resize(&self, edge: ResizeEdge) {
         self.platform_window.start_window_resize(edge);

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -37,7 +37,7 @@ use gpui::{
     PromptButton, PromptLevel, RequestFrameOptions, ResizeEdge, Scene, Size, Tiling,
     WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowControls,
     WindowDecorations, WindowKind, WindowParams,
-    layer_shell::{Anchor, LayerShellNotSupportedError},
+    layer_shell::{Anchor, KeyboardInteractivity, LayerShellNotSupportedError},
     popup::PopupOptions,
     px, size,
 };
@@ -1804,6 +1804,19 @@ impl PlatformWindow for WaylandWindow {
             // on the next frame.
             state.surface.commit();
         }
+    }
+
+    fn set_keyboard_interactivity(&self, keyboard_interactivity: KeyboardInteractivity) {
+        let state = self.borrow();
+        let Some(layer_surface) = state.surface_state.layer_surface() else {
+            return;
+        };
+        layer_surface.set_keyboard_interactivity(
+            super::layer_shell::wayland_keyboard_interactivity(keyboard_interactivity),
+        );
+        // Commit to apply it immediately, otherwise it only takes effect
+        // on the next frame.
+        state.surface.commit();
     }
 
     fn set_input_region(&self, region: Option<&[Bounds<Pixels>]>) {


### PR DESCRIPTION
# Objective

Layer-shell keyboard interactivity can currently only be selected when a GPUI window is created.

Some clients need to change keyboard behavior while keeping the same surface mapped. For example, a surface may initially avoid taking focus and later allow normal keyboard focus after user interaction.

## Solution

This PR adds `Window::set_keyboard_interactivity`.

The method forwards the new mode through `PlatformWindow`. On Wayland layer_shell windows, GPUI sends the new keyboard interactivity to `zwlr_layer_surface_v1` and immediately commits the surface.

This doesn't affect other platforms or window types other than layer_shell.

This is how we expose other wayland layer_shell APIs already:
- https://github.com/zed-industries/zed/pull/60163
- https://github.com/zed-industries/zed/pull/60161

## Testing

I tested the change with a mapped GPUI layer_shell surface on Linux with Wayland and Niri.

Reviewers can test this by opening a layer_shell window with `KeyboardInteractivity::None`, calling `set_keyboard_interactivity` after the window is mapped, and observing the resulting keyboard focus behavior.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A