### PR TITLE
breadpaper: Add Wrap Today/Yesterday skills and wire skills into Claude Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,10 +2458,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "editor",
  "fs",
  "git",
  "gpui",
  "log",
+ "markdown_preview",
  "menu",
  "project",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fs",
+ "git",
  "gpui",
  "log",
  "menu",
@@ -2467,6 +2469,7 @@ dependencies = [
  "toml 0.8.23",
  "ui",
  "util",
+ "which 6.0.3",
  "workspace",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "breadpaper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "gpui",
+ "log",
+ "menu",
+ "project",
+ "serde",
+ "tempfile",
+ "toml 0.8.23",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "brush-parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23162,6 +23180,7 @@ dependencies = [
  "auto_update",
  "auto_update_ui",
  "breadcrumbs",
+ "breadpaper",
  "call",
  "channel",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/bedrock",
     "crates/benchmarks",
     "crates/breadcrumbs",
+    "crates/breadpaper",
     "crates/buffer_diff",
     "crates/call",
     "crates/channel",
@@ -289,6 +290,7 @@ auto_update_ui = { path = "crates/auto_update_ui" }
 aws_http_client = { path = "crates/aws_http_client" }
 bedrock = { path = "crates/bedrock" }
 breadcrumbs = { path = "crates/breadcrumbs" }
+breadpaper = { path = "crates/breadpaper" }
 buffer_diff = { path = "crates/buffer_diff" }
 call = { path = "crates/call" }
 channel = { path = "crates/channel" }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -699,6 +699,7 @@
       "ctrl-shift-b": "outline_panel::ToggleFocus",
       "ctrl-shift-g": "git_panel::ToggleFocus",
       "ctrl-shift-d": "debug_panel::ToggleFocus",
+      "ctrl-2": "breadpaper::ToggleFocus",
       "ctrl-?": "agent::ToggleFocus",
       "alt-save": "workspace::SaveAll",
       "ctrl-alt-s": "workspace::SaveAll",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -710,7 +710,7 @@
       "cmd-shift-n": "workspace::NewWindow",
       "ctrl-`": "terminal_panel::Toggle",
       "cmd-1": ["workspace::ActivatePane", 0],
-      "cmd-2": ["workspace::ActivatePane", 1],
+      "cmd-2": "breadpaper::ToggleFocus",
       "cmd-3": ["workspace::ActivatePane", 2],
       "cmd-4": ["workspace::ActivatePane", 3],
       "cmd-5": ["workspace::ActivatePane", 4],

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1063,6 +1063,27 @@
     },
   },
   {
+    "context": "BreadPaperTimelinePanel",
+    "bindings": {
+      "j": "vim::MenuSelectNext",
+      "k": "vim::MenuSelectPrevious",
+      "down": "vim::MenuSelectNext",
+      "up": "vim::MenuSelectPrevious",
+      "shift-g": "menu::SelectLast",
+      "g g": "menu::SelectFirst",
+      "0": ["vim::Number", 0],
+      "1": ["vim::Number", 1],
+      "2": ["vim::Number", 2],
+      "3": ["vim::Number", 3],
+      "4": ["vim::Number", 4],
+      "5": ["vim::Number", 5],
+      "6": ["vim::Number", 6],
+      "7": ["vim::Number", 7],
+      "8": ["vim::Number", 8],
+      "9": ["vim::Number", 9],
+    },
+  },
+  {
     "context": "GitGraph",
     "bindings": {
       "tab": "git_graph::FocusNextTabStop",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1616,6 +1616,7 @@
   // Files or globs of files that will be excluded by Zed entirely. They will be skipped during file
   // scans, file searches, and not be displayed in the project file tree. Takes precedence over `file_scan_inclusions`.
   "file_scan_exclusions": [
+    "**/.breadpaper/history",
     "**/.git",
     "**/.svn",
     "**/.hg",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -802,7 +802,7 @@
     // Default width of the project panel.
     "default_width": 240,
     // Where to dock the project panel. Can be 'left' or 'right'.
-    "dock": "right",
+    "dock": "left",
     // Spacing between worktree entries in the project panel. Can be 'comfortable' or 'standard'.
     "entry_spacing": "comfortable",
     // Whether to show file icons in the project panel.
@@ -919,7 +919,7 @@
     // Default width of the outline panel.
     "default_width": 300,
     // Where to dock the outline panel. Can be 'left' or 'right'.
-    "dock": "right",
+    "dock": "left",
     // Whether to show file icons in the outline panel.
     "file_icons": true,
     // Whether to show folder icons or chevrons for directories in the outline panel.
@@ -971,7 +971,7 @@
     // Whether to show the collaboration panel button in the status bar.
     "button": true,
     // Where to dock the collaboration panel. Can be 'left' or 'right'.
-    "dock": "right",
+    "dock": "left",
     // Default width of the collaboration panel.
     "default_width": 240,
   },
@@ -979,7 +979,7 @@
     // Whether to show the git panel button in the status bar.
     "button": true,
     // Where to dock the git panel. Can be 'left' or 'right'.
-    "dock": "right",
+    "dock": "left",
     // Default width of the git panel.
     "default_width": 360,
     // Style of the git status indicator in the panel.
@@ -1056,7 +1056,7 @@
     // Whether to show the agent panel button in the status bar.
     "button": true,
     // Where to dock the agent panel. Can be 'left', 'right' or 'bottom'.
-    "dock": "left",
+    "dock": "right",
     // Whether the agent panel should use flexible (proportional) sizing.
     //
     // Default: true
@@ -1334,7 +1334,7 @@
   // Settings related to the editor's tab bar.
   "tab_bar": {
     // Whether or not to show the tab bar in the editor
-    "show": true,
+    "show": false,
     // Whether or not to show the navigation history buttons.
     "show_nav_history_buttons": true,
     // Whether or not to show the tab bar buttons.

--- a/breadpaper/VISION.md
+++ b/breadpaper/VISION.md
@@ -173,6 +173,43 @@ _Source pointers:_ `zed-industries/zed` `crates/extension_api/src/extension_api.
 - _A second brain that ships with a system — not a blank page._
 - _Local-first life OS. Bring your own brain._
 
+## 12. Feature roadmap (living)
+
+> This section is the running build log. It is **updated over the course of the project** as features move `planned → in progress → shipped`. Status reflects code on the `main` fork, not intent.
+
+### Milestone 0 — Fork foundation
+- [x] **Fork Zed, isolate BreadPaper delta** — `/breadpaper/` docs + `crates/breadpaper/`, `upstream` remote for rebases. _(shipped)_
+- [x] **Vault model** — folder + `.breadpaper` marker + config, naming conventions encoded. _(shipped)_
+- [x] **Timeline panel** — Today / Yesterday / This Week / Last Week GPUI dock panel. _(shipped)_
+- [x] **Daily & weekly note creation** — resolve `YYYYMMDD_MMM-DDD.md` / `YYYY_WW_MMM.md`, create-if-missing. _(shipped)_
+- [ ] **Invisible git — checkpoint service** — background snapshots to hidden `.breadpaper/history` git-dir. _(in progress)_
+
+### Milestone 1 — The core loop (thinnest thing that proves it)
+- [ ] **Daily & Weekly Area** — first packaged Area (folders + templates + context view). _(planned)_
+- [ ] **Daily Closure skill** — reads tasks + commits, appends a review to the day's note. _(planned)_
+- [ ] **Invisible git — restore UI** — human "history / restore this version" surface; no git vocabulary. _(planned)_
+- [ ] **Checkpoint triggers** — autosave / idle / pre-AI-write commit points. _(planned)_
+- [ ] **BYO-LLM connection** — ride Zed's existing agent/console rails; user brings their own key. _(planned)_
+
+### Milestone 2 — Areas & Skills framework
+- [ ] **Area package format** — declarative bundle spec (folders + view + skills + README). _(planned)_
+- [ ] **Areas left rail + gallery** — switchable enabled domains; add/remove from a gallery. _(planned)_
+- [ ] **Skills view** — rituals as inspectable, editable objects with declared read/write scope. _(planned)_
+- [ ] **Skill contract & write sandbox** — enforce inputs/outputs so writes are previewable and scoped. _(planned)_
+
+### Milestone 3 — Context rail & connectors
+- [ ] **Page-aware Context right rail** — day-planner / week calendar / finance dashboard per open doc. _(planned)_
+- [ ] **MCP connector onboarding** — Monarch, GitHub/GitLab, calendar as a guided step, not hand-edited JSON. _(planned)_
+- [ ] **Week Review skill** — aggregate daily notes + PRs/MRs, append review, feed dashboard. _(planned)_
+- [ ] **Friday Finance skill** — live Monarch pull, credit-card sweep + LoC residual, action list, log outcome. _(planned)_
+- [ ] **Journaling Topic skill** — detect avoidance/momentum, surface a neglected topic. Read-only. _(planned)_
+- [ ] **Dashboard output type** — `data.js → static HTML that computes its own analytics`, generalized. _(planned)_
+
+### Milestone 4 — Onboarding & de-Zed-ification
+- [ ] **First-run onboarding** — point at a folder, connect an LLM, pick Areas, run first ritual in <10 min. _(planned)_
+- [ ] **Remove code-editor chrome** — disable git pane + subscription/billing surfaces that conflict with the life-OS framing. _(planned)_
+- [ ] **BYO-LLM cost visibility** — key/model choice, local vs cloud, graceful failure. _(planned)_
+
 ---
 
 _This is a starting point, not a spec. It exists to give designers and engineers a shared picture of the destination so we can argue productively about the route._

--- a/breadpaper/VISION.md
+++ b/breadpaper/VISION.md
@@ -1,0 +1,178 @@
+# BreadPaper — Product Vision (v0.1)
+
+> **Working tagline:** _Your private second brain, powered by the LLM you already trust._
+> _(alternatives to workshop below)_
+
+**Status:** Discussion draft — for the founding design + engineering team.
+**Author:** Diego · **Date:** 2026-07-20
+
+**Decisions so far (2026-07-20):**
+- **Fork strategy:** _fork required — scope now known._ A custom left-nav pane (Timeline) is a V1 must-have, and Zed's extension API **cannot render any custom panel/dock/UI** (confirmed against the extension API source, docs, and maintainer statements — see §7.1). Panels are core Rust/GPUI. So BreadPaper is a **fork whose custom surface is a small set of new GPUI panels + an invisible-git service**, with the AI rituals riding the *existing* extension + MCP rails (those need no fork). "Prototype first" still holds — but the prototype is a minimal fork, not an extension.
+- **v1 audience:** _technical-first_ — ship rough and powerful for engineers who already live in editors; onboarding polish comes later. (§10 Q4)
+- **Repo layout:** _single repo — the fork is the product._ Development happens directly on the Zed fork (`github.com/DiegoTavares/bpaper`, cloned to `~/dev/bpaper`), **not** a submodule. All non-Zed content (this doc, design docs, Area packages) lives isolated under `/breadpaper/` so the fork's delta against upstream stays legible and is trivially extractable later (`git filter-repo`). `upstream` remote → `zed-industries/zed` for ongoing rebases. The personal vault (`~/dev/bread-paper`) stays **out** of this repo — private data, separate concern. Named `bpaper`, distinct from the `bread-paper` vault to avoid on-disk/name collision.
+
+---
+
+## 1. The one-sentence pitch
+
+BreadPaper is a desktop app — a private fork of the [Zed](https://zed.dev) editor — that turns a folder of plain Markdown files into a **guided, LLM-augmented second brain**. It ships with pre-built "Areas" (finance, weekly reviews, journaling, team notes) that each come with their own files, layout, and AI rituals, so a person gets the power of a hand-tuned Obsidian-plus-Claude-Code setup **without having to build it themselves.**
+
+## 2. Why this, why now
+
+Today the author runs a system that most people would love to have but almost nobody can assemble:
+
+- A plain-text vault (Obsidian's format) edited in a fast, real code editor (Zed).
+- A set of **LLM rituals** — "Friday finance," "week review," "daily closure," "journaling topic" — that read live data (Monarch, GitHub, GitLab), synthesize it, and **append** their findings to human-written notes.
+- **Living source-of-truth files** (e.g. `finance_plan_2026.md`) the AI must read before it advises and must update when reality changes, so guidance never drifts.
+- A **static HTML dashboard** the LLM feeds with structured data, which then computes its own warnings (time-sinks, lingering projects, carried-over goals).
+
+The problem: this stack is held together by conventions in a `CLAUDE.md`, four slash-command files, two MCP servers, and a folder-naming discipline that only their author fully understands. It is powerful and completely non-transferable. Obsidian is open but generic; Zed is fast but is a code editor with no notion of "your life"; Claude Code is capable but unopinionated. **Nobody ships the opinion.**
+
+BreadPaper is that opinion, productized: the folder structure, the rituals, the layouts, and the AI guardrails become **first-class, visible, editable features** instead of tribal knowledge.
+
+## 3. Who it's for
+
+- **Primary (v1):** technically comfortable people who already keep notes in plain text and want AI woven into their life-admin — but don't want to hand-build the plumbing. "Power journalers," indie hackers, engineers, PKM enthusiasts.
+- **Aspirational (later):** anyone who wants a private, local-first "life OS" and is willing to bring their own LLM key. Non-technical users reached through onboarding that hides the machinery.
+
+**Non-goal:** competing with Obsidian as a general note-taking platform, or with Notion as a team wiki. BreadPaper is opinionated and personal by design.
+
+## 4. Principles (the soul of the product)
+
+These are the invariants. Design and engineering decisions should be checkable against them.
+
+1. **Your files, forever, in the open.** Everything is plain Markdown (or whatever format the user prefers) in a normal folder on disk. No proprietary database, no lock-in. If BreadPaper vanished tomorrow, the vault still opens in any editor.
+2. **Augmentation, not replacement.** The AI *appends* its synthesis alongside your raw words — it never silently rewrites what you wrote. Your capture and the machine's reflection coexist in the same file (`# LLM Review`, `# AI Week Review`, `# Friday Finance`).
+3. **Bring your own brain.** The user chooses and pays for their own LLM (Claude, local model, etc.) via their own key or a console integration. BreadPaper is not a subscription reseller of intelligence.
+4. **Human-in-the-loop for anything that matters.** The AI computes and recommends; the human acts. It will tell you exactly how much to pay down your line of credit — it will not (and cannot) move the money.
+5. **Living plans over frozen advice.** Canonical files are the source of truth. The AI reads them before advising and edits them when reality shifts, so the plan never drifts from the person.
+6. **Modular life.** Nobody wants every module. Areas are opt-in. A user can run only daily notes, or add finance, journaling, team notes — each independently.
+7. **Invisible versioning.** Git runs underneath for full history and safety, but the user never types a git command or sees a git pane. Time-travel, not source control.
+8. **Everything is editable.** Skills, layouts, prompts, and templates are files the user (and their LLM) can open and change. Power users can rewrite the rituals; the app just ships great defaults.
+
+## 5. The product experience
+
+BreadPaper looks like a focused, three-pane writing environment. Zed's speed and editing quality are the foundation; the chrome around it is re-conceived for life-management rather than code.
+
+### 5.1 Left rail A — **Timeline** (the "now" navigator)
+A small, always-present list of the files you almost always want: **Today**, **Yesterday**, **This Week**, **Last Week**. One click (or keystroke) opens the right note. It resolves the app's naming conventions for the user (daily = `YYYYMMDD_MMM-DDD.md`, weekly = `YYYY_WW_MMM.md`) so they never think about filenames. Creating today's note if it doesn't exist yet is a single action — replacing the current "open Obsidian just to trigger a plugin" workaround.
+
+### 5.2 Left rail B — **Areas** (the modular navigator)
+A switchable list of the life-domains the user has enabled: _Daily & Weekly_, _Finance_, _Journaling_, _Team_, etc. Each Area is a bundle of folders, templates, a right-pane context view, and skills. Users add or remove Areas from a gallery. Beneath the Areas view, the full file tree remains available for people who want to roam freely.
+
+### 5.3 Right rail — **Context** (page-aware companion)
+The right pane changes with the open document:
+
+- On a **daily note** → a time-block view of the day (a day-planner rail).
+- On a **weekly note** → the week's calendar with meetings and important markers.
+- On a **finance** file → the current dashboard: accounts, budgets, the computed sweep and LoC residual.
+- On any file → the relevant **skills** for that context, one click away.
+
+This is where BreadPaper stops feeling like a text editor and starts feeling like an instrument tuned to the thing you're doing.
+
+### 5.4 **Skills view** — the rituals, made visible and editable
+Every Area exposes its skills as first-class, inspectable objects, not hidden slash-commands. Example skills, drawn directly from the author's working setup:
+
+| Skill | What it does |
+|---|---|
+| **Friday Finance** | Pulls live Monarch data, computes the credit-card sweep and line-of-credit residual, presents an ordered action list, waits for the user to actually move the money, then logs what happened into the day's note. |
+| **Week Review** | Reads the week's daily notes, aggregates GitHub PRs + GitLab MRs, groups work by project, picks highlights, appends an AI review to the weekly file **and** feeds the dashboard. |
+| **Daily Closure** | Reads checked/unchecked tasks, pulls the day's commits, scans recent days for multi-day context, and appends a review with suggestions. |
+| **Journaling Topic** | Analyzes weeks of notes to detect avoidance/momentum and surfaces a neglected topic to write about. Read-only — the human owns the reflection. |
+
+Each skill is openable, has a plain-language description, a prompt/logic body the user or their LLM can edit, and clear declarations of **what it reads** (data sources) and **what it writes** (which files, append vs. edit). Trust comes from that transparency.
+
+### 5.5 **Onboarding** — teaching what's possible
+A first-run flow that (a) points BreadPaper at a new or existing folder, (b) connects an LLM, (c) lets the user pick their starting Areas from a gallery, and (d) walks them through their first ritual (e.g. create today's note, run a daily closure). The goal is that within ten minutes a new user has done one real, valuable thing — not stared at a blank editor.
+
+## 6. Relationship to Zed — kept / removed / added
+
+**Kept**
+- The editor core: speed, multi-format editing, full file-tree access, Markdown as the default.
+- Zed's AI integration path that talks to external models via console/agent, so users bring their own LLM.
+
+**Removed / disabled (initially)**
+- The subscription-gated AI/billing model — BreadPaper users bring their own key; no reselling of intelligence.
+- The Git pane and manual git surface — versioning becomes invisible (see §7).
+- Editor chrome and affordances that assume "you are writing software," where they conflict with the life-OS framing.
+
+**Added**
+- The **Timeline** left rail (Today / Yesterday / This Week / Last Week).
+- The **Areas** left rail + Area gallery / enable-disable.
+- The page-aware **Context** right rail (time blocks, week calendar, finance dashboard).
+- The **Skills view** (inspect + edit rituals; declared read/write scopes).
+- **Onboarding** flow.
+- **Invisible git** automation.
+- An **Area package format** — the bundle (folders + templates + right-pane view + skills + docs) that makes a domain installable.
+
+## 7. Technical shape (for the engineers)
+
+_High-level and provisional — meant to frame feasibility, not prescribe implementation._
+
+### 7.1 Settled constraint: the panes require a fork (Zed extensions can't render UI)
+
+Confirmed 2026-07-20 against primary sources (Zed's `crates/extension_api` trait, `docs/src/extensions`, and maintainer statements): **the Zed extension API is entirely non-visual.** Extensions can contribute language servers, themes, slash commands, and MCP/context servers — but there is **no** method to render a custom panel, dock, view, or webview, in stable or nightly. All panels (project tree, outline, terminal, agent, git) are compiled Rust/GPUI inside the core, registered via a `Panel` trait not exposed to extensions; WASM extensions are sandboxed with no handle to the window.
+
+Consequence for BreadPaper — a clean split:
+
+- **Requires touching core (fork):** the Timeline pane, the Areas pane, the page-aware Context pane — each is a new GPUI `Panel` registered in the workspace dock. Plus the invisible-git background service.
+- **Does _not_ require a fork:** the AI rituals. Daily Closure, Week Review, Friday Finance, and the Monarch/GitHub/GitLab connectors fit the existing **extension + MCP** model and can load into our fork as ordinary Zed extensions.
+
+Design implication: keep the fork's custom surface **small and panel-shaped**, and push as much logic as possible into extensions/MCP so we stay mergeable with upstream. The relevant upstream hope — RFC #53403 "Visual Extension API" (Apr 2026) — is maintainer-gated and explicitly deprioritized, so it must not be counted on.
+
+_Source pointers:_ `zed-industries/zed` `crates/extension_api/src/extension_api.rs`; `docs/src/extensions/developing-extensions.md`; Discussion #53403; Issues #17325, #18877, #21208.
+
+### 7.2 Building blocks
+
+- **Base:** private fork of Zed (Rust + GPUI). We inherit a fast, native, cross-platform editor. Risk: staying mergeable with upstream vs. diverging — mitigated by §7.1's small-fork/large-extension split.
+- **Vault = folder on disk.** No new storage engine. Conventions (naming, PARA-style folders) are encoded in the app so the user doesn't maintain them by hand.
+- **Areas as packages.** An Area is a declarative bundle: folder scaffolding + templates + a right-pane view spec + a set of skills + a `README`. Installing an Area writes its scaffolding into the vault and registers its views/skills. This is the key extensibility primitive and deserves early design attention.
+- **Skills = portable, declarable rituals.** Today they're Claude Code slash-commands with implicit behavior. In BreadPaper a skill declares its **inputs** (files, MCP data sources), its **actions**, and its **outputs** (which files, append vs. edit) so the UI can show scope and the app can sandbox writes. The runtime executes them through the user's chosen LLM.
+- **Data connectors via MCP.** Monarch, GitHub/GitLab, calendar, etc. arrive as MCP servers (the author already runs Obsidian + Monarch MCP). BreadPaper should make connecting an MCP source a first-class, guided step rather than hand-edited JSON.
+- **Invisible versioning.** A background service commits meaningful checkpoints (autosave/idle/pre-AI-write) to a hidden git repo, exposes a human "history / restore this version" UI, and surfaces conflict recovery — all without the word "git" ever appearing.
+- **Dashboards as an output type.** The `structured data (data.js) → static HTML that computes its own analytics` pattern is a repeatable Area capability: skills emit machine-readable feeds; a bundled viewer derives insight. Worth generalizing into the Area format.
+
+## 8. Why it's valuable
+
+- **It sells an opinion, not a blank canvas.** The hard part of PKM isn't the tool — it's designing the system. BreadPaper ships proven systems. That's the differentiated value Obsidian/Notion/Zed structurally can't offer.
+- **Local-first + BYO-LLM is a real position.** Privacy-conscious, lock-in-averse users are underserved by cloud note apps. "Your files, your model, your machine" is a clear, honest promise.
+- **The rituals compound.** Value grows the longer you use it — weeks of notes make the week-review and journaling skills smarter. That's retention that doesn't depend on a walled garden.
+- **A genuine wedge exists:** people already cobbling Obsidian + Claude Code together (a visibly growing crowd) are proof the demand is real and currently unmet by a polished product.
+
+## 9. Feasibility — the honest read
+
+**Encouraging**
+- The concept is already **de-risked by a working prototype**: the author's own vault _is_ BreadPaper minus the packaged UX. We're productizing a proven workflow, not inventing an unproven one.
+- Zed gives us a world-class editor for free. The genuinely new surface area is chrome + orchestration, not a text engine.
+- Markdown-on-disk means low storage/architecture risk and instant interop.
+
+**Hard parts to respect**
+- **Forking Zed is a serious commitment.** Rust + GPUI is a real codebase; keeping a private fork current with upstream is ongoing tax. We should decide early: deep fork vs. thin layer (extension/overlay) vs. building panes as Zed extensions where possible. This is the single biggest architectural fork-in-the-road.
+- **Invisible git is deceptively subtle.** Autosave churn, merge conflicts, large binaries (the vault already holds multi-MB images), and "restore" UX are all edge-case minefields. Getting "never lose data, never show git" right is a project of its own.
+- **Skills need a real trust + safety model.** The moment an AI can write to a user's files and read financial data, scope declarations, dry-runs, previews, and confirmation gates stop being nice-to-haves.
+- **BYO-LLM UX is fiddly.** Keys, model choice, local vs. cloud, cost visibility, and graceful failure need thought so non-experts aren't stranded.
+- **Onboarding a non-technical user into a fork of a code editor** is a real design challenge — the gap between "engineer's dream" and "my mom could use it" is wide, and v1 should pick a lane honestly.
+
+**Provisional recommendation:** Build the **thinnest thing that proves the core loop** first — Timeline rail + one Area (Daily/Weekly) + one working skill (Daily Closure) + invisible git — on top of Zed, before committing to the full Areas/Skills package framework. Treat it as a personal tool that earns its way to being a product.
+
+## 10. Open questions for the team
+
+1. **Fork depth:** deep Zed fork, thin overlay, or extension-based? What keeps us mergeable with upstream long enough to matter?
+2. **Area package format:** what's the minimum declarative spec for a bundle (folders + views + skills + connectors)?
+3. **Skill contract:** how do we declare/enforce a skill's read/write scope so users can trust it and the app can sandbox it?
+4. **Audience for v1:** technical-first (ship rough, powerful) or approachable-first (invest in onboarding early)? These pull the design in different directions.
+5. **Invisible git:** what exactly triggers a checkpoint, and what does "restore" look like to someone who's never heard of a commit?
+6. **Distribution & model:** open-source core? paid Areas? one-time vs. subscription (for the app, never the intelligence)?
+7. **The name & tagline:** does "BreadPaper" land, and how do we say the value in one line? (see below)
+
+## 11. Tagline candidates (to workshop)
+
+- _Your private second brain, powered by the LLM you already trust._
+- _The opinionated second brain. Your files, your model, your machine._
+- _Plain text in. Clarity out. Your life, with an AI that actually knows it._
+- _A second brain that ships with a system — not a blank page._
+- _Local-first life OS. Bring your own brain._
+
+---
+
+_This is a starting point, not a spec. It exists to give designers and engineers a shared picture of the destination so we can argue productively about the route._

--- a/breadpaper/VISION.md
+++ b/breadpaper/VISION.md
@@ -185,25 +185,25 @@ _Source pointers:_ `zed-industries/zed` `crates/extension_api/src/extension_api.
 - [ ] **Invisible git — checkpoint service** — background snapshots to hidden `.breadpaper/history` git-dir. _(in progress)_
 
 ### Milestone 1 — The core loop (thinnest thing that proves it)
-- [ ] **Daily & Weekly Area** — first packaged Area (folders + templates + context view). _(planned)_
+- [x] **Daily & Weekly Area** — first packaged Area, shipped as the installable **Timeline Area** (scaffolded folders + weekly dashboard + Week Review skill; page-aware context view still pending). _(shipped)_
 - [ ] **Daily Closure skill** — reads tasks + commits, appends a review to the day's note. _(planned)_
 - [ ] **Invisible git — restore UI** — human "history / restore this version" surface; no git vocabulary. _(planned)_
 - [ ] **Checkpoint triggers** — autosave / idle / pre-AI-write commit points. _(planned)_
 - [ ] **BYO-LLM connection** — ride Zed's existing agent/console rails; user brings their own key. _(planned)_
 
 ### Milestone 2 — Areas & Skills framework
-- [ ] **Area package format** — declarative bundle spec (folders + view + skills + README). _(planned)_
-- [ ] **Areas left rail + gallery** — switchable enabled domains; add/remove from a gallery. _(planned)_
-- [ ] **Skills view** — rituals as inspectable, editable objects with declared read/write scope. _(planned)_
-- [ ] **Skill contract & write sandbox** — enforce inputs/outputs so writes are previewable and scoped. _(planned)_
+- [x] **Area package format** — declarative `manifest.toml` bundle (folder/file scaffold + skills + surfaces + doc), materialized create-if-missing and recorded in a per-vault `[[areas.installed]]` registry. _(shipped)_
+- [x] **Areas left rail + gallery** — an Areas section in the Timeline panel: enabled Areas with their skills/surfaces, **Add Area** from the app catalog, and remove-with-confirmation that preserves user-modified files. A standalone gallery UI is still to come. _(shipped)_
+- [x] **Skills view** — an Area's skills are inspectable, openable Markdown files with a plain-language summary; read/write scopes are declared in the manifest. Surfacing those scopes in the UI is still pending. _(shipped)_
+- [ ] **Skill contract & write sandbox** — enforce inputs/outputs so writes are previewable and scoped. Scopes are now _declared_ in the manifest but not yet enforced. _(planned)_
 
 ### Milestone 3 — Context rail & connectors
 - [ ] **Page-aware Context right rail** — day-planner / week calendar / finance dashboard per open doc. _(planned)_
 - [ ] **MCP connector onboarding** — Monarch, GitHub/GitLab, calendar as a guided step, not hand-edited JSON. _(planned)_
-- [ ] **Week Review skill** — aggregate daily notes + PRs/MRs, append review, feed dashboard. _(planned)_
+- [x] **Week Review skill** — ships with the Timeline Area: aggregate daily/weekly notes + GitHub PRs (`gh`) / GitLab MRs (`glab`), append an AI review to the weekly note, and feed the dashboard. Rides the `gh`/`glab` CLIs; guided MCP connectors still pending. _(shipped)_
 - [ ] **Friday Finance skill** — live Monarch pull, credit-card sweep + LoC residual, action list, log outcome. _(planned)_
 - [ ] **Journaling Topic skill** — detect avoidance/momentum, surface a neglected topic. Read-only. _(planned)_
-- [ ] **Dashboard output type** — `data.js → static HTML that computes its own analytics`, generalized. _(planned)_
+- [x] **Dashboard output type** — `data.js → static HTML that computes its own analytics`, shipped as the Timeline Area's Weekly Dashboard and generalized into the Area format as an openable **surface**. _(shipped)_
 
 ### Milestone 4 — Onboarding & de-Zed-ification
 - [ ] **First-run onboarding** — point at a folder, connect an LLM, pick Areas, run first ritual in <10 min. _(planned)_

--- a/breadpaper/VISION.md
+++ b/breadpaper/VISION.md
@@ -55,7 +55,7 @@ These are the invariants. Design and engineering decisions should be checkable a
 BreadPaper looks like a focused, three-pane writing environment. Zed's speed and editing quality are the foundation; the chrome around it is re-conceived for life-management rather than code.
 
 ### 5.1 Left rail A — **Timeline** (the "now" navigator)
-A small, always-present list of the files you almost always want: **Today**, **Yesterday**, **This Week**, **Last Week**. One click (or keystroke) opens the right note. It resolves the app's naming conventions for the user (daily = `YYYYMMDD_MMM-DDD.md`, weekly = `YYYY_WW_MMM.md`) so they never think about filenames. Creating today's note if it doesn't exist yet is a single action — replacing the current "open Obsidian just to trigger a plugin" workaround.
+A small, always-present list of the files you almost always want: **Today**, **Yesterday**, **This Week**, **Last Week**. One click (or keystroke) opens the right note. It resolves the app's naming conventions for the user (daily = `YYYY-MM-DD.md`, weekly = ISO week `YYYY-Www.md`, e.g. `2026-W30.md`) so they never think about filenames. Creating today's note if it doesn't exist yet is a single action — replacing the current "open Obsidian just to trigger a plugin" workaround.
 
 ### 5.2 Left rail B — **Areas** (the modular navigator)
 A switchable list of the life-domains the user has enabled: _Daily & Weekly_, _Finance_, _Journaling_, _Team_, etc. Each Area is a bundle of folders, templates, a right-pane context view, and skills. Users add or remove Areas from a gallery. Beneath the Areas view, the full file tree remains available for people who want to roam freely.
@@ -181,7 +181,7 @@ _Source pointers:_ `zed-industries/zed` `crates/extension_api/src/extension_api.
 - [x] **Fork Zed, isolate BreadPaper delta** — `/breadpaper/` docs + `crates/breadpaper/`, `upstream` remote for rebases. _(shipped)_
 - [x] **Vault model** — folder + `.breadpaper` marker + config, naming conventions encoded. _(shipped)_
 - [x] **Timeline panel** — Today / Yesterday / This Week / Last Week GPUI dock panel. _(shipped)_
-- [x] **Daily & weekly note creation** — resolve `YYYYMMDD_MMM-DDD.md` / `YYYY_WW_MMM.md`, create-if-missing. _(shipped)_
+- [x] **Daily & weekly note creation** — resolve `YYYY-MM-DD.md` / ISO week `YYYY-Www.md`, create-if-missing. _(shipped)_
 - [ ] **Invisible git — checkpoint service** — background snapshots to hidden `.breadpaper/history` git-dir. _(in progress)_
 
 ### Milestone 1 — The core loop (thinnest thing that proves it)

--- a/breadpaper/specs/v1-daily-panel-maintainability.md
+++ b/breadpaper/specs/v1-daily-panel-maintainability.md
@@ -1,0 +1,98 @@
+# V1 Daily Panel — Maintainability Assessment
+
+**Status:** Complete — this is the go/no-go deliverable required by `v1-daily-panel.md` §2.7
+**Author:** Claude (implementation session) · **Date:** 2026-07-20
+**Verdict: GO.** The custom-panel approach is viable and the fork tax looks low.
+
+## 1. How invasive is the core diff?
+
+All feature logic lives in a new, self-contained crate (`crates/breadpaper/`, four
+files: vault config/discovery/scaffolding, date formatting + template expansion,
+the GPUI timeline panel, and the startup hook). The delta against upstream Zed
+(after the V1-final scope: Timeline header with Today/Yesterday/This Week/Last
+Week, `breadpaper:` open commands, panel open-by-default in vaults, classic
+layout as the default) is **8 files, +44/−27 lines**, and every touched line is
+either a registration one-liner, a default-value flip, or the one deliberate
+behavior change:
+
+| File | Change | Risk on rebase |
+|---|---|---|
+| `Cargo.toml` (root) | +2: workspace member + dependency entry | Trivial; alphabetical lists merge cleanly |
+| `Cargo.lock` | +18: lockfile entry for the new crate | Auto-regenerable |
+| `crates/zed/Cargo.toml` | +1: `breadpaper.workspace = true` | Trivial |
+| `crates/zed/src/zed.rs` | +11: `TimelinePanel::load` + `join!` arm + post-join `show_panel_if_vault` call in `initialize_panels` | Low; the panel-loading pattern is stable upstream |
+| `crates/zed/src/main.rs` | +1 `breadpaper::init(cx)`; −20/+5 in `restore_or_create_workspace` | **The one real conflict surface** (see below) |
+| `assets/keymaps/default-{macos,linux}.json` | +1 each: `breadpaper::ToggleFocus` binding | Trivial |
+| `assets/settings/default.json` | 5 dock defaults flipped so new users get the classic (editor-focused) layout | Low; value-only changes, though upstream layout reshuffles would need re-flipping |
+
+The only *behavioral* upstream change is in `restore_or_create_workspace`: when
+there is no session to restore, BreadPaper opens/scaffolds the default vault
+instead of Zed's onboarding view or an empty workspace. This replaces two
+branches (~20 lines) and removes the now-unused `onboarding` import. If upstream
+reworks that function, the rebase will conflict *there and only there* — and the
+resolution is mechanical (re-point the final `else` at
+`breadpaper::open_startup_vault`).
+
+## 2. Does it rebase cleanly?
+
+Tested against `upstream/main` (zed-industries/zed) via `git merge-tree`:
+**clean, zero conflicts**. Caveat: the fork is currently only one commit behind
+upstream, so this is a weak empirical signal. The structural argument above is
+the stronger one — six of the seven touched files are append-only registration
+points that upstream churns rarely and merges trivially.
+
+Recommended hygiene going forward: rebase weekly while the delta is this small,
+so any conflict in `restore_or_create_workspace` is caught while the upstream
+change is fresh.
+
+## 3. What the runtime shook out (traps for the next panel)
+
+- **`activation_priority` must be globally unique.** This fork's dock asserts it
+  (`dock.rs:719`) and panics at startup on collision. Taken: 0 agent, 1 project,
+  2 terminal, 3 git, 5 collab, 6 outline, 7 debug. The timeline panel uses **4**
+  — the last free small integer. The next BreadPaper panel needs 8+.
+- Panels need no settings registration and no DB persistence to work; hardcoding
+  position/size (à la `TestPanel`) keeps the panel fully self-contained. The
+  cost: dock position/size aren't remembered across restarts. Fine for V1.
+- The fork's `AsyncApp::update` is infallible (returns `R`, not `Result<R>`) —
+  upstream blog examples and older code suggest otherwise.
+
+## 4. Deliberate V1 shortcuts (recorded, not hidden)
+
+- **`std::fs` instead of Zed's `Fs` trait** for vault I/O, following the
+  `journal` crate's precedent. Simpler, but invisible to `FakeFs`-based GPUI
+  tests — the file logic is covered by 11 unit tests against real temp dirs
+  instead. Worth revisiting when invisible-git arrives (it will want the `Fs`
+  trait's atomic writes anyway).
+- **Vault detection runs on the foreground thread** (a stat + ~200-byte read on
+  worktree events). Cheap, but should move to the background if config files
+  ever grow.
+- Zed's onboarding flow is unreachable rather than removed — smallest possible
+  diff, dead code accepted.
+- Keybinding is `cmd-alt-t` / `ctrl-alt-t` ("t" for today). `ctrl-alt-t` may
+  collide with GNOME's terminal shortcut on Linux; acceptable for a
+  macOS-first V1.
+
+## 5. Verification record
+
+- 11 unit tests (vault detect/scaffold/no-clobber, config defaults, date tokens,
+  template expansion, note create/never-overwrite/missing-template) — all pass.
+- `cargo check` + `cargo clippy --deny warnings` clean for `breadpaper` and
+  `zed` (clippy run in debug profile scoped to the two crates; the repo's
+  `script/clippy --release --workspace` didn't fit on available disk).
+- Live first-run test (fresh `$HOME`): sample vault scaffolded at
+  `~/BreadPaper/` with config, template, and `welcome.md`; workspace opened;
+  first frame rendered; no panics. Today/Yesterday clicks created
+  `daily/2026-07-20.md` / `daily/2026-07-19.md` with correct per-note date
+  substitution.
+- Live non-vault test: opening a plain folder shows the panel's
+  not-a-vault state without crashing and scaffolds nothing.
+
+## 6. Go/no-go rationale
+
+The spec asked whether a custom GPUI panel can be added and **kept** without
+pain. Evidence says yes: the panel itself required zero upstream modifications;
+registration is seven mostly-one-line touches; the sole behavioral override is
+localized to one function with a mechanical resolution strategy. The pane-heavy
+vision (Areas pane, Context pane) can proceed on this pattern — each new panel
+costs ~4 upstream lines plus a unique priority.

--- a/breadpaper/specs/v1-daily-panel.md
+++ b/breadpaper/specs/v1-daily-panel.md
@@ -1,0 +1,163 @@
+# BreadPaper V1 — Daily Navigation Panel
+
+**Status:** Scope-locked, ready for implementation
+**Owner:** Diego · **Date:** 2026-07-20
+**Companion doc:** `../VISION.md`
+
+---
+
+## 1. Summary
+
+The first BreadPaper feature and the **feasibility gate for the whole fork**: a custom left-dock panel (built as a native GPUI `Panel` in the Zed fork) that lists **Today** and **Yesterday** as one-click links to daily notes. Clicking an entry opens that day's note, creating it from a template if it doesn't yet exist. On first run, BreadPaper scaffolds and opens a sample vault so the feature works end-to-end on a clean machine.
+
+This is deliberately narrow, but it exercises the three things the entire product depends on: **can we add a custom panel to Zed's dock, register it, and maintain it against upstream without pain?** If yes, the pane-heavy vision is real. If the GPUI panel integration proves unmaintainable, this is the moment we reconsider the fork.
+
+## 2. Goals & success criteria
+
+**Primary (the go/no-go):** Prove that a custom left-dock GPUI panel can be added to the Zed fork and **kept maintainable** — a small, legible diff against `upstream/main` that survives a rebase. Success is judged on the *final, real* implementation, not throwaway code ("code is cheap; maintainability is the question").
+
+**Secondary (the feature must actually be good):** Opening today's note is a single, obvious click every morning — replacing the current "open Obsidian just to trigger the daily-note plugin" workaround.
+
+**Definition of done:**
+1. Fresh launch with no configured vault → sample vault scaffolded at the default location and opened.
+2. A left-dock panel appears (coexisting with the file tree) showing **Today** and **Yesterday**.
+3. Clicking **Today** opens today's note, creating it from the template (with token substitution) if missing.
+4. Clicking **Yesterday** does the same for yesterday's date.
+5. Existing notes are opened, **never overwritten**.
+6. Opening a non-vault folder shows a graceful "not a vault" state, not a crash or blank.
+7. A written **maintainability assessment**: how invasive was the core diff, and does it rebase cleanly? This is the actual deliverable of the spike.
+
+## 3. Non-goals (explicitly out of V1)
+
+- **This Week / Last Week** entries (weekly notes — different template & filename scheme; the next increment).
+- **Invisible git / checkpointing** — creating a note is not versioned yet.
+- **Right-hand context pane**, Areas pane, skills, LLM rituals, onboarding flow.
+- **Multi-vault registry / switcher UI.** Switching vaults in V1 = open another folder that contains a `.breadpaper/` marker (normal workspace open). The config is shaped so a registry can be added later.
+- **Existence indicators**, auto-open-on-launch, "tomorrow" navigation.
+- Backfilling / migrating the author's real vault. V1 targets a **fresh default layout**, not the organically-grown existing one.
+
+## 4. Core concepts
+
+### 4.1 Vault
+A **vault** is a folder that BreadPaper recognizes as a life-workspace. It is Zed's workspace/worktree concept under a new name. BreadPaper is **multi-vault** in principle, but **~90% of users have exactly one**, so V1 optimizes for the single-default-vault path and treats extra vaults as an expert case (just open another vault folder).
+
+### 4.2 Vault marker & per-vault config
+A folder is a vault iff it contains a **`.breadpaper/` directory** with a **`config.toml`**. The marker is what makes "import a vault from a GitHub repo" and multi-vault coherent — each vault self-describes. The panel activates only when the open workspace is a recognized vault, and reads all paths/formats **from that vault's config** (not a global setting).
+
+`.breadpaper/` is a hidden directory by design, with room to grow (future home for invisible-git state, caches, per-vault Area packages). It remains user-editable via the file tree.
+
+## 5. The vault: default layout & config
+
+### 5.1 Default directory layout (what the sample vault contains)
+```
+<vault-root>/
+  .breadpaper/
+    config.toml          # marker + per-vault config
+  daily/                 # daily notes, flat (no year nesting in V1)
+  templates/
+    daily.md             # daily-note template
+  welcome.md             # opened on first run to orient the user
+```
+
+### 5.2 `config.toml` schema (V1)
+```toml
+schema = 1
+
+[daily]
+dir      = "daily"           # daily notes dir, relative to vault root
+filename = "YYYY-MM-DD"      # moment-style date format; ".md" is appended
+template = "templates/daily.md"
+```
+- `filename` and template tokens share **one moment-style date vocabulary** (`YYYY`, `MM`, `DD`, `dddd`, `MMMM`, `D`, …) for consistency.
+- Everything is a default with a sane value; the file is meant to be edited.
+
+### 5.3 Sample `templates/daily.md`
+Mirrors the author's real daily structure, with a dated heading via substitution:
+```markdown
+# {{date:dddd, MMMM D, YYYY}}
+
+## Journal
+
+## Day planner
+
+## Personal
+```
+
+## 6. Behavior specification
+
+### 6.1 Vault discovery
+- The panel operates on the **active workspace root**.
+- If `<workspace-root>/.breadpaper/config.toml` exists → the workspace is a vault; load its config.
+- Otherwise → non-vault state (§6.6).
+
+### 6.2 First run
+- On launch, if no vault is configured/known, BreadPaper **scaffolds the sample vault** at the default location `~/BreadPaper/` (creating `.breadpaper/config.toml`, `daily/`, `templates/daily.md`, `welcome.md`) and **opens it as the workspace**.
+- `welcome.md` is opened in the editor so the user lands on something oriented, not a blank pane.
+- Detection is allowed to be simple in V1 (e.g. "does the default vault exist yet?"); a real known-vaults registry is deferred.
+
+### 6.3 The panel
+- A native GPUI `Panel` registered in the **left dock**, toggled via a dock icon + keybinding.
+- **Coexists** with the built-in project (file-tree) panel — does not replace it.
+- Renders two entries as links: **Today** and **Yesterday**.
+- No existence indicator — entries are plain links regardless of whether the underlying file exists yet.
+
+### 6.4 Date resolution
+- **Naive local calendar date** (system timezone). No day-cutoff offset. At 1:00am Tuesday, "Today" = Tuesday; the "Yesterday" link is the way back to Monday.
+- **Today** = current date. **Yesterday** = current date − 1 day.
+- Target path = `<vault>/<daily.dir>/<formatted-date>.md`, where the date is formatted with `daily.filename`.
+
+### 6.5 Click behavior (both entries)
+1. Compute the target path for that date.
+2. **If the file exists → open it.** (Never modified, never overwritten — safety invariant.)
+3. **If it does not exist →** create it from `daily.template` with token substitution (§6.7), then open it.
+4. If `<daily.dir>` doesn't exist, create it silently first.
+
+### 6.6 Non-vault state
+When the open workspace has no `.breadpaper/` marker, the panel shows a gentle prompt — e.g. **"This folder isn't a BreadPaper vault"** with a **[Create vault here]** action (scaffolds a `.breadpaper/` + default dirs into the current workspace) — rather than rendering blank or erroring. _(Exact copy/affordance: confirm on review — see §8.)_
+
+### 6.7 Template token substitution
+Basic Obsidian-style substitution, applied when a note is created. V1 token set:
+
+| Token | Expands to | Example |
+|---|---|---|
+| `{{date}}` | ISO date | `2026-07-20` |
+| `{{date:FORMAT}}` | moment-style formatted date | `{{date:dddd, MMMM D}}` → `Monday, July 20` |
+| `{{time}}` | 24h local time | `14:31` |
+| `{{title}}` | note filename without extension | `2026-07-20` |
+
+`{{date}}`/`{{date:…}}` resolve to the **note's** date (so a created "Yesterday" note is dated yesterday, not now). `{{time}}` is creation time.
+
+### 6.8 Failure modes
+| Condition | Behavior |
+|---|---|
+| `daily/` dir missing | Create silently, then proceed. |
+| Template file missing | Create an **empty** note + non-blocking warning. _(confirm — §8)_ |
+| Write / permission error | Non-blocking error toast; no partial file left behind. |
+| Workspace not a vault | Non-vault state (§6.6). |
+
+## 7. Implementation notes (for engineering)
+
+- Built as a native GPUI `Panel` in a core Zed crate (the extension API cannot render UI — see `../VISION.md` §7.1). **Keep the core diff small, isolated, and clearly namespaced** so it rebases cleanly onto `upstream/main`.
+- Prefer isolating BreadPaper logic (vault discovery, config parsing, date/template handling) into a self-contained module/crate that the panel calls, so the delta against Zed's own files stays minimal.
+- Date formatting: a moment-compatible formatter for the token/filename vocabulary.
+- The spike's real output includes the **maintainability writeup** in §2 — record how many upstream files were touched and how the rebase felt.
+
+## 8. Open assumptions to confirm on review
+
+1. **Default vault location** `~/BreadPaper/` — acceptable, or prefer `~/Documents/BreadPaper/` / XDG-style?
+2. **Non-vault state** copy & the "Create vault here" action (§6.6).
+3. **Template-missing fallback** = empty note + warning (§6.8) — acceptable, or should it hard-fail with a clear error?
+4. **`welcome.md` content** — to be drafted; short orientation to the panel + how to edit `config.toml`.
+
+## 9. Decision log (from design interview, 2026-07-20)
+
+- Build the **real feature**, no throwaway lane; go/no-go judged on final maintainability.
+- Vault = **open workspace** at configurable-relative-paths with sane defaults; **multi-vault** product, single-vault-default UX.
+- Vault identity = **`.breadpaper/` marker + per-vault `config.toml`** (hidden dir, room to grow).
+- **Sample-vault scaffolding is in scope** (end-to-end on a clean machine).
+- Filenames = **clean ISO**, `daily/` is **flat**, marker stays **hidden**.
+- Date = **naive local calendar**; back-navigation via the Yesterday entry.
+- Template = **basic Obsidian-style token substitution**.
+- Panel = **Today + Yesterday** links, **coexists** with file tree, **no existence indicator**.
+- Click = **create-if-missing → open**, **never overwrite**; no auto-open; dirs created silently.
+- **Invisible git deferred** to a later iteration.

--- a/breadpaper/specs/v2-invisible-git-assessment.md
+++ b/breadpaper/specs/v2-invisible-git-assessment.md
@@ -1,0 +1,155 @@
+# BreadPaper V2 — Invisible Git: safety & maintainability assessment
+
+**Status:** Complete — go
+**Date:** 2026-07-21 · **Spec:** `v2-invisible-git.md`
+
+## 1. Verdict
+
+The invisible checkpoint engine is **feasible, safe, and maintainable**. It shipped
+as a self-contained `breadpaper::history` module driving a new general-purpose
+checkpoint primitive in the `git` crate, verified by automated tests at the
+plumbing level and by a live end-to-end run against a real vault. One material
+surprise was found and fixed during verification: the spec's invisibility premise
+("only an entry literally named `.git` is ever discovered") is **stale** — Zed's
+worktree scanner also heuristically registers *bare* repositories, which
+discovered our history repo the moment it was created (§4 below).
+
+## 2. What shipped
+
+- **`crates/git/src/repository.rs`** — the reusable plumbing (all next to the
+  existing agent-checkpoint code it mirrors):
+  - `RealGitRepository::new_with_separate_git_dir(git_dir, work_tree, …)` —
+    opens a repo whose git-dir is not named `.git`; commands are scoped with
+    `GIT_DIR`/`GIT_WORK_TREE` env vars (such repos are undiscoverable from cwd).
+  - `RealGitRepository::init_separate_git_dir(…)` — `git init` with an external
+    git-dir, leaving **nothing** named `.git` in the work tree.
+  - `RealGitRepository::checkpoint_onto_ref(ref, message, author, max_bytes)` —
+    the spec's checkpoint: temp index (real index never touched), the existing
+    `checkpoint.gitignore` + size-cap excludes, `add --all` → `write-tree` →
+    **no-op check against `HEAD^{tree}`** → `commit-tree -p HEAD` →
+    `update-ref`. The ref advances only after the commit is fully written
+    (crash-safety invariant §6.7). A successful commit is followed by
+    `git gc --auto` (plumbing never triggers auto-GC on its own).
+  - Small enablers: `GitBinary::envs` now extends instead of replacing;
+    `exclude_files` takes the size cap as a parameter (default unchanged).
+- **`crates/breadpaper/src/history.rs`** (new, ~470 lines) — the service:
+  per-workspace `HistoryService` created from `observe_new::<Workspace>`
+  (V1's activation pattern), detecting vaults per visible worktree, lazily
+  initializing `<vault>/.breadpaper/history` on a background task, with
+  idle-debounce + heartbeat + wired pre-AI-write (`checkpoint_before_ai_write`)
+  + best-effort close/quit triggers, single-flight with one pending coalesced
+  checkpoint, and failure handling that disables-and-logs-once (init) or
+  logs-at-debug-and-retries (per-checkpoint).
+- **`crates/breadpaper/src/vault.rs`** — `[history]` config table
+  (`enabled`, `idle_debounce_seconds`, `heartbeat_minutes`, `max_file_bytes`),
+  all defaulted, table optional.
+- **`crates/worktree/src/worktree.rs`** — the invisibility fix (§4).
+- **`assets/settings/default.json`** — `**/.breadpaper/history` added to
+  `file_scan_exclusions`.
+- **`crates/zed/src/main.rs`** — one line: `breadpaper::history::init(cx)`.
+
+## 3. Upstream delta (the maintainability question)
+
+| File | Nature | Size |
+|---|---|---|
+| `crates/git/src/repository.rs` | additive: new constructor + 2 methods + 2 tiny refactors; ~190 further lines are new tests | ~170 lines non-test |
+| `crates/worktree/src/worktree.rs` | one guarded branch in the FS-event git probe | +20 |
+| `assets/settings/default.json` | one default exclusion entry | +1 |
+| `crates/zed/src/main.rs` | registration | +1 |
+
+Everything else lives in the `breadpaper` crate. No existing function changed
+behavior for existing callers (`envs` extend is only observable if a caller sets
+overlapping keys, and none does; `exclude_files` callers pass the old constant).
+All 62 pre-existing `git` crate tests pass unchanged. **Rebase outlook:** the
+git-crate additions sit beside the agent checkpoint code and touch nothing that
+churns often; the worktree guard is inside a stable event loop but is the one
+hunk most likely to need hand-merging on a big upstream rebase. Verdict: small,
+isolated, additive — comparable to V1's footprint per capability.
+
+## 4. The invisibility finding (spec premise was stale)
+
+Spec §4.2 assumed repositories are discovered only via entries literally named
+`.git`. That is true of the *scan* path, but `worktree.rs` also has a
+**bare-repository heuristic** (`is_dot_git`): during FS-event processing, any
+ancestor directory containing `HEAD` + `config` files is registered as a git
+dir. In the first live run, the moment the service ran `git init`, the event
+probe registered `~/BreadPaper/.breadpaper/history` and the GitStore opened it
+(confirmed twice in `Zed.log`) — it would have appeared in git UI.
+
+**Fix:** the heuristic (and only the heuristic — literal `.git` is unaffected)
+now skips paths covered by `file_scan_exclusions`, and `**/.breadpaper/history`
+was added to the defaults. Rationale: a user who scan-excludes a directory has
+declared it invisible to the workspace; auto-registering a repository from
+inside it contradicts that. This is a general upstream rule, not a
+BreadPaper-specific carve-out. Verified live post-fix: a full
+init → initial checkpoint → idle checkpoint cycle produced **zero** repository
+opens in Zed's log. *Caveat:* a user who wholesale-overrides
+`file_scan_exclusions` without the history entry re-exposes the repo to the
+heuristic; acceptable for V2, worth revisiting if it bites.
+
+## 5. Safety results (tested trigger matrix)
+
+Automated (`cargo test -p git`, new tests `test_checkpoint_onto_ref*`):
+
+- Initial checkpoint on an unborn branch; second checkpoint parented on first
+  (walkable linear chain, verified via `rev-parse checkpoints^`).
+- **No-op discipline:** unchanged tree → no commit, no ref move.
+- **Excludes:** a `max_file_bytes` file stays out of the snapshot while the
+  checkpoint of everything else succeeds.
+- **Restore (DoD 8):** `restore_checkpoint` returns edited files to the
+  checkpointed state; files outside the snapshot are left alone.
+- **User-repo coexistence (DoD 6):** with a real `.git` in the vault, a
+  checkpoint leaves the user's status byte-identical, history and branches
+  untouched, and `.git` never enters the snapshot.
+
+Live run (dev build against the author's real `~/BreadPaper` V1 vault):
+
+- Existing V1 vault upgraded transparently: `history/` created lazily, initial
+  checkpoint recorded (`checkpoint: initial <utc>`, author `BreadPaper`),
+  zero visible side effects (DoD 1).
+- Edit → idle checkpoint within the debounce window (DoD 2); an edit racing the
+  in-flight initial checkpoint was captured by it and the subsequent idle
+  attempt correctly no-opped — the coalescing design working as intended.
+- 45+ seconds of quiescence produced **no** checkpoint churn: the engine's own
+  writes never re-trigger it (DoD 4).
+- `SIGTERM` mid-session (crash-equivalent): **no corruption** (`git fsck`
+  clean), previous head intact; the interrupted edit was caught up by the next
+  launch's initial checkpoint, which continued the same chain. This is §6.7's
+  invariant observed in practice. Note: the close trigger is wired via
+  `on_app_quit` + service-drop and is genuinely *best-effort* — a SIGTERM kill
+  bypasses it by design; nothing already committed is ever lost.
+- Failure modes: missing git binary / init failure → service disables for that
+  vault, logs once, editing unaffected (exercised in code review + the error
+  path is the same one the tests drive through `Result`); per-checkpoint
+  failure logs at debug and re-marks dirty so the heartbeat retries.
+
+Does it ever lose data? **No vault data is ever at risk** — the engine only
+reads the work tree; the only write into the vault is `git restore`, which V2
+never invokes outside tests. History-side, at-risk windows are the gaps between
+triggers (by design, bounded by the heartbeat) and edits made in the final
+seconds before a hard kill (caught up at next launch).
+
+## 6. Known limitations (accepted for V2)
+
+- Media files (`*.png`, `*.jpg`, …) are excluded by the reused
+  `checkpoint.gitignore` **regardless of size**, not just at ≥2 MB — matches
+  spec §6.5's "baseline + size cap", but worth restating: vault images are not
+  versioned at all in V2 (spec §8.3).
+- Two windows on the same vault run two services against one repo; git's ref
+  locking makes the race safe (one side may log a failed checkpoint and retry).
+  Same-vault-in-two-processes remains out of scope (spec §3).
+- Heartbeat is polled at 60 s granularity, so a heartbeat checkpoint can land
+  up to a minute after the configured floor elapses.
+- `is_dot_git`'s heuristic guard depends on `file_scan_exclusions` defaults
+  (§4 caveat).
+
+## 7. Suggested `.rules` additions
+
+- "Zed's worktree scanner registers git repositories not only for entries named
+  `.git` but for any directory containing `HEAD` + `config` (bare-repo
+  heuristic in `is_dot_git`, FS-event path). Anything that creates a repo-shaped
+  directory inside a worktree must pair it with a `file_scan_exclusions` entry,
+  which the event probe now honors."
+- "Shelling out to git anywhere in the workspace must go through
+  `GitBinary::build_command` — clippy denies `new_command` for this via
+  `disallowed-methods`."

--- a/breadpaper/specs/v2-invisible-git.md
+++ b/breadpaper/specs/v2-invisible-git.md
@@ -1,0 +1,177 @@
+# BreadPaper V2 — Invisible Git (checkpoint engine)
+
+**Status:** Scope-locked, ready for implementation
+**Owner:** Diego · **Date:** 2026-07-21
+**Companion docs:** `../VISION.md` (principle 7, §7.2), `v1-daily-panel.md`, `v1-daily-panel-maintainability.md`
+
+---
+
+## 1. Summary
+
+V2 gives every BreadPaper vault a **silent, always-on version history**. A background service watches the open vault and commits **checkpoints** of the whole vault into a **hidden, isolated git repository** — triggered by idle pauses, a slow heartbeat, and (by design) before any AI write. The user never types a git command, never sees a git pane, and never sees the word "git." History simply accrues underneath, so a later increment can offer jargon-free time-travel.
+
+This is the **engine only**. V2 ships **no user-facing surface at all** — no restore command, no history browser, no toast, no `.git` in the file tree. That is a deliberate scope choice (see §3): prove the versioning engine is safe and invisible first; build the "restore this version" UX on top of it in V3.
+
+Like V1, this is a **feasibility gate**. V1 asked "can we add a maintainable custom panel?" V2 asks: **can a background service checkpoint the vault reliably — never corrupting or losing data, never surfacing in Zed's git UI, and with a small, rebaseable core diff?** The good news, established during scoping: Zed's core *already* contains the exact primitive we need (§7.1), so V2 is mostly wiring, not new machinery.
+
+## 2. Goals & success criteria
+
+**Primary (the go/no-go):** Prove that an invisible checkpoint service is **safe and maintainable**. Safe = it never corrupts the vault, never destroys user edits, never blocks or slows editing, and never leaks into any git-facing UI. Maintainable = a small, isolated diff that leans on existing upstream checkpoint plumbing and survives a rebase — judged on the *final, real* implementation.
+
+**Secondary (it must actually work):** Every meaningful state of the vault is recoverable. After a day of editing there is a walkable chain of checkpoints covering idle pauses and AI-write boundaries, and a checkpoint can be restored **at the plumbing level** (proven by test), so V3's UI is de-risked before a single button is drawn.
+
+**Definition of done:**
+1. Opening a valid vault with no history → the hidden history repo is initialized and an **initial checkpoint** of current state is recorded — with zero visible side effects (no git-pane entry, no `.git` in the tree, no notification).
+2. Edit notes, then pause → a checkpoint is recorded within the idle-debounce window. (Dev-verifiable via `git --git-dir=<vault>/.breadpaper/history log`.)
+3. Edit continuously without pausing → the **heartbeat** floor still produces at least one checkpoint within the configured interval.
+4. **No-op discipline:** no checkpoint is created when the vault tree is unchanged since the last one (no empty commits, no churn).
+5. A large binary/media file in the vault is **excluded** from the snapshot, and the checkpoint still succeeds.
+6. A vault that is *itself* a user-managed git repo (has its own `.git`) → our history repo **coexists**: the user's `.git`, index, branches, and status are never touched, and Zed's git UI still shows only the user's repo — never ours.
+7. `git` binary unavailable / repo-init failure / write-lock error → editing is completely unaffected; the service disables or retries gracefully and logs once (never a user-facing error, never a partial/corrupt commit).
+8. `restore_checkpoint` works against the history repo, proven by an automated test (no UI ships).
+9. A written **safety & maintainability assessment** (the real deliverable of the spike): does it ever lose data, does it stay out of git_ui, how big is the core diff, and does it rebase cleanly?
+
+## 3. Non-goals (explicitly out of V2)
+
+- **Any restore / undo / time-travel UI.** No history panel, no diff viewer, no "restore this version" command in the palette. This is the single biggest scope cut and it is intentional — the engine is invisible in V2, full stop. (V3.)
+- **Conflict-recovery UX.** V2 assumes single-user, single-machine, single-process editing of a vault. Cross-device sync and merge/conflict handling are a separate, harder project (VISION §9).
+- **Pushing to a remote / cross-device history sync.** The repo is local-only.
+- **Pruning / GC policy UI or retention tuning.** We lean on git's own `--auto` GC (§6.6) and revisit only if growth becomes a real problem.
+- **Removing Zed's git pane** (VISION §6 "Removed"). Orthogonal to this increment; our job is to not *appear* in it, not to delete it.
+- **Versioning large binaries well.** V2 excludes them (§6.5); real large-file/media history is later.
+- **Checkpointing non-vault workspaces.** The service only activates for a recognized vault, exactly like the panel.
+- **Surfacing "pre-AI-write" checkpoints from third-party extensions/MCP.** The trigger is designed-for and wired to any *first-party* write path, but BreadPaper does not yet ship AI rituals (those are extensions — VISION §7.1), so in V2 this trigger is a ready hook, not a guaranteed interception of every AI write. Recorded honestly in §6.2.
+
+## 4. Core concepts
+
+### 4.1 Checkpoint
+A **checkpoint** is a full snapshot of the vault's working tree at a moment in time, stored as a git commit in the hidden history repo. Checkpoints form a **linear chain** (each parented on the previous), so history is walkable for V3. A checkpoint is cheap: git stores only changed blobs, and unchanged snapshots are skipped entirely (§6.4).
+
+### 4.2 The hidden history repo
+Each vault has its own git repository whose **git-dir is `<vault>/.breadpaper/history`** and whose **work-tree is the vault root**. It is a normal git repo in every respect except two, both of which make it invisible:
+
+- **It is not named `.git`.** Zed's worktree scanner registers a repository only when it finds an entry literally named `.git` inside a worktree (`worktree.rs` `DOT_GIT` match, `insert_git_repository`). A git-dir named `history` under the already-hidden `.breadpaper/` directory is therefore **never discovered**, never enters `GitStore.repositories`, and never appears in `git_ui`.
+- **It is fully isolated from any user git.** We drive it with an explicit git-dir + work-tree and our own index, so if the vault *also* has a real `.git`, the two never interact.
+
+`.breadpaper/` is already hidden and already the designated home for "invisible-git state" (VISION §4.4). Keeping history inside the vault means it travels with the vault (copy the folder, keep the history).
+
+### 4.3 Invisible ≠ dangling (a clarifying divergence from Zed's agent checkpoints)
+Zed's existing checkpoint feature keeps commits **dangling** (no ref) specifically so they don't disturb the *user's real repo* that the git UI is watching. Our history repo is a different situation: **nothing is watching it**, because it's never discovered (§4.2). So we don't need danglingness for invisibility — and we actively *don't want* it, because V3 needs a walkable chain. V2 therefore maintains a **real ref that advances** (e.g. `HEAD` on a `checkpoints` branch) with each checkpoint parented on the last. Invisibility comes from **repo isolation**, not from orphaning commits.
+
+## 5. Storage layout & config additions
+
+### 5.1 Layout additions (per vault)
+```
+<vault-root>/
+  .breadpaper/
+    config.toml          # V1 marker + config (gains an optional [history] table)
+    history/             # NEW: the hidden git-dir for this vault's checkpoint repo
+      HEAD, objects/, refs/, ...   # a normal git-dir, just not named .git
+  daily/  templates/  welcome.md   # (V1, unchanged)
+```
+`history/` is created lazily by the service on first activation (§6.1), so **existing V1 vaults are upgraded transparently** on next open — no re-scaffold required.
+
+### 5.2 `config.toml` additions (V2)
+```toml
+[history]
+enabled              = true       # master switch; omit table entirely = same as true
+idle_debounce_seconds = 20        # commit this long after edits stop
+heartbeat_minutes     = 5         # floor: commit if dirty and this long since last checkpoint
+max_file_bytes        = 2000000   # skip blobs larger than this (matches Zed's checkpoint default)
+```
+Every key has a sane default; the feature works with the `[history]` table entirely absent. `[history].enabled = false` fully disables the service for that vault.
+
+## 6. Behavior specification
+
+### 6.1 Activation & first init
+- The service activates **only for a recognized vault** — it reuses V1's `Vault::detect` and observes new `Workspace`/`Project` entities, mirroring how the timeline panel wires up.
+- On activation, if `<vault>/.breadpaper/history` does not exist → `git init` it as a **separate git-dir with work-tree = vault root**, set the author identity to a fixed BreadPaper identity (never the user's git identity), and record an **initial checkpoint** of the current vault state.
+- If it already exists → open it and continue the existing chain.
+- All of this happens on a **background task**; the foreground/editing path is never blocked.
+
+### 6.2 Triggers (conservative / milestone — confirmed)
+A checkpoint is attempted on any of:
+
+| Trigger | Fires when | Rationale |
+|---|---|---|
+| **Idle debounce** | Vault files stopped changing for `idle_debounce_seconds` | The primary trigger; captures a natural "I paused" boundary without a commit-per-keystroke explosion. |
+| **Heartbeat floor** | Vault is dirty **and** `heartbeat_minutes` elapsed since the last checkpoint | Guarantees progress even during long uninterrupted editing (idle never fires). |
+| **Pre-AI-write** | Immediately before a **first-party** AI/skill write to the vault | Guarantees a clean pre-mutation restore point. In V2 this is a **wired hook** (see §3) — active whenever a first-party write path exists; not yet a guarantee over third-party extension writes. |
+| **Workspace close / app quit** | Vault worktree closes or app shuts down, if dirty | Best-effort final safety net; must not delay shutdown (bounded, fire-and-forget). |
+
+Edit detection reuses existing plumbing — either the autosave debounce (`workspace` `AutosaveSetting` / `DelayedDebouncedEditAction`) or `Worktree::observe_updates` on the vault worktree. Checkpoints are **serialized** (a single-flight queue): overlapping triggers coalesce into at most one in-flight checkpoint plus at most one pending.
+
+### 6.3 What a checkpoint captures
+The entire vault working tree, **minus excludes** (§6.5), snapshotted via a **temporary index** so the real/user index is never touched (the pattern Zed's `checkpoint()` already uses: copy-to-temp-index → `add --all` under excludes → `write-tree` → `commit-tree -p <prev>` → advance our ref). Commit messages carry the trigger + timestamp (e.g. `checkpoint: idle 2026-07-21T14:31:07Z`) so V3 can label points meaningfully.
+
+### 6.4 No-op discipline
+Before committing, compare the freshly written tree hash to the last checkpoint's tree. **Identical → do nothing** (no commit, no ref move). This keeps the heartbeat and close triggers from producing empty/duplicate history.
+
+### 6.5 Excludes (what never enters history)
+- **The history git-dir itself** (`.breadpaper/history/**`) — mandatory, or the repo snapshots its own objects and grows without bound.
+- **Any user `.git`** present in the vault.
+- **Large blobs** ≥ `max_file_bytes` (default 2 MB) — the vault is known to hold multi-MB images (VISION §9); they're skipped so history stays lean and fast.
+- The **binary/media/DB/IDE exclude set** Zed already ships for checkpoints (`crates/git/src/checkpoint.gitignore`) is reused as the baseline.
+
+Exclusion is best-effort and never fatal: an over-large or binary file simply isn't in the snapshot; the checkpoint of everything else still succeeds.
+
+### 6.6 Repo growth / GC
+Rely on git's built-in `gc --auto` semantics (invoked opportunistically off the background task, never on the editing path). Explicit retention/pruning policy is a non-goal (§3); revisit only if real-world growth demands it. Record observed growth in the assessment.
+
+### 6.7 Failure modes (never surface to the user, never corrupt)
+| Condition | Behavior |
+|---|---|
+| `git` binary missing/unusable | Disable the service for the session; log **once**; editing fully unaffected. |
+| `history/` init fails (permissions, disk) | Disable for that vault; log once; no retry storm. |
+| A single checkpoint fails (lock, transient I/O) | Log at debug; **leave prior history intact**; retry on the next trigger. Never leave a half-written ref/index. |
+| Vault becomes non-vault / worktree closes | Tear down the task cleanly. |
+| Disk full | Skip the checkpoint; never partially write; surface nothing (editing must not break). |
+
+Invariant: **a checkpoint failure can never damage the vault or existing history.** Because commits are content-addressed and the ref only advances after a successful `commit-tree`, a crash mid-checkpoint leaves the previous checkpoint as the head.
+
+## 7. Implementation notes (for engineering)
+
+### 7.1 Reuse the existing checkpoint primitive — this is the maintainability win
+Zed core already implements exactly the mechanism we need, currently used only by the agent:
+- `GitRepository::checkpoint()` / `restore_checkpoint()` / `compare_checkpoints()` (`crates/git/src/repository.rs`), implemented in `RealGitRepository` via a **temp index** (`with_temp_index`, `GIT_INDEX_FILE`), runtime excludes (`checkpoint.gitignore` + the ≥2 MB rule), then `add --all` → `write-tree` → `commit-tree -p HEAD`. Author is forced via `checkpoint_author_envs()`.
+
+Prefer to **drive this existing plumbing** against our isolated repo rather than re-implement git access. Zed shells out to the `git` binary through `GitBinary`/`RealGitRepository`; there is currently **no `GIT_DIR`/`GIT_WORK_TREE` env plumbing** (commands are scoped by `current_dir` + `GIT_INDEX_FILE`). Two viable paths, pick the smaller-diff one at implementation time:
+  - **(a)** Construct a `RealGitRepository` pointed at `.breadpaper/history` (via `Fs::git_init` / `Fs::open_repo`) and adapt the checkpoint calls to advance a ref instead of dangling. Keeps everything in existing code paths.
+  - **(b)** Add a minimal `GIT_DIR`/`GIT_WORK_TREE` injection to `GitBinary::build_command` and reuse the checkpoint methods verbatim. Slightly more invasive upstream, but tiny and general.
+
+Either way, the **feature logic lives in the `breadpaper` crate** (a new self-contained module alongside `vault.rs` / `notes.rs` / `timeline_panel.rs`), keeping the upstream delta to registration + at most a small, general git-dir plumbing addition — the V1 pattern where "each new capability costs a few upstream lines."
+
+### 7.2 Registration
+Initialize alongside V1: a `breadpaper::history::init(cx)` next to `breadpaper::init(cx)` (`crates/zed/src/main.rs` ~line 744), and/or per-workspace wiring in `crates/zed/src/zed.rs` where vault detection and `show_panel_if_vault` already live. The service observes new `Workspace`/`Project` entities, detects a vault, and spawns a background checkpoint task per valid vault worktree (multiple open vaults → independent tasks/repos).
+
+### 7.3 Use the `Fs` trait, not `std::fs`
+The V1 maintainability assessment explicitly flagged that invisible-git "will want the `Fs` trait's atomic writes anyway." Any metadata BreadPaper writes itself (e.g. a small last-checkpoint marker, if needed) should go through Zed's `Fs` trait for atomicity, rather than V1's `std::fs` shortcut.
+
+### 7.4 Threading & safety
+All git work runs on `cx.background_spawn`. Never touch a real index (temp index only). Serialize checkpoints per vault (single-flight + coalesce). The ref advances **only** after a successful `commit-tree`, guaranteeing crash-safety (§6.7 invariant).
+
+### 7.5 No panel, no priority
+V2 adds **no** dock panel, so it consumes no `activation_priority` (the next BreadPaper panel still starts at 8 per the V1 assessment). There is no keybinding and no menu item — that's the point.
+
+### 7.6 The deliverable
+As in V1, the spike's real output includes the **safety & maintainability writeup** (§2): upstream files touched, whether it rebases cleanly, whether it ever loses data across the tested trigger matrix, and confirmation via `git_ui` inspection that the history repo is never discovered.
+
+## 8. Open assumptions to confirm on review
+
+1. **Repo location** = `<vault>/.breadpaper/history` (in-vault, travels with the folder), vs. an external store like `~/.local/share/breadpaper/checkpoints/<vault-hash>/` (keeps the vault directory pristine, but history doesn't travel). Spec assumes **in-vault**, per VISION §4.4.
+2. **Trigger defaults** — `idle_debounce_seconds = 20`, `heartbeat_minutes = 5`. Acceptable, or tune?
+3. **`max_file_bytes = 2 MB`** (matches Zed's default). The author's vault holds multi-MB images by design — confirm we're comfortable that those images are **not** versioned in V2.
+4. **Pre-AI-write trigger status** — V2 wires the hook but ships no first-party AI writes (§3, §6.2). Confirm that "designed-for, not yet guaranteed over extension writes" is acceptable for this increment.
+5. **Restore proof** — V2 proves `restore_checkpoint` via an automated test only, with **no** user-facing command. Confirm no hidden/debug restore affordance is wanted (even behind a flag).
+6. **GC** — relying on git `--auto` with no explicit retention policy (§6.6). Acceptable for V2?
+
+## 9. Decision log (from design interview, 2026-07-21)
+
+- V2 = **engine only, zero user-facing surface**; restore/time-travel deferred to V3. "Invisible to users" taken literally for this increment.
+- Triggers = **conservative / milestone**: idle-debounce + heartbeat floor + pre-AI-write (designed) + best-effort close/quit. No commit-per-save.
+- History lives in a **per-vault hidden repo** at `.breadpaper/history` (git-dir not named `.git`), **invisible via non-discovery**, isolated from any user `.git`.
+- **Invisible ≠ dangling**: unlike Zed's agent checkpoints, we keep a **real advancing ref** so history is walkable for V3; invisibility comes from repo isolation.
+- **Reuse Zed's existing checkpoint plumbing** (`RealGitRepository::checkpoint`/`restore_checkpoint`, temp-index + `commit-tree`) — the reason V2 is mostly wiring, not new machinery. Feature logic stays in a self-contained `breadpaper` module; upstream delta stays small and rebaseable.
+- **No-op discipline** (skip unchanged trees) and the **crash-safe "ref advances only on success"** invariant are load-bearing safety requirements, not optimizations.
+- Large binaries are **excluded, not versioned**, in V2.
+- Safety **and** maintainability writeup is the go/no-go deliverable, as in V1.

--- a/breadpaper/specs/v3-areas.md
+++ b/breadpaper/specs/v3-areas.md
@@ -1,0 +1,294 @@
+# BreadPaper V3 — Areas (modular life-domain packages)
+
+**Status:** Scope-locked from design interview (2026-07-21), ready for implementation
+**Owner:** Diego · **Date:** 2026-07-21
+**Companion docs:** `../VISION.md` (§4.6 Modular life, §5.2 Areas rail, §5.4 Skills, §7.2 Areas-as-packages), `v1-daily-panel.md` (vault model this builds on)
+
+---
+
+## 1. Summary
+
+V3 introduces **Areas** — the modular primitive at the heart of the product. An Area is an installable bundle that helps organize one domain of a person's life (finance, journaling, note-taking, weekly rhythm). Each Area packages **folders, templates, files, skills, and an explainer doc**, and can be **added or removed at any time** without touching the user's own notes.
+
+This version delivers three things:
+
+1. **The Area package format** — a declarative `manifest.toml` bundle, an app-shipped **catalog** of Areas, and the **materialization** flow that writes an Area's editable files into the vault and registers it in the vault config.
+2. **An "Areas" section** added to the existing BreadPaper dock panel (below the Timeline navigator). Each enabled Area is an entry; clicking it opens the Area's explainer doc **in viewing (rendered) mode**. Under each Area, its **skills** are listed as clickable entries — a first, basic Skills view.
+3. **The Timeline Area** — the first Area, shipped **pre-activated** in the sample vault. It is *additive*: it layers the **Week Review** skill and the **weekly progress dashboard** on top of the already-core Timeline navigator and daily/weekly note creation.
+
+This realizes VISION Milestone 2 ("Areas & Skills framework") in its first concrete, end-to-end slice, while deferring the full skill-contract write-sandbox (still M2) and the page-aware Context right rail (M3).
+
+## 2. Goals & success criteria
+
+**Primary:** Prove the Area primitive end-to-end — that a life-domain can be **packaged, installed into a vault, surfaced in the panel, and removed** — using a single real Area (Timeline) as the proof, while keeping the fork's core diff small (a new section in the existing panel, not a new dock panel).
+
+**Secondary:** A user can see the Areas they have, read what each one is for and what it can do (its explainer + skill list), reach a skill in one click, and add or remove an Area without fear of losing their writing.
+
+**Definition of done:**
+1. The sample vault scaffolds with the **Timeline Area pre-installed and enabled**, registered in `.breadpaper/config.toml`, with its files materialized on disk.
+2. The BreadPaper left-dock panel shows an **"Areas"** section listing each enabled Area beneath the existing Timeline navigator.
+3. Clicking an Area entry opens its explainer doc (e.g. `areas/Timeline.md`) **rendered in viewing mode**, not as a raw editable buffer.
+4. Each Area entry expands to list its **skills**; clicking a skill opens the skill file in viewing mode (its plain-language description + body).
+5. Clicking the Timeline Area's **dashboard** surface opens the weekly progress page (`_weekly/site/index.html`).
+6. An **Add Area** affordance lists catalog Areas not yet installed and, on add, materializes the Area's files and registers it — the new entry appears in the Areas section without a restart.
+7. A **Remove Area** action **prompts** the user to choose between *deactivate (keep all files)* and *deactivate and delete the Area's shipped files* — and the destructive path **never** deletes user-authored notes (`_daily/`, `_weekly/` note content).
+8. Removing the Timeline Area does **not** break the Timeline navigator or daily/weekly note creation (they are core, not Area-owned).
+
+## 3. Non-goals (explicitly out of V3)
+
+- **A second real Area** (Finance, Journaling, Team). V3 ships the format + one Area (Timeline). Others are catalog stubs at most.
+- **The full skill contract & write sandbox** — enforced, previewable, dry-run read/write scopes (VISION M2). V3 *declares* a skill's `reads`/`writes` in the manifest (so the explainer can show scope and M2 can enforce it) but does **not** sandbox execution.
+- **One-click skill *execution*.** Clicking a skill opens it for viewing. Actually *running* it through the user's LLM/agent depends on the BYO-LLM agent rails (VISION M1, not yet built); wiring "Run" to the agent panel is a flagged stretch (§6.4), not a committed deliverable.
+- **The page-aware Context right rail** (day-planner / week calendar / finance dashboard per open doc) — VISION M3.
+- **A polished Area gallery** — browsing, search, screenshots, versions/updates. V3's "Add Area" is a minimal list of installable catalog Areas.
+- **In-app rendering of the dashboard HTML.** Zed has no web view; the dashboard opens in the system browser (§7.4).
+- **Backfilling the author's real vault** into the Area layout. V3 targets the fresh sample vault.
+
+## 4. Core concepts
+
+### 4.1 Area
+An **Area** is a bundle that organizes one domain of a user's life. It contributes some or all of: **folders** (scaffolded into the vault), **templates**, **static files** (e.g. a dashboard), **skills** (LLM rituals), and a required **explainer doc**. Areas are **opt-in and independent** (VISION principle 6, "Modular life") — a user can run only Timeline, or add more.
+
+> **Naming note (open):** "Areas" is the VISION-committed working name but collides with two things — the PARA `02 - areas/` folder in the author's real vault (areas of *responsibility*, a different meaning) and the "Timeline" navigator section vs. the "Timeline" *Area* (same word, two panel elements). Flagged in §9; not re-decided here.
+
+### 4.2 Catalog vs. installed (the delivery model)
+- **Catalog** — a set of Areas that **ships inside the BreadPaper binary**. This is the source the "Add Area" list reads from, and the future gallery.
+- **Installed** — when an Area is added to a vault, BreadPaper **materializes** it: copies the Area's editable parts (manifest, skills, explainer doc, dashboard/static files) as **real files into the vault**, scaffolds its folders (create-if-missing, never clobbering), and **registers** it in `.breadpaper/config.toml`.
+
+Materialization is what honors two VISION principles at once: **"Everything is editable"** (once installed, an Area's skills and templates are ordinary files the user or their LLM can open and change) and **"Your files, forever"** (the vault is self-describing and complete on disk; if BreadPaper vanished, the Area's files still open in any editor).
+
+### 4.3 The Areas section
+Not a new dock panel — a **new section inside the existing BreadPaper panel**, below the Timeline navigator. This keeps the fork surface tiny (no new `activation_priority`, no new `add_panel_when_ready` wiring) and matches the request ("a new header added to the BreadPaper pane for Areas").
+
+### 4.4 Viewing mode
+An Area's explainer doc and its skill files open **rendered** (Zed's markdown preview), not as raw editable buffers — the user is *reading about* the Area, not editing it. Zed has no one-shot "open path as preview" call, so this is a two-step (§7.3).
+
+### 4.5 Skills view (basic)
+The Skills view in V3 is the **expandable skill list under each Area entry** in the panel. Each skill shows its name; clicking opens the skill file in viewing mode. This is the minimum inspectable surface for rituals; the rich editable Skills view with enforced scope is deferred (M2).
+
+## 5. The Area package format
+
+### 5.1 Catalog package layout (shipped in the app)
+Each catalog Area is a directory of source assets compiled into / bundled with the binary:
+
+```
+<area-id>/
+  manifest.toml          # the declarative spec (below)
+  doc.md                 # explainer, materialized to the vault's areas/<Name>.md
+  skills/
+    <skill-id>.md        # one file per skill
+  assets/                # optional static files (e.g. dashboard html/js seed)
+    ...
+```
+
+### 5.2 `manifest.toml` schema
+The declarative bundle spec — VISION open-question Q2, answered here:
+
+```toml
+schema  = 1
+id      = "timeline"                 # stable slug; the config registry key
+name    = "Timeline"                 # display name in the Areas section
+version = 1                          # bumped when the catalog package changes
+summary = "Daily & weekly rhythm — weekly review and a progress dashboard."
+doc     = "areas/Timeline.md"        # vault-relative path the explainer is materialized to
+
+# Folders/files created in the vault on install. create-if-missing; never clobber.
+[[scaffold]]
+kind = "dir"
+path = "_weekly/site"
+
+[[scaffold]]
+kind   = "file"
+path   = "_weekly/site/index.html"   # vault-relative destination
+source = "assets/index.html"         # path within the catalog package
+
+[[scaffold]]
+kind   = "file"
+path   = "_weekly/site/data.js"
+source = "assets/data.seed.js"       # seed feed; the skill appends to it thereafter
+
+# Skills the Area contributes. Materialized to `file`; listed in the panel + explainer.
+[[skill]]
+id      = "week-review"
+name    = "Week Review"
+file    = "skills/timeline/week-review.md"   # vault-relative destination
+summary = "Aggregate the week's notes + PRs/MRs, append a review, feed the dashboard."
+reads   = ["_daily/**", "_weekly/**", "mcp:github", "mcp:gitlab"]   # declared; not yet enforced
+writes  = ["_weekly/<week>.md (append)", "_weekly/site/data.js (append)"]
+
+# Non-skill surfaces the Area exposes in the panel (e.g. a dashboard to open).
+[[surface]]
+kind = "dashboard"
+name = "Weekly Dashboard"
+open = "_weekly/site/index.html"     # opened in the system browser (§7.4)
+```
+
+Rules:
+- All paths are **vault-relative** except `source`/`file`-within-catalog inputs.
+- `scaffold` is **idempotent and non-destructive** — reuses `vault.rs`'s existing `write_if_missing` discipline; re-installing or scaffolding over a populated folder is safe.
+- `reads`/`writes` on a skill are **declarations only** in V3 — surfaced in the explainer and the (future) skill contract, not enforced.
+
+### 5.3 Installed layout in the vault
+After installing Timeline, the vault contains:
+
+```
+<vault-root>/
+  .breadpaper/
+    config.toml                    # + [areas] registry (§5.4)
+    areas/
+      timeline/
+        manifest.toml              # installed copy (records version + what it owns)
+  areas/
+    Timeline.md                    # explainer doc (opened in viewing mode)
+  skills/
+    timeline/
+      week-review.md               # the Week Review skill
+  _weekly/
+    site/
+      index.html                   # dashboard viewer
+      data.js                      # dashboard feed (appended to by the skill)
+```
+
+The installed `manifest.toml` is the **provenance record**: it lists exactly the files the Area owns, which drives removal (§6.6) and the modified-since-install check.
+
+### 5.4 Config registry (`.breadpaper/config.toml`)
+Extends the existing `VaultConfig` (which today parses `schema`, `[daily]`, `[weekly]`, `[history]`) with an `[[areas.installed]]` array. Display order in the panel = array order.
+
+```toml
+schema = 1
+
+[daily]  # …unchanged…
+[weekly] # …unchanged…
+
+[[areas.installed]]
+id      = "timeline"
+enabled = true
+version = 1            # the installed package version (for future update detection)
+```
+
+Parsing mirrors the existing `*Content` → `resolve()` pattern in `vault.rs` (all fields defaulted, `deny_unknown_fields`), so a vault with no `[[areas.installed]]` simply has an empty Areas section. A registered-but-`enabled = false` Area stays materialized on disk but is hidden from the panel and its skills are not surfaced.
+
+## 6. Behavior specification
+
+### 6.1 The panel gains an Areas section
+- The existing BreadPaper panel (`TimelinePanel`, left dock) renders, **below** the Timeline navigator entries, an **"Areas"** header followed by one row per **enabled** installed Area (registry order).
+- If no Areas are enabled, the section shows a gentle empty state with the **Add Area** affordance (§6.5).
+- When the workspace is not a vault, the whole panel already shows the non-vault state (unchanged from V1); the Areas section does not render.
+- **Rename consideration:** with two sections in one panel, the panel's persistent name/title stays "BreadPaper"; the two sections are labeled "Timeline" and "Areas" (see the §9 naming flag for the Timeline/Timeline clash).
+
+### 6.2 Rendering the Areas tree
+Each Area row is expandable. Expanded, it shows:
+- Its **skills** (`[[skill]]` entries) as clickable rows, each showing the skill `name`.
+- Its **surfaces** (`[[surface]]`), e.g. the Timeline Area's "Weekly Dashboard" row.
+- The Area's own label click target = **open the explainer doc in viewing mode** (§6.3).
+
+### 6.3 Opening an Area doc in viewing mode
+Clicking an Area's name opens its `doc` (e.g. `areas/Timeline.md`) **rendered**:
+1. Open the file as an editor via the existing `workspace.open_abs_path(path, OpenOptions { visible: Some(OpenVisible::All), .. }, …)` pattern (as `open_note` already does).
+2. Convert/replace it into a markdown **preview** item (§7.3), so the user lands on the rendered doc.
+
+Same mechanism is used to open a **skill file** in viewing mode (§6.4).
+
+### 6.4 The Skills view (basic)
+- Clicking a skill row opens the **skill file in viewing mode** — the user reads the skill's plain-language description and body (what it reads, what it writes, what it does).
+- **Stretch (flagged, not committed):** a "Run" affordance on a skill row that dispatches the skill to the user's LLM/agent (Zed's agent panel). This depends on the BYO-LLM connection (VISION M1) not yet built; ship the view without it and add Run when the agent rails land. Do **not** fake execution.
+
+### 6.5 Adding an Area
+- An **Add Area** affordance (a `[+ Add Area]` row at the bottom of the Areas section) lists **catalog Areas not already installed** in this vault.
+- On selecting one, BreadPaper **materializes** it (all on a background thread, mirroring `ensure_note`):
+  1. For each `[[scaffold]]`: create dirs / write files **if missing** (never clobber).
+  2. Copy the explainer `doc` and each skill `file` into the vault.
+  3. Write the installed `manifest.toml` copy under `.breadpaper/areas/<id>/`.
+  4. Append `[[areas.installed]]` to `config.toml` with `enabled = true`.
+- The Areas section refreshes and shows the new Area **without a restart** (the panel already re-runs `refresh_vault_status` on worktree/entry changes; installation triggers the same refresh).
+- If the Area is already registered but disabled, "Add" just flips `enabled = true` (no re-copy) unless files are missing, in which case missing files are re-materialized.
+
+### 6.6 Removing an Area (prompt on removal)
+Removal always **asks** (the user's chosen model). A confirmation dialog offers two paths:
+
+| Choice | Effect |
+|---|---|
+| **Deactivate (keep all files)** | Set `enabled = false` in the registry, drop the Areas-panel entry, stop surfacing its skills. **Nothing on disk is deleted.** Fully reversible via Add. |
+| **Deactivate and delete Area files** | Also delete the files the installed `manifest.toml` records as Area-owned — the explainer doc, skill files, and scaffolded static assets (e.g. `_weekly/site/`). |
+
+Guardrails on the destructive path:
+- **User notes are never deleted.** Only files the Area *shipped* (recorded in its installed manifest) are candidates. `_daily/` and `_weekly/` **note files** authored by the user are out of scope by construction — the Timeline Area owns `_weekly/site/*` and `skills/timeline/*`, not the weekly `.md` notes.
+- **Modified-since-install files are preserved, not deleted.** Before deleting a shipped file, compare it against the catalog source (hash/content). If it differs (the user or their LLM edited it), **keep it** and report it in the result ("kept 1 modified file: `skills/timeline/week-review.md`"). This protects the "everything is editable" edits from silent loss.
+- The dialog **lists exactly what will be deleted** before confirming.
+- Either way, the `[[areas.installed]]` entry is removed from (or disabled in) the registry so the panel no longer shows it.
+
+### 6.7 Config registry read/write
+- Read: extend `VaultConfig` parsing with the `areas` table; absent → empty.
+- Write: install/enable/disable/remove edit `config.toml` in place. Preserve the rest of the file (round-trip the parsed document, or re-serialize the known schema — V3 may re-serialize the full known config; flagged in §9 if comment-preservation matters).
+
+### 6.8 Failure modes
+| Condition | Behavior |
+|---|---|
+| Catalog Area id unknown at Add time | Non-blocking error toast; nothing written. |
+| A scaffold destination already exists | Skip it (create-if-missing); not an error. |
+| Explainer/skill file missing at open time | Non-blocking toast; offer to re-materialize the Area. |
+| `config.toml` write/permission error during install | Roll back: do not leave a half-registered Area; surface a toast (per CLAUDE.md, errors propagate to the UI). |
+| Dashboard `open` target missing | Toast; offer to re-materialize. |
+| Remove: a shipped file was modified since install | Preserve it, report it (§6.6), continue. |
+
+## 7. The Timeline Area (the first, pre-activated Area)
+
+The Timeline Area is **additive** — the Timeline navigator and daily/weekly create-if-missing stay core and always-on. The Area contributes only the **Week Review skill**, the **weekly dashboard**, and the **explainer doc**.
+
+### 7.1 Manifest (catalog)
+As in §5.2 (`id = "timeline"`), with one skill (`week-review`), a `dashboard` surface, and scaffold entries for `_weekly/site/index.html` + `_weekly/site/data.js`.
+
+### 7.2 The Week Review skill (`skills/timeline/week-review.md`)
+Ported from the author's working `.claude/commands/week-review.md` (reference vault). Its behavior, verbatim in intent:
+- Reviews **Mon–Sun of the prior week**; locates the weekly file by listing `_weekly/` (naming is `YYYY_WW_Mon.md`, **not** ISO week number — an explicit trap called out in the source skill).
+- Reads the week's daily notes; folds in `# Week Goals` / `# Tentative` / `# Personal`.
+- Collects GitHub PRs (`gh search prs …`) and GitLab MRs (`glab api …`, host `gitlab.spimageworks.com`), dedups.
+- Groups work by project, sets the `goal` flag, picks 2–3 highlights.
+- **Appends** (never overwrites) a `# AI Week Review` section to the weekly `.md`.
+- **Appends one week object** to `window.WEEKS` in `_weekly/site/data.js` (schema fixed by the dashboard), then verifies the file still parses.
+
+Its manifest `writes` declaration (`_weekly/<week>.md (append)`, `_weekly/site/data.js (append)`) and `reads` (`_daily/**`, `_weekly/**`, `mcp:github`, `mcp:gitlab`) mirror this exactly — the append-only, augmentation-not-replacement contract (VISION principle 2).
+
+### 7.3 The dashboard
+- `_weekly/site/index.html` — the self-computing static viewer (reads `window.WEEKS`, derives stats, sparklines, lingering-project and carried-over-goal warnings). Shipped as an asset; **not** regenerated by BreadPaper.
+- `_weekly/site/data.js` — seeded with an empty (or single-example) `window.WEEKS` array on install; the Week Review skill appends to it each week. This is the reference implementation of VISION's "dashboards as an output type" (§7.2) — *structured feed → static HTML that computes its own analytics.*
+- Exposed as a `dashboard` surface row in the panel; clicking it opens `index.html` in the system browser (§7.4).
+
+### 7.4 The explainer doc (`areas/Timeline.md`)
+The doc opened in viewing mode when the Area is clicked. Content outline (to be drafted, kept short and plain-language):
+- **What the Timeline Area is for** — closing the loop on your daily/weekly rhythm; turning a week of notes + code activity into a reviewed, visualized record.
+- **What it adds** — the Week Review skill and the weekly progress dashboard (the daily/weekly navigator itself is always-on, not part of this Area).
+- **Skills available** — *Week Review*: what it reads (daily notes, GitHub/GitLab), what it writes (appends to the weekly note + the dashboard feed), append-only and safe.
+- **The dashboard** — how to open it, what its warnings mean (time-sinks, lingering projects, carried-over goals).
+- **How to run a review / where the files live** — pointers to `skills/timeline/week-review.md` and `_weekly/site/`.
+
+## 8. Implementation notes (for engineering)
+
+- **Keep it a section, not a panel.** Extend `TimelinePanel`'s render to add the Areas section; reuse its existing `refresh_vault_status` / subscription plumbing. No new `activation_priority` (Timeline holds 4; 0–3 and 5–7 are upstream), no new `add_panel_when_ready` wiring. This keeps the core diff small and rebase-friendly (VISION §7.1 mandate).
+- **Isolate Area logic in the `breadpaper` crate.** Add an `areas` module (`crates/breadpaper/src/areas.rs`) owning: the manifest schema (serde/`toml`), the catalog registry (app-shipped source), materialize/uninstall, and the modified-since-install diff. The panel calls into it; the delta against Zed's own files stays minimal.
+- **Config parsing** reuses the `vault.rs` `*Content` → `resolve()` pattern; add `AreasConfigContent` + a resolved `AreasConfig { installed: Vec<InstalledArea> }`.
+- **Viewing mode is a two-step** — there is **no** one-shot "open path as preview" API. To open rendered: `workspace.open_abs_path(...)` to get the markdown `Editor`, then build a preview via the core `markdown_preview` crate (`MarkdownPreviewView::create_markdown_view` / `open_preview_in_pane`, `MarkdownPreviewMode::Default`), or dispatch the existing `zed_actions::preview::markdown::OpenPreview` action against the just-opened editor. `markdown_preview` is already a core crate — no new dependency. **Add a small helper** `open_abs_path_as_preview(...)` in the breadpaper crate and use it for both Area docs and skill files. _(Confirm the exact preview entry point on review — §9.)_
+- **Materialization runs on a background thread** (mirror `ensure_note`'s `cx.background_spawn`); it is blocking file I/O. Errors propagate to a UI toast (CLAUDE.md: never silently discard; surface to the user).
+- **Extend `scaffold_vault`** (`vault.rs`) so the sample vault installs the Timeline Area at creation time: write the installed manifest, the explainer doc, the skill file, the dashboard assets, and the `[[areas.installed]]` registry entry. The Timeline catalog assets become bundled resources of the `breadpaper` crate.
+- **No `let _ =`, no `unwrap()`** on the fallible file/config operations (CLAUDE.md); propagate with `?` and surface failures.
+- **Catalog assets** (index.html, data.seed.js, skill markdown, explainer): decide how they ship — `include_str!`/`include_dir!` bundled into the crate vs. an on-disk resources dir. `include_*` keeps the binary self-contained; flagged in §9.
+
+## 9. Open assumptions to confirm on review
+
+1. **Naming collision.** "Timeline" names both the navigator section and the first Area; "Areas" collides with PARA `02 - areas/`. Options: rename the Area to "Daily & Weekly" (per VISION M1) while keeping the nav section "Timeline," or keep both "Timeline" and disambiguate by placement. Recommend renaming the *Area* to avoid the in-panel clash.
+2. **Preview entry point.** Which `markdown_preview` call to standardize on for "open as viewing mode" (independent preview tab vs. replace-in-place vs. to-the-side). Recommend an independent, focused preview tab (`MarkdownPreviewMode::Default`).
+3. **Catalog asset packaging** — `include_dir!` bundled vs. on-disk resources (§8).
+4. **`config.toml` round-tripping** — is re-serializing the known schema acceptable (may drop user comments in the config), or must we preserve the raw document?
+5. **Add Area surface** — a simple in-panel list vs. a modal picker for the (currently one-item) catalog.
+6. **`skills/` location** — top-level `skills/<area>/` (proposed) vs. under `.breadpaper/` vs. the reference vault's `.claude/commands/`. Proposed top-level so skills are visible and editable in the file tree.
+7. **Dashboard open target** — always the system browser (§7.4), acceptable given no in-app web view?
+8. **Explainer doc filename** — `areas/Timeline.md` (title-cased, human) vs. `.breadpaper/areas/timeline/doc.md` (hidden). Proposed the visible, human-named path.
+
+## 10. Decision log (from design interview, 2026-07-21)
+
+- **Package model:** app-shipped **catalog → materialize into the vault** on install; installed Areas are real, editable files + a `config.toml` registry entry. Honors "everything is editable" + "your files, forever."
+- **Removal:** **prompt on removal** — choose *deactivate (keep all files)* or *deactivate + delete Area-shipped files*; user notes are never deletable; modified-since-install files are preserved and reported.
+- **Timeline Area scope:** **additive** — the navigator + daily/weekly creation stay core; the Area adds only the Week Review skill + the weekly dashboard + the explainer doc. Removing it can't break navigation.
+- **Skills:** include a **basic Skills view now** — skills listed under each Area, clicking opens the skill file in viewing mode. Rich editable Skills view + enforced read/write scope stay M2. Actual skill *execution* ("Run") deferred to the BYO-LLM rails.
+- **Surface:** Areas are a **new section in the existing BreadPaper panel**, not a new dock panel (small fork surface, no new activation priority).
+- **Viewing mode:** Area docs + skill files open **rendered** (markdown preview), via a two-step open-then-preview helper.

--- a/breadpaper/specs/v3-areas.md
+++ b/breadpaper/specs/v3-areas.md
@@ -31,7 +31,7 @@ This realizes VISION Milestone 2 ("Areas & Skills framework") in its first concr
 4. Each Area entry expands to list its **skills**; clicking a skill opens the skill file in viewing mode (its plain-language description + body).
 5. Clicking the Timeline Area's **dashboard** surface opens the weekly progress page (`_weekly/site/index.html`).
 6. An **Add Area** affordance lists catalog Areas not yet installed and, on add, materializes the Area's files and registers it — the new entry appears in the Areas section without a restart.
-7. A **Remove Area** action **prompts** the user to choose between *deactivate (keep all files)* and *deactivate and delete the Area's shipped files* — and the destructive path **never** deletes user-authored notes (`_daily/`, `_weekly/` note content).
+7. A **Remove Area** action **prompts** the user to choose between *deactivate (keep all files)* and *deactivate and delete the Area's shipped files* — and the destructive path **never** deletes user-authored notes (`daily/`, `weekly/` note content).
 8. Removing the Timeline Area does **not** break the Timeline navigator or daily/weekly note creation (they are core, not Area-owned).
 
 ## 3. Non-goals (explicitly out of V3)
@@ -113,8 +113,8 @@ id      = "week-review"
 name    = "Week Review"
 file    = "skills/timeline/week-review.md"   # vault-relative destination
 summary = "Aggregate the week's notes + PRs/MRs, append a review, feed the dashboard."
-reads   = ["_daily/**", "_weekly/**", "mcp:github", "mcp:gitlab"]   # declared; not yet enforced
-writes  = ["_weekly/<week>.md (append)", "_weekly/site/data.js (append)"]
+reads   = ["daily/**", "weekly/**", "mcp:github", "mcp:gitlab"]   # declared; not yet enforced
+writes  = ["weekly/<week>.md (append)", "_weekly/site/data.js (append)"]
 
 # Non-skill surfaces the Area exposes in the panel (e.g. a dashboard to open).
 [[surface]]
@@ -212,7 +212,7 @@ Removal always **asks** (the user's chosen model). A confirmation dialog offers 
 | **Deactivate and delete Area files** | Also delete the files the installed `manifest.toml` records as Area-owned — the explainer doc, skill files, and scaffolded static assets (e.g. `_weekly/site/`). |
 
 Guardrails on the destructive path:
-- **User notes are never deleted.** Only files the Area *shipped* (recorded in its installed manifest) are candidates. `_daily/` and `_weekly/` **note files** authored by the user are out of scope by construction — the Timeline Area owns `_weekly/site/*` and `skills/timeline/*`, not the weekly `.md` notes.
+- **User notes are never deleted.** Only files the Area *shipped* (recorded in its installed manifest) are candidates. `daily/` and `weekly/` **note files** authored by the user are out of scope by construction — the Timeline Area owns `_weekly/site/*` and `skills/timeline/*`, not the weekly `.md` notes.
 - **Modified-since-install files are preserved, not deleted.** Before deleting a shipped file, compare it against the catalog source (hash/content). If it differs (the user or their LLM edited it), **keep it** and report it in the result ("kept 1 modified file: `skills/timeline/week-review.md`"). This protects the "everything is editable" edits from silent loss.
 - The dialog **lists exactly what will be deleted** before confirming.
 - Either way, the `[[areas.installed]]` entry is removed from (or disabled in) the registry so the panel no longer shows it.
@@ -240,14 +240,14 @@ As in §5.2 (`id = "timeline"`), with one skill (`week-review`), a `dashboard` s
 
 ### 7.2 The Week Review skill (`skills/timeline/week-review.md`)
 Ported from the author's working `.claude/commands/week-review.md` (reference vault). Its behavior, verbatim in intent:
-- Reviews **Mon–Sun of the prior week**; locates the weekly file by listing `_weekly/` (naming is `YYYY_WW_Mon.md`, **not** ISO week number — an explicit trap called out in the source skill).
-- Reads the week's daily notes; folds in `# Week Goals` / `# Tentative` / `# Personal`.
+- Reviews **Mon–Sun of the prior week**; locates the weekly file in `weekly/` by ISO week (`YYYY-Www.md`, e.g. `2026-W30.md`), computed from the week's Monday — realigned from the reference vault's `_weekly/YYYY_WW_Mon.md` to the layout the Area actually scaffolds.
+- Reads the week's daily notes from `daily/` (`YYYY-MM-DD.md`); folds in `# Week Goals` / `# Tentative` / `# Personal`.
 - Collects GitHub PRs (`gh search prs …`) and GitLab MRs (`glab api …`, host `gitlab.spimageworks.com`), dedups.
 - Groups work by project, sets the `goal` flag, picks 2–3 highlights.
 - **Appends** (never overwrites) a `# AI Week Review` section to the weekly `.md`.
 - **Appends one week object** to `window.WEEKS` in `_weekly/site/data.js` (schema fixed by the dashboard), then verifies the file still parses.
 
-Its manifest `writes` declaration (`_weekly/<week>.md (append)`, `_weekly/site/data.js (append)`) and `reads` (`_daily/**`, `_weekly/**`, `mcp:github`, `mcp:gitlab`) mirror this exactly — the append-only, augmentation-not-replacement contract (VISION principle 2).
+Its manifest `writes` declaration (`weekly/<week>.md (append)`, `_weekly/site/data.js (append)`) and `reads` (`daily/**`, `weekly/**`, `mcp:github`, `mcp:gitlab`) mirror this exactly — the append-only, augmentation-not-replacement contract (VISION principle 2).
 
 ### 7.3 The dashboard
 - `_weekly/site/index.html` — the self-computing static viewer (reads `window.WEEKS`, derives stats, sparklines, lingering-project and carried-over-goal warnings). Shipped as an asset; **not** regenerated by BreadPaper.

--- a/crates/breadpaper/Cargo.toml
+++ b/crates/breadpaper/Cargo.toml
@@ -15,10 +15,12 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
+editor.workspace = true
 fs.workspace = true
 git.workspace = true
 gpui.workspace = true
 log.workspace = true
+markdown_preview.workspace = true
 menu.workspace = true
 project.workspace = true
 serde.workspace = true

--- a/crates/breadpaper/Cargo.toml
+++ b/crates/breadpaper/Cargo.toml
@@ -15,6 +15,8 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
+fs.workspace = true
+git.workspace = true
 gpui.workspace = true
 log.workspace = true
 menu.workspace = true
@@ -23,6 +25,7 @@ serde.workspace = true
 toml.workspace = true
 ui.workspace = true
 util.workspace = true
+which.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/breadpaper/Cargo.toml
+++ b/crates/breadpaper/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "breadpaper"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/breadpaper.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+gpui.workspace = true
+log.workspace = true
+menu.workspace = true
+project.workspace = true
+serde.workspace = true
+toml.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/breadpaper/assets/areas/timeline/assets/data.seed.js
+++ b/crates/breadpaper/assets/areas/timeline/assets/data.seed.js
@@ -1,0 +1,23 @@
+// Weekly review data — one entry per week, newest last.
+// The Week Review skill appends a new object to this array each week.
+//
+// Schema (per week):
+// {
+//   id: "2026_29_Jul",       // week id = weekly filename stem
+//   week: 29,                // the WW number
+//   label: "Week 29",
+//   range: "Jul 13 – Jul 19, 2026",
+//   status: "reviewed",      // "reviewed", or "in-progress" if the week isn't over
+//   goals:     [ { text: "…", done: true } ],   // from # Week Goals
+//   tentative: [ { text: "…", done: false } ],  // from # Tentative (or [])
+//   personal:  [ { text: "…", done: false } ],  // from # Personal (or [])
+//   highlights: [ "…" ],     // 2–3 entries, or [] for an in-progress week
+//   projects: [
+//     { name: "Scheduler", goal: true, tasks: [ "task one" ] }  // omit `goal` when not a week goal
+//   ],
+//   prs: {
+//     created:  [ { ref: "OpenCue#2425", title: "…", status: "open", src: "github" } ],
+//     reviewed: [ { ref: "spi-centos!18", title: "…", src: "gitlab" } ]
+//   }
+// }
+window.WEEKS = [];

--- a/crates/breadpaper/assets/areas/timeline/assets/index.html
+++ b/crates/breadpaper/assets/areas/timeline/assets/index.html
@@ -1,0 +1,752 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Weekly Review</title>
+<style>
+  /* Zed One-Dark inspired palette */
+  :root {
+    --bg: #0d0f13;
+    --panel: #15181f;
+    --panel2: #1c202a;
+    --border: #262b36;
+    --text: #d7dce5;
+    --muted: #828b9c;
+    --accent: #61afef;
+    --green: #98c379;
+    --amber: #e5c07b;
+    --red: #e06c75;
+    --purple: #c678dd;
+    --cyan: #56b6c2;
+    --focus: #61afef;
+    --radius: 12px;
+    --font: "Inter", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f5f6f8;
+      --panel: #ffffff;
+      --panel2: #eef0f4;
+      --border: #e0e3ea;
+      --text: #1f2329;
+      --muted: #6a7280;
+      --accent: #3b7edd;
+      --green: #4a9c3f;
+      --amber: #b0851f;
+      --red: #d0475a;
+      --purple: #9450c4;
+      --cyan: #2b96a3;
+      --focus: #3b7edd;
+    }
+  }
+  :root[data-theme="dark"] { color-scheme: dark; }
+  :root[data-theme="light"] { color-scheme: light; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background:
+      radial-gradient(1200px 500px at 50% -200px, color-mix(in srgb, var(--accent) 6%, transparent), transparent),
+      var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    padding: 26px 22px 90px;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; }
+  ::selection { background: color-mix(in srgb, var(--accent) 30%, transparent); }
+
+  /* ── header / nav (titlebar) ──────────────── */
+  header {
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+    margin-bottom: 18px; padding-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .brand { display: flex; align-items: center; gap: 11px; }
+  .brand .logo {
+    width: 26px; height: 26px; border-radius: 7px; flex: none;
+    background: linear-gradient(140deg, var(--accent), var(--purple));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent), 0 6px 18px -6px var(--accent);
+  }
+  header h1 { font-size: 19px; font-weight: 600; letter-spacing: -.2px; }
+  header h1 span { color: var(--muted); font-weight: 400; }
+  .weeknav { display: flex; align-items: center; gap: 8px; }
+  .weeknav button {
+    background: var(--panel2); border: 1px solid var(--border); color: var(--text);
+    width: 36px; height: 36px; border-radius: 9px; font-size: 17px; cursor: pointer;
+    display: flex; align-items: center; justify-content: center; transition: .12s;
+  }
+  .weeknav button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, var(--panel2)); }
+  .weeknav button:disabled { opacity: .3; cursor: default; }
+  .weeknav .current { text-align: center; min-width: 220px; }
+  .weeknav .current .wk { font-weight: 650; font-size: 17px; letter-spacing: -.2px; }
+  .weeknav .current .rng { color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  .badge {
+    display: inline-block; font-size: 10.5px; font-weight: 600; padding: 2px 8px;
+    border-radius: 20px; vertical-align: 2px; margin-left: 8px; letter-spacing: .2px;
+  }
+  .badge.inprogress { background: color-mix(in srgb, var(--amber) 18%, transparent); color: var(--amber); }
+
+  /* ── timeline strip ───────────────────────── */
+  .timeline { display: flex; gap: 6px; margin: 14px 0 22px; }
+  .timeline .tw {
+    flex: 1; background: var(--panel); border: 1px solid var(--border);
+    border-radius: 8px; padding: 8px 6px 6px; cursor: pointer; text-align: center;
+  }
+  .timeline .tw:hover { border-color: var(--accent); }
+  .timeline .tw.active { border-color: var(--accent); background: var(--panel2); }
+  .timeline .tw .bars { display: flex; align-items: flex-end; justify-content: center; gap: 3px; height: 34px; margin-bottom: 5px; }
+  .timeline .tw .bars i { display: block; width: 9px; border-radius: 2px 2px 0 0; min-height: 2px; }
+  .timeline .tw .bars .b-tasks { background: var(--accent); }
+  .timeline .tw .bars .b-prs { background: var(--purple); }
+  .timeline .tw .lbl { font-size: 11.5px; color: var(--muted); }
+  .timeline .tw.active .lbl { color: var(--text); font-weight: 600; }
+  .legend { display: flex; gap: 14px; justify-content: flex-end; font-size: 11.5px; color: var(--muted); margin: -14px 0 18px; }
+  .legend i { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 5px; }
+
+  /* ── stat cards (sparkline dashboard) ─────── */
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(158px, 1fr)); gap: 13px; margin-bottom: 22px; }
+  .stat {
+    --c: var(--accent);
+    position: relative; overflow: hidden;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--c) 7%, var(--panel)), var(--panel));
+    border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 13px 15px 8px;
+    transition: .15s;
+  }
+  .stat::before {
+    content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+    background: var(--c); opacity: .9;
+  }
+  .stat:hover { border-color: color-mix(in srgb, var(--c) 45%, var(--border)); transform: translateY(-1px); }
+  .stat .caprow { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
+  .stat .cap {
+    color: var(--muted); font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: .7px; font-family: var(--mono);
+  }
+  .stat .num { font-size: 32px; font-weight: 700; line-height: 1.05; margin-top: 3px; letter-spacing: -1px; color: var(--text); }
+  .stat .num small { font-size: 16px; color: var(--muted); font-weight: 500; letter-spacing: 0; }
+  .stat .spark { display: block; width: 100%; height: auto; margin-top: 6px; overflow: visible; }
+  .stat .spark .area { fill: color-mix(in srgb, var(--c) 16%, transparent); }
+  .stat .spark .line { fill: none; stroke: var(--c); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+  .stat .spark .dot { fill: var(--c); }
+  .stat .spark .dot-ring { fill: var(--panel); stroke: var(--c); stroke-width: 2; }
+  .stat .delta { font-size: 11px; font-weight: 600; font-family: var(--mono); }
+  .stat .delta.up { color: var(--green); }
+  .stat .delta.down { color: var(--red); }
+  .stat .delta.flat { color: var(--muted); }
+
+  /* ── panels ───────────────────────────────── */
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .grid .full { grid-column: 1 / -1; }
+  @media (max-width: 780px) { .grid { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 18px 20px;
+  }
+  .panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .8px; color: var(--muted); margin-bottom: 14px; font-weight: 650; }
+
+  /* goals */
+  .goalbar { height: 8px; border-radius: 6px; background: var(--panel2); overflow: hidden; margin-bottom: 14px; }
+  .goalbar i { display: block; height: 100%; background: var(--green); border-radius: 6px; transition: width .4s; }
+  .goal { display: flex; gap: 10px; padding: 5px 0; align-items: baseline; }
+  .goal .box { flex: none; width: 16px; height: 16px; border-radius: 4px; border: 1.5px solid var(--muted); position: relative; top: 2px; }
+  .goal.done .box { background: var(--green); border-color: var(--green); }
+  .goal.done .box::after { content: "✓"; color: #fff; font-size: 11px; position: absolute; top: -1.5px; left: 2.5px; }
+  .goal.done .txt { color: var(--muted); text-decoration: line-through; text-decoration-color: color-mix(in srgb, var(--muted) 55%, transparent); }
+  .goal-group { font-size: 11.5px; color: var(--muted); text-transform: uppercase; letter-spacing: .6px; margin: 12px 0 2px; }
+  .empty { color: var(--muted); font-style: italic; }
+
+  /* project bars */
+  .proj { margin-bottom: 4px; }
+  .proj .row { display: flex; align-items: center; gap: 10px; padding: 6px 4px; cursor: pointer; border-radius: 6px; }
+  .proj .row:hover { background: var(--panel2); }
+  .proj .name { flex: 0 0 190px; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .proj .track { flex: 1; height: 16px; background: var(--panel2); border-radius: 4px; overflow: hidden; }
+  .proj .track i { display: block; height: 100%; border-radius: 4px; }
+  .proj .count { flex: 0 0 24px; text-align: right; font-size: 12.5px; color: var(--muted); font-variant-numeric: tabular-nums; }
+  .proj .caret { flex: 0 0 14px; color: var(--muted); font-size: 11px; transition: transform .15s; }
+  .proj.open .caret { transform: rotate(90deg); }
+  .proj ul { display: none; margin: 2px 0 10px 14px; padding-left: 14px; color: var(--muted); font-size: 13.5px; }
+  .proj.open ul { display: block; }
+  .proj ul li { margin: 3px 0; }
+
+  /* PRs */
+  .prsplit { display: flex; height: 14px; border-radius: 5px; overflow: hidden; margin-bottom: 6px; background: var(--panel2); }
+  .prsplit i { display: block; height: 100%; }
+  .prkey { display: flex; gap: 14px; font-size: 12px; color: var(--muted); margin-bottom: 14px; flex-wrap: wrap; }
+  .prkey i { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 5px; }
+  .prlist { max-height: 300px; overflow-y: auto; }
+  .pr { display: flex; gap: 8px; padding: 4px 0; font-size: 13px; align-items: baseline; }
+  .pr .src { flex: none; font-size: 9.5px; font-weight: 700; letter-spacing: .3px; width: 20px; text-align: center; padding: 1px 0; border-radius: 3px; }
+  .pr .src.github { background: color-mix(in srgb, var(--text) 12%, transparent); color: var(--muted); }
+  .pr .src.gitlab { background: color-mix(in srgb, var(--amber) 22%, transparent); color: var(--amber); }
+  .pr .ref { color: var(--accent); font-weight: 600; white-space: nowrap; font-family: ui-monospace, monospace; font-size: 12px; }
+  a.ref { text-decoration: none; }
+  a.ref:hover { text-decoration: underline; text-underline-offset: 2px; }
+  .pr .t { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .pr .t .draft { color: var(--amber); font-size: 10px; font-weight: 700; text-transform: uppercase; margin-right: 5px; letter-spacing: .3px; }
+  .pr .st { font-size: 11px; font-weight: 600; padding: 0 7px; border-radius: 20px; white-space: nowrap; }
+  .st.merged { background: color-mix(in srgb, var(--purple) 16%, transparent); color: var(--purple); }
+  .st.open { background: color-mix(in srgb, var(--green) 14%, transparent); color: var(--green); }
+  .st.closed { background: color-mix(in srgb, var(--red) 14%, transparent); color: var(--red); }
+  .st.reviewed { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
+  .prmore { margin-top: 6px; font-size: 12.5px; color: var(--accent); cursor: pointer; background: none; border: none; padding: 0; }
+  .srcsplit { display: flex; gap: 14px; font-size: 12px; color: var(--muted); margin: -4px 0 12px; }
+  .srcsplit b { color: var(--text); font-weight: 600; }
+
+  /* warnings */
+  .warn {
+    display: flex; gap: 12px; align-items: baseline;
+    padding: 10px 14px; margin-bottom: 8px; border-radius: 8px;
+    border: 1px solid color-mix(in srgb, var(--amber) 30%, var(--border));
+    background: color-mix(in srgb, var(--amber) 7%, transparent);
+    font-size: 13.5px;
+  }
+  .warn .tag {
+    flex: none; font-size: 10.5px; font-weight: 700; letter-spacing: .6px;
+    padding: 1px 8px; border-radius: 20px; text-transform: uppercase;
+    background: color-mix(in srgb, var(--amber) 18%, transparent); color: var(--amber);
+  }
+  .warn.sink .tag { background: color-mix(in srgb, var(--red) 15%, transparent); color: var(--red); }
+  .warn.sink { border-color: color-mix(in srgb, var(--red) 28%, var(--border)); background: color-mix(in srgb, var(--red) 6%, transparent); }
+  .allclear { color: var(--muted); font-size: 13.5px; }
+  .allclear b { color: var(--green); }
+  .goalchip {
+    font-size: 10px; font-weight: 700; letter-spacing: .5px; text-transform: uppercase;
+    padding: 0 6px; border-radius: 20px; margin-left: 6px; vertical-align: 1px;
+    background: color-mix(in srgb, var(--green) 14%, transparent); color: var(--green);
+  }
+
+  /* highlights */
+  .hl { display: flex; gap: 10px; padding: 6px 0; }
+  .hl .dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--amber); position: relative; top: 8px; }
+
+  footer { text-align: center; color: var(--muted); font-size: 12px; margin-top: 28px; }
+
+  /* ── vim navigation ───────────────────────── */
+  .vfocus {
+    outline: 2px solid var(--focus) !important;
+    outline-offset: 1px;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--focus) 12%, transparent) !important;
+    scroll-margin: 90px;
+  }
+  .timeline .tw.vfocus { outline-offset: 2px; }
+
+  /* status bar (Zed-style) */
+  .statusbar {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 40;
+    display: flex; align-items: center; gap: 18px;
+    padding: 7px 16px;
+    background: color-mix(in srgb, var(--panel) 85%, transparent);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-top: 1px solid var(--border);
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+  }
+  .statusbar .mode { color: var(--bg); background: var(--green); font-weight: 700; padding: 1px 9px; border-radius: 5px; letter-spacing: .5px; }
+  .statusbar .hint { display: flex; gap: 6px; align-items: center; }
+  .statusbar kbd {
+    font-family: var(--mono); font-size: 11px; color: var(--text);
+    background: var(--panel2); border: 1px solid var(--border); border-bottom-width: 2px;
+    border-radius: 4px; padding: 0 5px; min-width: 16px; text-align: center;
+  }
+  .statusbar .spacer { flex: 1; }
+  .statusbar .pos { color: var(--text); }
+  .statusbar .help-open { cursor: pointer; }
+  .statusbar .help-open:hover { color: var(--accent); }
+  @media (max-width: 720px) { .statusbar .hint.opt { display: none; } }
+
+  /* help overlay */
+  .overlay {
+    position: fixed; inset: 0; z-index: 50; display: none;
+    align-items: center; justify-content: center;
+    background: color-mix(in srgb, #000 55%, transparent);
+    backdrop-filter: blur(3px);
+  }
+  .overlay.show { display: flex; }
+  .help {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 14px;
+    padding: 22px 26px; width: min(440px, 90vw);
+    box-shadow: 0 24px 60px -20px #000;
+  }
+  .help h3 { font-size: 15px; margin-bottom: 4px; letter-spacing: -.2px; }
+  .help .sub { color: var(--muted); font-size: 12.5px; margin-bottom: 16px; font-family: var(--mono); }
+  .help .krow { display: flex; align-items: center; gap: 12px; padding: 6px 0; font-size: 13.5px; }
+  .help .krow .keys { display: flex; gap: 5px; flex: 0 0 96px; }
+  .help kbd {
+    font-family: var(--mono); font-size: 12px; color: var(--text);
+    background: var(--panel2); border: 1px solid var(--border); border-bottom-width: 2px;
+    border-radius: 5px; padding: 1px 7px; min-width: 20px; text-align: center;
+  }
+  .help .krow .desc { color: var(--muted); }
+  .help .close { margin-top: 16px; text-align: center; color: var(--muted); font-size: 12px; font-family: var(--mono); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="brand">
+      <span class="logo"></span>
+      <h1>Weekly Review <span>· dashboard</span></h1>
+    </div>
+    <div class="weeknav">
+      <button id="prev" title="Previous week (h)">‹</button>
+      <div class="current">
+        <div class="wk" id="wkLabel"></div>
+        <div class="rng" id="wkRange"></div>
+      </div>
+      <button id="next" title="Next week (l)">›</button>
+    </div>
+  </header>
+
+  <div class="timeline" id="timeline"></div>
+  <div class="legend">
+    <span><i style="background:var(--accent)"></i>tasks</span>
+    <span><i style="background:var(--purple)"></i>PRs + MRs</span>
+  </div>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="grid">
+    <div class="panel" id="goalsPanel">
+      <h2>Week Goals</h2>
+      <div id="goals"></div>
+    </div>
+    <div class="panel" id="hlPanel">
+      <h2>Highlights</h2>
+      <div id="highlights"></div>
+    </div>
+    <div class="panel full" id="warnPanel">
+      <h2>Warnings</h2>
+      <div id="warnings"></div>
+    </div>
+    <div class="panel full" id="projPanel">
+      <h2>Work by Project</h2>
+      <div id="projects"></div>
+    </div>
+    <div class="panel full" id="prPanel">
+      <h2>Pull &amp; Merge Requests</h2>
+      <div id="prs"></div>
+    </div>
+  </div>
+
+  <footer>Generated from <code>_weekly/</code> notes · data in <code>data.js</code></footer>
+</div>
+
+<div class="statusbar">
+  <span class="mode">NORMAL</span>
+  <span class="hint"><kbd>h</kbd><kbd>l</kbd> week</span>
+  <span class="hint"><kbd>j</kbd><kbd>k</kbd> move</span>
+  <span class="hint opt"><kbd>o</kbd> expand</span>
+  <span class="hint opt"><kbd>g</kbd><kbd>g</kbd>/<kbd>G</kbd> ends</span>
+  <span class="spacer"></span>
+  <span class="pos" id="statusPos"></span>
+  <span class="help-open" id="helpOpen">? help</span>
+</div>
+
+<div class="overlay" id="overlay">
+  <div class="help">
+    <h3>Keyboard navigation</h3>
+    <div class="sub">vim motions · press ? or Esc to close</div>
+    <div class="krow"><span class="keys"><kbd>h</kbd><kbd>l</kbd></span><span class="desc">previous / next week</span></div>
+    <div class="krow"><span class="keys"><kbd>j</kbd><kbd>k</kbd></span><span class="desc">move focus down / up</span></div>
+    <div class="krow"><span class="keys"><kbd>o</kbd><kbd>↵</kbd></span><span class="desc">expand / collapse focused row</span></div>
+    <div class="krow"><span class="keys"><kbd>g</kbd><kbd>g</kbd></span><span class="desc">jump to first week</span></div>
+    <div class="krow"><span class="keys"><kbd>G</kbd></span><span class="desc">jump to last week</span></div>
+    <div class="krow"><span class="keys"><kbd>0</kbd><kbd>$</kbd></span><span class="desc">first / last focus item</span></div>
+    <div class="krow"><span class="keys"><kbd>Esc</kbd></span><span class="desc">clear focus / close</span></div>
+    <div class="close">? or Esc to dismiss</div>
+  </div>
+</div>
+
+<script src="data.js"></script>
+<script>
+(function () {
+  const W = window.WEEKS;
+  // Empty-feed guard: the seed data.js ships with no weeks; the first Week
+  // Review appends one. Without this the page throws on an empty WEEKS array.
+  if (!Array.isArray(W) || W.length === 0) {
+    document.querySelector(".wrap").innerHTML =
+      '<header><div class="brand"><span class="logo"></span>' +
+      '<h1>Weekly Review <span>\u00b7 dashboard</span></h1></div></header>' +
+      '<p class="empty" style="margin-top:20px">No weeks recorded yet. ' +
+      'Run the Week Review skill to append the first entry to <code>data.js</code>, then reload this page.</p>';
+    const statusbar = document.querySelector(".statusbar");
+    if (statusbar) statusbar.remove();
+    return;
+  }
+  const PROJ_COLORS = ["#5eb0ef","#b58ef0","#4ec97a","#e5b454","#e06c75","#56c8d8","#d98cc4","#9db35e","#e08f5a","#7f9cf5"];
+  const $ = id => document.getElementById(id);
+
+  // Ref → web URL resolution. Refs look like "OpenCue#2486" (GitHub, "#")
+  // or "argocd!57" (GitLab MR, "!"). Repo short-names map to full paths below;
+  // add a row here when a new repo shows up in the data.
+  const GH_REPO = {
+    OpenCue: "AcademySoftwareFoundation/OpenCue",
+    reader: "DiegoTavares/reader",
+    "faire-sync": "DiegoTavares/faire-sync"
+  };
+  const GL_HOST = "https://gitlab.spimageworks.com";
+  const GL_PATH = {
+    argocd: "spi/dev/infrastructure/api/opencue_group/argocd",
+    shottree3: "spi/dev/infrastructure/api/shottree3",
+    opencue_spi: "spi/dev/infrastructure/api/opencue_group/opencue_spi",
+    OpenCue: "spi/dev/infrastructure/api/opencue_group/OpenCue",
+    "spi-centos": "spi/dev/infrastructure/api/docker/spi-centos",
+    "sbt-zeroc-ice": "spi/dev/infrastructure/api/sbt-zeroc-ice",
+    "scala-ice-server": "spi/dev/infrastructure/api/scala-ice-server",
+    "k8s-config": "spi/systems/k8s-config",
+    "middle-tier-server": "spi/dev/infrastructure/api/vnp3/middle-tier-server",
+    vfo: "spi/dev/infrastructure/api/vfo"
+  };
+  function refUrl(p) {
+    if ((p.src || "github") === "gitlab") {
+      const [name, num] = p.ref.split("!");
+      const path = GL_PATH[name];
+      return path && num ? `${GL_HOST}/${path}/-/merge_requests/${num}` : null;
+    }
+    const [name, num] = p.ref.split("#");
+    const repo = GH_REPO[name];
+    return repo && num ? `https://github.com/${repo}/pull/${num}` : null;
+  }
+
+  const taskCount = w => w.projects.reduce((n,p) => n + p.tasks.length, 0);
+  const prCount = w => w.prs.created.length + w.prs.reviewed.length;
+  const allGoals = w => [...w.goals, ...w.tentative, ...w.personal];
+
+  // Canonical project names, so lingering detection survives naming drift
+  // ("st3 / Infrastructure" vs "ST3 / ShotTree3"). First match wins.
+  const CANON = [
+    [/shottree|st3/i, "ST3"],
+    [/scheduler/i, "Scheduler"],
+    [/cuebot/i, "Cuebot"],
+    [/qlite|opencue.?lite/i, "Qlite"],
+    [/web team|shotgun/i, "Web Team"],
+    [/bom/i, "BOM"],
+    [/cueweb/i, "CueWeb"],
+    [/governance/i, "Governance"],
+    [/team|people/i, "Team"],
+    [/vfo/i, "VFO"],
+    [/personal|finance|faire/i, "Personal"]
+  ];
+  const canon = name => { for (const [re, c] of CANON) if (re.test(name)) return c; return name; };
+  const normGoal = t => t.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/\s+/g, " ").trim();
+  const ord = n => n + (["th","st","nd","rd"][n % 10 > 3 || Math.floor(n / 10) === 1 ? 0 : n % 10]);
+
+  // Projects that are ongoing by nature and shouldn't count as "lingering"
+  const LINGER_EXEMPT = ["Personal", "Team"];
+
+  function computeWarnings(i) {
+    const w = W[i], out = [];
+
+    // 1. Carried-over goals: same goal text, unfinished, in consecutive prior weeks
+    for (const g of allGoals(w)) {
+      if (g.done) continue;
+      let streak = 0;
+      for (let j = i - 1; j >= 0; j--) {
+        const prior = allGoals(W[j]).find(p => normGoal(p.text) === normGoal(g.text));
+        if (prior && !prior.done) streak++; else break;
+      }
+      if (streak >= 1) out.push({ cls: "carry", tag: "carry-over",
+        html: `<b>${esc(g.text)}</b> is on its <b>${ord(streak + 1)} week</b> as an unfinished goal.` });
+    }
+
+    // 2. Time sinks: share of the week's tasks in projects unrelated to any goal
+    const total = taskCount(w);
+    if (total) {
+      const goals = allGoals(w);
+      if (!goals.length) {
+        out.push({ cls: "sink", tag: "time sink",
+          html: `No goals were set this week — all <b>${total} logged tasks</b> were unplanned work.` });
+      } else {
+        const off = w.projects.filter(p => !p.goal);
+        const offTasks = off.reduce((n, p) => n + p.tasks.length, 0);
+        const share = Math.round(offTasks / total * 100);
+        if (share >= 50) {
+          const top = off.slice().sort((a, b) => b.tasks.length - a.tasks.length).slice(0, 3)
+            .map(p => `${esc(p.name)} (${p.tasks.length})`).join(", ");
+          out.push({ cls: "sink", tag: "time sink",
+            html: `<b>${share}%</b> of logged work went to projects outside your week goals. Biggest sinks: ${top}.` });
+        } else {
+          const big = off.find(p => p.tasks.length / total >= 0.3);
+          if (big) out.push({ cls: "sink", tag: "time sink",
+            html: `<b>${esc(big.name)}</b> consumed <b>${Math.round(big.tasks.length / total * 100)}%</b> of your week but wasn't a goal.` });
+        }
+      }
+    }
+
+    // 3. Lingering projects: active in >=3 of the last 4 reviewed weeks,
+    //    ~<=2 tasks/week, never elevated to a week goal
+    const span = W.slice(Math.max(0, i - 3), i + 1).filter(x => x.projects.length);
+    if (span.length >= 3) {
+      const agg = {};
+      for (const x of span) for (const p of x.projects) {
+        const c = canon(p.name);
+        const a = agg[c] = agg[c] || { weeks: 0, tasks: 0, goal: false };
+        a.weeks++; a.tasks += p.tasks.length; a.goal = a.goal || !!p.goal;
+      }
+      for (const [name, a] of Object.entries(agg)) {
+        if (LINGER_EXEMPT.includes(name) || a.goal) continue;
+        if (a.weeks >= 3 && a.tasks / a.weeks <= 2)
+          out.push({ cls: "linger", tag: "lingering",
+            html: `<b>${esc(name)}</b> has dragged through <b>${a.weeks} of the last ${span.length} reviewed weeks</b> with minimal progress (${a.tasks} tasks total) and was never a week goal. Finish it, schedule it, or drop it.` });
+      }
+    }
+
+    return out;
+  }
+
+  let idx = W.length - 1;
+  const fromHash = W.findIndex(w => "#" + w.id === location.hash);
+  if (fromHash >= 0) idx = fromHash;
+
+  function esc(s){ const d=document.createElement("div"); d.textContent=s; return d.innerHTML; }
+
+  function renderTimeline() {
+    const maxT = Math.max(...W.map(taskCount), 1);
+    const maxP = Math.max(...W.map(prCount), 1);
+    $("timeline").innerHTML = W.map((w,i) => `
+      <div class="tw ${i===idx?"active":""}" data-i="${i}" title="${w.label} · ${w.range}">
+        <div class="bars">
+          <i class="b-tasks" style="height:${Math.round(taskCount(w)/maxT*100)}%"></i>
+          <i class="b-prs" style="height:${Math.round(prCount(w)/maxP*100)}%"></i>
+        </div>
+        <div class="lbl">W${w.week}</div>
+      </div>`).join("");
+    $("timeline").querySelectorAll(".tw").forEach(el =>
+      el.addEventListener("click", () => go(+el.dataset.i)));
+  }
+
+  // Metric definitions — each renders a stat card with a cross-week sparkline.
+  const goalsPct = w => { const g = allGoals(w); return g.length ? Math.round(g.filter(x => x.done).length / g.length * 100) : 0; };
+  const mergedCount = w => w.prs.created.filter(p => p.status === "merged").length;
+  const METRICS = [
+    { cap: "goals done",  color: "--green",  val: goalsPct,                    unit: "%",
+      fmt: w => { const g = allGoals(w); return g.length ? `${g.filter(x => x.done).length}<small>/${g.length}</small>` : "–"; } },
+    { cap: "tasks",       color: "--accent", val: taskCount,                   fmt: w => taskCount(w) || "–" },
+    { cap: "created",     color: "--purple", val: w => w.prs.created.length,   fmt: w => w.prs.created.length || "–" },
+    { cap: "merged",      color: "--cyan",   val: mergedCount,                 fmt: w => w.prs.created.length ? `${mergedCount(w)}<small>/${w.prs.created.length}</small>` : "–" },
+    { cap: "reviewed",    color: "--amber",  val: w => w.prs.reviewed.length,  fmt: w => w.prs.reviewed.length || "–" },
+    { cap: "projects",    color: "--red",    val: w => w.projects.length,      fmt: w => w.projects.length || "–" }
+  ];
+
+  function sparkline(series, cur) {
+    const vw = 150, vh = 30, pad = 4;
+    const max = Math.max(...series, 1), min = Math.min(...series, 0);
+    const span = (max - min) || 1, n = series.length;
+    const X = i => n === 1 ? vw / 2 : pad + i * (vw - 2 * pad) / (n - 1);
+    const Y = v => vh - pad - (v - min) / span * (vh - 2 * pad);
+    const pts = series.map((v, i) => [X(i), Y(v)]);
+    const line = pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
+    const area = `M${pts[0][0].toFixed(1)} ${vh - pad} ` +
+      pts.map(p => "L" + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ") +
+      ` L${pts[n - 1][0].toFixed(1)} ${vh - pad} Z`;
+    const cx = X(cur).toFixed(1), cy = Y(series[cur]).toFixed(1);
+    return `<svg class="spark" viewBox="0 0 ${vw} ${vh}" preserveAspectRatio="xMidYMid meet">
+      <path class="area" d="${area}"/>
+      <path class="line" d="${line}" vector-effect="non-scaling-stroke"/>
+      <circle class="dot-ring" cx="${cx}" cy="${cy}" r="3.2" vector-effect="non-scaling-stroke"/>
+    </svg>`;
+  }
+
+  function statCard(m) {
+    const series = W.map(m.val);
+    const cur = series[idx], prev = idx > 0 ? series[idx - 1] : null;
+    let delta = "";
+    if (prev !== null) {
+      const d = cur - prev, cls = d > 0 ? "up" : d < 0 ? "down" : "flat";
+      const arrow = d > 0 ? "▲" : d < 0 ? "▼" : "–";
+      delta = `<span class="delta ${cls}">${arrow}${d === 0 ? "" : Math.abs(d) + (m.unit || "")}</span>`;
+    }
+    return `<div class="stat" style="--c: var(${m.color})">
+      <div class="caprow"><span class="cap">${m.cap}</span>${delta}</div>
+      <div class="num">${m.fmt(W[idx])}</div>
+      ${sparkline(series, idx)}
+    </div>`;
+  }
+
+  function render() {
+    const w = W[idx];
+    history.replaceState(null, "", "#" + w.id);
+
+    $("wkLabel").innerHTML = esc(w.label) +
+      (w.status === "in-progress" ? '<span class="badge inprogress">in progress</span>' : "");
+    $("wkRange").textContent = w.range;
+    $("prev").disabled = idx === 0;
+    $("next").disabled = idx === W.length - 1;
+
+    // stats (sparkline cards)
+    const goals = allGoals(w);
+    const done = goals.filter(g => g.done).length;
+    const created = w.prs.created.length;
+    const merged = w.prs.created.filter(p => p.status === "merged").length;
+    $("stats").innerHTML = METRICS.map(statCard).join("");
+
+    // goals
+    let gh = "";
+    if (goals.length) {
+      const pct = Math.round(done / goals.length * 100);
+      gh += `<div class="goalbar"><i style="width:${pct}%"></i></div>`;
+      const group = (list, name) => list.length
+        ? (name ? `<div class="goal-group">${name}</div>` : "") + list.map(g =>
+            `<div class="goal ${g.done?"done":""}"><span class="box"></span><span class="txt">${esc(g.text)}</span></div>`).join("")
+        : "";
+      gh += group(w.goals, w.tentative.length || w.personal.length ? "Work" : "");
+      gh += group(w.tentative, "Tentative");
+      gh += group(w.personal, "Personal");
+    } else {
+      gh = `<div class="empty">No goals were set this week.</div>`;
+    }
+    $("goals").innerHTML = gh;
+
+    // highlights
+    $("highlights").innerHTML = w.highlights.length
+      ? w.highlights.map(h => `<div class="hl"><span class="dot"></span><span>${esc(h)}</span></div>`).join("")
+      : `<div class="empty">${w.status==="in-progress" ? "Week in progress — review not written yet." : "No highlights recorded."}</div>`;
+
+    // warnings
+    const warns = computeWarnings(idx);
+    $("warnings").innerHTML = warns.length
+      ? warns.map(x => `<div class="warn ${x.cls}"><span class="tag">${x.tag}</span><span>${x.html}</span></div>`).join("")
+      : `<div class="allclear"><b>All clear.</b> No lingering projects, carried-over goals, or off-goal time sinks detected.</div>`;
+
+    // projects
+    if (w.projects.length) {
+      const max = Math.max(...w.projects.map(p => p.tasks.length));
+      $("projects").innerHTML = w.projects.map((p,i) => `
+        <div class="proj" data-i="${i}">
+          <div class="row">
+            <span class="caret">▶</span>
+            <span class="name">${esc(p.name)}${p.goal ? '<span class="goalchip">goal</span>' : ""}</span>
+            <span class="track"><i style="width:${Math.round(p.tasks.length/max*100)}%;background:${PROJ_COLORS[i%PROJ_COLORS.length]}"></i></span>
+            <span class="count">${p.tasks.length}</span>
+          </div>
+          <ul>${p.tasks.map(t => `<li>${esc(t)}</li>`).join("")}</ul>
+        </div>`).join("");
+      $("projects").querySelectorAll(".proj .row").forEach(row =>
+        row.addEventListener("click", () => row.parentElement.classList.toggle("open")));
+    } else {
+      $("projects").innerHTML = `<div class="empty">No work logged yet.</div>`;
+    }
+
+    // PRs + MRs
+    const revd = w.prs.reviewed.length;
+    const closed = w.prs.created.filter(p => p.status === "closed").length;
+    const open = created - merged - closed;
+    const total = created + revd;
+    if (total) {
+      const srcCount = (arr, s) => arr.filter(p => (p.src || "github") === s).length;
+      const gh = srcCount(w.prs.created, "github") + srcCount(w.prs.reviewed, "github");
+      const gl = srcCount(w.prs.created, "gitlab") + srcCount(w.prs.reviewed, "gitlab");
+      const seg = (n, c) => n ? `<i style="width:${n/total*100}%;background:${c}"></i>` : "";
+      let html = `<div class="prsplit">
+          ${seg(merged, "var(--purple)")}${seg(open, "var(--green)")}${seg(closed, "var(--red)")}${seg(revd, "var(--accent)")}
+        </div>
+        <div class="prkey">
+          <span><i style="background:var(--purple)"></i>merged (${merged})</span>
+          <span><i style="background:var(--green)"></i>open (${open})</span>
+          ${closed ? `<span><i style="background:var(--red)"></i>closed (${closed})</span>` : ""}
+          <span><i style="background:var(--accent)"></i>reviewed (${revd})</span>
+        </div>
+        <div class="srcsplit">
+          <span><b>${gh}</b> GitHub</span><span><b>${gl}</b> GitLab (SPI)</span>
+        </div>`;
+      const badge = p => `<span class="src ${p.src || "github"}">${(p.src || "github") === "gitlab" ? "GL" : "GH"}</span>`;
+      const draftTag = p => p.draft ? `<span class="draft">draft</span>` : "";
+      const refEl = p => { const u = refUrl(p); return u
+        ? `<a class="ref" href="${u}" target="_blank" rel="noopener">${esc(p.ref)}</a>`
+        : `<span class="ref">${esc(p.ref)}</span>`; };
+      const pr = (p, st) => `<div class="pr">${badge(p)}${refEl(p)}<span class="t">${draftTag(p)}${esc(p.title)}</span><span class="st ${st||p.status}">${st||p.status}</span></div>`;
+      const revShown = w.prs.reviewed.slice(0, 8);
+      html += `<div class="prlist" id="prlist">`
+        + w.prs.created.map(p => pr(p)).join("")
+        + revShown.map(p => pr(p, "reviewed")).join("")
+        + `</div>`;
+      if (revd > 8) html += `<button class="prmore" id="prmore">show ${revd - 8} more reviewed</button>`;
+      $("prs").innerHTML = html;
+      const more = $("prmore");
+      if (more) more.addEventListener("click", () => {
+        $("prlist").insertAdjacentHTML("beforeend",
+          w.prs.reviewed.slice(8).map(p => pr(p, "reviewed")).join(""));
+        more.remove();
+      });
+    } else {
+      $("prs").innerHTML = `<div class="empty">No PR or MR activity recorded.</div>`;
+    }
+
+    renderTimeline();
+  }
+
+  // ── vim navigation ─────────────────────────
+  let navItems = [], focusIdx = -1, gPending = false;
+
+  function buildNav() {
+    navItems = Array.from(document.querySelectorAll(".proj .row, #prmore"));
+    focusIdx = -1;
+    $("statusPos").textContent = `W${W[idx].week} · ${idx + 1}/${W.length}`;
+  }
+  function paintFocus() {
+    navItems.forEach((el, i) => el.classList.toggle("vfocus", i === focusIdx));
+    if (focusIdx >= 0) navItems[focusIdx].scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }
+  function moveFocus(d) {
+    if (!navItems.length) return;
+    focusIdx = focusIdx < 0
+      ? (d > 0 ? 0 : navItems.length - 1)
+      : Math.max(0, Math.min(navItems.length - 1, focusIdx + d));
+    paintFocus();
+  }
+  function focusEdge(end) { if (navItems.length) { focusIdx = end ? navItems.length - 1 : 0; paintFocus(); } }
+  function activate() {
+    if (focusIdx < 0) return;
+    const el = navItems[focusIdx];
+    el.click();
+    if (el.id === "prmore") setTimeout(() => { buildNav(); }, 0); // prmore removes itself
+  }
+  function clearFocus() { focusIdx = -1; paintFocus(); }
+
+  function go(i) { idx = Math.max(0, Math.min(W.length - 1, i)); render(); buildNav(); }
+  $("prev").addEventListener("click", () => go(idx - 1));
+  $("next").addEventListener("click", () => go(idx + 1));
+
+  // help overlay
+  const overlay = $("overlay");
+  const toggleHelp = () => overlay.classList.toggle("show");
+  $("helpOpen").addEventListener("click", toggleHelp);
+  overlay.addEventListener("click", e => { if (e.target === overlay) overlay.classList.remove("show"); });
+
+  document.addEventListener("keydown", e => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const k = e.key;
+
+    if (overlay.classList.contains("show")) {
+      if (k === "Escape" || k === "?") { overlay.classList.remove("show"); e.preventDefault(); }
+      return;
+    }
+    if (k === "g") { if (gPending) { gPending = false; go(0); } else { gPending = true; setTimeout(() => gPending = false, 500); } e.preventDefault(); return; }
+    if (gPending && k !== "g") gPending = false;
+
+    switch (k) {
+      case "h": case "ArrowLeft":  go(idx - 1); break;
+      case "l": case "ArrowRight": go(idx + 1); break;
+      case "j": case "ArrowDown":  moveFocus(1); e.preventDefault(); break;
+      case "k": case "ArrowUp":    moveFocus(-1); e.preventDefault(); break;
+      case "o": case "Enter": case " ": activate(); e.preventDefault(); break;
+      case "G": go(W.length - 1); break;
+      case "0": case "^": focusEdge(false); break;
+      case "$": focusEdge(true); break;
+      case "?": toggleHelp(); e.preventDefault(); break;
+      case "Escape": clearFocus(); break;
+    }
+  });
+
+  render();
+  buildNav();
+})();
+</script>
+</body>
+</html>

--- a/crates/breadpaper/assets/areas/timeline/doc.md
+++ b/crates/breadpaper/assets/areas/timeline/doc.md
@@ -1,0 +1,51 @@
+# Daily & Weekly (the Timeline Area)
+
+This Area closes the loop on your daily and weekly rhythm: it turns a week of
+notes and code activity into a reviewed, visualized record.
+
+The Timeline navigator itself — Today, Yesterday, This Week, Last Week — is a
+core part of BreadPaper and always on. This Area layers two things on top of
+it: the **Week Review** skill and the **weekly progress dashboard**.
+
+## The Week Review skill
+
+`skills/timeline/week-review.md`
+
+A ritual your LLM runs once a week. It:
+
+- **Reads** the week's daily and weekly notes (`daily/**`, `weekly/**`) and
+  your pull and merge requests on GitHub and GitLab.
+- **Writes** by appending only: a `# AI Week Review` section at the end of the
+  weekly note, and one week object to the dashboard feed
+  (`_weekly/site/data.js`).
+
+It never overwrites or deletes anything you wrote — augmentation, not
+replacement. Open the skill file to read (or edit) exactly what it does.
+
+## The weekly dashboard
+
+`_weekly/site/index.html`
+
+A static page that computes its own analytics from the feed in `data.js`:
+per-week stats and sparklines, goal completion, work grouped by project, and
+warnings —
+
+- **time sink** — a large share of the week's work went to projects outside
+  your goals;
+- **carry-over** — a goal has stayed unfinished across consecutive weeks;
+- **lingering** — a project drags on for weeks with minimal progress and was
+  never elevated to a week goal.
+
+Click **Weekly Dashboard** in the Areas section to open it in your browser.
+It starts empty; each Week Review appends one entry to the feed.
+
+## Where things live
+
+- `skills/timeline/week-review.md` — the Week Review skill (a plain, editable
+  markdown file).
+- `_weekly/site/` — the dashboard page and its data feed.
+- `.breadpaper/areas/timeline/manifest.toml` — the installed record of what
+  this Area shipped.
+
+Removing this Area never touches your notes, and any shipped file you have
+edited is kept.

--- a/crates/breadpaper/assets/areas/timeline/manifest.toml
+++ b/crates/breadpaper/assets/areas/timeline/manifest.toml
@@ -1,0 +1,34 @@
+schema  = 1
+id      = "timeline"
+name    = "Daily & Weekly"
+version = 1
+summary = "Daily & weekly rhythm — weekly review and a progress dashboard."
+doc     = "areas/Timeline.md"
+
+# Folders/files created in the vault on install. create-if-missing; never clobber.
+[[scaffold]]
+kind = "dir"
+path = "_weekly/site"
+
+[[scaffold]]
+kind   = "file"
+path   = "_weekly/site/index.html"
+source = "assets/index.html"
+
+[[scaffold]]
+kind   = "file"
+path   = "_weekly/site/data.js"
+source = "assets/data.seed.js"
+
+[[skill]]
+id      = "week-review"
+name    = "Week Review"
+file    = "skills/timeline/week-review.md"
+summary = "Aggregate the week's notes + PRs/MRs, append a review, feed the dashboard."
+reads   = ["daily/**", "weekly/**", "mcp:github", "mcp:gitlab"]
+writes  = ["weekly/<week>.md (append)", "_weekly/site/data.js (append)"]
+
+[[surface]]
+kind = "dashboard"
+name = "Weekly Dashboard"
+open = "_weekly/site/index.html"

--- a/crates/breadpaper/assets/areas/timeline/manifest.toml
+++ b/crates/breadpaper/assets/areas/timeline/manifest.toml
@@ -28,6 +28,22 @@ summary = "Aggregate the week's notes + PRs/MRs, append a review, feed the dashb
 reads   = ["daily/**", "weekly/**", "mcp:github", "mcp:gitlab"]
 writes  = ["weekly/<week>.md (append)", "_weekly/site/data.js (append)"]
 
+[[skill]]
+id      = "wrap-today"
+name    = "Wrap Today"
+file    = "skills/timeline/wrap-today.md"
+summary = "Close out today's note — tasks + commits + recent context, append a daily closure."
+reads   = ["daily/**", "git:log", "mcp:github", "mcp:gitlab"]
+writes  = ["daily/<today>.md (append)"]
+
+[[skill]]
+id      = "wrap-yesterday"
+name    = "Wrap Yesterday"
+file    = "skills/timeline/wrap-yesterday.md"
+summary = "Close out yesterday's note — tasks + commits + surrounding context, append a daily closure."
+reads   = ["daily/**", "git:log", "mcp:github", "mcp:gitlab"]
+writes  = ["daily/<yesterday>.md (append)"]
+
 [[surface]]
 kind = "dashboard"
 name = "Weekly Dashboard"

--- a/crates/breadpaper/assets/areas/timeline/skills/week-review.md
+++ b/crates/breadpaper/assets/areas/timeline/skills/week-review.md
@@ -1,0 +1,122 @@
+# Week Review
+
+Review the previous week's daily notes, GitHub activity, and GitLab (SPI) activity, then produce a summary organized by project, write it to the weekly markdown file, and append a structured entry to the dashboard data (`_weekly/site/data.js`).
+
+**Reads:** `daily/**`, `weekly/**`, GitHub (`gh`), GitLab (`glab`).
+**Writes (append-only):** the weekly `.md` file, `_weekly/site/data.js`.
+
+## 1. Determine the week and locate the weekly file
+
+1. The review covers **Monday–Sunday of the week before today**. Compute those two dates (YYYY-MM-DD).
+2. Weekly files are named by **ISO week**: `YYYY-Www.md`, where `YYYY` is the ISO week-year, `W` is a literal `W`, and `ww` is the zero-padded ISO week number — e.g. the week starting Mon 2026-07-20 is `2026-W30.md`. Compute this from the week's Monday. Look in `weekly/` for that file; if it doesn't exist yet, create it.
+3. The **week id** used everywhere below is the filename without `.md` (e.g. `2026-W30`).
+
+## 2. Read the daily notes
+
+1. Find all daily notes in `daily/` within the range. Daily notes are named `YYYY-MM-DD.md`.
+2. Read each one. Extract tasks and activities from day-planner sections, conversation notes, and anything else relevant.
+3. If a weekly note already exists, read it and fold in its `# Week Goals`, `# Tentative`, and `# Personal` sections (these become the goals in the dashboard) plus any context.
+
+## 3. Collect GitHub PRs (`gh`)
+
+Fetch everything you touched in the range:
+- Created: `gh search prs --author=@me --created=YYYY-MM-DD..YYYY-MM-DD`
+- Reviewed: `gh search prs --reviewed-by=@me --updated=YYYY-MM-DD..YYYY-MM-DD`
+- Merged: `gh search prs --author=@me --merged=YYYY-MM-DD..YYYY-MM-DD`
+
+Deduplicate. Each PR has a repo, number, title, and status (open/merged; reviewed if you reviewed it).
+
+## 4. Collect GitLab MRs (`glab`) — SPI internal
+
+Your SPI work lives on `gitlab.spimageworks.com` and is a large share of real output (deploys, releases, fixes) that GitHub does not see. One-time setup (already done on this machine): `glab` is installed and authenticated as **dtavares** (user id **163**). If a call fails with auth errors, re-run `glab auth login --hostname gitlab.spimageworks.com` (needs a `read_api` PAT).
+
+Always prefix calls with the host:
+
+```bash
+export GITLAB_HOST=gitlab.spimageworks.com
+```
+
+For a single week the counts are small, so one page (`per_page=100`) is enough — no pagination needed. (Only for multi-week backfills does `glab api --paginate` matter, and it concatenates one JSON array per page; merge with `jq -s 'add'`.)
+
+**Authored MRs** (→ `created`), created in the window:
+```bash
+glab api "merge_requests?scope=all&author_username=dtavares&created_after=YYYY-MM-DDT00:00:00Z&created_before=YYYY-MM-DDT00:00:00Z&per_page=100"
+```
+Map each: `ref` = `<project-path-tail>!<iid>` (e.g. `shottree3!265`), `title`, `status` = `merged`/`open`/`closed` (GitLab `merged`→`merged`, `opened`→`open`, `closed`→`closed`). Mark `draft: true` when the title starts with `Draft:`/`[Draft]`/`WIP:`.
+
+**Reviewed MRs** (→ `reviewed`): do **not** use `reviewer_username` — it returns MRs merely touched in the window and is noisy. Use real review actions from your events feed:
+```bash
+glab api "users/163/events?after=YYYY-MM-DD&before=YYYY-MM-DD&per_page=100"
+```
+Take events with `action_name: "approved"` and `target_type: "MergeRequest"` (optionally also `commented on` a `MergeRequest`/`DiffNote` on someone else's MR). Resolve the project path via `glab api "projects/<project_id>"` (field `path`) to build the `ref`. GitLab reviews are typically sparse — that is expected; your review volume is mostly on GitHub.
+
+Note: `action_name: "accepted"` means you merged an MR (counts toward `merged` on MRs you authored); `"opened"` means you authored it. Use these to sanity-check the authored list.
+
+## 5. Organize the content
+
+1. **Group tasks by project.** Infer short, consistent project names (Scheduler, Cuebot, ST3, Qlite, BOM, VFO, CueWeb, Team / People, Personal / Finance, etc.). Only include what was actually worked on — no padding.
+2. **Set the `goal: true` flag** on any project that served a `# Week Goals` item that week. This is the one judgment call the dashboard cannot make itself — it drives the "time sink" warning (share of work outside your goals). Leave it off for projects that were not goals. Never flag `Personal` or `Team` as lingering-exempt yourself; the page handles that.
+3. **Pick 2–3 highlights** — the week's most notable accomplishments, in your own words. For an unfinished in-progress week, leave highlights empty.
+
+## 6. Write the markdown review
+
+Append (never overwrite) a `# AI Week Review` section at the end of the weekly file, in this format:
+
+```
+## Week Review: YYYY-MM-DD to YYYY-MM-DD
+
+### Project Name
+- Task or activity completed
+- Another task
+
+### Pull & Merge Requests
+- **OpenCue#2425** - [scheduler] Add end-to-end stress tests (created, open) [GitHub]
+- **shottree3!265** - Optimize st3-metadata search query (created, merged) [GitLab]
+- **spi-centos!18** - Add en_US locale to SPI 9.5 image (reviewed) [GitLab]
+```
+
+Keep it short and factual. Tag each PR/MR with `[GitHub]` or `[GitLab]`. No commentary unless asked.
+
+## 7. Append to the dashboard (`_weekly/site/data.js`)
+
+The dashboard reads `window.WEEKS` (an array, newest last). Append **one new week object** immediately before the closing `];` of the `window.WEEKS` array. Never rewrite existing entries — new weeks carry their MRs inline with `src` tags.
+
+Schema (match this exactly):
+
+```js
+{
+  id: "2026-W29",                    // week id = weekly filename stem
+  week: 29,                          // the WW number
+  label: "Week 29",
+  range: "Jul 13 – Jul 19, 2026",
+  status: "reviewed",                // "reviewed", or "in-progress" if the week isn't over
+  goals:     [ { text: "…", done: true } ],   // from # Week Goals
+  tentative: [ { text: "…", done: false } ],  // from # Tentative (or [])
+  personal:  [ { text: "…", done: false } ],  // from # Personal (or [])
+  highlights: [ "…", "…" ],          // 2–3, or [] for an in-progress week
+  projects: [
+    { name: "Scheduler", goal: true, tasks: [ "task one", "task two" ] },
+    { name: "Personal / Finance", tasks: [ "…" ] }   // omit `goal` when not a week goal
+  ],
+  prs: {
+    created: [
+      { ref: "OpenCue#2425", title: "[scheduler] Add end-to-end stress tests", status: "open",   src: "github" },
+      { ref: "shottree3!265", title: "Optimize st3-metadata search query",     status: "merged", src: "gitlab" },
+      { ref: "shottree3!263", title: "Draft: Upgrade to Java 21", status: "open", src: "gitlab", draft: true }
+    ],
+    reviewed: [
+      { ref: "OpenCue#2410", title: "[cueweb/docs] Add Allocations page", src: "github" },
+      { ref: "spi-centos!18", title: "Add en_US locale to SPI 9.5 image",  src: "gitlab" }
+    ]
+  }
+}
+```
+
+Rules:
+- Put **every** PR/MR in `prs.created` or `prs.reviewed` with an explicit `src: "github"` or `src: "gitlab"`. `status` applies to `created` entries only.
+- The dashboard computes stats, sparklines, and warnings from this data. It infers **lingering projects** and **carried-over goals** across weeks automatically — you only need accurate `projects` (with `goal` flags), `tasks`, `goals`, and `prs`. Keep project names stable across weeks so lingering detection works (the page canonicalizes common variants, but consistency helps).
+- After editing, verify the file still parses: `node -e "global.window={};require('./_weekly/site/data.js');console.log(window.WEEKS.length,'weeks')"`.
+
+## Output
+
+Show the user the markdown review (§6). Mention that the dashboard entry was appended and that they can open `_weekly/site/index.html` to view it.

--- a/crates/breadpaper/assets/areas/timeline/skills/wrap-today.md
+++ b/crates/breadpaper/assets/areas/timeline/skills/wrap-today.md
@@ -1,0 +1,56 @@
+# Wrap Today
+
+Close out **today's** daily note. Read what you planned and did, pull the day's commits, scan the last few days for multi-day context, then append an AI review with suggestions to today's note. Append-only — it never rewrites what you wrote.
+
+**Reads:** today's `daily/YYYY-MM-DD.md`, the prior few daily notes, git commits, GitHub (`gh`) / GitLab (`glab`) as available.
+**Writes (append-only):** today's daily note.
+
+## 1. Locate today's note
+
+1. Compute **today's** date (YYYY-MM-DD). Daily notes live in `daily/` named `YYYY-MM-DD.md`.
+2. Look for `daily/<today>.md`. If it doesn't exist yet, create it — the Timeline convention is create-if-missing.
+
+## 2. Read the day's tasks and activities
+
+1. Parse the day-planner and task sections. Separate **checked** (`- [x]`) from **unchecked** (`- [ ]`) tasks.
+2. Note anything meaningful captured during the day: decisions, conversation notes, blockers.
+
+## 3. Pull the day's commits
+
+Fetch what you shipped today. Use whichever sources are wired up:
+
+- GitHub: `gh search commits --author=@me --author-date=YYYY-MM-DD` (or `gh search prs --author=@me --updated=YYYY-MM-DD..YYYY-MM-DD`).
+- Local repos: `git log --author="$(git config user.email)" --since="YYYY-MM-DD 00:00" --until="YYYY-MM-DD 23:59" --oneline`.
+- GitLab (SPI): `export GITLAB_HOST=gitlab.spimageworks.com` then query the events feed as the Week Review skill does.
+
+Deduplicate. Keep repo, short SHA / ref, and message.
+
+## 4. Scan recent days for context
+
+Read the previous 2–3 daily notes so the review isn't myopic — catch carried-over tasks, ongoing threads, and multi-day projects. Note anything that has lingered.
+
+## 5. Append the review
+
+Append (never overwrite) a `# Daily Closure` section at the end of today's note:
+
+```
+# Daily Closure
+
+## Done
+- What actually got finished today
+
+## Open (carried forward)
+- [ ] Unchecked task worth continuing tomorrow
+
+## Commits
+- repo@abc123 — commit message
+
+## Suggestions
+- One or two concrete, actionable nudges (don't pad)
+```
+
+Keep it short and factual. Base "carried forward" on the unchecked tasks plus anything the recent-days scan shows lingering.
+
+## Output
+
+Show the user the review and confirm it was appended to today's note.

--- a/crates/breadpaper/assets/areas/timeline/skills/wrap-yesterday.md
+++ b/crates/breadpaper/assets/areas/timeline/skills/wrap-yesterday.md
@@ -1,0 +1,10 @@
+# Wrap Yesterday
+
+Close out **yesterday's** daily note — the retrospective you didn't get to before bed.
+
+This is the [Wrap Today](./wrap-today.md) ritual run against yesterday instead of today. Follow every step in that skill, with these substitutions:
+
+- **The target day is yesterday** (today minus one day, YYYY-MM-DD) — so the note is `daily/<yesterday>.md`, commits are yesterday's, and the review appends to yesterday's note. If the note doesn't exist, still create it, and note that the day went uncaptured.
+- **The context scan** (step 4) reads the 2–3 daily notes *before* yesterday, plus today's note if it already exists, to catch threads that lingered into today.
+
+Everything else — reading tasks, pulling commits, the `# Daily Closure` section format, and the output — is identical to Wrap Today.

--- a/crates/breadpaper/src/areas.rs
+++ b/crates/breadpaper/src/areas.rs
@@ -13,6 +13,10 @@ const TIMELINE_MANIFEST: &str = include_str!("../assets/areas/timeline/manifest.
 const TIMELINE_DOC: &str = include_str!("../assets/areas/timeline/doc.md");
 const TIMELINE_WEEK_REVIEW_SKILL: &str =
     include_str!("../assets/areas/timeline/skills/week-review.md");
+const TIMELINE_WRAP_TODAY_SKILL: &str =
+    include_str!("../assets/areas/timeline/skills/wrap-today.md");
+const TIMELINE_WRAP_YESTERDAY_SKILL: &str =
+    include_str!("../assets/areas/timeline/skills/wrap-yesterday.md");
 const TIMELINE_DASHBOARD_HTML: &str = include_str!("../assets/areas/timeline/assets/index.html");
 const TIMELINE_DASHBOARD_SEED: &str =
     include_str!("../assets/areas/timeline/assets/data.seed.js");
@@ -175,11 +179,60 @@ fn parse_manifest(manifest_toml: &str) -> Result<AreaManifest> {
         .resolve()
 }
 
+/// Vault-relative root under which Claude Code discovers project skills. Its
+/// files are generated from the manifest, not shipped as static assets.
+pub const CLAUDE_SKILLS_DIR: &str = ".claude/skills";
+
 /// A file an Area ships into the vault, pairing the vault-relative destination
 /// with the asset path inside the catalog package it came from.
 struct ShippedFile {
     destination: String,
     source: String,
+}
+
+/// A `.claude/skills/<id>/SKILL.md` bridge generated from a skill's manifest
+/// entry. Claude Code only discovers skills under `.claude/skills/`, so each
+/// Area skill gets a thin bridge there whose front matter Claude Code reads and
+/// whose body points back to the canonical skill file — keeping one source of
+/// truth for the ritual itself.
+struct ClaudeBridge {
+    destination: String,
+    content: String,
+}
+
+fn yaml_quote(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+fn claude_bridge_content(skill: &AreaSkill) -> String {
+    let mut content = format!(
+        "---\nname: {name}\ndescription: {description}\ndisable-model-invocation: true\n---\n\n\
+         This is a BreadPaper Area skill. Read and follow the full instructions in\n\
+         `{file}` (relative to the vault root), then carry out the ritual it describes.\n\
+         It appends to your notes and never rewrites what you wrote.\n",
+        name = yaml_quote(&skill.name),
+        description = yaml_quote(&skill.summary),
+        file = skill.file,
+    );
+    if !skill.reads.is_empty() {
+        content.push_str(&format!("\nReads: {}\n", skill.reads.join(", ")));
+    }
+    if !skill.writes.is_empty() {
+        content.push_str(&format!("Writes: {}\n", skill.writes.join(", ")));
+    }
+    content
+}
+
+fn claude_bridge_files(manifest: &AreaManifest) -> Vec<ClaudeBridge> {
+    manifest
+        .skills
+        .iter()
+        .map(|skill| ClaudeBridge {
+            destination: format!("{CLAUDE_SKILLS_DIR}/{}/SKILL.md", skill.id),
+            content: claude_bridge_content(skill),
+        })
+        .collect()
 }
 
 fn shipped_files(manifest: &AreaManifest) -> Vec<ShippedFile> {
@@ -229,6 +282,8 @@ pub fn catalog() -> Result<Vec<CatalogArea>> {
         assets: &[
             ("doc.md", TIMELINE_DOC),
             ("skills/week-review.md", TIMELINE_WEEK_REVIEW_SKILL),
+            ("skills/wrap-today.md", TIMELINE_WRAP_TODAY_SKILL),
+            ("skills/wrap-yesterday.md", TIMELINE_WRAP_YESTERDAY_SKILL),
             ("assets/index.html", TIMELINE_DASHBOARD_HTML),
             ("assets/data.seed.js", TIMELINE_DASHBOARD_SEED),
         ],
@@ -303,6 +358,12 @@ pub fn materialize_area(vault_root: &Path, area: &CatalogArea) -> Result<()> {
         })?;
         write_if_missing(&vault_file_path(vault_root, &file.destination)?, contents)?;
     }
+    for bridge in claude_bridge_files(&area.manifest) {
+        write_if_missing(
+            &vault_file_path(vault_root, &bridge.destination)?,
+            &bridge.content,
+        )?;
+    }
 
     // The installed manifest is provenance owned by the app, not a user file,
     // so re-installing overwrites it to record the current package.
@@ -335,6 +396,24 @@ pub fn install_area(vault_root: &Path, area_id: &str) -> Result<()> {
             });
         }
     })
+}
+
+/// Re-materializes every enabled installed Area (create-if-missing), so a vault
+/// opened after an app update gains any newly shipped Area files — new skills
+/// and their Claude Code bridges — without a manual reinstall. Idempotent and
+/// never clobbers user edits; the registry is left untouched. Areas that are
+/// registered but absent from the catalog are skipped. Blocking I/O — call from
+/// a background thread.
+pub fn reconcile_enabled_areas(vault: &Vault) -> Result<()> {
+    for entry in &vault.config.areas.installed {
+        if !entry.enabled {
+            continue;
+        }
+        if let Some(area) = catalog_area(&entry.id)? {
+            materialize_area(&vault.root, &area)?;
+        }
+    }
+    Ok(())
 }
 
 /// Disables an Area in the registry without touching any files.
@@ -428,6 +507,23 @@ pub fn plan_removal(vault_root: &Path, area_id: &str) -> Result<RemovalPlan> {
             _ => plan.keep_modified.push(file.destination),
         }
     }
+    // Claude Code bridges are generated, not shipped as assets, so compare each
+    // against its freshly-generated content instead of a catalog source.
+    for bridge in claude_bridge_files(&manifest) {
+        let path = vault_file_path(vault_root, &bridge.destination)?;
+        let current = match fs::read_to_string(&path) {
+            Ok(current) => current,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("reading {}", path.display()));
+            }
+        };
+        if current == bridge.content {
+            plan.delete.push(bridge.destination);
+        } else {
+            plan.keep_modified.push(bridge.destination);
+        }
+    }
     Ok(plan)
 }
 
@@ -516,8 +612,10 @@ mod tests {
         assert_eq!(manifest.id, TIMELINE_AREA_ID);
         assert_eq!(manifest.version, 1);
         assert_eq!(manifest.doc, "areas/Timeline.md");
-        assert_eq!(manifest.skills.len(), 1);
+        assert_eq!(manifest.skills.len(), 3);
         assert_eq!(manifest.skills[0].file, "skills/timeline/week-review.md");
+        assert_eq!(manifest.skills[1].file, "skills/timeline/wrap-today.md");
+        assert_eq!(manifest.skills[2].file, "skills/timeline/wrap-yesterday.md");
         assert_eq!(manifest.surfaces.len(), 1);
         assert_eq!(manifest.surfaces[0].open, "_weekly/site/index.html");
         // Every shipped file must have a bundled asset behind it.
@@ -539,6 +637,16 @@ mod tests {
         assert!(dir.path().join("_weekly/site/index.html").is_file());
         assert!(dir.path().join("_weekly/site/data.js").is_file());
         assert!(installed_manifest_path(dir.path(), TIMELINE_AREA_ID).is_file());
+        // Claude Code bridges are generated for every skill so a `claude`
+        // session opened in the vault can invoke them via `/<skill-id>`.
+        for skill_id in ["week-review", "wrap-today", "wrap-yesterday"] {
+            assert!(
+                dir.path()
+                    .join(format!(".claude/skills/{skill_id}/SKILL.md"))
+                    .is_file(),
+                "missing Claude bridge for {skill_id}"
+            );
+        }
 
         let vault = detect(dir.path());
         let installed = &vault.config.areas.installed;
@@ -546,6 +654,67 @@ mod tests {
         assert_eq!(installed[0].id, TIMELINE_AREA_ID);
         assert!(installed[0].enabled);
         assert_eq!(enabled_areas(&vault).len(), 1);
+    }
+
+    #[test]
+    fn claude_bridges_carry_frontmatter_and_survive_edits() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let bridge = dir.path().join(".claude/skills/wrap-today/SKILL.md");
+        let content = fs::read_to_string(&bridge).unwrap();
+        // Diego's choice: explicit `/wrap-today` only, never model-invoked.
+        assert!(content.contains("disable-model-invocation: true"));
+        // Body points back to the canonical skill file — one source of truth.
+        assert!(content.contains("skills/timeline/wrap-today.md"));
+
+        // create-if-missing: a user (or their LLM) edit survives re-materialize.
+        fs::write(&bridge, "edited by hand").unwrap();
+        let area = catalog_area(TIMELINE_AREA_ID).unwrap().unwrap();
+        materialize_area(dir.path(), &area).unwrap();
+        assert_eq!(fs::read_to_string(&bridge).unwrap(), "edited by hand");
+
+        // An edited bridge is preserved on removal, like any user-touched file.
+        let plan = plan_removal(dir.path(), TIMELINE_AREA_ID).unwrap();
+        assert!(
+            plan.keep_modified
+                .contains(&".claude/skills/wrap-today/SKILL.md".to_string())
+        );
+    }
+
+    #[test]
+    fn reconcile_backfills_missing_files_on_existing_vault() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        // Simulate a vault scaffolded by an older app that lacked bridges and
+        // the wrap skills: drop the whole `.claude` tree and one skill file.
+        fs::remove_dir_all(dir.path().join(".claude")).unwrap();
+        fs::remove_file(dir.path().join("skills/timeline/wrap-yesterday.md")).unwrap();
+
+        let vault = detect(dir.path());
+        reconcile_enabled_areas(&vault).unwrap();
+        assert!(dir.path().join("skills/timeline/wrap-yesterday.md").is_file());
+        assert!(
+            dir.path()
+                .join(".claude/skills/wrap-today/SKILL.md")
+                .is_file()
+        );
+        assert!(
+            dir.path()
+                .join(".claude/skills/week-review/SKILL.md")
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn reconcile_skips_disabled_areas() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        deactivate_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        fs::remove_dir_all(dir.path().join(".claude")).unwrap();
+
+        let vault = detect(dir.path());
+        reconcile_enabled_areas(&vault).unwrap();
+        assert!(!dir.path().join(".claude").exists());
     }
 
     #[test]
@@ -583,6 +752,9 @@ mod tests {
         assert!(skill_path.is_file());
         assert!(!dir.path().join("areas/Timeline.md").is_file());
         assert!(!dir.path().join("_weekly/site").exists());
+        // The generated bridges are unmodified, so removal deletes them and
+        // prunes the now-empty `.claude` tree.
+        assert!(!dir.path().join(".claude").exists());
         assert!(!installed_manifest_path(dir.path(), TIMELINE_AREA_ID).exists());
         // The now-empty installed-areas dir is pruned, but `.breadpaper/`
         // survives because config.toml keeps it non-empty.

--- a/crates/breadpaper/src/areas.rs
+++ b/crates/breadpaper/src/areas.rs
@@ -1,0 +1,654 @@
+use anyhow::{Context as _, Result, bail};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use crate::vault::{VAULT_MARKER_DIR, Vault, write_if_missing};
+
+pub const TIMELINE_AREA_ID: &str = "timeline";
+pub const INSTALLED_AREAS_DIR: &str = "areas";
+pub const AREA_MANIFEST_FILE: &str = "manifest.toml";
+
+const TIMELINE_MANIFEST: &str = include_str!("../assets/areas/timeline/manifest.toml");
+const TIMELINE_DOC: &str = include_str!("../assets/areas/timeline/doc.md");
+const TIMELINE_WEEK_REVIEW_SKILL: &str =
+    include_str!("../assets/areas/timeline/skills/week-review.md");
+const TIMELINE_DASHBOARD_HTML: &str = include_str!("../assets/areas/timeline/assets/index.html");
+const TIMELINE_DASHBOARD_SEED: &str =
+    include_str!("../assets/areas/timeline/assets/data.seed.js");
+
+/// The parsed shape of an Area's `manifest.toml` (§5.2 of the V3 spec).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AreaManifestContent {
+    schema: Option<u32>,
+    id: String,
+    name: String,
+    version: Option<u32>,
+    summary: Option<String>,
+    doc: String,
+    #[serde(default)]
+    scaffold: Vec<ScaffoldEntryContent>,
+    #[serde(default)]
+    skill: Vec<AreaSkillContent>,
+    #[serde(default)]
+    surface: Vec<AreaSurfaceContent>,
+}
+
+impl AreaManifestContent {
+    fn resolve(self) -> Result<AreaManifest> {
+        Ok(AreaManifest {
+            schema: self.schema.unwrap_or(1),
+            id: self.id,
+            name: self.name,
+            version: self.version.unwrap_or(1),
+            summary: self.summary.unwrap_or_default(),
+            doc: self.doc,
+            scaffold: self
+                .scaffold
+                .into_iter()
+                .map(ScaffoldEntryContent::resolve)
+                .collect::<Result<_>>()?,
+            skills: self.skill.into_iter().map(AreaSkillContent::resolve).collect(),
+            surfaces: self
+                .surface
+                .into_iter()
+                .map(AreaSurfaceContent::resolve)
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScaffoldEntryContent {
+    kind: String,
+    path: String,
+    source: Option<String>,
+}
+
+impl ScaffoldEntryContent {
+    fn resolve(self) -> Result<ScaffoldEntry> {
+        match self.kind.as_str() {
+            "dir" => Ok(ScaffoldEntry::Dir { path: self.path }),
+            "file" => Ok(ScaffoldEntry::File {
+                source: self.source.with_context(|| {
+                    format!("scaffold file entry {:?} is missing a source", self.path)
+                })?,
+                path: self.path,
+            }),
+            other => bail!("unknown scaffold kind {other:?} (expected \"dir\" or \"file\")"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AreaSkillContent {
+    id: String,
+    name: String,
+    file: String,
+    summary: Option<String>,
+    #[serde(default)]
+    reads: Vec<String>,
+    #[serde(default)]
+    writes: Vec<String>,
+}
+
+impl AreaSkillContent {
+    fn resolve(self) -> AreaSkill {
+        AreaSkill {
+            id: self.id,
+            name: self.name,
+            file: self.file,
+            summary: self.summary.unwrap_or_default(),
+            reads: self.reads,
+            writes: self.writes,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AreaSurfaceContent {
+    kind: String,
+    name: String,
+    open: String,
+}
+
+impl AreaSurfaceContent {
+    fn resolve(self) -> AreaSurface {
+        AreaSurface {
+            kind: self.kind,
+            name: self.name,
+            open: self.open,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AreaManifest {
+    pub schema: u32,
+    pub id: String,
+    pub name: String,
+    pub version: u32,
+    pub summary: String,
+    /// Vault-relative path the explainer doc is materialized to.
+    pub doc: String,
+    pub scaffold: Vec<ScaffoldEntry>,
+    pub skills: Vec<AreaSkill>,
+    pub surfaces: Vec<AreaSurface>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScaffoldEntry {
+    Dir { path: String },
+    /// `path` is the vault-relative destination; `source` is the asset path
+    /// within the catalog package.
+    File { path: String, source: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AreaSkill {
+    pub id: String,
+    pub name: String,
+    /// Vault-relative path the skill file is materialized to.
+    pub file: String,
+    pub summary: String,
+    /// Declared read scope; surfaced only, not enforced in V3.
+    pub reads: Vec<String>,
+    /// Declared write scope; surfaced only, not enforced in V3.
+    pub writes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AreaSurface {
+    pub kind: String,
+    pub name: String,
+    /// Vault-relative path this surface opens.
+    pub open: String,
+}
+
+fn parse_manifest(manifest_toml: &str) -> Result<AreaManifest> {
+    toml::from_str::<AreaManifestContent>(manifest_toml)
+        .context("parsing Area manifest")?
+        .resolve()
+}
+
+/// A file an Area ships into the vault, pairing the vault-relative destination
+/// with the asset path inside the catalog package it came from.
+struct ShippedFile {
+    destination: String,
+    source: String,
+}
+
+fn shipped_files(manifest: &AreaManifest) -> Vec<ShippedFile> {
+    let mut files = vec![ShippedFile {
+        destination: manifest.doc.clone(),
+        source: "doc.md".to_string(),
+    }];
+    for skill in &manifest.skills {
+        files.push(ShippedFile {
+            destination: skill.file.clone(),
+            source: format!("skills/{}.md", skill.id),
+        });
+    }
+    for entry in &manifest.scaffold {
+        if let ScaffoldEntry::File { path, source } = entry {
+            files.push(ShippedFile {
+                destination: path.clone(),
+                source: source.clone(),
+            });
+        }
+    }
+    files
+}
+
+/// An Area package shipped inside the BreadPaper binary.
+pub struct CatalogArea {
+    pub manifest: AreaManifest,
+    manifest_toml: &'static str,
+    assets: &'static [(&'static str, &'static str)],
+}
+
+impl CatalogArea {
+    fn asset(&self, source: &str) -> Option<&'static str> {
+        self.assets
+            .iter()
+            .find(|(path, _)| *path == source)
+            .map(|(_, contents)| *contents)
+    }
+}
+
+/// The app-shipped Area catalog, in gallery order.
+pub fn catalog() -> Result<Vec<CatalogArea>> {
+    Ok(vec![CatalogArea {
+        manifest: parse_manifest(TIMELINE_MANIFEST)
+            .context("parsing the bundled Timeline Area manifest")?,
+        manifest_toml: TIMELINE_MANIFEST,
+        assets: &[
+            ("doc.md", TIMELINE_DOC),
+            ("skills/week-review.md", TIMELINE_WEEK_REVIEW_SKILL),
+            ("assets/index.html", TIMELINE_DASHBOARD_HTML),
+            ("assets/data.seed.js", TIMELINE_DASHBOARD_SEED),
+        ],
+    }])
+}
+
+pub fn catalog_area(area_id: &str) -> Result<Option<CatalogArea>> {
+    Ok(catalog()?
+        .into_iter()
+        .find(|area| area.manifest.id == area_id))
+}
+
+/// Joins a manifest-declared vault-relative path onto the vault root,
+/// rejecting absolute paths and `..` so a manifest can never reach outside
+/// the vault.
+pub fn vault_file_path(vault_root: &Path, relative: &str) -> Result<PathBuf> {
+    let relative_path = Path::new(relative);
+    let plain = !relative_path.as_os_str().is_empty()
+        && relative_path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)));
+    if !plain {
+        bail!("Area path {relative:?} must be a plain vault-relative path");
+    }
+    Ok(vault_root.join(relative_path))
+}
+
+fn installed_area_dir(vault_root: &Path, area_id: &str) -> PathBuf {
+    vault_root
+        .join(VAULT_MARKER_DIR)
+        .join(INSTALLED_AREAS_DIR)
+        .join(area_id)
+}
+
+pub fn installed_manifest_path(vault_root: &Path, area_id: &str) -> PathBuf {
+    installed_area_dir(vault_root, area_id).join(AREA_MANIFEST_FILE)
+}
+
+/// Loads the installed provenance copy of an Area's manifest, if present.
+pub fn load_installed_manifest(vault_root: &Path, area_id: &str) -> Result<Option<AreaManifest>> {
+    let manifest_path = installed_manifest_path(vault_root, area_id);
+    let manifest_toml = match fs::read_to_string(&manifest_path) {
+        Ok(manifest_toml) => manifest_toml,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("reading {}", manifest_path.display()));
+        }
+    };
+    parse_manifest(&manifest_toml)
+        .with_context(|| format!("parsing {}", manifest_path.display()))
+        .map(Some)
+}
+
+/// Writes an Area's editable files into the vault (create-if-missing, never
+/// clobbering) and records the installed manifest copy under
+/// `.breadpaper/areas/<id>/`. Idempotent; missing files are re-materialized.
+/// Blocking I/O — call from a background thread.
+pub fn materialize_area(vault_root: &Path, area: &CatalogArea) -> Result<()> {
+    for entry in &area.manifest.scaffold {
+        if let ScaffoldEntry::Dir { path } = entry {
+            let dir = vault_file_path(vault_root, path)?;
+            fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        }
+    }
+    for file in shipped_files(&area.manifest) {
+        let contents = area.asset(&file.source).with_context(|| {
+            format!(
+                "the {} Area package has no asset {:?}",
+                area.manifest.id, file.source
+            )
+        })?;
+        write_if_missing(&vault_file_path(vault_root, &file.destination)?, contents)?;
+    }
+
+    // The installed manifest is provenance owned by the app, not a user file,
+    // so re-installing overwrites it to record the current package.
+    let manifest_path = installed_manifest_path(vault_root, &area.manifest.id);
+    if let Some(parent) = manifest_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(&manifest_path, area.manifest_toml)
+        .with_context(|| format!("writing {}", manifest_path.display()))?;
+    Ok(())
+}
+
+/// Materializes a catalog Area and registers it (enabled) in the vault
+/// config. Registration happens last, so a failed install never leaves a
+/// registered-but-missing Area behind. Blocking I/O — call from a background
+/// thread.
+pub fn install_area(vault_root: &Path, area_id: &str) -> Result<()> {
+    let area = catalog_area(area_id)?
+        .with_context(|| format!("no Area {area_id:?} in the catalog"))?;
+    materialize_area(vault_root, &area)?;
+    crate::vault::update_areas_registry(vault_root, |installed| {
+        if let Some(entry) = installed.iter_mut().find(|entry| entry.id == area_id) {
+            entry.enabled = true;
+            entry.version = area.manifest.version;
+        } else {
+            installed.push(crate::vault::InstalledArea {
+                id: area_id.to_string(),
+                enabled: true,
+                version: area.manifest.version,
+            });
+        }
+    })
+}
+
+/// Disables an Area in the registry without touching any files.
+pub fn deactivate_area(vault_root: &Path, area_id: &str) -> Result<()> {
+    crate::vault::update_areas_registry(vault_root, |installed| {
+        if let Some(entry) = installed.iter_mut().find(|entry| entry.id == area_id) {
+            entry.enabled = false;
+        }
+    })
+}
+
+/// The manifests of the vault's enabled Areas, in registry order. Individual
+/// load failures are logged and skipped so one broken Area can't blank the
+/// whole panel section.
+pub fn enabled_areas(vault: &Vault) -> Vec<AreaManifest> {
+    let mut manifests = Vec::new();
+    for entry in &vault.config.areas.installed {
+        if !entry.enabled {
+            continue;
+        }
+        match load_installed_manifest(&vault.root, &entry.id) {
+            Ok(Some(manifest)) => manifests.push(manifest),
+            Ok(None) => match catalog_area(&entry.id) {
+                Ok(Some(area)) => manifests.push(area.manifest),
+                Ok(None) => log::warn!(
+                    "BreadPaper: Area {:?} is registered but has no installed manifest and is not in the catalog",
+                    entry.id
+                ),
+                Err(error) => {
+                    log::error!("BreadPaper: couldn't load the Areas catalog: {error:?}")
+                }
+            },
+            Err(error) => log::warn!(
+                "BreadPaper: couldn't load the installed manifest for Area {:?}: {error:?}",
+                entry.id
+            ),
+        }
+    }
+    manifests
+}
+
+/// What removing an Area's files would do, computed before the user confirms.
+#[derive(Debug, PartialEq)]
+pub struct RemovalPlan {
+    pub area_name: String,
+    /// Vault-relative shipped files that still match their catalog source.
+    pub delete: Vec<String>,
+    /// Vault-relative shipped files modified since install; always preserved.
+    pub keep_modified: Vec<String>,
+}
+
+/// Compares the Area's shipped files (from the installed manifest, falling
+/// back to the catalog manifest) against their catalog sources. Files that
+/// differ — edited by the user or their LLM — are preserved, never deleted.
+/// Blocking I/O — call from a background thread.
+pub fn plan_removal(vault_root: &Path, area_id: &str) -> Result<RemovalPlan> {
+    let catalog_area = catalog_area(area_id)?;
+    let manifest = match load_installed_manifest(vault_root, area_id)? {
+        Some(manifest) => manifest,
+        None => catalog_area
+            .as_ref()
+            .map(|area| area.manifest.clone())
+            .with_context(|| {
+                format!("Area {area_id:?} has no installed manifest and is not in the catalog")
+            })?,
+    };
+
+    let mut plan = RemovalPlan {
+        area_name: manifest.name.clone(),
+        delete: Vec::new(),
+        keep_modified: Vec::new(),
+    };
+    for file in shipped_files(&manifest) {
+        let path = vault_file_path(vault_root, &file.destination)?;
+        let current = match fs::read(&path) {
+            Ok(current) => current,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("reading {}", path.display()));
+            }
+        };
+        let original = catalog_area
+            .as_ref()
+            .and_then(|area| area.asset(&file.source));
+        match original {
+            Some(original) if current == original.as_bytes() => {
+                plan.delete.push(file.destination);
+            }
+            // No catalog source to compare against (or the contents differ):
+            // treat the file as user-modified and keep it.
+            _ => plan.keep_modified.push(file.destination),
+        }
+    }
+    Ok(plan)
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RemovalOutcome {
+    pub deleted: Vec<String>,
+    pub kept_modified: Vec<String>,
+}
+
+/// Deletes the Area's unmodified shipped files, its installed manifest, and
+/// its registry entry. Recomputes the plan at deletion time so edits made
+/// while the confirmation dialog was open are still preserved. Blocking I/O —
+/// call from a background thread.
+pub fn delete_area(vault_root: &Path, area_id: &str) -> Result<RemovalOutcome> {
+    let plan = plan_removal(vault_root, area_id)?;
+    let mut deleted = Vec::new();
+    for destination in &plan.delete {
+        let path = vault_file_path(vault_root, destination)?;
+        match fs::remove_file(&path) {
+            Ok(()) => {
+                deleted.push(destination.clone());
+                prune_empty_parents(vault_root, &path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("deleting {}", path.display()));
+            }
+        }
+    }
+
+    let installed_dir = installed_area_dir(vault_root, area_id);
+    if installed_dir.exists() {
+        fs::remove_dir_all(&installed_dir)
+            .with_context(|| format!("deleting {}", installed_dir.display()))?;
+        // `installed_dir` is now gone; prune from it as the deleted entry so
+        // pruning starts at its parent (`.breadpaper/areas/`). The walk stops
+        // at `.breadpaper/` because config.toml keeps it non-empty.
+        prune_empty_parents(vault_root, &installed_dir);
+    }
+
+    crate::vault::update_areas_registry(vault_root, |installed| {
+        installed.retain(|entry| entry.id != area_id);
+    })?;
+
+    Ok(RemovalOutcome {
+        deleted,
+        kept_modified: plan.keep_modified,
+    })
+}
+
+/// Removes now-empty directories left behind by a deleted file, walking up
+/// toward (but never past) the vault root.
+fn prune_empty_parents(vault_root: &Path, deleted_file: &Path) {
+    let mut current = deleted_file.parent();
+    while let Some(directory) = current {
+        if directory == vault_root || !directory.starts_with(vault_root) {
+            break;
+        }
+        // remove_dir refuses to delete non-empty directories, which is
+        // exactly the stop condition; any failure just means the directory
+        // stays behind.
+        if fs::remove_dir(directory).is_err() {
+            break;
+        }
+        current = directory.parent();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::{VaultStatus, scaffold_vault};
+
+    fn detect(root: &Path) -> Vault {
+        match Vault::detect(root) {
+            VaultStatus::Valid(vault) => vault,
+            other => panic!("expected valid vault, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn catalog_parses() {
+        let catalog = catalog().unwrap();
+        assert_eq!(catalog.len(), 1);
+        let manifest = &catalog[0].manifest;
+        assert_eq!(manifest.id, TIMELINE_AREA_ID);
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.doc, "areas/Timeline.md");
+        assert_eq!(manifest.skills.len(), 1);
+        assert_eq!(manifest.skills[0].file, "skills/timeline/week-review.md");
+        assert_eq!(manifest.surfaces.len(), 1);
+        assert_eq!(manifest.surfaces[0].open, "_weekly/site/index.html");
+        // Every shipped file must have a bundled asset behind it.
+        for file in shipped_files(manifest) {
+            assert!(
+                catalog[0].asset(&file.source).is_some(),
+                "missing asset {:?}",
+                file.source
+            );
+        }
+    }
+
+    #[test]
+    fn scaffold_preinstalls_timeline_area() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        assert!(dir.path().join("areas/Timeline.md").is_file());
+        assert!(dir.path().join("skills/timeline/week-review.md").is_file());
+        assert!(dir.path().join("_weekly/site/index.html").is_file());
+        assert!(dir.path().join("_weekly/site/data.js").is_file());
+        assert!(installed_manifest_path(dir.path(), TIMELINE_AREA_ID).is_file());
+
+        let vault = detect(dir.path());
+        let installed = &vault.config.areas.installed;
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].id, TIMELINE_AREA_ID);
+        assert!(installed[0].enabled);
+        assert_eq!(enabled_areas(&vault).len(), 1);
+    }
+
+    #[test]
+    fn materialize_never_clobbers() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let skill_path = dir.path().join("skills/timeline/week-review.md");
+        fs::write(&skill_path, "my edited skill").unwrap();
+
+        let area = catalog_area(TIMELINE_AREA_ID).unwrap().unwrap();
+        materialize_area(dir.path(), &area).unwrap();
+        assert_eq!(fs::read_to_string(&skill_path).unwrap(), "my edited skill");
+    }
+
+    #[test]
+    fn plan_keeps_modified_files_and_delete_preserves_them() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let skill_path = dir.path().join("skills/timeline/week-review.md");
+        fs::write(&skill_path, "my edited skill").unwrap();
+
+        let plan = plan_removal(dir.path(), TIMELINE_AREA_ID).unwrap();
+        assert_eq!(
+            plan.keep_modified,
+            vec!["skills/timeline/week-review.md".to_string()]
+        );
+        assert!(plan.delete.contains(&"areas/Timeline.md".to_string()));
+        assert!(plan.delete.contains(&"_weekly/site/index.html".to_string()));
+
+        let outcome = delete_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        assert_eq!(
+            outcome.kept_modified,
+            vec!["skills/timeline/week-review.md".to_string()]
+        );
+        assert!(skill_path.is_file());
+        assert!(!dir.path().join("areas/Timeline.md").is_file());
+        assert!(!dir.path().join("_weekly/site").exists());
+        assert!(!installed_manifest_path(dir.path(), TIMELINE_AREA_ID).exists());
+        // The now-empty installed-areas dir is pruned, but `.breadpaper/`
+        // survives because config.toml keeps it non-empty.
+        assert!(
+            !dir.path()
+                .join(VAULT_MARKER_DIR)
+                .join(INSTALLED_AREAS_DIR)
+                .exists()
+        );
+        assert!(dir.path().join(VAULT_MARKER_DIR).is_dir());
+
+        let vault = detect(dir.path());
+        assert!(vault.config.areas.installed.is_empty());
+        // Core config survives the registry rewrite.
+        assert_eq!(vault.config.daily.dir, "daily");
+    }
+
+    #[test]
+    fn delete_never_touches_user_notes() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let daily_note = dir.path().join("daily/2026-07-20.md");
+        fs::write(&daily_note, "my day").unwrap();
+        let weekly_note = dir.path().join("weekly/2026-W30.md");
+        fs::write(&weekly_note, "my week").unwrap();
+
+        delete_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        assert_eq!(fs::read_to_string(&daily_note).unwrap(), "my day");
+        assert_eq!(fs::read_to_string(&weekly_note).unwrap(), "my week");
+    }
+
+    #[test]
+    fn deactivate_then_reinstall_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+
+        deactivate_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        let vault = detect(dir.path());
+        assert!(!vault.config.areas.installed[0].enabled);
+        assert!(enabled_areas(&vault).is_empty());
+        // Files stay on disk.
+        assert!(dir.path().join("areas/Timeline.md").is_file());
+
+        install_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        let vault = detect(dir.path());
+        assert!(vault.config.areas.installed[0].enabled);
+        assert_eq!(vault.config.areas.installed.len(), 1);
+    }
+
+    #[test]
+    fn install_rematerializes_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let doc_path = dir.path().join("areas/Timeline.md");
+        fs::remove_file(&doc_path).unwrap();
+
+        install_area(dir.path(), TIMELINE_AREA_ID).unwrap();
+        assert!(doc_path.is_file());
+    }
+
+    #[test]
+    fn vault_file_path_rejects_escapes() {
+        let root = Path::new("/vault");
+        assert!(vault_file_path(root, "notes/ok.md").is_ok());
+        assert!(vault_file_path(root, "../outside.md").is_err());
+        assert!(vault_file_path(root, "/etc/passwd").is_err());
+        assert!(vault_file_path(root, "").is_err());
+    }
+}

--- a/crates/breadpaper/src/breadpaper.rs
+++ b/crates/breadpaper/src/breadpaper.rs
@@ -1,0 +1,62 @@
+pub mod notes;
+pub mod timeline_panel;
+pub mod vault;
+
+use anyhow::Result;
+use gpui::{App, AppContext as _, Task};
+use std::sync::Arc;
+use workspace::AppState;
+
+pub use timeline_panel::{TimelinePanel, init, show_panel_if_vault};
+pub use vault::{Vault, VaultStatus, default_vault_path, scaffold_vault};
+
+/// Opens the default vault as the workspace, scaffolding the sample vault
+/// first if it doesn't exist yet. On a fresh scaffold, `welcome.md` is opened
+/// alongside so the user lands on something oriented. Used at startup when
+/// there is no previous session to restore.
+pub fn open_startup_vault(app_state: Arc<AppState>, cx: &mut App) -> Task<Result<()>> {
+    let vault_root = vault::default_vault_path();
+    let scaffold = cx.background_spawn({
+        let vault_root = vault_root.clone();
+        async move {
+            let already_vault = vault_root
+                .join(vault::VAULT_MARKER_DIR)
+                .join(vault::VAULT_CONFIG_FILE)
+                .is_file();
+            if !already_vault {
+                vault::scaffold_vault(&vault_root)?;
+            }
+            anyhow::Ok(!already_vault)
+        }
+    });
+
+    cx.spawn(async move |cx| {
+        let open_result = async {
+            let freshly_scaffolded = scaffold.await?;
+            let mut paths = vec![vault_root.clone()];
+            if freshly_scaffolded {
+                paths.push(vault_root.join(vault::WELCOME_FILE));
+            }
+            cx.update(|cx| {
+                workspace::open_paths(
+                    &paths,
+                    app_state.clone(),
+                    workspace::OpenOptions::default(),
+                    cx,
+                )
+            })
+            .await?;
+            anyhow::Ok(())
+        }
+        .await;
+
+        if let Err(error) = open_result {
+            log::error!(
+                "BreadPaper: couldn't open the default vault, falling back to an empty workspace: {error:?}"
+            );
+            cx.update(|cx| workspace::open_new(Default::default(), app_state, cx, |_, _, _| {}))
+                .await?;
+        }
+        Ok(())
+    })
+}

--- a/crates/breadpaper/src/breadpaper.rs
+++ b/crates/breadpaper/src/breadpaper.rs
@@ -1,3 +1,4 @@
+pub mod history;
 pub mod notes;
 pub mod timeline_panel;
 pub mod vault;

--- a/crates/breadpaper/src/breadpaper.rs
+++ b/crates/breadpaper/src/breadpaper.rs
@@ -1,15 +1,51 @@
+pub mod areas;
 pub mod history;
 pub mod notes;
 pub mod timeline_panel;
 pub mod vault;
 
-use anyhow::Result;
-use gpui::{App, AppContext as _, Task};
+use anyhow::{Context as _, Result};
+use editor::Editor;
+use gpui::{App, AppContext as _, AsyncWindowContext, Task, WeakEntity};
+use markdown_preview::markdown_preview_view::MarkdownPreviewView;
+use std::path::PathBuf;
 use std::sync::Arc;
-use workspace::AppState;
+use workspace::{AppState, OpenOptions, OpenVisible, Workspace};
 
 pub use timeline_panel::{TimelinePanel, init, show_panel_if_vault};
 pub use vault::{Vault, VaultStatus, default_vault_path, scaffold_vault};
+
+/// Opens `path` and lands the user on a rendered markdown preview of it
+/// ("viewing mode") instead of the raw buffer. There is no one-shot
+/// open-as-preview API, so this opens the file as an editor first and then
+/// attaches an independent preview item to the same pane.
+pub async fn open_abs_path_as_preview(
+    workspace: WeakEntity<Workspace>,
+    path: PathBuf,
+    cx: &mut AsyncWindowContext,
+) -> Result<()> {
+    let item = workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_abs_path(
+                path.clone(),
+                OpenOptions {
+                    visible: Some(OpenVisible::All),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        })?
+        .await?;
+    let editor = item
+        .downcast::<Editor>()
+        .with_context(|| format!("{} did not open as a markdown editor", path.display()))?;
+    workspace.update_in(cx, |workspace, window, cx| {
+        let pane = workspace.active_pane().clone();
+        MarkdownPreviewView::open_preview_in_pane(workspace, editor, pane, window, cx);
+    })?;
+    Ok(())
+}
 
 /// Opens the default vault as the workspace, scaffolding the sample vault
 /// first if it doesn't exist yet. On a fresh scaffold, `welcome.md` is opened

--- a/crates/breadpaper/src/history.rs
+++ b/crates/breadpaper/src/history.rs
@@ -1,0 +1,521 @@
+//! Invisible checkpoint history for BreadPaper vaults (spec: v2-invisible-git).
+//!
+//! A background service that commits snapshots of the whole vault into a
+//! hidden git repository whose git-dir is `<vault>/.breadpaper/history`.
+//! Because that directory is never named `.git`, Zed's worktree scanner never
+//! discovers it, so it never appears in the git UI; isolation from any
+//! user-managed `.git` comes from driving every command with explicit
+//! `GIT_DIR`/`GIT_WORK_TREE` scoping. There is intentionally no user-facing
+//! surface here: no panel, no actions, no notifications.
+
+use anyhow::{Context as _, Result};
+use chrono::Utc;
+use fs::Fs;
+use git::repository::{GitRepositoryCheckpoint, RealGitRepository};
+use gpui::{
+    App, AppContext as _, BackgroundExecutor, Context, Entity, EntityId, Global, Subscription,
+    Task,
+};
+use project::{Project, WorktreeId};
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use util::ResultExt as _;
+use workspace::Workspace;
+
+use crate::vault::{HistoryConfig, VAULT_CONFIG_FILE, VAULT_MARKER_DIR, Vault, VaultStatus};
+
+const HISTORY_DIR: &str = "history";
+const CHECKPOINTS_BRANCH: &str = "checkpoints";
+const CHECKPOINTS_REF: &str = "refs/heads/checkpoints";
+const AUTHOR_NAME: &str = "BreadPaper";
+const AUTHOR_EMAIL: &str = "history@breadpaper.local";
+/// The history repo must always ignore its own git-dir — a snapshot would
+/// otherwise include its own objects and grow without bound. `.git` is listed
+/// for clarity even though git never tracks a directory with that name.
+const BASE_EXCLUDES: &str = "/.breadpaper/history/\n/.git/\n";
+const HEARTBEAT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+pub fn init(cx: &mut App) {
+    // The same bundled-git resolution Zed itself uses; outside bundled macOS
+    // builds the service falls back to the system `git`.
+    let bundled_git_binary_path =
+        if cfg!(target_os = "macos") && option_env!("ZED_BUNDLE").as_deref() == Some("true") {
+            cx.path_for_auxiliary_executable("git").log_err()
+        } else {
+            None
+        };
+    cx.observe_new(move |workspace: &mut Workspace, _window, cx| {
+        let project = workspace.project().clone();
+        if !project.read(cx).is_local() {
+            return;
+        }
+        let service =
+            cx.new(|cx| HistoryService::new(project.clone(), bundled_git_binary_path.clone(), cx));
+        let project_id = project.entity_id();
+        cx.default_global::<GlobalHistoryServices>()
+            .0
+            .insert(project_id, service);
+        cx.on_release(move |_, cx| {
+            cx.default_global::<GlobalHistoryServices>()
+                .0
+                .remove(&project_id);
+        })
+        .detach();
+    })
+    .detach();
+}
+
+/// The designed-for pre-AI-write trigger (spec §6.2): first-party code that is
+/// about to write into a vault calls this immediately beforehand so a clean
+/// pre-mutation restore point exists. No first-party AI write path exists yet
+/// in V2, so nothing calls it in production.
+pub fn checkpoint_before_ai_write(project: &Entity<Project>, cx: &mut App) {
+    let service = cx
+        .default_global::<GlobalHistoryServices>()
+        .0
+        .get(&project.entity_id())
+        .cloned();
+    if let Some(service) = service {
+        service.update(cx, |service, cx| {
+            service.checkpoint_all(CheckpointTrigger::PreAiWrite, cx)
+        });
+    }
+}
+
+#[derive(Default)]
+struct GlobalHistoryServices(HashMap<EntityId, Entity<HistoryService>>);
+
+impl Global for GlobalHistoryServices {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CheckpointTrigger {
+    Initial,
+    Idle,
+    Heartbeat,
+    PreAiWrite,
+    Close,
+}
+
+impl CheckpointTrigger {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Initial => "initial",
+            Self::Idle => "idle",
+            Self::Heartbeat => "heartbeat",
+            Self::PreAiWrite => "pre-ai-write",
+            Self::Close => "close",
+        }
+    }
+}
+
+enum HistoryPhase {
+    Initializing,
+    Ready(Arc<RealGitRepository>),
+    Disabled,
+}
+
+struct VaultHistory {
+    root: PathBuf,
+    config: HistoryConfig,
+    phase: HistoryPhase,
+    /// Vault files changed since the last checkpoint attempt finished.
+    dirty: bool,
+    in_flight: bool,
+    pending_trigger: Option<CheckpointTrigger>,
+    last_checkpoint_at: Option<Instant>,
+    /// Re-armed on every edit; fires the idle-debounce checkpoint. Replacing
+    /// the task cancels the previous timer.
+    idle_task: Option<Task<()>>,
+    _tasks: Vec<Task<()>>,
+}
+
+pub struct HistoryService {
+    project: Entity<Project>,
+    bundled_git_binary_path: Option<PathBuf>,
+    executor: BackgroundExecutor,
+    vaults: HashMap<WorktreeId, VaultHistory>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl HistoryService {
+    fn new(
+        project: Entity<Project>,
+        bundled_git_binary_path: Option<PathBuf>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let subscriptions = vec![
+            cx.subscribe(&project, Self::handle_project_event),
+            cx.on_app_quit(Self::checkpoint_on_quit),
+        ];
+        let mut this = Self {
+            project,
+            bundled_git_binary_path,
+            executor: cx.background_executor().clone(),
+            vaults: HashMap::new(),
+            _subscriptions: subscriptions,
+        };
+        this.sync_vaults(cx);
+        this
+    }
+
+    fn handle_project_event(
+        &mut self,
+        _: Entity<Project>,
+        event: &project::Event,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            project::Event::WorktreeAdded(_) | project::Event::WorktreeRemoved(_) => {
+                self.sync_vaults(cx)
+            }
+            project::Event::WorktreeUpdatedEntries(worktree_id, changes) => {
+                if changes
+                    .iter()
+                    .any(|(path, _, _)| path.as_unix_str() == vault_config_rel_path())
+                {
+                    self.sync_vaults(cx);
+                }
+                // Never treat our own repo's writes as edits, or every
+                // checkpoint would schedule the next one forever.
+                if changes
+                    .iter()
+                    .any(|(path, _, _)| !is_history_repo_path(path.as_unix_str()))
+                {
+                    self.note_edit(*worktree_id, cx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Aligns the tracked vaults with the project's current visible worktrees,
+    /// starting history for new vaults and dropping ones that disappeared or
+    /// were disabled. Cheap enough to run on any worktree/config change.
+    fn sync_vaults(&mut self, cx: &mut Context<Self>) {
+        let worktrees: Vec<(WorktreeId, PathBuf)> = self
+            .project
+            .read(cx)
+            .visible_worktrees(cx)
+            .map(|worktree| {
+                let worktree = worktree.read(cx);
+                (worktree.id(), worktree.abs_path().to_path_buf())
+            })
+            .collect();
+
+        self.vaults
+            .retain(|worktree_id, _| worktrees.iter().any(|(id, _)| id == worktree_id));
+
+        for (worktree_id, root) in worktrees {
+            let config = match Vault::detect(&root) {
+                VaultStatus::Valid(vault) if vault.config.history.enabled => vault.config.history,
+                _ => {
+                    self.vaults.remove(&worktree_id);
+                    continue;
+                }
+            };
+            match self.vaults.get_mut(&worktree_id) {
+                Some(state) if state.root == root => state.config = config,
+                _ => {
+                    let state = self.start_vault(worktree_id, root, config, cx);
+                    self.vaults.insert(worktree_id, state);
+                }
+            }
+        }
+    }
+
+    fn start_vault(
+        &self,
+        worktree_id: WorktreeId,
+        root: PathBuf,
+        config: HistoryConfig,
+        cx: &mut Context<Self>,
+    ) -> VaultHistory {
+        let git_dir = root.join(VAULT_MARKER_DIR).join(HISTORY_DIR);
+        let fs = self.project.read(cx).fs().clone();
+        let bundled_git_binary_path = self.bundled_git_binary_path.clone();
+        let executor = self.executor.clone();
+
+        let init_task = cx.spawn({
+            let root = root.clone();
+            async move |this, cx| {
+                let result = cx
+                    .background_spawn(open_or_init_repo(
+                        fs,
+                        git_dir,
+                        root.clone(),
+                        bundled_git_binary_path,
+                        executor,
+                    ))
+                    .await;
+                this.update(cx, |this, cx| {
+                    let Some(state) = this.vaults.get_mut(&worktree_id) else {
+                        return;
+                    };
+                    match result {
+                        Ok(repository) => {
+                            state.phase = HistoryPhase::Ready(repository);
+                            this.try_checkpoint(worktree_id, CheckpointTrigger::Initial, cx);
+                        }
+                        Err(error) => {
+                            log::warn!(
+                                "BreadPaper history disabled for {}: {error:#}",
+                                root.display()
+                            );
+                            state.phase = HistoryPhase::Disabled;
+                        }
+                    }
+                })
+                .ok();
+            }
+        });
+
+        let heartbeat_task = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(HEARTBEAT_POLL_INTERVAL).await;
+                let keep_going = this.update(cx, |this, cx| {
+                    let Some(state) = this.vaults.get_mut(&worktree_id) else {
+                        return false;
+                    };
+                    let due = state.dirty
+                        && !state.in_flight
+                        && matches!(state.phase, HistoryPhase::Ready(_))
+                        && state
+                            .last_checkpoint_at
+                            .is_none_or(|at| at.elapsed() >= state.config.heartbeat);
+                    if due {
+                        this.try_checkpoint(worktree_id, CheckpointTrigger::Heartbeat, cx);
+                    }
+                    true
+                });
+                if !keep_going.unwrap_or(false) {
+                    break;
+                }
+            }
+        });
+
+        VaultHistory {
+            root,
+            config,
+            phase: HistoryPhase::Initializing,
+            dirty: false,
+            in_flight: false,
+            pending_trigger: None,
+            last_checkpoint_at: None,
+            idle_task: None,
+            _tasks: vec![init_task, heartbeat_task],
+        }
+    }
+
+    fn note_edit(&mut self, worktree_id: WorktreeId, cx: &mut Context<Self>) {
+        let Some(state) = self.vaults.get_mut(&worktree_id) else {
+            return;
+        };
+        state.dirty = true;
+        let debounce = state.config.idle_debounce;
+        state.idle_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(debounce).await;
+            this.update(cx, |this, cx| {
+                this.try_checkpoint(worktree_id, CheckpointTrigger::Idle, cx)
+            })
+            .ok();
+        }));
+    }
+
+    fn checkpoint_all(&mut self, trigger: CheckpointTrigger, cx: &mut Context<Self>) {
+        let worktree_ids: Vec<WorktreeId> = self.vaults.keys().copied().collect();
+        for worktree_id in worktree_ids {
+            self.try_checkpoint(worktree_id, trigger, cx);
+        }
+    }
+
+    fn try_checkpoint(
+        &mut self,
+        worktree_id: WorktreeId,
+        trigger: CheckpointTrigger,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(state) = self.vaults.get_mut(&worktree_id) else {
+            return;
+        };
+        let HistoryPhase::Ready(repository) = &state.phase else {
+            return;
+        };
+        if state.in_flight {
+            // Coalesce: at most one in-flight checkpoint plus one pending.
+            state.pending_trigger = Some(trigger);
+            return;
+        }
+        state.in_flight = true;
+        state.dirty = false;
+        state.idle_task = None;
+        let checkpoint = checkpoint_future(repository, trigger, state.config.max_file_bytes);
+        cx.spawn(async move |this, cx| {
+            let result = checkpoint.await;
+            this.update(cx, |this, cx| {
+                this.finish_checkpoint(worktree_id, result, cx)
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn finish_checkpoint(
+        &mut self,
+        worktree_id: WorktreeId,
+        result: Result<Option<GitRepositoryCheckpoint>>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(state) = self.vaults.get_mut(&worktree_id) else {
+            return;
+        };
+        state.in_flight = false;
+        match result {
+            // A no-op (unchanged tree) still counts: the vault is known clean.
+            Ok(_) => state.last_checkpoint_at = Some(Instant::now()),
+            Err(error) => {
+                log::debug!(
+                    "BreadPaper history: checkpoint of {} failed (will retry on the next trigger): {error:#}",
+                    state.root.display()
+                );
+                // Prior history is intact; mark dirty so the heartbeat retries.
+                state.dirty = true;
+            }
+        }
+        if let Some(trigger) = state.pending_trigger.take() {
+            self.try_checkpoint(worktree_id, trigger, cx);
+        }
+    }
+
+    fn checkpoint_on_quit(&mut self, _: &mut Context<Self>) -> impl Future<Output = ()> + use<> {
+        let checkpoints: Vec<_> = self
+            .vaults
+            .values()
+            .filter_map(|state| {
+                if !state.dirty {
+                    return None;
+                }
+                let HistoryPhase::Ready(repository) = &state.phase else {
+                    return None;
+                };
+                Some(checkpoint_future(
+                    repository,
+                    CheckpointTrigger::Close,
+                    state.config.max_file_bytes,
+                ))
+            })
+            .collect();
+        async move {
+            for checkpoint in checkpoints {
+                checkpoint.await.log_err();
+            }
+        }
+    }
+}
+
+impl Drop for HistoryService {
+    fn drop(&mut self) {
+        // Workspace-close safety net (spec §6.2): best-effort and
+        // fire-and-forget. The ref only advances on success, so dying
+        // mid-write cannot damage existing history.
+        for state in self.vaults.values() {
+            if !state.dirty {
+                continue;
+            }
+            let HistoryPhase::Ready(repository) = &state.phase else {
+                continue;
+            };
+            let checkpoint =
+                checkpoint_future(repository, CheckpointTrigger::Close, state.config.max_file_bytes);
+            self.executor
+                .spawn(async move {
+                    checkpoint.await.log_err();
+                })
+                .detach();
+        }
+    }
+}
+
+fn checkpoint_future(
+    repository: &RealGitRepository,
+    trigger: CheckpointTrigger,
+    max_file_bytes: u64,
+) -> impl Future<Output = Result<Option<GitRepositoryCheckpoint>>> + use<> {
+    repository.checkpoint_onto_ref(
+        CHECKPOINTS_REF.to_string(),
+        format!(
+            "checkpoint: {} {}",
+            trigger.label(),
+            Utc::now().format("%Y-%m-%dT%H:%M:%SZ")
+        ),
+        AUTHOR_NAME.to_string(),
+        AUTHOR_EMAIL.to_string(),
+        max_file_bytes,
+    )
+}
+
+async fn open_or_init_repo(
+    fs: Arc<dyn Fs>,
+    git_dir: PathBuf,
+    work_tree: PathBuf,
+    bundled_git_binary_path: Option<PathBuf>,
+    executor: BackgroundExecutor,
+) -> Result<Arc<RealGitRepository>> {
+    let system_git_binary_path = which::which("git").ok();
+    if !fs.is_file(&git_dir.join("HEAD")).await {
+        let git_binary_path = system_git_binary_path
+            .as_deref()
+            .or(bundled_git_binary_path.as_deref())
+            .context("no git binary available")?;
+        RealGitRepository::init_separate_git_dir(
+            &git_dir,
+            &work_tree,
+            git_binary_path,
+            CHECKPOINTS_BRANCH,
+            executor.clone(),
+        )
+        .await?;
+    }
+    // Rewritten on every activation so the mandatory excludes are self-healing.
+    let info_dir = git_dir.join("info");
+    fs.create_dir(&info_dir).await?;
+    fs.atomic_write(info_dir.join("exclude"), BASE_EXCLUDES.to_string())
+        .await?;
+
+    let repository = RealGitRepository::new_with_separate_git_dir(
+        git_dir,
+        work_tree,
+        bundled_git_binary_path,
+        system_git_binary_path,
+        executor,
+    )?;
+    Ok(Arc::new(repository))
+}
+
+fn vault_config_rel_path() -> String {
+    format!("{VAULT_MARKER_DIR}/{VAULT_CONFIG_FILE}")
+}
+
+fn is_history_repo_path(unix_path: &str) -> bool {
+    let history_prefix = ".breadpaper/history";
+    unix_path == history_prefix
+        || unix_path
+            .strip_prefix(history_prefix)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_repo_paths_are_filtered() {
+        assert!(is_history_repo_path(".breadpaper/history"));
+        assert!(is_history_repo_path(".breadpaper/history/objects/ab/cd"));
+        assert!(!is_history_repo_path(".breadpaper/config.toml"));
+        assert!(!is_history_repo_path(".breadpaper/history-notes.md"));
+        assert!(!is_history_repo_path("daily/2026-07-21.md"));
+    }
+}

--- a/crates/breadpaper/src/notes.rs
+++ b/crates/breadpaper/src/notes.rs
@@ -1,0 +1,384 @@
+use anyhow::{Context as _, Result};
+use chrono::{Datelike, Days, NaiveDate, NaiveTime};
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::vault::Vault;
+
+/// The kinds of periodic notes a vault holds, each with its own directory,
+/// filename format, and template in `config.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteKind {
+    Daily,
+    Weekly,
+}
+
+/// An entry in the Timeline panel (and its matching `breadpaper:` command).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimelineEntry {
+    Today,
+    Yesterday,
+    Tomorrow,
+    ThisWeek,
+    LastWeek,
+}
+
+impl TimelineEntry {
+    /// Resolves the entry to the kind of note it opens and the date that
+    /// identifies the note. Weekly notes are identified by the Monday starting
+    /// their ISO week.
+    pub fn resolve(self, today: NaiveDate) -> Option<(NoteKind, NaiveDate)> {
+        match self {
+            Self::Today => Some((NoteKind::Daily, today)),
+            Self::Yesterday => today.pred_opt().map(|date| (NoteKind::Daily, date)),
+            Self::Tomorrow => today.succ_opt().map(|date| (NoteKind::Daily, date)),
+            Self::ThisWeek => week_start(today).map(|date| (NoteKind::Weekly, date)),
+            Self::LastWeek => week_start(today)
+                .and_then(|monday| monday.checked_sub_days(Days::new(7)))
+                .map(|date| (NoteKind::Weekly, date)),
+        }
+    }
+}
+
+fn week_start(date: NaiveDate) -> Option<NaiveDate> {
+    date.checked_sub_days(Days::new(date.weekday().num_days_from_monday() as u64))
+}
+
+/// Formats a date using the moment.js-style token vocabulary shared by
+/// filename formats and `{{date:...}}` template tokens.
+///
+/// Supported tokens: `YYYY`, `YY`, `MMMM`, `MMM`, `MM`, `M`, `DD`, `D`,
+/// `dddd`, `ddd`, `dd`, `d`, `WW`, `W` (ISO week), `GGGG`, `GG` (ISO week
+/// year). Text inside `[brackets]` is emitted literally; all other characters
+/// pass through unchanged.
+pub fn format_date(date: NaiveDate, format: &str) -> String {
+    let mut output = String::with_capacity(format.len() + 8);
+    let characters: Vec<char> = format.chars().collect();
+    let mut index = 0;
+    while index < characters.len() {
+        let character = characters[index];
+        match character {
+            '[' => {
+                index += 1;
+                while index < characters.len() && characters[index] != ']' {
+                    output.push(characters[index]);
+                    index += 1;
+                }
+                if index < characters.len() {
+                    index += 1;
+                }
+            }
+            'Y' | 'M' | 'D' | 'd' | 'W' | 'G' => {
+                let mut run = 1;
+                while index + run < characters.len() && characters[index + run] == character {
+                    run += 1;
+                }
+                emit_date_token(&mut output, date, character, run);
+                index += run;
+            }
+            _ => {
+                output.push(character);
+                index += 1;
+            }
+        }
+    }
+    output
+}
+
+fn emit_date_token(output: &mut String, date: NaiveDate, token: char, run: usize) {
+    let expansion = match (token, run) {
+        ('Y', 2) => format!("{:02}", date.year() % 100),
+        ('Y', _) => format!("{:04}", date.year()),
+        ('M', 1) => date.month().to_string(),
+        ('M', 2) => format!("{:02}", date.month()),
+        ('M', 3) => date.format("%b").to_string(),
+        ('M', _) => date.format("%B").to_string(),
+        ('D', 1) => date.day().to_string(),
+        ('D', _) => format!("{:02}", date.day()),
+        ('d', 1) => date.weekday().num_days_from_sunday().to_string(),
+        ('d', 2) => {
+            let mut name = date.format("%A").to_string();
+            name.truncate(2);
+            name
+        }
+        ('d', 3) => date.format("%a").to_string(),
+        ('d', _) => date.format("%A").to_string(),
+        ('W', 1) => date.iso_week().week().to_string(),
+        ('W', _) => format!("{:02}", date.iso_week().week()),
+        ('G', 2) => format!("{:02}", date.iso_week().year() % 100),
+        ('G', _) => format!("{:04}", date.iso_week().year()),
+        _ => date.format("%A").to_string(),
+    };
+    output.push_str(&expansion);
+}
+
+/// Expands Obsidian-style template tokens: `{{date}}`, `{{date:FORMAT}}`,
+/// `{{time}}`, and `{{title}}`. Unrecognized tokens are left as-is.
+pub fn expand_template(
+    template: &str,
+    date: NaiveDate,
+    time: NaiveTime,
+    title: &str,
+) -> String {
+    let mut output = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        let Some(end_offset) = rest[start + 2..].find("}}") else {
+            break;
+        };
+        let token = &rest[start + 2..start + 2 + end_offset];
+        output.push_str(&rest[..start]);
+        match token {
+            "date" => output.push_str(&date.format("%Y-%m-%d").to_string()),
+            "time" => output.push_str(&time.format("%H:%M").to_string()),
+            "title" => output.push_str(title),
+            _ => {
+                if let Some(format) = token.strip_prefix("date:") {
+                    output.push_str(&format_date(date, format));
+                } else {
+                    output.push_str(&rest[start..start + 2 + end_offset + 2]);
+                }
+            }
+        }
+        rest = &rest[start + 2 + end_offset + 2..];
+    }
+    output.push_str(rest);
+    output
+}
+
+/// The outcome of ensuring a note exists.
+#[derive(Debug, PartialEq)]
+pub enum EnsureNoteOutcome {
+    AlreadyExisted,
+    Created,
+    /// The note was created empty because the configured template is missing.
+    CreatedWithoutTemplate,
+}
+
+/// Ensures the note of `kind` for `date` exists, creating it from the vault's
+/// template if missing, and returns its path. Existing notes are never
+/// touched. Blocking I/O — call from a background thread.
+pub fn ensure_note(
+    vault: &Vault,
+    kind: NoteKind,
+    date: NaiveDate,
+    time: NaiveTime,
+) -> Result<(PathBuf, EnsureNoteOutcome)> {
+    let path = vault.note_path(kind, date);
+    if path.exists() {
+        return Ok((path, EnsureNoteOutcome::AlreadyExisted));
+    }
+
+    let template_path = vault.template_path(kind);
+    let (template, outcome) = match fs::read_to_string(&template_path) {
+        Ok(template) => (template, EnsureNoteOutcome::Created),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            (String::new(), EnsureNoteOutcome::CreatedWithoutTemplate)
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("reading template {}", template_path.display()));
+        }
+    };
+
+    let title = path
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let contents = expand_template(&template, date, time, &title);
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    write_new_file(&path, &contents)?;
+    Ok((path, outcome))
+}
+
+/// Creates `path` with `contents`, failing if it already exists, and removing
+/// the file again if the write fails partway so no partial note is left behind.
+fn write_new_file(path: &Path, contents: &str) -> Result<()> {
+    let mut file = match fs::OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("creating {}", path.display()));
+        }
+    };
+    if let Err(error) = file.write_all(contents.as_bytes()) {
+        drop(file);
+        if let Err(cleanup_error) = fs::remove_file(path) {
+            log::error!(
+                "failed to clean up partially written note {}: {cleanup_error}",
+                path.display()
+            );
+        }
+        return Err(error).with_context(|| format!("writing {}", path.display()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::{VaultStatus, scaffold_vault};
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn format_date_tokens() {
+        let d = date(2026, 7, 20); // a Monday
+        assert_eq!(format_date(d, "YYYY-MM-DD"), "2026-07-20");
+        assert_eq!(format_date(d, "YY M D"), "26 7 20");
+        assert_eq!(format_date(d, "dddd, MMMM D, YYYY"), "Monday, July 20, 2026");
+        assert_eq!(format_date(d, "ddd MMM DD"), "Mon Jul 20");
+        assert_eq!(format_date(d, "dd"), "Mo");
+        assert_eq!(format_date(d, "d"), "1");
+        assert_eq!(format_date(date(2026, 7, 5), "D MMM"), "5 Jul");
+    }
+
+    #[test]
+    fn format_date_week_tokens() {
+        for d in [
+            date(2026, 7, 20),
+            date(2026, 1, 1),
+            date(2025, 12, 29), // ISO week year differs from calendar year
+            date(2027, 1, 3),
+        ] {
+            assert_eq!(
+                format_date(d, "GGGG-[W]WW"),
+                format!("{:04}-W{:02}", d.iso_week().year(), d.iso_week().week()),
+                "for {d}"
+            );
+        }
+        assert_eq!(format_date(date(2026, 2, 2), "[Week] W"), "Week 6");
+    }
+
+    #[test]
+    fn format_date_literals_pass_through() {
+        let d = date(2026, 7, 20);
+        assert_eq!(format_date(d, "[Day] D [of] MMMM"), "Day 20 of July");
+        assert_eq!(format_date(d, "YYYY/MM/DD daily"), "2026/07/20 1aily");
+    }
+
+    #[test]
+    fn timeline_entries_resolve() {
+        let tuesday = date(2026, 7, 21);
+        assert_eq!(
+            TimelineEntry::Today.resolve(tuesday),
+            Some((NoteKind::Daily, tuesday))
+        );
+        assert_eq!(
+            TimelineEntry::Yesterday.resolve(tuesday),
+            Some((NoteKind::Daily, date(2026, 7, 20)))
+        );
+        assert_eq!(
+            TimelineEntry::Tomorrow.resolve(tuesday),
+            Some((NoteKind::Daily, date(2026, 7, 22)))
+        );
+        assert_eq!(
+            TimelineEntry::ThisWeek.resolve(tuesday),
+            Some((NoteKind::Weekly, date(2026, 7, 20)))
+        );
+        assert_eq!(
+            TimelineEntry::LastWeek.resolve(tuesday),
+            Some((NoteKind::Weekly, date(2026, 7, 13)))
+        );
+
+        // A Monday's ThisWeek is itself; a Sunday's is the previous Monday.
+        assert_eq!(
+            TimelineEntry::ThisWeek.resolve(date(2026, 7, 20)),
+            Some((NoteKind::Weekly, date(2026, 7, 20)))
+        );
+        assert_eq!(
+            TimelineEntry::ThisWeek.resolve(date(2026, 7, 26)),
+            Some((NoteKind::Weekly, date(2026, 7, 20)))
+        );
+    }
+
+    #[test]
+    fn expand_template_tokens() {
+        let d = date(2026, 7, 19);
+        let t = NaiveTime::from_hms_opt(14, 31, 0).unwrap();
+        assert_eq!(
+            expand_template(
+                "# {{date:dddd, MMMM D, YYYY}}\n{{date}} {{time}} {{title}}",
+                d,
+                t,
+                "2026-07-19",
+            ),
+            "# Sunday, July 19, 2026\n2026-07-19 14:31 2026-07-19"
+        );
+    }
+
+    #[test]
+    fn expand_template_leaves_unknown_tokens() {
+        let d = date(2026, 7, 19);
+        let t = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        assert_eq!(
+            expand_template("{{weather}} and {{unclosed", d, t, "x"),
+            "{{weather}} and {{unclosed"
+        );
+    }
+
+    #[test]
+    fn ensure_note_creates_daily_from_template() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let VaultStatus::Valid(vault) = crate::vault::Vault::detect(dir.path()) else {
+            panic!("expected valid vault");
+        };
+        let d = date(2026, 7, 20);
+        let t = NaiveTime::from_hms_opt(9, 0, 0).unwrap();
+
+        let (path, outcome) = ensure_note(&vault, NoteKind::Daily, d, t).unwrap();
+        assert_eq!(outcome, EnsureNoteOutcome::Created);
+        assert_eq!(path, dir.path().join("daily/2026-07-20.md"));
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("# Monday, July 20, 2026\n"));
+
+        // A second call must not touch the file.
+        fs::write(&path, "user edits").unwrap();
+        let (_, outcome) = ensure_note(&vault, NoteKind::Daily, d, t).unwrap();
+        assert_eq!(outcome, EnsureNoteOutcome::AlreadyExisted);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "user edits");
+    }
+
+    #[test]
+    fn ensure_note_creates_weekly_from_template() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let VaultStatus::Valid(vault) = crate::vault::Vault::detect(dir.path()) else {
+            panic!("expected valid vault");
+        };
+        let monday = date(2026, 7, 20);
+        let t = NaiveTime::from_hms_opt(9, 0, 0).unwrap();
+
+        let (path, outcome) = ensure_note(&vault, NoteKind::Weekly, monday, t).unwrap();
+        assert_eq!(outcome, EnsureNoteOutcome::Created);
+        assert_eq!(path, dir.path().join("weekly/2026-W30.md"));
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("# Week 30, 2026\n"), "got: {contents}");
+    }
+
+    #[test]
+    fn ensure_note_missing_template_creates_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        fs::remove_file(dir.path().join("templates/daily.md")).unwrap();
+        let VaultStatus::Valid(vault) = crate::vault::Vault::detect(dir.path()) else {
+            panic!("expected valid vault");
+        };
+        let (path, outcome) = ensure_note(
+            &vault,
+            NoteKind::Daily,
+            date(2026, 7, 20),
+            NaiveTime::from_hms_opt(9, 0, 0).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(outcome, EnsureNoteOutcome::CreatedWithoutTemplate);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "");
+    }
+}

--- a/crates/breadpaper/src/timeline_panel.rs
+++ b/crates/breadpaper/src/timeline_panel.rs
@@ -1,0 +1,475 @@
+use anyhow::Result;
+use chrono::Local;
+use gpui::{
+    Action, App, AsyncWindowContext, Context, Entity, EventEmitter, FocusHandle, Focusable,
+    KeyContext, Pixels, Subscription, WeakEntity, Window, actions, px,
+};
+use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
+use project::Project;
+use std::path::PathBuf;
+use ui::prelude::*;
+use ui::{Button, Icon, IconSize, Label, ListHeader, ListItem};
+use util::ResultExt as _;
+use workspace::dock::{DockPosition, Panel, PanelEvent};
+use workspace::notifications::NotificationId;
+use workspace::{OpenOptions, OpenVisible, Toast, Workspace};
+
+use crate::notes::{EnsureNoteOutcome, TimelineEntry, ensure_note};
+use crate::vault::{Vault, VaultStatus, scaffold_vault};
+
+const TIMELINE_PANEL_KEY: &str = "BreadPaperTimelinePanel";
+
+const TIMELINE_ENTRIES: [(&str, &str, TimelineEntry); 4] = [
+    ("breadpaper-today", "Today", TimelineEntry::Today),
+    ("breadpaper-yesterday", "Yesterday", TimelineEntry::Yesterday),
+    ("breadpaper-this-week", "This Week", TimelineEntry::ThisWeek),
+    ("breadpaper-last-week", "Last Week", TimelineEntry::LastWeek),
+];
+
+actions!(
+    breadpaper,
+    [
+        /// Toggles focus on the BreadPaper timeline panel.
+        ToggleFocus,
+        /// Opens today's daily note, creating it if needed.
+        OpenToday,
+        /// Opens yesterday's daily note, creating it if needed.
+        OpenYesterday,
+        /// Opens tomorrow's daily note, creating it if needed.
+        OpenTomorrow,
+        /// Opens this week's weekly note, creating it if needed.
+        OpenThisWeek,
+        /// Opens last week's weekly note, creating it if needed.
+        OpenLastWeek
+    ]
+);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(|workspace: &mut Workspace, _, _| {
+        workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
+            workspace.toggle_panel_focus::<TimelinePanel>(window, cx);
+        });
+        register_open_action::<OpenToday>(workspace, TimelineEntry::Today);
+        register_open_action::<OpenYesterday>(workspace, TimelineEntry::Yesterday);
+        register_open_action::<OpenTomorrow>(workspace, TimelineEntry::Tomorrow);
+        register_open_action::<OpenThisWeek>(workspace, TimelineEntry::ThisWeek);
+        register_open_action::<OpenLastWeek>(workspace, TimelineEntry::LastWeek);
+    })
+    .detach();
+}
+
+fn register_open_action<A: Action>(workspace: &mut Workspace, entry: TimelineEntry) {
+    workspace.register_action(move |workspace, _: &A, window, cx| {
+        if let Some(panel) = workspace.panel::<TimelinePanel>(cx) {
+            panel.update(cx, |panel, cx| panel.open_note(entry, window, cx));
+        }
+    });
+}
+
+/// Shows the timeline panel (opening the left dock) when the workspace is a
+/// vault. Called once at startup after all panels are registered, so the
+/// timeline — not the file tree — is what a vault opens on.
+pub fn show_panel_if_vault(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let is_vault = workspace
+        .visible_worktrees(cx)
+        .next()
+        .is_some_and(|worktree| {
+            matches!(
+                Vault::detect(&worktree.read(cx).abs_path()),
+                VaultStatus::Valid(_)
+            )
+        });
+    if is_vault {
+        workspace.open_panel::<TimelinePanel>(window, cx);
+    }
+}
+
+pub struct TimelinePanel {
+    workspace: WeakEntity<Workspace>,
+    project: Entity<Project>,
+    focus_handle: FocusHandle,
+    vault_status: VaultStatus,
+    /// Keyboard cursor over `TIMELINE_ENTRIES`. `None` means the highlight
+    /// follows whichever entry matches the active editor item.
+    selected_index: Option<usize>,
+    position: DockPosition,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl TimelinePanel {
+    pub async fn load(
+        workspace: WeakEntity<Workspace>,
+        mut cx: AsyncWindowContext,
+    ) -> Result<Entity<Self>> {
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            TimelinePanel::new(workspace, window, cx)
+        })
+    }
+
+    pub fn new(
+        workspace: &mut Workspace,
+        _window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Entity<Self> {
+        let project = workspace.project().clone();
+        let weak_workspace = workspace.weak_handle();
+        let workspace_entity = cx.entity();
+        cx.new(|cx| {
+            let project_subscription =
+                cx.subscribe(&project, |this: &mut Self, _, event, cx| {
+                    if matches!(
+                        event,
+                        project::Event::WorktreeAdded(_)
+                            | project::Event::WorktreeRemoved(_)
+                            | project::Event::WorktreeUpdatedEntries(..)
+                    ) {
+                        this.refresh_vault_status(cx);
+                    }
+                });
+            // On active-item changes, drop the keyboard cursor so the
+            // highlight goes back to following the open note.
+            let workspace_subscription = cx.subscribe(
+                &workspace_entity,
+                |this: &mut Self, _, event: &workspace::Event, cx| {
+                    if matches!(event, workspace::Event::ActiveItemChanged) {
+                        this.selected_index = None;
+                        cx.notify();
+                    }
+                },
+            );
+            let mut this = Self {
+                workspace: weak_workspace,
+                project,
+                focus_handle: cx.focus_handle(),
+                vault_status: VaultStatus::NotAVault,
+                selected_index: None,
+                position: DockPosition::Left,
+                _subscriptions: vec![project_subscription, workspace_subscription],
+            };
+            this.refresh_vault_status(cx);
+            this
+        })
+    }
+
+    fn workspace_root(&self, cx: &App) -> Option<PathBuf> {
+        let worktree = self.project.read(cx).visible_worktrees(cx).next()?;
+        Some(worktree.read(cx).abs_path().to_path_buf())
+    }
+
+    fn refresh_vault_status(&mut self, cx: &mut Context<Self>) {
+        let status = match self.workspace_root(cx) {
+            Some(root) => Vault::detect(&root),
+            None => VaultStatus::NotAVault,
+        };
+        if status != self.vault_status {
+            self.vault_status = status;
+            cx.notify();
+        }
+    }
+
+    fn open_note(&mut self, entry: TimelineEntry, window: &mut Window, cx: &mut Context<Self>) {
+        let VaultStatus::Valid(vault) = &self.vault_status else {
+            // Only reachable via the `breadpaper:` commands; the panel itself
+            // renders no entries outside a valid vault.
+            self.workspace
+                .update(cx, |workspace, cx| {
+                    struct NotAVaultToast;
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<NotAVaultToast>(),
+                            "This workspace isn't a BreadPaper vault.",
+                        )
+                        .autohide(),
+                        cx,
+                    );
+                })
+                .log_err();
+            return;
+        };
+        let vault = vault.clone();
+        let now = Local::now();
+        let Some((kind, date)) = entry.resolve(now.date_naive()) else {
+            return;
+        };
+        let time = now.time();
+        let workspace = self.workspace.clone();
+
+        let ensure_note = cx.background_spawn(async move { ensure_note(&vault, kind, date, time) });
+        cx.spawn_in(window, async move |_, cx| {
+            match ensure_note.await {
+                Ok((path, outcome)) => {
+                    if outcome == EnsureNoteOutcome::CreatedWithoutTemplate {
+                        workspace
+                            .update(cx, |workspace, cx| {
+                                struct TemplateMissingToast;
+                                workspace.show_toast(
+                                    Toast::new(
+                                        NotificationId::unique::<TemplateMissingToast>(),
+                                        "The note template is missing, so an empty note was created.",
+                                    )
+                                    .autohide(),
+                                    cx,
+                                );
+                            })
+                            .log_err();
+                    }
+                    workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            workspace.open_abs_path(
+                                path,
+                                OpenOptions {
+                                    visible: Some(OpenVisible::All),
+                                    ..Default::default()
+                                },
+                                window,
+                                cx,
+                            )
+                        })?
+                        .await?;
+                    Ok(())
+                }
+                Err(error) => {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.show_error(format!("Couldn't open the note: {error}"), cx);
+                        })
+                        .log_err();
+                    Err(error)
+                }
+            }
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn create_vault_here(&mut self, cx: &mut Context<Self>) {
+        let Some(root) = self.workspace_root(cx) else {
+            return;
+        };
+        let workspace = self.workspace.clone();
+        let scaffold = cx.background_spawn(async move { scaffold_vault(&root) });
+        cx.spawn(async move |this, cx| {
+            match scaffold.await {
+                Ok(()) => this.update(cx, |this, cx| this.refresh_vault_status(cx)),
+                Err(error) => {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace
+                                .show_error(format!("Couldn't create the vault: {error}"), cx);
+                        })
+                        .log_err();
+                    Err(error)
+                }
+            }
+        })
+        .detach_and_log_err(cx);
+    }
+
+    /// The absolute path of the note open in the active editor, if any.
+    fn active_item_path(&self, cx: &App) -> Option<PathBuf> {
+        let workspace = self.workspace.upgrade()?;
+        let item = workspace.read(cx).active_item(cx)?;
+        let project_path = item.project_path(cx)?;
+        self.project.read(cx).absolute_path(&project_path, cx)
+    }
+
+    /// The entry whose note is open in the active editor, if any.
+    fn active_entry_index(&self, cx: &App) -> Option<usize> {
+        let VaultStatus::Valid(vault) = &self.vault_status else {
+            return None;
+        };
+        let active_path = self.active_item_path(cx)?;
+        let today = Local::now().date_naive();
+        TIMELINE_ENTRIES.iter().position(|(_, _, entry)| {
+            entry
+                .resolve(today)
+                .is_some_and(|(kind, date)| vault.note_path(kind, date) == active_path)
+        })
+    }
+
+    /// The highlighted entry: the keyboard cursor if one is set, otherwise the
+    /// entry matching the active editor item.
+    fn effective_selected_index(&self, cx: &App) -> Option<usize> {
+        self.selected_index.or_else(|| self.active_entry_index(cx))
+    }
+
+    fn select_next(&mut self, _: &SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+        self.selected_index = Some(match self.effective_selected_index(cx) {
+            Some(index) => (index + 1).min(TIMELINE_ENTRIES.len() - 1),
+            None => 0,
+        });
+        cx.notify();
+    }
+
+    fn select_previous(
+        &mut self,
+        _: &SelectPrevious,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.selected_index = Some(match self.effective_selected_index(cx) {
+            Some(index) => index.saturating_sub(1),
+            None => TIMELINE_ENTRIES.len() - 1,
+        });
+        cx.notify();
+    }
+
+    fn select_first(&mut self, _: &SelectFirst, _window: &mut Window, cx: &mut Context<Self>) {
+        self.selected_index = Some(0);
+        cx.notify();
+    }
+
+    fn select_last(&mut self, _: &SelectLast, _window: &mut Window, cx: &mut Context<Self>) {
+        self.selected_index = Some(TIMELINE_ENTRIES.len() - 1);
+        cx.notify();
+    }
+
+    fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some((_, _, entry)) = self
+            .effective_selected_index(cx)
+            .and_then(|index| TIMELINE_ENTRIES.get(index))
+        {
+            self.open_note(*entry, window, cx);
+        }
+    }
+
+    fn render_entries(&self, cx: &Context<Self>) -> impl IntoElement {
+        let selected_index = self.effective_selected_index(cx);
+        v_flex()
+            .gap_px()
+            .child(
+                ListHeader::new("Timeline").start_slot(
+                    Icon::new(IconName::Clock)
+                        .size(IconSize::Small)
+                        .color(Color::Muted),
+                ),
+            )
+            .children(TIMELINE_ENTRIES.iter().enumerate().map(
+                |(index, (id, label, entry))| {
+                    let entry = *entry;
+                    ListItem::new(*id)
+                        .toggle_state(selected_index == Some(index))
+                        .child(Label::new(*label))
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.open_note(entry, window, cx);
+                        }))
+                },
+            ))
+    }
+
+    fn render_non_vault(&self, cx: &Context<Self>) -> impl IntoElement {
+        v_flex()
+            .gap_2()
+            .p_2()
+            .child(Label::new("This folder isn't a BreadPaper vault.").color(Color::Muted))
+            .child(
+                Button::new("breadpaper-create-vault", "Create vault here").on_click(cx.listener(
+                    |this, _, _window, cx| {
+                        this.create_vault_here(cx);
+                    },
+                )),
+            )
+    }
+
+    fn render_invalid(&self, error: &str) -> impl IntoElement {
+        v_flex()
+            .gap_2()
+            .p_2()
+            .child(Label::new("This vault's config couldn't be loaded.").color(Color::Muted))
+            .child(
+                Label::new(error.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Error),
+            )
+            .child(
+                Label::new("Fix .breadpaper/config.toml and the panel will recover.")
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+    }
+}
+
+impl Render for TimelinePanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let content = match &self.vault_status {
+            VaultStatus::Valid(_) => self.render_entries(cx).into_any_element(),
+            VaultStatus::NotAVault => self.render_non_vault(cx).into_any_element(),
+            VaultStatus::Invalid { error } => self.render_invalid(error).into_any_element(),
+        };
+        let mut key_context = KeyContext::new_with_defaults();
+        key_context.add("BreadPaperTimelinePanel");
+        key_context.add("menu");
+        v_flex()
+            .id("breadpaper-timeline-panel")
+            .key_context(key_context)
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::select_previous))
+            .on_action(cx.listener(Self::select_first))
+            .on_action(cx.listener(Self::select_last))
+            .on_action(cx.listener(Self::confirm))
+            .size_full()
+            .p_1()
+            .pl_2()
+            .child(content)
+    }
+}
+
+impl EventEmitter<PanelEvent> for TimelinePanel {}
+
+impl Focusable for TimelinePanel {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Panel for TimelinePanel {
+    fn persistent_name() -> &'static str {
+        "BreadPaper Timeline Panel"
+    }
+
+    fn panel_key() -> &'static str {
+        TIMELINE_PANEL_KEY
+    }
+
+    fn position(&self, _window: &Window, _cx: &App) -> DockPosition {
+        self.position
+    }
+
+    fn position_is_valid(&self, position: DockPosition) -> bool {
+        matches!(position, DockPosition::Left | DockPosition::Right)
+    }
+
+    fn set_position(&mut self, position: DockPosition, _window: &mut Window, cx: &mut Context<Self>) {
+        self.position = position;
+        cx.notify();
+    }
+
+    fn default_size(&self, _window: &Window, _cx: &App) -> Pixels {
+        px(240.)
+    }
+
+    fn icon(&self, _window: &Window, _cx: &App) -> Option<IconName> {
+        Some(IconName::Notepad)
+    }
+
+    fn icon_tooltip(&self, _window: &Window, _cx: &App) -> Option<&'static str> {
+        Some("Timeline Panel")
+    }
+
+    fn toggle_action(&self) -> Box<dyn Action> {
+        ToggleFocus.boxed_clone()
+    }
+
+    fn starts_open(&self, _window: &Window, _cx: &App) -> bool {
+        true
+    }
+
+    fn activation_priority(&self) -> u32 {
+        // Must be unique across all panels; 0-3 and 5-7 are taken upstream.
+        4
+    }
+}

