### PR TITLE
gpui_wgpu: Lower required compute and storage texture limits to 0

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -162,7 +162,16 @@ impl WgpuContext {
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("gpui_device"),
                 required_features,
-                required_limits: wgpu::Limits::downlevel_defaults()
+                required_limits: wgpu::Limits {
+                        max_compute_workgroup_storage_size: 0,
+                        max_compute_invocations_per_workgroup: 0,
+                        max_compute_workgroup_size_x: 0,
+                        max_compute_workgroup_size_y: 0,
+                        max_compute_workgroup_size_z: 0,
+                        max_compute_workgroups_per_dimension: 0,
+                        max_storage_textures_per_shader_stage: 0,
+                        ..wgpu::Limits::downlevel_defaults()
+                    }
                     .using_resolution(adapter.limits())
                     .using_alignment(adapter.limits()),
                 memory_hints: wgpu::MemoryHints::MemoryUsage,


### PR DESCRIPTION
# Objective

- Enable GPU hardware acceleration for Linux/WSL2 users on Intel GPUs (such as Intel Iris Xe / UHD Graphics). Currently, these users are forced onto slow `llvmpipe` CPU software rendering because `wgpu` device initialization fails on GLES 3.1 due to limit mismatches.

## Solution

- GPUI's rendering pipeline (vertex/fragment shaders and storage buffers) does not use compute shaders (`@compute`) or storage textures (`image load/store`) anywhere.
- By zeroing out the compute shader limits and storage texture limit requested by `gpui_wgpu` (`max_compute_workgroup_storage_size`, `max_compute_invocations_per_workgroup`, `max_compute_workgroup_size_x/y/z`, `max_compute_workgroups_per_dimension`, and `max_storage_textures_per_shader_stage`), we allow `wgpu` to successfully create the device on Mesa's GLES 3.1 driver (which reports `0` for these capabilities under WSL2) without compromising GPUI's storage-buffer based rendering pipeline.
- This adheres to `wgpu`'s official recommendation of starting with the most restrictive limits possible and only requesting what the application actually uses.

## Testing
- **Did you test these changes? If so, how?**
  - Yes, tested locally on a WSL2 Ubuntu environment with an Intel Iris Xe GPU.
  - **Before:** Failing `wgpu` device creation and falling back to CPU software rendering (`llvmpipe`) due to:
    `Limit 'max_compute_workgroups_per_dimension' value 65535 is better than allowed 0` and `Limit 'max_storage_textures_per_shader_stage' value 4 is better than allowed 0`.
  - **After:** Zeroing out these limits successfully starts the editor with full hardware GPU acceleration:
    `Using GPU: GpuSpecs { is_software_emulated: false, device_name: "D3D12 (Intel(R) Iris(R) Xe Graphics)", driver_name: "", driver_info: "OpenGL ES 3.1 Mesa 26.1.5 - kisak-mesa PPA" }`
- **Are there any parts that need more testing?**
  - None. Lowering these limits has zero impact on other platforms (macOS, native Windows, Vulkan/Wayland Linux) because those platforms easily support `>= 0` for these limits, and GPUI does not compile compute or storage texture pipelines anyway.
- **How can other people (reviewers) test your changes?**
  - Force GLES fallback with Mesa overrides on an Intel GPU in WSL2, e.g.:
    `GALLIUM_DRIVER=d3d12 MESA_GL_VERSION_OVERRIDE=3.0 MESA_GLES_VERSION_OVERRIDE=3.1 cargo run --release`
- **If relevant, what platforms did you test these changes on, and are there any important ones you can't test?**
  - Tested on WSL2 (Intel GPU).


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Fixed an issue where Zed under WSL2 on Intel GPUs would fallback to CPU software rendering (llvmpipe) due to wgpu requesting unsupported compute and storage texture limits.