### PR TITLE
editor: Fix crash when copying and pasting using multiple cursors

### DIFF
--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -586,6 +586,7 @@ impl Editor {
 
         let max_point = buffer.max_point();
         let mut is_first = true;
+        let mut prev_selection_was_entire_line = false;
         for selection in &selections {
             let mut start = selection.start;
             let mut end = selection.end;
@@ -641,7 +642,6 @@ impl Editor {
 
             let is_multiline_trim = trimmed_selections.len() > 1;
             let mut selection_len: usize = 0;
-            let prev_selection_was_entire_line = is_entire_line && !is_multiline_trim;
 
             for trimmed_range in trimmed_selections {
                 if is_first {
@@ -661,6 +661,7 @@ impl Editor {
                     selection_len += 1;
                 }
             }
+            prev_selection_was_entire_line = is_entire_line && !is_multiline_trim;
 
             clipboard_selections.push(ClipboardSelection::for_buffer(
                 selection_len,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9691,6 +9691,32 @@ async fn test_clipboard(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_copy_and_paste_non_empty_selection_followed_by_empty_selection(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state(indoc! {"
+        «fooˇ»
+        barˇ
+    "});
+
+    cx.update_editor(|editor, window, cx| editor.copy(&Copy, window, cx));
+    assert_eq!(
+        cx.read_from_clipboard().and_then(|item| item.text()),
+        Some("foo\nbar\n".to_string())
+    );
+
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state(indoc! {"
+        fooˇ
+        bar
+        barˇ
+    "});
+}
+
+#[gpui::test]
 async fn test_copy_trim(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Fixes a crash when copying and pasting a mixed empty/nonempty multi-cursor selection.

`Editor::do_copy` is meant to insert a newline after each non-final selection that doesn't copy the entire line, but `prev_selection_was_entire_line` is currently based on the current selection instead of the previous one. `Editor::cut_common` does already correctly track this state across loop iterations.

This can lead to an out of bounds crash when pasting because the indexing logic in `Editor::do_paste` relies on these newlines being added correctly, depending on `is_entire_line`.

Repro:

```
foo
bar
```
1. select `foo`
2. option-click after `bar` to add an empty selection
```
«fooˇ»
barˇ
```
3. copy
4. paste

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed a crash when copying and pasting using multiple cursors.