--- a/crates/breadpaper/src/timeline_panel.rs
+++ b/crates/breadpaper/src/timeline_panel.rs
@@ -183,8 +183,31 @@ impl TimelinePanel {
         if status != self.vault_status {
             self.vault_status = status;
             self.refresh_areas();
+            self.reconcile_areas(cx);
             cx.notify();
         }
+    }
+
+    /// Re-materializes enabled Areas in the background whenever a vault is
+    /// (re)detected, so a vault opened after an app update self-heals any
+    /// newly shipped Area files (new skills, their Claude Code bridges) that a
+    /// plain open would otherwise never create. Idempotent and never clobbers
+    /// user edits; writing files leaves the registry unchanged, so it does not
+    /// re-trigger `refresh_vault_status`.
+    fn reconcile_areas(&mut self, cx: &mut Context<Self>) {
+        let VaultStatus::Valid(vault) = &self.vault_status else {
+            return;
+        };
+        let vault = vault.clone();
+        let reconcile = cx.background_spawn(async move { areas::reconcile_enabled_areas(&vault) });
+        cx.spawn(async move |this, cx| {
+            reconcile.await?;
+            this.update(cx, |this, cx| {
+                this.refresh_areas();
+                cx.notify();
+            })
+        })
+        .detach_and_log_err(cx);
     }
 
     /// Reloads the Areas section state from the vault's registry and the

