### PR TITLE
Stop bundling GLib in Linux release archives

### DIFF
--- a/crates/livekit_client/src/livekit_client/linux.rs
+++ b/crates/livekit_client/src/livekit_client/linux.rs
@@ -189,8 +189,8 @@ pub(crate) async fn start_wayland_desktop_capture(
         .ok_or_else(|| {
             stop_flag.store(true, Ordering::Relaxed);
             anyhow::anyhow!(
-                "Screen sharing was canceled or the portal denied permission. \
-                 You can try again from the screen share button."
+                "Screen sharing was canceled, permission was denied, or the PipeWire \
+                 connection failed. You can try again from the screen share button."
             )
         })?;
 

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -163,7 +163,7 @@ find_libs() {
     ldd ${target_dir}/${target_triple}/release/zed |\
         cut -d' ' -f3 |\
         grep -v '\<\(libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\|libasound.so\)' |\
-        grep -v '\<\(libglib-2.0.so\|libgobject-2.0.so\|libgio-2.0.so\|libgmodule-2.0.so\|libpcre.so\|libpcre2-8.so\|libmount.so\|libblkid.so\|libselinux.so\|libffi.so\|libresolv.so\|libbsd.so\|libz.so\)'
+        grep -v '\<\(libglib-2.0.so\|libgobject-2.0.so\|libgio-2.0.so\|libgmodule-2.0.so\|libpcre.so\|libpcre2-8.so\|libmount.so\|libblkid.so\|libselinux.so\|libffi.so\|libresolv.so\|libz.so\)'
 }
 
 mkdir -p "${zed_dir}/lib"

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -155,10 +155,15 @@ cp "${target_dir}/${target_triple}/release/cli" "${zed_dir}/bin/zed"
 # Libs
 # Bundle libstdc++ so older supported systems can run binaries built with our
 # toolchain even when their system libstdc++.so.6 lacks required GLIBCXX symbols.
+#
+# Never bundle the GLib family or its private dependencies: host libraries that
+# get dlopen'd are built against the system GLib, and resolving them against an
+# older bundled copy fails with missing symbols.
 find_libs() {
     ldd ${target_dir}/${target_triple}/release/zed |\
         cut -d' ' -f3 |\
-        grep -v '\<\(libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\|libasound.so\)'
+        grep -v '\<\(libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\|libasound.so\)' |\
+        grep -v '\<\(libglib-2.0.so\|libgobject-2.0.so\|libgio-2.0.so\|libgmodule-2.0.so\|libpcre.so\|libpcre2-8.so\|libmount.so\|libblkid.so\|libselinux.so\|libffi.so\|libresolv.so\|libbsd.so\|libz.so\)'
 }
 
 mkdir -p "${zed_dir}/lib"

--- a/script/install.sh
+++ b/script/install.sh
@@ -116,6 +116,16 @@ linux() {
     mkdir -p "$HOME/.local/zed$suffix.app"
     tar -xzf "$temp/zed-linux-$arch.tar.gz" -C "$HOME/.local/"
 
+    zed_editor="$HOME/.local/zed$suffix.app/libexec/zed-editor"
+    if [ -f "$zed_editor" ] && command -v ldd >/dev/null 2>&1; then
+        missing="$(ldd "$zed_editor" 2>/dev/null | sed -n 's/^[[:space:]]*\(.*\) => not found$/\1/p')"
+        if [ -n "$missing" ]; then
+            echo "Warning: your system is missing libraries that Zed needs:"
+            echo "$missing" | sed 's/^/    /'
+            echo "Install them with your package manager, or Zed will fail to start."
+        fi
+    fi
+
     # Setup ~/.local directories
     mkdir -p "$HOME/.local/bin" "$HOME/.local/share/applications"
 


### PR DESCRIPTION
Bundled GLib shadowed the system libraries for host plugins dlopen'd into the process,  like PipeWire's videoconvert on 1.6+, which would break Wayland screen sharing on newer distros. This PR makes Zed rely on system GLib instead, since the bundled version pulls from whatever is in CI (presently Ubuntu 20.04).

Release Notes:

- Removed GLib libraries from Linux release bundle, which could conflict with system plugins