### PR TITLE
Remove stale musl linker error workaround from Linux dev docs

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -53,31 +53,6 @@ You can install a local build on your machine with:
 
 This builds `zed` and the `cli` in release mode, installs the binary at `~/.local/bin/zed`, and installs `.desktop` files to `~/.local/share`.
 
-> **_Note_**: If you encounter linker errors similar to the following:
->
-> ```bash
-> error: linking with `cc` failed: exit status: 1 ...
-> = note: /usr/bin/ld: /tmp/rustcISMaod/libaws_lc_sys-79f08eb6d32e546e.rlib(f8e4fd781484bd36-bcm.o): in function `aws_lc_0_25_0_handle_cpu_env':
->           /aws-lc/crypto/fipsmodule/cpucap/cpu_intel.c:(.text.aws_lc_0_25_0_handle_cpu_env+0x63): undefined reference to `__isoc23_sscanf'
->           /usr/bin/ld: /tmp/rustcISMaod/libaws_lc_sys-79f08eb6d32e546e.rlib(f8e4fd781484bd36-bcm.o): in function `pkey_rsa_ctrl_str':
->           /aws-lc/crypto/fipsmodule/evp/p_rsa.c:741:(.text.pkey_rsa_ctrl_str+0x20d): undefined reference to `__isoc23_strtol'
->           /usr/bin/ld: /aws-lc/crypto/fipsmodule/evp/p_rsa.c:752:(.text.pkey_rsa_ctrl_str+0x258): undefined reference to `__isoc23_strtol'
->           collect2: error: ld returned 1 exit status
->   = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
->   = note: use the `-l` flag to specify native libraries to link
->   = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
-> error: could not compile `remote_server` (bin "remote_server") due to 1 previous error
-> ```
->
-> **Cause**:
-> This is caused by known bugs in aws-lc-rs (no GCC >= 14 support): [FIPS fails to build with GCC >= 14](https://github.com/aws/aws-lc-rs/issues/569)
-> & [GCC-14 - build failure for FIPS module](https://github.com/aws/aws-lc/issues/2010)
->
-> You can refer to [linux: Linker error for remote_server when using script/install-linux](https://github.com/zed-industries/zed/issues/24880) for more information.
->
-> **Workaround**:
-> Set the remote server target to `x86_64-unknown-linux-gnu` like so `export REMOTE_SERVER_TARGET=x86_64-unknown-linux-gnu; script/install-linux`
-
 ## Wayland & X11
 
 Zed supports both X11 and Wayland. By default, we pick whichever we can find at runtime. If you're on Wayland and want to run in X11 mode, use the environment variable `WAYLAND_DISPLAY=''`.


### PR DESCRIPTION
# Objective

- The Linux dev docs document a workaround for a musl/aws-lc-rs linker error (`undefined reference to __isoc23_sscanf` / `__isoc23_strtol`) that no longer applies now that the root cause is fixed.

## Solution

- #61203 fixed the underlying issue directly in `script/bundle-linux` by setting `CC_<target>=musl-gcc` when building the musl `remote_server` target, so the documented workaround (`REMOTE_SERVER_TARGET=x86_64-unknown-linux-gnu`) is stale and misleading. This PR removes it.

## Testing

- Did you test these changes? If so, how? — Confirmed the removed note referenced the exact linker error fixed by #61203, and that no other docs reference the removed workaround.
- Are there any parts that need more testing? — No, this is a docs-only removal.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? — Review the diff; confirm `script/install-linux` no longer hits this error after #61203.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? — N/A, docs-only change.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
- N/A