### PR TITLE
agent: Release idle ACP connections

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -69,6 +69,7 @@ pub struct ActiveAcpConnection {
 pub struct AgentConnectionStore {
     project: Entity<Project>,
     entries: HashMap<Agent, Entity<AgentConnectionEntry>>,
+    ref_counts: HashMap<Agent, usize>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -79,6 +80,7 @@ impl AgentConnectionStore {
         Self {
             project,
             entries: HashMap::default(),
+            ref_counts: HashMap::default(),
             _subscriptions: vec![subscription],
         }
     }
@@ -137,6 +139,7 @@ impl AgentConnectionStore {
         }
 
         self.entries.remove(&key);
+        self.ref_counts.remove(&key);
         self.request_connection(key, server, cx)
     }
 
@@ -198,6 +201,7 @@ impl AgentConnectionStore {
                             })
                             .ok();
                         this.entries.remove(&key);
+                        this.ref_counts.remove(&key);
                         cx.notify();
                     })
                     .ok();
@@ -228,6 +232,7 @@ impl AgentConnectionStore {
                             })
                             .ok();
                         this.entries.remove(&key);
+                        this.ref_counts.remove(&key);
                         cx.notify();
                     })
                     .ok();
@@ -265,6 +270,31 @@ impl AgentConnectionStore {
         entry
     }
 
+    pub fn acquire_connection(
+        &mut self,
+        key: Agent,
+        server: Rc<dyn AgentServer>,
+        cx: &mut Context<Self>,
+    ) -> Entity<AgentConnectionEntry> {
+        let entry = self.request_connection(key.clone(), server, cx);
+        *self.ref_counts.entry(key).or_default() += 1;
+        entry
+    }
+
+    pub fn release_connection(&mut self, key: &Agent, cx: &mut Context<Self>) {
+        let Some(count) = self.ref_counts.get_mut(key) else {
+            return;
+        };
+        *count = count.saturating_sub(1);
+        if *count > 0 {
+            return;
+        }
+
+        self.ref_counts.remove(key);
+        self.entries.remove(key);
+        cx.notify();
+    }
+
     fn handle_agent_servers_updated(
         &mut self,
         store: Entity<AgentServerStore>,
@@ -278,6 +308,8 @@ impl AgentConnectionStore {
             #[cfg(any(test, feature = "test-support"))]
             Agent::Stub => true,
         });
+        self.ref_counts
+            .retain(|key, _| self.entries.contains_key(key));
         cx.notify();
     }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -592,6 +592,7 @@ pub struct ConversationView {
     agent: Rc<dyn AgentServer>,
     connection_store: Entity<AgentConnectionStore>,
     connection_key: Agent,
+    connection_released: bool,
     agent_server_store: Entity<AgentServerStore>,
     workspace: WeakEntity<Workspace>,
     project: Entity<Project>,
@@ -846,6 +847,12 @@ impl ConversationView {
             if let Some(connected) = this.as_connected() {
                 connected.close_all_sessions(cx).detach();
             }
+            if !this.connection_released {
+                this.connection_store.update(cx, |store, cx| {
+                    store.release_connection(&this.connection_key, cx);
+                });
+                this.connection_released = true;
+            }
             for window in this.notifications.drain(..) {
                 window
                     .update(cx, |_, window, _| {
@@ -862,6 +869,7 @@ impl ConversationView {
             agent: agent.clone(),
             connection_store: connection_store.clone(),
             connection_key: connection_key.clone(),
+            connection_released: false,
             agent_server_store,
             workspace,
             project: project.clone(),
@@ -995,6 +1003,12 @@ impl ConversationView {
         self.clear_resolved_request_elicitations(cx);
         self.loading_status = None;
 
+        if !self.connection_released {
+            self.connection_store.update(cx, |store, cx| {
+                store.release_connection(&self.connection_key, cx);
+            });
+            self.connection_released = true;
+        }
         let state = Self::initial_state(
             self.agent.clone(),
             self.connection_store.clone(),
@@ -1008,6 +1022,7 @@ impl ConversationView {
             window,
             cx,
         );
+        self.connection_released = false;
         self.set_server_state(state, cx);
 
         if let Some(view) = self.root_thread_view() {
@@ -1045,7 +1060,7 @@ impl ConversationView {
         let session_work_dirs = work_dirs.unwrap_or_else(|| project.read(cx).default_path_list(cx));
 
         let connection_entry = connection_store.update(cx, |store, cx| {
-            store.request_connection(connection_key, agent.clone(), cx)
+            store.acquire_connection(connection_key, agent.clone(), cx)
         });
 
         let connection_entry_subscription =
@@ -10987,6 +11002,37 @@ pub(crate) mod tests {
         assert!(
             closed_count > 0,
             "close_session should have been called for each thread"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_releases_connection_after_last_conversation_drops(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(CloseCapableConnection::new()), cx).await;
+
+        cx.run_until_parked();
+        conversation_view.read_with(cx, |view, cx| {
+            assert_eq!(
+                view.connection_store
+                    .read(cx)
+                    .connection_status(view.agent_key(), cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+            );
+        });
+
+        let connection_store =
+            conversation_view.read_with(cx, |view, _cx| view.connection_store.clone());
+        let connection_key = conversation_view.read_with(cx, |view, _cx| view.agent_key().clone());
+        drop(conversation_view);
+        cx.update(|_window, _cx| {});
+        cx.run_until_parked();
+
+        assert_eq!(
+            connection_store
+                .read_with(cx, |store, cx| store.connection_status(&connection_key, cx)),
+            crate::agent_connection_store::AgentConnectionStatus::Disconnected,
         );
     }
 


### PR DESCRIPTION
## Summary

Release Agent Panel ACP connections when the last `ConversationView` using them is dropped, so external ACP agent server processes are not kept alive after their UI threads are closed.

## Details

`ConversationView` already sends `session/close` for its active ACP sessions on release, but `session/close` is session-scoped and does not terminate the agent server process. The `AgentConnectionStore` continued to hold the `Rc<dyn AgentConnection>`, so `AcpConnection::drop` never ran and the spawned ACP child process stayed alive.

This change adds reference-counted connection acquisition/release for conversation views:

- `AgentConnectionStore::acquire_connection` increments a view-level reference count.
- `ConversationView` releases its acquired connection on drop and before reset-driven reacquire.
- When the last view releases an agent connection, the store removes the entry, dropping the `AcpConnection` and allowing its existing child cleanup to run.

Non-view callers can keep using `request_connection`, which preserves the existing cached-connection behavior.

Fixes #56747.

## Tests

- `cargo check -p agent_ui`
- `cargo test -p agent_ui close_all_sessions`
- `cargo test -p agent_ui test_releases_connection_after_last_conversation_drops`