### PR TITLE
markdown: Scale mermaid diagrams with font size zoom

### DIFF
--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -87,7 +87,7 @@ impl RenderImage {
     }
 
     /// Get the size of this image, in pixels for display, adjusted for the scale factor.
-    pub(crate) fn render_size(&self, frame_index: usize) -> Size<Pixels> {
+    pub fn render_size(&self, frame_index: usize) -> Size<Pixels> {
         self.size(frame_index)
             .map(|v| (v.0 as f32 / self.scale_factor).into())
     }

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -427,13 +427,25 @@ pub(crate) fn render_mermaid_diagram(
     }
 }
 
+/// `merman` lays diagrams out against a 16px base font (see `inject_css.rs`), so
+/// one rem of diagram matches one rem of surrounding text. Sizing the image in
+/// rems (rather than the pixels it was rasterized at) is what lets `Ctrl +/-`,
+/// which only changes the window's rem size, scale diagrams too.
+const MERMAID_BASE_REM_SIZE: f32 = 16.0;
+
+fn mermaid_image_width(render_image: &RenderImage) -> Rems {
+    rems(f32::from(render_image.render_size(0).width) / MERMAID_BASE_REM_SIZE)
+}
+
 /// Renders a mermaid diagram image, scrolling at intrinsic size in preview or fit-to-pane elsewhere.
 fn render_mermaid_image(
     render_image: Arc<RenderImage>,
     allow_overflow_x: bool,
     source_offset: usize,
 ) -> AnyElement {
+    let width = mermaid_image_width(&render_image);
     let image = img(ImageSource::Render(render_image))
+        .w(width)
         .with_fallback(|| Label::new("Failed to Load Mermaid Diagram").into_any_element());
 
     if allow_overflow_x {
@@ -550,7 +562,8 @@ fn render_mermaid_code_view(contents: &SharedString) -> AnyElement {
 mod tests {
     use super::{
         CachedMermaidDiagram, MermaidDiagramCache, MermaidState,
-        ParsedMarkdownMermaidDiagramContents, extract_mermaid_diagrams, parse_mermaid_info,
+        ParsedMarkdownMermaidDiagramContents, extract_mermaid_diagrams, mermaid_image_width,
+        parse_mermaid_info,
     };
     use crate::{
         CodeBlockRenderer, CopyButtonVisibility, Markdown, MarkdownElement, MarkdownOptions,
@@ -669,6 +682,20 @@ mod tests {
             super::mermaid_font_family("Custom Font, sans-serif"),
             "Custom Font, sans-serif"
         );
+    }
+
+    #[gpui::test]
+    fn test_mermaid_image_width_scales_with_rem_base(cx: &mut TestAppContext) {
+        let render_image = cx.update(|cx| {
+            cx.svg_renderer()
+                .render_single_frame(
+                    br#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"></svg>"#,
+                    1.0,
+                )
+                .unwrap()
+        });
+
+        assert_eq!(mermaid_image_width(&render_image), gpui::rems(12.5));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #61710

Mermaid diagrams are rasterized to a bitmap once (`CachedMermaidDiagram::new` in `crates/markdown/src/mermaid.rs`) and rendered through `img(ImageSource::Render(..))` with no explicit size, so GPUI laid it out at its intrinsic device-pixel size (`crates/gpui/src/elements/img.rs`). `Ctrl +/-` only ever changed the window's rem size (`MarkdownPreviewView::adjust_font_size`, feeding `WithRemSize`), so a diagram sized in raw pixels never responded to it. Every other element in the preview scaled; the diagrams didn't.

This makes the diagram's width follow the rem size instead of the pixels it happened to be rasterized at. `merman` lays diagrams out against a 16px base font, so one rem of diagram matches one rem of surrounding text; dividing the rasterized width by 16 and setting that as the image's width (in rems) means the same zoom math GPUI already applies to text now applies to diagrams too, with no re-rasterization needed.

Manual test before the change :

[Screencast from 2026-07-27 17-43-37.webm](https://github.com/user-attachments/assets/9643b228-80ee-4602-ad1e-89b69574172b)

Manual test after the change :

[Screencast from 2026-07-27 17-39-41.webm](https://github.com/user-attachments/assets/d0f1dbb3-24f1-4977-8add-340dd7fd80e4)


## How to Review

**`crates/gpui/src/assets.rs`**

`RenderImage::render_size` was `pub(crate)`; it already computes exactly "intrinsic layout-pixel size, adjusted for the image's own supersample `scale_factor`" (mermaid bitmaps are rendered at 2x, see `SMOOTH_SVG_SCALE_FACTOR`). Made it `pub` so `markdown` can read a diagram's natural size without re-deriving it. Purely additive, with no existing caller changes.

**`crates/markdown/src/mermaid.rs`**

Added `mermaid_image_width`, which converts a `RenderImage`'s natural width into `Rems` (`natural_px / 16.0`), and applied it via `.w(width)` in `render_mermaid_image`. Height is left as `Length::Auto`, since `img.rs` already derives the missing dimension from `style.aspect_ratio` once one side is definite, so both existing rendering paths (the `overflow_x_scroll` branch used by preview, and the `max_w_full()` fit-to-pane branch used elsewhere) keep the correct aspect ratio. Both the "ready" and the pulsing-fallback render paths already funnel through `render_mermaid_image`, so no other call site needed to change. The `mermaid 150`-style scale annotation is baked into the bitmap at rasterization time, so it still multiplies on top of this unchanged.

No `cx.notify()` or cache-key change was needed: `adjust_markdown_preview_font_size` already calls `cx.refresh_windows()`, and rem-based lengths are resolved at layout time.

Added `test_mermaid_image_width_scales_with_rem_base`, which rasterizes a 200×100 mock SVG and asserts `mermaid_image_width` returns `rems(12.5)`, confirming the 2x supersample is divided back out and the 16px base is applied correctly. Existing mermaid tests (source-anchor mapping, fallback caching, scale parsing) continue to pass unmodified since they don't assert on pixel size.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed mermaid diagrams not scaling when zooming markdown preview in or out
