### PR TITLE
language: Fix JSX comment toggling on the outermost element

### DIFF
--- a/crates/grammars/src/javascript/overrides.scm
+++ b/crates/grammars/src/javascript/overrides.scm
@@ -5,7 +5,7 @@
 (template_string
   (string_fragment) @string)
 
-(jsx_element) @element
+(jsx_element) @element.inclusive_start
 
 [
   (jsx_opening_element)

--- a/crates/grammars/src/tsx/overrides.scm
+++ b/crates/grammars/src/tsx/overrides.scm
@@ -5,7 +5,7 @@
 (template_string
   (string_fragment) @string)
 
-(jsx_element) @element
+(jsx_element) @element.inclusive_start
 
 [
   (jsx_opening_element)

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2767,7 +2767,7 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
         )
         .with_override_query(
             r#"
-                (jsx_element) @element
+                (jsx_element) @element.inclusive_start
                 (string) @string
                 (comment) @comment.inclusive
                 [
@@ -2849,6 +2849,36 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
         assert_eq!(
             element_config.brackets().map(|e| e.1).collect::<Vec<_>>(),
             &[true, true]
+        );
+
+        // On the outermost element's opening `<`: use the `element` override.
+        // The offset equals the `jsx_element` node's start, which a strict
+        // containment check skips, falling back to line comments.
+        let outer_element_config = snapshot
+            .language_scope_at(text.find("<C").unwrap())
+            .unwrap();
+        assert_eq!(
+            outer_element_config.line_comment_prefixes(),
+            &[] as &[Arc<str>]
+        );
+        assert_eq!(
+            outer_element_config.block_comment(),
+            Some(&BlockCommentConfig {
+                start: "{/*".into(),
+                prefix: "".into(),
+                end: "*/}".into(),
+                tab_size: 0,
+            })
+        );
+
+        // Just past the element's closing `>` (the `;`): keep the default
+        // config, not the `element` override.
+        let after_element_config = snapshot
+            .language_scope_at(text.find("</C>;").unwrap() + "</C>".len())
+            .unwrap();
+        assert_eq!(
+            after_element_config.line_comment_prefixes(),
+            &[Arc::from("// ")]
         );
 
         // Within a JSX tag: use the default config.

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1876,6 +1876,10 @@ impl<'a> SyntaxLayer<'a> {
                     if offset < range.start || offset > range.end {
                         continue;
                     }
+                } else if override_entry.range_start_is_inclusive {
+                    if offset < range.start || offset >= range.end {
+                        continue;
+                    }
                 } else if offset <= range.start || offset >= range.end {
                     continue;
                 }

--- a/crates/language_core/src/grammar.rs
+++ b/crates/language_core/src/grammar.rs
@@ -166,6 +166,7 @@ pub struct OverrideConfig {
 pub struct OverrideEntry {
     pub name: String,
     pub range_is_inclusive: bool,
+    pub range_start_is_inclusive: bool,
     pub value: LanguageConfigOverride,
 }
 
@@ -679,10 +680,14 @@ impl Grammar {
         let mut override_configs_by_id = HashMap::default();
         for (ix, mut name) in query.capture_names().iter().copied().enumerate() {
             let mut range_is_inclusive = false;
+            let mut range_start_is_inclusive = false;
             if name.starts_with('_') {
                 continue;
             }
-            if let Some(prefix) = name.strip_suffix(".inclusive") {
+            if let Some(prefix) = name.strip_suffix(".inclusive_start") {
+                name = prefix;
+                range_start_is_inclusive = true;
+            } else if let Some(prefix) = name.strip_suffix(".inclusive") {
                 name = prefix;
                 range_is_inclusive = true;
             }
@@ -701,6 +706,7 @@ impl Grammar {
                 OverrideEntry {
                     name: name.to_string(),
                     range_is_inclusive,
+                    range_start_is_inclusive,
                     value,
                 },
             );

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -294,6 +294,12 @@ For example, in JavaScript, we also disable auto-closing of single quotes within
 (comment) @comment.inclusive
 ```
 
+If you only want the range to be inclusive at its start, use the `.inclusive_start` suffix instead. This makes a scope take effect when the cursor sits on the node's first character while keeping the end exclusive. JSX uses it so that toggling comments on an element's opening `<` picks the `element` scope, without the scope leaking onto the token right after the element's end:
+
+```scheme
+(jsx_element) @element.inclusive_start
+```
+
 ### Text objects
 
 The `textobjects.scm` file defines rules for navigating by text objects. This was added in Zed v0.165 and is currently used only in Vim mode.


### PR DESCRIPTION
# Objective

Fixes #61197

`ctrl+/` on the outermost JSX element gave you `//` instead of `{/* */}`, which breaks the JSX. Select the whole element and every line gets a `//`. Nested elements were fine, which was the giveaway.

## Solution

`override_id` uses strict containment, so on the outermost element the cursor sits exactly on the `jsx_element` node's start, the `@element` override gets skipped, and you fall back to line comments. Nested elements only worked because a parent `jsx_element` wrapped them.

Added an `.inclusive_start` capture suffix (start inclusive, end exclusive) and used it for `(jsx_element)` in the tsx and javascript queries. Plain `.inclusive` doesn't work, it also grabs the element's end, so the `;` right after `</div>` starts getting JSX comments too.

Left out on purpose: the issue's second case (once you comment the closing tag the JSX won't parse, so there's no node left to match), and outermost self-closing `<Foo />` (its inside is JS by design, so `@element` would break editing attributes).

## Testing

Added assertions to `test_language_scope_at_with_javascript` for the opening `<` and the spot just past the closing tag. `cargo test -p language` passes, and they fail on `main` without the fix.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed JSX/TSX comment toggling inserting `//` on the outermost element instead of `{/* */}`
