### PR TITLE
Fix agent model and profile selection writing to settings.json

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -2444,27 +2444,6 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             }
         });
 
-        update_settings_file(
-            self.connection.0.read(cx).fs.clone(),
-            cx,
-            move |settings, cx| {
-                let provider = model.provider_id().0.to_string();
-                let model = model.id().0.to_string();
-                let enable_thinking = thread.read(cx).thinking_enabled();
-                let speed = thread.read(cx).speed();
-                settings
-                    .agent
-                    .get_or_insert_default()
-                    .set_model(LanguageModelSelection {
-                        provider: provider.into(),
-                        model,
-                        enable_thinking,
-                        effort,
-                        speed,
-                    });
-            },
-        );
-
         Task::ready(Ok(()))
     }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1370,7 +1370,6 @@ impl ConversationView {
             .map(|native_thread| {
                 cx.new(|cx| {
                     ProfileSelector::new(
-                        <dyn Fs>::global(cx),
                         Arc::new(native_thread),
                         self.focus_handle(cx),
                         cx,

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -4,14 +4,13 @@ use crate::{
 use agent_settings::{
     AgentProfile, AgentProfileId, AgentSettings, AvailableProfiles, builtin_profiles,
 };
-use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     Action, AnyElement, AnyView, App, BackgroundExecutor, Context, DismissEvent, Empty, Entity,
     FocusHandle, Focusable, ForegroundExecutor, SharedString, Subscription, Task, Window,
 };
 use picker::{Picker, PickerDelegate, popover_menu::PickerPopoverMenu};
-use settings::{Settings as _, SettingsStore, update_settings_file};
+use settings::{Settings as _, SettingsStore};
 use std::{
     sync::atomic::Ordering,
     sync::{Arc, atomic::AtomicBool},
@@ -56,7 +55,6 @@ pub trait ProfileProvider {
 pub struct ProfileSelector {
     profiles: AvailableProfiles,
     pending_refresh: bool,
-    fs: Arc<dyn Fs>,
     provider: Arc<dyn ProfileProvider>,
     picker: Option<Entity<Picker<ProfilePickerDelegate>>>,
     picker_handle: PopoverMenuHandle<Picker<ProfilePickerDelegate>>,
@@ -66,7 +64,6 @@ pub struct ProfileSelector {
 
 impl ProfileSelector {
     pub fn new(
-        fs: Arc<dyn Fs>,
         provider: Arc<dyn ProfileProvider>,
         focus_handle: FocusHandle,
         cx: &mut Context<Self>,
@@ -79,7 +76,6 @@ impl ProfileSelector {
         Self {
             profiles: AgentProfile::available_profiles(cx),
             pending_refresh: false,
-            fs,
             provider,
             picker: None,
             picker_handle: PopoverMenuHandle::default(),
@@ -128,7 +124,6 @@ impl ProfileSelector {
     ) -> Entity<Picker<ProfilePickerDelegate>> {
         if self.picker.is_none() {
             let delegate = ProfilePickerDelegate::new(
-                self.fs.clone(),
                 self.provider.clone(),
                 self.profiles.clone(),
                 cx.foreground_executor().clone(),
@@ -278,7 +273,6 @@ enum ProfilePickerEntry {
 }
 
 pub struct ProfilePickerDelegate {
-    fs: Arc<dyn Fs>,
     provider: Arc<dyn ProfileProvider>,
     foreground: ForegroundExecutor,
     background: BackgroundExecutor,
@@ -294,7 +288,6 @@ pub struct ProfilePickerDelegate {
 
 impl ProfilePickerDelegate {
     fn new(
-        fs: Arc<dyn Fs>,
         provider: Arc<dyn ProfileProvider>,
         profiles: AvailableProfiles,
         foreground: ForegroundExecutor,
@@ -307,7 +300,6 @@ impl ProfilePickerDelegate {
         let filtered_entries = Self::entries_from_candidates(&candidates);
 
         let mut this = Self {
-            fs,
             provider,
             foreground,
             background,
@@ -575,18 +567,7 @@ impl PickerDelegate for ProfilePickerDelegate {
             Some(ProfilePickerEntry::Profile(entry)) => {
                 if let Some(candidate) = self.candidates.get(entry.candidate_index) {
                     let profile_id = candidate.id.clone();
-                    let fs = self.fs.clone();
                     let provider = self.provider.clone();
-
-                    update_settings_file(fs, cx, {
-                        let profile_id = profile_id.clone();
-                        move |settings, _cx| {
-                            settings
-                                .agent
-                                .get_or_insert_default()
-                                .set_profile(profile_id.0);
-                        }
-                    });
 
                     provider.set_profile(profile_id.clone(), cx);
 
@@ -846,7 +827,6 @@ impl PickerDelegate for ProfilePickerDelegate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fs::FakeFs;
     use gpui::TestAppContext;
 
     #[gpui::test]
@@ -889,7 +869,6 @@ mod tests {
             let focus_handle = cx.focus_handle();
 
             let delegate = ProfilePickerDelegate {
-                fs: FakeFs::new(cx.background_executor().clone()),
                 provider: Arc::new(TestProfileProvider::new(AgentProfileId("write".into()))),
                 foreground: cx.foreground_executor().clone(),
                 background: cx.background_executor().clone(),
@@ -927,7 +906,6 @@ mod tests {
             let focus_handle = cx.focus_handle();
 
             let delegate = ProfilePickerDelegate {
-                fs: FakeFs::new(cx.background_executor().clone()),
                 provider: Arc::new(TestProfileProvider::new(AgentProfileId("write".into()))),
                 foreground: cx.foreground_executor().clone(),
                 background: cx.background_executor().clone(),


### PR DESCRIPTION

# Objective

Fixes #61472

Selecting a model or profile from the agent panel's dropdown UI unconditionally writes the choice into `settings.json` as `default_model` / `default_profile`. This means that picking a model for **one** conversation permanently changes the user's global default — which is not the intended behavior. The dropdown should only affect the **current thread**, not the persisted settings file.

## Solution

The root cause is two `update_settings_file()` calls that were placed alongside the correct in-memory thread state updates:

### 1. Model selection (`NativeAgentModelSelector::select_model` in `crates/agent/src/agent.rs`)

The method already correctly sets the model on the thread via `thread.set_model()`, `thread.set_thinking_effort()`, `thread.set_thinking_enabled()`, and `thread.set_speed()`. These calls update the in-memory per-thread state, which is independently serialized when the thread is saved — so re-opening a thread restores its model without needing `settings.json`.

Immediately after those correct calls, there was an `update_settings_file()` block that called `set_model()` on the settings content, which writes to `default_model` in `settings.json`. This block was the entire bug — it was removed.

### 2. Profile selection (`ProfilePickerDelegate::confirm` in `crates/agent_ui/src/profile_selector.rs`)

Same pattern. The method calls `provider.set_profile(profile_id, cx)` to set the profile in-memory for the current session. But it also had an `update_settings_file()` block that called `set_profile()` on the settings content, persisting it to `default_profile` in `settings.json`. This block was removed.

Since `update_settings_file` was the only consumer of the `fs: Arc<dyn Fs>` field in `ProfileSelector` and `ProfilePickerDelegate`, the `fs` field and its plumbing (constructor parameter, imports, test fixtures) were also cleaned up.

### What was NOT changed

- The `AgentModelSelector` in `agent_model_selector.rs` (used for the **inline assistant**) was not touched — it correctly writes to `inline_assistant_model`, which is its own distinct setting.
- Thread serialization is unaffected — threads already persist their model/profile choices in their own saved state, independent of `settings.json`.

## Testing

- **Manual testing:** Open the agent panel → select a different model from the dropdown → verify that `settings.json` is *not* modified. Open a new thread → verify it uses the original default model from settings, not the one picked in the previous thread.
- **Profile testing:** Same flow with the profile picker — switching profiles in a thread should not alter `default_profile` in `settings.json`.
- Verified that re-opening a previously saved thread still restores the per-thread model selection correctly (this is handled by thread serialization, not settings).
- Tested on **Windows**. The fix is pure Rust logic deletion with no platform-specific behavior.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards (no UI changes in this PR)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the agent model and profile selectors writing the per-thread choice to `settings.json`, unintentionally changing the user's global default.