### PR TITLE
gpui: Fix deadlock in performance profiler and reenable it

### DIFF
--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -23,8 +23,7 @@ use crate::{SharedString, TasksIncluded, WindowId};
 #[cfg(feature = "profiler")]
 #[doc(hidden)]
 pub fn get_all_timings(included: gpui::TasksIncluded) -> Vec<gpui::ThreadTaskTimings> {
-    let global_thread_timings = GLOBAL_THREAD_TIMINGS.lock();
-    ThreadTaskTimings::collect(&global_thread_timings, included)
+    ThreadTaskTimings::collect(upgraded_thread_timings(), included)
 }
 
 #[cfg(feature = "profiler")]
@@ -36,8 +35,7 @@ pub fn get_current_thread_timings(included: TasksIncluded) -> gpui::ThreadTaskTi
 #[cfg(feature = "profiler")]
 #[doc(hidden)]
 pub fn take_all_stats(included: TasksIncluded) -> Vec<gpui::ThreadTaskStatistics> {
-    let global_timings = GLOBAL_THREAD_TIMINGS.lock();
-    ThreadTaskStatistics::collect_and_reset(&global_timings, included)
+    ThreadTaskStatistics::collect_and_reset(upgraded_thread_timings(), included)
 }
 
 #[cfg(not(feature = "profiler"))]
