### PR TITLE
gpui: Make HSLA functions const

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -421,7 +421,7 @@ impl Display for Hsla {
 }
 
 /// Construct an [`Hsla`] object from plain values
-pub fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
+pub const fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
     Hsla {
         h: h.clamp(0., 1.),
         s: s.clamp(0., 1.),
@@ -461,7 +461,7 @@ pub const fn transparent_white() -> Hsla {
 }
 
 /// Opaque grey in [`Hsla`], values will be clamped to the range [0, 1]
-pub fn opaque_grey(lightness: f32, opacity: f32) -> Hsla {
+pub const fn opaque_grey(lightness: f32, opacity: f32) -> Hsla {
     Hsla {
         h: 0.,
         s: 0.,


### PR DESCRIPTION
# Objective

Make hsla functions `const`.

## Solution

Made Hsla-related functions `const fn`.

## Testing

> Did you test these changes? If so, how?

Ran `cargo test -p gpui color` to verify the color-related tests pass.

> Are there any parts that need more testing?

No additional testing is required since this change only changes existing color functions to `const fn`.

> How can other people (reviewers) test your changes? Is there anything specific they need to know?
 
Reviewers can run `cargo test -p gpui color` to verify the changes.

> If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

Tested on macOS. No platform-specific behavior is expected.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A

