### PR TITLE
Feature/openrouter vercel model pricing

### DIFF
--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -6,11 +6,12 @@ use gpui::{App, AppContext, AsyncApp, Context, Entity, SharedString, Task};
 use http_client::{CustomHeaders, HttpClient};
 use language_model::{
     ApiKeyConfiguration, ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel,
-    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
-    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice,
-    LanguageModelToolResultContent, LanguageModelToolSchemaFormat, LanguageModelToolUse,
-    MessageContent, ProviderSettingsView, RateLimiter, Role, StopReason, TokenUsage, env_var,
+    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelCostInfo,
+    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
+    LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolSchemaFormat,
+    LanguageModelToolUse, MessageContent, ProviderSettingsView, RateLimiter, Role, StopReason,
+    TokenUsage, env_var,
 };
 use open_router::{
     Model, ModelMode as OpenRouterModelMode, OPEN_ROUTER_API_URL, ResponseStreamEvent, list_models,
@@ -229,6 +230,7 @@ impl LanguageModelProvider for OpenRouterLanguageModelProvider {
                 supports_images: model.supports_images,
                 mode: model.mode.unwrap_or_default(),
                 provider: model.provider.clone(),
+                pricing: None,
             });
         }
 
@@ -339,6 +341,24 @@ impl LanguageModel for OpenRouterLanguageModel {
 
     fn provider_name(&self) -> LanguageModelProviderName {
         PROVIDER_NAME
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        let pricing = self.model.pricing.as_ref()?;
+        let input_token_cost_per_1m = pricing.prompt.as_deref()?.parse::<f64>().ok()? * 1_000_000.0;
+        let output_token_cost_per_1m =
+            pricing.completion.as_deref()?.parse::<f64>().ok()? * 1_000_000.0;
+        if !input_token_cost_per_1m.is_finite()
+            || !output_token_cost_per_1m.is_finite()
+            || input_token_cost_per_1m < 0.0
+            || output_token_cost_per_1m < 0.0
+        {
+            return None;
+        }
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m,
+            output_token_cost_per_1m,
+        })
     }
 
     fn supports_tools(&self) -> bool {

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -8,10 +8,11 @@ use http_client::{
 };
 use language_model::{
     ApiKeyConfiguration, ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel,
-    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
-    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice,
-    LanguageModelToolSchemaFormat, ProviderSettingsView, RateLimiter, env_var,
+    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelCostInfo,
+    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
+    LanguageModelToolChoice, LanguageModelToolSchemaFormat, ProviderSettingsView, RateLimiter,
+    env_var,
 };
 use open_ai::ResponseStreamEvent;
 use serde::Deserialize;
@@ -172,6 +173,8 @@ impl VercelAiGatewayLanguageModelProvider {
             max_tokens: 400_000,
             max_output_tokens: Some(128_000),
             max_completion_tokens: None,
+            input_token_cost_per_1m: None,
+            output_token_cost_per_1m: None,
             capabilities: ModelCapabilities::default(),
         }
     }
@@ -370,6 +373,11 @@ fn clean_error_message(message: &str) -> String {
     message.to_string()
 }
 
