### PR TITLE
Reduce overdraw in GPUI by using the depth buffer

### DIFF
--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -50,6 +50,8 @@ pub struct Scene {
     pub subpixel_sprites: Vec<SubpixelSprite>,
     pub polychrome_sprites: Vec<PolychromeSprite>,
     pub surfaces: Vec<PaintSurface>,
+    pub blended_quad_indices: Vec<u32>,
+    pub opaque_quad_indices: Vec<u32>,
 }
 
 #[expect(missing_docs)]
@@ -66,6 +68,8 @@ impl Scene {
         self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
+        self.blended_quad_indices.clear();
+        self.opaque_quad_indices.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -160,8 +164,26 @@ impl Scene {
         self.polychrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.surfaces.sort_by_key(|surface| surface.order);
+        self.partition_quads();
     }
 
+    fn partition_quads(&mut self) {
+        self.blended_quad_indices.clear();
+        self.opaque_quad_indices.clear();
+        for (quad_id, quad) in self.quads.iter().enumerate() {
+            let has_opaque_core = quad.has_opaque_core();
+            if has_opaque_core {
+                self.opaque_quad_indices.push(quad_id as u32);
+            }
+            if !has_opaque_core || quad.has_rounded_corners() {
+                self.blended_quad_indices.push(quad_id as u32);
+            }
+        }
+        // Opaque quads are drawn front-to-back in the depth-writing pass.
+        self.opaque_quad_indices.reverse();
+    }
+
+    /// Iterates the frame's batches in draw order. Only valid after `finish`.
     #[cfg_attr(
         all(
             any(target_os = "linux", target_os = "freebsd"),
@@ -175,6 +197,8 @@ impl Scene {
             shadows_iter: self.shadows.iter().peekable(),
             quads_start: 0,
             quads_iter: self.quads.iter().peekable(),
+            blended_quad_indices: &self.blended_quad_indices,
+            blended_quad_indices_start: 0,
             paths_start: 0,
             paths_iter: self.paths.iter().peekable(),
             underlines_start: 0,
@@ -189,6 +213,16 @@ impl Scene {
             surfaces_iter: self.surfaces.iter().peekable(),
         }
     }
+}
+
+/// Maps a quad's index in [`Scene::quads`] to depth, with greater values closer.
+///
+/// Zero is reserved for the cleared depth buffer. `quad_depth(n)` also
+/// represents the cursor after the first `n` quads: with a strict greater-than
+/// test, it is above quads before the cursor and ties with the quad after it.
+/// Depth-based renderers must use this mapping in both CPU and shader code.
+pub fn quad_depth(quad_id: u32) -> f32 {
+    ((quad_id + 1) as f32 * (1.0 / 16777216.0)).min(1.0)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Default)]
@@ -271,6 +305,8 @@ struct BatchIterator<'a> {
     shadows_iter: Peekable<slice::Iter<'a, Shadow>>,
     quads_start: usize,
     quads_iter: Peekable<slice::Iter<'a, Quad>>,
+    blended_quad_indices: &'a [u32],
+    blended_quad_indices_start: usize,
     paths_start: usize,
     paths_iter: Peekable<slice::Iter<'a, Path<ScaledPixels>>>,
     underlines_start: usize,
@@ -354,7 +390,22 @@ impl<'a> Iterator for BatchIterator<'a> {
                     quads_end += 1;
                 }
                 self.quads_start = quads_end;
