### PR TITLE
agent_ui: Fix agent panel font inconsistencies

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6473,7 +6473,13 @@ impl Render for AgentPanel {
                     })
                 }
             }))
-            .child(self.render_toolbar(window, cx))
+            .child(
+                WithRemSize::new(crate::ui_chrome_rem_size(cx))
+                    .w_full()
+                    .flex_none()
+                    .font_family(ThemeSettings::get_global(cx).ui_font.family.clone())
+                    .child(self.render_toolbar(window, cx)),
+            )
             .children(self.render_new_user_onboarding(window, cx))
             .map(|parent| match self.visible_surface() {
                 VisibleSurface::Uninitialized if !self.has_open_project(cx) => {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -947,6 +947,18 @@ fn update_active_language_model_from_settings(cx: &mut App) {
     });
 }
 
+/// The rem size for agent panel chrome that follows the global UI font size
+/// while still tracking the panel's ephemeral zoom.
+pub(crate) fn ui_chrome_rem_size(cx: &App) -> gpui::Pixels {
+    let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+    let zoom_delta = theme_settings.agent_ui_font_size(cx)
+        - theme_settings
+            .agent_ui_font_size_settings()
+            .map(theme_settings::clamp_font_size)
+            .unwrap_or_else(|| theme_settings.ui_font_size(cx));
+    theme_settings.ui_font_size(cx) + zoom_delta
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -951,11 +951,15 @@ fn update_active_language_model_from_settings(cx: &mut App) {
 /// while still tracking the panel's ephemeral zoom.
 pub(crate) fn ui_chrome_rem_size(cx: &App) -> gpui::Pixels {
     let theme_settings = theme_settings::ThemeSettings::get_global(cx);
-    let zoom_delta = theme_settings.agent_ui_font_size(cx)
-        - theme_settings
+    // The baseline comes from the configured sizes rather than the resolved
+    // ones, so that an ephemeral agent zoom composes with the global UI zoom
+    // instead of cancelling it.
+    let baseline = theme_settings::clamp_font_size(
+        theme_settings
             .agent_ui_font_size_settings()
-            .map(theme_settings::clamp_font_size)
-            .unwrap_or_else(|| theme_settings.ui_font_size(cx));
+            .unwrap_or_else(|| theme_settings.ui_font_size_settings()),
+    );
+    let zoom_delta = theme_settings.agent_ui_font_size(cx) - baseline;
     theme_settings.ui_font_size(cx) + zoom_delta
 }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -41,9 +41,10 @@ use language_model::{
 };
 use notifications::status_toast::StatusToast;
 use settings::{update_settings_file, update_settings_file_with_completion};
+use theme_settings::ThemeSettings;
 use ui::{
     ButtonLike, CalloutBorderPosition, Checkbox, SpinnerLabel, SpinnerVariant, SplitButton,
-    SplitButtonStyle, Tab, ToggleState,
+    SplitButtonStyle, Tab, ToggleState, utils::WithRemSize,
 };
 use util::markdown::{source_position_from_fragment, split_local_url_fragment};
 use workspace::{OpenOptions, SERIALIZATION_THROTTLE_TIME};
@@ -4401,37 +4402,51 @@ impl ThreadView {
                             }),
                     )
                     .child(
-                        h_flex()
-                            .w_full()
-                            .min_w_0()
-                            .flex_none()
-                            .flex_wrap()
-                            .justify_between()
-                            .child(
-                                h_flex()
-                                    .min_w_0()
-                                    .flex_wrap()
-                                    .gap_0p5()
-                                    .child(self.render_add_context_button(cx))
-                                    .child(self.render_follow_toggle(cx))
-                                    .children(self.render_fast_mode_control(cx))
-                                    .children(self.render_thinking_control(cx)),
-                            )
-                            .child(
-                                h_flex()
-                                    .min_w_0()
-                                    .flex_wrap()
-                                    .gap_1()
-                                    .children(self.render_token_usage(cx))
-                                    .children(self.profile_selector.clone())
-                                    .map(|this| match self.config_options_view.clone() {
-                                        Some(config_view) => this.child(config_view),
-                                        None => this
-                                            .children(self.mode_selector.clone())
-                                            .children(self.model_selector.clone()),
-                                    })
-                                    .child(self.render_send_button(cx)),
-                            ),
+                        {
+                            let theme_settings = ThemeSettings::get_global(cx);
+                            let zoom_delta = theme_settings.agent_ui_font_size(cx)
+                                - theme_settings
+                                    .agent_ui_font_size_settings()
+                                    .map(theme_settings::clamp_font_size)
+                                    .unwrap_or_else(|| theme_settings.ui_font_size(cx));
+                            WithRemSize::new(theme_settings.ui_font_size(cx) + zoom_delta)
+                                .w_full()
+                                .flex_none()
+                                .font_family(theme_settings.ui_font.family.clone())
+                        }
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .min_w_0()
+                                .flex_none()
+                                .flex_wrap()
+                                .justify_between()
+                                .child(
+                                    h_flex()
+                                        .min_w_0()
+                                        .flex_wrap()
+                                        .gap_0p5()
+                                        .child(self.render_add_context_button(cx))
+                                        .child(self.render_follow_toggle(cx))
+                                        .children(self.render_fast_mode_control(cx))
+                                        .children(self.render_thinking_control(cx)),
+                                )
+                                .child(
+                                    h_flex()
+                                        .min_w_0()
+                                        .flex_wrap()
+                                        .gap_1()
+                                        .children(self.render_token_usage(cx))
+                                        .children(self.profile_selector.clone())
+                                        .map(|this| match self.config_options_view.clone() {
+                                            Some(config_view) => this.child(config_view),
+                                            None => this
+                                                .children(self.mode_selector.clone())
+                                                .children(self.model_selector.clone()),
+                                        })
+                                        .child(self.render_send_button(cx)),
+                                ),
+                        ),
                     ),
             )
             .into_any()
