### PR TITLE
editor: Fix phantom fold chevrons and lifted lines when folding

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2253,17 +2253,9 @@ impl DisplaySnapshot {
         }
 
         (buffer_row.0 + 1..=max_row.0)
-            .find_map(|next_row| {
-                let next_line_indent = self.line_indent_for_buffer_row(MultiBufferRow(next_row));
-                if next_line_indent.raw_len() > line_indent.raw_len() {
-                    Some(true)
-                } else if !next_line_indent.is_line_blank() {
-                    Some(false)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(false)
+            .map(|next_row| self.line_indent_for_buffer_row(MultiBufferRow(next_row)))
+            .find(|next_line_indent| !next_line_indent.is_line_blank())
+            .is_some_and(|next_line_indent| next_line_indent.raw_len() > line_indent.raw_len())
     }
 
     /// Returns the indent length of `row` if it starts with a closing bracket.
@@ -3971,6 +3963,34 @@ pub mod tests {
 
             map
         });
+    }
+
+    #[gpui::test]
+    fn test_starts_indent_with_whitespace_only_blank_lines(cx: &mut gpui::App) {
+        init_test(cx, &|_| {});
+
+        // The single-space lines are deliberate: such a line is blank but still has a non-zero
+        // indent length, so an indent comparison that does not skip it makes row 0 look foldable.
+        let buffer = MultiBuffer::build_simple("aaa\n \nbbb\nccc\n \n    ddd", cx);
+        let font_size = px(14.0);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer.clone(),
+                font("Helvetica"),
+                font_size,
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert!(!snapshot.starts_indent(MultiBufferRow(0)));
+        assert!(snapshot.crease_for_buffer_row(MultiBufferRow(0)).is_none());
+        assert!(snapshot.starts_indent(MultiBufferRow(3)));
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2296,10 +2296,20 @@ impl DisplaySnapshot {
             .collect();
 
         let scope = snapshot.language_scope_at(Point::new(row, 0))?;
-        if scope
+        // Pairs whose `start` and `end` are identical, like Markdown's `*` or Python's `"`, cannot
+        // be told apart lexically, so require the line to match an `end` more specifically than any
+        // `start`. That keeps real closers such as Rust's `"#` while rejecting `**bold**`.
+        let matched_len =
+            |delimiter: &str| line_text.starts_with(delimiter).then_some(delimiter.len());
+        let longest_end = scope
             .brackets()
-            .any(|(pair, _)| line_text.starts_with(&pair.end))
-        {
+            .filter_map(|(pair, _)| matched_len(&pair.end))
+            .max();
+        let longest_start = scope
+            .brackets()
+            .filter_map(|(pair, _)| matched_len(&pair.start))
+            .max();
+        if longest_end > longest_start {
             return Some(indent_len);
         }
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2258,27 +2258,92 @@ impl DisplaySnapshot {
             .is_some_and(|next_line_indent| next_line_indent.raw_len() > line_indent.raw_len())
     }
 
-    /// Returns the indent length of `row` if it starts with a closing bracket.
-    fn closing_bracket_indent_len(&self, row: u32) -> Option<u32> {
+    /// Returns the indent length of `row` if it starts with a delimiter that closes a bracket
+    /// pair opened on `open_row`.
+    fn closing_bracket_indent_len(&self, row: u32, open_row: u32) -> Option<u32> {
         let snapshot = self.buffer_snapshot();
         let indent_len = self
             .line_indent_for_buffer_row(MultiBufferRow(row))
             .raw_len();
         let content_start = Point::new(row, indent_len);
-        let line_text: String = snapshot
-            .chars_at(content_start)
-            .take_while(|ch| *ch != '\n')
-            .collect();
+        let scope = snapshot.language_scope_at(Point::new(open_row, 0))?;
 
-        let scope = snapshot.language_scope_at(Point::new(row, 0))?;
-        if scope
-            .brackets()
-            .any(|(pair, _)| line_text.starts_with(&pair.end))
-        {
-            return Some(indent_len);
+        if scope.has_brackets_query() {
+            return snapshot
+                .all_bracket_ranges(Point::new(open_row, 0)..content_start)
+                .is_some_and(|mut ranges| {
+                    ranges.any(|(open, close)| {
+                        open.start < open.end
+                            && close.start < close.end
+                            && open.start.to_point(snapshot).row == open_row
+                            && close.start.to_point(snapshot) == content_start
+                    })
+                })
+                .then_some(indent_len);
         }
 
-        None
+        let pairs = scope
+            .brackets()
+            .filter_map(|(pair, enabled)| {
+                (enabled && !pair.start.is_empty() && !pair.end.is_empty()).then_some(pair)
+            })
+            .collect::<Vec<_>>();
+        let text = snapshot
+            .chars_at(Point::new(open_row, 0))
+            .take_while(|ch| *ch != '\n')
+            .collect::<String>();
+        let mut stack: Vec<&language::BracketPair> = Vec::new();
+        let mut offset = 0;
+        while let Some(text) = text.get(offset..) {
+            if text.is_empty() {
+                break;
+            }
+            let start = pairs
+                .iter()
+                .filter(|pair| text.starts_with(&pair.start))
+                .max_by_key(|pair| pair.start.len());
+            let end_len = pairs
+                .iter()
+                .filter(|pair| text.starts_with(&pair.end))
+                .map(|pair| pair.end.len())
+                .max()
+                .unwrap_or_default();
+            let delimiter_len = start.map_or(0, |pair| pair.start.len()).max(end_len);
+            if stack
+                .last()
+                .is_some_and(|pair| pair.end.len() == delimiter_len && text.starts_with(&pair.end))
+            {
+                stack.pop();
+                offset += delimiter_len;
+            } else if let Some(pair) = start
+                && pair.start.len() == delimiter_len
+            {
+                stack.push(*pair);
+                offset += delimiter_len;
+            } else if delimiter_len > 0 {
+                offset += delimiter_len;
+            } else {
+                offset += text.chars().next()?.len_utf8();
+            }
+        }
+
+        let line_text = snapshot
+            .chars_at(content_start)
+            .take_while(|ch| *ch != '\n')
+            .collect::<String>();
+        let longest_delimiter_len = pairs
+            .iter()
+            .flat_map(|pair| [&pair.start, &pair.end])
+            .filter(|delimiter| line_text.starts_with(delimiter.as_str()))
+            .map(|delimiter| delimiter.len())
+            .max()
+            .unwrap_or_default();
+        stack
+            .last()
+            .is_some_and(|pair| {
+                pair.end.len() == longest_delimiter_len && line_text.starts_with(&pair.end)
+            })
+            .then_some(indent_len)
     }
 
     #[instrument(skip_all)]
@@ -2374,7 +2439,7 @@ impl DisplaySnapshot {
             };
 
             let end = if let Some(row) = closing_row {
-                if let Some(indent_len) = self.closing_bracket_indent_len(row) {
+                if let Some(indent_len) = self.closing_bracket_indent_len(row, buffer_row.0) {
                     // Include newline and whitespace before closing delimiter,
                     // so it appears on the same display line as the fold placeholder
                     Point::new(row, indent_len)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2272,12 +2272,12 @@ impl DisplaySnapshot {
         (buffer_row.0 + 1..=max_row.0)
             .find_map(|next_row| {
                 let next_line_indent = self.line_indent_for_buffer_row(MultiBufferRow(next_row));
-                if next_line_indent.raw_len() > line_indent.raw_len() {
-                    Some(true)
-                } else if !next_line_indent.is_line_blank() {
-                    Some(false)
-                } else {
+                // A whitespace-only line is blank but has a non-zero indent length, so it must
+                // be skipped before comparing indents.
+                if next_line_indent.is_line_blank() {
                     None
+                } else {
+                    Some(next_line_indent.raw_len() > line_indent.raw_len())
                 }
             })
             .unwrap_or(false)
@@ -3988,6 +3988,35 @@ pub mod tests {
 
             map
         });
+    }
+
+    #[gpui::test]
+    fn test_starts_indent_with_whitespace_only_blank_lines(cx: &mut gpui::App) {
+        init_test(cx, &|_| {});
+
+        // The lines holding a single space are deliberate: a whitespace-only line is blank
+        // but still has a non-zero indent length, so comparing indents before checking for
+        // blankness makes it look like the following line is indented.
+        let buffer = MultiBuffer::build_simple("aaa\n \nbbb\nccc\n \n    ddd", cx);
+        let font_size = px(14.0);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer.clone(),
+                font("Helvetica"),
+                font_size,
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert!(!snapshot.starts_indent(MultiBufferRow(0)));
+        assert!(snapshot.crease_for_buffer_row(MultiBufferRow(0)).is_none());
+        assert!(snapshot.starts_indent(MultiBufferRow(3)));
     }
 
     #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1820,6 +1820,195 @@ async fn test_fold_with_unindented_multiline_block_comment_includes_closing_brac
 }
 
 #[gpui::test]
+async fn test_fold_excludes_ambiguous_closing_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_lang()), cx));
+    cx.set_state(indoc! {"
+        ˇ# *Emphasis*
+          content
+        **bold**
+
+        # Heading
+          content
+        > quote
+
+        # See <link>
+          content
+        > quote
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        editor.fold_at(MultiBufferRow(4), window, cx);
+        editor.fold_at(MultiBufferRow(8), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                # *Emphasis*⋯
+                **bold**
+
+                # Heading⋯
+                > quote
+
+                # See <link>⋯
+                > quote
+            "},
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_fold_matches_plain_text_closing_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(PLAIN_TEXT.clone()), cx));
+    cx.set_state(indoc! {"
+        ˇsection {
+          content
+        }
+
+        section {closed}
+          content
+        }
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        editor.fold_at(MultiBufferRow(4), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                section {⋯}
+
+                section {closed}⋯
+                }
+            "},
+        );
+    });
+
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            brackets: BracketPairConfig {
+                pairs: vec![
+                    BracketPair {
+                        start: "*".into(),
+                        end: "*".into(),
+                        ..Default::default()
+                    },
+                    BracketPair {
+                        start: "**".into(),
+                        end: "**".into(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        None,
+    ));
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+    cx.set_state(indoc! {"
+        ˇ# *emphasis*
+          content
+        **bold**
+
+        # *
+          content
+        **bold**
+    "});
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        editor.fold_at(MultiBufferRow(4), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                # *emphasis*⋯
+                **bold**
+
+                # *⋯
+                **bold**
+            "},
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_fold_matches_configured_delimiter_without_bracket_query(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            brackets: BracketPairConfig {
+                pairs: vec![
+                    BracketPair::default(),
+                    BracketPair {
+                        start: "{".into(),
+                        end: "}".into(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    ));
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+    cx.set_state(indoc! {"
+        ˇsection {
+          content
+        }
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                section {⋯}
+            "},
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_fold_includes_bash_closing_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let language = languages::language("bash", tree_sitter_bash::LANGUAGE.into());
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+    cx.set_state(indoc! {"
+        ˇif true; then
+          echo yes
+        fi
+
+        for value in values; do
+          echo $value
+        done
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        editor.fold_at(MultiBufferRow(4), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                if true; then⋯fi
+
+                for value in values; do⋯done
+            "},
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_fold_preserves_top_level_comments_between_python_classes(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1819,6 +1819,33 @@ async fn test_fold_with_unindented_multiline_block_comment_includes_closing_brac
 }
 
 #[gpui::test]
+async fn test_fold_excludes_ambiguous_closing_delimiter(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Markdown pairs `*` with itself, so `**bold**` starts with a bracket `end` even though
+    // it closes nothing, and must not be pulled onto the folded heading's line.
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_lang()), cx));
+    cx.set_state(indoc! {"
+        ˇ# Heading
+          content
+        **bold**
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                # Heading⋯
+                **bold**
+            "},
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_fold_preserves_top_level_comments_between_python_classes(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1194,6 +1194,12 @@ pub fn build_highlight_map(capture_names: &[&str], theme: &SyntaxTheme) -> Highl
 }
 
 impl LanguageScope {
+    pub fn has_brackets_query(&self) -> bool {
+        self.language
+            .grammar()
+            .is_some_and(|grammar| grammar.brackets_config.is_some())
+    }
+
     pub fn path_suffixes(&self) -> &[String] {
         self.language.path_suffixes()
     }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5749,11 +5749,35 @@ impl MultiBufferSnapshot {
         &self,
         range: Range<T>,
     ) -> Option<impl Iterator<Item = (Range<MultiBufferOffset>, Range<MultiBufferOffset>)>> {
+        self.bracket_ranges_internal(range, false)
+    }
+
+    pub fn all_bracket_ranges<T: ToOffset>(
+        &self,
+        range: Range<T>,
+    ) -> Option<impl Iterator<Item = (Range<MultiBufferOffset>, Range<MultiBufferOffset>)>> {
+        self.bracket_ranges_internal(range, true)
+    }
+
+    fn bracket_ranges_internal<T: ToOffset>(
+        &self,
+        range: Range<T>,
+        include_newline_only: bool,
+    ) -> Option<impl Iterator<Item = (Range<MultiBufferOffset>, Range<MultiBufferOffset>)>> {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let results =
             self.map_excerpt_ranges(range, |buffer, excerpt_range, input_buffer_range| {
-                buffer
-                    .bracket_ranges(input_buffer_range)
+                let pairs = if include_newline_only {
+                    buffer
+                        .all_bracket_ranges(input_buffer_range.start.0..input_buffer_range.end.0)
+                        .collect::<Vec<_>>()
+                } else {
+                    buffer
+                        .bracket_ranges(input_buffer_range)
+                        .collect::<Vec<_>>()
+                };
+                pairs
+                    .into_iter()
                     .filter(|pair| {
                         excerpt_range.context.start.0 <= pair.open_range.start
                             && pair.close_range.end <= excerpt_range.context.end.0


### PR DESCRIPTION
# Objective

Closes #55580

Two stacking bugs affected indent-based folds.

A whitespace-only line is blank but has a nonzero raw indent length. `starts_indent` compared that length before checking whether the line was blank, so a content line followed by whitespace-only blank text could receive a phantom fold chevron with an empty crease.

The fold boundary logic also treated any line beginning with a configured closing delimiter as the closer for the folded block. Markdown emphasis, blockquotes, balanced `<link>` text, and other delimiter-like prose could therefore be pulled onto the folded display line.

## Solution

- Skip blank lines before comparing indentation.
- When a language provides a tree-sitter bracket query, join a closing delimiter only when the syntax data pairs it with an opener on the folded line. This includes newline-only Bash pairs.
- When no bracket query exists, scan enabled configured delimiters on the opening line and require the closing line to match the remaining unmatched pair. Longest-delimiter matching handles overlapping and self-paired delimiters.
- Ignore configured pairs with empty delimiters so malformed extension configuration cannot stall the fallback scan.

This preserves closing-delimiter folding for braces, parentheses, brackets, Rust raw strings, Bash `done` and `fi`, plain text, and lines such as `} else {` while excluding unrelated Markdown and Python text.

## Testing

- `cargo test -p editor test_fold` (24 passed)
- `cargo test -p editor test_starts_indent_with_whitespace_only_blank_lines` (passed)
- `cargo fmt --all -- --check` (passed)
- `./script/clippy -p editor` (passed)

Coverage includes whitespace-only blank lines, Markdown emphasis and blockquotes, balanced `<link>` text, plain-text delimiter fallback, grammar-backed languages without bracket queries, empty configured delimiters, Bash closers, raw strings, block comments, and top-level comments.

## Self-Review Checklist:

- [x] I have reviewed the diff for quality, security, and reliability
- [x] Unsafe blocks, if any, have justifying comments
- [x] The content adheres to Zed UI standards
- [x] Tests cover the changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed phantom fold controls and unrelated lines being pulled into fold placeholders