### PR TITLE
collab_panel: Make focus and selected styles consistent

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -35,9 +35,9 @@ use theme::ActiveTheme;
 use theme_settings::ThemeSettings;
 use ui::{
     Avatar, AvatarAvailabilityIndicator, CollabNotification, ContextMenu, CopyButton,
-    DecoratedIcon, Disclosure, Facepile, HighlightedLabel, IconButtonShape, IconDecoration,
-    IconDecorationKind, IndentGuideColors, Indicator, ListHeader, ListItem, ScrollAxes, Scrollbars,
-    Tab, TintColor, Tooltip, WithScrollbar, prelude::*, tooltip_container,
+    DecoratedIcon, Disclosure, DockSide, Facepile, HighlightedLabel, IconButtonShape,
+    IconDecoration, IconDecorationKind, IndentGuideColors, Indicator, ListHeader, ListItem,
+    ScrollAxes, Scrollbars, Tab, TintColor, Tooltip, WithScrollbar, prelude::*, tooltip_container,
 };
 use util::{ResultExt, TryFutureExt, maybe};
 use workspace::{
@@ -1162,6 +1162,13 @@ impl CollabPanel {
         ))
     }
 
+    fn dock_side(&self, cx: &App) -> DockSide {
+        match CollaborationPanelSettings::get_global(cx).dock {
+            DockPosition::Right => DockSide::Right,
+            _ => DockSide::Left,
+        }
+    }
+
     fn render_call_participant(
         &self,
         user: &Arc<User>,
@@ -1205,7 +1212,8 @@ impl CollabPanel {
         ListItem::new(user.username.clone())
             .start_slot(Avatar::new(user.avatar_uri.clone()))
             .child(render_participant_name_and_handle(user))
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .end_slot(end_slot)
             .tooltip(Tooltip::text("Click to Follow"))
             .when_some(peer_id, |el, peer_id| {
@@ -1253,7 +1261,8 @@ impl CollabPanel {
 
         ListItem::new(project_id as usize)
             .height(panel_row_height())
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.workspace
                     .update(cx, |workspace, cx| {
@@ -1294,7 +1303,8 @@ impl CollabPanel {
 
         ListItem::new(("screen", id))
             .height(panel_row_height())
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .start_slot(
                 h_flex()
                     .gap_1p5()
@@ -1341,7 +1351,8 @@ impl CollabPanel {
 
         ListItem::new("channel-notes")
             .height(panel_row_height())
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.open_channel_notes(channel_id, window, cx);
             }))
@@ -2755,7 +2766,9 @@ impl CollabPanel {
     ) -> AnyElement {
         let entry = self.entries[ix].clone();
 
-        let is_selected = self.selection == Some(ix);
+        let is_selected =
+            self.selection == Some(ix) && self.focus_handle.contains_focused(window, cx);
+
         match entry {
             ListEntry::Header(section) => {
                 let is_collapsed = self.collapsed_sections.contains(&section);
@@ -3100,7 +3113,8 @@ impl CollabPanel {
                 })
                 .inset(true)
                 .end_slot::<AnyElement>(button)
-                .toggle_state(is_selected),
+                .focused(is_selected)
+                .dock(self.dock_side(cx)),
         )
     }
 
@@ -3127,7 +3141,9 @@ impl CollabPanel {
         let item = ListItem::new(username.clone())
             .indent_level(1)
             .indent_step_size(px(20.))
-            .toggle_state(is_selected || context_menu_open_via_row)
+            .toggle_state(context_menu_open_via_row)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .child(
                 h_flex()
                     .w_full()
@@ -3265,7 +3281,8 @@ impl CollabPanel {
         ListItem::new(username.clone())
             .indent_level(1)
             .indent_step_size(px(20.))
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .child(
                 h_flex()
                     .w_full()
@@ -3309,7 +3326,8 @@ impl CollabPanel {
         ];
 
         ListItem::new(("channel-invite", channel.id.0 as usize))
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .child(
                 h_flex()
                     .w_full()
@@ -3328,7 +3346,8 @@ impl CollabPanel {
         ListItem::new("contact-placeholder")
             .child(Icon::new(IconName::Plus))
             .child(Label::new("Add a Contact"))
-            .toggle_state(is_selected)
+            .focused(is_selected)
+            .dock(self.dock_side(cx))
             .on_click(cx.listener(|this, _, window, cx| this.toggle_contact_finder(window, cx)))
     }
 
@@ -3510,7 +3529,9 @@ impl CollabPanel {
                     .height(height)
                     .indent_level(depth)
                     .indent_step_size(px(20.))
-                    .toggle_state(is_selected || is_active)
+                    .toggle_state(is_active)
+                    .focused(is_selected)
+                    .dock(self.dock_side(cx))
                     .on_click(cx.listener(move |this, _, window, cx| {
                         if is_active {
                             this.open_channel_notes(channel_id, window, cx)

--- a/crates/ui/src/components/list/list_header.rs
+++ b/crates/ui/src/components/list/list_header.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{Disclosure, IconButtonShape, prelude::*};
+use crate::{Disclosure, DockSide, IconButtonShape, prelude::*};
 use component::{Component, ComponentScope, example_group_with_title, single_example};
 use gpui::{AnyElement, ClickEvent};
 use theme::UiDensity;
@@ -23,6 +23,8 @@ pub struct ListHeader {
     inset: bool,
     selected: bool,
     height: Option<DefiniteLength>,
+    focused: Option<bool>,
+    dock: Option<DockSide>,
 }
 
 impl ListHeader {
@@ -38,6 +40,8 @@ impl ListHeader {
             on_toggle: None,
             selected: false,
             height: None,
+            focused: None,
+            dock: None,
         }
     }
 
@@ -84,6 +88,16 @@ impl ListHeader {
         self.inset = inset;
         self
     }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = Some(focused);
+        self
+    }
+
+    pub fn dock(mut self, dock: impl Into<Option<DockSide>>) -> Self {
+        self.dock = dock.into();
+        self
+    }
 }
 
 impl Toggleable for ListHeader {
@@ -114,6 +128,16 @@ impl RenderOnce for ListHeader {
                     .when(self.inset, |this| this.px_2())
                     .when(self.selected, |this| {
                         this.bg(cx.theme().colors().ghost_element_selected)
+                    })
+                    .when_some(self.focused, |this, focused| {
+                        this.border_1()
+                            .when_some(self.dock, |this, dock| match dock {
+                                DockSide::Left => this.border_l_2(),
+                                DockSide::Right => this.border_r_2(),
+                            })
+                            .when(focused, |this| {
+                                this.border_color(cx.theme().colors().border_focused)
+                            })
                     })
                     .flex()
                     .flex_1()

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -14,6 +14,12 @@ pub enum ListItemSpacing {
     Sparse,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum DockSide {
+    Left,
+    Right,
+}
+
 #[derive(Default)]
 enum EndSlotVisibility {
     #[default]
@@ -51,7 +57,7 @@ pub struct ListItem {
     rounded: bool,
     overflow_x: bool,
     focused: Option<bool>,
-    docked_right: bool,
+    dock: Option<DockSide>,
     height: Option<DefiniteLength>,
     aria_role: Option<Role>,
     aria_label: Option<SharedString>,
@@ -87,7 +93,7 @@ impl ListItem {
             rounded: false,
             overflow_x: false,
             focused: None,
-            docked_right: false,
+            dock: None,
             height: None,
             aria_role: None,
             aria_label: None,
@@ -258,8 +264,8 @@ impl ListItem {
         self
     }
 
-    pub fn docked_right(mut self, docked_right: bool) -> Self {
-        self.docked_right = docked_right;
+    pub fn dock(mut self, dock: impl Into<Option<DockSide>>) -> Self {
+        self.dock = dock.into();
         self
     }
 
@@ -304,13 +310,14 @@ impl RenderOnce for ListItem {
             })
             .when(!self.inset, |this| {
                 this.when_some(self.focused, |this, focused| {
-                    if focused && !self.disabled {
-                        this.border_1()
-                            .when(self.docked_right, |this| this.border_r_2())
-                            .border_color(cx.theme().colors().border_focused)
-                    } else {
-                        this.border_1()
-                    }
+                    this.border_1()
+                        .when_some(self.dock, |this, dock| match dock {
+                            DockSide::Left => this.border_l_2(),
+                            DockSide::Right => this.border_r_2(),
+                        })
+                        .when(focused && !self.disabled, |this| {
+                            this.border_color(cx.theme().colors().border_focused)
+                        })
                 })
                 .when(self.selectable && !self.disabled, |this| {
                     this.hover(|style| style.bg(cx.theme().colors().ghost_element_hover))


### PR DESCRIPTION
As in, make it consistent with the other panels, where we use a blue border for the focused state and a different background color for the selected state. It's been a long time coming little design fix to the collab panel.

<img width="450" alt="Screenshot 2026-07-27 at 8  01@2x" src="https://github.com/user-attachments/assets/70724483-8092-4993-afd4-5faa3d3fae51" />

Release Notes:

- N/A