@@ -7748,9 +7763,11 @@ impl ThreadView {
             .unwrap_or(&command_source)
             .to_string();
 
-        let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
-        style.container_style.text.font_size = Some(rems_from_px(12.).into());
-        style.container_style.text.line_height = Some(rems_from_px(17.).into());
+        // Terminal command labels are parsed as plain text, so the command
+        // renders outside a code block; keep it on the buffer font.
+        let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx).with_buffer_font(cx);
+        style.container_style.text.font_size = Some(rems_from_px(11.).into());
+        style.container_style.text.line_height = Some(rems_from_px(16.).into());
         style.height_is_multiple_of_line_height = true;
         // Soft-wrap the command instead of horizontally scrolling it: the card is
         // narrow, and in scroll mode a long command wraps anyway but its wrapped

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7758,8 +7758,8 @@ impl ThreadView {
         // Terminal command labels are parsed as plain text, so the command
         // renders outside a code block; keep it on the buffer font.
         let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx).with_buffer_font(cx);
-        style.container_style.text.font_size = Some(rems_from_px(11.).into());
-        style.container_style.text.line_height = Some(rems_from_px(16.).into());
+        style.container_style.text.font_size = Some(rems_from_px(12.).into());
+        style.container_style.text.line_height = Some(rems_from_px(17.).into());
         style.height_is_multiple_of_line_height = true;
         // Soft-wrap the command instead of horizontally scrolling it: the card is
         // narrow, and in scroll mode a long command wraps anyway but its wrapped

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4402,51 +4402,43 @@ impl ThreadView {
                             }),
                     )
                     .child(
-                        {
-                            let theme_settings = ThemeSettings::get_global(cx);
-                            let zoom_delta = theme_settings.agent_ui_font_size(cx)
-                                - theme_settings
-                                    .agent_ui_font_size_settings()
-                                    .map(theme_settings::clamp_font_size)
-                                    .unwrap_or_else(|| theme_settings.ui_font_size(cx));
-                            WithRemSize::new(theme_settings.ui_font_size(cx) + zoom_delta)
-                                .w_full()
-                                .flex_none()
-                                .font_family(theme_settings.ui_font.family.clone())
-                        }
-                        .child(
-                            h_flex()
-                                .w_full()
-                                .min_w_0()
-                                .flex_none()
-                                .flex_wrap()
-                                .justify_between()
-                                .child(
-                                    h_flex()
-                                        .min_w_0()
-                                        .flex_wrap()
-                                        .gap_0p5()
-                                        .child(self.render_add_context_button(cx))
-                                        .child(self.render_follow_toggle(cx))
-                                        .children(self.render_fast_mode_control(cx))
-                                        .children(self.render_thinking_control(cx)),
-                                )
-                                .child(
-                                    h_flex()
-                                        .min_w_0()
-                                        .flex_wrap()
-                                        .gap_1()
-                                        .children(self.render_token_usage(cx))
-                                        .children(self.profile_selector.clone())
-                                        .map(|this| match self.config_options_view.clone() {
-                                            Some(config_view) => this.child(config_view),
-                                            None => this
-                                                .children(self.mode_selector.clone())
-                                                .children(self.model_selector.clone()),
-                                        })
-                                        .child(self.render_send_button(cx)),
-                                ),
-                        ),
+                        WithRemSize::new(crate::ui_chrome_rem_size(cx))
+                            .w_full()
+                            .flex_none()
+                            .font_family(ThemeSettings::get_global(cx).ui_font.family.clone())
+                            .child(
+                                h_flex()
+                                    .w_full()
+                                    .min_w_0()
+                                    .flex_none()
+                                    .flex_wrap()
+                                    .justify_between()
+                                    .child(
+                                        h_flex()
+                                            .min_w_0()
+                                            .flex_wrap()
+                                            .gap_0p5()
+                                            .child(self.render_add_context_button(cx))
+                                            .child(self.render_follow_toggle(cx))
+                                            .children(self.render_fast_mode_control(cx))
+                                            .children(self.render_thinking_control(cx)),
+                                    )
+                                    .child(
+                                        h_flex()
+                                            .min_w_0()
+                                            .flex_wrap()
+                                            .gap_1()
+                                            .children(self.render_token_usage(cx))
+                                            .children(self.profile_selector.clone())
+                                            .map(|this| match self.config_options_view.clone() {
+                                                Some(config_view) => this.child(config_view),
+                                                None => this
+                                                    .children(self.mode_selector.clone())
+                                                    .children(self.model_selector.clone()),
+                                            })
+                                            .child(self.render_send_button(cx)),
+                                    ),
+                            ),
                     ),
             )
             .into_any()

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -195,8 +195,14 @@ impl MarkdownStyle {
         };
         let code_font_family = match font {
             MarkdownFont::Preview => theme_settings.markdown_preview_code_font_family().clone(),
-            MarkdownFont::Agent => theme_settings.agent_ui_font_family().clone(),
+            // Fenced code blocks keep a buffer font rather than following the
+            // agent font family.
+            MarkdownFont::Agent => theme_settings.agent_buffer_font_family().clone(),
             MarkdownFont::Editor => theme_settings.buffer_font.family.clone(),
+        };
+        let inline_code_font_family = match font {
+            MarkdownFont::Agent => theme_settings.agent_ui_font_family().clone(),
+            MarkdownFont::Preview | MarkdownFont::Editor => code_font_family.clone(),
         };
 
         let mut text_style = window.text_style();
