### PR TITLE
repl: Render SVG cell outputs

### DIFF
--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -67,9 +67,12 @@ use settings::Settings;
 /// When deciding what to render from a collection of mediatypes, we need to rank them in order of importance
 fn rank_mime_type(mimetype: &MimeType) -> usize {
     match mimetype {
-        MimeType::DataTable(_) => 7,
-        MimeType::Html(_) => 6,
-        MimeType::Json(_) => 5,
+        MimeType::DataTable(_) => 8,
+        MimeType::Html(_) => 7,
+        MimeType::Json(_) => 6,
+        // Rank SVG above raster images so a kernel that offers both is shown
+        // as the scalable version.
+        MimeType::Svg(_) => 5,
         MimeType::Png(_) => 4,
         MimeType::Jpeg(_) => 3,
         MimeType::Markdown(_) => 2,
@@ -422,6 +425,13 @@ impl Output {
                     display_id,
                 },
                 Err(error) => Output::Message(format!("Failed to load image: {}", error)),
+            },
+            Some(MimeType::Svg(data)) => match ImageView::from_svg(data, cx) {
+                Ok(view) => Output::Image {
+                    content: cx.new(|_| view),
+                    display_id,
+                },
+                Err(error) => Output::Message(format!("Failed to render SVG: {}", error)),
             },
             Some(MimeType::DataTable(data)) => Output::Table {
                 content: cx.new(|cx| TableView::new(data, window, cx)),

--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -3,7 +3,10 @@ use base64::{
     Engine as _, alphabet,
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
 };
-use gpui::{App, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, Window, img};
+use gpui::{
+    App, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, SMOOTH_SVG_SCALE_FACTOR, Window,
+    img,
+};
 use settings::Settings as _;
 use std::sync::Arc;
 use ui::{IntoElement, Styled, prelude::*};
@@ -67,6 +70,27 @@ impl ImageView {
             height,
             width,
             image: Arc::new(gpui_image_data),
+        })
+    }
+
+    pub fn from_svg(svg: &str, cx: &App) -> Result<Self> {
+        // SVG is vector text rather than a raster format, so it goes through
+        // GPUI's SVG renderer instead of the `image` crate used above.
+        let image = Image::from_bytes(ImageFormat::Svg, svg.as_bytes().to_vec());
+        let render_image = image.to_image_data(cx.svg_renderer())?;
+
+        // The SVG renderer rasterizes at SMOOTH_SVG_SCALE_FACTOR for crispness,
+        // so the pixel dimensions are scaled up from the logical size we want
+        // to lay out at.
+        let size = render_image.size(0);
+        let width = (size.width.0.max(0) as f32 / SMOOTH_SVG_SCALE_FACTOR).round() as u32;
+        let height = (size.height.0.max(0) as f32 / SMOOTH_SVG_SCALE_FACTOR).round() as u32;
+
+        Ok(ImageView {
+            clipboard_image: Arc::new(image),
+            height,
+            width,
+            image: render_image,
         })
     }
 
@@ -155,6 +179,16 @@ mod tests {
         }
 
         base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[gpui::test]
+    async fn test_image_view_from_svg_uses_intrinsic_size(cx: &mut gpui::TestAppContext) {
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80"><rect width="120" height="80" fill="red"/></svg>"#;
+        let view = cx
+            .update(|cx| ImageView::from_svg(svg, cx))
+            .expect("valid SVG should render");
+        assert_eq!(view.width, 120);
+        assert_eq!(view.height, 80);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #61717

SVG outputs from kernels (image/svg+xml) were showing "Unsupported media type" instead of the image. matplotlib, plotly, and other libraries commonly emit SVG, so this was a visible gap for data science users. This came up in discussion #25936.

This renders SVG outputs through GPUI's SVG renderer, reusing the existing ImageView with a from_svg constructor. It also ranks SVG above raster images so a kernel that provides both shows the scalable version.

I added a unit test that checks an SVG renders at its intrinsic size. This caught a scale factor bug where SVGs were rendering at twice their size. I also tested it locally on macOS and a cell producing image/svg+xml now renders the vector image inline.

![SVG output rendered inline](https://raw.githubusercontent.com/ArneshBanerjee/zed-jupyter/pr-assets/61717-svg-after.png)

Release Notes:

- Added rendering of SVG outputs in the REPL and notebook editor