### PR TITLE
Add option to not persist agent model and profile selection to user settings

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -462,7 +462,7 @@ pub trait AgentModelSelector: 'static {
     ///
     /// # Returns
     /// A task resolving to `Ok(())` on success or an error.
-    fn select_model(&self, model_id: AgentModelId, cx: &mut App) -> Task<Result<()>>;
+    fn select_model(&self, model_id: AgentModelId, save_to_settings: bool, cx: &mut App) -> Task<Result<()>>;
 
     /// Retrieves the currently selected model for a specific session (thread).
     ///
@@ -1116,7 +1116,7 @@ mod test_support {
             Task::ready(Ok(AgentModelList::Flat(vec![model])))
         }
 
-        fn select_model(&self, model_id: AgentModelId, _cx: &mut App) -> Task<Result<()>> {
+        fn select_model(&self, model_id: AgentModelId, _save_to_settings: bool, _cx: &mut App) -> Task<Result<()>> {
             self.selected_model.lock().id = model_id;
             Task::ready(Ok(()))
         }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -2398,7 +2398,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
         })
     }
 
-    fn select_model(&self, model_id: AgentModelId, cx: &mut App) -> Task<Result<()>> {
+    fn select_model(&self, model_id: AgentModelId, save_to_settings: bool, cx: &mut App) -> Task<Result<()>> {
         log::debug!(
             "Setting model for session {}: {}",
             self.session_id,
@@ -2444,26 +2444,28 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             }
         });
 
-        update_settings_file(
-            self.connection.0.read(cx).fs.clone(),
-            cx,
-            move |settings, cx| {
-                let provider = model.provider_id().0.to_string();
-                let model = model.id().0.to_string();
-                let enable_thinking = thread.read(cx).thinking_enabled();
-                let speed = thread.read(cx).speed();
-                settings
-                    .agent
-                    .get_or_insert_default()
-                    .set_model(LanguageModelSelection {
-                        provider: provider.into(),
-                        model,
-                        enable_thinking,
-                        effort,
-                        speed,
-                    });
-            },
-        );
+        if save_to_settings {
+            update_settings_file(
+                self.connection.0.read(cx).fs.clone(),
+                cx,
+                move |settings, cx| {
+                    let provider = model.provider_id().0.to_string();
+                    let model = model.id().0.to_string();
+                    let enable_thinking = thread.read(cx).thinking_enabled();
+                    let speed = thread.read(cx).speed();
+                    settings
+                        .agent
+                        .get_or_insert_default()
+                        .set_model(LanguageModelSelection {
+                            provider: provider.into(),
+                            model,
+                            enable_thinking,
+                            effort,
+                            speed,
+                        });
+                },
+            );
+        }
 
         Task::ready(Ok(()))
     }
@@ -5648,7 +5650,7 @@ mod internal_tests {
         // Select a model
         let selector = connection.model_selector(&session_id).unwrap();
         let model_id = AgentModelId::new("fake/fake");
-        cx.update(|cx| selector.select_model(model_id.clone(), cx))
+        cx.update(|cx| selector.select_model(model_id.clone(), true, cx))
             .await
             .unwrap();
 
@@ -5698,7 +5700,7 @@ mod internal_tests {
         agent.update(cx, |agent, cx| agent.models.refresh_list(cx));
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), true, cx))
             .await
             .unwrap();
         cx.run_until_parked();
@@ -5772,7 +5774,7 @@ mod internal_tests {
 
         // Select the thinking model via select_model.
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), true, cx))
             .await
             .unwrap();
 
@@ -5789,7 +5791,7 @@ mod internal_tests {
 
         // Switch back to the non-thinking model.
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake/fake"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake/fake"), true, cx))
             .await
             .unwrap();
 
@@ -5906,7 +5908,7 @@ mod internal_tests {
         let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), true, cx))
             .await
             .unwrap();
 
@@ -6009,7 +6011,7 @@ mod internal_tests {
         let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/custom-model-id"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/custom-model-id"), true, cx))
             .await
             .unwrap();
 
@@ -6119,7 +6121,7 @@ mod internal_tests {
         let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/custom-model-id"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/custom-model-id"), true, cx))
             .await
             .unwrap();
 
