### PR TITLE
helix: Add `vim::HelixGotoLine` action and bind it to `G`

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -456,6 +456,7 @@
       "alt-.": "vim::RepeatFind",
       "alt-b": "editor::MoveToStartOfLargerSyntaxNode",
       "alt-e": "editor::MoveToEndOfLargerSyntaxNode",
+      "shift-g": "vim::HelixGotoLine",
 
       // Changes
       "shift-r": "editor::Paste",

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -42,6 +42,8 @@ actions!(
         HelixInsertEndOfLine,
         /// Goes to the location of the last modification.
         HelixGotoLastModification,
+        /// Goes to the line specified by the count.
+        HelixGotoLine,
         /// Select entire line or multiple lines, extending downwards.
         HelixSelectLine,
         /// Select all matches of a given pattern within the current selection.
@@ -73,6 +75,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_insert_end_of_line);
     Vim::action(editor, cx, Vim::helix_yank);
     Vim::action(editor, cx, Vim::helix_goto_last_modification);
+    Vim::action(editor, cx, Vim::helix_goto_line);
     Vim::action(editor, cx, Vim::helix_paste);
     Vim::action(editor, cx, Vim::helix_select_regex);
     Vim::action(editor, cx, Vim::helix_keep_newest_selection);
@@ -832,6 +835,17 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.jump(".".into(), false, false, window, cx);
+    }
+
+    pub fn helix_goto_line(
+        &mut self,
+        _: &HelixGotoLine,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(line_number) = Vim::take_count(cx) {
+            self.helix_move_cursor(Motion::StartOfDocument, Some(line_number), window, cx);
+        }
     }
 
     pub fn helix_select_lines(
@@ -4190,6 +4204,97 @@ mod test {
             indoc! {"
             «ˇline one
             line two»
+            line three"},
+            Mode::HelixSelect,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_goto_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // <count G> lands at column 0 of the target line
+        cx.set_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("2 shift-g");
+        cx.assert_state(
+            indoc! {"
+            line one
+            ˇ  line two
+            line three"},
+            Mode::HelixNormal,
+        );
+
+        // including when targeting the current line
+        cx.set_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("3 shift-g");
+        cx.assert_state(
+            indoc! {"
+            line one
+              line two
+            ˇline three"},
+            Mode::HelixNormal,
+        );
+
+        // but not when count is missing entirely
+        cx.set_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("shift-g");
+        cx.assert_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixNormal,
+        );
+
+        // bare shift-g does not exit select mode
+        cx.set_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixSelect,
+        );
+        cx.simulate_keystrokes("shift-g");
+        cx.assert_state(
+            indoc! {"
+            line one
+              line two
+            line ˇthree"},
+            Mode::HelixSelect,
+        );
+
+        // shift-g with count jumps without extending the selection, unlike <count>gg
+        cx.set_state(
+            indoc! {"
+            line one
+              line two
+            line «ˇthree»"},
+            Mode::HelixSelect,
+        );
+        cx.simulate_keystrokes("1 shift-g");
+        cx.assert_state(
+            indoc! {"
+            ˇline one
+              line two
             line three"},
             Mode::HelixSelect,
         );


### PR DESCRIPTION
# Objective

Make `G` keybinding in Helix mode work like in Helix and not like in Vim.

Fixes https://github.com/zed-industries/zed/issues/61580

## Solution

Helix has two ways to jump to a line by line number.

One is the `goto_file_start` command (bound to `gg`) that optionally takes a count to go to that line instead of the start of the file. Zed already supports it as `vim::StartOfDocument`.

The other is the dedicated `goto_line` command (bound to `G`) that only does that and nothing else. Zed did not have it.

What's worse, the default `"shift-g": "vim::EndOfDocument"` binding leaked from Vim keymap into Helix keymap, which previously made `<count>G` accidentally work in Helix mode for the wrong reason, until https://github.com/zed-industries/zed/pull/59449 fixed the behavior of `vim::StartOfDocument` and `vim::EndOfDocument` actions to match Helix exactly. This broke `<count>G` and exposed that `G` was bound to the wrong action in Helix mode, and the correct one didn't exist.

This PR fixes that in the following way:
- adds new`vim::HelixGotoLine` action
- binds it to `shift-g` in `helix_normal` and `helix_select` modes in the default Vim keymap

## Testing

- Unit tests
- Manual testing

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the behavior of `G` binding in Helix mode and added new `vim::HelixGotoLine` action