-                Some(PrimitiveBatch::Quads(quads_start..quads_end))
+
+                let blended_quad_indices_start = self.blended_quad_indices_start;
+                let mut blended_quad_indices_end = blended_quad_indices_start;
+                while self
+                    .blended_quad_indices
+                    .get(blended_quad_indices_end)
+                    .is_some_and(|&quad_id| (quad_id as usize) < quads_end)
+                {
+                    blended_quad_indices_end += 1;
+                }
+                self.blended_quad_indices_start = blended_quad_indices_end;
+
+                Some(PrimitiveBatch::Quads {
+                    range: quads_start..quads_end,
+                    blended_range: blended_quad_indices_start..blended_quad_indices_end,
+                })
             }
             PrimitiveKind::Path => {
                 let paths_start = self.paths_start;
@@ -476,7 +527,10 @@ impl<'a> Iterator for BatchIterator<'a> {
 #[allow(missing_docs)]
 pub enum PrimitiveBatch {
     Shadows(Range<usize>),
-    Quads(Range<usize>),
+    Quads {
+        range: Range<usize>,
+        blended_range: Range<usize>,
+    },
     Paths(Range<usize>),
     Underlines(Range<usize>),
     MonochromeSprites {
@@ -500,7 +554,7 @@ impl PrimitiveBatch {
     pub fn label(&self) -> String {
         match self {
             Self::Shadows(range) => format!("shadows ({})", range.len()),
-            Self::Quads(range) => format!("quads ({})", range.len()),
+            Self::Quads { range, .. } => format!("quads ({})", range.len()),
             Self::Paths(range) => format!("paths ({})", range.len()),
             Self::Underlines(range) => format!("underlines ({})", range.len()),
             Self::MonochromeSprites { texture_id, range } => {
@@ -541,6 +595,27 @@ pub struct Quad {
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
+}
+
+impl Quad {
+    fn has_opaque_core(&self) -> bool {
+        let zero = ScaledPixels(0.);
+        self.background
+            .as_solid()
+            .is_some_and(|solid| solid.a >= 1.0)
+            && self.border_widths.top == zero
+            && self.border_widths.right == zero
+            && self.border_widths.bottom == zero
+            && self.border_widths.left == zero
+    }
+
+    fn has_rounded_corners(&self) -> bool {
+        let zero = ScaledPixels(0.);
+        self.corner_radii.top_left != zero
+            || self.corner_radii.top_right != zero
+            || self.corner_radii.bottom_right != zero
+            || self.corner_radii.bottom_left != zero
+    }
 }
 
 impl From<Quad> for Primitive {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3820,6 +3820,45 @@ impl Window {
         }
     }
 
+    fn largest_border_interior(quad: &Quad) -> Bounds<ScaledPixels> {
+        let radii = &quad.corner_radii;
+        let widths = &quad.border_widths;
+        let edge_radii = Edges {
+            top: radii.top_left.max(radii.top_right),
+            right: radii.top_right.max(radii.bottom_right),
+            bottom: radii.bottom_left.max(radii.bottom_right),
+            left: radii.top_left.max(radii.bottom_left),
+        };
+
+        let antialias_inset = point(ScaledPixels(1.0), ScaledPixels(1.0));
+        let inset_bounds = |top_left_inset, bottom_right_inset| {
+            Bounds::from_corners(
+                quad.bounds.origin + top_left_inset + antialias_inset,
+                quad.bounds.bottom_right() - bottom_right_inset - antialias_inset,
+            )
+        };
+
+        // Rounded corners need only be excluded on one axis. Either candidate
+        // is empty of border pixels, so use the larger interior.
+        let horizontal_band = inset_bounds(
+            point(widths.left, widths.top.max(edge_radii.top)),
+            point(widths.right, widths.bottom.max(edge_radii.bottom)),
+        );
+        let vertical_band = inset_bounds(
+            point(widths.left.max(edge_radii.left), widths.top),
+            point(widths.right.max(edge_radii.right), widths.bottom),
+        );
+
+        let area = |bounds: &Bounds<ScaledPixels>| {
+            bounds.size.width.0.max(0.) * bounds.size.height.0.max(0.)
+        };
+        if area(&horizontal_band) >= area(&vertical_band) {
+            horizontal_band
+        } else {
+            vertical_band
+        }
+    }
+
     /// Paint one or more quads into the scene for the next frame at the current stacking context.
     /// Quads are colored rectangular regions with an optional background, border, and corner radius.
     /// see [`fill`], [`outline`], and [`quad`] to construct this type.
@@ -3851,29 +3890,10 @@ impl Window {
             return;
         }
 
-        // We're drawing a quad with a border but no fill color. Painting this quad would run the quad shader for every
-        // transparent interior pixel, which is especially costly when the quad is large.
-        // Instead, split it into four non-overlapping strips that cover the regions where borders are painted:
-        // the side strips own the straight left and right edges, while the top and bottom strips own the horizontal
-        // edges and the rounded corners.
-        let radii = &quad.corner_radii;
-        let widths = &quad.border_widths;
-
-        let antialias_slack = point(ScaledPixels(1.0), ScaledPixels(1.0));
-        let top_left_inset = point(
-            widths.left,
-            widths.top.max(radii.top_left).max(radii.top_right),
-        ) + antialias_slack;
-        let bottom_right_inset = point(
-            widths.right,
-            widths.bottom.max(radii.bottom_left).max(radii.bottom_right),
-        ) + antialias_slack;
-
+        // Splitting a border-only quad around its empty interior avoids shading
+        // every transparent pixel inside large outlines.
         let outer_bounds = quad.bounds;
-        let inner_bounds = Bounds::from_corners(
-            outer_bounds.origin + top_left_inset,
-            outer_bounds.bottom_right() - bottom_right_inset,
-        );
+        let inner_bounds = Self::largest_border_interior(&quad);
 
         if inner_bounds.is_empty() {
             self.next_frame.scene.insert_primitive(quad);

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -856,7 +856,7 @@ impl MetalRenderer {
                     viewport_size,
                     command_encoder,
                 ),
-                PrimitiveBatch::Quads(range) => self.draw_quads(
+                PrimitiveBatch::Quads { range, .. } => self.draw_quads(
                     &scene.quads[range],
                     instance_buffer,
                     &mut instance_offset,

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -1,5 +1,5 @@
 use crate::metal_atlas::MetalAtlas;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use block::ConcreteBlock;
 use cocoa::{
     base::{NO, YES},
@@ -7,9 +7,8 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, PaintSurface, Path, Point,
+    PrimitiveBatch, ScaledPixels, Scene, Size, point, quad_depth, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -21,13 +20,13 @@ use core_video::{
 };
 use foreign_types::{ForeignType, ForeignTypeRef};
 use metal::{
-    CAMetalLayer, CommandQueue, MTLGPUFamily, MTLPixelFormat, MTLResourceOptions, NSRange,
-    RenderPassColorAttachmentDescriptorRef,
+    CAMetalLayer, CommandQueue, MTLCompareFunction, MTLGPUFamily, MTLPixelFormat,
+    MTLResourceOptions, NSRange,
 };
 use objc::{self, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
-use std::{cell::Cell, ffi::c_void, mem, ptr, sync::Arc};
+use std::{cell::Cell, ffi::c_void, mem, mem::MaybeUninit, ops::Range, ptr, slice, sync::Arc};
 
 // Exported to metal
 pub(crate) type PointF = gpui::Point<f32>;
@@ -39,6 +38,12 @@ const SHADERS_SOURCE_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/stitch
 // Use 4x MSAA, all devices support it.
 // https://developer.apple.com/documentation/metal/mtldevice/1433355-supportstexturesamplecount
 const PATH_SAMPLE_COUNT: u32 = 4;
+/// Every bit of this format's mantissa is needed, since [`quad_depth`] maps
+/// each quad in the scene onto its own depth.
+const DEPTH_FORMAT: MTLPixelFormat = MTLPixelFormat::Depth32Float;
+/// Metal requires the offset a buffer is bound at to be 256-byte aligned.
+const INSTANCE_BUFFER_ALIGNMENT: usize = 256;
+const MAX_INSTANCE_BUFFER_SIZE: usize = 256 * 1024 * 1024;
 
 pub(crate) type Context = Arc<Mutex<InstanceBufferPool>>;
 pub(crate) type Renderer = MetalRenderer;
@@ -121,15 +126,19 @@ pub(crate) struct MetalRenderer {
     path_sprites_pipeline_state: metal::RenderPipelineState,
     shadows_pipeline_state: metal::RenderPipelineState,
     quads_pipeline_state: metal::RenderPipelineState,
+    opaque_quads_pipeline_state: metal::RenderPipelineState,
     underlines_pipeline_state: metal::RenderPipelineState,
     monochrome_sprites_pipeline_state: metal::RenderPipelineState,
     polychrome_sprites_pipeline_state: metal::RenderPipelineState,
     surfaces_pipeline_state: metal::RenderPipelineState,
+    depth_write_state: metal::DepthStencilState,
+    depth_test_state: metal::DepthStencilState,
     unit_vertices: metal::Buffer,
     #[allow(clippy::arc_with_non_send_sync)]
     instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
     sprite_atlas: Arc<MetalAtlas>,
     core_video_texture_cache: core_video::metal_texture_cache::CVMetalTextureCache,
+    depth_texture: Option<metal::Texture>,
     path_intermediate_texture: Option<metal::Texture>,
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
@@ -290,6 +299,14 @@ impl MetalRenderer {
             "quad_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
+        let opaque_quads_pipeline_state = build_opaque_quads_pipeline_state(
+            &device,
+            &library,
+            "opaque_quads",
+            "opaque_quad_vertex",
+            "opaque_quad_fragment",
+            MTLPixelFormat::BGRA8Unorm,
+        );
         let underlines_pipeline_state = build_pipeline_state(
             &device,
             &library,
@@ -323,6 +340,9 @@ impl MetalRenderer {
             MTLPixelFormat::BGRA8Unorm,
         );
 
+        let depth_write_state = build_depth_stencil_state(&device, true);
+        let depth_test_state = build_depth_stencil_state(&device, false);
+
         let command_queue = device.new_command_queue();
         let sprite_atlas = Arc::new(MetalAtlas::new(device.clone(), is_apple_gpu));
         let core_video_texture_cache =
@@ -340,14 +360,18 @@ impl MetalRenderer {
             path_sprites_pipeline_state,
             shadows_pipeline_state,
             quads_pipeline_state,
+            opaque_quads_pipeline_state,
             underlines_pipeline_state,
             monochrome_sprites_pipeline_state,
             polychrome_sprites_pipeline_state,
             surfaces_pipeline_state,
+            depth_write_state,
+            depth_test_state,
             unit_vertices,
             instance_buffer_pool,
             sprite_atlas,
             core_video_texture_cache,
+            depth_texture: None,
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
@@ -391,18 +415,30 @@ impl MetalRenderer {
                 ];
             }
         }
-        self.update_path_intermediate_textures(size);
+        self.update_intermediate_textures(size);
     }
 
-    fn update_path_intermediate_textures(&mut self, size: Size<DevicePixels>) {
+    fn update_intermediate_textures(&mut self, size: Size<DevicePixels>) {
         // We are uncertain when this happens, but sometimes size can be 0 here. Most likely before
         // the layout pass on window creation. Zero-sized texture creation causes SIGABRT.
         // https://github.com/zed-industries/zed/issues/36229
         if size.width.0 <= 0 || size.height.0 <= 0 {
+            self.depth_texture = None;
             self.path_intermediate_texture = None;
             self.path_intermediate_msaa_texture = None;
             return;
         }
+
+        let depth_descriptor = metal::TextureDescriptor::new();
+        depth_descriptor.set_width(size.width.0 as u64);
+        depth_descriptor.set_height(size.height.0 as u64);
+        depth_descriptor.set_pixel_format(DEPTH_FORMAT);
+        // Path batches end the main render pass and start a new one, so unlike
+        // the MSAA texture below this cannot be memoryless: its contents have
+        // to survive from one encoder to the next.
+        depth_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+        depth_descriptor.set_usage(metal::MTLTextureUsage::RenderTarget);
+        self.depth_texture = Some(self.device.new_texture(&depth_descriptor));
 
         let texture_descriptor = metal::TextureDescriptor::new();
         texture_descriptor.set_width(size.width.0 as u64);
@@ -468,56 +504,66 @@ impl MetalRenderer {
             return;
         };
 
-        loop {
-            let mut instance_buffer = self
-                .instance_buffer_pool
-                .lock()
-                .acquire(&self.device, self.is_unified_memory);
-
-            let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
-
-            match command_buffer {
-                Ok(command_buffer) => {
-                    let instance_buffer_pool = self.instance_buffer_pool.clone();
-                    let instance_buffer = Cell::new(Some(instance_buffer));
-                    let block = ConcreteBlock::new(move |_| {
-                        if let Some(instance_buffer) = instance_buffer.take() {
-                            instance_buffer_pool.lock().release(instance_buffer);
-                        }
-                    });
-                    let block = block.copy();
-                    command_buffer.add_completed_handler(&block);
-
-                    if self.presents_with_transaction {
-                        command_buffer.commit();
-                        command_buffer.wait_until_scheduled();
-                        drawable.present();
-                    } else {
-                        command_buffer.present_drawable(drawable);
-                        command_buffer.commit();
-                    }
-                    return;
-                }
-                Err(err) => {
-                    log::error!(
-                        "failed to render: {}. retrying with larger instance buffer size",
-                        err
-                    );
-                    let mut instance_buffer_pool = self.instance_buffer_pool.lock();
-                    let buffer_size = instance_buffer_pool.buffer_size;
-                    if buffer_size >= 256 * 1024 * 1024 {
-                        log::error!("instance buffer size grew too large: {}", buffer_size);
-                        break;
-                    }
-                    instance_buffer_pool.reset(buffer_size * 2);
-                    log::info!(
-                        "increased instance buffer size to {}",
-                        instance_buffer_pool.buffer_size
-                    );
-                }
+        let command_buffer = match self.render_frame(scene, drawable.texture(), viewport_size) {
+            Ok(command_buffer) => command_buffer,
+            Err(error) => {
+                log::error!("failed to render: {error:#}");
+                return;
             }
+        };
+
+        if self.presents_with_transaction {
+            command_buffer.commit();
+            command_buffer.wait_until_scheduled();
+            drawable.present();
+        } else {
+            command_buffer.present_drawable(drawable);
+            command_buffer.commit();
         }
+    }
+
+    fn render_frame(
+        &mut self,
+        scene: &Scene,
+        texture: &metal::TextureRef,
+        viewport_size: Size<DevicePixels>,
+    ) -> Result<metal::CommandBuffer> {
+        let mut writer = InstanceBufferWriter::new(
+            &self.device,
+            &self.instance_buffer_pool,
+            self.is_unified_memory,
+        );
+        let instances = upload_frame_instances(scene, &mut writer).with_context(|| {
+            format!(
+                "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces",
+                scene.paths.len(),
+                scene.shadows.len(),
+                scene.quads.len(),
+                scene.underlines.len(),
+                scene.monochrome_sprites.len(),
+                scene.polychrome_sprites.len(),
+                scene.surfaces.len(),
+            )
+        })?;
+        let command_buffer = self.draw_primitives_to_texture(
+            scene,
+            &instances,
+            &mut writer,
+            texture,
+            viewport_size,
+        )?;
+
+        let instance_buffer_pool = self.instance_buffer_pool.clone();
+        let instance_buffer = Cell::new(Some(writer.finish()));
+        let block = ConcreteBlock::new(move |_| {
+            if let Some(instance_buffer) = instance_buffer.take() {
+                instance_buffer_pool.lock().release(instance_buffer);
+            }
+        });
+        let block = block.copy();
+        command_buffer.add_completed_handler(&block);
+
+        Ok(command_buffer)
     }
 
     /// Renders the scene to a texture and returns the pixel data as an RGBA image.
@@ -541,83 +587,13 @@ impl MetalRenderer {
             .next_drawable()
             .ok_or_else(|| anyhow::anyhow!("Failed to get drawable for render_to_image"))?;
 
-        loop {
-            let mut instance_buffer = self
-                .instance_buffer_pool
-                .lock()
-                .acquire(&self.device, self.is_unified_memory);
+        let command_buffer = self.render_frame(scene, drawable.texture(), viewport_size)?;
 
-            let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
+        // Commit and wait for completion without presenting
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
 
-            match command_buffer {
-                Ok(command_buffer) => {
-                    let instance_buffer_pool = self.instance_buffer_pool.clone();
-                    let instance_buffer = Cell::new(Some(instance_buffer));
-                    let block = ConcreteBlock::new(move |_| {
-                        if let Some(instance_buffer) = instance_buffer.take() {
-                            instance_buffer_pool.lock().release(instance_buffer);
-                        }
-                    });
-                    let block = block.copy();
-                    command_buffer.add_completed_handler(&block);
-
-                    // Commit and wait for completion without presenting
-                    command_buffer.commit();
-                    command_buffer.wait_until_completed();
-
-                    // Read pixels from the texture
-                    let texture = drawable.texture();
-                    let width = texture.width() as u32;
-                    let height = texture.height() as u32;
-                    let bytes_per_row = width as usize * 4;
-                    let buffer_size = height as usize * bytes_per_row;
-
-                    let mut pixels = vec![0u8; buffer_size];
-
-                    let region = metal::MTLRegion {
-                        origin: metal::MTLOrigin { x: 0, y: 0, z: 0 },
-                        size: metal::MTLSize {
-                            width: width as u64,
-                            height: height as u64,
-                            depth: 1,
-                        },
-                    };
-
-                    texture.get_bytes(
-                        pixels.as_mut_ptr() as *mut std::ffi::c_void,
-                        bytes_per_row as u64,
-                        region,
-                        0,
-                    );
-
-                    // Convert BGRA to RGBA (swap B and R channels)
-                    for chunk in pixels.chunks_exact_mut(4) {
-                        chunk.swap(0, 2);
-                    }
-
-                    return RgbaImage::from_raw(width, height, pixels).ok_or_else(|| {
-                        anyhow::anyhow!("Failed to create RgbaImage from pixel data")
-                    });
-                }
-                Err(err) => {
-                    log::error!(
-                        "failed to render: {}. retrying with larger instance buffer size",
-                        err
-                    );
-                    let mut instance_buffer_pool = self.instance_buffer_pool.lock();
-                    let buffer_size = instance_buffer_pool.buffer_size;
-                    if buffer_size >= 256 * 1024 * 1024 {
-                        anyhow::bail!("instance buffer size grew too large: {}", buffer_size);
-                    }
-                    instance_buffer_pool.reset(buffer_size * 2);
-                    log::info!(
-                        "increased instance buffer size to {}",
-                        instance_buffer_pool.buffer_size
-                    );
-                }
-            }
-        }
+        read_texture_to_image(drawable.texture())
     }
 
     /// Renders a scene to an image without requiring a window or CAMetalLayer.
@@ -634,8 +610,8 @@ impl MetalRenderer {
             anyhow::bail!("Invalid size for render_scene_to_image: {:?}", size);
         }
 
-        // Update path intermediate textures for this size
-        self.update_path_intermediate_textures(size);
+        // Update intermediate textures for this size
+        self.update_intermediate_textures(size);
 
         // Create an offscreen texture as render target
         let texture_descriptor = metal::TextureDescriptor::new();
@@ -647,92 +623,22 @@ impl MetalRenderer {
         texture_descriptor.set_storage_mode(metal::MTLStorageMode::Managed);
         let target_texture = self.device.new_texture(&texture_descriptor);
 
-        loop {
-            let mut instance_buffer = self
-                .instance_buffer_pool
-                .lock()
-                .acquire(&self.device, self.is_unified_memory);
+        let command_buffer = self.render_frame(scene, &target_texture, size)?;
 
-            let command_buffer =
-                self.draw_primitives_to_texture(scene, &mut instance_buffer, &target_texture, size);
-
-            match command_buffer {
-                Ok(command_buffer) => {
-                    let instance_buffer_pool = self.instance_buffer_pool.clone();
-                    let instance_buffer = Cell::new(Some(instance_buffer));
-                    let block = ConcreteBlock::new(move |_| {
-                        if let Some(instance_buffer) = instance_buffer.take() {
-                            instance_buffer_pool.lock().release(instance_buffer);
-                        }
-                    });
-                    let block = block.copy();
-                    command_buffer.add_completed_handler(&block);
-
-                    // On discrete GPUs (non-unified memory), Managed textures
-                    // require an explicit blit synchronize before the CPU can
-                    // read back the rendered data. Without this, get_bytes
-                    // returns stale zeros.
-                    if !self.is_unified_memory {
-                        let blit = command_buffer.new_blit_command_encoder();
-                        blit.synchronize_resource(&target_texture);
-                        blit.end_encoding();
-                    }
-
-                    // Commit and wait for completion
-                    command_buffer.commit();
-                    command_buffer.wait_until_completed();
-
-                    // Read pixels from the texture
-                    let width = size.width.0 as u32;
-                    let height = size.height.0 as u32;
-                    let bytes_per_row = width as usize * 4;
-                    let buffer_size = height as usize * bytes_per_row;
-
-                    let mut pixels = vec![0u8; buffer_size];
-
-                    let region = metal::MTLRegion {
-                        origin: metal::MTLOrigin { x: 0, y: 0, z: 0 },
-                        size: metal::MTLSize {
-                            width: width as u64,
-                            height: height as u64,
-                            depth: 1,
-                        },
-                    };
-
-                    target_texture.get_bytes(
-                        pixels.as_mut_ptr() as *mut std::ffi::c_void,
-                        bytes_per_row as u64,
-                        region,
-                        0,
-                    );
-
-                    // Convert BGRA to RGBA (swap B and R channels)
-                    for chunk in pixels.chunks_exact_mut(4) {
-                        chunk.swap(0, 2);
-                    }
-
-                    return RgbaImage::from_raw(width, height, pixels).ok_or_else(|| {
-                        anyhow::anyhow!("Failed to create RgbaImage from pixel data")
-                    });
-                }
-                Err(err) => {
-                    log::error!(
-                        "failed to render: {}. retrying with larger instance buffer size",
-                        err
-                    );
-                    let mut instance_buffer_pool = self.instance_buffer_pool.lock();
-                    let buffer_size = instance_buffer_pool.buffer_size;
-                    if buffer_size >= 256 * 1024 * 1024 {
-                        anyhow::bail!("instance buffer size grew too large: {}", buffer_size);
-                    }
-                    instance_buffer_pool.reset(buffer_size * 2);
-                    log::info!(
-                        "increased instance buffer size to {}",
-                        instance_buffer_pool.buffer_size
-                    );
-                }
-            }
+        // On discrete GPUs (non-unified memory), Managed textures require an
+        // explicit blit synchronize before the CPU can read back the rendered
+        // data. Without this, get_bytes returns stale zeros.
+        if !self.is_unified_memory {
+            let blit = command_buffer.new_blit_command_encoder();
+            blit.synchronize_resource(&target_texture);
+            blit.end_encoding();
         }
+
+        // Commit and wait for completion
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        read_texture_to_image(&target_texture)
     }
 
     /// Renders a scene to a reused offscreen texture without reading pixels
@@ -748,7 +654,7 @@ impl MetalRenderer {
             anyhow::bail!("Invalid size for render_scene: {:?}", size);
         }
 
-        self.update_path_intermediate_textures(size);
+        self.update_intermediate_textures(size);
 
         let needs_new_target = self.headless_render_target.as_ref().is_none_or(|texture| {
             texture.width() != size.width.0 as u64 || texture.height() != size.height.0 as u64
@@ -769,191 +675,140 @@ impl MetalRenderer {
             .clone()
             .expect("just ensured the render target exists");
 
-        loop {
-            let mut instance_buffer = self
-                .instance_buffer_pool
-                .lock()
-                .acquire(&self.device, self.is_unified_memory);
+        let command_buffer = self.render_frame(scene, &target_texture, size)?;
 
-            let command_buffer =
-                self.draw_primitives_to_texture(scene, &mut instance_buffer, &target_texture, size);
-
-            match command_buffer {
-                Ok(command_buffer) => {
-                    let instance_buffer_pool = self.instance_buffer_pool.clone();
-                    let instance_buffer = Cell::new(Some(instance_buffer));
-                    let block = ConcreteBlock::new(move |_| {
-                        if let Some(instance_buffer) = instance_buffer.take() {
-                            instance_buffer_pool.lock().release(instance_buffer);
-                        }
-                    });
-                    let block = block.copy();
-                    command_buffer.add_completed_handler(&block);
-
-                    // Commit without waiting, mirroring presentation to a real
-                    // window where the CPU doesn't block on the GPU.
-                    command_buffer.commit();
-                    return Ok(());
-                }
-                Err(err) => {
-                    log::error!(
-                        "failed to render: {}. retrying with larger instance buffer size",
-                        err
-                    );
-                    let mut instance_buffer_pool = self.instance_buffer_pool.lock();
-                    let buffer_size = instance_buffer_pool.buffer_size;
-                    if buffer_size >= 256 * 1024 * 1024 {
-                        anyhow::bail!("instance buffer size grew too large: {}", buffer_size);
-                    }
-                    instance_buffer_pool.reset(buffer_size * 2);
-                    log::info!(
-                        "increased instance buffer size to {}",
-                        instance_buffer_pool.buffer_size
-                    );
-                }
-            }
-        }
-    }
-
-    fn draw_primitives(
-        &mut self,
-        scene: &Scene,
-        instance_buffer: &mut InstanceBuffer,
-        drawable: &metal::MetalDrawableRef,
-        viewport_size: Size<DevicePixels>,
-    ) -> Result<metal::CommandBuffer> {
-        self.draw_primitives_to_texture(scene, instance_buffer, drawable.texture(), viewport_size)
+        // Commit without waiting, mirroring presentation to a real window where
+        // the CPU doesn't block on the GPU.
+        command_buffer.commit();
+        Ok(())
     }
 
     fn draw_primitives_to_texture(
         &mut self,
         scene: &Scene,
-        instance_buffer: &mut InstanceBuffer,
+        instances: &FrameInstances,
+        writer: &mut InstanceBufferWriter,
         texture: &metal::TextureRef,
         viewport_size: Size<DevicePixels>,
     ) -> Result<metal::CommandBuffer> {
+        let depth_texture = self
+            .depth_texture
+            .clone()
+            .context("missing depth texture")?;
         let command_queue = self.command_queue.clone();
         let command_buffer = command_queue.new_command_buffer();
         let alpha = if self.opaque { 1. } else { 0. };
-        let mut instance_offset = 0;
 
         let mut command_encoder = new_command_encoder_for_texture(
             command_buffer,
             texture,
+            &depth_texture,
             viewport_size,
-            |color_attachment| {
-                color_attachment.set_load_action(metal::MTLLoadAction::Clear);
-                color_attachment.set_clear_color(metal::MTLClearColor::new(0., 0., 0., alpha));
-            },
+            Some(metal::MTLClearColor::new(0., 0., 0., alpha)),
         );
 
+        command_encoder.set_depth_stencil_state(&self.depth_write_state);
+        let opaque_quad_indices = scene.blended_quad_indices.len()
+            ..scene.blended_quad_indices.len() + scene.opaque_quad_indices.len();
+        self.draw_quads(
+            &self.opaque_quads_pipeline_state,
+            opaque_quad_indices,
+            instances,
+            viewport_size,
+            command_encoder,
+        );
+        command_encoder.set_depth_stencil_state(&self.depth_test_state);
+
+        let mut quad_cursor: u32 = 0;
         for batch in scene.batches() {
-            let ok = match batch {
-                PrimitiveBatch::Shadows(range) => self.draw_shadows(
-                    &scene.shadows[range],
-                    instance_buffer,
-                    &mut instance_offset,
-                    viewport_size,
-                    command_encoder,
-                ),
-                PrimitiveBatch::Quads { range, .. } => self.draw_quads(
-                    &scene.quads[range],
-                    instance_buffer,
-                    &mut instance_offset,
-                    viewport_size,
-                    command_encoder,
-                ),
+            // Quads carry their own depth. Every other batch is flattened onto
+            // the depth of the quad cursor by collapsing the viewport's depth
+            // range onto a single value.
+            let batch_depth = quad_depth(quad_cursor) as f64;
+            if matches!(batch, PrimitiveBatch::Quads { .. }) {
+                set_viewport(command_encoder, viewport_size, 0., 1.);
+            } else {
+                set_viewport(command_encoder, viewport_size, batch_depth, batch_depth);
+            }
+
+            match batch {
+                PrimitiveBatch::Shadows(range) => {
+                    self.draw_shadows(range, instances, viewport_size, command_encoder)
+                }
+                PrimitiveBatch::Quads {
+                    range,
+                    blended_range,
+                } => {
+                    quad_cursor += range.len() as u32;
+                    self.draw_quads(
+                        &self.quads_pipeline_state,
+                        blended_range,
+                        instances,
+                        viewport_size,
+                        command_encoder,
+                    );
+                }
                 PrimitiveBatch::Paths(range) => {
                     let paths = &scene.paths[range];
                     command_encoder.end_encoding();
 
                     let did_draw = self.draw_paths_to_intermediate(
                         paths,
-                        instance_buffer,
-                        &mut instance_offset,
+                        writer,
                         viewport_size,
                         command_buffer,
-                    );
+                    )?;
 
                     command_encoder = new_command_encoder_for_texture(
                         command_buffer,
                         texture,
+                        &depth_texture,
                         viewport_size,
-                        |color_attachment| {
-                            color_attachment.set_load_action(metal::MTLLoadAction::Load);
-                        },
+                        None,
                     );
+                    command_encoder.set_depth_stencil_state(&self.depth_test_state);
+                    set_viewport(command_encoder, viewport_size, batch_depth, batch_depth);
 
                     if did_draw {
                         self.draw_paths_from_intermediate(
                             paths,
-                            instance_buffer,
-                            &mut instance_offset,
+                            writer,
                             viewport_size,
                             command_encoder,
-                        )
-                    } else {
-                        false
+                        )?;
                     }
                 }
-                PrimitiveBatch::Underlines(range) => self.draw_underlines(
-                    &scene.underlines[range],
-                    instance_buffer,
-                    &mut instance_offset,
-                    viewport_size,
-                    command_encoder,
-                ),
+                PrimitiveBatch::Underlines(range) => {
+                    self.draw_underlines(range, instances, viewport_size, command_encoder)
+                }
                 PrimitiveBatch::MonochromeSprites { texture_id, range } => self
                     .draw_monochrome_sprites(
                         texture_id,
-                        &scene.monochrome_sprites[range],
-                        instance_buffer,
-                        &mut instance_offset,
+                        range,
+                        instances,
                         viewport_size,
                         command_encoder,
                     ),
                 PrimitiveBatch::PolychromeSprites { texture_id, range } => self
                     .draw_polychrome_sprites(
                         texture_id,
-                        &scene.polychrome_sprites[range],
-                        instance_buffer,
-                        &mut instance_offset,
+                        range,
+                        instances,
                         viewport_size,
                         command_encoder,
                     ),
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(
-                    &scene.surfaces[range],
-                    instance_buffer,
-                    &mut instance_offset,
+                    &scene.surfaces[range.clone()],
+                    range.start,
+                    instances,
                     viewport_size,
                     command_encoder,
                 ),
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
-            };
-            if !ok {
-                command_encoder.end_encoding();
-                anyhow::bail!(
-                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces",
-                    scene.paths.len(),
-                    scene.shadows.len(),
-                    scene.quads.len(),
-                    scene.underlines.len(),
-                    scene.monochrome_sprites.len(),
-                    scene.polychrome_sprites.len(),
-                    scene.surfaces.len(),
-                );
             }
         }
 
         command_encoder.end_encoding();
-
-        if !self.is_unified_memory {
-            // Sync the instance buffer to the GPU
-            instance_buffer.metal_buffer.did_modify_range(NSRange {
-                location: 0,
-                length: instance_offset as NSUInteger,
-            });
-        }
 
         Ok(command_buffer.to_owned())
     }
@@ -961,16 +816,15 @@ impl MetalRenderer {
     fn draw_paths_to_intermediate(
         &self,
         paths: &[Path<ScaledPixels>],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        writer: &mut InstanceBufferWriter,
         viewport_size: Size<DevicePixels>,
         command_buffer: &metal::CommandBufferRef,
-    ) -> bool {
+    ) -> Result<bool> {
         if paths.is_empty() {
-            return true;
+            return Ok(false);
         }
         let Some(intermediate_texture) = &self.path_intermediate_texture else {
-            return false;
+            return Ok(false);
         };
 
         let render_pass_descriptor = metal::RenderPassDescriptor::new();
@@ -993,7 +847,6 @@ impl MetalRenderer {
         let command_encoder = command_buffer.new_render_command_encoder(render_pass_descriptor);
         command_encoder.set_render_pipeline_state(&self.paths_rasterization_pipeline_state);
 
-        align_offset(instance_offset);
         let mut vertices = Vec::new();
         for path in paths {
             vertices.extend(path.vertices.iter().map(|v| PathRasterizationVertex {
@@ -1003,16 +856,11 @@ impl MetalRenderer {
                 bounds: path.bounds.intersect(&path.content_mask.bounds),
             }));
         }
-        let vertices_bytes_len = mem::size_of_val(vertices.as_slice());
-        let next_offset = *instance_offset + vertices_bytes_len;
-        if next_offset > instance_buffer.size {
-            command_encoder.end_encoding();
-            return false;
-        }
+        let vertex_instances = writer.write(&vertices)?;
         command_encoder.set_vertex_buffer(
             PathRasterizationInputIndex::Vertices as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&vertex_instances.buffer),
+            vertex_instances.offset as u64,
         );
         command_encoder.set_vertex_bytes(
             PathRasterizationInputIndex::ViewportSize as u64,
@@ -1021,41 +869,29 @@ impl MetalRenderer {
         );
         command_encoder.set_fragment_buffer(
             PathRasterizationInputIndex::Vertices as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&vertex_instances.buffer),
+            vertex_instances.offset as u64,
         );
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-        unsafe {
-            ptr::copy_nonoverlapping(
-                vertices.as_ptr() as *const u8,
-                buffer_contents,
-                vertices_bytes_len,
-            );
-        }
         command_encoder.draw_primitives(
             metal::MTLPrimitiveType::Triangle,
             0,
             vertices.len() as u64,
         );
-        *instance_offset = next_offset;
 
         command_encoder.end_encoding();
-        true
+        Ok(true)
     }
 
     fn draw_shadows(
         &self,
-        shadows: &[Shadow],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        shadows: Range<usize>,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) {
         if shadows.is_empty() {
-            return true;
+            return;
         }
-        align_offset(instance_offset);
 
         command_encoder.set_render_pipeline_state(&self.shadows_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1065,62 +901,44 @@ impl MetalRenderer {
         );
         command_encoder.set_vertex_buffer(
             ShadowInputIndex::Shadows as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.shadows.buffer),
+            instances.shadows.offset as u64,
         );
         command_encoder.set_fragment_buffer(
             ShadowInputIndex::Shadows as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.shadows.buffer),
+            instances.shadows.offset as u64,
         );
-
         command_encoder.set_vertex_bytes(
             ShadowInputIndex::ViewportSize as u64,
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
 
-        let shadow_bytes_len = mem::size_of_val(shadows);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
-        let next_offset = *instance_offset + shadow_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-
-        unsafe {
-            ptr::copy_nonoverlapping(
-                shadows.as_ptr() as *const u8,
-                buffer_contents,
-                shadow_bytes_len,
-            );
-        }
-
-        command_encoder.draw_primitives_instanced(
+        command_encoder.draw_primitives_instanced_base_instance(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
             shadows.len() as u64,
+            shadows.start as u64,
         );
-        *instance_offset = next_offset;
-        true
     }
 
+    /// Draws the quads named by `quad_indices`, a range of the frame's quad
+    /// index buffer, through the blended or the opaque quad pipeline.
     fn draw_quads(
         &self,
-        quads: &[Quad],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        pipeline_state: &metal::RenderPipelineState,
+        quad_indices: Range<usize>,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
-        if quads.is_empty() {
-            return true;
+    ) {
+        if quad_indices.is_empty() {
+            return;
         }
-        align_offset(instance_offset);
 
-        command_encoder.set_render_pipeline_state(&self.quads_pipeline_state);
+        command_encoder.set_render_pipeline_state(pipeline_state);
         command_encoder.set_vertex_buffer(
             QuadInputIndex::Vertices as u64,
             Some(&self.unit_vertices),
@@ -1128,58 +946,46 @@ impl MetalRenderer {
         );
         command_encoder.set_vertex_buffer(
             QuadInputIndex::Quads as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.quads.buffer),
+            instances.quads.offset as u64,
+        );
+        command_encoder.set_vertex_buffer(
+            QuadInputIndex::QuadIndices as u64,
+            Some(&instances.quad_indices.buffer),
+            instances.quad_indices.offset as u64,
         );
         command_encoder.set_fragment_buffer(
             QuadInputIndex::Quads as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.quads.buffer),
+            instances.quads.offset as u64,
         );
-
         command_encoder.set_vertex_bytes(
             QuadInputIndex::ViewportSize as u64,
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
 
-        let quad_bytes_len = mem::size_of_val(quads);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
-        let next_offset = *instance_offset + quad_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-
-        unsafe {
-            ptr::copy_nonoverlapping(quads.as_ptr() as *const u8, buffer_contents, quad_bytes_len);
-        }
-
-        command_encoder.draw_primitives_instanced(
+        command_encoder.draw_primitives_instanced_base_instance(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
-            quads.len() as u64,
+            quad_indices.len() as u64,
+            quad_indices.start as u64,
         );
-        *instance_offset = next_offset;
-        true
     }
 
     fn draw_paths_from_intermediate(
         &self,
         paths: &[Path<ScaledPixels>],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        writer: &mut InstanceBufferWriter,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) -> Result<()> {
         let Some(first_path) = paths.first() else {
-            return true;
+            return Ok(());
         };
-
         let Some(ref intermediate_texture) = self.path_intermediate_texture else {
-            return false;
+            return Ok(());
         };
 
         command_encoder.set_render_pipeline_state(&self.path_sprites_pipeline_state);
@@ -1222,28 +1028,13 @@ impl MetalRenderer {
             sprites = vec![PathSprite { bounds }];
         }
 
-        align_offset(instance_offset);
-        let sprite_bytes_len = mem::size_of_val(sprites.as_slice());
-        let next_offset = *instance_offset + sprite_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
+        let sprite_instances = writer.write(&sprites)?;
 
         command_encoder.set_vertex_buffer(
             SpriteInputIndex::Sprites as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&sprite_instances.buffer),
+            sprite_instances.offset as u64,
         );
-
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-        unsafe {
-            ptr::copy_nonoverlapping(
-                sprites.as_ptr() as *const u8,
-                buffer_contents,
-                sprite_bytes_len,
-            );
-        }
 
         command_encoder.draw_primitives_instanced(
             metal::MTLPrimitiveType::Triangle,
@@ -1251,23 +1042,19 @@ impl MetalRenderer {
             6,
             sprites.len() as u64,
         );
-        *instance_offset = next_offset;
-
-        true
+        Ok(())
     }
 
     fn draw_underlines(
         &self,
-        underlines: &[Underline],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        underlines: Range<usize>,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) {
         if underlines.is_empty() {
-            return true;
+            return;
         }
-        align_offset(instance_offset);
 
         command_encoder.set_render_pipeline_state(&self.underlines_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1277,69 +1064,39 @@ impl MetalRenderer {
         );
         command_encoder.set_vertex_buffer(
             UnderlineInputIndex::Underlines as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.underlines.buffer),
+            instances.underlines.offset as u64,
         );
         command_encoder.set_fragment_buffer(
             UnderlineInputIndex::Underlines as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.underlines.buffer),
+            instances.underlines.offset as u64,
         );
-
         command_encoder.set_vertex_bytes(
             UnderlineInputIndex::ViewportSize as u64,
             mem::size_of_val(&viewport_size) as u64,
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
 
-        let underline_bytes_len = mem::size_of_val(underlines);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
-        let next_offset = *instance_offset + underline_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-
-        unsafe {
-            ptr::copy_nonoverlapping(
-                underlines.as_ptr() as *const u8,
-                buffer_contents,
-                underline_bytes_len,
-            );
-        }
-
-        command_encoder.draw_primitives_instanced(
+        command_encoder.draw_primitives_instanced_base_instance(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
             underlines.len() as u64,
+            underlines.start as u64,
         );
-        *instance_offset = next_offset;
-        true
     }
 
     fn draw_monochrome_sprites(
         &self,
         texture_id: AtlasTextureId,
-        sprites: &[MonochromeSprite],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        sprites: Range<usize>,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) {
         if sprites.is_empty() {
-            return true;
-        }
-        align_offset(instance_offset);
-
-        let sprite_bytes_len = mem::size_of_val(sprites);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
-        let next_offset = *instance_offset + sprite_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
+            return;
         }
 
         let texture = self.sprite_atlas.metal_texture(texture_id);
@@ -1355,8 +1112,8 @@ impl MetalRenderer {
         );
         command_encoder.set_vertex_buffer(
             SpriteInputIndex::Sprites as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.monochrome_sprites.buffer),
+            instances.monochrome_sprites.offset as u64,
         );
         command_encoder.set_vertex_bytes(
             SpriteInputIndex::ViewportSize as u64,
@@ -1370,42 +1127,31 @@ impl MetalRenderer {
         );
         command_encoder.set_fragment_buffer(
             SpriteInputIndex::Sprites as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.monochrome_sprites.buffer),
+            instances.monochrome_sprites.offset as u64,
         );
         command_encoder.set_fragment_texture(SpriteInputIndex::AtlasTexture as u64, Some(&texture));
 
-        unsafe {
-            ptr::copy_nonoverlapping(
-                sprites.as_ptr() as *const u8,
-                buffer_contents,
-                sprite_bytes_len,
-            );
-        }
-
-        command_encoder.draw_primitives_instanced(
+        command_encoder.draw_primitives_instanced_base_instance(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
             sprites.len() as u64,
+            sprites.start as u64,
         );
-        *instance_offset = next_offset;
-        true
     }
 
     fn draw_polychrome_sprites(
         &self,
         texture_id: AtlasTextureId,
-        sprites: &[PolychromeSprite],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        sprites: Range<usize>,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) {
         if sprites.is_empty() {
-            return true;
+            return;
         }
-        align_offset(instance_offset);
 
         let texture = self.sprite_atlas.metal_texture(texture_id);
         let texture_size = size(
@@ -1420,8 +1166,8 @@ impl MetalRenderer {
         );
         command_encoder.set_vertex_buffer(
             SpriteInputIndex::Sprites as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.polychrome_sprites.buffer),
+            instances.polychrome_sprites.offset as u64,
         );
         command_encoder.set_vertex_bytes(
             SpriteInputIndex::ViewportSize as u64,
@@ -1435,51 +1181,42 @@ impl MetalRenderer {
         );
         command_encoder.set_fragment_buffer(
             SpriteInputIndex::Sprites as u64,
-            Some(&instance_buffer.metal_buffer),
-            *instance_offset as u64,
+            Some(&instances.polychrome_sprites.buffer),
+            instances.polychrome_sprites.offset as u64,
         );
         command_encoder.set_fragment_texture(SpriteInputIndex::AtlasTexture as u64, Some(&texture));
 
-        let sprite_bytes_len = mem::size_of_val(sprites);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
-        let next_offset = *instance_offset + sprite_bytes_len;
-        if next_offset > instance_buffer.size {
-            return false;
-        }
-
-        unsafe {
-            ptr::copy_nonoverlapping(
-                sprites.as_ptr() as *const u8,
-                buffer_contents,
-                sprite_bytes_len,
-            );
-        }
-
-        command_encoder.draw_primitives_instanced(
+        command_encoder.draw_primitives_instanced_base_instance(
             metal::MTLPrimitiveType::Triangle,
             0,
             6,
             sprites.len() as u64,
+            sprites.start as u64,
         );
-        *instance_offset = next_offset;
-        true
     }
 
     fn draw_surfaces(
         &mut self,
         surfaces: &[PaintSurface],
-        instance_buffer: &mut InstanceBuffer,
-        instance_offset: &mut usize,
+        first_surface: usize,
+        instances: &FrameInstances,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
-    ) -> bool {
+    ) {
+        if surfaces.is_empty() {
+            return;
+        }
+
         command_encoder.set_render_pipeline_state(&self.surfaces_pipeline_state);
         command_encoder.set_vertex_buffer(
             SurfaceInputIndex::Vertices as u64,
             Some(&self.unit_vertices),
             0,
+        );
+        command_encoder.set_vertex_buffer(
+            SurfaceInputIndex::Surfaces as u64,
+            Some(&instances.surfaces.buffer),
+            instances.surfaces.offset as u64,
         );
         command_encoder.set_vertex_bytes(
             SurfaceInputIndex::ViewportSize as u64,
@@ -1487,7 +1224,7 @@ impl MetalRenderer {
             &viewport_size as *const Size<DevicePixels> as *const _,
         );
 
-        for surface in surfaces {
+        for (index, surface) in surfaces.iter().enumerate() {
             let texture_size = size(
                 DevicePixels::from(surface.image_buffer.get_width() as i32),
                 DevicePixels::from(surface.image_buffer.get_height() as i32),
@@ -1521,17 +1258,6 @@ impl MetalRenderer {
                 )
                 .unwrap();
 
-            align_offset(instance_offset);
-            let next_offset = *instance_offset + mem::size_of::<Surface>();
-            if next_offset > instance_buffer.size {
-                return false;
-            }
-
-            command_encoder.set_vertex_buffer(
-                SurfaceInputIndex::Surfaces as u64,
-                Some(&instance_buffer.metal_buffer),
-                *instance_offset as u64,
-            );
             command_encoder.set_vertex_bytes(
                 SurfaceInputIndex::TextureSize as u64,
                 mem::size_of_val(&texture_size) as u64,
@@ -1547,31 +1273,23 @@ impl MetalRenderer {
                 Some(metal::TextureRef::from_ptr(texture as *mut _))
             });
 
-            unsafe {
-                let buffer_contents = (instance_buffer.metal_buffer.contents() as *mut u8)
-                    .add(*instance_offset)
-                    as *mut SurfaceBounds;
-                ptr::write(
-                    buffer_contents,
-                    SurfaceBounds {
-                        bounds: surface.bounds,
-                        content_mask: surface.content_mask,
-                    },
-                );
-            }
-
-            command_encoder.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 6);
-            *instance_offset = next_offset;
+            command_encoder.draw_primitives_instanced_base_instance(
+                metal::MTLPrimitiveType::Triangle,
+                0,
+                6,
+                1,
+                (first_surface + index) as u64,
+            );
         }
-        true
     }
 }
 
 fn new_command_encoder_for_texture<'a>(
     command_buffer: &'a metal::CommandBufferRef,
     texture: &'a metal::TextureRef,
+    depth_texture: &metal::TextureRef,
     viewport_size: Size<DevicePixels>,
-    configure_color_attachment: impl Fn(&RenderPassColorAttachmentDescriptorRef),
+    clear_color: Option<metal::MTLClearColor>,
 ) -> &'a metal::RenderCommandEncoderRef {
     let render_pass_descriptor = metal::RenderPassDescriptor::new();
     let color_attachment = render_pass_descriptor
@@ -1580,18 +1298,72 @@ fn new_command_encoder_for_texture<'a>(
         .unwrap();
     color_attachment.set_texture(Some(texture));
     color_attachment.set_store_action(metal::MTLStoreAction::Store);
-    configure_color_attachment(color_attachment);
+
+    let depth_attachment = render_pass_descriptor.depth_attachment().unwrap();
+    depth_attachment.set_texture(Some(depth_texture));
+    depth_attachment.set_store_action(metal::MTLStoreAction::Store);
+
+    if let Some(clear_color) = clear_color {
+        color_attachment.set_load_action(metal::MTLLoadAction::Clear);
+        color_attachment.set_clear_color(clear_color);
+        depth_attachment.set_load_action(metal::MTLLoadAction::Clear);
+        // Zero is reserved by `quad_depth` for the cleared buffer, so nothing
+        // is occluded until an opaque quad writes over it.
+        depth_attachment.set_clear_depth(0.0);
+    } else {
+        color_attachment.set_load_action(metal::MTLLoadAction::Load);
+        depth_attachment.set_load_action(metal::MTLLoadAction::Load);
+    }
 
     let command_encoder = command_buffer.new_render_command_encoder(render_pass_descriptor);
+    set_viewport(command_encoder, viewport_size, 0.0, 1.0);
+    command_encoder
+}
+
+fn set_viewport(
+    command_encoder: &metal::RenderCommandEncoderRef,
+    viewport_size: Size<DevicePixels>,
+    near_depth: f64,
+    far_depth: f64,
+) {
     command_encoder.set_viewport(metal::MTLViewport {
         originX: 0.0,
         originY: 0.0,
         width: i32::from(viewport_size.width) as f64,
         height: i32::from(viewport_size.height) as f64,
-        znear: 0.0,
-        zfar: 1.0,
+        znear: near_depth,
+        zfar: far_depth,
     });
-    command_encoder
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn read_texture_to_image(texture: &metal::TextureRef) -> Result<RgbaImage> {
+    let width = texture.width() as u32;
+    let height = texture.height() as u32;
+    let bytes_per_row = width as usize * 4;
+    let mut pixels = vec![0u8; height as usize * bytes_per_row];
+
+    let region = metal::MTLRegion {
+        origin: metal::MTLOrigin { x: 0, y: 0, z: 0 },
+        size: metal::MTLSize {
+            width: width as u64,
+            height: height as u64,
+            depth: 1,
+        },
+    };
+    texture.get_bytes(
+        pixels.as_mut_ptr() as *mut std::ffi::c_void,
+        bytes_per_row as u64,
+        region,
+        0,
+    );
+
+    // Convert BGRA to RGBA (swap B and R channels)
+    for chunk in pixels.chunks_exact_mut(4) {
+        chunk.swap(0, 2);
+    }
+
+    RgbaImage::from_raw(width, height, pixels).context("failed to create RgbaImage from pixel data")
 }
 
 fn build_pipeline_state(
@@ -1613,6 +1385,7 @@ fn build_pipeline_state(
     descriptor.set_label(label);
     descriptor.set_vertex_function(Some(vertex_fn.as_ref()));
     descriptor.set_fragment_function(Some(fragment_fn.as_ref()));
+    descriptor.set_depth_attachment_pixel_format(DEPTH_FORMAT);
     let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
     color_attachment.set_pixel_format(pixel_format);
     color_attachment.set_blending_enabled(true);
@@ -1626,6 +1399,45 @@ fn build_pipeline_state(
     device
         .new_render_pipeline_state(&descriptor)
         .expect("could not create render pipeline state")
+}
+
+fn build_opaque_quads_pipeline_state(
+    device: &metal::DeviceRef,
+    library: &metal::LibraryRef,
+    label: &str,
+    vertex_fn_name: &str,
+    fragment_fn_name: &str,
+    pixel_format: metal::MTLPixelFormat,
+) -> metal::RenderPipelineState {
+    let vertex_fn = library
+        .get_function(vertex_fn_name, None)
+        .expect("error locating vertex function");
+    let fragment_fn = library
+        .get_function(fragment_fn_name, None)
+        .expect("error locating fragment function");
+
+    let descriptor = metal::RenderPipelineDescriptor::new();
+    descriptor.set_label(label);
+    descriptor.set_vertex_function(Some(vertex_fn.as_ref()));
+    descriptor.set_fragment_function(Some(fragment_fn.as_ref()));
+    descriptor.set_depth_attachment_pixel_format(DEPTH_FORMAT);
+    let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
+    color_attachment.set_pixel_format(pixel_format);
+    color_attachment.set_blending_enabled(false);
+
+    device
+        .new_render_pipeline_state(&descriptor)
+        .expect("could not create render pipeline state")
+}
+
+fn build_depth_stencil_state(
+    device: &metal::DeviceRef,
+    write_depth: bool,
+) -> metal::DepthStencilState {
+    let descriptor = metal::DepthStencilDescriptor::new();
+    descriptor.set_depth_compare_function(MTLCompareFunction::Greater);
+    descriptor.set_depth_write_enabled(write_depth);
+    device.new_depth_stencil_state(&descriptor)
 }
 
 fn build_path_sprite_pipeline_state(
@@ -1647,6 +1459,7 @@ fn build_path_sprite_pipeline_state(
     descriptor.set_label(label);
     descriptor.set_vertex_function(Some(vertex_fn.as_ref()));
     descriptor.set_fragment_function(Some(fragment_fn.as_ref()));
+    descriptor.set_depth_attachment_pixel_format(DEPTH_FORMAT);
     let color_attachment = descriptor.color_attachments().object_at(0).unwrap();
     color_attachment.set_pixel_format(pixel_format);
     color_attachment.set_blending_enabled(true);
@@ -1701,9 +1514,178 @@ fn build_path_rasterization_pipeline_state(
         .expect("could not create render pipeline state")
 }
 
-// Align to multiples of 256 make Metal happy.
-fn align_offset(offset: &mut usize) {
-    *offset = (*offset).div_ceil(256) * 256;
+#[derive(Clone)]
+struct BufferRegion {
+    buffer: metal::Buffer,
+    offset: usize,
+}
+
+struct FrameInstances {
+    quads: BufferRegion,
+    quad_indices: BufferRegion,
+    shadows: BufferRegion,
+    underlines: BufferRegion,
+    monochrome_sprites: BufferRegion,
+    polychrome_sprites: BufferRegion,
+    surfaces: BufferRegion,
+}
+
+fn upload_frame_instances(
+    scene: &Scene,
+    writer: &mut InstanceBufferWriter,
+) -> Result<FrameInstances> {
+    Ok(FrameInstances {
+        quads: writer.write(&scene.quads)?,
+        quad_indices: writer.write_iter(
+            scene.blended_quad_indices.len() + scene.opaque_quad_indices.len(),
+            scene
+                .blended_quad_indices
+                .iter()
+                .chain(&scene.opaque_quad_indices)
+                .copied(),
+        )?,
+        shadows: writer.write(&scene.shadows)?,
+        underlines: writer.write(&scene.underlines)?,
+        monochrome_sprites: writer.write(&scene.monochrome_sprites)?,
+        polychrome_sprites: writer.write(&scene.polychrome_sprites)?,
+        surfaces: writer.write_iter(
+            scene.surfaces.len(),
+            scene.surfaces.iter().map(|surface| SurfaceBounds {
+                bounds: surface.bounds,
+                content_mask: surface.content_mask,
+            }),
+        )?,
+    })
+}
+
+/// Packs a frame's instance data into pooled Metal buffers.
+/// When the current buffer runs out of room the writer moves on to a larger one.
+struct InstanceBufferWriter {
+    device: metal::Device,
+    pool: Arc<Mutex<InstanceBufferPool>>,
+    unified_memory: bool,
+    /// Buffers the frame has finished with, and how many bytes each holds.
+    filled: Vec<(InstanceBuffer, usize)>,
+    current: InstanceBuffer,
+    offset: usize,
+}
+
+impl InstanceBufferWriter {
+    fn new(
+        device: &metal::Device,
+        pool: &Arc<Mutex<InstanceBufferPool>>,
+        unified_memory: bool,
+    ) -> Self {
+        let current = pool.lock().acquire(device, unified_memory);
+        Self {
+            device: device.clone(),
+            pool: pool.clone(),
+            unified_memory,
+            filled: Vec::new(),
+            current,
+            offset: 0,
+        }
+    }
+
+    fn allocate<T>(&mut self, count: usize) -> Result<(BufferRegion, &mut [MaybeUninit<T>])> {
+        let size = mem::size_of::<T>() * count;
+        let mut offset = self.offset.next_multiple_of(INSTANCE_BUFFER_ALIGNMENT);
+        if offset + size > self.current.size {
+            self.grow(size)?;
+            offset = 0;
+        }
+        self.offset = offset + size;
+
+        let region = BufferRegion {
+            buffer: self.current.metal_buffer.clone(),
+            offset,
+        };
+        // Safety: the reservation lies within a buffer this frame owns
+        // exclusively, and never overlaps one handed out earlier.
+        let values = unsafe {
+            let start = (self.current.metal_buffer.contents() as *mut u8).add(offset);
+            slice::from_raw_parts_mut(start.cast::<MaybeUninit<T>>(), count)
+        };
+        Ok((region, values))
+    }
+
+    fn write<T>(&mut self, values: &[T]) -> Result<BufferRegion> {
+        let (region, destination) = self.allocate::<T>(values.len())?;
+        unsafe {
+            ptr::copy_nonoverlapping(
+                values.as_ptr(),
+                destination.as_mut_ptr().cast::<T>(),
+                values.len(),
+            );
+        }
+        Ok(region)
+    }
+
+    fn write_iter<T>(
+        &mut self,
+        count: usize,
+        values: impl IntoIterator<Item = T>,
+    ) -> Result<BufferRegion> {
+        let (region, destination) = self.allocate::<T>(count)?;
+        let mut written = 0;
+        for (slot, value) in destination.iter_mut().zip(values) {
+            slot.write(value);
+            written += 1;
+        }
+        debug_assert_eq!(written, count, "instance count did not match the iterator");
+        Ok(region)
+    }
+
+    /// Replaces the current buffer with one large enough for a `required`-byte reservation.
+    fn grow(&mut self, required: usize) -> Result<()> {
+        let mut pool = self.pool.lock();
+        let buffer_size = (pool.buffer_size * 2)
+            .max(required.next_power_of_two())
+            .min(MAX_INSTANCE_BUFFER_SIZE);
+        anyhow::ensure!(
+            buffer_size >= required,
+            "instance buffer needs {required} bytes, above the maximum of {MAX_INSTANCE_BUFFER_SIZE}"
+        );
+        log::info!("increased instance buffer size to {buffer_size}");
+
+        pool.reset(buffer_size);
+        let buffer = pool.acquire(&self.device, self.unified_memory);
+        drop(pool);
+
+        let filled = mem::replace(&mut self.current, buffer);
+        self.filled.push((filled, self.offset));
+        self.offset = 0;
+        Ok(())
+    }
+
+    /// Flushes the frame's writes and returns the buffer worth recycling.
+    fn finish(self) -> InstanceBuffer {
+        let Self {
+            unified_memory,
+            mut filled,
+            current,
+            offset,
+            ..
+        } = self;
+        filled.push((current, offset));
+
+        if !unified_memory {
+            for (buffer, written) in &filled {
+                // An allocation larger than the whole buffer retires it before
+                // anything has been written to it.
+                if *written == 0 {
+                    continue;
+                }
+                buffer.metal_buffer.did_modify_range(NSRange {
+                    location: 0,
+                    length: *written as NSUInteger,
+                });
+            }
+        }
+
+        let (current, _) = filled.pop().expect("the current buffer was just pushed");
+        current
+    }
 }
 
 #[repr(C)]
@@ -1718,6 +1700,7 @@ enum QuadInputIndex {
     Vertices = 0,
     Quads = 1,
     ViewportSize = 2,
+    QuadIndices = 3,
 }
 
 #[repr(C)]

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -13,6 +13,7 @@ float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
 float4 to_device_position_transformed(float2 unit_vertex, Bounds_ScaledPixels bounds,
                           TransformationMatrix transformation,
                           constant Size_DevicePixels *input_viewport_size);
+float quad_depth(uint quad_id);
 
 float2 to_tile_position(float2 unit_vertex, AtlasTile tile,
                         constant Size_DevicePixels *atlas_size);
@@ -64,17 +65,21 @@ struct QuadFragmentInput {
 };
 
 vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
-                                    uint quad_id [[instance_id]],
+                                    uint instance_id [[instance_id]],
                                     constant float2 *unit_vertices
                                     [[buffer(QuadInputIndex_Vertices)]],
                                     constant Quad *quads
                                     [[buffer(QuadInputIndex_Quads)]],
+                                    constant uint *quad_indices
+                                    [[buffer(QuadInputIndex_QuadIndices)]],
                                     constant Size_DevicePixels *viewport_size
                                     [[buffer(QuadInputIndex_ViewportSize)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
+  uint quad_id = quad_indices[instance_id];
   Quad quad = quads[quad_id];
   float4 device_position =
       to_device_position(unit_vertex, quad.bounds, viewport_size);
+  device_position.z = quad_depth(quad_id);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds,
                                                  quad.content_mask.bounds);
   float4 border_color = hsla_to_rgba(quad.border_color);
@@ -444,6 +449,104 @@ float quarter_ellipse_sdf(float2 point, float2 radii) {
   // TODO: A better solution would be to use the gradient of the implicit
   // function for an ellipse to approximate a scaling factor.
   return unit_circle_sdf * (radii.x + radii.y) * -0.5;
+}
+
+struct OpaqueQuadVertexOutput {
+  float4 position [[position]];
+  float4 color [[flat]];
+  float clip_distance [[clip_distance]][4];
+};
+
+struct OpaqueQuadFragmentInput {
+  float4 position [[position]];
+  float4 color [[flat]];
+};
+
+Bounds_ScaledPixels opaque_quad_core(Quad quad) {
+  bool has_rounded_corners = quad.corner_radii.top_left != 0.0 ||
+                             quad.corner_radii.top_right != 0.0 ||
+                             quad.corner_radii.bottom_right != 0.0 ||
+                             quad.corner_radii.bottom_left != 0.0;
+  if (!has_rounded_corners) {
+    return quad.bounds;
+  }
+
+  const float antialias_inset = 1.0;
+  float left_inset =
+      max(quad.corner_radii.top_left, quad.corner_radii.bottom_left) +
+      antialias_inset;
+  float right_inset =
+      max(quad.corner_radii.top_right, quad.corner_radii.bottom_right) +
+      antialias_inset;
+  float top_inset =
+      max(quad.corner_radii.top_left, quad.corner_radii.top_right) +
+      antialias_inset;
+  float bottom_inset =
+      max(quad.corner_radii.bottom_left, quad.corner_radii.bottom_right) +
+      antialias_inset;
+
+  float2 size = float2(quad.bounds.size.width, quad.bounds.size.height);
+
+  // A horizontal band avoids the top and bottom corner arcs; a vertical band
+  // avoids the left and right arcs. Either is fully opaque, so use the larger.
+  float2 horizontal_band = max(
+      size - float2(2.0 * antialias_inset, top_inset + bottom_inset),
+      float2(0.0));
+  float2 vertical_band = max(
+      size - float2(left_inset + right_inset, 2.0 * antialias_inset),
+      float2(0.0));
+
+  Bounds_ScaledPixels core = quad.bounds;
+  if (horizontal_band.x * horizontal_band.y >=
+      vertical_band.x * vertical_band.y) {
+    core.origin.x += antialias_inset;
+    core.origin.y += top_inset;
+    core.size.width = horizontal_band.x;
+    core.size.height = horizontal_band.y;
+  } else {
+    core.origin.x += left_inset;
+    core.origin.y += antialias_inset;
+    core.size.width = vertical_band.x;
+    core.size.height = vertical_band.y;
+  }
+  return core;
+}
+
+vertex OpaqueQuadVertexOutput opaque_quad_vertex(
+    uint unit_vertex_id [[vertex_id]], uint instance_id [[instance_id]],
+    constant float2 *unit_vertices [[buffer(QuadInputIndex_Vertices)]],
+    constant Quad *quads [[buffer(QuadInputIndex_Quads)]],
+    constant uint *quad_indices [[buffer(QuadInputIndex_QuadIndices)]],
+    constant Size_DevicePixels *viewport_size
+    [[buffer(QuadInputIndex_ViewportSize)]]) {
+  uint quad_id = quad_indices[instance_id];
+  Quad quad = quads[quad_id];
+  Bounds_ScaledPixels core = opaque_quad_core(quad);
+
+  if (core.size.width <= 0.0 || core.size.height <= 0.0) {
+    // Zero-area triangles are rejected before rasterization.
+    return OpaqueQuadVertexOutput{float4(0.0, 0.0, 0.0, 1.0), float4(0.0),
+                                  {1.0, 1.0, 1.0, 1.0}};
+  }
+
+  float2 unit_vertex = unit_vertices[unit_vertex_id];
+  float4 device_position = to_device_position(unit_vertex, core, viewport_size);
+  device_position.z = quad_depth(quad_id);
+  float4 clip_distance =
+      distance_from_clip_rect(unit_vertex, core, quad.content_mask.bounds);
+  // Matches the blended quad shader's solid-background output exactly: tag-0
+  // quads resolve to `hsla_to_rgba(solid)`, and alpha-1 blending is an
+  // overwrite.
+  float4 color = hsla_to_rgba(quad.background.solid);
+
+  return OpaqueQuadVertexOutput{
+      device_position, color,
+      {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
+}
+
+fragment float4 opaque_quad_fragment(OpaqueQuadFragmentInput input
+                                     [[stage_in]]) {
+  return input.color;
 }
 
 struct ShadowVertexOutput {
@@ -1007,6 +1110,11 @@ float4 to_device_position(float2 unit_vertex, Bounds_ScaledPixels bounds,
   float2 device_position =
       position / viewport_size * float2(2., -2.) + float2(-1., 1.);
   return float4(device_position, 0., 1.);
+}
+
+// Must match `gpui::quad_depth`.
+float quad_depth(uint quad_id) {
+  return saturate(float(quad_id + 1u) * (1.0 / 16777216.0));
 }
 
 float4 to_device_position_transformed(float2 unit_vertex, Bounds_ScaledPixels bounds,

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -93,8 +93,8 @@ struct GammaParams {
 
 @group(0) @binding(0) var<uniform> globals: GlobalParams;
 @group(0) @binding(1) var<uniform> gamma_params: GammaParams;
-@group(1) @binding(1) var t_sprite: texture_2d<f32>;
-@group(1) @binding(2) var s_sprite: sampler;
+@group(2) @binding(0) var t_sprite: texture_2d<f32>;
+@group(2) @binding(1) var s_sprite: sampler;
 
 const M_PI_F: f32 = 3.1415926;
 const GRAYSCALE_FACTORS: vec3<f32> = vec3<f32>(0.2126, 0.7152, 0.0722);
@@ -175,6 +175,11 @@ fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
 fn to_device_position(unit_vertex: vec2<f32>, bounds: Bounds) -> vec4<f32> {
     let position = unit_vertex * vec2<f32>(bounds.size) + bounds.origin;
     return to_device_position_impl(position);
+}
+
+// Must match `gpui::quad_depth`.
+fn quad_depth(quad_id: u32) -> f32 {
+    return saturate(f32(quad_id + 1u) * (1.0 / 16777216.0));
 }
 
 fn to_device_position_transformed(unit_vertex: vec2<f32>, bounds: Bounds, transform: TransformationMatrix) -> vec4<f32> {
@@ -527,6 +532,7 @@ struct Quad {
     border_widths: Edges,
 }
 @group(1) @binding(0) var<storage, read> b_quads: array<Quad>;
+@group(1) @binding(1) var<storage, read> b_quad_indices: array<u32>;
 
 struct QuadVarying {
     @builtin(position) position: vec4<f32>,
@@ -542,10 +548,12 @@ struct QuadVarying {
 @vertex
 fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> QuadVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let quad = b_quads[instance_id];
+    let quad_id = b_quad_indices[instance_id];
+    let quad = b_quads[quad_id];
 
     var out = QuadVarying();
     out.position = to_device_position(unit_vertex, quad.bounds);
+    out.position.z = quad_depth(quad_id);
 
     let gradient = prepare_gradient_color(
         quad.background.tag,
@@ -557,7 +565,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     out.background_color0 = gradient.color0;
     out.background_color1 = gradient.color1;
     out.border_color = hsla_to_rgba(quad.border_color);
-    out.quad_id = instance_id;
+    out.quad_id = quad_id;
     out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
     return out;
 }
@@ -944,6 +952,91 @@ fn quarter_ellipse_sdf(point: vec2<f32>, radii: vec2<f32>) -> f32 {
 // Modulus that has the same sign as `a`.
 fn fmod(a: f32, b: f32) -> f32 {
     return a - b * trunc(a / b);
+}
+
+// --- opaque quads --- //
+
+struct OpaqueQuadVarying {
+    @builtin(position) position: vec4<f32>,
+    @location(0) @interpolate(flat) color: vec4<f32>,
+}
+
+fn bounds_area(bounds: Bounds) -> f32 {
+    return bounds.size.x * bounds.size.y;
+}
+
+fn intersect_bounds(a: Bounds, b: Bounds) -> Bounds {
+    let origin = max(a.origin, b.origin);
+    let bottom_right = min(a.origin + a.size, b.origin + b.size);
+    return Bounds(origin, max(bottom_right - origin, vec2<f32>(0.0)));
+}
+
+fn opaque_quad_core(quad: Quad) -> Bounds {
+    let has_rounded_corners = quad.corner_radii.top_left != 0.0
+        || quad.corner_radii.top_right != 0.0
+        || quad.corner_radii.bottom_right != 0.0
+        || quad.corner_radii.bottom_left != 0.0;
+    if (!has_rounded_corners) {
+        return quad.bounds;
+    }
+
+    let antialias_inset = 1.0;
+    let left_inset =
+        max(quad.corner_radii.top_left, quad.corner_radii.bottom_left) + antialias_inset;
+    let right_inset =
+        max(quad.corner_radii.top_right, quad.corner_radii.bottom_right) + antialias_inset;
+    let top_inset =
+        max(quad.corner_radii.top_left, quad.corner_radii.top_right) + antialias_inset;
+    let bottom_inset =
+        max(quad.corner_radii.bottom_left, quad.corner_radii.bottom_right) + antialias_inset;
+
+    // A horizontal band avoids the top and bottom corner arcs; a vertical band
+    // avoids the left and right arcs. Either is fully opaque, so use the larger.
+    let horizontal_band = Bounds(
+        quad.bounds.origin + vec2<f32>(antialias_inset, top_inset),
+        max(quad.bounds.size - vec2<f32>(2.0 * antialias_inset, top_inset + bottom_inset),
+            vec2<f32>(0.0)));
+    let vertical_band = Bounds(
+        quad.bounds.origin + vec2<f32>(left_inset, antialias_inset),
+        max(quad.bounds.size - vec2<f32>(left_inset + right_inset, 2.0 * antialias_inset),
+            vec2<f32>(0.0)));
+
+    if (bounds_area(horizontal_band) >= bounds_area(vertical_band)) {
+        return horizontal_band;
+    }
+    return vertical_band;
+}
+
+@vertex
+fn vs_opaque_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> OpaqueQuadVarying {
+    let quad_id = b_quad_indices[instance_id];
+    let quad = b_quads[quad_id];
+    // Clipping the core against the content mask up front keeps this pass free
+    // of per-fragment tests, which would otherwise need `discard` and so would
+    // defeat the early depth write this pass exists for.
+    let core = intersect_bounds(opaque_quad_core(quad), quad.content_mask);
+
+    var out = OpaqueQuadVarying();
+    if (core.size.x <= 0.0 || core.size.y <= 0.0) {
+        // Zero-area triangle: rejected before rasterization.
+        out.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        out.color = vec4<f32>(0.0);
+        return out;
+    }
+
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    out.position = to_device_position(unit_vertex, core);
+    out.position.z = quad_depth(quad_id);
+    // Matches the blended quad shader's solid-background output exactly: tag-0
+    // quads resolve to `hsla_to_rgba(solid)`, and alpha-1 blending is an
+    // overwrite regardless of `premultiplied_alpha`.
+    out.color = hsla_to_rgba(quad.background.solid);
+    return out;
+}
+
+@fragment
+fn fs_opaque_quad(input: OpaqueQuadVarying) -> @location(0) vec4<f32> {
+    return input.color;
 }
 
 // --- shadows --- //

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1231,7 +1231,7 @@ impl WgpuRenderer {
 
                 for batch in scene.batches() {
                     let ok = match batch {
-                        PrimitiveBatch::Quads(range) => {
+                        PrimitiveBatch::Quads { range, .. } => {
                             self.draw_quads(&scene.quads[range], &mut instance_offset, &mut pass)
                         }
                         PrimitiveBatch::Shadows(range) => self.draw_shadows(

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,15 +1,16 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
+use anyhow::{Context as _, Result};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, Path, Point, PrimitiveBatch,
+    ScaledPixels, Scene, Size, get_gamma_correction_ratios, quad_depth,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::cell::RefCell;
 use std::num::NonZeroU64;
+use std::ops::Range;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -81,8 +82,11 @@ pub struct WgpuSurfaceConfig {
     pub preferred_present_mode: Option<wgpu::PresentMode>,
 }
 
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
 struct WgpuPipelines {
     quads: wgpu::RenderPipeline,
+    opaque_quads: wgpu::RenderPipeline,
     shadows: wgpu::RenderPipeline,
     path_rasterization: wgpu::RenderPipeline,
     paths: wgpu::RenderPipeline,
@@ -94,10 +98,37 @@ struct WgpuPipelines {
     surfaces: wgpu::RenderPipeline,
 }
 
+#[derive(Clone)]
+struct BufferRegion {
+    buffer: wgpu::Buffer,
+    offset: u64,
+    size: NonZeroU64,
+}
+
+impl BufferRegion {
+    fn binding(&self) -> wgpu::BindingResource<'_> {
+        wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+            buffer: &self.buffer,
+            offset: self.offset,
+            size: Some(self.size),
+        })
+    }
+}
+
+struct FrameInstances {
+    quads: wgpu::BindGroup,
+    shadows: wgpu::BindGroup,
+    underlines: wgpu::BindGroup,
+    monochrome_sprites: wgpu::BindGroup,
+    subpixel_sprites: wgpu::BindGroup,
+    polychrome_sprites: wgpu::BindGroup,
+}
+
 struct WgpuBindGroupLayouts {
     globals: wgpu::BindGroupLayout,
     instances: wgpu::BindGroupLayout,
-    instances_with_texture: wgpu::BindGroupLayout,
+    quads: wgpu::BindGroupLayout,
+    texture: wgpu::BindGroupLayout,
     surfaces: wgpu::BindGroupLayout,
 }
 
@@ -116,6 +147,8 @@ struct WgpuResources {
     globals_bind_group: wgpu::BindGroup,
     path_globals_bind_group: wgpu::BindGroup,
     instance_buffer: wgpu::Buffer,
+    depth_texture: Option<wgpu::Texture>,
+    depth_view: Option<wgpu::TextureView>,
     path_intermediate_texture: Option<wgpu::Texture>,
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
@@ -124,6 +157,8 @@ struct WgpuResources {
 
 impl WgpuResources {
     fn invalidate_intermediate_textures(&mut self) {
+        self.depth_texture = None;
+        self.depth_view = None;
         self.path_intermediate_texture = None;
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
@@ -459,6 +494,8 @@ impl WgpuRenderer {
             instance_buffer,
             // Defer intermediate texture creation to first draw call via ensure_intermediate_textures().
             // This avoids panics when the device/surface is in an invalid state during initialization.
+            depth_texture: None,
+            depth_view: None,
             path_intermediate_texture: None,
             path_intermediate_view: None,
             path_msaa_texture: None,
@@ -539,29 +576,32 @@ impl WgpuRenderer {
             entries: &[storage_buffer_entry(0)],
         });
 
-        let instances_with_texture =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("instances_with_texture_layout"),
-                entries: &[
-                    storage_buffer_entry(0),
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
+        let quads = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("quads_layout"),
+            entries: &[storage_buffer_entry(0), storage_buffer_entry(1)],
+        });
+
+        let texture = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("texture_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
-                    },
-                ],
-            });
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
 
         let surfaces = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("surfaces_layout"),
@@ -610,7 +650,8 @@ impl WgpuRenderer {
         WgpuBindGroupLayouts {
             globals,
             instances,
-            instances_with_texture,
+            quads,
+            texture,
             surfaces,
         }
     }
@@ -677,18 +718,32 @@ impl WgpuRenderer {
             write_mask: wgpu::ColorWrites::ALL,
         };
 
+        let depth_stencil = |depth_write_enabled: bool| {
+            Some(wgpu::DepthStencilState {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: Some(depth_write_enabled),
+                depth_compare: Some(wgpu::CompareFunction::Greater),
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            })
+        };
+
         let create_pipeline = |name: &str,
                                vs_entry: &str,
                                fs_entry: &str,
                                globals_layout: &wgpu::BindGroupLayout,
                                data_layout: &wgpu::BindGroupLayout,
+                               texture_layout: Option<&wgpu::BindGroupLayout>,
                                topology: wgpu::PrimitiveTopology,
                                color_targets: &[Option<wgpu::ColorTargetState>],
+                               depth_stencil: Option<wgpu::DepthStencilState>,
                                sample_count: u32,
                                module: &wgpu::ShaderModule| {
+            let mut group_layouts = vec![Some(globals_layout), Some(data_layout)];
+            group_layouts.extend(texture_layout.map(Some));
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some(&format!("{name}_layout")),
-                bind_group_layouts: &[Some(globals_layout), Some(data_layout)],
+                bind_group_layouts: &group_layouts,
                 immediate_size: 0,
             });
 
@@ -716,7 +771,7 @@ impl WgpuRenderer {
                     unclipped_depth: false,
                     conservative: false,
                 },
-                depth_stencil: None,
+                depth_stencil,
                 multisample: wgpu::MultisampleState {
                     count: sample_count,
                     mask: !0,
@@ -732,9 +787,29 @@ impl WgpuRenderer {
             "vs_quad",
             "fs_quad",
             &layouts.globals,
-            &layouts.instances,
+            &layouts.quads,
+            None,
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target.clone())],
+            depth_stencil(false),
+            1,
+            &shader_module,
+        );
+
+        let opaque_quads = create_pipeline(
+            "opaque_quads",
+            "vs_opaque_quad",
+            "fs_opaque_quad",
+            &layouts.globals,
+            &layouts.quads,
+            None,
+            wgpu::PrimitiveTopology::TriangleStrip,
+            &[Some(wgpu::ColorTargetState {
+                format: surface_format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            depth_stencil(true),
             1,
             &shader_module,
         );
@@ -745,8 +820,10 @@ impl WgpuRenderer {
             "fs_shadow",
             &layouts.globals,
             &layouts.instances,
+            None,
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target.clone())],
+            depth_stencil(false),
             1,
             &shader_module,
         );
@@ -757,12 +834,14 @@ impl WgpuRenderer {
             "fs_path_rasterization",
             &layouts.globals,
             &layouts.instances,
+            None,
             wgpu::PrimitiveTopology::TriangleList,
             &[Some(wgpu::ColorTargetState {
                 format: surface_format,
                 blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                 write_mask: wgpu::ColorWrites::ALL,
             })],
+            None,
             path_sample_count,
             &shader_module,
         );
@@ -785,13 +864,15 @@ impl WgpuRenderer {
             "vs_path",
             "fs_path",
             &layouts.globals,
-            &layouts.instances_with_texture,
+            &layouts.instances,
+            Some(&layouts.texture),
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(wgpu::ColorTargetState {
                 format: surface_format,
                 blend: Some(paths_blend),
                 write_mask: wgpu::ColorWrites::ALL,
             })],
+            depth_stencil(false),
             1,
             &shader_module,
         );
@@ -802,8 +883,10 @@ impl WgpuRenderer {
             "fs_underline",
             &layouts.globals,
             &layouts.instances,
+            None,
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target.clone())],
+            depth_stencil(false),
             1,
             &shader_module,
         );
@@ -813,9 +896,11 @@ impl WgpuRenderer {
             "vs_mono_sprite",
             "fs_mono_sprite",
             &layouts.globals,
-            &layouts.instances_with_texture,
+            &layouts.instances,
+            Some(&layouts.texture),
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target.clone())],
+            depth_stencil(false),
             1,
             &shader_module,
         );
@@ -839,13 +924,15 @@ impl WgpuRenderer {
                 "vs_subpixel_sprite",
                 "fs_subpixel_sprite",
                 &layouts.globals,
-                &layouts.instances_with_texture,
+                &layouts.instances,
+                Some(&layouts.texture),
                 wgpu::PrimitiveTopology::TriangleStrip,
                 &[Some(wgpu::ColorTargetState {
                     format: surface_format,
                     blend: Some(subpixel_blend),
                     write_mask: wgpu::ColorWrites::COLOR,
                 })],
+                depth_stencil(false),
                 1,
                 subpixel_module,
             ))
@@ -858,9 +945,11 @@ impl WgpuRenderer {
             "vs_poly_sprite",
             "fs_poly_sprite",
             &layouts.globals,
-            &layouts.instances_with_texture,
+            &layouts.instances,
+            Some(&layouts.texture),
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target.clone())],
+            depth_stencil(false),
             1,
             &shader_module,
         );
@@ -871,14 +960,17 @@ impl WgpuRenderer {
             "fs_surface",
             &layouts.globals,
             &layouts.surfaces,
+            None,
             wgpu::PrimitiveTopology::TriangleStrip,
             &[Some(color_target)],
+            depth_stencil(false),
             1,
             &shader_module,
         );
 
         WgpuPipelines {
             quads,
+            opaque_quads,
             shadows,
             path_rasterization,
             paths,
@@ -888,6 +980,29 @@ impl WgpuRenderer {
             poly_sprites,
             surfaces,
         }
+    }
+
+    fn create_depth_texture(
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+    ) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("depth"),
+            size: wgpu::Extent3d {
+                width: width.max(1),
+                height: height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
     }
 
     fn create_path_intermediate(
@@ -975,6 +1090,9 @@ impl WgpuRenderer {
             }
 
             // Destroy old textures before allocating new ones to avoid GPU memory spikes
+            if let Some(ref texture) = resources.depth_texture {
+                texture.destroy();
+            }
             if let Some(ref texture) = resources.path_intermediate_texture {
                 texture.destroy();
             }
@@ -1003,6 +1121,11 @@ impl WgpuRenderer {
         let height = self.surface_config.height;
         let path_sample_count = self.rendering_params.path_sample_count;
         let resources = self.resources_mut();
+
+        let (depth_texture, depth_view) =
+            Self::create_depth_texture(&resources.device, width, height);
+        resources.depth_texture = Some(depth_texture);
+        resources.depth_view = Some(depth_view);
 
         let (t, v) = Self::create_path_intermediate(&resources.device, format, width, height);
         resources.path_intermediate_texture = Some(t);
@@ -1155,6 +1278,11 @@ impl WgpuRenderer {
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
 
+        let Some(depth_view) = self.resources().depth_view.clone() else {
+            log::error!("depth buffer missing after ensuring intermediate textures");
+            return false;
+        };
+
         let gamma_params = GammaParams {
             gamma_ratios: self.rendering_params.gamma_ratios,
             grayscale_enhanced_contrast: self.rendering_params.grayscale_enhanced_contrast,
@@ -1202,383 +1330,357 @@ impl WgpuRenderer {
             );
         }
 
-        loop {
-            let mut instance_offset: u64 = 0;
-            let mut overflow = false;
+        if let Err(error) = self.record_frame(scene, &frame_view, &depth_view) {
+            log::error!("{error:#}");
+            return false;
+        }
 
-            let mut encoder =
-                self.resources()
-                    .device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                        label: Some("main_encoder"),
-                    });
+        frame.present();
+        true
+    }
 
-            {
-                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("main_pass"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &frame_view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                            store: wgpu::StoreOp::Store,
-                        },
-                        depth_slice: None,
-                    })],
-                    depth_stencil_attachment: None,
-                    ..Default::default()
+    /// Records and submits the frame's commands.
+    fn record_frame(
+        &mut self,
+        scene: &Scene,
+        frame_view: &wgpu::TextureView,
+        depth_view: &wgpu::TextureView,
+    ) -> Result<()> {
+        let mut instance_offset: u64 = 0;
+        let frame_instances = self
+            .upload_frame_instances(scene, &mut instance_offset)
+            .with_context(|| {
+                format!(
+                    "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} subpixel, {} poly",
+                    scene.paths.len(),
+                    scene.shadows.len(),
+                    scene.quads.len(),
+                    scene.underlines.len(),
+                    scene.monochrome_sprites.len(),
+                    scene.subpixel_sprites.len(),
+                    scene.polychrome_sprites.len(),
+                )
+            })?;
+
+        let mut encoder =
+            self.resources()
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("main_encoder"),
                 });
 
-                for batch in scene.batches() {
-                    let ok = match batch {
-                        PrimitiveBatch::Quads { range, .. } => {
-                            self.draw_quads(&scene.quads[range], &mut instance_offset, &mut pass)
-                        }
-                        PrimitiveBatch::Shadows(range) => self.draw_shadows(
-                            &scene.shadows[range],
-                            &mut instance_offset,
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("main_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: frame_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: depth_view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(0.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                ..Default::default()
+            });
+
+            self.draw_instances(
+                &frame_instances.quads,
+                &self.resources().pipelines.opaque_quads,
+                scene.blended_quad_indices.len() as u32
+                    ..(scene.blended_quad_indices.len() + scene.opaque_quad_indices.len()) as u32,
+                &mut pass,
+            );
+
+            let mut quad_cursor: u32 = 0;
+            for batch in scene.batches() {
+                // Quad shaders assign each quad its own depth. Every other batch
+                // is flattened onto the depth of the quad cursor by collapsing
+                // the viewport's depth range onto a single value.
+                let batch_depth = quad_depth(quad_cursor);
+                if matches!(batch, PrimitiveBatch::Quads { .. }) {
+                    self.set_pass_depth_range(&mut pass, 0.0, 1.0);
+                } else {
+                    self.set_pass_depth_range(&mut pass, batch_depth, batch_depth);
+                }
+
+                match batch {
+                    PrimitiveBatch::Quads {
+                        range,
+                        blended_range,
+                    } => {
+                        quad_cursor += range.len() as u32;
+                        self.draw_instances(
+                            &frame_instances.quads,
+                            &self.resources().pipelines.quads,
+                            instance_range(blended_range),
                             &mut pass,
-                        ),
-                        PrimitiveBatch::Paths(range) => {
-                            let paths = &scene.paths[range];
-                            if paths.is_empty() {
-                                continue;
-                            }
+                        );
+                    }
+                    PrimitiveBatch::Shadows(range) => self.draw_instances(
+                        &frame_instances.shadows,
+                        &self.resources().pipelines.shadows,
+                        instance_range(range),
+                        &mut pass,
+                    ),
+                    PrimitiveBatch::Paths(range) => {
+                        let paths = &scene.paths[range];
+                        if paths.is_empty() {
+                            continue;
+                        }
 
-                            drop(pass);
+                        drop(pass);
 
-                            let did_draw = self.draw_paths_to_intermediate(
-                                &mut encoder,
-                                paths,
-                                &mut instance_offset,
-                            );
+                        let rasterized = self.draw_paths_to_intermediate(
+                            &mut encoder,
+                            paths,
+                            &mut instance_offset,
+                        )?;
 
-                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                label: Some("main_pass_continued"),
-                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                    view: &frame_view,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
+                        pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("main_pass_continued"),
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: frame_view,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load,
+                                    store: wgpu::StoreOp::Store,
+                                },
+                                depth_slice: None,
+                            })],
+                            depth_stencil_attachment: Some(
+                                wgpu::RenderPassDepthStencilAttachment {
+                                    view: depth_view,
+                                    depth_ops: Some(wgpu::Operations {
                                         load: wgpu::LoadOp::Load,
                                         store: wgpu::StoreOp::Store,
-                                    },
-                                    depth_slice: None,
-                                })],
-                                depth_stencil_attachment: None,
-                                ..Default::default()
-                            });
+                                    }),
+                                    stencil_ops: None,
+                                },
+                            ),
+                            ..Default::default()
+                        });
+                        self.set_pass_depth_range(&mut pass, batch_depth, batch_depth);
 
-                            if did_draw {
-                                self.draw_paths_from_intermediate(
-                                    paths,
-                                    &mut instance_offset,
-                                    &mut pass,
-                                )
-                            } else {
-                                false
-                            }
+                        if rasterized {
+                            self.draw_paths_from_intermediate(
+                                paths,
+                                &mut instance_offset,
+                                &mut pass,
+                            )?;
                         }
-                        PrimitiveBatch::Underlines(range) => self.draw_underlines(
-                            &scene.underlines[range],
-                            &mut instance_offset,
-                            &mut pass,
-                        ),
-                        PrimitiveBatch::MonochromeSprites { texture_id, range } => self
-                            .draw_monochrome_sprites(
-                                &scene.monochrome_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::SubpixelSprites { texture_id, range } => self
-                            .draw_subpixel_sprites(
-                                &scene.subpixel_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::PolychromeSprites { texture_id, range } => self
-                            .draw_polychrome_sprites(
-                                &scene.polychrome_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::Surfaces(_surfaces) => {
-                            // Surfaces are macOS-only for video playback
-                            // Not implemented for Linux/wgpu
-                            true
-                        }
-                    };
-                    if !ok {
-                        overflow = true;
-                        break;
                     }
+                    PrimitiveBatch::Underlines(range) => self.draw_instances(
+                        &frame_instances.underlines,
+                        &self.resources().pipelines.underlines,
+                        instance_range(range),
+                        &mut pass,
+                    ),
+                    PrimitiveBatch::MonochromeSprites { texture_id, range } => self.draw_sprites(
+                        &frame_instances.monochrome_sprites,
+                        texture_id,
+                        &self.resources().pipelines.mono_sprites,
+                        instance_range(range),
+                        &mut pass,
+                    ),
+                    PrimitiveBatch::SubpixelSprites { texture_id, range } => {
+                        let resources = self.resources();
+                        self.draw_sprites(
+                            &frame_instances.subpixel_sprites,
+                            texture_id,
+                            resources
+                                .pipelines
+                                .subpixel_sprites
+                                .as_ref()
+                                .unwrap_or(&resources.pipelines.mono_sprites),
+                            instance_range(range),
+                            &mut pass,
+                        );
+                    }
+                    PrimitiveBatch::PolychromeSprites { texture_id, range } => self.draw_sprites(
+                        &frame_instances.polychrome_sprites,
+                        texture_id,
+                        &self.resources().pipelines.poly_sprites,
+                        instance_range(range),
+                        &mut pass,
+                    ),
+                    // Surfaces are macOS-only for video playback, and are
+                    // not implemented for Linux/wgpu.
+                    PrimitiveBatch::Surfaces(_surfaces) => {}
                 }
             }
-
-            if overflow {
-                drop(encoder);
-                if self.instance_buffer_capacity >= self.max_buffer_size {
-                    log::error!(
-                        "instance buffer size grew too large: {}",
-                        self.instance_buffer_capacity
-                    );
-                    frame.present();
-                    return true;
-                }
-                self.grow_instance_buffer();
-                continue;
-            }
-
-            self.resources()
-                .queue
-                .submit(std::iter::once(encoder.finish()));
-            frame.present();
-            return true;
         }
+
+        self.resources()
+            .queue
+            .submit(std::iter::once(encoder.finish()));
+        Ok(())
     }
 
-    fn draw_quads(
-        &self,
-        quads: &[Quad],
+    fn upload_frame_instances(
+        &mut self,
+        scene: &Scene,
         instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let data = unsafe { Self::instance_bytes(quads) };
-        self.draw_instances(
-            data,
-            quads.len() as u32,
-            &self.resources().pipelines.quads,
+    ) -> Result<FrameInstances> {
+        let quads = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.quads)
+        })?;
+        let quad_indices = self.write_parts_to_instance_buffer(
             instance_offset,
-            pass,
-        )
-    }
+            &[
+                bytemuck::cast_slice(&scene.blended_quad_indices),
+                bytemuck::cast_slice(&scene.opaque_quad_indices),
+            ],
+        )?;
+        let shadows = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.shadows)
+        })?;
+        let underlines = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.underlines)
+        })?;
+        let monochrome_sprites = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.monochrome_sprites)
+        })?;
+        let subpixel_sprites = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.subpixel_sprites)
+        })?;
+        let polychrome_sprites = self.write_to_instance_buffer(instance_offset, unsafe {
+            Self::instance_bytes(&scene.polychrome_sprites)
+        })?;
 
-    fn draw_shadows(
-        &self,
-        shadows: &[Shadow],
-        instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let data = unsafe { Self::instance_bytes(shadows) };
-        self.draw_instances(
-            data,
-            shadows.len() as u32,
-            &self.resources().pipelines.shadows,
-            instance_offset,
-            pass,
-        )
-    }
-
-    fn draw_underlines(
-        &self,
-        underlines: &[Underline],
-        instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let data = unsafe { Self::instance_bytes(underlines) };
-        self.draw_instances(
-            data,
-            underlines.len() as u32,
-            &self.resources().pipelines.underlines,
-            instance_offset,
-            pass,
-        )
-    }
-
-    fn draw_monochrome_sprites(
-        &self,
-        sprites: &[MonochromeSprite],
-        texture_id: AtlasTextureId,
-        instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let tex_info = self.atlas.get_texture_info(texture_id);
-        let data = unsafe { Self::instance_bytes(sprites) };
-        self.draw_instances_with_texture(
-            data,
-            sprites.len() as u32,
-            &tex_info.view,
-            &self.resources().pipelines.mono_sprites,
-            instance_offset,
-            pass,
-        )
-    }
-
-    fn draw_subpixel_sprites(
-        &self,
-        sprites: &[SubpixelSprite],
-        texture_id: AtlasTextureId,
-        instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let tex_info = self.atlas.get_texture_info(texture_id);
-        let data = unsafe { Self::instance_bytes(sprites) };
         let resources = self.resources();
-        let pipeline = resources
-            .pipelines
-            .subpixel_sprites
-            .as_ref()
-            .unwrap_or(&resources.pipelines.mono_sprites);
-        self.draw_instances_with_texture(
-            data,
-            sprites.len() as u32,
-            &tex_info.view,
-            pipeline,
-            instance_offset,
-            pass,
-        )
+        Ok(FrameInstances {
+            quads: resources
+                .device
+                .create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("quads_bind_group"),
+                    layout: &resources.bind_group_layouts.quads,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: quads.binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: quad_indices.binding(),
+                        },
+                    ],
+                }),
+            shadows: self.create_instances_bind_group("shadows_bind_group", &shadows),
+            underlines: self.create_instances_bind_group("underlines_bind_group", &underlines),
+            monochrome_sprites: self
+                .create_instances_bind_group("monochrome_sprites_bind_group", &monochrome_sprites),
+            subpixel_sprites: self
+                .create_instances_bind_group("subpixel_sprites_bind_group", &subpixel_sprites),
+            polychrome_sprites: self
+                .create_instances_bind_group("polychrome_sprites_bind_group", &polychrome_sprites),
+        })
     }
 
-    fn draw_polychrome_sprites(
+    fn create_instances_bind_group(
         &self,
-        sprites: &[PolychromeSprite],
-        texture_id: AtlasTextureId,
-        instance_offset: &mut u64,
+        label: &str,
+        instances: &BufferRegion,
+    ) -> wgpu::BindGroup {
+        let resources = self.resources();
+        resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(label),
+                layout: &resources.bind_group_layouts.instances,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: instances.binding(),
+                }],
+            })
+    }
+
+    fn create_texture_bind_group(&self, texture_view: &wgpu::TextureView) -> wgpu::BindGroup {
+        let resources = self.resources();
+        resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &resources.bind_group_layouts.texture,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&resources.atlas_sampler),
+                    },
+                ],
+            })
+    }
+
+    fn set_pass_depth_range(
+        &self,
         pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let tex_info = self.atlas.get_texture_info(texture_id);
-        let data = unsafe { Self::instance_bytes(sprites) };
-        self.draw_instances_with_texture(
-            data,
-            sprites.len() as u32,
-            &tex_info.view,
-            &self.resources().pipelines.poly_sprites,
-            instance_offset,
-            pass,
-        )
+        min_depth: f32,
+        max_depth: f32,
+    ) {
+        pass.set_viewport(
+            0.0,
+            0.0,
+            self.surface_config.width as f32,
+            self.surface_config.height as f32,
+            min_depth,
+            max_depth,
+        );
     }
 
     fn draw_instances(
         &self,
-        data: &[u8],
-        instance_count: u32,
+        bind_group: &wgpu::BindGroup,
         pipeline: &wgpu::RenderPipeline,
-        instance_offset: &mut u64,
+        instances: Range<u32>,
         pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        if instance_count == 0 {
-            return true;
+    ) {
+        if instances.is_empty() {
+            return;
         }
-        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
-            return false;
-        };
-        let resources = self.resources();
-        let bind_group = resources
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: None,
-                layout: &resources.bind_group_layouts.instances,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: self.instance_binding(offset, size),
-                }],
-            });
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
-        pass.set_bind_group(1, &bind_group, &[]);
-        pass.draw(0..4, 0..instance_count);
-        true
+        pass.set_bind_group(0, &self.resources().globals_bind_group, &[]);
+        pass.set_bind_group(1, bind_group, &[]);
+        pass.draw(0..4, instances);
     }
 
