### PR TITLE
Fix not being able to split a preview

### DIFF
--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1455,6 +1455,7 @@ pub mod test {
         pub reload_count: usize,
         pub is_dirty: bool,
         pub buffer_kind: ItemBufferKind,
+        can_split: bool,
         pub has_conflict: bool,
         pub has_deleted_file: bool,
         pub project_items: Vec<Entity<TestProjectItem>>,
@@ -1549,6 +1550,7 @@ pub mod test {
                 has_deleted_file: false,
                 project_items: Vec::new(),
                 buffer_kind: ItemBufferKind::Singleton,
+                can_split: true,
                 nav_history: None,
                 tab_descriptions: None,
                 tab_detail: Default::default(),
@@ -1572,6 +1574,11 @@ pub mod test {
 
         pub fn with_buffer_kind(mut self, buffer_kind: ItemBufferKind) -> Self {
             self.buffer_kind = buffer_kind;
+            self
+        }
+
+        pub fn with_can_split(mut self, can_split: bool) -> Self {
+            self.can_split = can_split;
             self
         }
 
@@ -1713,7 +1720,7 @@ pub mod test {
         }
 
         fn can_split(&self) -> bool {
-            true
+            self.can_split
         }
 
         fn clone_on_split(
@@ -1734,6 +1741,7 @@ pub mod test {
                     reload_count: self.reload_count,
                     is_dirty: self.is_dirty,
                     buffer_kind: self.buffer_kind,
+                    can_split: self.can_split,
                     has_conflict: self.has_conflict,
                     has_deleted_file: self.has_deleted_file,
                     project_items: self.project_items.clone(),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2565,6 +2565,17 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let mode = if mode == SplitMode::ClonePane
+            && self.items.len() > 1
+            && self
+                .active_item()
+                .is_some_and(|active_item| !active_item.can_split(cx))
+        {
+            SplitMode::MovePane
+        } else {
+            mode
+        };
+
         if self.items.len() <= 1 && mode == SplitMode::MovePane {
             // MovePane with only one pane present behaves like a SplitEmpty in the opposite direction
             let active_item = self.active_item();
@@ -8772,6 +8783,69 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_split_clone_moves_non_clonable_active_item(cx: &mut TestAppContext) {
+        for split_direction in SplitDirection::all() {
+            test_single_pane_split_with_active_item_can_split(
+                ["A", "B"],
+                split_direction,
+                SplitMode::ClonePane,
+                SplitMode::MovePane,
+                false,
+                cx,
+            )
+            .await;
+        }
+    }
+
+    #[gpui::test]
+    async fn test_split_action_moves_non_clonable_active_item(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+        let pane_before = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        add_labeled_item_with_can_split(&pane_before, "A", false, true, cx);
+        add_labeled_item_with_can_split(&pane_before, "B", false, false, cx);
+        cx.executor().run_until_parked();
+        pane_before.update_in(cx, |pane, window, cx| {
+            pane.focus_active_item(window, cx);
+        });
+
+        cx.dispatch_action(SplitRight::default());
+        cx.executor().run_until_parked();
+
+        let pane_after = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        assert_ne!(pane_before, pane_after);
+        assert_item_labels(&pane_before, ["A*"], cx);
+        assert_item_labels(&pane_after, ["B*"], cx);
+    }
+
+    #[gpui::test]
+    async fn test_split_clone_non_clonable_single_item_is_noop(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        add_labeled_item_with_can_split(&pane, "A", false, false, cx);
+
+        for split_direction in SplitDirection::all() {
+            pane.update_in(cx, |pane, window, cx| {
+                pane.split(split_direction, SplitMode::ClonePane, window, cx)
+            });
+            cx.executor().run_until_parked();
+
+            assert_eq!(
+                workspace.read_with(cx, |workspace, _| workspace.panes().len()),
+                1
+            );
+            assert_item_labels(&pane, ["A*"], cx);
+        }
+    }
+
+    #[gpui::test]
     async fn test_split_move_right_on_single_pane(cx: &mut TestAppContext) {
         test_single_pane_split(["A"], SplitDirection::Right, SplitMode::MovePane, cx).await;
     }
@@ -8918,9 +8992,23 @@ mod tests {
         is_dirty: bool,
         cx: &mut VisualTestContext,
     ) -> Box<Entity<TestItem>> {
+        add_labeled_item_with_can_split(pane, label, is_dirty, true, cx)
+    }
+
+    fn add_labeled_item_with_can_split(
+        pane: &Entity<Pane>,
+        label: &str,
+        is_dirty: bool,
+        can_split: bool,
+        cx: &mut VisualTestContext,
+    ) -> Box<Entity<TestItem>> {
         pane.update_in(cx, |pane, window, cx| {
-            let labeled_item =
-                Box::new(cx.new(|cx| TestItem::new(cx).with_label(label).with_dirty(is_dirty)));
+            let labeled_item = Box::new(cx.new(|cx| {
+                TestItem::new(cx)
+                    .with_label(label)
+                    .with_dirty(is_dirty)
+                    .with_can_split(can_split)
+            }));
             pane.add_item(labeled_item.clone(), false, false, None, window, cx);
             labeled_item
         })
@@ -9061,7 +9149,26 @@ mod tests {
     async fn test_single_pane_split<const COUNT: usize>(
         pane_labels: [&str; COUNT],
         direction: SplitDirection,
-        operation: SplitMode,
+        mode: SplitMode,
+        cx: &mut TestAppContext,
+    ) {
+        test_single_pane_split_with_active_item_can_split(
+            pane_labels,
+            direction,
+            mode,
+            mode,
+            true,
+            cx,
+        )
+        .await;
+    }
+
+    async fn test_single_pane_split_with_active_item_can_split<const COUNT: usize>(
+        pane_labels: [&str; COUNT],
+        direction: SplitDirection,
+        requested_mode: SplitMode,
+        expected_mode: SplitMode,
+        active_item_can_split: bool,
         cx: &mut TestAppContext,
     ) {
         init_test(cx);
@@ -9072,11 +9179,12 @@ mod tests {
 
         let mut pane_before =
             workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
-        for label in pane_labels {
-            add_labeled_item(&pane_before, label, false, cx);
+        for (index, label) in pane_labels.iter().copied().enumerate() {
+            let can_split = index + 1 != COUNT || active_item_can_split;
+            add_labeled_item_with_can_split(&pane_before, label, false, can_split, cx);
         }
         pane_before.update_in(cx, |pane, window, cx| {
-            pane.split(direction, operation, window, cx)
+            pane.split(direction, requested_mode, window, cx)
         });
         cx.executor().run_until_parked();
         let pane_after = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
@@ -9085,7 +9193,7 @@ mod tests {
         let last_as_active = format!("{}*", String::from(pane_labels[num_labels - 1]));
 
         // check labels for all split operations
-        match operation {
+        match expected_mode {
             SplitMode::EmptyPane => {
                 assert_item_labels_active_index(&pane_before, &pane_labels, num_labels - 1, cx);
                 assert_item_labels(&pane_after, [], cx);
@@ -9141,7 +9249,7 @@ mod tests {
         };
 
         // check pane axes for all operations
-        match operation {
+        match expected_mode {
             SplitMode::EmptyPane | SplitMode::ClonePane => {
                 assert_pane_ids_on_axis(&workspace, expected_ids, expected_axis, cx);
             }


### PR DESCRIPTION
# Objective

- Fix pane split actions doing nothing when a non-clonable item, such as a Markdown preview, is active.
- Make splits invoked through keyboard shortcuts and the Command Palette behave consistently with the tab-bar split button.
- Fixes #36790

## Solution

- When a clone split is requested for a non-clonable active item, move the item into the new pane if another tab can remain in the original pane.
- Preserve the existing no-op behavior when the non-clonable item is the pane's only tab.
- Keep normal clone behavior unchanged for clonable items.
- Add configurable split support to the workspace test item and cover the fallback through both direct split calls and action dispatch.

## Testing

- Added regression coverage for:
  - Moving a non-clonable active item when splitting left, right, up, or down.
  - Dispatching the default split action used by keyboard shortcuts and the Command Palette.
  - Preserving the no-op behavior for a sole non-clonable item.
- Verified formatting with `cargo fmt --all -- --check`.
- Verified that the modified files have no reported diagnostics.
- Verified diff hygiene with `git diff --check`.
- The Rust tests were not completed because the workspace test build was canceled after several minutes.
- Reviewers can test manually by:
  1. Opening a Markdown file and its preview in the same pane.
  2. Focusing the Markdown preview.
  3. Running `pane::Split Right` from the Command Palette or its keyboard shortcut.
  4. Confirming that the preview moves into the new pane while the Markdown editor remains in the original pane.
  5. Repeating for the other split directions.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
