### PR TITLE
git_ui: Fix clipboard diff appending a trailing newline

### DIFF
--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -105,8 +105,15 @@ impl TextDiffView {
         let source_buffer_snapshot = source_buffer.read(cx).snapshot();
         let mut clipboard_text = diff_data.clipboard_text.clone();
 
-        if !clipboard_text.ends_with("\n") {
-            clipboard_text.push_str("\n");
+        // Only mirror a trailing newline the selection actually has: appending one
+        // unconditionally leaves a buffer without one never diffing clean.
+        let selection_ends_with_newline = source_buffer_snapshot
+            .reversed_chars_at(expanded_selection_range.end)
+            .next()
+            == Some('\n');
+
+        if selection_ends_with_newline && !clipboard_text.ends_with('\n') {
+            clipboard_text.push('\n');
         }
 
         let workspace = workspace.weak_handle();
@@ -552,6 +559,42 @@ mod tests {
             ),
             "Clipboard ↔ text.txt @ L1:1-3",
             &format!("Clipboard ↔ {} @ L1:1-3", path!("test/text.txt")),
+            cx,
+        )
+        .await;
+    }
+
+    /// Regression test for #49204.
+    #[gpui::test]
+    async fn test_diffing_identical_clipboard_against_buffer_without_trailing_newline(
+        cx: &mut TestAppContext,
+    ) {
+        base_test(
+            path!("/test"),
+            path!("/test/text.txt"),
+            "abc",
+            "ˇabc",
+            "ˇabc",
+            "Clipboard ↔ text.txt @ L1:1-4",
+            &format!("Clipboard ↔ {} @ L1:1-4", path!("test/text.txt")),
+            cx,
+        )
+        .await;
+    }
+
+    /// Counterpart to the test above: here the newline must still be appended.
+    #[gpui::test]
+    async fn test_diffing_clipboard_without_trailing_newline_against_buffer_with_one(
+        cx: &mut TestAppContext,
+    ) {
+        base_test(
+            path!("/test"),
+            path!("/test/text.txt"),
+            "abc",
+            "ˇabc\n",
+            "ˇabc\n",
+            "Clipboard ↔ text.txt @ L1:1-L2:1",
+            &format!("Clipboard ↔ {} @ L1:1-L2:1", path!("test/text.txt")),
             cx,
         )
         .await;


### PR DESCRIPTION
# Objective

Fixes #49204

`editor: diff clipboard with selection` always appends a trailing newline to the clipboard text before diffing. When the buffer you are diffing against does not end in a newline, the source side has no newline to match, so the last line always shows as changed. When copying a buffer and diffing it against itself it still reports a difference.

## Solution

Selections are expanded to whole lines, so the range being replaced normally ends with `\n`. Without a matching newline on the clipboard side, the last selected line would run into the line after it and the diff would be wrong.

The problem is that the append was unconditional. When the selection reaches the end of a buffer with no trailing newline (either an empty selection, which uses the whole buffer, or a selection on the last line) the replaced range does not end with `\n` either, so adding one to the clipboard side invents a difference that is not there

Now the newline is only added when the source selection actually ends with one. I read the character immediately before the end of the range with `reversed_chars_at`, so this does not walk the selected text.

The unconditional append came in with #34999, which added the line extension. This matches the diagnosis @lingyaochu posted on the issue: when the selection already includes the last line there is no next line to extend into, so the selection gains no `\n` while the clipboard side still gets one.

The thread also discusses the selection moving after the command runs, which comes from the same line extension. That is a separate behaviour and I have not touched it here.

## Testing

Added two tests:

- Identical content with no trailing newline, expecting a clean diff. This fails on `main` with a phantom `- abc` / `+ abc` hunk.
- Clipboard without a trailing newline against a buffer that has one, which is the case where the newline must still be appended.

The second covers a case none of the existing tests did, so the append path had no coverage before.

- `cargo test -p git_ui`: 153 passed on Linux (x86_64) and on macOS (aarch64)
- `./script/clippy`: clean
- `cargo fmt --all -- --check`: clean

I also ran the repro from the issue in a real build on Linux. I have not verified on Windows.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Diffing a file with no trailing newline against an identical clipboard.

Before:
<img width="976" height="652" alt="1-BEFORE" src="https://github.com/user-attachments/assets/4637e934-681f-4e9c-974c-83da555fd0d8" />

After:
<img width="854" height="710" alt="2-AFTER" src="https://github.com/user-attachments/assets/fccfde7c-fe64-4e65-abb4-c26a74370731" />

---

Release Notes:

- Fixed `editor: diff clipboard with selection` adding a trailing newline to the clipboard content
