### PR TITLE
keymaps: Free ctrl-enter for newline below on Linux and Windows

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -118,7 +118,7 @@
       "ctrl-;": "editor::ToggleLineNumbers",
       "ctrl-'": "editor::ToggleSelectedDiffHunks",
       "ctrl-\"": "editor::ExpandAllDiffHunks",
-      "ctrl-i": "editor::ShowSignatureHelp",
+      // Signature help: ctrl-shift-space (VS Code). ctrl-i is reserved for inline assist.
       "alt-g b": "git::Blame",
       "alt-g m": "git::OpenModifiedFiles",
       "alt-g r": "git::ReviewDiff",
@@ -589,7 +589,8 @@
       "ctrl-k ctrl-0": "editor::FoldAll",
       "ctrl-k ctrl-j": "editor::UnfoldAll",
       "ctrl-space": "editor::ShowCompletions",
-      "ctrl-shift-space": "editor::ShowWordCompletions",
+      // Match VS Code: parameter hints on ctrl-shift-space. (ctrl-i is used for inline assist.)
+      "ctrl-shift-space": "editor::ShowSignatureHelp",
       "ctrl-.": "editor::ToggleCodeActions",
       "ctrl-k r": "editor::RevealInFileManager",
       "ctrl-k p": "editor::CopyPath",
@@ -908,7 +909,8 @@
       "ctrl-shift-e": "pane::RevealInProjectPanel",
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
-      "ctrl-enter": "assistant::InlineAssist",
+      // Use ctrl-i (VS Code inline chat) so ctrl-enter can insert a line below.
+      "ctrl-i": "assistant::InlineAssist",
       "ctrl-:": "editor::ToggleInlayHints",
     },
   },
@@ -1243,7 +1245,8 @@
       "paste": "terminal::Paste",
       "shift-insert": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
-      "ctrl-enter": "assistant::InlineAssist",
+      // Match editor: ctrl-i for inline assist (VS Code), leaving ctrl-enter free for the shell.
+      "ctrl-i": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],
       "alt-f": ["terminal::SendText", "\u001bf"],
       "alt-.": ["terminal::SendText", "\u001b."],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -114,7 +114,7 @@
       "ctrl-;": "editor::ToggleLineNumbers",
       "ctrl-'": "editor::ToggleSelectedDiffHunks",
       "ctrl-\"": "editor::ExpandAllDiffHunks",
-      "ctrl-i": "editor::ShowSignatureHelp",
+      // Signature help: ctrl-shift-space (VS Code). ctrl-i is reserved for inline assist.
       "alt-g b": "git::Blame",
       "alt-g m": "git::OpenModifiedFiles",
       "alt-g r": "git::ReviewDiff",
@@ -587,7 +587,8 @@
       "ctrl-k ctrl-0": "editor::FoldAll",
       "ctrl-k ctrl-j": "editor::UnfoldAll",
       "ctrl-space": "editor::ShowCompletions",
-      "ctrl-shift-space": "editor::ShowWordCompletions",
+      // Match VS Code: parameter hints on ctrl-shift-space. (ctrl-i is used for inline assist.)
+      "ctrl-shift-space": "editor::ShowSignatureHelp",
       "ctrl-.": "editor::ToggleCodeActions",
       "ctrl-k r": "editor::RevealInFileManager",
       "ctrl-k p": "editor::CopyPath",
@@ -908,7 +909,8 @@
       "ctrl-shift-e": "pane::RevealInProjectPanel",
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
-      "ctrl-enter": "assistant::InlineAssist",
+      // Use ctrl-i (VS Code inline chat) so ctrl-enter can insert a line below.
+      "ctrl-i": "assistant::InlineAssist",
       "ctrl-shift-;": "editor::ToggleInlayHints",
     },
   },


### PR DESCRIPTION
## Objective

Fixes #49620

On Linux and Windows with the default VS Code keymap, `ctrl-enter` was bound to both `editor::NewlineBelow` and `assistant::InlineAssist`. The more specific inline-assist context always won, so insert-line-below never ran.

## Solution

Align Linux/Windows defaults with VS Code:

| Key | Before | After |
|-----|--------|--------|
| `ctrl-enter` (full editor) | Inline assist (shadowed newline below) | **`editor::NewlineBelow` works** |
| `ctrl-i` (editor / terminal) | Signature help (editor) | **`assistant::InlineAssist`** (VS Code inline chat) |
| `ctrl-shift-space` (editor) | Word completions | **`editor::ShowSignatureHelp`** (VS Code parameter hints) |

macOS is unchanged: newline below already uses `cmd-enter`, and inline assist stays on `ctrl-enter`.

This re-applies the Linux/Windows portion of #39587 (later reverted in #40903) in a narrower form—no macOS key churn.

To restore the previous inline-assist shortcut:

```json
[
  {
    "context": "!AcpThread > Editor && mode == full",
    "bindings": {
      "ctrl-enter": "assistant::InlineAssist"
    }
  }
]
```

## Testing

- Parsed both keymap files as JSON (with comments stripped) and confirmed bindings:
  - `Editor && mode == full` → `ctrl-enter` → `editor::NewlineBelow`
  - `!AcpThread > Editor && mode == full` → `ctrl-i` → `assistant::InlineAssist`
  - `Editor` → `ctrl-shift-space` → `editor::ShowSignatureHelp`
  - `Terminal` → `ctrl-i` → `assistant::InlineAssist`
- Ran `./script/check-keymaps`
- Manual verification recommended on Linux/Windows: Ctrl+Enter inserts a line below; Ctrl+I opens inline assist; Ctrl+Shift+Space shows signature help

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior (keymap JSON validation; behavior is config-only)
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Ctrl+Enter inserting a new line below on Linux and Windows; inline assist is now Ctrl+I to match VS Code