--- a/crates/breadpaper/src/timeline_panel.rs
+++ b/crates/breadpaper/src/timeline_panel.rs
@@ -1,19 +1,22 @@
 use anyhow::Result;
 use chrono::Local;
 use gpui::{
-    Action, App, AsyncWindowContext, Context, Entity, EventEmitter, FocusHandle, Focusable,
-    KeyContext, Pixels, Subscription, WeakEntity, Window, actions, px,
+    Action, App, AsyncWindowContext, Context, ElementId, Entity, EventEmitter, FocusHandle,
+    Focusable, KeyContext, Pixels, PromptLevel, SharedString, Subscription, WeakEntity, Window,
+    actions, px,
 };
 use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use project::Project;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use ui::prelude::*;
-use ui::{Button, Icon, IconSize, Label, ListHeader, ListItem};
+use ui::{Button, Icon, IconButton, IconSize, Label, ListHeader, ListItem, Tooltip};
 use util::ResultExt as _;
 use workspace::dock::{DockPosition, Panel, PanelEvent};
 use workspace::notifications::NotificationId;
 use workspace::{OpenOptions, OpenVisible, Toast, Workspace};
 
+use crate::areas::{self, AreaManifest};
 use crate::notes::{EnsureNoteOutcome, TimelineEntry, ensure_note};
 use crate::vault::{Vault, VaultStatus, scaffold_vault};
 