@@ -6248,7 +6250,7 @@ mod internal_tests {
         cx.run_until_parked();
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(AgentModelId::new("other-corp/other-model-id"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("other-corp/other-model-id"), true, cx))
             .await
             .unwrap();
 

--- a/crates/agent_ui/src/agent_model_selector.rs
+++ b/crates/agent_ui/src/agent_model_selector.rs
@@ -34,17 +34,19 @@ impl AgentModelSelector {
                     },
                     {
                         let fs = fs.clone();
-                        move |model, cx| {
+                        move |model, save_to_settings, cx| {
                             let provider = model.provider_id().0.to_string();
                             let model_id = model.id().0.to_string();
                             match &model_usage_context {
                                 ModelUsageContext::InlineAssistant => {
-                                    update_settings_file(fs.clone(), cx, move |settings, _cx| {
-                                        settings
-                                            .agent
-                                            .get_or_insert_default()
-                                            .set_inline_assistant_model(provider.clone(), model_id);
-                                    });
+                                    if save_to_settings {
+                                        update_settings_file(fs.clone(), cx, move |settings, _cx| {
+                                            settings
+                                                .agent
+                                                .get_or_insert_default()
+                                                .set_inline_assistant_model(provider.clone(), model_id);
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -11780,7 +11780,7 @@ impl ThreadView {
         else {
             return;
         };
-        let select = selector.select_model(model_id, cx);
+        let select = selector.select_model(model_id, false, cx);
         cx.spawn(async move |this, cx| {
             select.await?;
             this.update(cx, |this, cx| this.retry_generation(cx))?;

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -19,7 +19,7 @@ use zed_actions::agent::OpenSettings;
 
 use crate::ui::{ModelSelectorFooter, ModelSelectorHeader, ModelSelectorListItem};
 
-type OnModelChanged = Arc<dyn Fn(Arc<dyn LanguageModel>, &mut App) + 'static>;
+type OnModelChanged = Arc<dyn Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static>;
 type GetActiveModel = Arc<dyn Fn(&App) -> Option<ConfiguredModel> + 'static>;
 type OnToggleFavorite = Arc<dyn Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static>;
 
@@ -27,7 +27,7 @@ pub type LanguageModelSelector = Picker<LanguageModelPickerDelegate>;
 
 pub fn language_model_selector(
     get_active_model: impl Fn(&App) -> Option<ConfiguredModel> + 'static,
-    on_model_changed: impl Fn(Arc<dyn LanguageModel>, &mut App) + 'static,
+    on_model_changed: impl Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static,
     on_toggle_favorite: impl Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static,
     popover_styles: bool,
     focus_handle: FocusHandle,
@@ -488,7 +488,8 @@ impl PickerDelegate for LanguageModelPickerDelegate {
             self.filtered_entries.get(self.selected_index)
         {
             let model = model_info.model.clone();
-            (self.on_model_changed)(model.clone(), cx);
+            let save_to_settings = !window.modifiers().shift;
+            (self.on_model_changed)(model.clone(), save_to_settings, cx);
 
             let current_index = self.selected_index;
             self.set_selected_index(current_index, window, cx);

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -172,7 +172,7 @@ impl ModelPickerDelegate {
         let next_model = favorite_models[next_index].clone();
 
         self.selector
-            .select_model(next_model.id.clone(), cx)
+            .select_model(next_model.id.clone(), true, cx)
             .detach_and_log_err(cx);
 
         self.selected_model = Some(next_model);
@@ -271,8 +271,9 @@ impl PickerDelegate for ModelPickerDelegate {
             self.filtered_entries.get(self.selected_index)
             && model_info.disabled.is_none()
         {
+            let save_to_settings = !window.modifiers().shift;
             self.selector
-                .select_model(model_info.id.clone(), cx)
+                .select_model(model_info.id.clone(), save_to_settings, cx)
                 .detach_and_log_err(cx);
             self.selected_model = Some(model_info.clone());
             let current_index = self.selected_index;
@@ -646,7 +647,7 @@ mod tests {
             Task::ready(Ok(AgentModelList::Flat(self.models.clone())))
         }
 
-        fn select_model(&self, model_id: AgentModelId, _cx: &mut App) -> Task<Result<()>> {
+        fn select_model(&self, model_id: AgentModelId, _save_to_settings: bool, _cx: &mut App) -> Task<Result<()>> {
             self.selected_models.borrow_mut().push(model_id.clone());
             if let Some(model) = self.models.iter().find(|model| model.id == model_id) {
                 *self.selected_model.borrow_mut() = model.clone();

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -570,7 +570,7 @@ impl PickerDelegate for ProfilePickerDelegate {
         })
     }
 
-    fn confirm(&mut self, _: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         match self.filtered_entries.get(self.selected_index) {
             Some(ProfilePickerEntry::Profile(entry)) => {
                 if let Some(candidate) = self.candidates.get(entry.candidate_index) {
@@ -578,15 +578,17 @@ impl PickerDelegate for ProfilePickerDelegate {
                     let fs = self.fs.clone();
                     let provider = self.provider.clone();
 
-                    update_settings_file(fs, cx, {
-                        let profile_id = profile_id.clone();
-                        move |settings, _cx| {
-                            settings
-                                .agent
-                                .get_or_insert_default()
-                                .set_profile(profile_id.0);
-                        }
-                    });
+                    if !window.modifiers().shift {
+                        update_settings_file(fs, cx, {
+                            let profile_id = profile_id.clone();
+                            move |settings, _cx| {
+                                settings
+                                    .agent
+                                    .get_or_insert_default()
+                                    .set_profile(profile_id.0);
+                            }
+                        });
+                    }
 
                     provider.set_profile(profile_id.clone(), cx);
 


### PR DESCRIPTION
## Objective

Fixes #61472.  
Selecting a model or profile from the agent panel dropdown currently always writes the choice into `settings.json` as the global default. This makes it impossible to temporarily switch models for a single conversation without altering the permanent default. A modifier key approach was suggested by maintainers to preserve both workflows.

## Solution

Holding **Shift** while selecting a model or profile applies the choice to the current session/thread only, without modifying `settings.json`. The default behavior (no modifier) remains unchanged.

### How it works

- A `save_to_settings: bool` flag is threaded from the UI to the model/profile selection logic.
- In the picker `confirm` methods, `!window.modifiers().shift` is passed as `save_to_settings`.  
- The `update_settings_file()` calls that persist `default_model` / `default_profile` are gated behind this flag.
- The retry‑with‑different‑model flow always passes `false` (session‑only); cycling favorite models always passes `true`.

### What is *not* affected

- Thread serialization continues to save per‑thread model/profile state independently. Re‑opening a thread restores its selections correctly.
- All existing tests and the default (no‑Shift) UX remain identical.

## Testing

- **Manual:** Selecting a model/profile without Shift still writes to `settings.json`. Holding Shift skips the write but applies the change to the current thread.  
- **Retry:** “Retry with different model” does not modify `settings.json`.  
- **Favorite cycling:** The keyboard shortcut still updates `settings.json`.  
- Existing automated tests pass (all call sites supply the expected flag).

## Release Notes

- Added Shift+click/Enter support in the agent model and profile selectors: holding Shift while selecting makes the change session‑only without writing to `settings.json`. Default behavior (no Shift) is unchanged.