@@ -128,14 +126,13 @@ pub struct ThreadTaskTimings {
 }
 
 impl ThreadTaskTimings {
-    /// Convert global thread timings into their structured format.
-    pub fn collect(timings: &[GlobalThreadTimings], included: TasksIncluded) -> Vec<Self> {
+    /// Convert upgraded per-thread timings into their structured format.
+    pub fn collect(
+        timings: Vec<(ThreadId, Arc<GuardedTaskTimings>)>,
+        included: TasksIncluded,
+    ) -> Vec<Self> {
         timings
-            .iter()
-            .filter_map(|t| match t.timings.upgrade() {
-                Some(timings) => Some((t.thread_id, timings)),
-                _ => None,
-            })
+            .into_iter()
             .map(|(thread_id, timings)| {
                 let timings = timings.lock();
                 let thread_name = timings.thread_name.clone();
@@ -179,15 +176,11 @@ pub struct ThreadTaskStatistics {
 
 impl ThreadTaskStatistics {
     pub fn collect_and_reset(
-        timings: &[GlobalThreadTimings],
+        timings: Vec<(ThreadId, Arc<GuardedTaskTimings>)>,
         include_running: TasksIncluded,
     ) -> Vec<Self> {
         timings
-            .iter()
-            .filter_map(|t| match t.timings.upgrade() {
-                Some(timings) => Some((t.thread_id, timings)),
-                _ => None,
-            })
+            .into_iter()
             .map(|(thread_id, timings)| {
                 let mut timings = timings.lock();
                 let thread_name = timings.thread_name.clone();
@@ -511,6 +504,23 @@ impl TaskStatistics {
 pub static GLOBAL_THREAD_TIMINGS: spin::Mutex<Vec<GlobalThreadTimings>> =
     spin::Mutex::new(Vec::new());
 
+/// Upgrades all live per-thread timing handles, holding the global registry
+/// lock only for the duration of the upgrades.
+///
+/// The upgraded `Arc`s must never be dropped while `GLOBAL_THREAD_TIMINGS` is
+/// locked: dropping the last strong reference runs [`ThreadTimings::drop`],
+/// which locks `GLOBAL_THREAD_TIMINGS` again and would deadlock the
+/// non-reentrant spinlock. A thread exiting concurrently can hand off its last
+/// reference to us at any time, so callers of this function process (lock,
+/// read, drop) the returned handles only after the global lock is released.
+fn upgraded_thread_timings() -> Vec<(ThreadId, Arc<GuardedTaskTimings>)> {
+    let global_thread_timings = GLOBAL_THREAD_TIMINGS.lock();
+    global_thread_timings
+        .iter()
+        .filter_map(|t| Some((t.thread_id, t.timings.upgrade()?)))
+        .collect()
+}
+
 thread_local! {
     #[doc(hidden)]
     pub static THREAD_TIMINGS: LazyCell<Arc<GuardedTaskTimings>> = LazyCell::new(|| {
@@ -679,13 +689,11 @@ pub fn set_trace_enabled(enabled: bool) -> bool {
     }
 
     if !enabled {
-        for global in GLOBAL_THREAD_TIMINGS.lock().iter() {
-            if let Some(timings) = global.timings.upgrade() {
-                let mut timings = timings.lock();
-                timings.timings.clear();
-                timings.timings.shrink_to_fit();
-                timings.total_pushed = 0;
-            }
+        for (_, timings) in upgraded_thread_timings() {
+            let mut timings = timings.lock();
+            timings.timings.clear();
+            timings.timings.shrink_to_fit();
+            timings.total_pushed = 0;
         }
     }
     true

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -39,7 +39,7 @@ fs.workspace = true
 futures.workspace = true
 git.workspace = true
 git_hosting_providers.workspace = true
-gpui.workspace = true
+gpui = { workspace = true, features = ["profiler"] }
 gpui_platform.workspace = true
 gpui_tokio.workspace = true
 http_client.workspace = true

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -117,7 +117,7 @@ git_hosting_providers.workspace = true
 git_ui = { workspace = true, features = ["call"] }
 go_to_line.workspace = true
 system_specs.workspace = true
-gpui = { workspace = true, features = ["input-latency-histogram"] }
+gpui = { workspace = true, features = ["input-latency-histogram", "profiler"] }
 gpui_platform = {workspace = true, features=["screen-capture", "font-kit", "wayland", "x11"]}
 hdrhistogram.workspace = true
 image = { workspace = true, optional = true }


### PR DESCRIPTION
### Summary

PR #58942 disabled the performance profiler within Zed because there was a race condition that caused Zed to hang forever due to a deadlock involving the foreground thread. This PR fixes the deadlock and re-enables the performance profiler.

The deadlock happened because `ThreadTimings::drop()` locks `GLOBAL_THREAD_TIMINGS`, and that drop could run in places where `GLOBAL_THREAD_TIMINGS` was already locked: the collection paths (`get_all_timings`, `take_all_stats`, `set_trace_enabled(false)`) held the global lock while upgrading and then dropping per-thread `Arc<GuardedTaskTimings>` handles. If a worker thread exited in that window (e.g. GCD reclaiming an idle thread), the collector inherited the last strong reference, and dropping it ran `ThreadTimings::drop` -> `GLOBAL_THREAD_TIMINGS.lock()` reentrantly on the same thread. The spinlock is not reentrant, so the thread spun forever while holding the lock, hanging every other thread that touched the profiler.

The fix: hold `GLOBAL_THREAD_TIMINGS` only long enough to upgrade the `Weak` handles (`upgraded_thread_timings()`), and release it before any per-thread buffer is locked, copied, or dropped. A last-reference drop now always runs with the global lock free. As a side benefit, the up-to-16MiB per-thread buffer copies no longer happen under the global lock.

### Diagram

```mermaid
sequenceDiagram
    participant C as Collector thread (get_all_timings)
    participant G as GLOBAL_THREAD_TIMINGS (spin::Mutex)
    participant T as Worker thread (exiting)

    Note over T: holds the only strong Arc<br/>in its THREAD_TIMINGS TLS
    C->>G: lock() — guard held for entire collection
    C->>C: Weak::upgrade() (strong: 1 → 2)
    T->>T: thread exits, TLS destructor drops its Arc (strong: 2 → 1)
    C->>C: temp Arc dropped at end of iteration (strong: 1 → 0)
    C->>C: ThreadTimings::drop() runs on collector thread
    C->>G: lock() again — already held by this thread
    Note over C,G: spin lock is not reentrant → spins forever,<br/>every other profiler user spins behind it

    Note over C,T: Fix: upgrade all Weaks under the lock, release it,<br/>then lock/copy/drop per-thread handles — the reentrant<br/>drop can now only ever run with the global lock free
```

Release Notes:

- Fixed a deadlock in the performance profiler and re-enabled it (`zed: open performance profiler`)
