### PR TITLE
Fix C++ direct-initialization highlights

### DIFF
--- a/crates/grammars/src/cpp/highlights.scm
+++ b/crates/grammars/src/cpp/highlights.scm
@@ -69,8 +69,18 @@
 (template_method
   name: (field_identifier) @function)
 
-(function_declarator
-  declarator: (identifier) @function)
+; `Type var(args)` in a function body is direct-initialization, not a function
+; declaration.
+(compound_statement
+  (declaration
+    declarator: (function_declarator
+      parameters: (parameter_list
+        (parameter_declaration
+          type: (type_identifier) @variable)))))
+
+((function_declarator
+  declarator: (identifier) @function) @function.declarator
+  (#not-has-parent-chain? @function.declarator declaration compound_statement))
 
 (function_declarator
   declarator: (qualified_identifier
@@ -93,7 +103,8 @@
 
 (auto) @type
 
-(type_identifier) @type
+((type_identifier) @type
+  (#not-has-parent-chain? @type parameter_declaration parameter_list function_declarator declaration compound_statement))
 
 type: (primitive_type) @type.builtin
 

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -103,6 +103,7 @@ struct SyntaxMapCapturesLayer<'a> {
     depth: usize,
     captures: QueryCaptures<'a, 'a, TextProvider<'a>, &'a [u8]>,
     next_capture: Option<QueryCapture<'a>>,
+    query: &'a Query,
     grammar_index: usize,
     _query_cursor: QueryCursorHandle,
 }
@@ -1139,6 +1140,7 @@ impl<'a> SyntaxMapCaptures<'a> {
                 grammar_index,
                 next_capture: None,
                 captures,
+                query,
                 _query_cursor: query_cursor,
             };
 
@@ -1366,7 +1368,17 @@ impl<'a> SyntaxMapMatches<'a> {
 
 impl SyntaxMapCapturesLayer<'_> {
     fn advance(&mut self) {
-        self.next_capture = self.captures.next().map(|(mat, ix)| mat.captures[*ix]);
+        loop {
+            let Some((mat, capture_index)) = self.captures.next() else {
+                self.next_capture = None;
+                return;
+            };
+
+            if satisfies_custom_predicates(self.query, mat) {
+                self.next_capture = Some(mat.captures[*capture_index]);
+                return;
+            }
+        }
     }
 
     fn sort_key(&self) -> (usize, Reverse<usize>, usize) {
@@ -1428,6 +1440,8 @@ fn satisfies_custom_predicates(query: &Query, mat: &QueryMatch) -> bool {
         let satisfied = match predicate.operator.as_ref() {
             "has-parent?" => has_parent(&predicate.args, mat),
             "not-has-parent?" => !has_parent(&predicate.args, mat),
+            "has-parent-chain?" => has_parent_chain(&predicate.args, mat),
+            "not-has-parent-chain?" => !has_parent_chain(&predicate.args, mat),
             _ => true,
         };
         if !satisfied {
@@ -1454,6 +1468,33 @@ fn has_parent(args: &[QueryPredicateArg], mat: &QueryMatch) -> bool {
         .node
         .parent()
         .is_some_and(|p| p.kind() == parent_kind.as_ref())
+}
+
+fn has_parent_chain(args: &[QueryPredicateArg], mat: &QueryMatch) -> bool {
+    let Some(QueryPredicateArg::Capture(capture_ix)) = args.first() else {
+        return false;
+    };
+
+    let Some(capture) = mat.captures.iter().find(|c| c.index == *capture_ix) else {
+        return false;
+    };
+
+    let mut node = capture.node;
+    for parent_kind in &args[1..] {
+        let QueryPredicateArg::String(parent_kind) = parent_kind else {
+            return false;
+        };
+
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        if parent.kind() != parent_kind.as_ref() {
+            return false;
+        }
+        node = parent;
+    }
+
+    true
 }
 
 fn join_ranges(

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -400,6 +400,48 @@ fn test_rust_json_macro_empty_string_highlighting(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_highlight_captures_filter_custom_predicates(cx: &mut App) {
+    let language = Language::new(
+        LanguageConfig {
+            name: "Rust".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["rs".to_string()],
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    )
+    .with_queries(LanguageQueries {
+        highlights: Some(Cow::from(
+            "((closure_expression) @function (#not-has-parent? @function arguments))",
+        )),
+        ..Default::default()
+    })
+    .expect("Could not parse queries");
+
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    registry.add(language.clone());
+    let buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        "fn main() { let standalone = || {}; foo(|| {}); }",
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(language, &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["function"],
+        "fn main() { let standalone = «|| {}»; foo(|| {}); }",
+    );
+}
+
+#[gpui::test]
 fn test_typing_multiple_new_injections(cx: &mut App) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",


### PR DESCRIPTION
Closes #61494

Summary:
- Prevents generic function and type captures from overriding C++ direct-initialization variables.
- Applies custom Tree-sitter predicates while iterating syntax-highlight captures.
- Adds a regression test covering predicate-filtered highlight captures.

Validation:
- Confirmed the reproduced parse tree: function_declarator -> declaration -> compound_statement.
- Ran rustfmt and git diff --check.

Release Notes:

- Fixed C++ direct-initialization variables being highlighted as functions or types.