### PR TITLE
Print Asset Error with the whole context

### DIFF
--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -61,7 +61,7 @@ impl<T, R, E> Asset for AssetLogger<T>
 where
     T: Asset<Output = Result<R, E>>,
     R: Clone + Send,
-    E: Clone + Send + std::fmt::Display,
+    E: Clone + Send + Debug,
 {
     type Source = T::Source;
 
@@ -72,7 +72,7 @@ where
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         let load = T::load(source, cx);
-        load.inspect_err(|e| log::error!("Failed to load asset: {}", e))
+        load.inspect_err(|e| log::error!("Failed to load asset: {:?}", e))
     }
 }
 


### PR DESCRIPTION
# Objective

So while using gpui I didn't know that you needed to register a http_client if you wanted to use images with a link as a source.
So I enabled logs, and I did get errors.
```
20:48:11 [ERROR] Failed to load asset2: error: loading image asset from "https://im.fumo.ing/tLNyIY4n7PEG.jpg"
```
But they didn't tell me what was wrong.

## Solution

I change 2 lines to print the whole error with all the context.

```
20:49:09 [ERROR] Failed to load asset2: Other(loading image asset from "https://im.fumo.ing/tLNyIY4n7PEG.jpg"

Caused by:
    No HttpClient available)
```
And now it does tell you why it doesn't work. ✨Amazing✨.

## Testing

Because I did change the traits needed for the AssetLogger I build zed to check if it didn't break anything. And it build, so it fine I think.

A quick way to test the change in logging is the gpui example `image_gallery.rs` and commenting the lines 259 & 260
```rust
        #[cfg(not(target_family = "wasm"))]
        {
            let http_client = ReqwestClient::user_agent("gpui example").unwrap();
            cx.set_http_client(Arc::new(http_client));
        }
```
Or change the URI on line 42 to something non existing.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Improved Error logging for Asset loading
