### PR TITLE
collab_panel: Fix pressed state of the channel item

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -280,6 +280,7 @@ pub struct CollabPanel {
     filter_occupied_channels: bool,
     workspace: WeakEntity<Workspace>,
     hovered_channel: Option<(ChannelId, bool)>,
+    pressed_channel: Option<(ChannelId, bool)>,
     notification_store: Entity<NotificationStore>,
     current_notification_toast: Option<(u64, Task<()>)>,
     mark_as_read_tasks: HashMap<u64, Task<anyhow::Result<()>>>,
@@ -399,6 +400,7 @@ impl CollabPanel {
                 focus_handle: cx.focus_handle(),
                 channel_clipboard: None,
                 hovered_channel: None,
+                pressed_channel: None,
                 fs: workspace.app_state().fs.clone(),
                 pending_panel_serialization: Task::ready(None),
                 pending_favorites_serialization: Task::ready(None),
@@ -3447,6 +3449,7 @@ impl CollabPanel {
         let panel_bg = cx.theme().colors().panel_background;
         let hover_bg = panel_bg.blend(cx.theme().colors().ghost_element_hover);
         let active_bg = panel_bg.blend(cx.theme().colors().ghost_element_active);
+        let is_pressed = self.pressed_channel == Some((channel_id, is_favorite_entry));
 
         h_flex()
             .id(ix)
@@ -3463,6 +3466,29 @@ impl CollabPanel {
                     cx.notify();
                 }
             }))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    this.pressed_channel = Some((channel_id, is_favorite_entry));
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    if this.pressed_channel.take().is_some() {
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    if this.pressed_channel.take().is_some() {
+                        cx.notify();
+                    }
+                }),
+            )
             .when(!channel.is_root_channel(), |el| {
                 el.on_drag(channel.clone(), move |channel, _, _, cx| {
                     cx.new(|_| DraggedChannelView {
@@ -3553,10 +3579,9 @@ impl CollabPanel {
                     .absolute()
                     .right_0()
                     .pl_1()
-                    .pr_1p5()
+                    .pr_2()
                     .gap_px()
-                    .bg(hover_bg)
-                    .group_active("", |s| s.bg(active_bg))
+                    .bg(if is_pressed { active_bg } else { hover_bg })
                     .child({
                         let focus_handle = self.focus_handle.clone();
                         IconButton::new("channel_favorite", favorite_icon)


### PR DESCRIPTION
Quick follow up to https://github.com/zed-industries/zed/pull/61397, where there was a bug in background color for the extra controls on each item flashing as a click on any item's disclosure occurred.

Release Notes:

- N/A
