### PR TITLE
sidebar: Add drag-and-drop project reordering

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -515,6 +515,27 @@ struct SidebarContents {
     has_open_projects: bool,
 }
 
+#[derive(Clone)]
+struct DraggedProjectGroup {
+    key: ProjectGroupKey,
+    label: SharedString,
+    index: usize,
+}
+
+impl Render for DraggedProjectGroup {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .h(Tab::content_height(cx))
+            .px_2()
+            .bg(cx.theme().colors().elevated_surface_background)
+            .border_1()
+            .border_color(cx.theme().colors().border)
+            .rounded_sm()
+            .shadow_md()
+            .child(Label::new(self.label.clone()))
+    }
+}
+
 /// Identity-and-layout key for a [`ListEntry`] used to preserve measured list items
 /// across rebuilds. Equal shapes must render to the same height; add any new
 /// height-affecting state here.
@@ -2322,6 +2343,20 @@ impl Sidebar {
 
         let key_for_toggle = key.clone();
         let key_for_focus = key.clone();
+        let drag_label = label.clone();
+        // Sticky headers are a scroll artifact rather than a real list position, and
+        // while a filter is active the visible order isn't the stored order, so a drop
+        // index would be misleading.
+        let project_group_index = (!is_sticky && !has_filter)
+            .then(|| {
+                self.multi_workspace
+                    .read_with(cx, |multi_workspace, _| {
+                        multi_workspace.reorderable_project_group_index(key)
+                    })
+                    .ok()
+                    .flatten()
+            })
+            .flatten();
 
         // The fade gradient renders as a visible patch on transparent windows,
         // so truncate the label instead.
@@ -2474,6 +2509,44 @@ impl Sidebar {
                     cx.stop_propagation();
                     menu_handle.toggle(window, cx);
                 }
+            })
+            .when_some(project_group_index, |this, target_index| {
+                let multi_workspace = self.multi_workspace.clone();
+                let target_key = key.clone();
+                let dragged = DraggedProjectGroup {
+                    key: key.clone(),
+                    label: drag_label.clone(),
+                    index: target_index,
+                };
+                this.on_drag(dragged, |dragged, _, _, cx| cx.new(|_| dragged.clone()))
+                    .drag_over::<DraggedProjectGroup>(
+                        move |header, dragged: &DraggedProjectGroup, _, cx| {
+                            if dragged.index == target_index {
+                                return header;
+                            }
+
+                            let header = header
+                                .bg(cx.theme().colors().drop_target_background)
+                                .border_0()
+                                .border_color(cx.theme().colors().drop_target_border);
+                            if dragged.index < target_index {
+                                header.border_b_2()
+                            } else {
+                                header.border_t_2()
+                            }
+                        },
+                    )
+                    .on_drop(move |dragged: &DraggedProjectGroup, _, cx| {
+                        multi_workspace
+                            .update(cx, |multi_workspace, cx| {
+                                multi_workspace.move_project_group_to(
+                                    &dragged.key,
+                                    &target_key,
+                                    cx,
+                                );
+                            })
+                            .ok();
+                    })
             })
             .on_click(
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -903,6 +903,50 @@ impl MultiWorkspace {
         true
     }
 
+    /// Returns the index of the given project group, but only when reordering is
+    /// meaningful (i.e. there is more than one group). Mirrors the gating used for
+    /// the "Move Up"/"Move Down" menu entries.
+    pub fn reorderable_project_group_index(&self, key: &ProjectGroupKey) -> Option<usize> {
+        if self.project_groups.len() < 2 {
+            return None;
+        }
+        self.project_groups
+            .iter()
+            .position(|group| group.key == *key)
+    }
+
+    pub fn move_project_group_to(
+        &mut self,
+        key: &ProjectGroupKey,
+        target: &ProjectGroupKey,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(index) = self
+            .project_groups
+            .iter()
+            .position(|group| group.key == *key)
+        else {
+            return false;
+        };
+        let Some(target_index) = self
+            .project_groups
+            .iter()
+            .position(|group| group.key == *target)
+        else {
+            return false;
+        };
+        if index == target_index {
+            return false;
+        }
+
+        let group = self.project_groups.remove(index);
+        self.project_groups.insert(target_index, group);
+        cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
+        self.serialize(cx);
+        cx.notify();
+        true
+    }
+
     pub fn workspaces_for_project_group(
         &self,
         key: &ProjectGroupKey,

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -196,6 +196,57 @@ async fn test_project_group_keys_add_workspace(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_move_project_group_to(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root_a", json!({ "file.txt": "" })).await;
+    fs.insert_tree("/root_b", json!({ "file.txt": "" })).await;
+    fs.insert_tree("/root_c", json!({ "file.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    let project_b = Project::test(fs.clone(), ["/root_b".as_ref()], cx).await;
+    let project_c = Project::test(fs, ["/root_c".as_ref()], cx).await;
+
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_a, window, cx));
+
+    multi_workspace.update(cx, |multi_workspace, cx| {
+        multi_workspace.open_sidebar(cx);
+        multi_workspace.test_add_project_group(ProjectGroup {
+            key: key_b.clone(),
+            workspaces: Vec::new(),
+            expanded: true,
+        });
+        multi_workspace.test_add_project_group(ProjectGroup {
+            key: key_c.clone(),
+            workspaces: Vec::new(),
+            expanded: true,
+        });
+    });
+
+    multi_workspace.update(cx, |multi_workspace, cx| {
+        assert!(multi_workspace.move_project_group_to(&key_a, &key_c, cx));
+        assert_eq!(
+            multi_workspace.project_group_keys(),
+            vec![key_b.clone(), key_c.clone(), key_a.clone()]
+        );
+
+        assert!(multi_workspace.move_project_group_to(&key_a, &key_b, cx));
+        assert_eq!(
+            multi_workspace.project_group_keys(),
+            vec![key_a.clone(), key_b.clone(), key_c.clone()]
+        );
+
+        assert!(!multi_workspace.move_project_group_to(&key_a, &key_a, cx));
+        let missing_key = ProjectGroupKey::new(None, PathList::new(&[path!("/missing_project")]));
+        assert!(!multi_workspace.move_project_group_to(&missing_key, &key_a, cx));
+        assert!(!multi_workspace.move_project_group_to(&key_a, &missing_key, cx));
+    });
+}
+
+#[gpui::test]
 async fn test_open_new_window_does_not_open_sidebar_on_existing_window(cx: &mut TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
# Objective

[#57448](https://github.com/zed-industries/zed/pull/57448) added "Move Up" / "Move Down" entries to the project header's ellipsis menu, and called out drag and drop as the intended next step:

> This PR adds the first step towards allowing to reorganize the threads sidebar. Drag and drop should be supported in the near future, maybe even replacing this entirely.

This PR implements that step. Reordering projects currently costs one menu open per position moved, so moving a project from the bottom of a long list to the top means repeating "Move Up" once per slot. Dragging the header does it in one gesture.

## Solution

Project headers in the sidebar are now draggable, using the same GPUI interaction pattern Zed already uses for editor tabs (`crates/workspace/src/pane.rs`) and system window tabs (`crates/platform_title_bar/src/system_window_tabs.rs`): `on_drag` with a payload that implements `Render` for the drag preview, `drag_over` for the drop affordance, and `on_drop` to commit.

**Drop affordance.** While a drag is over another header, that header paints `drop_target_background` and a 2px `drop_target_border` on the edge the dragged project will land on: bottom border when moving down, top border when moving up. This is the tab affordance rotated 90°, where `border_r_2` / `border_l_2` become `border_b_2` / `border_t_2`. The header being dragged doesn't highlight itself.

**Reordering.** `MultiWorkspace::move_project_group_to` removes the group and reinserts it at the target index, matching the semantics of GPUI's own `SystemWindowTabController::update_tab_position`. It sits directly next to `move_project_group_up` / `move_project_group_down` and follows their shape: return `false` on any lookup miss or no-op, otherwise emit `ProjectGroupsChanged`, call `serialize`, and `notify`. Persistence and refresh reuse the existing paths, so order survives restart exactly as it already does for the menu actions.

**Gating.** Dragging is enabled only when there are at least two groups, the header isn't the sticky (scrolled) header, and no filter query is active. The first condition mirrors the `show_reorder_entries` check the ellipsis menu already performs. The other two are cases where the visible row order isn't the stored order, so a drop index would be misleading. The header already drops `cursor_pointer` and its hover style while a filter is active, so this is consistent with existing behavior.

**Move Up / Move Down are unchanged.** They remain the keyboard- and screen-reader-accessible path to the same operation. The diff is purely additive (168 insertions, 0 deletions) and doesn't touch the existing menu code.

### Notes on what this deliberately doesn't add

- **No setting.** Reordering is reversible and doesn't destroy state, so gating it behind a preference adds configuration surface without protecting the user from anything.
- **No dedicated drag handle.** Zed drags tabs by the whole tab rather than by a grip affordance, and adding hover chrome to the header would compete with the disclosure triangle, the thread/notification indicators, and the ellipsis menu that already live there.
- **No cross-window or cross-list drops.** The payload type is private to the sidebar, so headers only accept other headers.

## Testing

`test_move_project_group_to` in `crates/workspace/src/multi_workspace_tests.rs` builds three project groups and covers:

- moving a group downward (A → C position) and asserting the resulting order
- moving it back upward (A → B position) and asserting the original order is restored
- dropping a group onto itself, which must return `false` and leave the order untouched
- a source key that isn't in the list, which must return `false`
- a target key that isn't in the list, which must return `false`

```
cargo test -p workspace --lib -- multi_workspace
test result: ok. 22 passed; 0 failed
```

`cargo check -p sidebar -p workspace` is clean, and `cargo fmt --check` passes. The one warning reported under `-p sidebar` is a pre-existing `falling back to f32` diagnostic in `crates/sidebar/src/thread_switcher.rs`, unrelated to this change.

Manually verified on **macOS**: dragging upward and downward across a three-project sidebar, the insertion marker matching the resulting position, dropping a header onto itself being a no-op, and the order persisting across a restart. The drag wiring is platform-independent GPUI, but I haven't exercised it on Linux or Windows.

**For reviewers:** open at least two projects so the sidebar lists more than one, then drag a project header. Worth checking that the insertion marker points the way you expect in both directions, that a self-drop does nothing, and that the order is still there after quitting and reopening.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — none added
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines) — reuses the existing `drop_target_background` / `drop_target_border` theme colors and the established tab drag affordance; no new icons or colors
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — the per-header render does an allocation-free index lookup (`reorderable_project_group_index`) rather than cloning the key list, and the drag/drop closures only run during an active drag

## Showcase

<!--
TODO before opening the PR: replace this block with a short screen recording.

What to capture (roughly 15-20 seconds):
  1. Sidebar with 3 projects, so the starting order is legible.
  2. Drag the bottom project to the top; pause mid-drag so the top border
     marker is visible in the recording.
  3. Drag it back down; pause so the bottom border marker is visible.
  4. Quit and reopen Zed to show the order persisted.

On macOS: Cmd+Shift+5 -> Record Selected Portion. Drop the .mov straight
into the GitHub comment box and GitHub will host it.
-->

---

Release Notes:

- Sidebar: Added the ability to reorder projects by dragging their headers.