@@ -96,6 +99,14 @@ pub struct TimelinePanel {
     /// Keyboard cursor over `TIMELINE_ENTRIES`. `None` means the highlight
     /// follows whichever entry matches the active editor item.
     selected_index: Option<usize>,
+    /// Enabled Areas in registry order, loaded whenever the vault status
+    /// changes.
+    areas: Vec<AreaManifest>,
+    /// Catalog Areas without an enabled registry entry, offered by "Add Area".
+    addable_areas: Vec<AreaManifest>,
+    /// Area rows start expanded; this tracks the ones the user collapsed.
+    collapsed_areas: HashSet<String>,
+    show_add_areas: bool,
     position: DockPosition,
     _subscriptions: Vec<Subscription>,
 }
@@ -147,6 +158,10 @@ impl TimelinePanel {
                 focus_handle: cx.focus_handle(),
                 vault_status: VaultStatus::NotAVault,
                 selected_index: None,
+                areas: Vec::new(),
+                addable_areas: Vec::new(),
+                collapsed_areas: HashSet::new(),
+                show_add_areas: false,
                 position: DockPosition::Left,
                 _subscriptions: vec![project_subscription, workspace_subscription],
             };
@@ -167,8 +182,39 @@ impl TimelinePanel {
         };
         if status != self.vault_status {
             self.vault_status = status;
+            self.refresh_areas();
             cx.notify();
         }
