### PR TITLE
Handle rendering of mermaid with inline style definitions

### DIFF
--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -30,6 +30,32 @@ pub(crate) struct ParsedMarkdownMermaidDiagramContents {
     pub(crate) scale: u32,
 }
 
+impl ParsedMarkdownMermaidDiagramContents {
+    fn get_frontmatter_and_diagram_code(&self) -> (Option<SharedString>, SharedString) {
+        // Extract any YAML frontmatter. Any mermaid formatting specified in frontmatter
+        // is currently not supported. We just store it for future use when we implement custom,
+        // diagram defined styling.
+        if self.contents.trim_start().starts_with("---") {
+            let rest = self.contents.trim_start().strip_prefix("---").unwrap();
+            if let Some(end_index) = rest.find("\n---") {
+                let frontmatter = rest[..end_index].trim();
+                let remaining = rest[end_index + 4..].trim_start();
+                (Some(frontmatter.into()), remaining.into())
+            } else {
+                (None, self.contents.clone())
+            }
+        } else {
+            (None, self.contents.clone())
+        }
+    }
+
+    pub(crate) fn get_diagram_code(&self) -> SharedString {
+        let (_, diagram_content) = self.get_frontmatter_and_diagram_code();
+        diagram_content
+    }
+
+}
+
 #[derive(Default, Clone)]
 pub(crate) struct MermaidState {
     cache: MermaidDiagramCache,
@@ -260,6 +286,22 @@ fn is_supported_diagram_type(source: &str) -> bool {
         .any(|prefix| first_token.eq_ignore_ascii_case(prefix))
 }
 
+fn parse_mermaid_diagram_contents(
+    contents: &str,
+    scale: u32,
+) -> Option<ParsedMarkdownMermaidDiagramContents> {
+    let diagram_contents = ParsedMarkdownMermaidDiagramContents {
+        contents: contents.into(),
+        scale,
+    };
+
+    if !is_supported_diagram_type(&diagram_contents.get_diagram_code()) {
+        return None;
+    };
+
+    diagram_contents.into()
+}
+
 pub(crate) fn extract_mermaid_diagrams(
     source: &str,
     events: &[(Range<usize>, MarkdownEvent)],
@@ -292,17 +334,15 @@ pub(crate) fn extract_mermaid_diagrams(
             .strip_suffix('\n')
             .unwrap_or(&source[metadata.content_range.clone()])
             .to_string();
-        if !is_supported_diagram_type(&contents) {
-            continue;
-        }
+        let parsed_diagram = match parse_mermaid_diagram_contents(&contents, scale) {
+            Some(diagram) => diagram,
+            None => continue,
+        };
         mermaid_diagrams.insert(
             source_range.start,
             ParsedMarkdownMermaidDiagram {
                 content_range: metadata.content_range.clone(),
-                contents: ParsedMarkdownMermaidDiagramContents {
-                    contents: contents.into(),
-                    scale,
-                },
+                contents: parsed_diagram,
             },
         );
     }
@@ -554,7 +594,7 @@ mod tests {
     };
     use crate::{
         CodeBlockRenderer, CopyButtonVisibility, Markdown, MarkdownElement, MarkdownOptions,
-        MarkdownStyle, WrapButtonVisibility,
+        MarkdownStyle, WrapButtonVisibility, mermaid::parse_mermaid_diagram_contents,
     };
     use collections::HashMap;
     use gpui::{Context, IntoElement, Render, RenderImage, TestAppContext, Window, size};
@@ -678,6 +718,29 @@ mod tests {
         assert_eq!(parse_mermaid_info("mermaid 5"), Some(10));
         assert_eq!(parse_mermaid_info("mermaid 999"), Some(500));
         assert_eq!(parse_mermaid_info("rust"), None);
+    }
+
+    #[test]
+    fn test_parse_mermaid_diagram_contents_with_frontmatter() {
+        let code_block_content =
+            "---\ntitle: frontmatter example\ndisplayMode: compact\n---graph TD;";
+        let parsed_contents = parse_mermaid_diagram_contents(code_block_content, 100).unwrap();
+        assert_eq!(parsed_contents.scale, 100);
+        assert!(parsed_contents.frontmatter.is_some());
+        assert_eq!(
+            parsed_contents.frontmatter.unwrap(),
+            "title: frontmatter example\ndisplayMode: compact"
+        );
+        assert_eq!(parsed_contents.contents, "graph TD;");
+    }
+
+    #[test]
+    fn test_parse_mermaid_diagram_contents_without_frontmatter() {
+        let code_block_content = "graph TD;";
+        let parsed_contents = parse_mermaid_diagram_contents(code_block_content, 100).unwrap();
+        assert_eq!(parsed_contents.scale, 100);
+        assert!(parsed_contents.frontmatter.is_none());
+        assert_eq!(parsed_contents.contents, "graph TD;");
     }
 
     #[test]

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
-use ui::{CopyButton, TintColor, prelude::*};
+use ui::{Banner, CopyButton, TintColor, prelude::*};
 
 use crate::parser::{CodeBlockKind, MarkdownEvent, MarkdownTag};
 use settings::Settings as _;
@@ -50,8 +50,11 @@ impl ParsedMarkdownMermaidDiagramContents {
     }
 
     pub(crate) fn get_diagram_code(&self) -> SharedString {
-        let (_, diagram_content) = self.get_frontmatter_and_diagram_code();
-        diagram_content
+        self.get_frontmatter_and_diagram_code().1
+    }
+
+    pub(crate) fn get_frontmatter(&self) -> Option<SharedString> {
+        self.get_frontmatter_and_diagram_code().0
     }
 
 }
@@ -386,6 +389,10 @@ pub(crate) fn render_mermaid_diagram(
                         markdown.clone(),
                     ))
                 })
+                .when(
+                    show_interactive && parsed.contents.get_frontmatter().is_some(),
+                    |container| container.child(render_mermaid_frontmatter_banner()),
+                )
                 .child(body)
                 .when(show_interactive, |container| {
                     container.child(render_mermaid_copy_button(
@@ -541,6 +548,17 @@ fn render_mermaid_tab_header(
                     });
                 }),
         )
+}
+
+fn render_mermaid_frontmatter_banner() -> impl IntoElement {
+    div().mb_2p5().child(
+        Banner::new()
+            .severity(Severity::Info)
+            .child(Label::new(
+                "Ignoring custom inline styling and metadata for mermaid diagrams as it is not yet supported.",
+            ))
+            .into_any_element(),
+    )
 }
 
 fn render_mermaid_copy_button(


### PR DESCRIPTION
# Objective

This PR fixes the rendering of mermaid diagrams that have YAML frontmatter. As described in #61361, diagrams with a directive or frontmatter were not rendered at all as the check regarding "supported diagram types" failed. 

Fixes #61361 

>[!NOTE]
> The original bug report focuses on `directives`. Given that they are deprecated, the fix here focuses only on YAML frontmatter (the recommendation). See mermaid documentation: https://mermaid.js.org/config/directives.html#directives

## Solution

This PR fixes the issue by detecting YAML frontmatter in the mermaid diagram content and handling it accordingly. The PR does not implement rendering of custom styles, but at least renders the diagram instead of only showing the code representation. 

## Testing

All changes are covered by unit tests. The UI banner that is shown was tested by locally building and rendering mermaid diagrams in a markdown document. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="1479" height="875" alt="image" src="https://github.com/user-attachments/assets/444e6073-453a-4d22-97f7-6ada30f9e3ea" />

---

Release Notes:

- N/A or Added/Fixed/Improved ...
