### PR TITLE
Fix permission for pull request labelling script

### DIFF
--- a/.github/workflows/pr_issue_labeler.yml
+++ b/.github/workflows/pr_issue_labeler.yml
@@ -36,7 +36,7 @@ jobs:
           repositories: zed
           permission-issues: write
           permission-members: read
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - id: apply-authorship-label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
While its the `issues` API we use for labelling, it seems that GitHub still wants PR permissions for those. Hence, fixing here.

Release Notes:

- N/A