### PR TITLE
ci: Grant version bump token more permissions

### DIFF
--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -26,6 +26,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-workflows: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:

--- a/.github/workflows/bump_zed_version.yml
+++ b/.github/workflows/bump_zed_version.yml
@@ -151,6 +151,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-workflows: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:
@@ -209,6 +210,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-workflows: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       with:

--- a/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
@@ -67,7 +67,10 @@ fn run_bump_patch_version(branch: &WorkflowInput) -> steps::NamedJob {
 
     let (authenticate, token) = steps::authenticate_as_zippy()
         .for_repository(steps::RepositoryTarget::current())
-        .with_permissions([(steps::TokenPermissions::Contents, Level::Write)])
+        .with_permissions([
+            (steps::TokenPermissions::Contents, Level::Write),
+            (steps::TokenPermissions::Workflows, Level::Write),
+        ])
         .into();
     let channel_step = read_channel();
     let tag_suffix = StepOutput::new(&channel_step, "tag_suffix");

--- a/tooling/xtask/src/tasks/workflows/bump_zed_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_zed_version.rs
@@ -186,7 +186,10 @@ fn create_preview_branch(
 
     let (authenticate, token) = steps::authenticate_as_zippy()
         .for_repository(steps::RepositoryTarget::current())
-        .with_permissions([(steps::TokenPermissions::Contents, Level::Write)])
+        .with_permissions([
+            (steps::TokenPermissions::Contents, Level::Write),
+            (steps::TokenPermissions::Workflows, Level::Write),
+        ])
         .into();
 
     let main_sha_step = get_main_sha();
@@ -239,7 +242,10 @@ fn promote_to_stable(
 ) -> steps::NamedJob {
     let (authenticate, token) = steps::authenticate_as_zippy()
         .for_repository(steps::RepositoryTarget::current())
-        .with_permissions([(steps::TokenPermissions::Contents, Level::Write)])
+        .with_permissions([
+            (steps::TokenPermissions::Contents, Level::Write),
+            (steps::TokenPermissions::Workflows, Level::Write),
+        ])
         .into();
 
     let read_version_step = named::bash(indoc::indoc! {r#"


### PR DESCRIPTION
This should hopefully fix the issue with the version bumps we were seeing - to bypass push protections, the token seems to need workflow permissions for some reason as well.

Release Notes:

- N/A
