### PR TITLE
Trim trailing newline from git clone error messages

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1202,7 +1202,7 @@ impl Fs for RealFs {
         if !output.status.success() {
             anyhow::bail!(
                 "git clone failed: {}",
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&output.stderr).trim_end()
             );
         }
 


### PR DESCRIPTION
# Objective

When `git clone` fails, the error message produced by git is collected, propagated, and finally displayed to the user in a pop-up. However, the pop-up always contains an extra blank line.

The root cause is that Zed builds the error message using simple string concatenation:
https://github.com/zed-industries/zed/blob/82aef44308540b576e4e51fb379efa71614e5c91/crates/fs/src/fs.rs#L1253-L1258
and the error message from `git clone` contains a trailing newline, which results in the blank line in Zed's error pop-up.

## Solution

Trim the trailing whitespace from the error message produced by `git clone`.

## Testing

Built and tested locally. The before/after comparison is shown below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

## Show Case

| Before | After |
| :--: | :--: |
| <img width="846" height="937" alt="Before" src="https://github.com/user-attachments/assets/26b918b9-57dc-46e8-880a-525dd4ae257d" /> | <img width="840" height="952" alt="After" src="https://github.com/user-attachments/assets/fb6380e3-afad-4a5a-98b1-05e059fd16f5" /> |

Release Notes:

- Fixed extra blank line appearing in git clone error messages
