### PR TITLE
agent_ui: Keep message editor usable at narrow panel widths

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -104,6 +104,10 @@ use workspace::{
 
 const AGENT_PANEL_KEY: &str = "agent_panel";
 const MIN_PANEL_WIDTH: Pixels = px(300.);
+/// `MIN_PANEL_WIDTH` expressed in rems at the default 16px rem size. The message
+/// editor's footer controls are all sized in rems, so the floor has to grow with
+/// the UI font size or those controls overflow the panel.
+const MIN_PANEL_WIDTH_REMS: f32 = 18.75;
 const LAST_USED_AGENT_KEY: &str = "agent_panel__last_used_external_agent";
 const LAST_CREATED_ENTRY_KIND_KEY: &str = "agent_panel__last_created_entry_kind";
 const TERMINAL_AGENT_TELEMETRY_ID: &str = "terminal";
@@ -4988,7 +4992,18 @@ impl Panel for AgentPanel {
 
     fn min_size(&self, window: &Window, cx: &App) -> Option<Pixels> {
         match self.position(window, cx) {
-            DockPosition::Left | DockPosition::Right => Some(MIN_PANEL_WIDTH),
+            DockPosition::Left | DockPosition::Right => {
+                // Agent threads render inside a `WithRemSize` using
+                // `agent_ui_font_size`, so the window's own rem size is the wrong
+                // yardstick for how wide the panel's controls actually are.
+                let rem_size = match self.visible_font_size() {
+                    WhichFontSize::AgentFont => {
+                        ThemeSettings::get_global(cx).agent_ui_font_size(cx)
+                    }
+                    WhichFontSize::None => window.rem_size(),
+                };
+                Some(MIN_PANEL_WIDTH.max(rem_size * MIN_PANEL_WIDTH_REMS))
+            }
             DockPosition::Bottom => None,
         }
     }

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -573,6 +573,10 @@ impl Render for ConfigOptionSelector {
                     .id(ElementId::Name(
                         format!("config-option-{}", option_id.0).into(),
                     ))
+                    // Match the horizontal padding the select triggers get from
+                    // `Button`, so boolean options line up with them once the
+                    // footer wraps onto multiple rows.
+                    .pl(DynamicSpacing::Base04.rems(cx))
                     .pr_1()
                     .tooltip(tooltip)
                     .child(

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4310,8 +4310,12 @@ impl ThreadView {
                         v_flex()
                             .relative()
                             .w_full()
-                            .min_h_0()
-                            .when(fills_container, |this| this.flex_1())
+                            // `min_h_0` is only safe while this wrapper fills the
+                            // container and scrolls internally. Otherwise it lets the
+                            // editor shrink past its `min_lines` height, and since the
+                            // editor keeps painting its full content, the text ends up
+                            // drawn over the footer controls below.
+                            .when(fills_container, |this| this.min_h_0().flex_1())
                             .pt_1()
                             .pr_2p5()
                             .child(self.message_editor.clone())
@@ -4359,6 +4363,10 @@ impl ThreadView {
                                 h_flex()
                                     .min_w_0()
                                     .flex_wrap()
+                                    // Icon glyphs carry whitespace inside their SVG box,
+                                    // so they read as indented next to the text triggers
+                                    // once the footer wraps them onto separate rows.
+                                    .ml_neg_0p5()
                                     .gap_0p5()
                                     .child(self.render_add_context_button(cx))
                                     .child(self.render_follow_toggle(cx))
@@ -4730,6 +4738,7 @@ impl ThreadView {
                     .id("split_token_usage")
                     .flex_shrink_0()
                     .gap_1p5()
+                    .pl(DynamicSpacing::Base04.rems(cx))
                     .mr_1()
                     .child(
                         h_flex()
@@ -4777,6 +4786,9 @@ impl ThreadView {
                 h_flex()
                     .id("circular_progress_tokens")
                     .mt_px()
+                    // Line the ring up with the select triggers, which get this
+                    // padding from `Button`, once the footer wraps onto rows.
+                    .pl(DynamicSpacing::Base04.rems(cx))
                     .mr_1()
                     .child(
                         CircularProgress::new(
@@ -6018,6 +6030,11 @@ impl ThreadView {
                 div()
                     .when_some(max_content_width, |this, max_w| this.max_w(max_w))
                     .w_full()
+                    // Without this, entries whose content can't wrap (long mention
+                    // pills, say) keep the container at its min-content width, and
+                    // `justify_center` then spills the overflow off *both* edges,
+                    // clipping the start of each line.
+                    .min_w_0()
                     .child(content),
             )
         };


### PR DESCRIPTION
# Objective

Message editor breaks at narrow agent panel width. Observed on macOS + Windows, non-default UI font.

1. Editor collapses. Footer controls wrap to extra rows → editor shrinks past `min_lines` → text draws over `+` / follow buttons.
2. Content clips (see screenshots below)

Builds on #61395, which introduced wrapping for these controls. Same area as #61391 and #60876.

## Solution

- **Panel floor was font-blind.** `MIN_PANEL_WIDTH` is a hard `px(300.)`. Agent threads render inside a `WithRemSize` using `agent_ui_font_size`, so `min_size` now scales with that, falling back to `window.rem_size()` for the terminal view.
- **Editor could shrink to nothing.** `min_h_0` on the editor wrapper is now gated on `fills_container`. Needed when the wrapper fills the container and scrolls internally; otherwise wrapped rows take height from the editor, which keeps painting full content over the controls.
- **Entries overflowed both edges.** `centered_container` had no `min_w_0`, so content that can't wrap held it at min-content width and `justify_center` spilled it left as well as right.

Wrapped rows also exposed inconsistent left insets, since only the select triggers get horizontal padding from `Button`. Matched it on the token usage ring, the split token usage row, and boolean config options, and compensated the icon group for whitespace inside the SVG glyph box.

## Testing

Manual, macOS, dev build at the panel's hard minimum width.

Custom font — `ui_font_family: "IBM Plex Sans Condensed"`, `agent_ui_font_size: 15`, `ui_font_size: 14.0`:

- Empty thread and thread with messages, dragged wide → minimum
- Expanded message editor, confirming the gated `min_h_0` didn't regress the 80vh case
- Footer rows wrapped: `+` / follow icons, context ring, `Plan Mode`, `Opus (1M context)`, `Xhigh`, `Fast mode` all share a left edge

Default UI font — same sweep, see screenshots below. No visual change at wide widths, alignment holds once rows wrap.

`cargo fmt --all -- --check` and `./script/clippy` pass.

Needs more testing:

- Linux. Verified on macOS and Windows only.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The top Zed window is this PR, and the bottom window is a release stable version, both `agent_ui_font_size: 15`, `ui_font_size: 14.0`:

With IBM Plex Sans Condensed UI font on macOS:


<img width="619" height="563" alt="Screenshot 2026-07-24 at 6 22 03 PM" src="https://github.com/user-attachments/assets/0ca95aa2-3491-48d6-bebb-cbbf1de5730c" />


With default Zed Sans UI font on macOS:


<img width="595" height="522" alt="Screenshot 2026-07-24 at 6 22 45 PM" src="https://github.com/user-attachments/assets/e97f74c9-7814-4360-aaef-d67ae5615f12" />

---

Release Notes:

- Fixed the agent panel message editor collapsing and its controls clipping at narrow panel widths
