### PR TITLE
gpui_linux: Enforce Wayland output discovery during application startup

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -638,7 +638,8 @@ impl WaylandClient {
         let startup_activation_token = take_startup_activation_token_from_environment();
         let conn = Connection::connect_to_env().unwrap();
 
-        let (globals, event_queue) = registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();
+        let (globals, mut event_queue) =
+            registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();
         let qh = event_queue.handle();
 
         let mut seat: Option<wl_seat::WlSeat> = None;
@@ -845,6 +846,9 @@ impl WaylandClient {
             event_loop: Some(event_loop),
             ime_enabled: None,
         }));
+
+        let mut state_ptr = WaylandClientStatePtr(Rc::downgrade(&state));
+        event_queue.roundtrip(&mut state_ptr).unwrap();
 
         WaylandSource::new(conn, event_queue)
             .insert(handle)


### PR DESCRIPTION
# Objective

Fixes [#46378 GPUI (Wayland): displays() not available during startup, breaks layer-shell output selection](https://github.com/zed-industries/zed/issues/46378)

## Solution

Introduce proper initialization of the Wayland client by performing a synchronous roundtrip, this ensures that output information is available during application startup.

Action is performed right after state object is created:

```rust
let mut state_ptr = WaylandClientStatePtr(Rc::downgrade(&state));
event_queue.roundtrip(&mut state_ptr).unwrap();
```

It is recommended by wayland client [docs](https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#method.roundtrip)

```
Synchronous roundtrip

This function will cause a synchronous round trip with the wayland server. This function will block until all requests in the queue are sent and processed by the server.

This function may be useful during initial setup of your app. This function may also be useful where you need to guarantee all requests prior to calling this function are completed.
```

I didn't bother with error handling since constructor doesn't allow returning any errors, so I think it is safe to panic here.

## Testing

- Tested with Zed debug build, no issues observed.
- Tested with my custom shell application which is built on top of gpui. After the fix displays are available during application startup, no longer need to delay initialization.

Didn't find any unit tests to extend tbh, otherwise would do so.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Wayland output discovery during application startup