+fn price_per_token_to_per_million(price: &str) -> Option<f64> {
+    let price = price.parse::<f64>().ok()? * 1_000_000.0;
+    (price.is_finite() && price >= 0.0).then_some(price)
+}
+
 fn has_tag(tags: &[String], expected: &str) -> bool {
     tags.iter()
         .any(|tag| tag.trim().eq_ignore_ascii_case(expected))
@@ -395,6 +403,13 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
 
     fn provider_name(&self) -> LanguageModelProviderName {
         PROVIDER_NAME
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: self.model.input_token_cost_per_1m?,
+            output_token_cost_per_1m: self.model.output_token_cost_per_1m?,
+        })
     }
 
     fn supports_tools(&self) -> bool {
@@ -491,6 +506,13 @@ struct ApiModel {
     #[serde(default)]
     tags: Vec<String>,
     architecture: Option<ApiModelArchitecture>,
+    pricing: Option<ApiModelPricing>,
+}
+
+#[derive(Deserialize)]
+struct ApiModelPricing {
+    input: Option<String>,
+    output: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -589,6 +611,16 @@ async fn list_models(
             max_tokens: model.context_window.or(model.max_tokens).unwrap_or(128_000),
             max_output_tokens: model.max_tokens,
             max_completion_tokens: None,
+            input_token_cost_per_1m: model
+                .pricing
+                .as_ref()
+                .and_then(|pricing| pricing.input.as_deref())
+                .and_then(price_per_token_to_per_million),
+            output_token_cost_per_1m: model
+                .pricing
+                .as_ref()
+                .and_then(|pricing| pricing.output.as_deref())
+                .and_then(price_per_token_to_per_million),
             capabilities: ModelCapabilities {
                 tools: supports_tools,
                 images: supports_images,
@@ -602,4 +634,18 @@ async fn list_models(
     }
 
     Ok(models)
+}
+
+#[cfg(test)]
+mod pricing_tests {
+    #[test]
+    fn converts_token_pricing_to_per_million() {
+        assert_eq!(
+            super::price_per_token_to_per_million("0.0000005"),
+            Some(0.5)
+        );
+        assert_eq!(super::price_per_token_to_per_million("0"), Some(0.0));
+        assert_eq!(super::price_per_token_to_per_million("invalid"), None);
+        assert_eq!(super::price_per_token_to_per_million("-0.1"), None);
+    }
 }

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -72,6 +72,13 @@ impl From<Role> for String {
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ModelPricing {
+    pub prompt: Option<String>,
+    pub completion: Option<String>,
+}
+
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Model {
     pub name: String,
     pub display_name: Option<String>,
@@ -81,6 +88,7 @@ pub struct Model {
     #[serde(default)]
     pub mode: ModelMode,
     pub provider: Option<Provider>,
+    pub pricing: Option<ModelPricing>,
 }
 
 impl Model {
@@ -113,6 +121,7 @@ impl Model {
             supports_images,
             mode: mode.unwrap_or(ModelMode::Default),
             provider,
+            pricing: None,
         }
     }
 
@@ -473,6 +482,8 @@ pub struct ModelEntry {
     pub supported_parameters: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub architecture: Option<ModelArchitecture>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing: Option<ModelPricing>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
@@ -647,6 +658,7 @@ pub async fn list_models(
                     ModelMode::Default
                 },
                 provider: None,
+                pricing: entry.pricing,
             })
             .collect();
 

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -489,6 +489,8 @@ pub struct VercelAiGatewayAvailableModel {
     pub max_tokens: u64,
     pub max_output_tokens: Option<u64>,
     pub max_completion_tokens: Option<u64>,
+    pub input_token_cost_per_1m: Option<f64>,
+    pub output_token_cost_per_1m: Option<f64>,
     #[serde(default)]
     pub capabilities: OpenAiCompatibleModelCapabilities,
 }


### PR DESCRIPTION
# Objective

Display input and output token pricing for dynamically discovered OpenRouter and Vercel AI Gateway models in Zed's existing model selector.

Both providers already return model pricing metadata from their model catalogue endpoints, but that metadata was discarded before models reached the UI. As a result, their entries did not use Zed's existing model cost badge support.

## Solution

This PR:

- Retains the `prompt` and `completion` pricing returned by OpenRouter.
- Retains the `input` and `output` pricing returned by Vercel AI Gateway.
- Converts the providers' per-token prices to Zed's per-million-token representation.
- Implements `LanguageModel::model_cost_info()` for both providers.
- Uses the existing `LanguageModelCostInfo::TokenCost` and model selector cost badge rather than adding new selector UI.
- Ignores missing, malformed, negative, or non-finite prices so model discovery and usage continue to work normally.
- Leaves manually configured models without pricing unchanged.

The displayed format follows the model selector's existing convention:

```text
<input price per 1M tokens>$/<output price per 1M tokens>$
```

## Testing

Automated checks completed successfully:

```text
cargo fmt --all
cargo check -p open_router -p language_models -p settings_content
cargo test -p open_router -p language_models vercel_ai_gateway --lib
```

The pricing conversion tests cover:

- Valid per-token prices.
- Zero-cost models.
- Malformed values.
- Negative values.

Manual testing was performed on Windows using a local debug build created with:

```text
cargo run
```

Verified with OpenRouter:

- Models are still discovered normally.
- Input and output pricing appears in the model selector.
- Searching and selecting models continues to work.
- A selected model can still be used for a completion request.

Vercel AI Gateway uses the same existing selector cost interface and passed the affected-crate checks and pricing conversion tests. A manual UI smoke test with a configured Vercel account would provide additional provider-endpoint coverage.

Reviewers can test this by:

1. Configure an OpenRouter or Vercel AI Gateway API key.
2. Open the Agent panel's model selector.
3. Search for a dynamically discovered model.
4. Confirm that a price badge appears on models whose API metadata contains both input and output pricing.
5. Select the model and send a completion request.
6. Confirm that models without valid pricing still appear without a badge.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

OpenRouter model pricing displayed in the existing model selector:

<img width="368" height="371" alt="image" src="https://github.com/user-attachments/assets/3f4e9711-6bec-42d1-a408-4e623f2eea82" />


The values shown represent input and output prices per one million tokens.

---

Release Notes:

- Improved the model selector to display input and output token pricing for OpenRouter and Vercel AI Gateway models.
