### PR TITLE
gpui_linux: Fix Wayland serial token tracking

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -87,7 +87,7 @@ use crate::linux::{
     wayland::{
         clipboard::{Clipboard, DataOffer, FILE_LIST_MIME_TYPE, TEXT_MIME_TYPES},
         cursor::Cursor,
-        serial::{SerialKind, SerialTracker},
+        serial::{Serial, SerialKind, SerialTracker},
         to_shape,
         window::WaylandWindow,
     },
@@ -411,7 +411,7 @@ impl WaylandClientStatePtr {
             .expect("The pointer should always be valid when dispatching in wayland")
     }
 
-    pub fn get_serial(&self, kind: SerialKind) -> u32 {
+    pub fn get_serial(&self, kind: SerialKind) -> Serial {
         self.0.upgrade().unwrap().borrow().serial_tracker.get(kind)
     }
 
@@ -539,7 +539,7 @@ impl WaylandClientState {
             return;
         };
         let serial = self.serial_tracker.get(SerialKind::MouseEnter);
-        wl_pointer.set_cursor(serial, None, 0, 0);
+        wl_pointer.set_cursor(serial.as_raw(), None, 0, 0);
         self.cursor_hidden_window = Some(focused_window);
     }
 
@@ -552,7 +552,7 @@ impl WaylandClientState {
         };
         let serial = self.serial_tracker.get(SerialKind::MouseEnter);
         if let Some(cursor_shape_device) = &self.cursor_shape_device {
-            cursor_shape_device.set_shape(serial, to_shape(style));
+            cursor_shape_device.set_shape(serial.as_raw(), to_shape(style));
             return;
         }
         let Some(focused_window) = self.mouse_focused_window.clone() else {
@@ -572,7 +572,7 @@ impl WaylandClientState {
         let scale = focused_window.primary_output_scale();
         self.cursor.set_icon(
             &wl_pointer,
-            serial,
+            serial.as_raw(),
             cursor_style_to_icon_names(style),
             scale,
         );
@@ -935,7 +935,8 @@ impl LinuxClient for WaylandClient {
                     let serial = state
                         .serial_tracker
                         .get(SerialKind::MousePress)
-                        .max(state.serial_tracker.get(SerialKind::KeyPress));
+                        .as_raw()
+                        .max(state.serial_tracker.get(SerialKind::KeyPress).as_raw());
                     (serial != 0).then(|| (serial, state.wl_seat.clone()))
                 });
                 (Some(parent), popup_grab.flatten())
@@ -999,7 +1000,7 @@ impl LinuxClient for WaylandClient {
 
         let serial = state.serial_tracker.get(SerialKind::MouseEnter);
         if let Some(cursor_shape_device) = &state.cursor_shape_device {
-            cursor_shape_device.set_shape(serial, to_shape(style));
+            cursor_shape_device.set_shape(serial.as_raw(), to_shape(style));
         } else if let Some(focused_window) = &state.mouse_focused_window {
             // cursor-shape-v1 isn't supported, set the cursor using a surface.
             let wl_pointer = state
@@ -1009,7 +1010,7 @@ impl LinuxClient for WaylandClient {
             let scale = focused_window.primary_output_scale();
             state.cursor.set_icon(
                 &wl_pointer,
-                serial,
+                serial.as_raw(),
                 cursor_style_to_icon_names(style),
                 scale,
             );
@@ -1033,7 +1034,7 @@ impl LinuxClient for WaylandClient {
             state.pending_activation = Some(PendingActivation::Uri(uri.to_string()));
             let token = activation.get_activation_token(&state.globals.qh, ());
             let serial = state.serial_tracker.get(SerialKind::MousePress);
-            token.set_serial(serial, &state.wl_seat);
+            token.set_serial(serial.as_raw(), &state.wl_seat);
             token.set_surface(&window.surface());
             token.commit();
         } else {
@@ -1051,7 +1052,7 @@ impl LinuxClient for WaylandClient {
             state.pending_activation = Some(PendingActivation::Path(path));
             let token = activation.get_activation_token(&state.globals.qh, ());
             let serial = state.serial_tracker.get(SerialKind::MousePress);
-            token.set_serial(serial, &state.wl_seat);
+            token.set_serial(serial.as_raw(), &state.wl_seat);
             token.set_surface(&window.surface());
             token.commit();
         } else {
@@ -1091,13 +1092,18 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set_primary(item);
-            let serial = state.serial_tracker.get_latest();
+            let Some(serial) = state.serial_tracker.selection_serial() else {
+                log::warn!(
+                    "Skipping Wayland primary selection ownership request because no keyboard or pointer press serial has been received"
+                );
+                return;
+            };
             let data_source = primary_selection_manager.create_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
             }
             data_source.offer(state.clipboard.self_mime());
-            primary_selection.set_selection(Some(&data_source), serial);
+            primary_selection.set_selection(Some(&data_source), serial.as_raw());
         }
     }
 
@@ -1111,13 +1117,18 @@ impl LinuxClient for WaylandClient {
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
             state.clipboard.set(item);
-            let serial = state.serial_tracker.get_latest();
+            let Some(serial) = state.serial_tracker.selection_serial() else {
+                log::warn!(
+                    "Skipping Wayland clipboard ownership request because no keyboard or pointer press serial has been received"
+                );
+                return;
+            };
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
             }
             data_source.offer(state.clipboard.self_mime());
-            data_device.set_selection(Some(&data_source), serial);
+            data_device.set_selection(Some(&data_source), serial.as_raw());
         }
     }
 
@@ -1713,7 +1724,9 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 state: WEnum::Value(key_state),
                 ..
             } => {
-                state.serial_tracker.update(SerialKind::KeyPress, serial);
+                if key_state == wl_keyboard::KeyState::Pressed {
+                    state.serial_tracker.update(SerialKind::KeyPress, serial);
+                }
 
                 let focused_window = state.keyboard_focused_window.clone();
                 let Some(focused_window) = focused_window else {
@@ -1899,7 +1912,7 @@ impl Dispatch<zwp_text_input_v3::ZwpTextInputV3, ()> for WaylandClientStatePtr {
                             text_input,
                             &mut state.last_ime_cursor_rectangle,
                             area,
-                            last_serial == serial,
+                            last_serial.as_raw() == serial,
                         );
                     }
                 } else {
@@ -2026,7 +2039,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                             state.cursor_style = Some(default_style);
 
                             if let Some(cursor_shape_device) = &state.cursor_shape_device {
-                                cursor_shape_device.set_shape(serial, to_shape(default_style));
+                                cursor_shape_device
+                                    .set_shape(serial.as_raw(), to_shape(default_style));
                             } else {
                                 // cursor-shape-v1 isn't supported, set the cursor using a surface.
                                 let wl_pointer = state
@@ -2036,7 +2050,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                                 let scale = window.primary_output_scale();
                                 state.cursor.set_icon(
                                     &wl_pointer,
-                                    serial,
+                                    serial.as_raw(),
                                     cursor_style_to_icon_names(default_style),
                                     scale,
                                 );
@@ -2585,7 +2599,7 @@ impl Dispatch<wl_data_offer::WlDataOffer, ()> for WaylandClientStatePtr {
             if mime_type == FILE_LIST_MIME_TYPE {
                 let serial = state.serial_tracker.get(SerialKind::DataDevice);
                 let mime_type = mime_type.clone();
-                data_offer.accept(serial, Some(mime_type));
+                data_offer.accept(serial.as_raw(), Some(mime_type));
             }
 
             // Clipboard

--- a/crates/gpui_linux/src/linux/wayland/serial.rs
+++ b/crates/gpui_linux/src/linux/wayland/serial.rs
@@ -9,60 +9,58 @@ pub(crate) enum SerialKind {
     KeyPress,
 }
 
-#[derive(Debug)]
-struct SerialData {
-    serial: u32,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Serial(u32);
+
+impl Serial {
+    pub(super) fn as_raw(self) -> u32 {
+        self.0
+    }
 }
 
-impl SerialData {
-    fn new(value: u32) -> Self {
-        Self { serial: value }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SelectionSerial(Serial);
+
+impl SelectionSerial {
+    pub(super) fn as_raw(self) -> u32 {
+        self.0.as_raw()
     }
 }
 
 #[derive(Debug)]
 /// Helper for tracking of different serial kinds.
 pub(crate) struct SerialTracker {
-    serials: HashMap<SerialKind, SerialData>,
+    serials: HashMap<SerialKind, Serial>,
+    selection_serial: Option<SelectionSerial>,
 }
 
 impl SerialTracker {
     pub fn new() -> Self {
         Self {
             serials: HashMap::default(),
+            selection_serial: None,
         }
     }
 
     pub fn update(&mut self, kind: SerialKind, value: u32) {
-        self.serials.insert(kind, SerialData::new(value));
+        let serial = Serial(value);
+
+        if matches!(&kind, SerialKind::KeyPress | SerialKind::MousePress) {
+            self.selection_serial = Some(SelectionSerial(serial));
+        }
+
+        self.serials.insert(kind, serial);
     }
 
-    /// Returns the latest tracked serial of the provided [`SerialKind`]
+    /// Returns the latest tracked serial of the provided [`SerialKind`].
     ///
-    /// Will return 0 if not tracked.
-    pub fn get(&self, kind: SerialKind) -> u32 {
-        self.serials
-            .get(&kind)
-            .map(|serial_data| serial_data.serial)
-            .unwrap_or(0)
+    /// Returns a serial with a raw value of 0 if the kind has not been tracked.
+    pub fn get(&self, kind: SerialKind) -> Serial {
+        self.serials.get(&kind).copied().unwrap_or(Serial(0))
     }
 
-    /// Returns the most recent serial across all tracked kinds.
-    ///
-    /// Wayland compositor serial numbers are monotonically increasing, so the
-    /// highest value is always the most recently received one. This is the
-    /// correct serial to use for [`set_selection`] when the triggering event
-    /// may have been a mouse press rather than a key press: using 0 (the
-    /// default when a kind has never been seen) causes compositors to silently
-    /// reject the request.
-    ///
-    /// Returns 0 only if no serial of any kind has been received yet.
-    pub fn get_latest(&self) -> u32 {
-        self.serials
-            .values()
-            .map(|serial_data| serial_data.serial)
-            .max()
-            .unwrap_or(0)
+    pub fn selection_serial(&self) -> Option<SelectionSerial> {
+        self.selection_serial
     }
 }
 
@@ -70,8 +68,14 @@ impl SerialTracker {
 mod tests {
     use super::*;
 
+    fn raw_selection_serial(serial_tracker: &SerialTracker) -> Option<u32> {
+        serial_tracker
+            .selection_serial()
+            .map(SelectionSerial::as_raw)
+    }
+
     #[test]
-    fn test_clipboard_serial_ignores_unrelated_serial_kinds() {
+    fn test_selection_serial_ignores_unrelated_serial_kinds() {
         let mut serial_tracker = SerialTracker::new();
         serial_tracker.update(SerialKind::MousePress, 3783);
         serial_tracker.update(SerialKind::InputMethod, 5011);
@@ -79,23 +83,44 @@ mod tests {
         serial_tracker.update(SerialKind::MouseEnter, 6000);
         serial_tracker.update(SerialKind::DataDevice, 7000);
 
-        assert_eq!(serial_tracker.get_latest(), 3787);
+        assert_eq!(raw_selection_serial(&serial_tracker), Some(3787));
     }
 
     #[test]
-    fn test_clipboard_serial_uses_mouse_press_without_key_press() {
+    fn test_selection_serial_uses_mouse_press_without_key_press() {
         let mut serial_tracker = SerialTracker::new();
         serial_tracker.update(SerialKind::MousePress, 3783);
 
-        assert_eq!(serial_tracker.get_latest(), 3783);
+        assert_eq!(raw_selection_serial(&serial_tracker), Some(3783));
     }
 
     #[test]
-    fn test_clipboard_serial_uses_latest_eligible_event_across_rollover() {
+    fn test_selection_serial_uses_event_arrival_order_across_rollover() {
         let mut serial_tracker = SerialTracker::new();
         serial_tracker.update(SerialKind::KeyPress, 0xffff_fff0);
         serial_tracker.update(SerialKind::MousePress, 0x0000_0010);
 
-        assert_eq!(serial_tracker.get_latest(), 0x0000_0010);
+        assert_eq!(raw_selection_serial(&serial_tracker), Some(0x0000_0010));
+    }
+
+    #[test]
+    fn test_selection_serial_is_unavailable_without_eligible_input() {
+        let mut serial_tracker = SerialTracker::new();
+
+        assert_eq!(raw_selection_serial(&serial_tracker), None);
+
+        serial_tracker.update(SerialKind::InputMethod, 5011);
+        serial_tracker.update(SerialKind::MouseEnter, 6000);
+        serial_tracker.update(SerialKind::DataDevice, 7000);
+
+        assert_eq!(raw_selection_serial(&serial_tracker), None);
+    }
+
+    #[test]
+    fn test_zero_is_a_valid_selection_serial() {
+        let mut serial_tracker = SerialTracker::new();
+        serial_tracker.update(SerialKind::KeyPress, 0);
+
+        assert_eq!(raw_selection_serial(&serial_tracker), Some(0));
     }
 }

--- a/crates/gpui_linux/src/linux/wayland/serial.rs
+++ b/crates/gpui_linux/src/linux/wayland/serial.rs
@@ -65,3 +65,37 @@ impl SerialTracker {
             .unwrap_or(0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clipboard_serial_ignores_unrelated_serial_kinds() {
+        let mut serial_tracker = SerialTracker::new();
+        serial_tracker.update(SerialKind::MousePress, 3783);
+        serial_tracker.update(SerialKind::InputMethod, 5011);
+        serial_tracker.update(SerialKind::KeyPress, 3787);
+        serial_tracker.update(SerialKind::MouseEnter, 6000);
+        serial_tracker.update(SerialKind::DataDevice, 7000);
+
+        assert_eq!(serial_tracker.get_latest(), 3787);
+    }
+
+    #[test]
+    fn test_clipboard_serial_uses_mouse_press_without_key_press() {
+        let mut serial_tracker = SerialTracker::new();
+        serial_tracker.update(SerialKind::MousePress, 3783);
+
+        assert_eq!(serial_tracker.get_latest(), 3783);
+    }
+
+    #[test]
+    fn test_clipboard_serial_uses_latest_eligible_event_across_rollover() {
+        let mut serial_tracker = SerialTracker::new();
+        serial_tracker.update(SerialKind::KeyPress, 0xffff_fff0);
+        serial_tracker.update(SerialKind::MousePress, 0x0000_0010);
+
+        assert_eq!(serial_tracker.get_latest(), 0x0000_0010);
+    }
+}

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1579,7 +1579,7 @@ impl PlatformWindow for WaylandWindow {
             // The serial isn't exactly important here, since the activation is probably going to be rejected anyway.
             let serial = state.client.get_serial(SerialKind::MousePress);
             token.set_app_id(app_id);
-            token.set_serial(serial, &state.globals.seat);
+            token.set_serial(serial.as_raw(), &state.globals.seat);
             token.set_surface(&state.surface);
             token.commit();
         }
@@ -1759,7 +1759,7 @@ impl PlatformWindow for WaylandWindow {
         if let Some(toplevel) = state.surface_state.toplevel() {
             toplevel.show_window_menu(
                 &state.globals.seat,
-                serial,
+                serial.as_raw(),
                 f32::from(position.x) as i32,
                 f32::from(position.y) as i32,
             );
@@ -1770,7 +1770,7 @@ impl PlatformWindow for WaylandWindow {
         let state = self.borrow();
         let serial = state.client.get_serial(SerialKind::MousePress);
         if let Some(toplevel) = state.surface_state.toplevel() {
-            toplevel._move(&state.globals.seat, serial);
+            toplevel._move(&state.globals.seat, serial.as_raw());
         }
     }
 
@@ -1779,7 +1779,7 @@ impl PlatformWindow for WaylandWindow {
         if let Some(toplevel) = state.surface_state.toplevel() {
             toplevel.resize(
                 &state.globals.seat,
-                state.client.get_serial(SerialKind::MousePress),
+                state.client.get_serial(SerialKind::MousePress).as_raw(),
                 edge.to_xdg(),
             )
         }


### PR DESCRIPTION
Closes #58651 
Closes FR-123

https://github.com/zed-industries/zed/pull/50406/ while fixing one issue regressed serial tracking in Wayland. What happens is we conflated unrelated serials into a common value which is wrong. For example, `InputMethod` serial does not come from the same source as `MousePress` or `KeyPress`, and if Zed is running for a while and the user performs lots of IME commits (`zwp_text_input_v3.commit`), `InputMethod` will overtake other serial values and will be incorrectly used for clipboard authorisation/selection by the compositor such as Mutter or kWin. This will effectively poison the clipboard making Zed the indefinite owner until we kill Zed. More concretely, we use `get_latest()` on the serial tracker to extract *the largest serial REGARDLESS of kind* which is wrong since not every serial kind comes from the same pool.

Release Notes:

- Fixed copy-paste behaviour in Wayland.