### PR TITLE
collab_panel: Adjust list item height across the panel

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -55,6 +55,10 @@ const FAVORITE_CHANNELS_KEY: &str = "favorite_channels";
 const COLLABORATION_PANEL_KEY: &str = "CollaborationPanel";
 const TOAST_DURATION: Duration = Duration::from_secs(5);
 
+fn panel_row_height() -> Rems {
+    rems_from_px(26.)
+}
+
 actions!(
     collab_panel,
     [
@@ -1237,7 +1241,7 @@ impl CollabPanel {
         .into();
 
         ListItem::new(project_id as usize)
-            .height(rems_from_px(24.))
+            .height(panel_row_height())
             .toggle_state(is_selected)
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.workspace
@@ -1278,7 +1282,7 @@ impl CollabPanel {
         let id = peer_id.map_or(usize::MAX, |id| id.as_u64() as usize);
 
         ListItem::new(("screen", id))
-            .height(rems_from_px(24.))
+            .height(panel_row_height())
             .toggle_state(is_selected)
             .start_slot(
                 h_flex()
@@ -1325,7 +1329,7 @@ impl CollabPanel {
         let has_channel_buffer_changed = channel_store.has_channel_buffer_changed(channel_id);
 
         ListItem::new("channel-notes")
-            .height(rems_from_px(24.))
+            .height(panel_row_height())
             .toggle_state(is_selected)
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.open_channel_notes(channel_id, window, cx);
@@ -3072,6 +3076,7 @@ impl CollabPanel {
 
         h_flex().group("section-header").w_full().child(
             ListHeader::new(text)
+                .height(panel_row_height())
                 .when(can_collapse, |header| {
                     header
                         .toggle(Some(!is_collapsed))
@@ -3392,7 +3397,7 @@ impl CollabPanel {
             (IconName::Star, Color::Default, "Add to Favorites")
         };
 
-        let height = rems_from_px(24.);
+        let height = panel_row_height();
 
         let icon_name = if is_public {
             IconName::Hash
@@ -3801,7 +3806,6 @@ fn render_tree_branch(
     cx: &mut App,
 ) -> impl IntoElement {
     let rem_size = window.rem_size();
-    let line_height = window.text_style().line_height_in_pixels(rem_size);
     let thickness = px(1.);
     let color = cx.theme().colors().icon_disabled;
 
@@ -3834,7 +3838,7 @@ fn render_tree_branch(
         },
     )
     .w(rem_size)
-    .h(line_height - px(2.))
+    .h(panel_row_height())
 }
 
 fn render_participant_name_and_handle(user: &User) -> impl IntoElement {

--- a/crates/ui/src/components/list/list_header.rs
+++ b/crates/ui/src/components/list/list_header.rs
@@ -22,6 +22,7 @@ pub struct ListHeader {
     on_toggle: Option<Arc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     inset: bool,
     selected: bool,
+    height: Option<DefiniteLength>,
 }
 
 impl ListHeader {
@@ -36,7 +37,13 @@ impl ListHeader {
             disclosure_shape: None,
             on_toggle: None,
             selected: false,
+            height: None,
         }
+    }
+
+    pub fn height(mut self, height: impl Into<DefiniteLength>) -> Self {
+        self.height = Some(height.into());
+        self
     }
 
     pub fn toggle(mut self, toggle: impl Into<Option<bool>>) -> Self {
@@ -97,9 +104,12 @@ impl RenderOnce for ListHeader {
             .group("list_header")
             .child(
                 div()
-                    .map(|this| match ui_density {
-                        UiDensity::Comfortable => this.h_5(),
-                        _ => this.h_7(),
+                    .map(|this| match self.height {
+                        Some(height) => this.h(height),
+                        None => match ui_density {
+                            UiDensity::Comfortable => this.h_5(),
+                            _ => this.h_7(),
+                        },
                     })
                     .when(self.inset, |this| this.px_2())
                     .when(self.selected, |this| {


### PR DESCRIPTION
Yet another quick follow up to https://github.com/zed-industries/zed/pull/61397, making sure the height of each item is consistent. This is particularly important so that the tree-connecting-lines that show up when you share a project or screen don't get disconnected.

Release Notes:

- N/A
