### PR TITLE
git: Allow using system GPG pinentry

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1658,6 +1658,14 @@
     "enable_status": true,
     // Whether to enable git diff display.
     "enable_diff": true,
+    // Controls how passphrase prompts are handled when signing Git commits with GPG.
+    // This setting controls Zed's GPG wrapper, which is not available on Windows.
+    // May take 2 values:
+    // 1. Show passphrase prompts in Zed:
+    //      "gpg_signing_prompt": "zed"
+    // 2. Let GPG use its configured pinentry program:
+    //      "gpg_signing_prompt": "system"
+    "gpg_signing_prompt": "zed",
     // Control whether the git gutter is shown. May take 2 values:
     // 1. Show the gutter
     //      "git_gutter": "tracked_files"

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -42,9 +42,17 @@ pub enum AskPassResult {
     Timedout,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GpgSigningPrompt {
+    #[default]
+    Zed,
+    System,
+}
+
 pub struct AskPassDelegate {
     tx: mpsc::UnboundedSender<(String, oneshot::Sender<EncryptedPassword>)>,
     executor: BackgroundExecutor,
+    gpg_signing_prompt: GpgSigningPrompt,
     _task: Task<()>,
 }
 
@@ -66,7 +74,17 @@ impl AskPassDelegate {
             tx,
             _task: task,
             executor: cx.background_executor().clone(),
+            gpg_signing_prompt: GpgSigningPrompt::default(),
         }
+    }
+
+    pub fn with_gpg_signing_prompt(mut self, gpg_signing_prompt: GpgSigningPrompt) -> Self {
+        self.gpg_signing_prompt = gpg_signing_prompt;
+        self
+    }
+
+    pub fn gpg_signing_prompt(&self) -> GpgSigningPrompt {
+        self.gpg_signing_prompt
     }
 
     pub fn ask_password(&mut self, prompt: String) -> Task<Option<EncryptedPassword>> {
@@ -83,6 +101,7 @@ pub struct AskPassSession {
     #[cfg(target_os = "windows")]
     secret: std::sync::Arc<std::sync::Mutex<Option<EncryptedPassword>>>,
     askpass_task: PasswordProxy,
+    gpg_signing_prompt: GpgSigningPrompt,
     askpass_opened_rx: Option<oneshot::Receiver<()>>,
     askpass_kill_master_rx: Option<oneshot::Receiver<()>>,
     executor: BackgroundExecutor,
@@ -99,6 +118,8 @@ impl AskPassSession {
     /// You must retain this session until the master process exits.
     #[must_use]
     pub async fn new(executor: BackgroundExecutor, mut delegate: AskPassDelegate) -> Result<Self> {
+        let gpg_signing_prompt = delegate.gpg_signing_prompt();
+
         #[cfg(target_os = "windows")]
         let secret = std::sync::Arc::new(std::sync::Mutex::new(None));
 
@@ -146,6 +167,7 @@ impl AskPassSession {
             secret,
 
             askpass_task,
+            gpg_signing_prompt,
             askpass_kill_master_rx: Some(askpass_kill_master_rx),
             askpass_opened_rx: Some(askpass_opened_rx),
             executor,
@@ -200,6 +222,10 @@ impl AskPassSession {
     /// On Windows this is the path to cli.exe directly — no script needed.
     pub fn script_path(&self) -> impl AsRef<OsStr> {
         self.askpass_task.script_path()
+    }
+
+    pub fn gpg_signing_prompt(&self) -> GpgSigningPrompt {
+        self.gpg_signing_prompt
     }
 
     /// Path to a script suitable for git's `gpg.program`, routing GnuPG

--- a/crates/collab/tests/integration/git_tests.rs
+++ b/crates/collab/tests/integration/git_tests.rs
@@ -9,7 +9,8 @@ use collections::HashMap;
 use git::{
     Oid,
     repository::{
-        CommitData, GitCommitTemplate, InitialGraphCommitData, RepoPath, Worktree as GitWorktree,
+        AskPassDelegate, CommitData, CommitOptions, GitCommitTemplate, GpgSigningPrompt,
+        InitialGraphCommitData, RepoPath, Worktree as GitWorktree,
     },
     status::{DiffStat, FileStatus, StatusCode, TrackedStatus},
 };
@@ -17,7 +18,7 @@ use git_ui::git_graph::GitGraph;
 use git_ui::{git_panel::GitPanel, project_diff::ProjectDiff};
 use gpui::{
     AppContext as _, BackgroundExecutor, Entity, IntoElement as _, SharedString, TestAppContext,
-    VisualContext as _, VisualTestContext, point, px, size,
+    UpdateGlobal as _, VisualContext as _, VisualTestContext, point, px, size,
 };
 use project::{
     ProjectPath,
@@ -25,11 +26,85 @@ use project::{
 };
 use rand::{SeedableRng, rngs::StdRng};
 use serde_json::json;
+use settings::{GpgSigningPrompt as GpgSigningPromptSetting, SettingsStore};
 
 use util::{path, rel_path::rel_path};
 use workspace::{MultiWorkspace, Workspace};
 
 use crate::TestServer;
+
+#[gpui::test]
+async fn test_gpg_signing_prompt_is_forwarded_to_shared_project(
+    executor: BackgroundExecutor,
+    cx_a: &mut TestAppContext,
+    cx_b: &mut TestAppContext,
+) {
+    let mut server = TestServer::start(executor.clone()).await;
+    let client_a = server.create_client(cx_a, "user_a").await;
+    let client_b = server.create_client(cx_b, "user_b").await;
+    server
+        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b)])
+        .await;
+    let active_call_a = cx_a.read(ActiveCall::global);
+
+    cx_b.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.git.get_or_insert_default().gpg_signing_prompt =
+                    Some(GpgSigningPromptSetting::System);
+            });
+        });
+    });
+
+    client_a
+        .fs()
+        .insert_tree(
+            path!("/project"),
+            json!({ ".git": {}, "file.txt": "content" }),
+        )
+        .await;
+
+    let (project_a, _) = client_a.build_local_project(path!("/project"), cx_a).await;
+    executor.run_until_parked();
+
+    let project_id = active_call_a
+        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
+        .await
+        .unwrap();
+    let project_b = client_b.join_remote_project(project_id, cx_b).await;
+    executor.run_until_parked();
+
+    let repository_b = project_b.read_with(cx_b, |project, cx| {
+        project
+            .active_repository(cx)
+            .expect("shared project should have an active repository")
+    });
+    let askpass = cx_b.update(|cx| AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}));
+    repository_b
+        .update(cx_b, |repository, cx| {
+            repository.commit(
+                "Test system GPG prompt".into(),
+                None,
+                CommitOptions {
+                    allow_empty: true,
+                    ..Default::default()
+                },
+                askpass,
+                cx,
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let gpg_signing_prompts = client_a
+        .fs()
+        .with_git_state(Path::new(path!("/project/.git")), false, |state| {
+            state.gpg_signing_prompts.clone()
+        })
+        .unwrap();
+    assert_eq!(gpg_signing_prompts, vec![GpgSigningPrompt::System]);
+}
 
 #[gpui::test]
 async fn test_root_repo_common_dir_sync(

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -13,8 +13,8 @@ use git::{
     repository::{
         AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitOptions,
         CreateWorktreeTarget, FetchOptions, FileHistoryChangedFileSets, GRAPH_CHUNK_SIZE,
-        GitRepository, GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource,
-        PushOptions, RefEdit, Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
+        GitRepository, GitRepositoryCheckpoint, GpgSigningPrompt, InitialGraphCommitData, LogOrder,
+        LogSource, PushOptions, RefEdit, Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
         commit_hash_search_query,
     },
     stash::GitStash,
@@ -58,6 +58,7 @@ pub enum FakeCommitDataEntry {
 #[derive(Debug, Clone)]
 pub struct FakeGitRepositoryState {
     pub commit_history: Vec<FakeCommitSnapshot>,
+    pub gpg_signing_prompts: Vec<GpgSigningPrompt>,
     pub event_emitter: async_channel::Sender<PathBuf>,
     pub unmerged_paths: HashMap<RepoPath, UnmergedStatus>,
     pub head_contents: HashMap<RepoPath, String>,
@@ -86,6 +87,7 @@ impl FakeGitRepositoryState {
     pub fn new(event_emitter: async_channel::Sender<PathBuf>) -> Self {
         FakeGitRepositoryState {
             event_emitter,
+            gpg_signing_prompts: Default::default(),
             head_contents: Default::default(),
             index_contents: Default::default(),
             unmerged_paths: Default::default(),
@@ -1059,10 +1061,12 @@ impl GitRepository for FakeGitRepository {
         _message: gpui::SharedString,
         _name_and_email: Option<(gpui::SharedString, gpui::SharedString)>,
         options: CommitOptions,
-        _askpass: AskPassDelegate,
+        askpass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
         self.with_state_async(true, move |state| {
+            state.gpg_signing_prompts.push(askpass.gpg_signing_prompt());
+
             if !options.allow_empty && !options.amend && state.index_contents == state.head_contents
             {
                 anyhow::bail!("nothing to commit (use allow_empty to create an empty commit)");

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -39,7 +39,7 @@ use util::rel_path::RelPath;
 use util::{ResultExt, paths};
 use uuid::Uuid;
 
-pub use askpass::{AskPassDelegate, AskPassResult, AskPassSession};
+pub use askpass::{AskPassDelegate, AskPassResult, AskPassSession, GpgSigningPrompt};
 
 pub const REMOTE_CANCELLED_BY_USER: &str = "Operation cancelled by user";
 
@@ -3733,6 +3733,23 @@ struct GitBinaryCommandError {
     status: ExitStatus,
 }
 
+fn configure_gpg_program(
+    command: &mut util::command::Command,
+    env: &HashMap<String, String>,
+    gpg_signing_prompt: GpgSigningPrompt,
+    gpg_wrapper: Option<&Path>,
+) {
+    if gpg_signing_prompt == GpgSigningPrompt::Zed
+        && !env.contains_key("GIT_CONFIG_COUNT")
+        && let Some(gpg_wrapper) = gpg_wrapper
+    {
+        command
+            .env("GIT_CONFIG_COUNT", "1")
+            .env("GIT_CONFIG_KEY_0", "gpg.program")
+            .env("GIT_CONFIG_VALUE_0", gpg_wrapper);
+    }
+}
+
 async fn run_git_command(
     env: Arc<HashMap<String, String>>,
     ask_pass: AskPassDelegate,
@@ -3758,14 +3775,12 @@ async fn run_git_command(
             .env("SSH_ASKPASS", ask_pass.script_path())
             .env("SSH_ASKPASS_REQUIRE", "force");
 
-        if !env.contains_key("GIT_CONFIG_COUNT")
-            && let Some(gpg_wrapper) = ask_pass.gpg_wrapper_path()
-        {
-            command
-                .env("GIT_CONFIG_COUNT", "1")
-                .env("GIT_CONFIG_KEY_0", "gpg.program")
-                .env("GIT_CONFIG_VALUE_0", gpg_wrapper);
-        }
+        configure_gpg_program(
+            &mut command,
+            &env,
+            ask_pass.gpg_signing_prompt(),
+            ask_pass.gpg_wrapper_path(),
+        );
 
         #[cfg(target_os = "windows")]
         command.env("ZED_ASKPASS_SOCKET", ask_pass.socket_path());
@@ -4693,6 +4708,96 @@ mod tests {
         let graph_data = request_rx.recv().await.unwrap();
         assert_eq!(graph_data.len(), 1);
         assert_eq!(graph_data[0].sha, commit_sha);
+    }
+
+    async fn configured_gpg_program(
+        executor: BackgroundExecutor,
+        working_directory: &Path,
+        global_config: &Path,
+        env: &HashMap<String, String>,
+        gpg_signing_prompt: GpgSigningPrompt,
+    ) -> String {
+        let git = GitBinary::new(
+            PathBuf::from("git"),
+            working_directory.to_path_buf(),
+            working_directory.join(".git"),
+            executor,
+            true,
+        );
+        let mut command = git.build_command(&["config", "--get", "gpg.program"]);
+        command
+            .env_remove("GIT_CONFIG_COUNT")
+            .env_remove("GIT_CONFIG_KEY_0")
+            .env_remove("GIT_CONFIG_VALUE_0")
+            .env_remove("GIT_CONFIG_PARAMETERS")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", global_config)
+            .envs(env.iter());
+        configure_gpg_program(
+            &mut command,
+            env,
+            gpg_signing_prompt,
+            Some(Path::new("zed-gpg-wrapper")),
+        );
+
+        let output = command.output().await.expect("git config should run");
+        assert!(
+            output.status.success(),
+            "git config failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git config output should be UTF-8")
+            .trim()
+            .to_string()
+    }
+
+    #[gpui::test]
+    async fn test_gpg_signing_prompt_controls_gpg_program(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        assert_eq!(GpgSigningPrompt::default(), GpgSigningPrompt::Zed);
+
+        let temp_dir = tempfile::tempdir().expect("temporary directory should be created");
+        let global_config = temp_dir.path().join("gitconfig");
+        fs::write(&global_config, "[gpg]\n\tprogram = system-gpg\n")
+            .expect("global git config should be written");
+
+        let env = HashMap::default();
+        assert_eq!(
+            configured_gpg_program(
+                cx.executor(),
+                temp_dir.path(),
+                &global_config,
+                &env,
+                GpgSigningPrompt::Zed,
+            )
+            .await,
+            "zed-gpg-wrapper"
+        );
+        assert_eq!(
+            configured_gpg_program(
+                cx.executor(),
+                temp_dir.path(),
+                &global_config,
+                &env,
+                GpgSigningPrompt::System,
+            )
+            .await,
+            "system-gpg"
+        );
+
+        let env = HashMap::from_iter([("GIT_CONFIG_COUNT".to_string(), "0".to_string())]);
+        assert_eq!(
+            configured_gpg_program(
+                cx.executor(),
+                temp_dir.path(),
+                &global_config,
+                &env,
+                GpgSigningPrompt::Zed,
+            )
+            .await,
+            "system-gpg"
+        );
     }
 
     #[gpui::test]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -14,7 +14,9 @@ use crate::{
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
 use anyhow::{Context as _, Result, anyhow, bail};
-use askpass::{AskPassDelegate, EncryptedPassword, IKnowWhatIAmDoingAndIHaveReadTheDocs};
+use askpass::{
+    AskPassDelegate, EncryptedPassword, GpgSigningPrompt, IKnowWhatIAmDoingAndIHaveReadTheDocs,
+};
 use buffer_diff::{BufferDiff, DiffHunk, DiffHunkSecondaryStatus, PendingHunk, PendingSense};
 use client::ProjectId;
 use collections::HashMap;
@@ -2830,6 +2832,7 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let fetch_options = FetchOptions::from_proto(envelope.payload.remote);
+        let gpg_signing_prompt = gpg_signing_prompt_from_proto(envelope.payload.gpg_signing_prompt);
         let askpass_id = envelope.payload.askpass_id;
 
         let askpass = make_remote_delegate(
@@ -2842,7 +2845,12 @@ impl GitStore {
 
         let remote_output = repository_handle
             .update(&mut cx, |repository_handle, cx| {
-                repository_handle.fetch(fetch_options, askpass, cx)
+                repository_handle.fetch_with_gpg_signing_prompt(
+                    fetch_options,
+                    askpass,
+                    gpg_signing_prompt,
+                    cx,
+                )
             })
             .await??;
 
@@ -2861,6 +2869,7 @@ impl GitStore {
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
 
         let askpass_id = envelope.payload.askpass_id;
+        let gpg_signing_prompt = gpg_signing_prompt_from_proto(envelope.payload.gpg_signing_prompt);
         let askpass = make_remote_delegate(
             this,
             envelope.payload.project_id,
@@ -2884,12 +2893,13 @@ impl GitStore {
 
         let remote_output = repository_handle
             .update(&mut cx, |repository_handle, cx| {
-                repository_handle.push(
+                repository_handle.push_with_gpg_signing_prompt(
                     branch_name,
                     remote_branch_name,
                     remote_name,
                     options,
                     askpass,
+                    gpg_signing_prompt,
                     cx,
                 )
             })
@@ -2908,6 +2918,7 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let askpass_id = envelope.payload.askpass_id;
+        let gpg_signing_prompt = gpg_signing_prompt_from_proto(envelope.payload.gpg_signing_prompt);
         let askpass = make_remote_delegate(
             this,
             envelope.payload.project_id,
@@ -2921,8 +2932,14 @@ impl GitStore {
         let rebase = envelope.payload.rebase;
 
         let remote_message = repository_handle
-            .update(&mut cx, |repository_handle, cx| {
-                repository_handle.pull(branch_name, remote_name, rebase, askpass, cx)
+            .update(&mut cx, |repository_handle, _cx| {
+                repository_handle.pull_with_gpg_signing_prompt(
+                    branch_name,
+                    remote_name,
+                    rebase,
+                    askpass,
+                    gpg_signing_prompt,
+                )
             })
             .await??;
 
@@ -3103,6 +3120,7 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let askpass_id = envelope.payload.askpass_id;
+        let gpg_signing_prompt = gpg_signing_prompt_from_proto(envelope.payload.gpg_signing_prompt);
 
         let askpass = make_remote_delegate(
             this,
@@ -3118,8 +3136,8 @@ impl GitStore {
         let options = envelope.payload.options.unwrap_or_default();
 
         repository_handle
-            .update(&mut cx, |repository_handle, cx| {
-                repository_handle.commit(
+            .update(&mut cx, |repository_handle, _cx| {
+                repository_handle.commit_with_gpg_signing_prompt(
                     message,
                     name.zip(email),
                     CommitOptions {
@@ -3128,7 +3146,7 @@ impl GitStore {
                         allow_empty: options.allow_empty,
                     },
                     askpass,
-                    cx,
+                    gpg_signing_prompt,
                 )
             })
             .await??;
@@ -5092,6 +5110,22 @@ impl BufferGitState {
 
             Ok(())
         }));
+    }
+}
+
+fn gpg_signing_prompt_to_proto(gpg_signing_prompt: GpgSigningPrompt) -> i32 {
+    match gpg_signing_prompt {
+        GpgSigningPrompt::Zed => proto::GpgSigningPrompt::Zed as i32,
+        GpgSigningPrompt::System => proto::GpgSigningPrompt::System as i32,
+    }
+}
+
+fn gpg_signing_prompt_from_proto(gpg_signing_prompt: i32) -> GpgSigningPrompt {
+    match proto::GpgSigningPrompt::from_i32(gpg_signing_prompt)
+        .unwrap_or(proto::GpgSigningPrompt::Zed)
+    {
+        proto::GpgSigningPrompt::Zed => GpgSigningPrompt::Zed,
+        proto::GpgSigningPrompt::System => GpgSigningPrompt::System,
     }
 }
 
@@ -7526,9 +7560,28 @@ impl Repository {
         name_and_email: Option<(SharedString, SharedString)>,
         options: CommitOptions,
         askpass: AskPassDelegate,
-        _cx: &mut App,
+        cx: &mut App,
+    ) -> oneshot::Receiver<Result<()>> {
+        let gpg_signing_prompt = ProjectSettings::get_global(cx).git.gpg_signing_prompt;
+        self.commit_with_gpg_signing_prompt(
+            message,
+            name_and_email,
+            options,
+            askpass,
+            gpg_signing_prompt,
+        )
+    }
+
+    fn commit_with_gpg_signing_prompt(
+        &mut self,
+        message: SharedString,
+        name_and_email: Option<(SharedString, SharedString)>,
+        options: CommitOptions,
+        askpass: AskPassDelegate,
+        gpg_signing_prompt: GpgSigningPrompt,
     ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
+        let askpass = askpass.with_gpg_signing_prompt(gpg_signing_prompt);
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
 
@@ -7566,6 +7619,7 @@ impl Repository {
                                     allow_empty: options.allow_empty,
                                 }),
                                 askpass_id,
+                                gpg_signing_prompt: gpg_signing_prompt_to_proto(gpg_signing_prompt),
                             })
                             .await?;
 
@@ -7616,6 +7670,18 @@ impl Repository {
         askpass: AskPassDelegate,
         cx: &mut Context<Self>,
     ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let gpg_signing_prompt = ProjectSettings::get_global(cx).git.gpg_signing_prompt;
+        self.fetch_with_gpg_signing_prompt(fetch_options, askpass, gpg_signing_prompt, cx)
+    }
+
+    fn fetch_with_gpg_signing_prompt(
+        &mut self,
+        fetch_options: FetchOptions,
+        askpass: AskPassDelegate,
+        gpg_signing_prompt: GpgSigningPrompt,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let askpass = askpass.with_gpg_signing_prompt(gpg_signing_prompt);
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
         let id = self.id;
@@ -7661,6 +7727,7 @@ impl Repository {
                                 repository_id: id.to_proto(),
                                 askpass_id,
                                 remote: fetch_options.to_proto(),
+                                gpg_signing_prompt: gpg_signing_prompt_to_proto(gpg_signing_prompt),
                             })
                             .await?;
 
@@ -7683,6 +7750,30 @@ impl Repository {
         askpass: AskPassDelegate,
         cx: &mut Context<Self>,
     ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let gpg_signing_prompt = ProjectSettings::get_global(cx).git.gpg_signing_prompt;
+        self.push_with_gpg_signing_prompt(
+            branch,
+            remote_branch,
+            remote,
+            options,
+            askpass,
+            gpg_signing_prompt,
+            cx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn push_with_gpg_signing_prompt(
+        &mut self,
+        branch: SharedString,
+        remote_branch: SharedString,
+        remote: SharedString,
+        options: Option<PushOptions>,
+        askpass: AskPassDelegate,
+        gpg_signing_prompt: GpgSigningPrompt,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let askpass = askpass.with_gpg_signing_prompt(gpg_signing_prompt);
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
         let id = self.id;
@@ -7752,6 +7843,7 @@ impl Repository {
                                     }
                                 }
                                     as i32),
+                                gpg_signing_prompt: gpg_signing_prompt_to_proto(gpg_signing_prompt),
                             })
                             .await?;
 
@@ -7771,8 +7863,21 @@ impl Repository {
         remote: SharedString,
         rebase: bool,
         askpass: AskPassDelegate,
-        _cx: &mut App,
+        cx: &mut App,
     ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let gpg_signing_prompt = ProjectSettings::get_global(cx).git.gpg_signing_prompt;
+        self.pull_with_gpg_signing_prompt(branch, remote, rebase, askpass, gpg_signing_prompt)
+    }
+
+    fn pull_with_gpg_signing_prompt(
+        &mut self,
+        branch: Option<SharedString>,
+        remote: SharedString,
+        rebase: bool,
+        askpass: AskPassDelegate,
+        gpg_signing_prompt: GpgSigningPrompt,
+    ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let askpass = askpass.with_gpg_signing_prompt(gpg_signing_prompt);
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
         let id = self.id;
@@ -7821,6 +7926,7 @@ impl Repository {
                                 rebase,
                                 branch_name: branch.as_ref().map(|b| b.to_string()),
                                 remote_name: remote.to_string(),
+                                gpg_signing_prompt: gpg_signing_prompt_to_proto(gpg_signing_prompt),
                             })
                             .await?;
 

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1,4 +1,5 @@
 use anyhow::Context as _;
+use askpass::GpgSigningPrompt;
 use collections::HashMap;
 use context_server::ContextServerCommand;
 use dap::adapters::DebugAdapterName;
@@ -465,6 +466,10 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: settings::GitGutterSetting,
+    /// Controls how passphrase prompts are handled when signing Git commits with GPG.
+    ///
+    /// Default: zed
+    pub gpg_signing_prompt: GpgSigningPrompt,
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
     /// Default: 0
@@ -683,6 +688,10 @@ impl Settings for ProjectSettings {
         let git_settings = GitSettings {
             enabled: git_enabled,
             git_gutter: git.git_gutter.unwrap(),
+            gpg_signing_prompt: match git.gpg_signing_prompt.unwrap_or_default() {
+                settings::GpgSigningPrompt::Zed => GpgSigningPrompt::Zed,
+                settings::GpgSigningPrompt::System => GpgSigningPrompt::System,
+            },
             gutter_debounce: git.gutter_debounce.unwrap_or_default(),
             inline_blame: {
                 let inline = git.inline_blame.unwrap();

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -398,6 +398,11 @@ message StashDrop {
   optional uint64 stash_index = 3;
 }
 
+enum GpgSigningPrompt {
+  ZED = 0;
+  SYSTEM = 1;
+}
+
 message Commit {
   uint64 project_id = 1;
   reserved 2;
@@ -408,6 +413,7 @@ message Commit {
   optional CommitOptions options = 7;
   reserved 8;
   uint64 askpass_id = 9;
+  GpgSigningPrompt gpg_signing_prompt = 10;
 
   message CommitOptions {
     bool amend = 1;
@@ -431,6 +437,7 @@ message Push {
   optional PushOptions options = 6;
   uint64 askpass_id = 7;
   string remote_branch_name = 8;
+  GpgSigningPrompt gpg_signing_prompt = 9;
 
   enum PushOptions {
     SET_UPSTREAM = 0;
@@ -444,6 +451,7 @@ message Fetch {
   uint64 repository_id = 3;
   uint64 askpass_id = 4;
   optional string remote = 5;
+  GpgSigningPrompt gpg_signing_prompt = 6;
 }
 
 message GetRemotes {
@@ -471,6 +479,7 @@ message Pull {
   optional string branch_name = 5;
   uint64 askpass_id = 6;
   bool rebase = 7;
+  GpgSigningPrompt gpg_signing_prompt = 8;
 }
 
 message RemoteMessageResponse {

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -530,6 +530,11 @@ pub struct GitSettings {
     ///
     /// Default: tracked_files
     pub git_gutter: Option<GitGutterSetting>,
+    /// Controls how passphrase prompts are handled when signing Git commits with GPG.
+    /// This setting controls Zed's GPG wrapper, which is not available on Windows.
+    ///
+    /// Default: zed
+    pub gpg_signing_prompt: Option<GpgSigningPrompt>,
     /// Sets the debounce threshold (in milliseconds) after which changes are reflected in the git gutter.
     ///
     /// Default: 0
@@ -580,6 +585,28 @@ pub struct GitSettings {
     ///
     /// Default: ../worktrees
     pub worktree_directory: Option<String>,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum GpgSigningPrompt {
+    /// Show GPG signing passphrase prompts in Zed.
+    #[default]
+    Zed,
+    /// Let GPG use its configured pinentry program.
+    System,
 }
 
 #[with_fallible_options]

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2302,6 +2302,7 @@ To interpret all `.c` files as C++, files called `MyLockFile` as TOML and files 
 {
   "git": {
     "git_gutter": "tracked_files",
+    "gpg_signing_prompt": "zed",
     "inline_blame": {
       "enabled": true
     },
@@ -2360,6 +2361,36 @@ Example:
   }
 }
 ```
+
+### GPG Signing Prompt
+
+- Description: Controls how passphrase prompts are handled when signing Git commits with GPG.
+- Setting: `gpg_signing_prompt`
+- Default: `"zed"`
+
+**Options**
+
+1. Show GPG signing passphrase prompts in Zed:
+
+```json [settings]
+{
+  "git": {
+    "gpg_signing_prompt": "zed"
+  }
+}
+```
+
+2. Let GPG use its configured pinentry program:
+
+```json [settings]
+{
+  "git": {
+    "gpg_signing_prompt": "system"
+  }
+}
+```
+
+Zed's Git processes do not have a terminal attached, so the `"system"` option requires a graphical or otherwise non-terminal pinentry program. This setting controls Zed's GPG wrapper, which is not available on Windows.
 
 ### Inline Git Blame
 


### PR DESCRIPTION
## Summary

This is a follow-up to #58791 and #61265, where commit `b76e4db` made Zed inject a temporary `gpg.program` wrapper for Git operations. That enables Zed passphrase prompts, but prevents users from choosing their configured system pinentry.

This adds `git.gpg_signing_prompt`:

- `"zed"` keeps the current behavior and remains the default.
- `"system"` leaves `gpg.program` untouched so GPG can use its configured pinentry.

Windows behavior is unchanged because the Zed GPG wrapper is not available there, from my understanding.

## Testing

- `cargo test -p git test_gpg_signing_prompt_controls_gpg_program -- --nocapture`
- `ITERATIONS=10 cargo test -p collab -p gpui_macos --features gpui_macos/runtime_shaders test_gpg_signing_prompt_is_forwarded_to_shared_project -- --nocapture`
- `cargo check -p project -p gpui_macos --features gpui_macos/runtime_shaders`
- `./script/clippy -p git -p askpass`
- `cargo fmt --all --check`
- Built `target/debug/zed` and manually verified both prompt modes on macOS.
- Windows was not manually tested. The GPG wrapper is compiled only on non-Windows platforms, so the setting is expected to have no effect there.


https://github.com/user-attachments/assets/f95e0f8b-7187-4324-9cc9-938d1502c2d7

Release Notes:

- Added a Git setting to use system GPG pinentry for commit signing.
