### PR TITLE
Detect GLSL from `swsl` extension

### DIFF
--- a/extensions/glsl/languages/glsl/config.toml
+++ b/extensions/glsl/languages/glsl/config.toml
@@ -10,7 +10,8 @@ path_suffixes = [
     # Ray tracing pipeline shaders
     "rgen", "rint", "rahit", "rchit", "rmiss", "rcall",
     # Other
-    "glsl", "gdshader", "swsl"
+    "glsl",
+    "swsl"
     ]
 first_line_pattern = '^#version \d+'
 line_comments = ["// "]

--- a/extensions/glsl/languages/glsl/config.toml
+++ b/extensions/glsl/languages/glsl/config.toml
@@ -10,7 +10,7 @@ path_suffixes = [
     # Ray tracing pipeline shaders
     "rgen", "rint", "rahit", "rchit", "rmiss", "rcall",
     # Other
-    "glsl"
+    "glsl", "gdshader", "swsl"
     ]
 first_line_pattern = '^#version \d+'
 line_comments = ["// "]


### PR DESCRIPTION
title

those two are *not* really glsl, but they're based on it (hence are VERY similar) and are too niche (especially swsl) for someone to write separate extensions for them. so this works and makes life of people who work with them much easier

see https://docs.godotengine.org/en/stable/classes/class_shader.html and https://docs.spacestation14.com/en/robust-toolbox/rendering/shaders.html#swsl