@@ -266,7 +272,7 @@ impl MarkdownStyle {
                 ..Default::default()
             },
             inline_code: TextStyleRefinement {
-                font_family: Some(code_font_family),
+                font_family: Some(inline_code_font_family),
                 font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                 font_features: Some(theme_settings.buffer_font.features.clone()),
                 font_size: Some(buffer_font_size.into()),


### PR DESCRIPTION
#59629 applies `agent_ui_font_family` and the agent panel rem size to the message editor's controls, which should follow the global UI font. It also moved fenced code blocks and terminal command labels off the buffer font.

Keep the message editor controls on the global UI font family and size, render terminal commands in the buffer font next to the working directory label, and point fenced code blocks at `agent_buffer_font_family` so they fall back to the buffer font. Inline code is unchanged.

## Showcase

| Aspect | Main (current) | This PR |
|---|---|---|
| Screenshot | ![Main](https://github.com/user-attachments/assets/6c5e2f32-5902-4659-90db-993bcf88a4a6) | ![This PR](https://github.com/user-attachments/assets/7cd6c4f8-796e-418e-b134-28231fd05d68) |
| Toolbar/titlebar sizing | Scales with `agent_ui_font_size` → becomes disproportionately huge | Fixed size, uses global UI font |
| Dropdown buttons | Oversized when `agent_ui_font_size` increased | Fixed, normal-sized |
| Font source for editor controls/toolbar | Agent font settings | Global UI font (since it's panel UI, not conversation content) |

Release Notes:

- Fixed the agent panel's message editor controls following the agent font settings instead of the UI font, and restored the buffer font for terminal commands and fenced code blocks.