### PR TITLE
search: Preserve cleared query when reopening the text finder

### DIFF
--- a/crates/search/src/text_finder.rs
+++ b/crates/search/src/text_finder.rs
@@ -474,10 +474,8 @@ impl ModalView for TextFinder {
     ) -> DismissDecision {
         let picker = self.picker.read(cx);
         let query = picker.query(cx);
-        if !query.is_empty() {
-            let options = picker.delegate.search_options;
-            store_last_search(self.workspace_id, query, options, cx);
-        }
+        let options = picker.delegate.search_options;
+        store_last_search(self.workspace_id, query, options, cx);
         DismissDecision::Dismiss(true)
     }
 }
@@ -515,6 +513,7 @@ mod tests {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
+            cx.set_global(db::AppDatabase::test_new());
 
             theme_settings::init(theme::LoadThemes::JustBase, cx);
 
@@ -543,10 +542,6 @@ mod tests {
             .unwrap();
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
-        // Seed a query: the last-search persistence in `on_before_dismiss` (the
-        // code path that read the workspace entity) only runs when the query is
-        // non-empty, which is the common case in practice since the finder seeds
-        // the previous query on open.
         let seed_query = SearchSeed {
             query: "ONE".to_string(),
             options: None,
@@ -568,5 +563,75 @@ mod tests {
         workspace.update(cx, |workspace, cx| {
             assert!(workspace.active_modal::<TextFinder>(cx).is_none());
         });
+    }
+
+    #[gpui::test]
+    async fn test_clearing_query_does_not_restore_previous_query(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(path!("/dir"), json!({"one.rs": "const ONE: usize = 1;"}))
+            .await;
+        let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = window
+            .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let persistence_task = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.flush_serialization(window, cx)
+        });
+        persistence_task.await;
+
+        let initial_query = "unique_search_query";
+        let seed_query = SearchSeed {
+            query: initial_query.to_string(),
+            options: None,
+        };
+        workspace
+            .update_in(cx, |_, window, cx| {
+                TextFinder::open(Some(seed_query), window, cx)
+            })
+            .await;
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.hide_modal(window, cx));
+        });
+        cx.run_until_parked();
+
+        let seed_query = workspace.update_in(cx, |workspace, window, cx| {
+            TextFinder::seed_query(workspace, window, cx)
+        });
+        assert_eq!(
+            seed_query.as_ref().map(|seed| seed.query.as_str()),
+            Some(initial_query)
+        );
+        workspace
+            .update_in(cx, |_, window, cx| TextFinder::open(seed_query, window, cx))
+            .await;
+
+        let picker = workspace.update(cx, |workspace, cx| {
+            workspace
+                .active_modal::<TextFinder>(cx)
+                .expect("Text Finder should be open")
+                .read(cx)
+                .picker
+                .clone()
+        });
+        picker.update_in(cx, |picker, window, cx| {
+            picker.set_query("", window, cx);
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.hide_modal(window, cx));
+        });
+        cx.run_until_parked();
+
+        let seed_query = workspace.update_in(cx, |workspace, window, cx| {
+            TextFinder::seed_query(workspace, window, cx)
+        });
+        assert!(seed_query.is_none());
     }
 }


### PR DESCRIPTION
## Context

Closes #61394

The Text Finder persists the last query per workspace (in the `text_finder_queries` table) so it can seed itself on reopen. Persistence happens in `TextFinder::on_before_dismiss`, but it was guarded by `if !query.is_empty()`, so clearing the query and dismissing never wrote anything. The stale non-empty query stayed in the database and got restored on the next open, making it impossible to "clear and keep it cleared."

This removes the guard so dismissal always persists the current query, including an empty one. The read side already treats an empty stored query as "nothing to restore" (`load_last_search` returns `None` for an empty string), so an empty write cleanly clears the seed instead of leaving the previous query behind.

Manual test below :

[Screencast from 2026-07-24 15-24-33.webm](https://github.com/user-attachments/assets/ba305f54-8ec2-4d3d-be0b-e2eb001bb204)


## How to Review

**`crates/search/src/text_finder.rs`**

`on_before_dismiss` no longer gates the write on a non-empty query. It always calls `store_last_search` with the picker's current query and options. `store_last_search` still early-returns for workspaces without a `database_id`, so unpersisted workspaces are unaffected, and `load_last_search` still maps an empty persisted query to `None`, so `seed_query` won't resurrect it. The active-item selection still takes priority over the persisted value on reopen, so seeding from a live editor selection is unchanged.

The tests' shared `init_test` now installs a test `db::AppDatabase` global. This is required because the new test is the first one to actually reach `TextFinderDb::global(cx)`. The existing `test_dismiss_from_within_workspace_update` leaves the workspace's `database_id` as `None`, so it short-circuits before touching the DB.

`test_clearing_query_does_not_restore_previous_query` exercises the real persistence path: it assigns a workspace `database_id` (`set_random_database_id` + `flush_serialization`), opens the finder with a query, dismisses, and asserts the query round-trips through `seed_query`; then it reopens, clears the query via `set_query("")`, dismisses, and asserts `seed_query` is now `None`. The positive round-trip assertion keeps the negative case from passing vacuously.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed the project search / Text Finder restoring a previous query after it had been cleared and dismissed
