### PR TITLE
Tag Windows crash reports with injected third-party DLLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6113,7 +6113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7331,7 +7331,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11147,6 +11147,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "minidump"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a902ca21d9772a66d3d1b050b3436dcadb192694be01409e0219902dcf4bc1e8"
+dependencies = [
+ "debugid",
+ "encoding_rs",
+ "memmap2",
+ "minidump-common",
+ "num-traits",
+ "procfs-core",
+ "prost 0.13.5",
+ "range-map",
+ "scroll",
+ "thiserror 2.0.17",
+ "time",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "minidump-common"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11269,7 +11290,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11706,7 +11727,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14377,6 +14398,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes 1.11.1",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14438,6 +14469,19 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15875,7 +15919,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17341,7 +17385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18471,7 +18515,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21494,7 +21538,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -23250,6 +23294,7 @@ dependencies = [
  "menu",
  "migrator",
  "mimalloc",
+ "minidump",
  "miniprofiler_ui",
  "node_runtime",
  "notifications",
@@ -23327,6 +23372,7 @@ dependencies = [
  "zed_env_vars",
  "zlog",
  "zlog_settings",
+ "zstd",
  "ztracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -671,6 +671,7 @@ lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "f4dfa8
 mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
 metal = "0.33"
+minidump = "0.26"
 minidumper = "0.9"
 moka = { version = "0.12.10", features = ["sync"] }
 nanoid = "0.4"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -156,6 +156,7 @@ markdown.workspace = true
 markdown_preview.workspace = true
 menu.workspace = true
 migrator.workspace = true
+minidump.workspace = true
 miniprofiler_ui.workspace = true
 mimalloc = { version = "0.1", optional = true }
 node_runtime.workspace = true
@@ -227,6 +228,7 @@ zed_actions.workspace = true
 zed_env_vars.workspace = true
 zlog.workspace = true
 zlog_settings.workspace = true
+zstd.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 etw_tracing.workspace = true
@@ -308,4 +310,4 @@ osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed"]
 
 [package.metadata.cargo-machete]
-ignored = ["profiling", "zstd", "tracing"]
+ignored = ["profiling", "tracing"]

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -280,6 +280,7 @@ async fn upload_minidump(
         log::warn!("No commit sha set, skipping minidump upload");
         return Ok(());
     }
+    let injected_modules = injected_modules_from_minidump(&minidump);
     let mut form = Form::new()
         .part(
             "upload_file_minidump",
@@ -295,6 +296,17 @@ async fn upload_minidump(
         .text("sentry[tags][binary]", metadata.init.binary.clone())
         .text("sentry[release]", metadata.init.commit_sha.clone())
         .text("platform", "rust");
+    if !injected_modules.is_empty() {
+        form = form
+            .text(
+                "sentry[tags][injected_dlls]",
+                injected_dlls_tag(&injected_modules),
+            )
+            .text(
+                "sentry[contexts][injected_modules][paths]",
+                injected_modules.join("\n"),
+            );
+    }
     let mut panic_message = "".to_owned();
     if let Some(panic_info) = metadata.panic.as_ref() {
         panic_message = panic_info.message.clone();
@@ -431,6 +443,115 @@ async fn upload_minidump(
     Ok(())
 }
 
+/// Sentry limits tag values to 200 characters.
+const SENTRY_TAG_MAX_LEN: usize = 200;
+
+/// Returns the modules loaded into the crashed process that are neither
+/// Windows system libraries nor part of Zed's own installation. Software that
+/// hooks Win32 APIs by injecting a DLL into other processes (overlays,
+/// antivirus, IMEs, endpoint monitors) is a common cause of
+/// otherwise-unexplainable memory corruption crashes, so we tag crash events
+/// with these modules to make affected reports easy to identify during
+/// triage. Returns an empty list for non-Windows dumps.
+fn injected_modules_from_minidump(minidump_contents: &[u8]) -> Vec<String> {
+    use minidump::Module as _;
+
+    // Minidumps are stored zstd-compressed on disk; fall back to treating the
+    // input as a raw dump if decompression fails.
+    let dump_bytes =
+        zstd::decode_all(minidump_contents).unwrap_or_else(|_| minidump_contents.to_vec());
+    let Some(dump) = minidump::Minidump::read(dump_bytes)
+        .context("parsing minidump for module list")
+        .log_err()
+    else {
+        return Vec::new();
+    };
+    let Some(modules) = dump
+        .get_stream::<minidump::MinidumpModuleList>()
+        .context("reading minidump module list")
+        .log_err()
+    else {
+        return Vec::new();
+    };
+    let main_module_path = modules
+        .main_module()
+        .map(|module| module.code_file().into_owned());
+    filter_injected_module_paths(
+        main_module_path.as_deref(),
+        modules.iter().map(|module| module.code_file().into_owned()),
+    )
+}
+
+fn filter_injected_module_paths(
+    main_module_path: Option<&str>,
+    module_paths: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    // Only Windows dumps are classified: DLL injection is where this signal
+    // matters, and Windows paths are easy to distinguish reliably.
+    let Some(app_dir) = main_module_path.and_then(windows_parent_dir) else {
+        return Vec::new();
+    };
+    let app_dir = app_dir.to_lowercase();
+    module_paths
+        .into_iter()
+        .filter(|path| {
+            let lower = path.to_lowercase();
+            lower.contains('\\')
+                && !is_windows_system_module(&lower)
+                && !lower.starts_with(&app_dir)
+        })
+        .collect()
+}
+
+/// The containing directory of a Windows path, including the trailing
+/// backslash, or `None` if this doesn't look like a Windows path.
+fn windows_parent_dir(path: &str) -> Option<&str> {
+    let index = path.rfind('\\')?;
+    Some(&path[..=index])
+}
+
+fn is_windows_system_module(lower_path: &str) -> bool {
+    let bytes = lower_path.as_bytes();
+    bytes.len() > 3
+        && bytes[0].is_ascii_lowercase()
+        && bytes[1] == b':'
+        && bytes[2] == b'\\'
+        && lower_path[3..].starts_with("windows\\")
+}
+
+/// Comma-separated module file names, deduplicated, fitting within Sentry's
+/// tag length limit.
+fn injected_dlls_tag(module_paths: &[String]) -> String {
+    let mut tag = String::new();
+    let mut seen = Vec::new();
+    for path in module_paths {
+        let name = path.rsplit('\\').next().unwrap_or(path);
+        if seen.contains(&name) {
+            continue;
+        }
+        seen.push(name);
+        let needed = if tag.is_empty() {
+            name.len()
+        } else {
+            name.len() + 1
+        };
+        if tag.len() + needed > SENTRY_TAG_MAX_LEN {
+            break;
+        }
+        if !tag.is_empty() {
+            tag.push(',');
+        }
+        tag.push_str(name);
+    }
+    if tag.is_empty()
+        && let Some(first) = module_paths.first()
+    {
+        let name = first.rsplit('\\').next().unwrap_or(first);
+        tag = name.chars().take(SENTRY_TAG_MAX_LEN).collect();
+    }
+    tag
+}
+
 #[derive(Debug, Deserialize)]
 struct BuildTiming {
     started_at: chrono::DateTime<chrono::Utc>,
@@ -524,5 +645,75 @@ impl FormExt for Form {
             Some(value) => self.text(label.into(), value.into()),
             None => self,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|path| path.to_string()).collect()
+    }
+
+    #[test]
+    fn test_filter_injected_module_paths() {
+        let main_module = r"C:\Users\me\AppData\Local\Programs\Zed Preview\Zed.exe";
+        let injected = filter_injected_module_paths(
+            Some(main_module),
+            strings(&[
+                main_module,
+                r"C:\Users\me\AppData\Local\Programs\Zed Preview\conpty.dll",
+                r"C:\Windows\System32\ntdll.dll",
+                r"C:\WINDOWS\System32\KERNELBASE.dll",
+                r"C:\Windows\System32\DriverStore\FileRepository\u.inf_amd64\amdxx64.dll",
+                r"C:\Program Files (x86)\RivaTuner Statistics Server\RTSSHooks64.dll",
+                r"C:\Program Files\ESET\ESET Security\ebehmoni.dll",
+            ]),
+        );
+        assert_eq!(
+            injected,
+            strings(&[
+                r"C:\Program Files (x86)\RivaTuner Statistics Server\RTSSHooks64.dll",
+                r"C:\Program Files\ESET\ESET Security\ebehmoni.dll",
+            ])
+        );
+    }
+
+    #[test]
+    fn test_filter_injected_module_paths_skips_non_windows_dumps() {
+        assert_eq!(
+            filter_injected_module_paths(
+                Some("/Applications/Zed.app/Contents/MacOS/zed"),
+                strings(&[
+                    "/Applications/Zed.app/Contents/MacOS/zed",
+                    "/usr/lib/libSystem.B.dylib",
+                ]),
+            ),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            filter_injected_module_paths(None, strings(&[r"C:\Windows\System32\ntdll.dll"])),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_injected_dlls_tag_dedupes_and_respects_length_limit() {
+        let tag = injected_dlls_tag(&strings(&[
+            r"C:\Program Files (x86)\RivaTuner Statistics Server\RTSSHooks64.dll",
+            r"C:\Program Files\ESET\ESET Security\ebehmoni.dll",
+            r"C:\Program Files\ESET\ESET Security\ebehmoni.dll",
+        ]));
+        assert_eq!(tag, "RTSSHooks64.dll,ebehmoni.dll");
+
+        let long_name = format!(r"C:\hooks\{}.dll", "a".repeat(300));
+        let tag = injected_dlls_tag(&strings(&[&long_name]));
+        assert_eq!(tag.len(), SENTRY_TAG_MAX_LEN);
+
+        let many: Vec<String> = (0..100).map(|i| format!(r"C:\hooks\hook{i}.dll")).collect();
+        let tag = injected_dlls_tag(&many);
+        assert!(tag.len() <= SENTRY_TAG_MAX_LEN);
+        assert!(tag.starts_with("hook0.dll,hook1.dll"));
     }
 }


### PR DESCRIPTION
While investigating ZED-AD2 (a `STATUS_HEAP_CORRUPTION` crash on Windows), I found that 7 of the 10 heap-corruption minidumps I sampled had API-hooking DLLs injected into our process — RivaTuner, Sangfor VPN, ESET's behavior monitor, SKYSEA endpoint monitoring, Sogou IME, and friends. Corruption caused by foreign code in our process shows up as a Zed crash, and right now the only way to spot it is to manually dig the module list out of each Sentry event.

This PR parses the minidump's module list client-side at upload time (using rust-minidump) and flags any modules that live outside both `C:\Windows\` and Zed's install directory. Affected events get an `injected_dlls` tag with the DLL names plus a context entry with the full paths; clean machines get no tag. That means triage can split the two populations with `has:injected_dlls` / `!has:injected_dlls`, and we can finally see what fraction of our Windows crash volume is externally-caused rather than relying on anecdotes.

Classification only engages for Windows dumps, since that's where DLL injection is endemic and the path rules are reliable. Dumps from other platforms (and anything that fails to parse) upload exactly as before.

Should help with investigating issues like FR-134.

Release Notes:

- N/A
