### PR TITLE
gpui_wgpu: Fix bidi paragraph shaping crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8058,6 +8058,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "swash",
+ "unicode-bidi",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -857,6 +857,10 @@ tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"
 unicase = "2.6"
+# Features match `cosmic-text`'s selection so the two unify to one build.
+unicode-bidi = { version = "0.3.18", default-features = false, features = [
+    "hardcoded-data",
+] }
 unicode-script = "0.5.7"
 unicode-segmentation = "1.10"
 unicode-width = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -857,7 +857,6 @@ tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"
 unicase = "2.6"
-# Features match `cosmic-text`'s selection so the two unify to one build.
 unicode-bidi = { version = "0.3.18", default-features = false, features = [
     "hardcoded-data",
 ] }

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -29,6 +29,7 @@ profiling.workspace = true
 raw-window-handle.workspace = true
 smallvec.workspace = true
 swash.workspace = true
+unicode-bidi.workspace = true
 unicode-segmentation.workspace = true
 gpui_util.workspace = true
 wgpu.workspace = true

--- a/crates/gpui_wgpu/benches/layout_line.rs
+++ b/crates/gpui_wgpu/benches/layout_line.rs
@@ -56,6 +56,10 @@ fn bench_layout_line(c: &mut Criterion) {
 
     let text = code_text();
 
+    // Same text, but with a bidi paragraph separator (U+001C) and RTL content
+    // forcing the per-paragraph shaping path.
+    let text_mixed_direction = text.clone() + "\u{001c}\u{05d0}\u{05d1}";
+
     let runs_no_fallback = vec![FontRun {
         len: text.len(),
         font_id: font_id_no_fallback,
@@ -63,6 +67,10 @@ fn bench_layout_line(c: &mut Criterion) {
     let runs_with_fallback = vec![FontRun {
         len: text.len(),
         font_id: font_id_with_fallback,
+    }];
+    let runs_mixed_direction = vec![FontRun {
+        len: text_mixed_direction.len(),
+        font_id: font_id_no_fallback,
     }];
 
     let mut group = c.benchmark_group("layout_line");
@@ -73,6 +81,10 @@ fn bench_layout_line(c: &mut Criterion) {
 
     group.bench_function("with_fallback_ascii", |b| {
         b.iter(|| system.layout_line(&text, px(14.0), &runs_with_fallback))
+    });
+
+    group.bench_function("mixed_direction_paragraphs", |b| {
+        b.iter(|| system.layout_line(&text_mixed_direction, px(14.0), &runs_mixed_direction))
     });
 
     group.finish();

--- a/crates/gpui_wgpu/benches/layout_line.rs
+++ b/crates/gpui_wgpu/benches/layout_line.rs
@@ -7,7 +7,12 @@ const LILEX: &[u8] = include_bytes!("../../../assets/fonts/lilex/Lilex-Regular.t
 const IBM_PLEX: &[u8] =
     include_bytes!("../../../assets/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf");
 
-// ~4 000 chars of typical ASCII code text.
+// ~4 000 chars of typical ASCII code text, as a single display line.
+//
+// `layout_line` is handed one line at a time, already split on `\n` by its
+// callers, so the newlines are replaced rather than kept: leaving them in would
+// make this measure the multi-paragraph path instead of the common one, since
+// `\n` is itself a bidi paragraph separator.
 fn code_text() -> String {
     concat!(
         "    fn compute_run_spans(\n",
@@ -38,6 +43,7 @@ fn code_text() -> String {
         "    }\n",
     )
     .repeat(8) // ~3 800 chars
+    .replace('\n', " ")
 }
 
 fn bench_layout_line(c: &mut Criterion) {
@@ -59,6 +65,10 @@ fn bench_layout_line(c: &mut Criterion) {
     // Same text, but with a bidi paragraph separator (U+001C) and RTL content
     // forcing the per-paragraph shaping path.
     let text_mixed_direction = text.clone() + "\u{001c}\u{05d0}\u{05d1}";
+    assert!(
+        !text.contains('\n'),
+        "fast-path corpus must contain no separator"
+    );
 
     let runs_no_fallback = vec![FontRun {
         len: text.len(),

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -14,7 +14,7 @@ use gpui::{
 use itertools::Itertools;
 use parking_lot::RwLock;
 use smallvec::SmallVec;
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, ops::Range, sync::Arc};
 use swash::{
     scale::{Render, ScaleContext, Source, StrikeWith},
     zeno::{Format, Vector},
@@ -454,6 +454,117 @@ impl CosmicTextSystemState {
 
     #[profiling::function]
     fn layout_line(&mut self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
+        // `ShapeLine` panics when the text it is given resolves to multiple bidi
+        // paragraphs that do not share a base direction, so a line containing a
+        // paragraph separator is shaped one paragraph at a time. Lines without one
+        // - virtually all of them - take the single-pass path unchanged.
+        if contains_paragraph_separator(text) {
+            self.layout_line_with_separators(text, font_size, font_runs)
+        } else {
+            self.layout_line_no_separators(text, font_size, font_runs)
+        }
+    }
+
+    /// Shapes each bidi paragraph of `text` separately and places them
+    /// left-to-right in logical order. Paragraph separators are shaped as their
+    /// own slices so every byte of `text` is still covered by a glyph, which
+    /// keeps byte offsets and hit testing exact.
+    fn layout_line_with_separators(
+        &mut self,
+        text: &str,
+        font_size: Pixels,
+        font_runs: &[FontRun],
+    ) -> LineLayout {
+        let mut runs = Vec::new();
+        let mut line = Segment::default();
+        let mut paragraph_start = 0;
+
+        for (separator_start, separator) in text
+            .char_indices()
+            .filter(|(_, character)| is_paragraph_separator(*character))
+        {
+            let separator_end = separator_start + separator.len_utf8();
+            self.shape_segment(
+                text,
+                paragraph_start..separator_start,
+                font_size,
+                font_runs,
+                &mut runs,
+                &mut line,
+            );
+            self.shape_segment(
+                text,
+                separator_start..separator_end,
+                font_size,
+                font_runs,
+                &mut runs,
+                &mut line,
+            );
+            paragraph_start = separator_end;
+        }
+
+        self.shape_segment(
+            text,
+            paragraph_start..text.len(),
+            font_size,
+            font_runs,
+            &mut runs,
+            &mut line,
+        );
+
+        LineLayout {
+            font_size,
+            width: line.width,
+            ascent: line.ascent,
+            descent: line.descent,
+            runs,
+            len: text.len(),
+        }
+    }
+
+    /// Shapes `text[range]` and appends it to `runs` at the width accumulated so
+    /// far, growing `line` to cover the new segment.
+    fn shape_segment(
+        &mut self,
+        text: &str,
+        range: Range<usize>,
+        font_size: Pixels,
+        font_runs: &[FontRun],
+        runs: &mut Vec<ShapedRun>,
+        line: &mut Segment,
+    ) {
+        if range.is_empty() {
+            return;
+        }
+
+        let segment_runs = clip_font_runs(font_runs, range.clone());
+        let segment =
+            self.layout_line_no_separators(&text[range.clone()], font_size, &segment_runs);
+
+        for mut run in segment.runs {
+            for glyph in &mut run.glyphs {
+                glyph.index += range.start;
+                glyph.position.x += line.width;
+            }
+
+            // Keep runs coalesced across the segment boundary.
+            match runs.last_mut().filter(|last| last.font_id == run.font_id) {
+                Some(last) => last.glyphs.append(&mut run.glyphs),
+                None => runs.push(run),
+            }
+        }
+
+        line.width += segment.width;
+        line.ascent = line.ascent.max(segment.ascent);
+        line.descent = line.descent.max(segment.descent);
+    }
+
+    fn layout_line_no_separators(
+        &mut self,
+        text: &str,
+        font_size: Pixels,
+        font_runs: &[FontRun],
+    ) -> LineLayout {
         let mut attrs_list = AttrsList::new(&Attrs::new());
         let mut offs = 0;
         for run in font_runs {
@@ -617,6 +728,69 @@ impl CosmicTextSystemState {
             len: text.len(),
         }
     }
+}
+
+/// Width and vertical metrics of a shaped span of text: one paragraph or
+/// separator on its own, or a whole line once its segments are accumulated.
+#[derive(Default)]
+struct Segment {
+    width: Pixels,
+    ascent: Pixels,
+    descent: Pixels,
+}
+
+/// `true` for code points of Unicode `Bidi_Class=B`.
+///
+/// [`unicode_bidi::BidiInfo`] begins a new paragraph at each of these, and
+/// [`ShapeLine`] asserts that every paragraph in the text it is given resolves to
+/// the same base direction. Splitting on exactly this predicate is what keeps
+/// that assertion satisfiable, so it is derived from the same crate `cosmic-text`
+/// uses rather than from a hand-written list.
+#[inline(always)]
+fn is_paragraph_separator(character: char) -> bool {
+    unicode_bidi::bidi_class(character) == unicode_bidi::BidiClass::B
+}
+
+/// `true` when `text` holds a code point that would start a new bidi paragraph.
+///
+/// The ASCII separators are found with a byte scan, because a byte below `0x80`
+/// is always a standalone code point in UTF-8 and so cannot be matched inside a
+/// multi-byte sequence. That keeps the overwhelmingly common all-ASCII line off
+/// the per-character `bidi_class` table lookup.
+fn contains_paragraph_separator(text: &str) -> bool {
+    if text
+        .bytes()
+        .any(|byte| matches!(byte, b'\n' | b'\r' | 0x1c | 0x1d | 0x1e))
+    {
+        return true;
+    }
+
+    !text.is_ascii() && text.chars().any(is_paragraph_separator)
+}
+
+/// Restricts `font_runs` to `range`, returning runs relative to `range.start`.
+fn clip_font_runs(font_runs: &[FontRun], range: Range<usize>) -> SmallVec<[FontRun; 4]> {
+    let mut clipped = SmallVec::new();
+    let mut offs = 0;
+    for run in font_runs {
+        let run_start = offs;
+        offs += run.len;
+        if offs <= range.start {
+            continue;
+        }
+        if run_start >= range.end {
+            break;
+        }
+        let start = run_start.max(range.start);
+        let end = offs.min(range.end);
+        if start < end {
+            clipped.push(FontRun {
+                len: end - start,
+                font_id: run.font_id,
+            });
+        }
+    }
+    clipped
 }
 
 #[cfg(feature = "font-kit")]
@@ -883,6 +1057,223 @@ mod tests {
             slot,
             font_id,
         }
+    }
+
+    const IBM_PLEX: &[u8] =
+        include_bytes!("../../../assets/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf");
+
+    /// Every code point of `Bidi_Class=B`, each of which starts a new bidi
+    /// paragraph and so can split one line into mixed-direction paragraphs.
+    const SEPARATORS: &[char] = &[
+        '\u{000a}', '\u{000d}', '\u{001c}', '\u{001d}', '\u{001e}', '\u{0085}', '\u{2029}',
+    ];
+
+    fn text_system() -> Result<CosmicTextSystem> {
+        let text_system = CosmicTextSystem::new_without_system_fonts("IBM Plex Sans");
+        text_system.add_fonts(vec![Cow::Borrowed(IBM_PLEX)])?;
+        Ok(text_system)
+    }
+
+    fn layout_text(text_system: &CosmicTextSystem, text: &str) -> Result<LineLayout> {
+        let font_id = text_system.font_id(&gpui::font("IBM Plex Sans"))?;
+        let runs = [FontRun {
+            len: text.len(),
+            font_id,
+        }];
+        Ok(text_system.layout_line(text, gpui::px(14.0), &runs))
+    }
+
+    /// Mirrors the original crash: mixed-direction text reaching the shaper
+    /// through `shape_text`, which only splits lines on `\n`.
+    #[test]
+    fn shape_text_with_mixed_direction_paragraphs() -> Result<()> {
+        let platform_text_system = Arc::new(text_system()?);
+        let text_system = Arc::new(gpui::TextSystem::new(platform_text_system));
+        let window_text_system = gpui::WindowTextSystem::new(text_system);
+
+        let text: SharedString = "first line\n\u{05d0}\u{001c}A".into();
+        let runs = [gpui::TextRun {
+            len: text.len(),
+            font: gpui::font("IBM Plex Sans"),
+            ..Default::default()
+        }];
+
+        let lines = window_text_system.shape_text(text, gpui::px(14.0), &runs, None, None)?;
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[1].len(), "\u{05d0}\u{001c}A".len());
+        assert!(lines[1].width() > Pixels::ZERO);
+        Ok(())
+    }
+
+    #[test]
+    fn layout_line_with_mixed_direction_paragraphs() -> Result<()> {
+        let text_system = text_system()?;
+
+        for separator in SEPARATORS {
+            for text in [
+                format!("\u{05d0}{separator}A"),
+                format!("A{separator}\u{05d0}"),
+            ] {
+                let layout = layout_text(&text_system, &text)?;
+
+                assert_eq!(layout.len, text.len(), "{text:?}");
+                assert!(layout.width > Pixels::ZERO, "{text:?}");
+                assert!(
+                    layout.runs.iter().any(|run| !run.glyphs.is_empty()),
+                    "{text:?}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn layout_line_with_separators_at_line_edges() -> Result<()> {
+        let text_system = text_system()?;
+
+        for text in [
+            "\u{001c}",
+            "\u{001c}\u{001c}",
+            "\u{001c}\u{05d0}",
+            "\u{05d0}\u{001c}",
+            "\u{05d0}\u{001c}\u{001c}A",
+            "\u{001c}\u{05d0}\u{001c}A\u{001c}",
+        ] {
+            let layout = layout_text(&text_system, text)?;
+            assert_eq!(layout.len, text.len(), "{text:?}");
+        }
+
+        Ok(())
+    }
+
+    /// Glyph indices must stay absolute and positions ordered across segment
+    /// boundaries, otherwise cursor placement and hit testing desync. Uses
+    /// single-direction text so visual order matches logical order.
+    #[test]
+    fn layout_line_keeps_indices_and_positions_ordered_across_paragraphs() -> Result<()> {
+        let text_system = text_system()?;
+        let text = "ab\u{001c}cd\u{2029}ef";
+        let layout = layout_text(&text_system, text)?;
+
+        let glyphs: Vec<_> = layout.runs.iter().flat_map(|run| &run.glyphs).collect();
+        assert!(!glyphs.is_empty());
+
+        for glyph in &glyphs {
+            assert!(glyph.index < text.len(), "{:?}", glyph.index);
+            assert!(text.is_char_boundary(glyph.index), "{:?}", glyph.index);
+        }
+        for pair in glyphs.windows(2) {
+            assert!(pair[0].index < pair[1].index);
+            assert!(pair[0].position.x <= pair[1].position.x);
+        }
+
+        // Every segment contributes width, so the whole line is wider than its
+        // leading paragraph alone.
+        assert!(layout.width > layout_text(&text_system, "ab")?.width);
+        Ok(())
+    }
+
+    /// A font run boundary that does not line up with a paragraph boundary must
+    /// still be clipped to the right segments.
+    #[test]
+    fn layout_line_with_font_run_straddling_a_separator() -> Result<()> {
+        let text_system = text_system()?;
+        let font_id = text_system.font_id(&gpui::font("IBM Plex Sans"))?;
+        let text = "ab\u{001c}\u{05d0}\u{05d1}";
+
+        // The run boundary falls inside the trailing RTL paragraph.
+        let runs = [
+            FontRun {
+                len: "ab\u{001c}\u{05d0}".len(),
+                font_id,
+            },
+            FontRun {
+                len: "\u{05d1}".len(),
+                font_id,
+            },
+        ];
+        let layout = text_system.layout_line(text, gpui::px(14.0), &runs);
+
+        assert_eq!(layout.len, text.len());
+        assert!(layout.width > Pixels::ZERO);
+        Ok(())
+    }
+
+    /// Lines with no separator take the fast path and must be shaped exactly as
+    /// they were before paragraph splitting existed.
+    #[test]
+    fn layout_line_without_separators_takes_fast_path() -> Result<()> {
+        let text_system = text_system()?;
+
+        for text in [
+            "hello world",
+            "\u{05d0}\u{05d1}\u{05d2}",
+            "mixed \u{05d0}\u{05d1}",
+        ] {
+            assert!(!contains_paragraph_separator(text), "{text:?}");
+            let layout = layout_text(&text_system, text)?;
+            assert_eq!(layout.len, text.len(), "{text:?}");
+            assert!(layout.width > Pixels::ZERO, "{text:?}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn paragraph_separator_detection() {
+        for separator in SEPARATORS {
+            assert!(is_paragraph_separator(*separator), "{separator:?}");
+            assert!(contains_paragraph_separator(&format!("a{separator}b")));
+        }
+
+        for text in [
+            "",
+            "plain ascii",
+            "\u{05d0}",
+            "tab\there",
+            "emoji \u{1f600}",
+        ] {
+            assert!(!contains_paragraph_separator(text), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn font_runs_are_clipped_to_segment() {
+        let runs = [
+            FontRun {
+                len: 3,
+                font_id: fid(1),
+            },
+            FontRun {
+                len: 4,
+                font_id: fid(2),
+            },
+        ];
+
+        assert_eq!(clip_font_runs(&runs, 0..7).as_slice(), &runs);
+        assert_eq!(
+            clip_font_runs(&runs, 2..5).as_slice(),
+            &[
+                FontRun {
+                    len: 1,
+                    font_id: fid(1)
+                },
+                FontRun {
+                    len: 2,
+                    font_id: fid(2)
+                },
+            ]
+        );
+        assert_eq!(
+            clip_font_runs(&runs, 3..7).as_slice(),
+            &[FontRun {
+                len: 4,
+                font_id: fid(2)
+            }]
+        );
+        assert!(clip_font_runs(&runs, 5..5).is_empty());
     }
 
     #[test]

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -454,10 +454,6 @@ impl CosmicTextSystemState {
 
     #[profiling::function]
     fn layout_line(&mut self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
-        // `ShapeLine` panics when the text it is given resolves to multiple bidi
-        // paragraphs that do not share a base direction, so a line containing a
-        // paragraph separator is shaped one paragraph at a time. Lines without one
-        // - virtually all of them - take the single-pass path unchanged.
         if contains_paragraph_separator(text) {
             self.layout_line_with_separators(text, font_size, font_runs)
         } else {
@@ -465,18 +461,17 @@ impl CosmicTextSystemState {
         }
     }
 
-    /// Shapes each bidi paragraph of `text` separately and places them
-    /// left-to-right in logical order. Paragraph separators are shaped as their
-    /// own slices so every byte of `text` is still covered by a glyph, which
-    /// keeps byte offsets and hit testing exact.
     fn layout_line_with_separators(
         &mut self,
         text: &str,
         font_size: Pixels,
         font_runs: &[FontRun],
     ) -> LineLayout {
-        let mut runs = Vec::new();
-        let mut line = Segment::default();
+        let mut layout = LineLayout {
+            font_size,
+            len: text.len(),
+            ..Default::default()
+        };
         let mut paragraph_start = 0;
 
         for (separator_start, separator) in text
@@ -489,16 +484,14 @@ impl CosmicTextSystemState {
                 paragraph_start..separator_start,
                 font_size,
                 font_runs,
-                &mut runs,
-                &mut line,
+                &mut layout,
             );
             self.shape_segment(
                 text,
                 separator_start..separator_end,
                 font_size,
                 font_runs,
-                &mut runs,
-                &mut line,
+                &mut layout,
             );
             paragraph_start = separator_end;
         }
@@ -508,30 +501,19 @@ impl CosmicTextSystemState {
             paragraph_start..text.len(),
             font_size,
             font_runs,
-            &mut runs,
-            &mut line,
+            &mut layout,
         );
 
-        LineLayout {
-            font_size,
-            width: line.width,
-            ascent: line.ascent,
-            descent: line.descent,
-            runs,
-            len: text.len(),
-        }
+        layout
     }
 
-    /// Shapes `text[range]` and appends it to `runs` at the width accumulated so
-    /// far, growing `line` to cover the new segment.
     fn shape_segment(
         &mut self,
         text: &str,
         range: Range<usize>,
         font_size: Pixels,
         font_runs: &[FontRun],
-        runs: &mut Vec<ShapedRun>,
-        line: &mut Segment,
+        layout: &mut LineLayout,
     ) {
         if range.is_empty() {
             return;
@@ -544,19 +526,22 @@ impl CosmicTextSystemState {
         for mut run in segment.runs {
             for glyph in &mut run.glyphs {
                 glyph.index += range.start;
-                glyph.position.x += line.width;
+                glyph.position.x += layout.width;
             }
 
-            // Keep runs coalesced across the segment boundary.
-            match runs.last_mut().filter(|last| last.font_id == run.font_id) {
+            match layout
+                .runs
+                .last_mut()
+                .filter(|last| last.font_id == run.font_id)
+            {
                 Some(last) => last.glyphs.append(&mut run.glyphs),
-                None => runs.push(run),
+                None => layout.runs.push(run),
             }
         }
 
-        line.width += segment.width;
-        line.ascent = line.ascent.max(segment.ascent);
-        line.descent = line.descent.max(segment.descent);
+        layout.width += segment.width;
+        layout.ascent = layout.ascent.max(segment.ascent);
+        layout.descent = layout.descent.max(segment.descent);
     }
 
     fn layout_line_no_separators(
@@ -730,33 +715,11 @@ impl CosmicTextSystemState {
     }
 }
 
-/// Width and vertical metrics of a shaped span of text: one paragraph or
-/// separator on its own, or a whole line once its segments are accumulated.
-#[derive(Default)]
-struct Segment {
-    width: Pixels,
-    ascent: Pixels,
-    descent: Pixels,
-}
-
-/// `true` for code points of Unicode `Bidi_Class=B`.
-///
-/// [`unicode_bidi::BidiInfo`] begins a new paragraph at each of these, and
-/// [`ShapeLine`] asserts that every paragraph in the text it is given resolves to
-/// the same base direction. Splitting on exactly this predicate is what keeps
-/// that assertion satisfiable, so it is derived from the same crate `cosmic-text`
-/// uses rather than from a hand-written list.
 #[inline(always)]
 fn is_paragraph_separator(character: char) -> bool {
     unicode_bidi::bidi_class(character) == unicode_bidi::BidiClass::B
 }
 
-/// `true` when `text` holds a code point that would start a new bidi paragraph.
-///
-/// The ASCII separators are found with a byte scan, because a byte below `0x80`
-/// is always a standalone code point in UTF-8 and so cannot be matched inside a
-/// multi-byte sequence. That keeps the overwhelmingly common all-ASCII line off
-/// the per-character `bidi_class` table lookup.
 fn contains_paragraph_separator(text: &str) -> bool {
     if text
         .bytes()
@@ -768,7 +731,6 @@ fn contains_paragraph_separator(text: &str) -> bool {
     !text.is_ascii() && text.chars().any(is_paragraph_separator)
 }
 
-/// Restricts `font_runs` to `range`, returning runs relative to `range.start`.
 fn clip_font_runs(font_runs: &[FontRun], range: Range<usize>) -> SmallVec<[FontRun; 4]> {
     let mut clipped = SmallVec::new();
     let mut offs = 0;

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -523,7 +523,7 @@ impl CosmicTextSystemState {
         let segment =
             self.layout_line_no_separators(&text[range.clone()], font_size, &segment_font_runs);
 
-        let mut segment_runs = segment.runs.clone();
+        let mut segment_runs = segment.runs;
         for run in &mut segment_runs {
             for glyph in &mut run.glyphs {
                 glyph.index += range.start;

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -519,23 +519,27 @@ impl CosmicTextSystemState {
             return;
         }
 
-        let segment_runs = clip_font_runs(font_runs, range.clone());
+        let segment_font_runs = clip_font_runs(font_runs, range.clone());
         let segment =
-            self.layout_line_no_separators(&text[range.clone()], font_size, &segment_runs);
+            self.layout_line_no_separators(&text[range.clone()], font_size, &segment_font_runs);
 
-        for mut run in segment.runs {
+        let mut segment_runs = segment.runs.clone();
+        for run in &mut segment_runs {
             for glyph in &mut run.glyphs {
                 glyph.index += range.start;
                 glyph.position.x += layout.width;
             }
+        }
 
-            match layout
+        for mut run in segment_runs {
+            if let Some(same_run) = layout
                 .runs
                 .last_mut()
                 .filter(|last| last.font_id == run.font_id)
             {
-                Some(last) => last.glyphs.append(&mut run.glyphs),
-                None => layout.runs.push(run),
+                same_run.glyphs.append(&mut run.glyphs);
+            } else {
+                layout.runs.push(run);
             }
         }
 


### PR DESCRIPTION
Closes FR-133

`cosmic-text`'s BiDi line shaping machinery (`ShapeLine::new`) asserts that every BiDi paragraph is following the same direction. It turns out that our `gpui_wgpu` line shaping adapter would not account for that leading to panics if text contained multiple BiDi paragraphs with multiple directions. Not super common but worth fixing as the fix is not super complicated. At the same time, I'd like to point out that there is a patch submitted to `cosmic-text` that redoes shaping logic so that this is no longer illegal: https://github.com/pop-os/cosmic-text/pull/508 If it gets accepted, we can revert this fix.

Release Notes:
- Fixed panic in `gpui_wgpu` if text contained multiple BiDi paragraphs with mismatched directions.