-    fn draw_instances_with_texture(
+    fn draw_sprites(
         &self,
-        data: &[u8],
-        instance_count: u32,
-        texture_view: &wgpu::TextureView,
+        sprite_instances: &wgpu::BindGroup,
+        texture_id: AtlasTextureId,
         pipeline: &wgpu::RenderPipeline,
-        instance_offset: &mut u64,
+        instances: Range<u32>,
         pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        if instance_count == 0 {
-            return true;
+    ) {
+        if instances.is_empty() {
+            return;
         }
-        let Some((offset, size)) = self.write_to_instance_buffer(instance_offset, data) else {
-            return false;
-        };
-        let resources = self.resources();
-        let bind_group = resources
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: None,
-                layout: &resources.bind_group_layouts.instances_with_texture,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: self.instance_binding(offset, size),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::TextureView(texture_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::Sampler(&resources.atlas_sampler),
-                    },
-                ],
-            });
+        let texture_info = self.atlas.get_texture_info(texture_id);
+        let texture = self.create_texture_bind_group(&texture_info.view);
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
-        pass.set_bind_group(1, &bind_group, &[]);
-        pass.draw(0..4, 0..instance_count);
-        true
-    }
-
-    unsafe fn instance_bytes<T>(instances: &[T]) -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(
-                instances.as_ptr() as *const u8,
-                std::mem::size_of_val(instances),
-            )
-        }
-    }
-
-    fn draw_paths_from_intermediate(
-        &self,
-        paths: &[Path<ScaledPixels>],
-        instance_offset: &mut u64,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
-        let first_path = &paths[0];
-        let sprites: Vec<PathSprite> = if paths.last().map(|p| &p.order) == Some(&first_path.order)
-        {
-            paths
-                .iter()
-                .map(|p| PathSprite {
-                    bounds: p.clipped_bounds(),
-                })
-                .collect()
-        } else {
-            let mut bounds = first_path.clipped_bounds();
-            for path in paths.iter().skip(1) {
-                bounds = bounds.union(&path.clipped_bounds());
-            }
-            vec![PathSprite { bounds }]
-        };
-
-        let resources = self.resources();
-        let Some(path_intermediate_view) = resources.path_intermediate_view.as_ref() else {
-            return true;
-        };
-
-        let sprite_data = unsafe { Self::instance_bytes(&sprites) };
-        self.draw_instances_with_texture(
-            sprite_data,
-            sprites.len() as u32,
-            path_intermediate_view,
-            &resources.pipelines.paths,
-            instance_offset,
-            pass,
-        )
+        pass.set_bind_group(0, &self.resources().globals_bind_group, &[]);
+        pass.set_bind_group(1, sprite_instances, &[]);
+        pass.set_bind_group(2, &texture, &[]);
+        pass.draw(0..4, instances);
     }
 
     fn draw_paths_to_intermediate(
-        &self,
+        &mut self,
         encoder: &mut wgpu::CommandEncoder,
         paths: &[Path<ScaledPixels>],
         instance_offset: &mut u64,
-    ) -> bool {
+    ) -> Result<bool> {
         let mut vertices = Vec::new();
         for path in paths {
             let bounds = path.clipped_bounds();
@@ -1589,32 +1691,18 @@ impl WgpuRenderer {
                 bounds,
             }));
         }
