### PR TITLE
agent: Improve error messaging for `edit_file` tool

### DIFF
--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -47,17 +47,29 @@ where
     T: DeserializeOwned,
     D: Deserializer<'de>,
 {
-    let raw = serde_json::Value::deserialize(deserializer)
-        .map_err(|e| D::Error::custom(format!("invalid JSON: {e}")))?;
-
-    // If the model stringified the argument, parse the inner JSON.
-    if let Ok(string) = String::deserialize(&raw) {
-        return serde_json::from_str::<T>(&string)
-            .map_err(|e| D::Error::custom(format!("failed to parse stringified value: {e}")));
+    fn to_custom_error<E>(e: serde_json::Error) -> E
+    where
+        E: serde::de::Error,
+    {
+        E::custom(format!("{e}"))
     }
 
-    // Otherwise, deserialize directly and pass errors through.
-    T::deserialize(&raw).map_err(|e| D::Error::custom(format!("{e}")))
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum RawInput<'a> {
+        #[serde(borrow)]
+        String(&'a str),
+        #[serde(borrow)]
+        Value(&'a RawValue),
+    }
+
+    let raw_input = RawInput::deserialize(deserializer)
+        .map_err(|e| D::Error::custom(format!("invalid JSON: {e}")))?;
+
+    match raw_input {
+        RawInput::String(s) => serde_json::from_str(s).map_err(to_custom_error),
+        RawInput::Value(v) => T::deserialize(v).map_err(to_custom_error),
+    }
 }
 
 pub use apply_code_action_tool::*;
@@ -79,6 +91,7 @@ pub use list_directory_tool::*;
 pub use move_path_tool::*;
 pub use read_file_tool::*;
 pub use rename_tool::*;
+use serde_json::value::RawValue;
 pub use skill_tool::*;
 pub use spawn_agent_tool::*;
 pub use symbol_locator::*;

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -54,21 +54,18 @@ where
         E::custom(format!("{e}"))
     }
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum RawInput<'a> {
-        #[serde(borrow)]
-        String(&'a str),
-        #[serde(borrow)]
-        Value(&'a RawValue),
-    }
+    let raw_value = serde_json::Value::deserialize(deserializer)
+        .map_err(|error| D::Error::custom(format!("invalid JSON: {error}")))?;
 
-    let raw_input = RawInput::deserialize(deserializer)
-        .map_err(|e| D::Error::custom(format!("invalid JSON: {e}")))?;
+    match T::deserialize(&raw_value) {
+        Ok(value) => Ok(value),
+        Err(original_error) => {
+            let Some(string) = raw_value.as_str() else {
+                return Err(to_custom_error(original_error));
+            };
 
-    match raw_input {
-        RawInput::String(s) => serde_json::from_str(s).map_err(to_custom_error),
-        RawInput::Value(v) => T::deserialize(v).map_err(to_custom_error),
+            serde_json::from_str(string).map_err(to_custom_error)
+        }
     }
 }
 
@@ -91,7 +88,6 @@ pub use list_directory_tool::*;
 pub use move_path_tool::*;
 pub use read_file_tool::*;
 pub use rename_tool::*;
-use serde_json::value::RawValue;
 pub use skill_tool::*;
 pub use spawn_agent_tool::*;
 pub use symbol_locator::*;

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -47,19 +47,17 @@ where
     T: DeserializeOwned,
     D: Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum ValueOrJsonString<T> {
-        Value(T),
-        String(String),
+    let raw = serde_json::Value::deserialize(deserializer)
+        .map_err(|e| D::Error::custom(format!("invalid JSON: {e}")))?;
+
+    // If the model stringified the argument, parse the inner JSON.
+    if let Ok(string) = String::deserialize(&raw) {
+        return serde_json::from_str::<T>(&string)
+            .map_err(|e| D::Error::custom(format!("failed to parse stringified value: {e}")));
     }
 
-    match ValueOrJsonString::<T>::deserialize(deserializer)? {
-        ValueOrJsonString::Value(value) => Ok(value),
-        ValueOrJsonString::String(string) => serde_json::from_str::<T>(&string).map_err(|error| {
-            D::Error::custom(format!("failed to parse stringified value: {error}"))
-        }),
-    }
+    // Otherwise, deserialize directly and pass errors through.
+    T::deserialize(&raw).map_err(|e| D::Error::custom(format!("{e}")))
 }
 
 pub use apply_code_action_tool::*;

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -3061,6 +3061,19 @@ mod tests {
         assert!(input.edits.is_none());
     }
 
+    #[test]
+    fn test_wrong_edit_field_names_produce_actionable_error() {
+        let err = serde_json::from_value::<EditFileToolInput>(json!({
+            "path": "test.go",
+            "edits": [{"old_str": "hello", "new_text": "world"}]
+        }))
+        .unwrap_err();
+
+        // When the model uses incorrect field names, the error should
+        // tell it what to fix.
+        assert_eq!(err.to_string(), "missing field `old_text`");
+    }
+
     async fn setup_test_with_fs(
         cx: &mut TestAppContext,
         fs: Arc<project::FakeFs>,


### PR DESCRIPTION
# Objective

Currently, when a model provides the wrong parameters to the edit file tool, it gets back the opaque error message `data did not match any variant of untagged enum ValueOrJsonString`.

At least some models (DeepSeek in my experience) can't figure out what to do from this point, and keep trying the same wrong parameter names in the tool call before eventually falling back to using `ed`.

This may address https://github.com/zed-industries/zed/issues/58622.

## Solution

Rather than attempting to deserialize to the `ValueOrJsonString` enum, try to deserialize as a JSON string and then as a value in turn, so that deserialization errors better propagate.

## Testing

Using DeepSeek V4 Pro.

Tried it out in a reloaded conversation where the edit tool was consistently failing.

Asked it to stress-test the edit tool. Only one edit failed after a few successful attempts, and returned the error message "missing field `new_text`".

Subsequent edits worked again rather than resulting in a doom loop. I don't think the model noticed what happened, but it seemed to help.

<img width="366" height="551" alt="image" src="https://github.com/user-attachments/assets/6f9c0c8d-bf94-4670-bad0-0ead5c1fff4e" />

...

<img width="346" height="153" alt="image" src="https://github.com/user-attachments/assets/2afa2901-9a90-4142-aa9d-ff32a7be0d0c" />


---

Release Notes:

- Improved edit_file tool error messaging.
