### PR TITLE
Improve auto indentation in situations with multiline comments present

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4249,7 +4249,7 @@ fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
             assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
 
             editor.newline(&Newline, window, cx);
-            assert_eq!(editor.text(cx), "    hello\n\n\n    world\n");
+            assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
         })
         .unwrap();
 
@@ -4298,7 +4298,7 @@ fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
             assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
 
             editor.newline(&Newline, window, cx);
-            assert_eq!(editor.text(cx), "\thello\n\n\n\tworld\n");
+            assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
         })
         .unwrap();
 }
@@ -5350,6 +5350,44 @@ async fn test_newline_closing_comment_indent_across_languages(cx: &mut TestAppCo
 }
 
 #[gpui::test]
+async fn test_newline_after_closing_delimiter_lookalike_in_string(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+
+    // A line inside a string literal that happens to look like a block comment's
+    // closing delimiter does not close anything, so it keeps its own indentation.
+    cx.set_state("func test() {\n\tvar s = `\n*/ˇ\n`\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("func test() {\n\tvar s = `\n*/\nˇ\n`\n}");
+}
+
+#[gpui::test]
+async fn test_newline_twice_inside_block(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+
+    cx.set_state("func test() {ˇ}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("func test() {\n    ˇ\n}");
+    // The blank line the cursor sits on holds nothing but auto-indent
+    // whitespace, but the line that replaces it still belongs inside the block.
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("func test() {\n\n    ˇ\n}");
+}
+
+#[gpui::test]
 async fn test_newline_comments_with_block_comment(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.tab_size = NonZeroU32::new(4)
@@ -5672,6 +5710,24 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
             ˇ)
         );
     "});
+}
+
+#[gpui::test]
+async fn test_tab_after_closing_comment_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+
+    // The suggested indent is taken from the line the comment opened on, so that
+    // it agrees with what pressing enter after the closing delimiter produces.
+    cx.set_state("func test() {\n\t/**\n\t * doc\n\t */\nˇ\n}");
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.assert_editor_state("func test() {\n\t/**\n\t * doc\n\t */\n\tˇ\n}");
 }
 
 #[gpui::test]
@@ -10134,11 +10190,8 @@ async fn test_paste_after_closing_documentation_comment(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
-async fn test_paste_removes_common_leading_indent(cx: &mut TestAppContext) {
+async fn test_paste_shifts_block_by_first_line_delta(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
-    cx.write_to_clipboard(ClipboardItem::new_string(
-        " func find() {\n \treturn 1\n }".into(),
-    ));
 
     let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| {
@@ -10147,9 +10200,40 @@ async fn test_paste_removes_common_leading_indent(cx: &mut TestAppContext) {
             cx,
         )
     });
+
+    cx.write_to_clipboard(ClipboardItem::new_string(
+        " func find() {\n \treturn 1\n }".into(),
+    ));
     cx.set_state("package test\n\nˇ");
     cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
     cx.assert_editor_state("package test\n\nfunc find() {\n\treturn 1\n}ˇ");
+
+    // The block moves by however far its first line moved, so a first line that
+    // is indented deeper than the lines below it stays deeper.
+    cx.write_to_clipboard(ClipboardItem::new_string("        foo()\n    bar()".into()));
+    cx.set_state("func test() {\nˇ\n}");
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state("func test() {\n    foo()\nbar()ˇ\n}");
+}
+
+#[gpui::test]
+async fn test_paste_after_closing_comment_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+
+    // The closing delimiter's line is not part of the paste, so it keeps its own
+    // indentation even though that indentation differs from the opening line's.
+    cx.write_to_clipboard(ClipboardItem::new_string("x := 1\ny := 2".into()));
+    cx.set_state("package test\n\n/*\n * test\n */ˇ");
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state("package test\n\n/*\n * test\n */x := 1\n y := 2ˇ");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4249,7 +4249,7 @@ fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
             assert_eq!(editor.text(cx), "    hello\n    \n    world\n");
 
             editor.newline(&Newline, window, cx);
-            assert_eq!(editor.text(cx), "    hello\n\n    \n    world\n");
+            assert_eq!(editor.text(cx), "    hello\n\n\n    world\n");
         })
         .unwrap();
 