+    }
+
+    /// Reloads the Areas section state from the vault's registry and the
+    /// app-shipped catalog. Registry changes flow through `Vault` equality in
+    /// `refresh_vault_status`, so install/remove refresh without a restart.
+    fn refresh_areas(&mut self) {
+        let VaultStatus::Valid(vault) = &self.vault_status else {
+            self.areas = Vec::new();
+            self.addable_areas = Vec::new();
+            return;
+        };
+        self.areas = areas::enabled_areas(vault);
+        self.addable_areas = match areas::catalog() {
+            Ok(catalog) => catalog
+                .into_iter()
+                .map(|area| area.manifest)
+                .filter(|manifest| {
+                    !vault
+                        .config
+                        .areas
+                        .installed
+                        .iter()
+                        .any(|entry| entry.enabled && entry.id == manifest.id)
+                })
+                .collect(),
+            Err(error) => {
+                log::error!("BreadPaper: couldn't load the Areas catalog: {error:?}");
+                Vec::new()
+            }
+        };
     }
 
     fn open_note(&mut self, entry: TimelineEntry, window: &mut Window, cx: &mut Context<Self>) {
@@ -259,6 +305,273 @@ impl TimelinePanel {
                         .update(cx, |workspace, cx| {
                             workspace
                                 .show_error(format!("Couldn't create the vault: {error}"), cx);
+                        })
+                        .log_err();
+                    Err(error)
+                }
+            }
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn vault_root(&self) -> Option<PathBuf> {
+        match &self.vault_status {
+            VaultStatus::Valid(vault) => Some(vault.root.clone()),
+            _ => None,
+        }
+    }
+
+    /// Opens an Area-shipped markdown file (explainer doc or skill) in
+    /// viewing mode. A missing file gets a toast offering to re-materialize
+    /// the Area.
+    fn open_area_file(
+        &mut self,
+        relative_path: String,
+        area_id: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(root) = self.vault_root() else {
+            return;
+        };
+        let path = match areas::vault_file_path(&root, &relative_path) {
+            Ok(path) => path,
+            Err(error) => {
+                self.workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.show_error(format!("Couldn't open the file: {error}"), cx);
+                    })
+                    .log_err();
+                return;
+            }
+        };
+        if !path.is_file() {
+            self.show_missing_file_toast(relative_path, area_id, cx);
+            return;
+        }
+        let workspace = self.workspace.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            let open_result =
+                crate::open_abs_path_as_preview(workspace.clone(), path, cx).await;
+            if let Err(error) = &open_result {
+                workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.show_error(format!("Couldn't open the file: {error}"), cx);
+                    })
+                    .log_err();
+            }
+            open_result
+        })
+        .detach_and_log_err(cx);
+    }
+
+    /// Opens an Area surface (e.g. the weekly dashboard) with the system
+    /// handler — Zed has no web view, so HTML opens in the default browser.
+    fn open_surface(&mut self, relative_path: String, area_id: String, cx: &mut Context<Self>) {
+        let Some(root) = self.vault_root() else {
+            return;
+        };
+        let path = match areas::vault_file_path(&root, &relative_path) {
+            Ok(path) => path,
+            Err(error) => {
+                self.workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.show_error(format!("Couldn't open the file: {error}"), cx);
+                    })
+                    .log_err();
+                return;
+            }
+        };
+        if !path.is_file() {
+            self.show_missing_file_toast(relative_path, area_id, cx);
+            return;
+        }
+        cx.open_with_system(&path);
+    }
+
+    fn show_missing_file_toast(
+        &mut self,
+        relative_path: String,
+        area_id: String,
+        cx: &mut Context<Self>,
+    ) {
+        let panel = cx.entity().downgrade();
+        self.workspace
+            .update(cx, |workspace, cx| {
+                struct AreaFileMissingToast;
+                workspace.show_toast(
+                    Toast::new(
+                        NotificationId::unique::<AreaFileMissingToast>(),
+                        format!("{relative_path} is missing from the vault."),
+                    )
+                    .on_click("Reinstall the Area's files", move |_window, cx| {
+                        panel
+                            .update(cx, |panel, cx| panel.install_area(area_id.clone(), cx))
+                            .log_err();
+                    }),
+                    cx,
+                );
+            })
+            .log_err();
+    }
+
+    /// Materializes a catalog Area into the vault (or re-enables a disabled
+    /// one) and registers it; the section refreshes without a restart.
+    fn install_area(&mut self, area_id: String, cx: &mut Context<Self>) {
+        let Some(root) = self.vault_root() else {
+            return;
+        };
+        let workspace = self.workspace.clone();
+        let install =
+            cx.background_spawn(async move { areas::install_area(&root, &area_id) });
+        cx.spawn(async move |this, cx| {
+            match install.await {
+                Ok(()) => this.update(cx, |this, cx| {
+                    this.show_add_areas = false;
+                    this.refresh_vault_status(cx);
+                }),
+                Err(error) => {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.show_error(format!("Couldn't add the Area: {error}"), cx);
+                        })
+                        .log_err();
+                    Err(error)
+                }
+            }
+        })
+        .detach_and_log_err(cx);
+    }
+
+    /// Removing always asks: deactivate (keep all files) or deactivate and
+    /// delete the Area-shipped files. The prompt lists exactly what would be
+    /// deleted; user notes and modified-since-install files are never deleted.
+    fn remove_area(&mut self, area_id: String, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(root) = self.vault_root() else {
+            return;
+        };
+        let workspace = self.workspace.clone();
+        let plan = cx.background_spawn({
+            let root = root.clone();
+            let area_id = area_id.clone();
+            async move { areas::plan_removal(&root, &area_id) }
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            let plan = match plan.await {
+                Ok(plan) => plan,
+                Err(error) => {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.show_error(
+                                format!("Couldn't prepare the Area removal: {error}"),
+                                cx,
+                            );
+                        })
+                        .log_err();
+                    return Err(error);
+                }
+            };
+
+            let mut detail = String::new();
+            if plan.delete.is_empty() {
+                detail.push_str("No Area-shipped files would be deleted.\n");
+            } else {
+                detail.push_str("Deleting the Area's files removes:\n");
+                for file in &plan.delete {
+                    detail.push_str("  - ");
+                    detail.push_str(file);
+                    detail.push('\n');
+                }
+            }
+            if !plan.keep_modified.is_empty() {
+                detail.push_str("\nModified since install, always kept:\n");
+                for file in &plan.keep_modified {
+                    detail.push_str("  - ");
+                    detail.push_str(file);
+                    detail.push('\n');
+                }
+            }
+            detail.push_str("\nYour notes are never deleted.");
+
+            let answer = cx.update(|window, cx| {
+                window.prompt(
+                    PromptLevel::Warning,
+                    &format!("Remove the {} Area?", plan.area_name),
+                    Some(&detail),
+                    &[
+                        "Deactivate, Keep All Files",
+                        "Deactivate and Delete Area Files",
+                        "Cancel",
+                    ],
+                    cx,
+                )
+            })?;
+            let Some(answer) = answer.await.log_err() else {
+                return Ok(());
+            };
+
+            let operation = match answer {
+                0 => cx
+                    .background_spawn({
+                        let root = root.clone();
+                        let area_id = area_id.clone();
+                        async move { areas::deactivate_area(&root, &area_id).map(|()| None) }
+                    })
+                    .await,
+                1 => cx
+                    .background_spawn({
+                        let root = root.clone();
+                        let area_id = area_id.clone();
+                        async move { areas::delete_area(&root, &area_id).map(Some) }
+                    })
+                    .await,
+                _ => return Ok(()),
+            };
+
+            match operation {
+                Ok(outcome) => {
+                    let message = match outcome {
+                        None => format!(
+                            "Deactivated the {} Area. All of its files were kept.",
+                            plan.area_name
+                        ),
+                        Some(outcome) => {
+                            let mut message = format!(
+                                "Removed the {} Area and deleted {} of its files.",
+                                plan.area_name,
+                                outcome.deleted.len()
+                            );
+                            if !outcome.kept_modified.is_empty() {
+                                message.push_str(&format!(
+                                    " Kept {} modified: {}.",
+                                    outcome.kept_modified.len(),
+                                    outcome.kept_modified.join(", ")
+                                ));
+                            }
+                            message
+                        }
+                    };
+                    this.update(cx, |this, cx| this.refresh_vault_status(cx))?;
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            struct AreaRemovedToast;
+                            workspace.show_toast(
+                                Toast::new(
+                                    NotificationId::unique::<AreaRemovedToast>(),
+                                    message,
+                                )
+                                .autohide(),
+                                cx,
+                            );
+                        })
+                        .log_err();
+                    Ok(())
+                }
+                Err(error) => {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace
+                                .show_error(format!("Couldn't remove the Area: {error}"), cx);
                         })
                         .log_err();
                     Err(error)