-
         if vertices.is_empty() {
-            return true;
+            return Ok(false);
         }
 
         let vertex_data = unsafe { Self::instance_bytes(&vertices) };
-        let Some((vertex_offset, vertex_size)) =
-            self.write_to_instance_buffer(instance_offset, vertex_data)
-        else {
-            return false;
-        };
+        let vertex_instances = self.write_to_instance_buffer(instance_offset, vertex_data)?;
+        let data_bind_group =
+            self.create_instances_bind_group("path_rasterization_bind_group", &vertex_instances);
 
         let resources = self.resources();
-        let data_bind_group = resources
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("path_rasterization_bind_group"),
-                layout: &resources.bind_group_layouts.instances,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: self.instance_binding(vertex_offset, vertex_size),
-                }],
-            });
-
         let Some(path_intermediate_view) = resources.path_intermediate_view.as_ref() else {
-            return true;
+            return Ok(false);
         };
 
         let (target_view, resolve_target) = if let Some(ref msaa_view) = resources.path_msaa_view {
@@ -1645,46 +1733,124 @@ impl WgpuRenderer {
             pass.draw(0..vertices.len() as u32, 0..1);
         }
 
-        true
+        Ok(true)
     }
 
-    fn grow_instance_buffer(&mut self) {
-        let new_capacity = (self.instance_buffer_capacity * 2).min(self.max_buffer_size);
-        log::info!("increased instance buffer size to {}", new_capacity);
-        let resources = self.resources_mut();
-        resources.instance_buffer = resources.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("instance_buffer"),
-            size: new_capacity,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        self.instance_buffer_capacity = new_capacity;
+    fn draw_paths_from_intermediate(
+        &mut self,
+        paths: &[Path<ScaledPixels>],
+        instance_offset: &mut u64,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> Result<()> {
+        let first_path = &paths[0];
+        let sprites: Vec<PathSprite> = if paths.last().map(|p| &p.order) == Some(&first_path.order)
+        {
+            paths
+                .iter()
+                .map(|p| PathSprite {
+                    bounds: p.clipped_bounds(),
+                })
+                .collect()
+        } else {
+            let mut bounds = first_path.clipped_bounds();
+            for path in paths.iter().skip(1) {
+                bounds = bounds.union(&path.clipped_bounds());
+            }
+            vec![PathSprite { bounds }]
+        };
+
+        let Some(path_intermediate_view) = self.resources().path_intermediate_view.clone() else {
+            return Ok(());
+        };
+        let sprite_data = unsafe { Self::instance_bytes(&sprites) };
+        let sprite_instances = self.write_to_instance_buffer(instance_offset, sprite_data)?;
+
+        let instances =
+            self.create_instances_bind_group("path_sprites_bind_group", &sprite_instances);
+        let texture = self.create_texture_bind_group(&path_intermediate_view);
+        let resources = self.resources();
+        pass.set_pipeline(&resources.pipelines.paths);
+        pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+        pass.set_bind_group(1, &instances, &[]);
+        pass.set_bind_group(2, &texture, &[]);
+        pass.draw(0..4, 0..sprites.len() as u32);
+        Ok(())
+    }
+
+    unsafe fn instance_bytes<T>(instances: &[T]) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                instances.as_ptr() as *const u8,
+                std::mem::size_of_val(instances),
+            )
+        }
     }
 
     fn write_to_instance_buffer(
-        &self,
+        &mut self,
         instance_offset: &mut u64,
         data: &[u8],
-    ) -> Option<(u64, NonZeroU64)> {
-        let offset = (*instance_offset).next_multiple_of(self.storage_buffer_alignment);
-        let size = (data.len() as u64).max(16);
-        if offset + size > self.instance_buffer_capacity {
-            return None;
-        }
-        let resources = self.resources();
-        resources
-            .queue
-            .write_buffer(&resources.instance_buffer, offset, data);
-        *instance_offset = offset + size;
-        Some((offset, NonZeroU64::new(size).expect("size is at least 16")))
+    ) -> Result<BufferRegion> {
+        self.write_parts_to_instance_buffer(instance_offset, &[data])
     }
 