@@ -4298,7 +4298,7 @@ fn test_newline_trailing_whitespace(cx: &mut TestAppContext) {
             assert_eq!(editor.text(cx), "\thello\n\t\n\tworld\n");
 
             editor.newline(&Newline, window, cx);
-            assert_eq!(editor.text(cx), "\thello\n\n\t\n\tworld\n");
+            assert_eq!(editor.text(cx), "\thello\n\n\n\tworld\n");
         })
         .unwrap();
 }
@@ -5263,8 +5263,12 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
          *
          */
-         ˇ
+        ˇ
     "});
+
+        cx.set_state("fn test() {\n    /**\n     *\n     */ˇ\n}");
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state("fn test() {\n    /**\n     *\n     */\n    ˇ\n}");
 
         // Ensure that inline comment followed by code
         // doesn't add comment prefix on newline
@@ -5289,7 +5293,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
          *
          */
-         ˇtext
+        ˇtext
     "});
 
         // Ensure if not comment block it doesn't
@@ -5316,6 +5320,33 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
         ˇ
     "});
+}
+
+#[gpui::test]
+async fn test_newline_closing_comment_indent_across_languages(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let go_language = languages::language("go", tree_sitter_go::LANGUAGE.into());
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(go_language), cx));
+    cx.set_state("func test() {\n\t/**\n\t * doc\n\t */ˇ\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("func test() {\n\t/**\n\t * doc\n\t */\n\tˇ\n}");
+
+    let typescript_language = languages::language(
+        "typescript",
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+    );
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(typescript_language), cx));
+    cx.set_state("function test() {\n    /**\n     * doc\n     */ˇ\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("function test() {\n    /**\n     * doc\n     */\n    ˇ\n}");
+
+    let python_language = languages::language("python", tree_sitter_python::LANGUAGE.into());
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(python_language), cx));
+    cx.set_state("def test():\n    \"\"\"doc\n    \"\"\"ˇ\n");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("def test():\n    \"\"\"doc\n    \"\"\"\n    ˇ\n");
 }
 
 #[gpui::test]
@@ -10072,6 +10103,26 @@ async fn test_paste_content_from_other_app(cx: &mut TestAppContext) {
         ˇ
         }
     "});