@@ -360,6 +673,179 @@ impl TimelinePanel {
             ))
     }
 
+    fn render_areas_section(&self, cx: &Context<Self>) -> impl IntoElement {
+        v_flex()
+            .gap_px()
+            .mt_2()
+            .child(
+                ListHeader::new("Areas").start_slot(
+                    Icon::new(IconName::Blocks)
+                        .size(IconSize::Small)
+                        .color(Color::Muted),
+                ),
+            )
+            .when(self.areas.is_empty(), |this| {
+                this.child(
+                    div().px_2().py_1().child(
+                        Label::new("No Areas are enabled in this vault.")
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    ),
+                )
+            })
+            .children(
+                self.areas
+                    .iter()
+                    .map(|manifest| self.render_area(manifest, cx)),
+            )
+            .child(self.render_add_area(cx))
+    }
+
+    fn render_area(&self, manifest: &AreaManifest, cx: &Context<Self>) -> AnyElement {
+        let area_id = manifest.id.clone();
+        let expanded = !self.collapsed_areas.contains(&manifest.id);
+        let mut section = v_flex().child(
+            ListItem::new(ElementId::Name(SharedString::from(format!(
+                "breadpaper-area-{}",
+                manifest.id
+            ))))
+            .toggle(expanded)
+            .always_show_disclosure_icon(true)
+            .on_toggle(cx.listener({
+                let area_id = area_id.clone();
+                move |this, _, _window, cx| {
+                    if !this.collapsed_areas.remove(&area_id) {
+                        this.collapsed_areas.insert(area_id.clone());
+                    }
+                    cx.notify();
+                }
+            }))
+            .child(Label::new(manifest.name.clone()))
+            .end_slot(
+                IconButton::new(
+                    ElementId::Name(SharedString::from(format!(
+                        "breadpaper-remove-area-{}",
+                        manifest.id
+                    ))),
+                    IconName::Trash,
+                )
+                .icon_size(IconSize::XSmall)
+                .icon_color(Color::Muted)
+                .tooltip(Tooltip::text("Remove Area…"))
+                .on_click(cx.listener({
+                    let area_id = area_id.clone();
+                    move |this, _, window, cx| {
+                        this.remove_area(area_id.clone(), window, cx);
+                    }
+                })),
+            )
+            .on_click(cx.listener({
+                let area_id = area_id.clone();
+                let doc = manifest.doc.clone();
+                move |this, _, window, cx| {
+                    this.open_area_file(doc.clone(), area_id.clone(), window, cx);
+                }
+            })),
+        );
+        if expanded {
+            section = section
+                .children(manifest.skills.iter().map(|skill| {
+                    ListItem::new(ElementId::Name(SharedString::from(format!(
+                        "breadpaper-skill-{}-{}",
+                        manifest.id, skill.id
+                    ))))
+                    .indent_level(1)
+                    .indent_step_size(px(12.))
+                    .start_slot(
+                        Icon::new(IconName::Book)
+                            .size(IconSize::XSmall)
+                            .color(Color::Muted),
+                    )
+                    .child(Label::new(skill.name.clone()).size(LabelSize::Small))
+                    .when(!skill.summary.is_empty(), |item| {
+                        item.tooltip(Tooltip::text(skill.summary.clone()))
+                    })
+                    .on_click(cx.listener({
+                        let area_id = area_id.clone();
+                        let file = skill.file.clone();
+                        move |this, _, window, cx| {
+                            this.open_area_file(file.clone(), area_id.clone(), window, cx);
+                        }
+                    }))
+                }))
+                .children(manifest.surfaces.iter().enumerate().map(
+                    |(surface_index, surface)| {
+                        ListItem::new(ElementId::Name(SharedString::from(format!(
+                            "breadpaper-surface-{}-{surface_index}",
+                            manifest.id
+                        ))))
+                        .indent_level(1)
+                        .indent_step_size(px(12.))
+                        .start_slot(
+                            Icon::new(IconName::ArrowUpRight)
+                                .size(IconSize::XSmall)
+                                .color(Color::Muted),
+                        )
+                        .child(Label::new(surface.name.clone()).size(LabelSize::Small))
+                        .on_click(cx.listener({
+                            let area_id = area_id.clone();
+                            let open = surface.open.clone();
+                            move |this, _, _window, cx| {
+                                this.open_surface(open.clone(), area_id.clone(), cx);
+                            }
+                        }))
+                    },
+                ));
+        }
+        section.into_any_element()
+    }
+
+    fn render_add_area(&self, cx: &Context<Self>) -> impl IntoElement {
+        v_flex()
+            .child(
+                ListItem::new("breadpaper-add-area")
+                    .toggle_state(self.show_add_areas)
+                    .start_slot(
+                        Icon::new(IconName::Plus)
+                            .size(IconSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(Label::new("Add Area").color(Color::Muted))
+                    .on_click(cx.listener(|this, _, _window, cx| {
+                        this.show_add_areas = !this.show_add_areas;
+                        cx.notify();
+                    })),
+            )
+            .when(self.show_add_areas, |this| {
+                if self.addable_areas.is_empty() {
+                    this.child(
+                        div().px_2().py_1().child(
+                            Label::new("Every catalog Area is already installed.")
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        ),
+                    )
+                } else {
+                    this.children(self.addable_areas.iter().map(|manifest| {
+                        let area_id = manifest.id.clone();
+                        ListItem::new(ElementId::Name(SharedString::from(format!(
+                            "breadpaper-install-area-{}",
+                            manifest.id
+                        ))))
+                        .indent_level(1)
+                        .indent_step_size(px(12.))
+                        .child(Label::new(manifest.name.clone()).size(LabelSize::Small))
+                        .when(!manifest.summary.is_empty(), |item| {
+                            item.tooltip(Tooltip::text(manifest.summary.clone()))
+                        })
+                        .on_click(cx.listener(move |this, _, _window, cx| {
+                            this.install_area(area_id.clone(), cx);
+                        }))
+                    }))
+                }
+            })
+    }
+
     fn render_non_vault(&self, cx: &Context<Self>) -> impl IntoElement {
         v_flex()
             .gap_2()
@@ -395,7 +881,10 @@ impl TimelinePanel {
 impl Render for TimelinePanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let content = match &self.vault_status {
-            VaultStatus::Valid(_) => self.render_entries(cx).into_any_element(),
+            VaultStatus::Valid(_) => v_flex()
+                .child(self.render_entries(cx))
+                .child(self.render_areas_section(cx))
+                .into_any_element(),
             VaultStatus::NotAVault => self.render_non_vault(cx).into_any_element(),
             VaultStatus::Invalid { error } => self.render_invalid(error).into_any_element(),
         };

--- a/crates/breadpaper/src/vault.rs
+++ b/crates/breadpaper/src/vault.rs
@@ -1,0 +1,320 @@
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::notes::NoteKind;
+
+pub const VAULT_MARKER_DIR: &str = ".breadpaper";
+pub const VAULT_CONFIG_FILE: &str = "config.toml";
+pub const WELCOME_FILE: &str = "welcome.md";
+
+pub const DEFAULT_CONFIG_TOML: &str = r#"schema = 1
+
+[daily]
+dir      = "daily"           # daily notes dir, relative to vault root
+filename = "YYYY-MM-DD"      # moment-style date format; ".md" is appended
+template = "templates/daily.md"
+
+[weekly]
+dir      = "weekly"          # weekly notes dir, relative to vault root
+filename = "GGGG-[W]WW"      # ISO week year + week number, e.g. 2026-W30
+template = "templates/weekly.md"
+"#;
+
+pub const DEFAULT_DAILY_TEMPLATE: &str = r#"# {{date:dddd, MMMM D, YYYY}}
+
+## Journal
+
+## Day planner
+
+## Personal
+"#;
+
+pub const DEFAULT_WEEKLY_TEMPLATE: &str = r#"# Week {{date:W}}, {{date:GGGG}}
+
+## Goals
+
+## Notes
+
+## Week review
+"#;
+
+pub const DEFAULT_WELCOME: &str = r#"# Welcome to BreadPaper
+
+This folder is your **vault** — a plain folder of Markdown files that belongs to you.
+
+## The Timeline
+
+Open the **Timeline** panel in the left sidebar and click an entry:
+
+- **Today** / **Yesterday** open daily notes, created from `templates/daily.md`.
+- **This Week** / **Last Week** open weekly notes, created from `templates/weekly.md`.
+
+The same entries (plus **Tomorrow**) are available from the command palette as
+`breadpaper: open today`, `breadpaper: open tomorrow`, and friends.
+
+Notes live in `daily/` and `weekly/`, one file per day or week. Existing notes
+are only ever opened — never overwritten.
+
+## Make it yours
+
+Everything is a plain file you can edit:
+
+- `templates/daily.md` and `templates/weekly.md` — the templates for new notes.
+  Tokens like `{{date:dddd, MMMM D, YYYY}}`, `{{time}}`, and `{{title}}` are
+  filled in when a note is created.
+- `.breadpaper/config.toml` — where notes go and how they are named.
+
+This file is just a note, too. Edit it, or delete it once you've found your feet.
+"#;
+
+/// The parsed shape of `config.toml`; every field is optional so partially
+/// specified sections fall back to defaults.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct VaultConfigContent {
+    schema: Option<u32>,
+    daily: NotesConfigContent,
+    weekly: NotesConfigContent,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct NotesConfigContent {
+    dir: Option<String>,
+    filename: Option<String>,
+    template: Option<String>,
+}
+
+impl NotesConfigContent {
+    fn resolve(self, defaults: NotesConfig) -> NotesConfig {
+        NotesConfig {
+            dir: self.dir.unwrap_or(defaults.dir),
+            filename: self.filename.unwrap_or(defaults.filename),
+            template: self.template.unwrap_or(defaults.template),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VaultConfig {
+    pub schema: u32,
+    pub daily: NotesConfig,
+    pub weekly: NotesConfig,
+}
+
+impl Default for VaultConfig {
+    fn default() -> Self {
+        VaultConfigContent::default().resolve()
+    }
+}
+
+impl VaultConfigContent {
+    fn resolve(self) -> VaultConfig {
+        VaultConfig {
+            schema: self.schema.unwrap_or(1),
+            daily: self.daily.resolve(NotesConfig::daily_default()),
+            weekly: self.weekly.resolve(NotesConfig::weekly_default()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotesConfig {
+    pub dir: String,
+    pub filename: String,
+    pub template: String,
+}
+
+impl NotesConfig {
+    fn daily_default() -> Self {
+        Self {
+            dir: "daily".to_string(),
+            filename: "YYYY-MM-DD".to_string(),
+            template: "templates/daily.md".to_string(),
+        }
+    }
+
+    fn weekly_default() -> Self {
+        Self {
+            dir: "weekly".to_string(),
+            filename: "GGGG-[W]WW".to_string(),
+            template: "templates/weekly.md".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Vault {
+    pub root: PathBuf,
+    pub config: VaultConfig,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VaultStatus {
+    /// The folder has no `.breadpaper/` marker.
+    NotAVault,
+    /// The marker exists but `config.toml` could not be read or parsed.
+    Invalid { error: String },
+    Valid(Vault),
+}
+
+impl Vault {
+    /// Determines whether `root` is a BreadPaper vault and loads its config.
+    pub fn detect(root: &Path) -> VaultStatus {
+        let config_path = root.join(VAULT_MARKER_DIR).join(VAULT_CONFIG_FILE);
+        if !config_path.is_file() {
+            return VaultStatus::NotAVault;
+        }
+        match fs::read_to_string(&config_path) {
+            Ok(contents) => match toml::from_str::<VaultConfigContent>(&contents) {
+                Ok(content) => VaultStatus::Valid(Vault {
+                    root: root.to_path_buf(),
+                    config: content.resolve(),
+                }),
+                Err(error) => VaultStatus::Invalid {
+                    error: format!("failed to parse {}: {}", config_path.display(), error),
+                },
+            },
+            Err(error) => VaultStatus::Invalid {
+                error: format!("failed to read {}: {}", config_path.display(), error),
+            },
+        }
+    }
+
+    pub fn notes_config(&self, kind: NoteKind) -> &NotesConfig {
+        match kind {
+            NoteKind::Daily => &self.config.daily,
+            NoteKind::Weekly => &self.config.weekly,
+        }
+    }
+
+    pub fn note_path(&self, kind: NoteKind, date: chrono::NaiveDate) -> PathBuf {
+        let config = self.notes_config(kind);
+        let stem = crate::notes::format_date(date, &config.filename);
+        self.root.join(&config.dir).join(format!("{stem}.md"))
+    }
+
+    pub fn template_path(&self, kind: NoteKind) -> PathBuf {
+        self.root.join(&self.notes_config(kind).template)
+    }
+}
+
+/// Writes the default vault structure into `root`, creating it if needed.
+///
+/// Only files that don't exist yet are written, so scaffolding into a non-empty
+/// folder (the "Create vault here" action) never clobbers user data.
+pub fn scaffold_vault(root: &Path) -> Result<()> {
+    let write_if_missing = |path: &Path, contents: &str| -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        if !path.exists() {
+            fs::write(path, contents).with_context(|| format!("writing {}", path.display()))?;
+        }
+        Ok(())
+    };
+
+    write_if_missing(
+        &root.join(VAULT_MARKER_DIR).join(VAULT_CONFIG_FILE),
+        DEFAULT_CONFIG_TOML,
+    )?;
+    fs::create_dir_all(root.join("daily")).context("creating daily dir")?;
+    fs::create_dir_all(root.join("weekly")).context("creating weekly dir")?;
+    write_if_missing(&root.join("templates").join("daily.md"), DEFAULT_DAILY_TEMPLATE)?;
+    write_if_missing(
+        &root.join("templates").join("weekly.md"),
+        DEFAULT_WEEKLY_TEMPLATE,
+    )?;
+    write_if_missing(&root.join(WELCOME_FILE), DEFAULT_WELCOME)?;
+    Ok(())
+}
+
+/// The default location for the vault scaffolded on first run.
+pub fn default_vault_path() -> PathBuf {
+    util::paths::home_dir().join("BreadPaper")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn detect_non_vault() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(Vault::detect(dir.path()), VaultStatus::NotAVault);
+    }
+
+    #[test]
+    fn detect_invalid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(VAULT_MARKER_DIR);
+        fs::create_dir_all(&marker).unwrap();
+        fs::write(marker.join(VAULT_CONFIG_FILE), "not [valid toml").unwrap();
+        match Vault::detect(dir.path()) {
+            VaultStatus::Invalid { .. } => {}
+            other => panic!("expected invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scaffold_then_detect_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        let vault = match Vault::detect(dir.path()) {
+            VaultStatus::Valid(vault) => vault,
+            other => panic!("expected valid vault, got {other:?}"),
+        };
+        assert_eq!(vault.config, VaultConfig::default());
+        assert!(dir.path().join("daily").is_dir());
+        assert!(dir.path().join("weekly").is_dir());
+        assert!(dir.path().join("templates/daily.md").is_file());
+        assert!(dir.path().join("templates/weekly.md").is_file());
+        assert!(dir.path().join(WELCOME_FILE).is_file());
+
+        let date = NaiveDate::from_ymd_opt(2026, 7, 20).unwrap();
+        assert_eq!(
+            vault.note_path(NoteKind::Daily, date),
+            dir.path().join("daily/2026-07-20.md")
+        );
+        assert_eq!(
+            vault.note_path(NoteKind::Weekly, date),
+            dir.path().join("weekly/2026-W30.md")
+        );
+    }
+
+    #[test]
+    fn scaffold_preserves_existing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(WELCOME_FILE), "my own welcome").unwrap();
+        scaffold_vault(dir.path()).unwrap();
+        assert_eq!(
+            fs::read_to_string(dir.path().join(WELCOME_FILE)).unwrap(),
+            "my own welcome"
+        );
+    }
+
+    #[test]
+    fn partial_config_uses_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(VAULT_MARKER_DIR);
+        fs::create_dir_all(&marker).unwrap();
+        fs::write(
+            marker.join(VAULT_CONFIG_FILE),
+            "schema = 1\n[daily]\ndir = \"notes/daily\"\n",
+        )
+        .unwrap();
+        match Vault::detect(dir.path()) {
+            VaultStatus::Valid(vault) => {
+                assert_eq!(vault.config.daily.dir, "notes/daily");
+                assert_eq!(vault.config.daily.filename, "YYYY-MM-DD");
+                // A config written before weekly notes existed still works.
+                assert_eq!(vault.config.weekly, NotesConfig::weekly_default());
+            }
+            other => panic!("expected valid vault, got {other:?}"),
+        }
+    }
+}

--- a/crates/breadpaper/src/vault.rs
+++ b/crates/breadpaper/src/vault.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context as _, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -21,6 +21,11 @@ template = "templates/daily.md"
 dir      = "weekly"          # weekly notes dir, relative to vault root
 filename = "GGGG-[W]WW"      # ISO week year + week number, e.g. 2026-W30
 template = "templates/weekly.md"
+
+[[areas.installed]]
+id      = "timeline"
+enabled = true
+version = 1
 "#;
 
 pub const DEFAULT_DAILY_TEMPLATE: &str = r#"# {{date:dddd, MMMM D, YYYY}}
@@ -71,21 +76,32 @@ This file is just a note, too. Edit it, or delete it once you've found your feet
 "#;
 
 /// The parsed shape of `config.toml`; every field is optional so partially
-/// specified sections fall back to defaults.
-#[derive(Debug, Default, Deserialize)]
+/// specified sections fall back to defaults. Also `Serialize` so the areas
+/// registry can rewrite the file: only fields the user actually set are
+/// re-emitted (comments are not preserved).
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 struct VaultConfigContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
     schema: Option<u32>,
+    #[serde(skip_serializing_if = "NotesConfigContent::is_unset")]
     daily: NotesConfigContent,
+    #[serde(skip_serializing_if = "NotesConfigContent::is_unset")]
     weekly: NotesConfigContent,
+    #[serde(skip_serializing_if = "HistoryConfigContent::is_unset")]
     history: HistoryConfigContent,
+    #[serde(skip_serializing_if = "AreasConfigContent::is_unset")]
+    areas: AreasConfigContent,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 struct NotesConfigContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
     dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     template: Option<String>,
 }
 
@@ -97,14 +113,22 @@ impl NotesConfigContent {
             template: self.template.unwrap_or(defaults.template),
         }
     }
+
+    fn is_unset(&self) -> bool {
+        self.dir.is_none() && self.filename.is_none() && self.template.is_none()
+    }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 struct HistoryConfigContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     idle_debounce_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     heartbeat_minutes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_file_bytes: Option<u64>,
 }
 
@@ -115,6 +139,80 @@ impl HistoryConfigContent {
             idle_debounce: Duration::from_secs(self.idle_debounce_seconds.unwrap_or(20)),
             heartbeat: Duration::from_secs(self.heartbeat_minutes.unwrap_or(5) * 60),
             max_file_bytes: self.max_file_bytes.unwrap_or(2_000_000),
+        }
+    }
+
+    fn is_unset(&self) -> bool {
+        self.enabled.is_none()
+            && self.idle_debounce_seconds.is_none()
+            && self.heartbeat_minutes.is_none()
+            && self.max_file_bytes.is_none()
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+struct AreasConfigContent {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    installed: Vec<InstalledAreaContent>,
+}
+
+impl AreasConfigContent {
+    fn resolve(self) -> AreasConfig {
+        AreasConfig {
+            installed: self
+                .installed
+                .into_iter()
+                .map(InstalledAreaContent::resolve)
+                .collect(),
+        }
+    }
+
+    fn is_unset(&self) -> bool {
+        self.installed.is_empty()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct InstalledAreaContent {
+    id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<u32>,
+}
+
+impl InstalledAreaContent {
+    fn resolve(self) -> InstalledArea {
+        InstalledArea {
+            id: self.id,
+            enabled: self.enabled.unwrap_or(true),
+            version: self.version.unwrap_or(1),
+        }
+    }
+}
+
+/// The `[[areas.installed]]` registry (the V3 Areas spec §5.4). Array order is
+/// display order in the panel's Areas section.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AreasConfig {
+    pub installed: Vec<InstalledArea>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstalledArea {
+    pub id: String,
+    pub enabled: bool,
+    pub version: u32,
+}
+
+impl InstalledArea {
+    fn into_content(self) -> InstalledAreaContent {
+        InstalledAreaContent {
+            id: self.id,
+            enabled: Some(self.enabled),
+            version: Some(self.version),
         }
     }
 }
@@ -141,6 +239,7 @@ pub struct VaultConfig {
     pub daily: NotesConfig,
     pub weekly: NotesConfig,
     pub history: HistoryConfig,
+    pub areas: AreasConfig,
 }
 
 impl Default for VaultConfig {
@@ -156,6 +255,7 @@ impl VaultConfigContent {
             daily: self.daily.resolve(NotesConfig::daily_default()),
             weekly: self.weekly.resolve(NotesConfig::weekly_default()),
             history: self.history.resolve(),
+            areas: self.areas.resolve(),
         }
     }
 }
@@ -241,26 +341,63 @@ impl Vault {
     }
 }
 
+/// Creates `path`'s parent directories and writes `contents`, unless the file
+/// already exists — scaffolding and Area materialization never clobber user
+/// data.
+pub(crate) fn write_if_missing(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    if !path.exists() {
+        fs::write(path, contents).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Rewrites `.breadpaper/config.toml` with `mutate` applied to the
+/// `[[areas.installed]]` registry. Re-serializes the known config schema, so
+/// only fields present in the file are kept and comments are dropped.
+/// Blocking I/O — call from a background thread.
+pub fn update_areas_registry(
+    root: &Path,
+    mutate: impl FnOnce(&mut Vec<InstalledArea>),
+) -> Result<()> {
+    let config_path = root.join(VAULT_MARKER_DIR).join(VAULT_CONFIG_FILE);
+    let raw = fs::read_to_string(&config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let mut content: VaultConfigContent = toml::from_str(&raw)
+        .with_context(|| format!("parsing {}", config_path.display()))?;
+
+    let mut installed: Vec<InstalledArea> = content
+        .areas
+        .installed
+        .drain(..)
+        .map(InstalledAreaContent::resolve)
+        .collect();
+    mutate(&mut installed);
+    content.areas.installed = installed
+        .into_iter()
+        .map(InstalledArea::into_content)
+        .collect();
+
+    let serialized =
+        toml::to_string_pretty(&content).context("serializing vault config")?;
+    fs::write(&config_path, serialized)
+        .with_context(|| format!("writing {}", config_path.display()))?;
+    Ok(())
+}
+
 /// Writes the default vault structure into `root`, creating it if needed.
 ///
 /// Only files that don't exist yet are written, so scaffolding into a non-empty
 /// folder (the "Create vault here" action) never clobbers user data.
 pub fn scaffold_vault(root: &Path) -> Result<()> {
-    let write_if_missing = |path: &Path, contents: &str| -> Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("creating {}", parent.display()))?;
-        }
-        if !path.exists() {
-            fs::write(path, contents).with_context(|| format!("writing {}", path.display()))?;
-        }
-        Ok(())
-    };
-
-    write_if_missing(
-        &root.join(VAULT_MARKER_DIR).join(VAULT_CONFIG_FILE),
-        DEFAULT_CONFIG_TOML,
-    )?;
+    let config_path = root.join(VAULT_MARKER_DIR).join(VAULT_CONFIG_FILE);
+    // The Timeline Area ships pre-installed, but only when this scaffold is
+    // creating the vault: an existing config.toml wouldn't register the Area,
+    // and materializing unregistered files would clutter an existing vault.
+    let install_default_areas = !config_path.exists();
+    write_if_missing(&config_path, DEFAULT_CONFIG_TOML)?;
     fs::create_dir_all(root.join("daily")).context("creating daily dir")?;
     fs::create_dir_all(root.join("weekly")).context("creating weekly dir")?;
     write_if_missing(&root.join("templates").join("daily.md"), DEFAULT_DAILY_TEMPLATE)?;
@@ -269,6 +406,11 @@ pub fn scaffold_vault(root: &Path) -> Result<()> {
         DEFAULT_WEEKLY_TEMPLATE,
     )?;
     write_if_missing(&root.join(WELCOME_FILE), DEFAULT_WELCOME)?;
+    if install_default_areas {
+        let timeline = crate::areas::catalog_area(crate::areas::TIMELINE_AREA_ID)?
+            .context("the bundled Timeline Area is missing from the catalog")?;
+        crate::areas::materialize_area(root, &timeline)?;
+    }
     Ok(())
 }
 
@@ -308,7 +450,17 @@ mod tests {
             VaultStatus::Valid(vault) => vault,
             other => panic!("expected valid vault, got {other:?}"),
         };
-        assert_eq!(vault.config, VaultConfig::default());
+        assert_eq!(vault.config.daily, VaultConfig::default().daily);
+        assert_eq!(vault.config.weekly, VaultConfig::default().weekly);
+        assert_eq!(vault.config.history, VaultConfig::default().history);
+        assert_eq!(
+            vault.config.areas.installed,
+            vec![InstalledArea {
+                id: "timeline".to_string(),
+                enabled: true,
+                version: 1,
+            }]
+        );
         assert!(dir.path().join("daily").is_dir());
         assert!(dir.path().join("weekly").is_dir());
         assert!(dir.path().join("templates/daily.md").is_file());
@@ -357,6 +509,54 @@ mod tests {
             }
             other => panic!("expected valid vault, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn update_areas_registry_preserves_other_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(VAULT_MARKER_DIR);
+        fs::create_dir_all(&marker).unwrap();
+        fs::write(
+            marker.join(VAULT_CONFIG_FILE),
+            "schema = 1\n\n[daily]\ndir = \"notes/daily\"\n\n[history]\nenabled = false\n",
+        )
+        .unwrap();
+
+        update_areas_registry(dir.path(), |installed| {
+            installed.push(InstalledArea {
+                id: "timeline".to_string(),
+                enabled: true,
+                version: 1,
+            });
+        })
+        .unwrap();
+        update_areas_registry(dir.path(), |installed| {
+            if let Some(entry) = installed.first_mut() {
+                entry.enabled = false;
+            }
+        })
+        .unwrap();
+
+        match Vault::detect(dir.path()) {
+            VaultStatus::Valid(vault) => {
+                assert_eq!(vault.config.daily.dir, "notes/daily");
+                // Unset fields must stay unset, not be materialized as defaults.
+                assert_eq!(vault.config.daily.filename, "YYYY-MM-DD");
+                assert!(!vault.config.history.enabled);
+                assert_eq!(vault.config.weekly, NotesConfig::weekly_default());
+                assert_eq!(
+                    vault.config.areas.installed,
+                    vec![InstalledArea {
+                        id: "timeline".to_string(),
+                        enabled: false,
+                        version: 1,
+                    }]
+                );
+            }
+            other => panic!("expected valid vault, got {other:?}"),
+        }
+        let raw = fs::read_to_string(marker.join(VAULT_CONFIG_FILE)).unwrap();
+        assert!(!raw.contains("[weekly]"), "unset section reappeared: {raw}");
     }
 
     #[test]

--- a/crates/breadpaper/src/vault.rs
+++ b/crates/breadpaper/src/vault.rs
@@ -2,6 +2,7 @@ use anyhow::{Context as _, Result};
 use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::notes::NoteKind;
 
@@ -77,6 +78,7 @@ struct VaultConfigContent {
     schema: Option<u32>,
     daily: NotesConfigContent,
     weekly: NotesConfigContent,
+    history: HistoryConfigContent,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -97,11 +99,48 @@ impl NotesConfigContent {
     }
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct HistoryConfigContent {
+    enabled: Option<bool>,
+    idle_debounce_seconds: Option<u64>,
+    heartbeat_minutes: Option<u64>,
+    max_file_bytes: Option<u64>,
+}
+
+impl HistoryConfigContent {
+    fn resolve(self) -> HistoryConfig {
+        HistoryConfig {
+            enabled: self.enabled.unwrap_or(true),
+            idle_debounce: Duration::from_secs(self.idle_debounce_seconds.unwrap_or(20)),
+            heartbeat: Duration::from_secs(self.heartbeat_minutes.unwrap_or(5) * 60),
+            max_file_bytes: self.max_file_bytes.unwrap_or(2_000_000),
+        }
+    }
+}
+
+/// Settings for the invisible checkpoint history (the `[history]` table).
+/// Every field has a default, so the table may be entirely absent.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HistoryConfig {
+    pub enabled: bool,
+    pub idle_debounce: Duration,
+    pub heartbeat: Duration,
+    pub max_file_bytes: u64,
+}
+
+impl Default for HistoryConfig {
+    fn default() -> Self {
+        HistoryConfigContent::default().resolve()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct VaultConfig {
     pub schema: u32,
     pub daily: NotesConfig,
     pub weekly: NotesConfig,
+    pub history: HistoryConfig,
 }
 
 impl Default for VaultConfig {
@@ -116,6 +155,7 @@ impl VaultConfigContent {
             schema: self.schema.unwrap_or(1),
             daily: self.daily.resolve(NotesConfig::daily_default()),
             weekly: self.weekly.resolve(NotesConfig::weekly_default()),
+            history: self.history.resolve(),
         }
     }
 }
@@ -295,6 +335,28 @@ mod tests {
             fs::read_to_string(dir.path().join(WELCOME_FILE)).unwrap(),
             "my own welcome"
         );
+    }
+
+    #[test]
+    fn history_config_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(VAULT_MARKER_DIR);
+        fs::create_dir_all(&marker).unwrap();
+        fs::write(
+            marker.join(VAULT_CONFIG_FILE),
+            "schema = 1\n[history]\nenabled = false\nidle_debounce_seconds = 5\n",
+        )
+        .unwrap();
+        match Vault::detect(dir.path()) {
+            VaultStatus::Valid(vault) => {
+                assert!(!vault.config.history.enabled);
+                assert_eq!(vault.config.history.idle_debounce, Duration::from_secs(5));
+                // Unspecified keys keep their defaults.
+                assert_eq!(vault.config.history.heartbeat, Duration::from_secs(300));
+                assert_eq!(vault.config.history.max_file_bytes, 2_000_000);
+            }
+            other => panic!("expected valid vault, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1223,6 +1223,10 @@ pub struct RealGitRepository {
     any_git_binary_help_output: Arc<Mutex<Option<SharedString>>>,
     executor: BackgroundExecutor,
     is_trusted: Arc<AtomicBool>,
+    /// When true, the git-dir is not named `.git` and cannot be discovered
+    /// from the working directory, so commands are scoped to the repository
+    /// with `GIT_DIR`/`GIT_WORK_TREE` environment variables instead.
+    separate_git_dir: bool,
 }
 
 #[derive(Debug)]
@@ -1312,7 +1316,82 @@ impl RealGitRepository {
             executor,
             any_git_binary_help_output: Arc::new(Mutex::new(None)),
             is_trusted: Arc::new(AtomicBool::new(false)),
+            separate_git_dir: false,
         })
+    }
+
+    /// Opens a repository whose git-dir lives at an arbitrary path (not named
+    /// `.git`) with its work tree at `work_tree`, like a repository created by
+    /// [`Self::init_separate_git_dir`]. Such a repository cannot be discovered
+    /// by walking up from the working directory, so every command is scoped to
+    /// it explicitly via `GIT_DIR`/`GIT_WORK_TREE`.
+    pub fn new_with_separate_git_dir(
+        git_dir: PathBuf,
+        work_tree: PathBuf,
+        bundled_git_binary_path: Option<PathBuf>,
+        system_git_binary_path: Option<PathBuf>,
+        executor: BackgroundExecutor,
+    ) -> Result<Self> {
+        let any_git_binary_path = system_git_binary_path
+            .clone()
+            .or(bundled_git_binary_path)
+            .context("no git binary available")?;
+        let git_dir = normalize_git_metadata_path(git_dir)?;
+        Ok(Self {
+            common_dir: git_dir.clone(),
+            git_dir,
+            working_directory: Some(normalize_git_metadata_path(work_tree)?),
+            system_git_binary_path,
+            any_git_binary_path,
+            executor,
+            any_git_binary_help_output: Arc::new(Mutex::new(None)),
+            is_trusted: Arc::new(AtomicBool::new(false)),
+            separate_git_dir: true,
+        })
+    }
+
+    /// Initializes a repository with its git-dir at `git_dir` and its work
+    /// tree at `work_tree`, without creating any `.git` entry inside the work
+    /// tree. `HEAD` is left pointing at the (unborn) `branch`.
+    pub async fn init_separate_git_dir(
+        git_dir: &Path,
+        work_tree: &Path,
+        git_binary_path: &Path,
+        branch: &str,
+        executor: BackgroundExecutor,
+    ) -> Result<()> {
+        // `git init` creates the git-dir itself but not its parents.
+        smol::fs::create_dir_all(git_dir).await?;
+        let git = GitBinary::new(
+            git_binary_path.to_path_buf(),
+            work_tree.to_path_buf(),
+            git_dir.to_path_buf(),
+            executor,
+            false,
+        )
+        .envs(HashMap::from_iter([(
+            "GIT_DIR".to_string(),
+            git_dir.to_string_lossy().into_owned(),
+        )]));
+        git.run(&["init", "-b", branch])
+            .await
+            .context("initializing repository with separate git-dir")?;
+        Ok(())
+    }
+
+    fn separate_git_dir_envs(&self) -> HashMap<String, String> {
+        let mut envs = HashMap::default();
+        envs.insert(
+            "GIT_DIR".to_string(),
+            self.git_dir.to_string_lossy().into_owned(),
+        );
+        if let Some(work_tree) = &self.working_directory {
+            envs.insert(
+                "GIT_WORK_TREE".to_string(),
+                work_tree.to_string_lossy().into_owned(),
+            );
+        }
+        envs
     }
 
     fn working_directory(&self) -> Result<PathBuf> {
@@ -1328,23 +1407,31 @@ impl RealGitRepository {
     }
 
     fn git_binary_in_worktree(&self) -> Result<GitBinary> {
-        Ok(GitBinary::new(
+        let mut git = GitBinary::new(
             self.any_git_binary_path.clone(),
             self.working_directory()?,
             self.path(),
             self.executor.clone(),
             self.is_trusted(),
-        ))
+        );
+        if self.separate_git_dir {
+            git = git.envs(self.separate_git_dir_envs());
+        }
+        Ok(git)
     }
 
     fn git_binary(&self) -> GitBinary {
-        GitBinary::new(
+        let mut git = GitBinary::new(
             self.any_git_binary_path.clone(),
             self.command_directory(),
             self.path(),
             self.executor.clone(),
             self.is_trusted(),
-        )
+        );
+        if self.separate_git_dir {
+            git = git.envs(self.separate_git_dir_envs());
+        }
+        git
     }
 
     fn edit_ref(&self, edit: RefEdit) -> BoxFuture<'_, Result<()>> {
@@ -1372,6 +1459,73 @@ impl RealGitRepository {
             .into();
         *self.any_git_binary_help_output.lock() = Some(output.clone());
         output
+    }
+
+    /// Records a checkpoint of the working tree as a commit on `ref_name`,
+    /// parented on the current `HEAD`, using a temporary index so the real
+    /// index is never touched. Files matching `checkpoint.gitignore` or whose
+    /// size is at least `max_file_bytes` are excluded from the snapshot.
+    ///
+    /// Unlike [`GitRepository::checkpoint`], the commit is not left dangling:
+    /// `ref_name` advances to it, forming a walkable chain. The ref is only
+    /// updated after the commit is fully written, so an interruption at any
+    /// point leaves the previous checkpoint as the head.
+    ///
+    /// Returns `Ok(None)` without committing when the tree is identical to
+    /// the current `HEAD`'s tree.
+    pub fn checkpoint_onto_ref(
+        &self,
+        ref_name: String,
+        message: String,
+        author_name: String,
+        author_email: String,
+        max_file_bytes: u64,
+    ) -> BoxFuture<'static, Result<Option<GitRepositoryCheckpoint>>> {
+        let git = self.git_binary_in_worktree();
+        self.executor
+            .spawn(async move {
+                let mut git = git?.envs(commit_identity_envs(&author_name, &author_email));
+                let checkpoint = git
+                    .with_temp_index(async |git| {
+                        let head_sha = git.run(&["rev-parse", "HEAD"]).await.ok();
+                        let mut excludes = exclude_files(git, max_file_bytes).await?;
+                        git.run(&["add", "--all"]).await?;
+                        let tree = git.run(&["write-tree"]).await?;
+                        excludes.restore_original().await?;
+
+                        if let Some(head_sha) = head_sha.as_deref() {
+                            let head_tree =
+                                git.run(&["rev-parse", &format!("{head_sha}^{{tree}}")]).await?;
+                            if head_tree == tree {
+                                return Ok(None);
+                            }
+                        }
+
+                        let checkpoint_sha = if let Some(head_sha) = head_sha.as_deref() {
+                            git.run(&["commit-tree", &tree, "-p", head_sha, "-m", &message])
+                                .await?
+                        } else {
+                            git.run(&["commit-tree", &tree, "-m", &message]).await?
+                        };
+                        git.run(&["update-ref", &ref_name, &checkpoint_sha]).await?;
+
+                        Ok(Some(GitRepositoryCheckpoint {
+                            commit_sha: checkpoint_sha.parse()?,
+                        }))
+                    })
+                    .await?;
+
+                if checkpoint.is_some() {
+                    // Plumbing commands never trigger git's automatic GC, so
+                    // loose objects would otherwise accumulate forever.
+                    // `--auto` is a fast no-op below git's thresholds, and a
+                    // GC failure must never fail the checkpoint.
+                    git.run(&["gc", "--auto", "--quiet"]).await.log_err();
+                }
+
+                Ok(checkpoint)
+            })
+            .boxed()
     }
 }
 
@@ -2845,7 +2999,7 @@ impl GitRepository for RealGitRepository {
                 let mut git = git?.envs(checkpoint_author_envs());
                 git.with_temp_index(async |git| {
                     let head_sha = git.run(&["rev-parse", "HEAD"]).await.ok();
-                    let mut excludes = exclude_files(git).await?;
+                    let mut excludes = exclude_files(git, DEFAULT_MAX_CHECKPOINT_FILE_SIZE).await?;
 
                     git.run(&["add", "--all"]).await?;
                     let tree = git.run(&["write-tree"]).await?;
@@ -3527,9 +3681,10 @@ fn git_status_args(path_prefixes: &[RepoPath]) -> Vec<OsString> {
     args
 }
 
-/// Temporarily git-ignore commonly ignored files and files over 2MB
-async fn exclude_files(git: &GitBinary) -> Result<GitExcludeOverride> {
-    const MAX_SIZE: u64 = 2 * 1024 * 1024; // 2 MB
+const DEFAULT_MAX_CHECKPOINT_FILE_SIZE: u64 = 2 * 1024 * 1024; // 2 MB
+
+/// Temporarily git-ignore commonly ignored files and files of at least `max_file_bytes`
+async fn exclude_files(git: &GitBinary, max_file_bytes: u64) -> Result<GitExcludeOverride> {
     let mut excludes = git.with_exclude_overrides().await?;
     excludes
         .add_excludes(include_str!("./checkpoint.gitignore"))
@@ -3542,7 +3697,7 @@ async fn exclude_files(git: &GitBinary) -> Result<GitExcludeOverride> {
         smol::spawn(async move {
             let full_path = working_directory.join(path.clone());
             match smol::fs::metadata(&full_path).await {
-                Ok(metadata) if metadata.is_file() && metadata.len() >= MAX_SIZE => {
+                Ok(metadata) if metadata.is_file() && metadata.len() >= max_file_bytes => {
                     Some(PathBuf::from("/").join(path.clone()))
                 }
                 _ => None,
@@ -3608,7 +3763,7 @@ impl GitBinary {
     }
 
     fn envs(mut self, envs: HashMap<String, String>) -> Self {
-        self.envs = envs;
+        self.envs.extend(envs);
         self
     }
 
@@ -3979,11 +4134,15 @@ fn parse_upstream_track(upstream_track: &str) -> Result<UpstreamTracking> {
 }
 
 fn checkpoint_author_envs() -> HashMap<String, String> {
+    commit_identity_envs("Zed", "hi@zed.dev")
+}
+
+fn commit_identity_envs(name: &str, email: &str) -> HashMap<String, String> {
     HashMap::from_iter([
-        ("GIT_AUTHOR_NAME".to_string(), "Zed".to_string()),
-        ("GIT_AUTHOR_EMAIL".to_string(), "hi@zed.dev".to_string()),
-        ("GIT_COMMITTER_NAME".to_string(), "Zed".to_string()),
-        ("GIT_COMMITTER_EMAIL".to_string(), "hi@zed.dev".to_string()),
+        ("GIT_AUTHOR_NAME".to_string(), name.to_string()),
+        ("GIT_AUTHOR_EMAIL".to_string(), email.to_string()),
+        ("GIT_COMMITTER_NAME".to_string(), name.to_string()),
+        ("GIT_COMMITTER_EMAIL".to_string(), email.to_string()),
     ])
 }
 
@@ -5128,6 +5287,192 @@ mod tests {
                 None,
             ]
         );
+    }
+
+    #[gpui::test]
+    async fn test_checkpoint_onto_ref(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let vault_dir = temp_dir.path().join("vault");
+        fs::create_dir_all(vault_dir.join("daily")).unwrap();
+        fs::write(vault_dir.join("daily/note.md"), "hello").unwrap();
+        let git_dir = vault_dir.join(".breadpaper").join("history");
+
+        RealGitRepository::init_separate_git_dir(
+            &git_dir,
+            &vault_dir,
+            Path::new("git"),
+            "checkpoints",
+            cx.executor(),
+        )
+        .await
+        .unwrap();
+        // The whole point of a separate git-dir: nothing named `.git` appears
+        // in the work tree.
+        assert!(!vault_dir.join(".git").exists());
+        fs::create_dir_all(git_dir.join("info")).unwrap();
+        fs::write(git_dir.join("info/exclude"), "/.breadpaper/history/\n").unwrap();
+
+        let repo = RealGitRepository::new_with_separate_git_dir(
+            git_dir.clone(),
+            vault_dir.clone(),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+        let checkpoint = |message: &str| {
+            repo.checkpoint_onto_ref(
+                "refs/heads/checkpoints".to_string(),
+                message.to_string(),
+                "BreadPaper".to_string(),
+                "history@breadpaper.local".to_string(),
+                1024 * 1024,
+            )
+        };
+
+        let first = checkpoint("checkpoint: initial")
+            .await
+            .unwrap()
+            .expect("initial checkpoint should commit");
+
+        // No-op discipline: an unchanged tree produces no commit and no ref move.
+        assert!(checkpoint("checkpoint: idle").await.unwrap().is_none());
+
+        fs::write(vault_dir.join("daily/note.md"), "hello, again").unwrap();
+        let second = checkpoint("checkpoint: idle")
+            .await
+            .unwrap()
+            .expect("changed tree should commit");
+
+        let git_dir_arg = format!("--git-dir={}", git_dir.display());
+        assert_eq!(
+            git_command_output(&vault_dir, [git_dir_arg.as_str(), "rev-parse", "checkpoints"]),
+            second.commit_sha.to_string()
+        );
+        assert_eq!(
+            git_command_output(&vault_dir, [git_dir_arg.as_str(), "rev-parse", "checkpoints^"]),
+            first.commit_sha.to_string()
+        );
+        assert_eq!(
+            git_command_output(
+                &vault_dir,
+                [git_dir_arg.as_str(), "log", "-1", "--format=%s %an"]
+            ),
+            "checkpoint: idle BreadPaper"
+        );
+
+        // A file at or above `max_file_bytes` stays out of the snapshot; the
+        // checkpoint of everything else still succeeds.
+        fs::write(vault_dir.join("big.dat"), vec![0u8; 2 * 1024 * 1024]).unwrap();
+        assert!(checkpoint("checkpoint: idle").await.unwrap().is_none());
+        fs::write(vault_dir.join("daily/note.md"), "with big file around").unwrap();
+        let third = checkpoint("checkpoint: idle")
+            .await
+            .unwrap()
+            .expect("changed tree should commit");
+        assert_eq!(
+            git_command_output(
+                &vault_dir,
+                [
+                    git_dir_arg.as_str(),
+                    "ls-tree",
+                    "-r",
+                    "--name-only",
+                    "checkpoints"
+                ]
+            ),
+            "daily/note.md"
+        );
+
+        // Restore at the plumbing level.
+        fs::write(vault_dir.join("daily/note.md"), "ruined").unwrap();
+        repo.restore_checkpoint(third.clone()).await.unwrap();
+        assert_eq!(
+            fs::read_to_string(vault_dir.join("daily/note.md")).unwrap(),
+            "with big file around"
+        );
+        assert!(vault_dir.join("big.dat").exists());
+    }
+
+    #[gpui::test]
+    async fn test_checkpoint_onto_ref_coexists_with_user_repo(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let vault_dir = temp_dir.path().join("vault");
+        fs::create_dir_all(&vault_dir).unwrap();
+        fs::write(vault_dir.join("note.md"), "hello").unwrap();
+        git_init_repo(&vault_dir);
+        git_command(&vault_dir, ["add", "."]);
+        git_command(&vault_dir, ["commit", "-m", "user commit"]);
+
+        let git_dir = vault_dir.join(".breadpaper").join("history");
+        RealGitRepository::init_separate_git_dir(
+            &git_dir,
+            &vault_dir,
+            Path::new("git"),
+            "checkpoints",
+            cx.executor(),
+        )
+        .await
+        .unwrap();
+        fs::create_dir_all(git_dir.join("info")).unwrap();
+        fs::write(git_dir.join("info/exclude"), "/.breadpaper/history/\n").unwrap();
+        let repo = RealGitRepository::new_with_separate_git_dir(
+            git_dir.clone(),
+            vault_dir.clone(),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        fs::write(vault_dir.join("note.md"), "edited").unwrap();
+        let user_status_before = git_command_output(&vault_dir, ["status", "--porcelain"]);
+
+        repo.checkpoint_onto_ref(
+            "refs/heads/checkpoints".to_string(),
+            "checkpoint: idle".to_string(),
+            "BreadPaper".to_string(),
+            "history@breadpaper.local".to_string(),
+            1024 * 1024,
+        )
+        .await
+        .unwrap()
+        .expect("checkpoint should commit");
+
+        // The user's repository is untouched: same status, same history, no
+        // new branches.
+        assert_eq!(
+            git_command_output(&vault_dir, ["status", "--porcelain"]),
+            user_status_before
+        );
+        assert_eq!(
+            git_command_output(&vault_dir, ["log", "--format=%s"]),
+            "user commit"
+        );
+        assert_eq!(
+            git_command_output(&vault_dir, ["branch", "--format=%(refname:short)"]),
+            "main"
+        );
+
+        // And the user's `.git` never enters the snapshot.
+        let git_dir_arg = format!("--git-dir={}", git_dir.display());
+        let snapshot_files = git_command_output(
+            &vault_dir,
+            [
+                git_dir_arg.as_str(),
+                "ls-tree",
+                "-r",
+                "--name-only",
+                "checkpoints",
+            ],
+        );
+        assert_eq!(snapshot_files, "note.md");
     }
 
     #[gpui::test]

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4748,6 +4748,26 @@ impl BackgroundScanner {
                 if self.track_git_repositories {
                     for ancestor in abs_path.as_path().ancestors() {
                         if is_dot_git(ancestor, self.fs.as_ref()).await {
+                            // An entry literally named `.git` is always
+                            // tracked (the default file_scan_exclusions cover
+                            // `.git`, yet its metadata must still update).
+                            // The bare-repository heuristic, however, must
+                            // not register repositories the user has excluded
+                            // from scanning, such as tool-managed repos
+                            // inside hidden state directories.
+                            if ancestor.file_name() != Some(OsStr::new(DOT_GIT)) {
+                                let ancestor_sanitized = SanitizedPath::new(ancestor);
+                                let relative_path = ancestor_sanitized
+                                    .strip_prefix(&root_canonical_path)
+                                    .or_else(|_| ancestor_sanitized.strip_prefix(&root_path))
+                                    .ok()
+                                    .and_then(|path| RelPath::new(path, PathStyle::local()).ok());
+                                if relative_path
+                                    .is_some_and(|path| self.settings.is_path_excluded(&path))
+                                {
+                                    continue;
+                                }
+                            }
                             let path_in_git_dir = abs_path
                                 .as_path()
                                 .strip_prefix(ancestor)

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -77,6 +77,7 @@ audio.workspace = true
 auto_update.workspace = true
 auto_update_ui.workspace = true
 breadcrumbs.workspace = true
+breadpaper.workspace = true
 call.workspace = true
 chrono.workspace = true
 channel.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -36,7 +36,6 @@ use gpui_platform;
 
 use gpui_tokio::Tokio;
 use language::LanguageRegistry;
-use onboarding::{FIRST_OPEN, show_onboarding_view};
 use project_panel::ProjectPanel;
 use prompt_store::PromptBuilder;
 use remote::RemoteConnectionOptions;
@@ -742,6 +741,7 @@ fn main() {
         tab_switcher::init(cx);
         outline::init(cx);
         project_symbols::init(cx);
+        breadpaper::init(cx);
         project_panel::init(cx);
         outline_panel::init(cx);
         tasks_ui::init(cx);
@@ -1401,7 +1401,6 @@ pub(crate) async fn restore_or_create_workspace(
     app_state: Arc<AppState>,
     cx: &mut AsyncApp,
 ) -> Result<()> {
-    let kvp = cx.update(|cx| KeyValueStore::global(cx));
     if let Some(multi_workspaces) = restorable_workspaces(cx, &app_state).await {
         let mut error_count = 0;
         for multi_workspace in multi_workspaces {
@@ -1531,26 +1530,11 @@ pub(crate) async fn restore_or_create_workspace(
             })
             .await?;
         }
-    } else if matches!(kvp.read_kvp(FIRST_OPEN), Ok(None)) {
-        cx.update(|cx| show_onboarding_view(app_state, cx)).await?;
     } else {
-        cx.update(|cx| {
-            workspace::open_new(
-                Default::default(),
-                app_state,
-                cx,
-                |workspace, window, cx| {
-                    let restore_on_startup = WorkspaceSettings::get_global(cx).restore_on_startup;
-                    match restore_on_startup {
-                        workspace::RestoreOnStartupBehavior::Launchpad => {}
-                        _ => {
-                            Editor::new_file(workspace, &Default::default(), window, cx);
-                        }
-                    }
-                },
-            )
-        })
-        .await?;
+        // BreadPaper: with nothing to restore, open the default vault (scaffolding
+        // it on first run) instead of Zed's onboarding view or an empty workspace.
+        cx.update(|cx| breadpaper::open_startup_vault(app_state, cx))
+            .await?;
     }
 
     Ok(())

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -742,6 +742,7 @@ fn main() {
         outline::init(cx);
         project_symbols::init(cx);
         breadpaper::init(cx);
+        breadpaper::history::init(cx);
         project_panel::init(cx);
         outline_panel::init(cx);
         tasks_ui::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -772,6 +772,8 @@ fn show_software_emulation_warning_if_needed(
 
 fn initialize_panels(window: &mut Window, cx: &mut Context<Workspace>) -> Task<anyhow::Result<()>> {
     cx.spawn_in(window, async move |workspace_handle, cx| {
+        let breadpaper_timeline_panel =
+            breadpaper::TimelinePanel::load(workspace_handle.clone(), cx.clone());
         let project_panel = ProjectPanel::load(workspace_handle.clone(), cx.clone());
         let outline_panel = OutlinePanel::load(workspace_handle.clone(), cx.clone());
         let terminal_panel = TerminalPanel::load(workspace_handle.clone(), cx.clone());
@@ -796,14 +798,22 @@ fn initialize_panels(window: &mut Window, cx: &mut Context<Workspace>) -> Task<a
         }
 
         futures::join!(
+            add_panel_when_ready(breadpaper_timeline_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(project_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(outline_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(terminal_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(git_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(channels_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(debug_panel, workspace_handle.clone(), cx.clone()),
-            initialize_agent_panel(workspace_handle, cx.clone()).map(|r| r.log_err()),
+            initialize_agent_panel(workspace_handle.clone(), cx.clone()).map(|r| r.log_err()),
         );
+
+        // BreadPaper: default the left dock to the timeline panel in vaults.
+        workspace_handle
+            .update_in(cx, |workspace, window, cx| {
+                breadpaper::show_panel_if_vault(workspace, window, cx);
+            })
+            .log_err();
 
         anyhow::Ok(())
     })


### PR DESCRIPTION
## Summary

Adds two Daily Closure skills to the Timeline Area and makes an Area's skills discoverable by a Claude Code session opened in the vault.

### New skills
- **Wrap Today** / **Wrap Yesterday** — read the day's checked/unchecked tasks, pull the day's commits, scan surrounding days for multi-day context, and append a `# Daily Closure` review to the day's note (append-only, per the augmentation principle). This is the Daily Closure ritual from `breadpaper/VISION.md` §5.4.
- Wrap Yesterday delegates to Wrap Today's instructions (only the target day and context-scan window differ), so the ritual text lives in one place.

### Claude Code discovery
Claude Code only finds project skills under `.claude/skills/<name>/SKILL.md`, but BreadPaper materializes its skills at `skills/timeline/*.md` — so a `claude` session in the vault saw nothing. Each skill now also gets a generated **bridge** at `.claude/skills/<id>/SKILL.md`:
- Front matter (`name`, `description`) is derived from the manifest; the body points back to the canonical `skills/timeline/<id>.md` (single source of truth).
- Marked `disable-model-invocation: true` — these note-writing rituals run only when the user types `/wrap-today` etc., never auto-fired by Claude.
- Create-if-missing (user edits survive); removal deletes unmodified bridges and prunes the empty `.claude` tree.

### On-open self-heal
Previously only a fresh scaffold or explicit reinstall materialized Area files, so an existing vault would never gain newly shipped files after an app update. Enabled Areas now re-materialize (idempotent, no clobber, registry untouched) whenever a vault is detected.

## Testing
- 11 area tests pass (`cargo test -p breadpaper areas::`), including new coverage for bridge front matter, edit survival, removal preservation, and reconcile backfill on an existing vault.
- Clippy clean on the `breadpaper` crate.
- Verified in the running app: opening `~/BreadPaper` materialized `.claude/skills/{week-review,wrap-today,wrap-yesterday}/SKILL.md`; the skills appear as slash commands in a Claude Code session in the vault.

## Follow-up (not in this PR)
The shipped skills hardcode `daily/YYYY-MM-DD.md` / `weekly/YYYY-Www.md`, but a vault may customize `[daily]`/`[weekly]` dir and filename in `config.toml` (the dogfood vault uses `_daily` with `YYYYMMDD_MMM-ddd`). The skills — including the existing Week Review — should read the vault config instead of hardcoding. Worth a separate change.

Release Notes:

- Added Wrap Today and Wrap Yesterday daily-closure skills to the Timeline Area, discoverable as slash commands in a Claude Code session opened in the vault.