-    fn instance_binding(&self, offset: u64, size: NonZeroU64) -> wgpu::BindingResource<'_> {
-        wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-            buffer: &self.resources().instance_buffer,
+    fn write_parts_to_instance_buffer(
+        &mut self,
+        instance_offset: &mut u64,
+        parts: &[&[u8]],
+    ) -> Result<BufferRegion> {
+        let size = parts
+            .iter()
+            .map(|part| part.len() as u64)
+            .sum::<u64>()
+            .max(16);
+        let mut offset = (*instance_offset).next_multiple_of(self.storage_buffer_alignment);
+        if offset + size > self.instance_buffer_capacity {
+            self.grow_instance_buffer(size)?;
+            offset = 0;
+        }
+
+        let resources = self.resources();
+        let mut part_offset = offset;
+        for part in parts {
+            if part.is_empty() {
+                continue;
+            }
+            resources
+                .queue
+                .write_buffer(&resources.instance_buffer, part_offset, part);
+            part_offset += part.len() as u64;
+        }
+        *instance_offset = offset + size;
+        Ok(BufferRegion {
+            buffer: resources.instance_buffer.clone(),
             offset,
-            size: Some(size),
+            size: NonZeroU64::new(size).expect("size is at least 16"),
         })
+    }
+
+    fn grow_instance_buffer(&mut self, required: u64) -> Result<()> {
+        let capacity = (self.instance_buffer_capacity * 2)
+            .max(required.next_power_of_two())
+            .min(self.max_buffer_size);
+        anyhow::ensure!(
+            capacity >= required,
+            "instance buffer needs {required} bytes, above the device maximum of {}",
+            self.max_buffer_size
+        );
+        log::debug!(
+            "instance buffer grown from {} to {capacity}",
+            self.instance_buffer_capacity
+        );
+        let resources = self.resources_mut();
+        resources.instance_buffer = resources.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("instance_buffer"),
+            size: capacity,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        self.instance_buffer_capacity = capacity;
+        Ok(())
     }
 
     /// Mark the surface as unconfigured so rendering is skipped until a new
