### PR TITLE
fs: Update trash-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19434,7 +19434,7 @@ dependencies = [
 [[package]]
 name = "trash"
 version = "5.2.5"
-source = "git+https://github.com/zed-industries/trash-rs?rev=47761739192828a66b11a94ba5420b82d63c03c5#47761739192828a66b11a94ba5420b82d63c03c5"
+source = "git+https://github.com/zed-industries/trash-rs?rev=41c6c800d884a89351f3b8856d12894cccee261d#41c6c800d884a89351f3b8856d12894cccee261d"
 dependencies = [
  "chrono",
  "libc",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -46,7 +46,7 @@ util.workspace = true
 path.workspace = true
 is_executable = "1.0.5"
 notify = "9.0.0-rc.4"
-trash = { git = "https://github.com/zed-industries/trash-rs", rev = "47761739192828a66b11a94ba5420b82d63c03c5" }
+trash = { git = "https://github.com/zed-industries/trash-rs", rev = "41c6c800d884a89351f3b8856d12894cccee261d" }
 
 [target.'cfg(unix)'.dependencies]
 rustix.workspace = true


### PR DESCRIPTION
# Objective

Update the version of `trash-rs` used in order to contain the fix for the panic when restoring a non-existing trash item in Linux – https://github.com/zed-industries/trash-rs/commit/41c6c800d884a89351f3b8856d12894cccee261d .

## Solution

N/A

## Testing

N/A

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
