### PR TITLE
feature_flags: Enable project panel undo everywhere except stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6565,6 +6565,7 @@ dependencies = [
  "fs",
  "gpui",
  "inventory",
+ "release_channel",
  "schemars 1.0.4",
  "serde_json",
  "settings",

--- a/crates/feature_flags/Cargo.toml
+++ b/crates/feature_flags/Cargo.toml
@@ -17,6 +17,7 @@ feature_flags_macros.workspace = true
 fs.workspace = true
 gpui.workspace = true
 inventory.workspace = true
+release_channel.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -87,6 +87,13 @@ impl FeatureFlag for ProjectPanelUndoRedoFeatureFlag {
     fn enabled_for_staff() -> bool {
         true
     }
+
+    fn enabled_for_all() -> bool {
+        !matches!(
+            *release_channel::RELEASE_CHANNEL,
+            release_channel::ReleaseChannel::Stable
+        )
+    }
 }
 register_feature_flag!(ProjectPanelUndoRedoFeatureFlag);
 


### PR DESCRIPTION
# Objective

Enable the Project Panel Undo/Redo feature flag in all channels except stable. This gives us control over when it lands in Stable, while also allowing us to have it sit in Preview for longer than a single week, if we want to.

## Solution

Update `ProjectPanelUndoRedoFeatureFlag::enabled_for_all` to be true on all release channels except `ReleaseChannel::Stable`. The feature flag doesn't allow us to scope it per environment so there's no way we could enable the flag for all but only have it impact Preview, should have added that safeguard in the beginning as stable is already relying on the feature flag exclusively.

## Testing

N/A

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- Added support for undoing and redoing project panel operations.
