### PR TITLE
release_channel: Allow compile time overrides that don't use `include_str!`

### DIFF
--- a/crates/release_channel/build.rs
+++ b/crates/release_channel/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(__do_not_set_zed_release_channel)");
+    println!("cargo::rerun-if-env-changed=ZED_RELEASE_CHANNEL");
+
+    // Enabling this `cfg` will cause a runtime panic if the
+    // `ZED_RELEASE_CHANNEL` env var is not also set. TLDR: don't set the `cfg`
+    // directly, just set the env var (hence the name).
+    if std::env::var("ZED_RELEASE_CHANNEL").is_ok() {
+        println!("cargo::rustc-cfg=__do_not_set_zed_release_channel");
+    }
+}

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -12,12 +12,27 @@ const ZED_DOCS_URL: &str = "https://zed.dev/docs";
 /// stable | dev | nightly | preview
 pub static RELEASE_CHANNEL_NAME: LazyLock<String> = LazyLock::new(|| {
     if cfg!(debug_assertions) {
-        env::var("ZED_RELEASE_CHANNEL")
-            .unwrap_or_else(|_| include_str!("../../zed/RELEASE_CHANNEL").trim().to_string())
+        env::var("ZED_RELEASE_CHANNEL").unwrap_or_else(|_| compile_time_release_channel_name())
     } else {
-        include_str!("../../zed/RELEASE_CHANNEL").trim().to_string()
+        compile_time_release_channel_name()
     }
 });
+
+
+/// When a crate in zed is used as a dependency that uses the `crane` nix
+/// library, it vendors each crate separately and builds it in isolation, which
+/// makes the `include_str!` fail. 
+/// 
+/// The build script checks for `$ZED_RELEASE_CHANNEL` and emits the `cfg`
+#[cfg(__do_not_set_zed_release_channel)]
+fn compile_time_release_channel_name() -> String {
+    env!("ZED_RELEASE_CHANNEL").trim().to_string()
+}
+
+#[cfg(not(__do_not_set_zed_release_channel))]
+fn compile_time_release_channel_name() -> String {
+    include_str!("../../zed/RELEASE_CHANNEL").trim().to_string()
+}
 
 #[doc(hidden)]
 pub static RELEASE_CHANNEL: LazyLock<ReleaseChannel> =

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -18,11 +18,10 @@ pub static RELEASE_CHANNEL_NAME: LazyLock<String> = LazyLock::new(|| {
     }
 });
 
-
 /// When a crate in zed is used as a dependency that uses the `crane` nix
 /// library, it vendors each crate separately and builds it in isolation, which
-/// makes the `include_str!` fail. 
-/// 
+/// makes the `include_str!` fail.
+///
 /// The build script checks for `$ZED_RELEASE_CHANNEL` and emits the `cfg`
 #[cfg(__do_not_set_zed_release_channel)]
 fn compile_time_release_channel_name() -> String {


### PR DESCRIPTION
Some crates in zed use `include_str!("../../zed/RELEASE_CHANNEL")`, which breaks when used as a dependency in a crane nix build (each crate is built in isolation). 

This adds a compile time env var to skip that check, which allows crates in the zed repo to be used as dependencies in a crane build. 

---

Release Notes:

- N/A or Added/Fixed/Improved ...
