### PR TITLE
git_panel: Adjust commit items in the history tab

### DIFF
--- a/crates/git_ui/src/commit_context_menu.rs
+++ b/crates/git_ui/src/commit_context_menu.rs
@@ -59,7 +59,7 @@ pub(crate) fn commit_context_menu(
         context_menu
             .context(focus_handle)
             .header(header)
-            .entry("View Commit", Some(OpenCommitView.boxed_clone()), {
+            .entry("View Diff", Some(OpenCommitView.boxed_clone()), {
                 let repository = repository.clone();
                 let workspace = workspace.clone();
                 move |window, cx| {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6650,7 +6650,7 @@ impl GitPanel {
                                                         short_sha.clone(),
                                                     ))
                                                 } else {
-                                                    SharedString::from(short_sha.clone())
+                                                    short_sha.clone()
                                                 };
 
                                                 Tooltip::with_meta(

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6510,6 +6510,7 @@ impl GitPanel {
                                             .size(LabelSize::Small)
                                             .color(Color::Muted)
                                             .alpha(0.5)
+                                            .flex_none()
                                     };
 
                                     v_flex()
@@ -6574,6 +6575,12 @@ impl GitPanel {
                                                                 Chip::new(format!(
                                                                     "+{hidden_tag_count}"
                                                                 ))
+                                                                .bg_color(
+                                                                    cx.theme()
+                                                                        .colors()
+                                                                        .element_active
+                                                                        .opacity(0.8),
+                                                                )
                                                                 .when(!has_context_menu, |chip| {
                                                                     chip.tooltip(Tooltip::text(
                                                                         hidden_tag_names,
@@ -6584,13 +6591,30 @@ impl GitPanel {
                                                 }))
                                                 .when(is_unpushed, |this| {
                                                     this.child(
-                                                        Icon::new(IconName::ArrowUp)
-                                                            .size(IconSize::XSmall),
+                                                        h_flex()
+                                                            .size_4()
+                                                            .flex_none()
+                                                            .justify_center()
+                                                            .rounded_sm()
+                                                            .border_1()
+                                                            .border_color(
+                                                                cx.theme().colors().border,
+                                                            )
+                                                            .bg(cx
+                                                                .theme()
+                                                                .colors()
+                                                                .element_background)
+                                                            .child(
+                                                                Icon::new(IconName::ArrowUp)
+                                                                    .size(IconSize::XSmall),
+                                                            ),
                                                     )
                                                 }),
                                         )
                                         .child(
                                             h_flex()
+                                                .w_full()
+                                                .min_w_0()
                                                 .gap_1p5()
                                                 .child(div().flex_none().child(avatar))
                                                 .when(!author_name.is_empty(), |this| {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6592,12 +6592,13 @@ impl GitPanel {
                                         .child(
                                             h_flex()
                                                 .gap_1p5()
-                                                .child(avatar)
+                                                .child(div().flex_none().child(avatar))
                                                 .when(!author_name.is_empty(), |this| {
                                                     this.child(
                                                         Label::new(author_name)
                                                             .size(LabelSize::Small)
-                                                            .color(Color::Muted),
+                                                            .color(Color::Muted)
+                                                            .truncate(),
                                                     )
                                                     .child(dot_separator())
                                                 })
@@ -6605,14 +6606,16 @@ impl GitPanel {
                                                     this.child(
                                                         Label::new(relative_time)
                                                             .size(LabelSize::Small)
-                                                            .color(Color::Muted),
+                                                            .color(Color::Muted)
+                                                            .flex_none(),
                                                     )
                                                     .child(dot_separator())
                                                 })
                                                 .child(
                                                     Label::new(short_sha.clone())
                                                         .size(LabelSize::Small)
-                                                        .color(Color::Muted),
+                                                        .color(Color::Muted)
+                                                        .flex_none(),
                                                 ),
                                         )
                                         .when(!has_context_menu, |this| {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6617,10 +6617,19 @@ impl GitPanel {
                                         )
                                         .when(!has_context_menu, |this| {
                                             this.tooltip(move |_, cx| {
+                                                let description = if is_unpushed {
+                                                    SharedString::from(format!(
+                                                        "Contains Unpushed Changes — {}",
+                                                        short_sha.clone(),
+                                                    ))
+                                                } else {
+                                                    SharedString::from(short_sha.clone())
+                                                };
+
                                                 Tooltip::with_meta(
-                                                    "View Commit",
+                                                    "View Commit Diff",
                                                     None,
-                                                    short_sha.clone(),
+                                                    description,
                                                     cx,
                                                 )
                                             })


### PR DESCRIPTION
This PR is super small mostly adjusting a few things in the commit item within the history tab: author label truncation, tooltip label/description, and unpushed arrow icon design.

Release Notes:

- N/A
