### PR TITLE
editor: Fix horizontal autoscroll only revealing part of search matches

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -387,8 +387,24 @@ impl Editor {
                 if head.row() >= start_row
                     && head.row() < DisplayRow(start_row.0 + layouts.len() as u32)
                 {
-                    let start_column = head.column();
-                    let end_column = cmp::min(display_map.line_len(head.row()), head.column());
+                    let row_line_len = display_map.line_len(head.row());
+                    let start_dp = selection.start.to_display_point(&display_map);
+                    let end_dp = selection.end.to_display_point(&display_map);
+
+                    let start_column = if start_dp.row() == head.row() {
+                        start_dp.column()
+                    } else {
+                        0
+                    };
+                    let end_column = cmp::min(
+                        row_line_len,
+                        if end_dp.row() == head.row() {
+                            end_dp.column()
+                        } else {
+                            row_line_len
+                        },
+                    );
+
                     target_left = target_left.min(ScrollOffset::from(
                         layouts[head.row().minus(start_row) as usize]
                             .x_for_index(start_column as usize)


### PR DESCRIPTION
# Objective

- While navigating between search matches with word wrap off via Select Next match and Select Previous Match, the horizontal autoscroll would sometimes fail to scroll the viewport enough to show the full searched word. This happened in both the cases of Previous match and next search till we had to come to the first appearance of the word.
- Fixes #61409

## Solution

- In `/crates/editor/src/scroll/autoscroll.rs` the function `autoscroll_horizontally`, the scroll bounds were both being derived from `selection.head()`, I inferred that head is the position of the cursor at the end of the selection. But for the correct `start_column` and `end_column` it needs to depend not just on the cursor at the end. So rather than using the head for the calculation for both, I have calculated them using `selection.start` and `selection.end` directly to display pts.
-  Falling back to col 0 or the full line length when the start or end lies on different row than the current being processed. Now it scrolls enough to reveal the entire match. 

## Testing

- Did you test these changes? If so, how?
1. Ran full tests using `cargo test` on the full repository
2. Manual test present in the showcase section

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Disable word wrap, create a file with a short match near the start of a long unwrapped line and another match further right, search for it, and use Select Next/Previous Match to jump between them. The full match should scroll into view each time.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Tested on macOS Tahoe 26.5.2 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase


https://github.com/user-attachments/assets/ace25b26-560d-47f1-a905-f04879f23f15



---

Release Notes:

- Fixed horizontal autoscroll not fully revealing search matches when
  navigating between matches with word wrap disabled.