### PR TITLE
agent: Show effort selector for anthropic compatible providers

### DIFF
--- a/crates/language_models/src/provider/anthropic_compatible.rs
+++ b/crates/language_models/src/provider/anthropic_compatible.rs
@@ -77,9 +77,88 @@ fn available_model_to_anthropic_model(available: &AvailableModel) -> anthropic::
         supports_images: available.capabilities.images,
         supports_speed: false,
         supports_compaction: false,
-        supported_effort_levels: Vec::new(),
+        supported_effort_levels: if supports_adaptive_thinking {
+            vec![
+                anthropic::Effort::Low,
+                anthropic::Effort::Medium,
+                anthropic::Effort::High,
+                anthropic::Effort::XHigh,
+                anthropic::Effort::Max,
+            ]
+        } else {
+            Vec::new()
+        },
         tool_override: available.tool_override.clone(),
         extra_beta_headers: available.extra_beta_headers.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_available_model(json: &str) -> AvailableModel {
+        serde_json::from_str(json).expect("test fixture should parse")
+    }
+
+    #[test]
+    fn adaptive_mode_maps_to_adaptive_thinking_with_all_effort_levels() {
+        let available = parse_available_model(
+            r#"{
+                "name": "claude-opus-4-7",
+                "max_tokens": 1000000,
+                "max_output_tokens": 128000,
+                "mode": { "type": "adaptive" }
+            }"#,
+        );
+        let model = available_model_to_anthropic_model(&available);
+
+        assert_eq!(model.mode, AnthropicModelMode::AdaptiveThinking);
+        assert!(model.supports_thinking);
+        assert!(model.supports_adaptive_thinking);
+        assert_eq!(
+            model.supported_effort_levels,
+            vec![
+                anthropic::Effort::Low,
+                anthropic::Effort::Medium,
+                anthropic::Effort::High,
+                anthropic::Effort::XHigh,
+                anthropic::Effort::Max,
+            ]
+        );
+    }
+
+    #[test]
+    fn thinking_mode_does_not_enable_adaptive() {
+        let available = parse_available_model(
+            r#"{
+                "name": "claude-sonnet-4-5",
+                "max_tokens": 200000,
+                "mode": { "type": "thinking", "budget_tokens": 4096 }
+            }"#,
+        );
+        let model = available_model_to_anthropic_model(&available);
+
+        assert!(matches!(model.mode, AnthropicModelMode::Thinking { .. }));
+        assert!(model.supports_thinking);
+        assert!(!model.supports_adaptive_thinking);
+        assert!(model.supported_effort_levels.is_empty());
+    }
+
+    #[test]
+    fn default_mode_disables_thinking() {
+        let available = parse_available_model(
+            r#"{
+                "name": "claude-3-5-haiku",
+                "max_tokens": 200000
+            }"#,
+        );
+        let model = available_model_to_anthropic_model(&available);
+
+        assert_eq!(model.mode, AnthropicModelMode::Default);
+        assert!(!model.supports_thinking);
+        assert!(!model.supports_adaptive_thinking);
+        assert!(model.supported_effort_levels.is_empty());
     }
 }
 
@@ -311,6 +390,28 @@ impl LanguageModel for AnthropicCompatibleLanguageModel {
 
     fn supports_thinking(&self) -> bool {
         self.model.supports_thinking
+    }
+
+    fn supported_effort_levels(&self) -> Vec<language_model::LanguageModelEffortLevel> {
+        self.model
+            .supported_effort_levels
+            .iter()
+            .map(|effort| {
+                let is_default = matches!(effort, anthropic::Effort::High);
+                let (name, value) = match effort {
+                    anthropic::Effort::Low => ("Low".into(), "low".into()),
+                    anthropic::Effort::Medium => ("Medium".into(), "medium".into()),
+                    anthropic::Effort::High => ("High".into(), "high".into()),
+                    anthropic::Effort::XHigh => ("XHigh".into(), "xhigh".into()),
+                    anthropic::Effort::Max => ("Max".into(), "max".into()),
+                };
+                language_model::LanguageModelEffortLevel {
+                    name,
+                    value,
+                    is_default,
+                }
+            })
+            .collect()
     }
 
     fn telemetry_id(&self) -> String {


### PR DESCRIPTION
Follow up to #57207

Release Notes:

- agent: Show reasoning effort selector for anthropic compatible providers if model supports adaptive thinking