@@ -1849,6 +2015,10 @@ impl WgpuRenderer {
         log::info!("GPU recovery complete");
         Ok(())
     }
+}
+
+fn instance_range(range: Range<usize>) -> Range<u32> {
+    range.start as u32..range.end as u32
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/crates/gpui_windows/build.rs
+++ b/crates/gpui_windows/build.rs
@@ -31,6 +31,7 @@ mod shader_compilation {
         // Define all modules
         let modules = [
             "quad",
+            "opaque_quad",
             "shadow",
             "path_rasterization",
             "path_sprite",

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -44,6 +44,7 @@ pub(crate) struct DirectXRenderer {
     pipelines: DirectXRenderPipelines,
     direct_composition: Option<DirectComposition>,
     font_info: &'static FontInfo,
+    frame_scratch: FrameScratch,
 
     width: u32,
     height: u32,
@@ -71,26 +72,31 @@ struct DirectXResources {
     swap_chain: IDXGISwapChain1,
     render_target: Option<ID3D11Texture2D>,
     render_target_view: Option<ID3D11RenderTargetView>,
-
-    // Path intermediate textures (with MSAA)
     path_intermediate_texture: ID3D11Texture2D,
     path_intermediate_srv: Option<ID3D11ShaderResourceView>,
     path_intermediate_msaa_texture: ID3D11Texture2D,
     path_intermediate_msaa_view: Option<ID3D11RenderTargetView>,
-
-    // Cached viewport
+    depth_stencil_texture: ID3D11Texture2D,
+    depth_stencil_view: Option<ID3D11DepthStencilView>,
     viewport: D3D11_VIEWPORT,
 }
 
 struct DirectXRenderPipelines {
     shadow_pipeline: PipelineState<Shadow>,
     quad_pipeline: PipelineState<Quad>,
+    opaque_quad_pipeline: OpaqueQuadPipeline,
     path_rasterization_pipeline: PipelineState<PathRasterizationSprite>,
     path_sprite_pipeline: PipelineState<PathSprite>,
     underline_pipeline: PipelineState<Underline>,
     mono_sprites: PipelineState<MonochromeSprite>,
     subpixel_sprites: PipelineState<SubpixelSprite>,
     poly_sprites: PipelineState<PolychromeSprite>,
+}
+
+#[derive(Default)]
+struct FrameScratch {
+    path_vertices: Vec<PathRasterizationSprite>,
+    path_sprites: Vec<PathSprite>,
 }
 
 struct DirectXGlobalElements {
@@ -189,6 +195,7 @@ impl DirectXRenderer {
             pipelines,
             direct_composition,
             font_info: Self::get_font_info(),
+            frame_scratch: FrameScratch::default(),
             width: 1,
             height: 1,
             skip_draws: false,
@@ -226,9 +233,24 @@ impl DirectXRenderer {
                     .context("missing render target view")?,
                 clear_color,
             );
-            device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+            device_context.ClearDepthStencilView(
+                resources
+                    .depth_stencil_view
+                    .as_ref()
+                    .context("missing depth stencil view")?,
+                D3D11_CLEAR_DEPTH.0,
+                0.0,
+                0,
+            );
+            device_context.OMSetRenderTargets(
+                Some(slice::from_ref(&resources.render_target_view)),
+                resources.depth_stencil_view.as_ref(),
+            );
             device_context.RSSetViewports(Some(slice::from_ref(&resources.viewport)));
+            device_context
+                .VSSetConstantBuffers(0, Some(slice::from_ref(&self.globals.global_params_buffer)));
+            device_context
+                .PSSetConstantBuffers(0, Some(slice::from_ref(&self.globals.global_params_buffer)));
         }
         Ok(())
     }
@@ -306,9 +328,10 @@ impl DirectXRenderer {
             .handle_device_lost(&devices.device, &devices.device_context);
 
         unsafe {
-            devices
-                .device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+            devices.device_context.OMSetRenderTargets(
+                Some(slice::from_ref(&resources.render_target_view)),
+                resources.depth_stencil_view.as_ref(),
+            );
         }
         self.devices = Some(devices);
         self.resources = Some(resources);
@@ -335,19 +358,62 @@ impl DirectXRenderer {
         })?;
 
         self.upload_scene_buffers(scene)?;
+        self.update_quad_indices(scene)?;
 
         let annotation = self
             .devices
             .as_ref()
             .and_then(|devices| devices.annotation.clone())
             .filter(|annotation| unsafe { annotation.GetStatus().as_bool() });
+
+        if !scene.opaque_quad_indices.is_empty() {
+            let _annotation = annotation.as_ref().map(|annotation| {
+                Annotation::new(
+                    annotation,
+                    HSTRING::from(format!(
+                        "opaque quads ({})",
+                        scene.opaque_quad_indices.len()
+                    )),
+                )
+            });
+            self.draw_opaque_quads(
+                scene.blended_quad_indices.len(),
+                scene.opaque_quad_indices.len(),
+            )?;
+        }
+
+        self.pipelines.opaque_quad_pipeline.enable_depth_test(
+            &self
+                .devices
+                .as_ref()
+                .context("devices missing")?
+                .device_context,
+        );
+
+        let mut quad_cursor: u32 = 0;
         for batch in scene.batches() {
             let _annotation = annotation
                 .as_ref()
                 .map(|annotation| Annotation::new(annotation, HSTRING::from(batch.label())));
+
+            // Quad shaders assign each quad its own depth.
+            // In every other batch type, the depth is fixed to the position of the quad cursor.
+            if matches!(&batch, PrimitiveBatch::Quads { .. }) {
+                self.set_viewport_depth_range(0.0, 1.0)?;
+            } else {
+                let depth = quad_depth(quad_cursor);
+                self.set_viewport_depth_range(depth, depth)?;
+            }
+
             match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(range.start, range.len()),
-                PrimitiveBatch::Quads(range) => self.draw_quads(range.start, range.len()),
+                PrimitiveBatch::Quads {
+                    range,
+                    blended_range,
+                } => {
+                    quad_cursor += range.len() as u32;
+                    self.draw_blended_quads(blended_range.start, blended_range.len())
+                }
                 PrimitiveBatch::Paths(range) => {
                     let paths = &scene.paths[range];
                     self.draw_paths_to_intermediate(paths)?;
@@ -380,7 +446,57 @@ impl DirectXRenderer {
                 )
             })?;
         }
+
+        self.pipelines.opaque_quad_pipeline.disable_depth(
+            &self
+                .devices
+                .as_ref()
+                .context("devices missing")?
+                .device_context,
+        );
+
         self.present()
+    }
+
+    fn set_viewport_depth_range(&self, minimum_depth: f32, maximum_depth: f32) -> Result<()> {
+        let devices = self.devices.as_ref().context("devices missing")?;
+        let resources = self.resources.as_ref().context("resources missing")?;
+        // Equal endpoints collapse every shader depth to the same value.
+        let viewport = D3D11_VIEWPORT {
+            MinDepth: minimum_depth,
+            MaxDepth: maximum_depth,
+            ..resources.viewport
+        };
+        unsafe {
+            devices
+                .device_context
+                .RSSetViewports(Some(slice::from_ref(&viewport)))
+        };
+        Ok(())
+    }
+
+    fn update_quad_indices(&mut self, scene: &Scene) -> Result<()> {
+        if scene.blended_quad_indices.is_empty() && scene.opaque_quad_indices.is_empty() {
+            return Ok(());
+        }
+        let devices = self.devices.as_ref().context("devices missing")?;
+        self.pipelines.opaque_quad_pipeline.update_quad_indices(
+            &devices.device,
+            &devices.device_context,
+            &scene.blended_quad_indices,
+            &scene.opaque_quad_indices,
+        )
+    }
+
+    fn draw_opaque_quads(&self, quad_indices_start: usize, quad_count: usize) -> Result<()> {
+        let devices = self.devices.as_ref().context("devices missing")?;
+        self.pipelines.opaque_quad_pipeline.draw(
+            &devices.device,
+            &devices.device_context,
+            &self.pipelines.quad_pipeline.view,
+            quad_indices_start as u32,
+            quad_count as u32,
+        )
     }
 
     pub(crate) fn resize(&mut self, new_size: Size<DevicePixels>) -> Result<()> {
@@ -419,9 +535,10 @@ impl DirectXRenderer {
         resources.recreate_resources(devices, width, height)?;
 
         unsafe {
-            devices
-                .device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+            devices.device_context.OMSetRenderTargets(
+                Some(slice::from_ref(&resources.render_target_view)),
+                resources.depth_stencil_view.as_ref(),
+            );
         }
 
         Ok(())
@@ -489,40 +606,38 @@ impl DirectXRenderer {
         self.pipelines.shadow_pipeline.draw_range(
             &devices.device,
             &devices.device_context,
-            slice::from_ref(
-                &self
-                    .resources
-                    .as_ref()
-                    .context("resources missing")?
-                    .viewport,
-            ),
-            slice::from_ref(&self.globals.global_params_buffer),
             4,
             start as u32,
             len as u32,
         )
     }
 
-    fn draw_quads(&mut self, start: usize, len: usize) -> Result<()> {
-        if len == 0 {
+    fn draw_blended_quads(&mut self, quad_indices_start: usize, quad_count: usize) -> Result<()> {
+        if quad_count == 0 {
             return Ok(());
         }
         let devices = self.devices.as_ref().context("devices missing")?;
-        self.pipelines.quad_pipeline.draw_range(
+        let quad_pipeline = &self.pipelines.quad_pipeline;
+        let quad_indices_view = self.pipelines.opaque_quad_pipeline.quad_indices_view(
             &devices.device,
+            quad_indices_start as u32,
+            quad_count as u32,
+        )?;
+        let views = [quad_pipeline.view.clone(), quad_indices_view];
+        set_pipeline_state(
             &devices.device_context,
-            slice::from_ref(
-                &self
-                    .resources
-                    .as_ref()
-                    .context("resources missing")?
-                    .viewport,
-            ),
-            slice::from_ref(&self.globals.global_params_buffer),
-            4,
-            start as u32,
-            len as u32,
-        )
+            &views,
+            D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
+            &quad_pipeline.vertex,
+            &quad_pipeline.fragment,
+            &quad_pipeline.blend_state,
+        );
+        unsafe {
+            devices
+                .device_context
+                .DrawInstanced(4, quad_count as u32, 0, 0);
+        }
+        Ok(())
     }
 
     fn draw_paths_to_intermediate(&mut self, paths: &[Path<ScaledPixels>]) -> Result<()> {
@@ -539,6 +654,9 @@ impl DirectXRenderer {
                 &[0.0; 4],
             );
             // Set intermediate MSAA texture as render target
+            self.pipelines
+                .opaque_quad_pipeline
+                .disable_depth(&devices.device_context);
             devices.device_context.OMSetRenderTargets(
                 Some(slice::from_ref(&resources.path_intermediate_msaa_view)),
                 None,
@@ -546,8 +664,8 @@ impl DirectXRenderer {
         }
 
         // Collect all vertices and sprites for a single draw call
-        let mut vertices = Vec::new();
-
+        let vertices = &mut self.frame_scratch.path_vertices;
+        vertices.clear();
         for path in paths {
             vertices.extend(path.vertices.iter().map(|v| PathRasterizationSprite {
                 xy_position: v.xy_position,
@@ -560,13 +678,11 @@ impl DirectXRenderer {
         self.pipelines.path_rasterization_pipeline.update_buffer(
             &devices.device,
             &devices.device_context,
-            &vertices,
+            vertices,
         )?;
 
         self.pipelines.path_rasterization_pipeline.draw(
             &devices.device_context,
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
             vertices.len() as u32,
             1,
@@ -582,9 +698,13 @@ impl DirectXRenderer {
                 RENDER_TARGET_FORMAT,
             );
             // Restore main render target
-            devices
-                .device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+            devices.device_context.OMSetRenderTargets(
+                Some(slice::from_ref(&resources.render_target_view)),
+                resources.depth_stencil_view.as_ref(),
+            );
+            self.pipelines
+                .opaque_quad_pipeline
+                .enable_depth_test(&devices.device_context);
         }
 
         Ok(())
@@ -602,35 +722,32 @@ impl DirectXRenderer {
         // disjoint, so we can copy each path's bounds individually. If this
         // batch combines different draw orders, we perform a single copy
         // for a minimal spanning rect.
-        let sprites = if paths.last().unwrap().order == first_path.order {
-            paths
-                .iter()
-                .map(|path| PathSprite {
-                    bounds: path.clipped_bounds(),
-                })
-                .collect::<Vec<_>>()
+        let sprites = &mut self.frame_scratch.path_sprites;
+        sprites.clear();
+        if paths.last().unwrap().order == first_path.order {
+            sprites.extend(paths.iter().map(|path| PathSprite {
+                bounds: path.clipped_bounds(),
+            }));
         } else {
             let mut bounds = first_path.clipped_bounds();
             for path in paths.iter().skip(1) {
                 bounds = bounds.union(&path.clipped_bounds());
             }
-            vec![PathSprite { bounds }]
-        };
+            sprites.push(PathSprite { bounds });
+        }
 
         let devices = self.devices.as_ref().context("devices missing")?;
         let resources = self.resources.as_ref().context("resources missing")?;
         self.pipelines.path_sprite_pipeline.update_buffer(
             &devices.device,
             &devices.device_context,
-            &sprites,
+            sprites,
         )?;
 
         // Draw the sprites with the path texture
         self.pipelines.path_sprite_pipeline.draw_with_texture(
             &devices.device_context,
             slice::from_ref(&resources.path_intermediate_srv),
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             slice::from_ref(&self.globals.sampler),
             sprites.len() as u32,
         )
@@ -641,12 +758,9 @@ impl DirectXRenderer {
             return Ok(());
         }
         let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
         self.pipelines.underline_pipeline.draw_range(
             &devices.device,
             &devices.device_context,
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             4,
             start as u32,
             len as u32,
@@ -663,14 +777,11 @@ impl DirectXRenderer {
             return Ok(());
         }
         let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
         let texture_view = self.atlas.get_texture_view(texture_id);
         self.pipelines.mono_sprites.draw_range_with_texture(
             &devices.device,
             &devices.device_context,
             &texture_view,
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             slice::from_ref(&self.globals.sampler),
             start as u32,
             len as u32,
@@ -687,14 +798,11 @@ impl DirectXRenderer {
             return Ok(());
         }
         let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
         let texture_view = self.atlas.get_texture_view(texture_id);
         self.pipelines.subpixel_sprites.draw_range_with_texture(
             &devices.device,
             &devices.device_context,
             &texture_view,
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             slice::from_ref(&self.globals.sampler),
             start as u32,
             len as u32,
@@ -711,14 +819,11 @@ impl DirectXRenderer {
             return Ok(());
         }
         let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
         let texture_view = self.atlas.get_texture_view(texture_id);
         self.pipelines.poly_sprites.draw_range_with_texture(
             &devices.device,
             &devices.device_context,
             &texture_view,
-            slice::from_ref(&resources.viewport),
-            slice::from_ref(&self.globals.global_params_buffer),
             slice::from_ref(&self.globals.sampler),
             start as u32,
             len as u32,
@@ -804,6 +909,8 @@ impl DirectXResources {
         let (
             render_target,
             render_target_view,
+            depth_stencil_texture,
+            depth_stencil_view,
             path_intermediate_texture,
             path_intermediate_srv,
             path_intermediate_msaa_texture,
@@ -816,6 +923,8 @@ impl DirectXResources {
             swap_chain,
             render_target: Some(render_target),
             render_target_view,
+            depth_stencil_texture,
+            depth_stencil_view,
             path_intermediate_texture,
             path_intermediate_msaa_texture,
             path_intermediate_msaa_view,
@@ -834,6 +943,8 @@ impl DirectXResources {
         let (
             render_target,
             render_target_view,
+            depth_stencil_texture,
+            depth_stencil_view,
             path_intermediate_texture,
             path_intermediate_srv,
             path_intermediate_msaa_texture,
@@ -842,6 +953,8 @@ impl DirectXResources {
         ) = create_resources(devices, &self.swap_chain, width, height)?;
         self.render_target = Some(render_target);
         self.render_target_view = render_target_view;
+        self.depth_stencil_texture = depth_stencil_texture;
+        self.depth_stencil_view = depth_stencil_view;
         self.path_intermediate_texture = path_intermediate_texture;
         self.path_intermediate_msaa_texture = path_intermediate_msaa_texture;
         self.path_intermediate_msaa_view = path_intermediate_msaa_view;
@@ -909,10 +1022,12 @@ impl DirectXRenderPipelines {
             16,
             create_blend_state(device)?,
         )?;
+        let opaque_quad_pipeline = OpaqueQuadPipeline::new(device)?;
 
         Ok(Self {
             shadow_pipeline,
             quad_pipeline,
+            opaque_quad_pipeline,
             path_rasterization_pipeline,
             path_sprite_pipeline,
             underline_pipeline,
@@ -1065,8 +1180,6 @@ impl<T> PipelineState<T> {
     fn draw(
         &self,
         device_context: &ID3D11DeviceContext,
-        viewport: &[D3D11_VIEWPORT],
-        global_params: &[Option<ID3D11Buffer>],
         topology: D3D_PRIMITIVE_TOPOLOGY,
         vertex_count: u32,
         instance_count: u32,
@@ -1075,10 +1188,8 @@ impl<T> PipelineState<T> {
             device_context,
             slice::from_ref(&self.view),
             topology,
-            viewport,
             &self.vertex,
             &self.fragment,
-            global_params,
             &self.blend_state,
         );
         unsafe {
@@ -1091,8 +1202,6 @@ impl<T> PipelineState<T> {
         &self,
         device_context: &ID3D11DeviceContext,
         texture: &[Option<ID3D11ShaderResourceView>],
-        viewport: &[D3D11_VIEWPORT],
-        global_params: &[Option<ID3D11Buffer>],
         sampler: &[Option<ID3D11SamplerState>],
         instance_count: u32,
     ) -> Result<()> {
@@ -1100,10 +1209,8 @@ impl<T> PipelineState<T> {
             device_context,
             slice::from_ref(&self.view),
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
-            viewport,
             &self.vertex,
             &self.fragment,
-            global_params,
             &self.blend_state,
         );
         unsafe {
@@ -1120,8 +1227,6 @@ impl<T> PipelineState<T> {
         &self,
         device: &ID3D11Device,
         device_context: &ID3D11DeviceContext,
-        viewport: &[D3D11_VIEWPORT],
-        global_params: &[Option<ID3D11Buffer>],
         vertex_count: u32,
         first_instance: u32,
         instance_count: u32,
@@ -1131,10 +1236,8 @@ impl<T> PipelineState<T> {
             device_context,
             slice::from_ref(&view),
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
-            viewport,
             &self.vertex,
             &self.fragment,
-            global_params,
             &self.blend_state,
         );
         unsafe {
@@ -1148,8 +1251,6 @@ impl<T> PipelineState<T> {
         device: &ID3D11Device,
         device_context: &ID3D11DeviceContext,
         texture: &[Option<ID3D11ShaderResourceView>],
-        viewport: &[D3D11_VIEWPORT],
-        global_params: &[Option<ID3D11Buffer>],
         sampler: &[Option<ID3D11SamplerState>],
         first_instance: u32,
         instance_count: u32,
@@ -1159,10 +1260,8 @@ impl<T> PipelineState<T> {
             device_context,
             slice::from_ref(&view),
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
-            viewport,
             &self.vertex,
             &self.fragment,
-            global_params,
             &self.blend_state,
         );
         unsafe {
@@ -1172,6 +1271,144 @@ impl<T> PipelineState<T> {
             device_context.DrawInstanced(4, instance_count, 0, 0);
         }
         Ok(())
+    }
+}
+
+struct OpaqueQuadPipeline {
+    vertex: ID3D11VertexShader,
+    fragment: ID3D11PixelShader,
+    quad_indices_buffer: ID3D11Buffer,
+    quad_indices_buffer_size: usize,
+    blend_state: ID3D11BlendState,
+    depth_write_state: ID3D11DepthStencilState,
+    depth_test_state: ID3D11DepthStencilState,
+    depth_disabled_state: ID3D11DepthStencilState,
+}
+
+impl OpaqueQuadPipeline {
+    fn new(device: &ID3D11Device) -> Result<Self> {
+        let vertex = {
+            let raw_shader = RawShaderBytes::new(ShaderModule::OpaqueQuad, ShaderTarget::Vertex)?;
+            create_vertex_shader(device, raw_shader.as_bytes())?
+        };
+        let fragment = {
+            let raw_shader = RawShaderBytes::new(ShaderModule::OpaqueQuad, ShaderTarget::Fragment)?;
+            create_fragment_shader(device, raw_shader.as_bytes())?
+        };
+        let quad_indices_buffer_size = 512;
+        Ok(OpaqueQuadPipeline {
+            vertex,
+            fragment,
+            quad_indices_buffer: create_buffer(
+                device,
+                std::mem::size_of::<u32>(),
+                quad_indices_buffer_size,
+            )?,
+            quad_indices_buffer_size,
+            blend_state: create_opaque_blend_state(device)?,
+            depth_write_state: create_depth_stencil_state(
+                device,
+                true,
+                D3D11_DEPTH_WRITE_MASK_ALL,
+            )?,
+            depth_test_state: create_depth_stencil_state(
+                device,
+                true,
+                D3D11_DEPTH_WRITE_MASK_ZERO,
+            )?,
+            depth_disabled_state: create_depth_stencil_state(
+                device,
+                false,
+                D3D11_DEPTH_WRITE_MASK_ZERO,
+            )?,
+        })
+    }
+
+    fn update_quad_indices(
+        &mut self,
+        device: &ID3D11Device,
+        device_context: &ID3D11DeviceContext,
+        blended_quad_indices: &[u32],
+        opaque_quad_indices: &[u32],
+    ) -> Result<()> {
+        let quad_index_count = blended_quad_indices.len() + opaque_quad_indices.len();
+        if self.quad_indices_buffer_size < quad_index_count {
+            let new_buffer_size = quad_index_count.next_power_of_two();
+            self.quad_indices_buffer =
+                create_buffer(device, std::mem::size_of::<u32>(), new_buffer_size)?;
+            self.quad_indices_buffer_size = new_buffer_size;
+        }
+        unsafe {
+            let mut destination = std::mem::zeroed();
+            device_context.Map(
+                &self.quad_indices_buffer,
+                0,
+                D3D11_MAP_WRITE_DISCARD,
+                0,
+                Some(&mut destination),
+            )?;
+            let destination = destination.pData as *mut u32;
+            std::ptr::copy_nonoverlapping(
+                blended_quad_indices.as_ptr(),
+                destination,
+                blended_quad_indices.len(),
+            );
+            std::ptr::copy_nonoverlapping(
+                opaque_quad_indices.as_ptr(),
+                destination.add(blended_quad_indices.len()),
+                opaque_quad_indices.len(),
+            );
+            device_context.Unmap(&self.quad_indices_buffer, 0);
+        }
+        Ok(())
+    }
+
+    fn quad_indices_view(
+        &self,
+        device: &ID3D11Device,
+        quad_indices_start: u32,
+        quad_index_count: u32,
+    ) -> Result<Option<ID3D11ShaderResourceView>> {
+        create_buffer_view_range(
+            device,
+            &self.quad_indices_buffer,
+            quad_indices_start,
+            quad_index_count,
+        )
+    }
+
+    fn draw(
+        &self,
+        device: &ID3D11Device,
+        device_context: &ID3D11DeviceContext,
+        quad_instances_view: &Option<ID3D11ShaderResourceView>,
+        quad_indices_start: u32,
+        quad_count: u32,
+    ) -> Result<()> {
+        if quad_count == 0 {
+            return Ok(());
+        }
+        let quad_indices_view = self.quad_indices_view(device, quad_indices_start, quad_count)?;
+        let views = [quad_instances_view.clone(), quad_indices_view];
+        unsafe { device_context.OMSetDepthStencilState(&self.depth_write_state, 0) };
+        set_pipeline_state(
+            device_context,
+            &views,
+            D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
+            &self.vertex,
+            &self.fragment,
+            &self.blend_state,
+        );
+        unsafe { device_context.DrawInstanced(4, quad_count, 0, 0) };
+        Ok(())
+    }
+
+    fn enable_depth_test(&self, device_context: &ID3D11DeviceContext) {
+        unsafe { device_context.OMSetDepthStencilState(&self.depth_test_state, 0) };
+    }
+
+    fn disable_depth(&self, device_context: &ID3D11DeviceContext) {
+        unsafe { device_context.OMSetDepthStencilState(&self.depth_disabled_state, 0) };
     }
 }
 
@@ -1271,6 +1508,8 @@ fn create_resources(
     ID3D11Texture2D,
     Option<ID3D11RenderTargetView>,
     ID3D11Texture2D,
+    Option<ID3D11DepthStencilView>,
+    ID3D11Texture2D,
     Option<ID3D11ShaderResourceView>,
     ID3D11Texture2D,
     Option<ID3D11RenderTargetView>,
@@ -1278,14 +1517,25 @@ fn create_resources(
 )> {
     let (render_target, render_target_view) =
         create_render_target_and_its_view(swap_chain, &devices.device)?;
+    let (depth_stencil_texture, depth_stencil_view) =
+        create_depth_stencil_texture_and_view(&devices.device, width, height)?;
     let (path_intermediate_texture, path_intermediate_srv) =
         create_path_intermediate_texture(&devices.device, width, height)?;
     let (path_intermediate_msaa_texture, path_intermediate_msaa_view) =
         create_path_intermediate_msaa_texture_and_view(&devices.device, width, height)?;
-    let viewport = set_viewport(&devices.device_context, width as f32, height as f32);
+    let viewport = D3D11_VIEWPORT {
+        TopLeftX: 0.0,
+        TopLeftY: 0.0,
+        Width: width as f32,
+        Height: height as f32,
+        MinDepth: 0.0,
+        MaxDepth: 1.0,
+    };
     Ok((
         render_target,
         render_target_view,
+        depth_stencil_texture,
+        depth_stencil_view,
         path_intermediate_texture,
         path_intermediate_srv,
         path_intermediate_msaa_texture,
@@ -1303,6 +1553,37 @@ fn create_render_target_and_its_view(
     let mut render_target_view = None;
     unsafe { device.CreateRenderTargetView(&render_target, None, Some(&mut render_target_view))? };
     Ok((render_target, render_target_view))
+}
+
+#[inline]
+fn create_depth_stencil_texture_and_view(
+    device: &ID3D11Device,
+    width: u32,
+    height: u32,
+) -> Result<(ID3D11Texture2D, Option<ID3D11DepthStencilView>)> {
+    let texture = unsafe {
+        let mut output = None;
+        let desc = D3D11_TEXTURE2D_DESC {
+            Width: width,
+            Height: height,
+            MipLevels: 1,
+            ArraySize: 1,
+            Format: DXGI_FORMAT_D32_FLOAT,
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            Usage: D3D11_USAGE_DEFAULT,
+            BindFlags: D3D11_BIND_DEPTH_STENCIL.0 as u32,
+            CPUAccessFlags: 0,
+            MiscFlags: 0,
+        };
+        device.CreateTexture2D(&desc, None, Some(&mut output))?;
+        output.unwrap()
+    };
+    let mut view = None;
+    unsafe { device.CreateDepthStencilView(&texture, None, Some(&mut view))? };
+    Ok((texture, view))
 }
 
 #[inline]
@@ -1370,20 +1651,6 @@ fn create_path_intermediate_msaa_texture_and_view(
 }
 
 #[inline]
-fn set_viewport(device_context: &ID3D11DeviceContext, width: f32, height: f32) -> D3D11_VIEWPORT {
-    let viewport = [D3D11_VIEWPORT {
-        TopLeftX: 0.0,
-        TopLeftY: 0.0,
-        Width: width,
-        Height: height,
-        MinDepth: 0.0,
-        MaxDepth: 1.0,
-    }];
-    unsafe { device_context.RSSetViewports(Some(&viewport)) };
-    viewport[0]
-}
-
-#[inline]
 fn set_rasterizer_state(device: &ID3D11Device, device_context: &ID3D11DeviceContext) -> Result<()> {
     let desc = D3D11_RASTERIZER_DESC {
         FillMode: D3D11_FILL_SOLID,
@@ -1406,7 +1673,6 @@ fn set_rasterizer_state(device: &ID3D11Device, device_context: &ID3D11DeviceCont
     Ok(())
 }
 
-// https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ns-d3d11-d3d11_blend_desc
 #[inline]
 fn create_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
     let mut desc = D3D11_BLEND_DESC::default();
@@ -1421,6 +1687,53 @@ fn create_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
     unsafe {
         let mut state = None;
         device.CreateBlendState(&desc, Some(&mut state))?;
+        Ok(state.unwrap())
+    }
+}
+
+#[inline]
+fn create_opaque_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
+    let mut desc = D3D11_BLEND_DESC::default();
+    desc.RenderTarget[0].BlendEnable = false.into();
+    desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+    desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+    desc.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+    desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+    desc.RenderTarget[0].DestBlend = D3D11_BLEND_ZERO;
+    desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
+    desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8;
+    unsafe {
+        let mut state = None;
+        device.CreateBlendState(&desc, Some(&mut state))?;
+        Ok(state.unwrap())
+    }
+}
+
+#[inline]
+fn create_depth_stencil_state(
+    device: &ID3D11Device,
+    depth_enable: bool,
+    write_mask: D3D11_DEPTH_WRITE_MASK,
+) -> Result<ID3D11DepthStencilState> {
+    let stencil_op = D3D11_DEPTH_STENCILOP_DESC {
+        StencilFailOp: D3D11_STENCIL_OP_KEEP,
+        StencilDepthFailOp: D3D11_STENCIL_OP_KEEP,
+        StencilPassOp: D3D11_STENCIL_OP_KEEP,
+        StencilFunc: D3D11_COMPARISON_ALWAYS,
+    };
+    let desc = D3D11_DEPTH_STENCIL_DESC {
+        DepthEnable: depth_enable.into(),
+        DepthWriteMask: write_mask,
+        DepthFunc: D3D11_COMPARISON_GREATER,
+        StencilEnable: false.into(),
+        StencilReadMask: D3D11_DEFAULT_STENCIL_READ_MASK as u8,
+        StencilWriteMask: D3D11_DEFAULT_STENCIL_WRITE_MASK as u8,
+        FrontFace: stencil_op,
+        BackFace: stencil_op,
+    };
+    unsafe {
+        let mut state = None;
+        device.CreateDepthStencilState(&desc, Some(&mut state))?;
         Ok(state.unwrap())
     }
 }
@@ -1448,8 +1761,6 @@ fn create_blend_state_for_subpixel_rendering(device: &ID3D11Device) -> Result<ID
 
 #[inline]
 fn create_blend_state_for_path_rasterization(device: &ID3D11Device) -> Result<ID3D11BlendState> {
-    // If the feature level is set to greater than D3D_FEATURE_LEVEL_9_3, the display
-    // device performs the blend in linear space, which is ideal.
     let mut desc = D3D11_BLEND_DESC::default();
     desc.RenderTarget[0].BlendEnable = true.into();
     desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
@@ -1468,8 +1779,6 @@ fn create_blend_state_for_path_rasterization(device: &ID3D11Device) -> Result<ID
 
 #[inline]
 fn create_blend_state_for_path_sprite(device: &ID3D11Device) -> Result<ID3D11BlendState> {
-    // If the feature level is set to greater than D3D_FEATURE_LEVEL_9_3, the display
-    // device performs the blend in linear space, which is ideal.
     let mut desc = D3D11_BLEND_DESC::default();
     desc.RenderTarget[0].BlendEnable = true.into();
     desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
@@ -1579,21 +1888,16 @@ fn set_pipeline_state(
     device_context: &ID3D11DeviceContext,
     buffer_view: &[Option<ID3D11ShaderResourceView>],
     topology: D3D_PRIMITIVE_TOPOLOGY,
-    viewport: &[D3D11_VIEWPORT],
     vertex_shader: &ID3D11VertexShader,
     fragment_shader: &ID3D11PixelShader,
-    global_params: &[Option<ID3D11Buffer>],
     blend_state: &ID3D11BlendState,
 ) {
     unsafe {
         device_context.VSSetShaderResources(1, Some(buffer_view));
         device_context.PSSetShaderResources(1, Some(buffer_view));
         device_context.IASetPrimitiveTopology(topology);
-        device_context.RSSetViewports(Some(viewport));
         device_context.VSSetShader(vertex_shader, None);
         device_context.PSSetShader(fragment_shader, None);
-        device_context.VSSetConstantBuffers(0, Some(global_params));
-        device_context.PSSetConstantBuffers(0, Some(global_params));
         device_context.OMSetBlendState(blend_state, None, 0xFFFFFFFF);
     }
 }
@@ -1614,16 +1918,14 @@ pub(crate) mod shader_resources {
 
     #[cfg(debug_assertions)]
     use windows::{
-        Win32::Graphics::Direct3D::{
-            Fxc::{D3DCOMPILE_DEBUG, D3DCOMPILE_SKIP_OPTIMIZATION, D3DCompileFromFile},
-            ID3DBlob,
-        },
+        Win32::Graphics::Direct3D::{Fxc::*, ID3DBlob},
         core::{HSTRING, PCSTR},
     };
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub(crate) enum ShaderModule {
         Quad,
+        OpaqueQuad,
         Shadow,
         Underline,
         PathRasterization,
@@ -1676,6 +1978,10 @@ pub(crate) mod shader_resources {
                 ShaderModule::Quad => match target {
                     ShaderTarget::Vertex => QUAD_VERTEX_BYTES,
                     ShaderTarget::Fragment => QUAD_FRAGMENT_BYTES,
+                },
+                ShaderModule::OpaqueQuad => match target {
+                    ShaderTarget::Vertex => OPAQUE_QUAD_VERTEX_BYTES,
+                    ShaderTarget::Fragment => OPAQUE_QUAD_FRAGMENT_BYTES,
                 },
                 ShaderModule::Shadow => match target {
                     ShaderTarget::Vertex => SHADOW_VERTEX_BYTES,
@@ -1788,6 +2094,7 @@ pub(crate) mod shader_resources {
         pub fn as_str(self) -> &'static str {
             match self {
                 ShaderModule::Quad => "quad",
+                ShaderModule::OpaqueQuad => "opaque_quad",
                 ShaderModule::Shadow => "shadow",
                 ShaderModule::Underline => "underline",
                 ShaderModule::PathRasterization => "path_rasterization",

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -103,6 +103,12 @@ float4 to_device_position(float2 unit_vertex, Bounds bounds) {
     return to_device_position_impl(position);
 }
 
+// Must match gpui::quad_depth. Later quads are closer, and `+ 1` reserves
+// zero for the cleared depth buffer.
+float quad_depth(uint quad_id) {
+    return saturate(float(quad_id + 1u) * (1.0 / 16777216.0));
+}
+
 float4 distance_from_clip_rect_impl(float2 position, Bounds clip_bounds) {
     float2 tl = position - clip_bounds.origin;
     float2 br = clip_bounds.origin + clip_bounds.size - position;
@@ -524,9 +530,11 @@ struct QuadFragmentInput {
 };
 
 StructuredBuffer<Quad> quads: register(t1);
+StructuredBuffer<uint> quad_indices: register(t2);
 
-QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_InstanceID) {
+QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_InstanceID) {
     float2 unit_vertex = float2(float(vertex_id & 1u), 0.5 * float(vertex_id & 2u));
+    uint quad_id = quad_indices[instance_id];
     Quad quad = quads[quad_id];
     float4 device_position = to_device_position(unit_vertex, quad.bounds);
 
@@ -541,6 +549,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_Insta
 
     QuadVertexOutput output;
     output.position = device_position;
+    output.position.z = quad_depth(quad_id);
     output.border_color = border_color;
     output.quad_id = quad_id;
     output.background_solid = gradient.solid;
@@ -839,6 +848,94 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     }
 
     return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf));
+}
+
+/*
+**
+**              Opaque quads
+**
+*/
+
+struct OpaqueQuadVertexOutput {
+    float4 position: SV_Position;
+    nointerpolation float4 color: COLOR0;
+    float4 clip_distance: SV_ClipDistance;
+};
+
+struct OpaqueQuadFragmentInput {
+    float4 position: SV_Position;
+    nointerpolation float4 color: COLOR0;
+};
+
+float bounds_area(Bounds bounds) {
+    return bounds.size.x * bounds.size.y;
+}
+
+Bounds opaque_quad_core(Quad quad) {
+    bool has_rounded_corners = quad.corner_radii.top_left != 0.0
+        || quad.corner_radii.top_right != 0.0
+        || quad.corner_radii.bottom_right != 0.0
+        || quad.corner_radii.bottom_left != 0.0;
+    if (!has_rounded_corners) {
+        return quad.bounds;
+    }
+
+    const float antialias_inset = 1.0;
+    float left_inset = max(quad.corner_radii.top_left, quad.corner_radii.bottom_left)
+        + antialias_inset;
+    float right_inset = max(quad.corner_radii.top_right, quad.corner_radii.bottom_right)
+        + antialias_inset;
+    float top_inset = max(quad.corner_radii.top_left, quad.corner_radii.top_right)
+        + antialias_inset;
+    float bottom_inset = max(quad.corner_radii.bottom_left, quad.corner_radii.bottom_right)
+        + antialias_inset;
+
+    // A horizontal band avoids the top and bottom corner arcs; a vertical band
+    // avoids the left and right arcs. Either is fully opaque, so use the larger.
+    Bounds horizontal_band = quad.bounds;
+    horizontal_band.origin += float2(antialias_inset, top_inset);
+    horizontal_band.size = max(
+        quad.bounds.size - float2(2.0 * antialias_inset, top_inset + bottom_inset),
+        0.0);
+
+    Bounds vertical_band = quad.bounds;
+    vertical_band.origin += float2(left_inset, antialias_inset);
+    vertical_band.size = max(
+        quad.bounds.size - float2(left_inset + right_inset, 2.0 * antialias_inset),
+        0.0);
+
+    if (bounds_area(horizontal_band) >= bounds_area(vertical_band)) {
+        return horizontal_band;
+    }
+    return vertical_band;
+}
+
+OpaqueQuadVertexOutput opaque_quad_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_InstanceID) {
+    uint quad_id = quad_indices[instance_id];
+    Quad quad = quads[quad_id];
+    Bounds core = opaque_quad_core(quad);
+
+    OpaqueQuadVertexOutput output;
+    if (core.size.x <= 0.0 || core.size.y <= 0.0) {
+        // Zero-area triangle: rejected before rasterization.
+        output.position = float4(0.0, 0.0, 0.0, 1.0);
+        output.color = float4(0.0, 0.0, 0.0, 0.0);
+        output.clip_distance = float4(1.0, 1.0, 1.0, 1.0);
+        return output;
+    }
+
+    float2 unit_vertex = float2(float(vertex_id & 1u), 0.5 * float(vertex_id & 2u));
+    output.position = to_device_position(unit_vertex, core);
+    output.position.z = quad_depth(quad_id);
+    // Matches the quad shader's solid-background output exactly: tag-0 quads
+    // resolve to hsla_to_rgba(solid), and alpha-1 blending is an overwrite.
+    output.color = hsla_to_rgba(quad.background.solid);
+    output.clip_distance = distance_from_clip_rect(unit_vertex, core, quad.content_mask);
+    return output;
+}
+
+float4 opaque_quad_fragment(OpaqueQuadFragmentInput input): SV_Target {
+    return input.color;
 }
 
 /*


### PR DESCRIPTION
GPUI paints a frame by recording primitives (quads, shadows, paths, underlines, glyph sprites, surfaces) into a `Scene`. When rendering the scene, each primitive kind is sorted by its paint order and the scene is walked in that order as a sequence of primitive batches. The renderer draws the batches back-to-front, one draw call per batch.

Since batches are drawn strictly back-to-front, every primitive is shaded even where a later primitive completely paints over it. In a deep UI, this results in substantial overdraw. For example, a message in the agent panel stacks the window background, the panel background, a drop shadow behind the message container, then the container's own fill, then the glyph sprites. So, a pixel inside the container is shaded up to five times even though only the last is visible. The wasted work is worst for expensive shaders; the 4-tap filter used to approximate the shadow's Gaussian runs for every pixel beneath the container even though none of those pixels are visible.

This PR reduces that overdraw with a two-pass scheme that uses depth testing, inspired by WebRender:
- The _opaque pass_ draws primitives that we know are fully opaque over a solid area. (The only primitive we can make that guarantee for are quads with an opaque solid fill, so the entire depth machinery is built around quads.) The primitives are drawn front-to-back, with the depth test and depth writes both enabled. Every other primitive kind is handled in the next pass.
- The _blended pass_ draws everything that needs alpha blending, back-to-front, with the depth test enabled but depth writes disabled. This pass is essentially the pre-existing render loop with the depth test added. Fragments that fall behind something already drawn in the opaque pass fail the depth test and are never shaded.

Since only quads write depth, the depth we assign a quad is its index among the quads in paint order. A quad painted later wins the depth test against any earlier one. A non-quad batch has no such index of its own, but the whole batch will fall at a single point among the quads: no quad is painted partway through it. So, the depth used for a non-quad batch is the number of quads painted before it.

We split quads into two buckets while the scene is finalized based on whether a quad has an 'opaque core' (an opaque solid fill and no border) and rounded corners:
- No opaque core: blended bucket only.
- Opaque core with square corners: opaque bucket only. (The whole quad is drawn in the opaque pass.)
- Opaque core, rounded corners: *both* buckets. The rectangular interior is opaque and is drawn during the opaque pass; the full quad is redrawn in the blended pass to fill in the rounded corners.

In general, this buys us:
- Opaque, square-cornered quads are all fully drawn in the single opaque pass. They aren't in the blended bucket, so the blended pass skips them entirely.
- Opaque, rounded-cornered quads get their opaque core drawn in the opaque pass. When it's redrawn in the blended pass, the opaque core isn't re-shaded due to the depth test, so only the rounded corners are shaded and blended.
- Everything else is drawn in the blended pass, but any fragment that is covered by a nearer opaque core is rejected by the depth test before shading.

In combination with https://github.com/zed-industries/zed/pull/61274, the active GPU time taken to draw a representative scene in Zed is halved:

```
old
---
Average           : 0.957798901098901
StandardDeviation : 0.0185511147665604
Property          : MsGPUBusy

depth-buffer
---
Average           : 0.439229527559055
StandardDeviation : 0.0178328945667738
Property          : MsGPUBusy
```

This will be implemented for all platforms before this PR is merged.

Fixes https://github.com/zed-industries/zed/issues/8043

Release Notes:

- Reduced GPU usage