+}
+
+#[gpui::test]
+async fn test_paste_after_closing_documentation_comment(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    cx.write_to_clipboard(ClipboardItem::new_string(
+        "func find() {\n\treturn 1\n}\n".into(),
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+    cx.set_state("package test\n\n/**\n * test\n */ˇ");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state("package test\n\n/**\n * test\n */\nfunc find() {\n\treturn 1\n}\nˇ");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10123,6 +10123,33 @@ async fn test_paste_after_closing_documentation_comment(cx: &mut TestAppContext)
     cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
     cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
     cx.assert_editor_state("package test\n\n/**\n * test\n */\nfunc find() {\n\treturn 1\n}\nˇ");
+
+    cx.write_to_clipboard(ClipboardItem::new_string(
+        " func find() {\n \treturn 1\n }".into(),
+    ));
+    cx.set_state("package test\n\n/**\n * test\n */ˇ");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state("package test\n\n/**\n * test\n */\nfunc find() {\n\treturn 1\n}ˇ");
+}
+
+#[gpui::test]
+async fn test_paste_removes_common_leading_indent(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    cx.write_to_clipboard(ClipboardItem::new_string(
+        " func find() {\n \treturn 1\n }".into(),
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("go", tree_sitter_go::LANGUAGE.into())),
+            cx,
+        )
+    });
+    cx.set_state("package test\n\nˇ");
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.assert_editor_state("package test\n\nfunc find() {\n\treturn 1\n}ˇ");
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -558,15 +558,8 @@ impl Editor {
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
-                        let logical_indent_language_scope = buffer
-                            .language_scope_at(Point::new(start_point.row, existing_indent.len));
-                        let (logical_indent, reset_auto_indent) = logical_indent_for_newline(
-                            &start_point,
-                            &buffer,
-                            logical_indent_language_scope.as_ref(),
-                            existing_indent,
-                        );
-                        existing_indent = logical_indent;
+                        existing_indent =
+                            logical_indent_for_newline(&start_point, &buffer, existing_indent);
                         let (delimiter, newline_config) = if let Some(language) = &language_scope {
                             let needs_extra_newline = NewlineConfig::insert_extra_newline_brackets(
                                 &buffer,
@@ -736,9 +729,7 @@ impl Editor {
                                 (
                                     start,
                                     new_text,
-                                    *prevent_auto_indent
-                                        || reset_auto_indent
-                                        || !apply_syntax_indent,
+                                    *prevent_auto_indent || !apply_syntax_indent,
                                 )
                             }
                         };
@@ -2630,55 +2621,26 @@ fn documentation_delimiter_for_newline(
     }
 }
 
+/// The indentation a line inserted at `start_point` should start at, which is
+/// `existing_indent` unless the cursor sits after the closing delimiter of a
+/// multi-line block comment. See [`language::BufferSnapshot::block_comment_closing_indent`].
 fn logical_indent_for_newline(
     start_point: &Point,
     buffer: &MultiBufferSnapshot,
-    language: Option<&LanguageScope>,
     existing_indent: IndentSize,
-) -> (IndentSize, bool) {
-    let row = MultiBufferRow(start_point.row);
-    let line_len = buffer.line_len(row);
-    let line = buffer
-        .text_for_range(Point::new(start_point.row, 0)..Point::new(start_point.row, line_len))
-        .collect::<String>();
-
-    if start_point.column == line_len && line.trim().is_empty() {
-        return (IndentSize::spaces(0), true);
-    }
-
-    let Some(language) = language else {
-        return (existing_indent, false);
+) -> IndentSize {
+    let Some((snapshot, line_range)) = buffer.buffer_line_for_row(MultiBufferRow(start_point.row))
+    else {
+        return existing_indent;
     };
-
-    let leading_whitespace_len = line
-        .bytes()
-        .take_while(|byte| matches!(byte, b' ' | b'\t'))
-        .count();
-    let line_content = &line[leading_whitespace_len..];
-    let Some(end_tag) = language::comment_or_string_end_tag(language, line_content) else {
-        return (existing_indent, false);
-    };
-    if start_point.column < (leading_whitespace_len + end_tag.len()) as u32 {
-        return (existing_indent, false);
-    }
-
-    let syntax_range = Point::new(start_point.row, leading_whitespace_len as u32)..*start_point;
-    let Some((node, node_range)) = buffer.syntax_ancestor(syntax_range) else {
-        return (existing_indent, false);
-    };
-    if !node.kind().contains("comment") && !node.kind().contains("string") {
-        return (existing_indent, false);
-    }
-
-    let opening_point = node_range.start.to_point(buffer);
-    if opening_point.row >= start_point.row {
-        return (existing_indent, false);
-    }
-
-    (
-        buffer.indent_size_for_line(MultiBufferRow(opening_point.row)),
-        true,
-    )
+    // Columns agree between the multi-buffer and the underlying buffer for a line
+    // an excerpt shows in full, which is the case we care about. For a partial
+    // first line the column comes out too small and the lookup below declines,
+    // leaving the indent alone.
+    let position = Point::new(line_range.start.row, start_point.column);
+    snapshot
+        .block_comment_closing_indent(position)
+        .unwrap_or(existing_indent)
 }
 
 fn list_delimiter_for_newline(

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -558,6 +558,15 @@ impl Editor {
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
+                        let logical_indent_language_scope = buffer
+                            .language_scope_at(Point::new(start_point.row, existing_indent.len));
+                        let (logical_indent, reset_auto_indent) = logical_indent_for_newline(
+                            &start_point,
+                            &buffer,
+                            logical_indent_language_scope.as_ref(),
+                            existing_indent,
+                        );
+                        existing_indent = logical_indent;
                         let (delimiter, newline_config) = if let Some(language) = &language_scope {
                             let needs_extra_newline = NewlineConfig::insert_extra_newline_brackets(
                                 &buffer,
@@ -727,7 +736,9 @@ impl Editor {
                                 (
                                     start,
                                     new_text,
-                                    *prevent_auto_indent || !apply_syntax_indent,
+                                    *prevent_auto_indent
+                                        || reset_auto_indent
+                                        || !apply_syntax_indent,
                                 )
                             }
                         };
@@ -2617,6 +2628,63 @@ fn documentation_delimiter_for_newline(
     } else {
         None
     }
+}
+
+fn logical_indent_for_newline(
+    start_point: &Point,
+    buffer: &MultiBufferSnapshot,
+    language: Option<&LanguageScope>,
+    existing_indent: IndentSize,
+) -> (IndentSize, bool) {
+    let row = MultiBufferRow(start_point.row);
+    let line_len = buffer.line_len(row);
+    let line = buffer
+        .text_for_range(Point::new(start_point.row, 0)..Point::new(start_point.row, line_len))
+        .collect::<String>();
+
+    if start_point.column == line_len && line.trim().is_empty() {
+        return (IndentSize::spaces(0), true);
+    }
+
+    let Some(language) = language else {
+        return (existing_indent, false);
+    };
+
+    let leading_whitespace_len = line
+        .bytes()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    let line_content = &line[leading_whitespace_len..];
+    if ![language.documentation_comment(), language.block_comment()]
+        .into_iter()
+        .flatten()
+        .any(|config| {
+            let end_tag = config.end.trim_start();
+            line_content.starts_with(end_tag)
+                && line_content[end_tag.len()..].trim().is_empty()
+                && start_point.column >= (leading_whitespace_len + end_tag.len()) as u32
+        })
+    {
+        return (existing_indent, false);
+    }
+
+    let syntax_range = Point::new(start_point.row, leading_whitespace_len as u32)..*start_point;
+    let Some((node, node_range)) = buffer.syntax_ancestor(syntax_range) else {
+        return (existing_indent, false);
+    };
+    if !node.kind().contains("comment") && !node.kind().contains("string") {
+        return (existing_indent, false);
+    }
+
+    let opening_point = node_range.start.to_point(buffer);
+    if opening_point.row >= start_point.row {
+        return (existing_indent, false);
+    }
+
+    (
+        buffer.indent_size_for_line(MultiBufferRow(opening_point.row)),
+        true,
+    )
 }
 
 fn list_delimiter_for_newline(

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -2655,16 +2655,10 @@ fn logical_indent_for_newline(
         .take_while(|byte| matches!(byte, b' ' | b'\t'))
         .count();
     let line_content = &line[leading_whitespace_len..];
-    if ![language.documentation_comment(), language.block_comment()]
-        .into_iter()
-        .flatten()
-        .any(|config| {
-            let end_tag = config.end.trim_start();
-            line_content.starts_with(end_tag)
-                && line_content[end_tag.len()..].trim().is_empty()
-                && start_point.column >= (leading_whitespace_len + end_tag.len()) as u32
-        })
-    {
+    let Some(end_tag) = language::comment_or_string_end_tag(language, line_content) else {
+        return (existing_indent, false);
+    };
+    if start_point.column < (leading_whitespace_len + end_tag.len()) as u32 {
         return (existing_indent, false);
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2090,7 +2090,7 @@ impl Buffer {
                                 .unwrap_or_else(|| {
                                     request
                                         .before_edit
-                                        .indent_size_for_line(suggestion.basis_row)
+                                        .logical_indent_size_for_line(suggestion.basis_row)
                                 })
                                 .with_delta(suggestion.delta, language_indent_size);
                             old_suggestions
@@ -2131,7 +2131,7 @@ impl Buffer {
                                 .copied()
                                 .map(|e| e.0)
                                 .unwrap_or_else(|| {
-                                    snapshot.indent_size_for_line(suggestion.basis_row)
+                                    snapshot.logical_indent_size_for_line(suggestion.basis_row)
                                 })
                                 .with_delta(suggestion.delta, language_indent_size);
 
@@ -2156,7 +2156,7 @@ impl Buffer {
                             if let Some((indent, _)) = indent_sizes.get(&row_range.start) {
                                 *indent
                             } else {
-                                snapshot.indent_size_for_line(row_range.start)
+                                snapshot.logical_indent_size_for_line(row_range.start)
                             };
                         let delta = new_indent.len as i64 - original_indent_column as i64;
                         if delta != 0 {
@@ -3550,6 +3550,49 @@ impl BufferSnapshot {
         indent_size_for_line(self, row)
     }
 
+    fn logical_indent_size_for_line(&self, row: u32) -> IndentSize {
+        let physical_indent = self.indent_size_for_line(row);
+        let line_len = self.line_len(row);
+        let line = self
+            .text_for_range(Point::new(row, 0)..Point::new(row, line_len))
+            .collect::<String>();
+        let leading_whitespace_len = line
+            .bytes()
+            .take_while(|byte| matches!(byte, b' ' | b'\t'))
+            .count();
+        let line_content = &line[leading_whitespace_len..];
+        let Some(language) = self.language_scope_at(Point::new(row, leading_whitespace_len as u32))
+        else {
+            return physical_indent;
+        };
+
+        if ![language.documentation_comment(), language.block_comment()]
+            .into_iter()
+            .flatten()
+            .any(|config| {
+                let end_tag = config.end.trim_start();
+                line_content.starts_with(end_tag) && line_content[end_tag.len()..].trim().is_empty()
+            })
+        {
+            return physical_indent;
+        }
+
+        let line_range = Point::new(row, leading_whitespace_len as u32)..Point::new(row, line_len);
+        let Some(node) = self.syntax_ancestor(line_range) else {
+            return physical_indent;
+        };
+        if !node.kind().contains("comment") && !node.kind().contains("string") {
+            return physical_indent;
+        }
+
+        let opening_row = node.start_position().row as u32;
+        if opening_row >= row {
+            physical_indent
+        } else {
+            self.indent_size_for_line(opening_row)
+        }
+    }
+
     /// Returns [`IndentSize`] for a given position that respects user settings
     /// and language preferences.
     pub fn language_indent_size_at<T: ToOffset>(&self, position: T, cx: &App) -> IndentSize {
@@ -3581,7 +3624,7 @@ impl BufferSnapshot {
                     result
                         .get(&suggestion.basis_row)
                         .copied()
-                        .unwrap_or_else(|| self.indent_size_for_line(suggestion.basis_row))
+                        .unwrap_or_else(|| self.logical_indent_size_for_line(suggestion.basis_row))
                         .with_delta(suggestion.delta, single_indent_size)
                 } else {
                     self.indent_size_for_line(row)

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -499,6 +499,7 @@ struct AutoindentRequestEntry {
     old_row: Option<u32>,
     indent_size: IndentSize,
     original_indent_column: Option<u32>,
+    target_indent: Option<IndentSize>,
 }
 
 #[derive(Debug)]
@@ -2052,7 +2053,11 @@ impl Buffer {
                     if let Some(old_row) = entry.old_row {
                         old_to_new_rows.insert(old_row, new_row);
                     }
-                    row_ranges.push((new_row..new_end_row, entry.original_indent_column));
+                    row_ranges.push((
+                        new_row..new_end_row,
+                        entry.original_indent_column,
+                        entry.target_indent,
+                    ));
                 }
 
                 // Build a map containing the suggested indentation for each of the edited lines
@@ -2104,7 +2109,7 @@ impl Buffer {
                 // if they differ from the old suggestion for that line.
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
                 let mut language_indent_size = IndentSize::default();
-                for (row_range, original_indent_column) in row_ranges {
+                for (row_range, original_indent_column, target_indent) in row_ranges {
                     let new_edited_row_range = if request.is_block_mode {
                         row_range.start..row_range.start + 1
                     } else {
@@ -2149,14 +2154,18 @@ impl Buffer {
                         }
                     }
 
-                    if let (true, Some(original_indent_column)) =
-                        (request.is_block_mode, original_indent_column)
+                    if let (true, Some(original_indent_column), Some(target_indent)) =
+                        (request.is_block_mode, original_indent_column, target_indent)
                     {
                         let new_indent =
                             if let Some((indent, _)) = indent_sizes.get(&row_range.start) {
                                 *indent
                             } else {
-                                snapshot.logical_indent_size_for_line(row_range.start)
+                                indent_sizes.insert(
+                                    row_range.start,
+                                    (target_indent, request.ignore_empty_lines),
+                                );
+                                target_indent
                             };
                         let delta = new_indent.len as i64 - original_indent_column as i64;
                         if delta != 0 {
@@ -2888,20 +2897,16 @@ impl Buffer {
                     } = &mode
                     {
                         original_indent_column = Some(if new_text.starts_with('\n') {
-                            indent_size_for_text(
-                                new_text[range_of_insertion_to_indent.clone()].chars(),
-                            )
-                            .len
+                            min_common_indent(&new_text[range_of_insertion_to_indent.clone()])
                         } else {
                             original_indent_columns
                                 .get(ix)
                                 .copied()
                                 .flatten()
                                 .unwrap_or_else(|| {
-                                    indent_size_for_text(
-                                        new_text[range_of_insertion_to_indent.clone()].chars(),
+                                    min_common_indent(
+                                        &new_text[range_of_insertion_to_indent.clone()],
                                     )
-                                    .len
                                 })
                         });
 
@@ -2919,6 +2924,9 @@ impl Buffer {
                             Some(old_start.row)
                         },
                         indent_size: before_edit.language_indent_size_at(range.start, cx),
+                        target_indent: (new_text.contains('\n')
+                            || original_indent_column.is_some_and(|indent| indent > 0))
+                        .then(|| before_edit.logical_indent_size_for_line(old_start.row)),
                         range: self.anchor_before(new_start + range_of_insertion_to_indent.start)
                             ..self.anchor_after(new_start + range_of_insertion_to_indent.end),
                     }
@@ -2984,6 +2992,7 @@ impl Buffer {
                 old_row: None,
                 indent_size: before_edit.language_indent_size_at(range.start, cx),
                 original_indent_column: None,
+                target_indent: None,
             })
             .collect();
         self.autoindent_requests.push(Arc::new(AutoindentRequest {
@@ -3566,14 +3575,7 @@ impl BufferSnapshot {
             return physical_indent;
         };
 
-        if ![language.documentation_comment(), language.block_comment()]
-            .into_iter()
-            .flatten()
-            .any(|config| {
-                let end_tag = config.end.trim_start();
-                line_content.starts_with(end_tag) && line_content[end_tag.len()..].trim().is_empty()
-            })
-        {
+        if comment_or_string_end_tag(&language, line_content).is_none() {
             return physical_indent;
         }
 
@@ -5630,6 +5632,20 @@ fn indent_size_for_line(text: &text::BufferSnapshot, row: u32) -> IndentSize {
     indent_size_for_text(text.chars_at(Point::new(row, 0)))
 }
 
+pub fn comment_or_string_end_tag<'a>(
+    language: &'a LanguageScope,
+    line_content: &str,
+) -> Option<&'a str> {
+    [language.documentation_comment(), language.block_comment()]
+        .into_iter()
+        .flatten()
+        .find_map(|config| {
+            let end_tag = config.end.trim_start();
+            (line_content.starts_with(end_tag) && line_content[end_tag.len()..].trim().is_empty())
+                .then_some(end_tag)
+        })
+}
+
 fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
     let mut result = IndentSize::spaces(0);
     for c in text {
@@ -5644,6 +5660,22 @@ fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
         result.len += 1;
     }
     result
+}
+
+fn min_common_indent(text: &str) -> u32 {
+    let mut min_indent = u32::MAX;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = indent_size_for_text(line.chars()).len;
+        min_indent = min_indent.min(indent);
+    }
+    if min_indent == u32::MAX {
+        0
+    } else {
+        min_indent
+    }
 }
 
 impl Clone for BufferSnapshot {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -499,7 +499,6 @@ struct AutoindentRequestEntry {
     old_row: Option<u32>,
     indent_size: IndentSize,
     original_indent_column: Option<u32>,
-    target_indent: Option<IndentSize>,
 }
 
 #[derive(Debug)]
@@ -2053,11 +2052,7 @@ impl Buffer {
                     if let Some(old_row) = entry.old_row {
                         old_to_new_rows.insert(old_row, new_row);
                     }
-                    row_ranges.push((
-                        new_row..new_end_row,
-                        entry.original_indent_column,
-                        entry.target_indent,
-                    ));
+                    row_ranges.push((new_row..new_end_row, entry.original_indent_column));
                 }
 
                 // Build a map containing the suggested indentation for each of the edited lines
@@ -2109,7 +2104,7 @@ impl Buffer {
                 // if they differ from the old suggestion for that line.
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
                 let mut language_indent_size = IndentSize::default();
-                for (row_range, original_indent_column, target_indent) in row_ranges {
+                for (row_range, original_indent_column) in row_ranges {
                     let new_edited_row_range = if request.is_block_mode {
                         row_range.start..row_range.start + 1
                     } else {
@@ -2154,18 +2149,14 @@ impl Buffer {
                         }
                     }
 
-                    if let (true, Some(original_indent_column), Some(target_indent)) =
-                        (request.is_block_mode, original_indent_column, target_indent)
+                    if let (true, Some(original_indent_column)) =
+                        (request.is_block_mode, original_indent_column)
                     {
                         let new_indent =
                             if let Some((indent, _)) = indent_sizes.get(&row_range.start) {
                                 *indent
                             } else {
-                                indent_sizes.insert(
-                                    row_range.start,
-                                    (target_indent, request.ignore_empty_lines),
-                                );
-                                target_indent
+                                snapshot.indent_size_for_line(row_range.start)
                             };
                         let delta = new_indent.len as i64 - original_indent_column as i64;
                         if delta != 0 {
@@ -2897,16 +2888,20 @@ impl Buffer {
                     } = &mode
                     {
                         original_indent_column = Some(if new_text.starts_with('\n') {
-                            min_common_indent(&new_text[range_of_insertion_to_indent.clone()])
+                            indent_size_for_text(
+                                new_text[range_of_insertion_to_indent.clone()].chars(),
+                            )
+                            .len
                         } else {
                             original_indent_columns
                                 .get(ix)
                                 .copied()
                                 .flatten()
                                 .unwrap_or_else(|| {
-                                    min_common_indent(
-                                        &new_text[range_of_insertion_to_indent.clone()],
+                                    indent_size_for_text(
+                                        new_text[range_of_insertion_to_indent.clone()].chars(),
                                     )
+                                    .len
                                 })
                         });
 
@@ -2924,9 +2919,6 @@ impl Buffer {
                             Some(old_start.row)
                         },
                         indent_size: before_edit.language_indent_size_at(range.start, cx),
-                        target_indent: (new_text.contains('\n')
-                            || original_indent_column.is_some_and(|indent| indent > 0))
-                        .then(|| before_edit.logical_indent_size_for_line(old_start.row)),
                         range: self.anchor_before(new_start + range_of_insertion_to_indent.start)
                             ..self.anchor_after(new_start + range_of_insertion_to_indent.end),
                     }
@@ -2992,7 +2984,6 @@ impl Buffer {
                 old_row: None,
                 indent_size: before_edit.language_indent_size_at(range.start, cx),
                 original_indent_column: None,
-                target_indent: None,
             })
             .collect();
         self.autoindent_requests.push(Arc::new(AutoindentRequest {
@@ -3559,40 +3550,81 @@ impl BufferSnapshot {
         indent_size_for_line(self, row)
     }
 
+    /// The indentation that the block comment closed on `position`'s row belongs
+    /// at, or `None` if that row is not the closing line of a multi-line block
+    /// comment.
+    ///
+    /// A closing delimiter is conventionally indented one column past its opening
+    /// delimiter, so that it lines up with the comment's prefixes:
+    ///
+    /// ```text
+    /// /**
+    ///  * doc
+    ///  */
+    /// ```
+    ///
+    /// That extra column belongs to the comment rather than to the surrounding
+    /// code, which makes the closing row's own indentation a poor basis for
+    /// indenting whatever follows it. The opening row's indentation is used
+    /// instead.
+    ///
+    /// Requires the row to hold nothing but whitespace and the closing delimiter,
+    /// and `position` to be at or past the end of that delimiter, so that
+    /// splitting the delimiter itself is left alone. Also requires the syntax node
+    /// containing the delimiter to end there, so that a line which merely looks
+    /// like a closing delimiter is not mistaken for one.
+    pub fn block_comment_closing_indent(&self, position: Point) -> Option<IndentSize> {
+        let row = position.row;
+        let indent_len = self.indent_size_for_line(row).len;
+        let delimiter_start = Point::new(row, indent_len);
+        let language = self.language_scope_at(delimiter_start)?;
+        // A few languages describe a string literal in `block_comment` rather
+        // than a comment (Python's `"""`), so either scope is accepted. Relying
+        // on the override scope keeps this out of the business of guessing at
+        // grammar node names.
+        if !matches!(language.override_name(), Some("comment" | "string")) {
+            return None;
+        }
+
+        let delimiter_len = [language.documentation_comment(), language.block_comment()]
+            .into_iter()
+            .flatten()
+            .find_map(|config| {
+                let delimiter = config.end.trim_start();
+                if delimiter.is_empty() {
+                    return None;
+                }
+                let mut chars = self.chars_at(delimiter_start);
+                if !delimiter
+                    .chars()
+                    .all(|expected| chars.next() == Some(expected))
+                {
+                    return None;
+                }
+                if !chars.take_while(|c| *c != '\n').all(char::is_whitespace) {
+                    return None;
+                }
+                Some(delimiter.len() as u32)
+            })?;
+        if position.column < indent_len + delimiter_len {
+            return None;
+        }
+
+        let delimiter_end = Point::new(row, indent_len + delimiter_len);
+        let node = self.syntax_ancestor(delimiter_start..delimiter_end)?;
+        if Point::from_ts_point(node.end_position()) != delimiter_end {
+            return None;
+        }
+        let opening_row = Point::from_ts_point(node.start_position()).row;
+        (opening_row < row).then(|| self.indent_size_for_line(opening_row))
+    }
+
+    /// Like [`Self::indent_size_for_line`], but reports the indentation a row
+    /// logically sits at, which differs from its physical indentation on the
+    /// closing line of a block comment. See [`Self::block_comment_closing_indent`].
     fn logical_indent_size_for_line(&self, row: u32) -> IndentSize {
-        let physical_indent = self.indent_size_for_line(row);
-        let line_len = self.line_len(row);
-        let line = self
-            .text_for_range(Point::new(row, 0)..Point::new(row, line_len))
-            .collect::<String>();
-        let leading_whitespace_len = line
-            .bytes()
-            .take_while(|byte| matches!(byte, b' ' | b'\t'))
-            .count();
-        let line_content = &line[leading_whitespace_len..];
-        let Some(language) = self.language_scope_at(Point::new(row, leading_whitespace_len as u32))
-        else {
-            return physical_indent;
-        };
-
-        if comment_or_string_end_tag(&language, line_content).is_none() {
-            return physical_indent;
-        }
-
-        let line_range = Point::new(row, leading_whitespace_len as u32)..Point::new(row, line_len);
-        let Some(node) = self.syntax_ancestor(line_range) else {
-            return physical_indent;
-        };
-        if !node.kind().contains("comment") && !node.kind().contains("string") {
-            return physical_indent;
-        }
-
-        let opening_row = node.start_position().row as u32;
-        if opening_row >= row {
-            physical_indent
-        } else {
-            self.indent_size_for_line(opening_row)
-        }
+        self.block_comment_closing_indent(Point::new(row, self.line_len(row)))
+            .unwrap_or_else(|| self.indent_size_for_line(row))
     }
 
     /// Returns [`IndentSize`] for a given position that respects user settings
@@ -5632,20 +5664,6 @@ fn indent_size_for_line(text: &text::BufferSnapshot, row: u32) -> IndentSize {
     indent_size_for_text(text.chars_at(Point::new(row, 0)))
 }
 
-pub fn comment_or_string_end_tag<'a>(
-    language: &'a LanguageScope,
-    line_content: &str,
-) -> Option<&'a str> {
-    [language.documentation_comment(), language.block_comment()]
-        .into_iter()
-        .flatten()
-        .find_map(|config| {
-            let end_tag = config.end.trim_start();
-            (line_content.starts_with(end_tag) && line_content[end_tag.len()..].trim().is_empty())
-                .then_some(end_tag)
-        })
-}
-
 fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
     let mut result = IndentSize::spaces(0);
     for c in text {
@@ -5660,22 +5678,6 @@ fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
         result.len += 1;
     }
     result
-}
-
-fn min_common_indent(text: &str) -> u32 {
-    let mut min_indent = u32::MAX;
-    for line in text.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let indent = indent_size_for_text(line.chars()).len;
-        min_indent = min_indent.min(indent);
-    }
-    if min_indent == u32::MAX {
-        0
-    } else {
-        min_indent
-    }
 }
 
 impl Clone for BufferSnapshot {


### PR DESCRIPTION
## Objective

Fix incorrect indentation after multiline comments and when pasting multiline code immediately after a comment.

Fixes #61668 
Fixes #55597 

## Solution

- Calculate logical indentation from the opening line of block comments, documentation comments, and multiline strings.
- Reuse the logical indentation for both newline handling and multiline paste auto-indent.
- Preserve the relative indentation of pasted multiline content while using the logical indentation of the surrounding code as its basis.

## Testing

- `cargo test -p editor --lib test_newline -- --nocapture`
- `cargo test -p editor --lib test_paste -- --nocapture`
- `cargo test -p language --lib test_autoindent -- --nocapture`
- `./script/clippy -p language`
- `./script/clippy -p editor`
- Regression coverage includes Go, TypeScript, and Python comment/string indentation, plus Go multiline paste after a documentation comment.
- No platform-specific behavior is involved; the fix is implemented in shared editor and language auto-indent logic.

The demonstration video is as follows:

https://github.com/user-attachments/assets/2a2ee494-d4ea-4b16-8644-f868b9f31272

https://github.com/user-attachments/assets/9487f893-e584-448d-a1c7-a94c76c03f5b


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed incorrect indentation after multiline comments and multiline paste.
