### PR TITLE
language: Fix multi-cursor indentation cascade on block openers

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2094,6 +2094,13 @@ impl Buffer {
                     row_ranges.push((new_row..new_end_row, entry.original_indent_column));
                 }
 
+                // Rows of existing lines that this batch edited in place (one per
+                // cursor in a multi-cursor edit). A line's indentation must not be
+                // driven by a sibling in this set, otherwise typing a block opener
+                // like `:` at the end of every line makes each line indent into the
+                // one above it.
+                let edited_rows: HashSet<u32> = old_to_new_rows.values().copied().collect();
+
                 // Build a map containing the suggested indentation for each of the edited lines
                 // with respect to the state of the buffer before these edits. This map is keyed
                 // by the rows for these lines in the current state of the buffer.
@@ -2174,12 +2181,17 @@ impl Buffer {
                                 })
                                 .with_delta(suggestion.delta, language_indent_size);
 
-                            if old_suggestions.get(&new_row).is_none_or(
-                                |(old_indentation, was_within_error)| {
-                                    suggested_indent != *old_indentation
-                                        && (!suggestion.within_error || *was_within_error)
-                                },
-                            ) {
+                            let induced_by_edited_sibling = suggestion.basis_row != new_row
+                                && edited_rows.contains(&suggestion.basis_row);
+
+                            if !induced_by_edited_sibling
+                                && old_suggestions.get(&new_row).is_none_or(
+                                    |(old_indentation, was_within_error)| {
+                                        suggested_indent != *old_indentation
+                                            && (!suggestion.within_error || *was_within_error)
+                                    },
+                                )
+                            {
                                 indent_sizes.insert(
                                     new_row,
                                     (suggested_indent, request.ignore_empty_lines),

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2931,6 +2931,48 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_python_autoindent_multi_cursor_colon(cx: &mut TestAppContext) {
+        cx.executor().set_block_on_ticks(usize::MAX..=usize::MAX);
+        let language = crate::language("python", tree_sitter_python::LANGUAGE.into());
+        cx.update(|cx| {
+            let test_settings = SettingsStore::test(cx);
+            cx.set_global(test_settings);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |s| {
+                    s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
+                });
+            });
+        });
+
+        cx.new(|cx| {
+            let mut buffer = Buffer::local("a\nb\nc", cx).with_language(language, cx);
+
+            // A cursor at the end of every line types `:` at once. Each `:` opens
+            // a block, but the line below is a sibling being edited in the same
+            // batch, so it should not be pulled into the block above it.
+            buffer.edit(
+                [(1..1, ":"), (3..3, ":"), (5..5, ":")],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(buffer.text(), "a:\nb:\nc:");
+
+            // The guard only ignores edited siblings, not real parents: both lines
+            // keep their existing indent under `def f():`, and still don't cascade
+            // into each other.
+            buffer.edit([(0..buffer.len(), "def f():\n  a\n  b")], None, cx);
+            buffer.edit(
+                [(12..12, ":"), (16..16, ":")],
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
+            assert_eq!(buffer.text(), "def f():\n  a:\n  b:");
+
+            buffer
+        });
+    }
+
+    #[gpui::test]
     async fn test_python_autoindent(cx: &mut TestAppContext) {
         cx.executor().set_block_on_ticks(usize::MAX..=usize::MAX);
         let language = crate::language("python", tree_sitter_python::LANGUAGE.into());


### PR DESCRIPTION
# Objective

Fixes #59771

Drop a cursor at the end of a few Python lines, type `:`, and each line indents into the one above:

```
a:
  b:
    c:
```

## Solution

In `Buffer::compute_autoindents` a line's new indent chains off its `basis_row`. With multiple cursors that basis is the sibling line another cursor just added `:` to, so each block opener pulls the next line in and it snowballs.

Fix: grab the rows edited in place this batch (the ones with an `old_row`, so pastes and newline-appends are left out) and don't apply an indent change that's driven by one of those edited siblings. That's the check @van-sprundel suggested on the issue.

## Testing

`test_python_autoindent_multi_cursor_colon` (real Python grammar) covers the flat case above and a nested one (`def f():` with two cursors) so real parents still drive indent and only edited siblings get ignored. Fails on `main`, passes with the fix. `cargo test -p language` and the Python autoindent tests pass.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed typing `:` with multiple cursors in Python cascading the indentation of each line
