### PR TITLE
Refresh git state after branch switch so SSH projects update the branch name

### DIFF
--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -692,7 +692,7 @@ pub async fn restore_worktree_via_git(
     if let Some(branch_name) = &row.branch_name {
         // Attempt to check out the branch the worktree was previously on.
         let checkout_result = wt_repo
-            .update(cx, |repo, _cx| repo.change_branch(branch_name.clone()))
+            .update(cx, |repo, cx| repo.change_branch(branch_name.clone(), cx))
             .await;
 
         match checkout_result.map_err(|e| anyhow!("{e}")).flatten() {

--- a/crates/collab/tests/integration/git_tests.rs
+++ b/crates/collab/tests/integration/git_tests.rs
@@ -907,8 +907,8 @@ async fn test_branch_list_sync(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -7353,8 +7353,8 @@ async fn test_remote_git_branches(
     assert_eq!(branches_b, branches_set);
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch(new_branch.to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -7391,8 +7391,8 @@ async fn test_remote_git_branches(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
+++ b/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
@@ -311,8 +311,8 @@ async fn test_ssh_collaboration_git_branches(
     assert_eq!(&branches_b, &branches_set);
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repo_b, _cx| {
-            repo_b.change_branch(new_branch.to_string())
+        repo_b.update(cx, |repo_b, cx| {
+            repo_b.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -351,8 +351,8 @@ async fn test_ssh_collaboration_git_branches(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repo_b, _cx| {
-            repo_b.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repo_b, cx| {
+            repo_b.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1566,8 +1566,10 @@ impl PickerDelegate for BranchListDelegate {
 
                 let branch = branch.clone();
                 cx.spawn(async move |_, cx| {
-                    repo.update(cx, |repo, cx| repo.change_branch(branch.name().to_string(), cx))
-                        .await??;
+                    repo.update(cx, |repo, cx| {
+                        repo.change_branch(branch.name().to_string(), cx)
+                    })
+                    .await??;
 
                     anyhow::Ok(())
                 })

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1566,7 +1566,7 @@ impl PickerDelegate for BranchListDelegate {
 
                 let branch = branch.clone();
                 cx.spawn(async move |_, cx| {
-                    repo.update(cx, |repo, _| repo.change_branch(branch.name().to_string()))
+                    repo.update(cx, |repo, cx| repo.change_branch(branch.name().to_string(), cx))
                         .await??;
 
                     anyhow::Ok(())

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3607,8 +3607,8 @@ impl GitStore {
         let branch_name = envelope.payload.branch_name;
 
         repository_handle
-            .update(&mut cx, |repository_handle, _| {
-                repository_handle.change_branch(branch_name)
+            .update(&mut cx, |repository_handle, cx| {
+                repository_handle.change_branch(branch_name, cx)
             })
             .await??;
 
@@ -8673,9 +8673,13 @@ impl Repository {
         )
     }
 
-    pub fn change_branch(&mut self, branch_name: String) -> oneshot::Receiver<Result<()>> {
+    pub fn change_branch(
+        &mut self,
+        branch_name: String,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
-        self.send_job(
+        let receiver = self.send_job(
             "change_branch",
             Some(format!("git switch {branch_name}").into()),
             move |repo, _cx| async move {
@@ -8696,7 +8700,29 @@ impl Repository {
                     }
                 }
             },
-        )
+        );
+
+        // The worktree file watcher does not reliably observe the `.git/HEAD`
+        // change produced by `git switch` (notably over SSH, where the switch
+        // runs on the remote and the downstream `UpdateRepository` never gets
+        // sent). Refresh explicitly so the new branch propagates to the UI /
+        // downstream clients. Mirrors `reset`. `schedule_scan` is keyed by
+        // `ReloadGitState`, so any watcher-triggered scan is deduped.
+        let scan_updates_tx =
+            self.git_store()
+                .and_then(|git_store| match &git_store.read(cx).state {
+                    GitStoreState::Local { downstream, .. } => Some(
+                        downstream
+                            .as_ref()
+                            .map(|downstream| downstream.updates_tx.clone()),
+                    ),
+                    _ => None,
+                });
+        if let Some(updates_tx) = scan_updates_tx {
+            self.schedule_scan(updates_tx, cx);
+        }
+
+        receiver
     }
 
     pub fn delete_branch(

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -3320,8 +3320,8 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     assert_eq!(&remote_branches, &branches_set);
 
     cx.update(|cx| {
-        repository.update(cx, |repository, _cx| {
-            repository.change_branch(new_branch.to_string())
+        repository.update(cx, |repository, cx| {
+            repository.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -3349,6 +3349,20 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
 
     assert_eq!(server_branch.name(), branches[2]);
 
+    // The downstream (client) repository must observe the new branch too —
+    // its snapshot is updated via the `UpdateRepository` the server sends
+    // after the scan triggered by `change_branch`.
+    let client_branch = cx.update(|cx| {
+        repository
+            .read(cx)
+            .branch
+            .as_ref()
+            .unwrap()
+            .name()
+            .to_string()
+    });
+    assert_eq!(client_branch, branches[2]);
+
     // Also try creating a new branch
     cx.update(|cx| {
         repository.update(cx, |repo, _cx| {
@@ -3360,8 +3374,8 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     .unwrap();
 
     cx.update(|cx| {
-        repository.update(cx, |repo, _cx| {
-            repo.change_branch("totally-new-branch".to_string())
+        repository.update(cx, |repo, cx| {
+            repo.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await
@@ -3388,6 +3402,17 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     });
 
     assert_eq!(server_branch.name(), "totally-new-branch");
+
+    let client_branch = cx.update(|cx| {
+        repository
+            .read(cx)
+            .branch
+            .as_ref()
+            .unwrap()
+            .name()
+            .to_string()
+    });
+    assert_eq!(client_branch, "totally-new-branch");
 
     let default_branch = cx
         .update(|cx| repository.update(cx, |repository, _cx| repository.default_branch(false)))


### PR DESCRIPTION
## Summary

In a remote (SSH) project, clicking a branch in the branch picker switches the branch successfully (verified on the host with `git branch --show-current` / `cat .git/HEAD`), but the branch name shown in Zed's UI never updates. Local projects are unaffected.

This is the same family of bugs as #55133 / #13176. Two recent PRs (#59876, #61541) hardened the worktree file watcher so `.git` metadata changes reliably trigger a git-state reload. After those landed, however, a **UI-initiated** branch switch in an SSH project still leaves the branch indicator / branch picker stale for me — because `change_branch` itself still relies on the remote host's file watcher catching the `.git/HEAD` write, and that round-trip is not reliable on the SSH host in question. This change makes the UI-initiated switch not depend on the watcher, mirroring how `reset` and `fetch` already work.

## Root cause

`Repository::change_branch` ran `backend.change_branch()` (local) or sent a `GitChangeBranch` RPC (remote) and returned, relying entirely on the worktree file watcher noticing the `.git/HEAD` change to re-scan and propagate the new branch. On the SSH host that round-trip does not reliably fire, so the server never sends a downstream `UpdateRepository` with the new `branch_summary`, the client's `apply_remote_update` never emits `HeadChanged`, and the UI stays stale until something else touches `.git`.

This is inconsistent with the sibling mutating operations, both of which explicitly refresh git state after the mutation rather than trusting the watcher:

- `Repository::reset` calls `schedule_scan(updates_tx, cx)` after the job.
- `Repository::fetch` calls `refresh_branch_list(...)` after a successful fetch.

`change_branch` did neither.

## Fix

Mirror `reset`: make `Repository::change_branch` call `schedule_scan(updates_tx, cx)` after the change job.

- **Local repo:** `schedule_scan(None)` → `compute_snapshot` reads the new branch, emits `HeadChanged` locally.
- **SSH server:** `schedule_scan(Some(tx))` → `compute_snapshot` reads the new branch, sends `DownstreamUpdate::UpdateRepository` over the downstream channel → the client's `apply_remote_update` sees the new `branch_summary` and emits `HeadChanged`.
- **SSH client:** its own git store is `GitStoreState::Remote`, so no local scan runs; the server does it.

`schedule_scan` is keyed by `GitJobKey::ReloadGitState`, so any scan additionally triggered by the watcher is deduped — this change is purely additive and never causes a double scan.

Because `schedule_scan` needs `cx: &mut Context<Self>` (matching `reset`'s signature), `change_branch` now takes `cx`. Updated the branch picker, the server-side `handle_change_branch`, the agent worktree archive caller, and the collab/remote_server integration tests. Added assertions in `test_remote_git_branches` that the downstream client repository observes the new branch after a remote switch.

Because `compute_snapshot` recomputes the full snapshot — branch, HEAD commit, file statuses, and diff stats — the git panel's file list and per-file diff stats refresh together with the branch name, all via the same reliable path.

## Caveats

- I could not reproduce the watcher-unreliability deterministically in the FakeFs-based integration tests (FakeFs delivers watcher events perfectly), so the added assertions pass via the watcher path even without this change and do not, on their own, prove the fix. The evidence that this change matters is a real-world SSH reproduction: on a build that already includes #59876 / #61541, clicking a branch switch in an SSH project still leaves the branch indicator stale; with this change it updates immediately.
- I did not pinpoint exactly why the SSH host's watcher misses the `.git/HEAD` write after #59876 / #61541. The motivation for this change is consistency with `reset` / `fetch`: an in-app mutating git operation should refresh deterministically rather than depend on the remote watcher. If maintainers would rather chase the watcher root cause, I'm happy to help investigate; this PR is intended as a complementary, low-risk fix that makes the UI action not depend on the watcher at all.

## Related

- Closes #55133 (stale branch indicator / picker after switch in SSH projects), which was closed as a duplicate of #13176.
- Complements #59876 and #61541, which fixed the watcher path for stale git state but leave the UI-initiated switch still watcher-dependent.

Release Notes:

- Fixed the branch name in the UI not updating after switching branches in a remote (SSH) project, even though the switch succeeded on the host.