### PR TITLE
workspace: Cancel focus-follows-mouse when the pointer leaves the window

### DIFF
--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -6,7 +6,7 @@ use git::{
     Oid,
     repository::{InitialGraphCommitData, LogSource, RepoPath},
 };
-use gpui::{Empty, Entity, TestAppContext, VisualTestContext};
+use gpui::{Empty, Entity, MouseExitEvent, TestAppContext, VisualTestContext};
 use menu::Cancel;
 use pretty_assertions::assert_eq;
 use project::{FakeFs, ProjectPath};
@@ -11040,6 +11040,72 @@ async fn test_focus_follows_mouse_into_blank_area(cx: &mut gpui::TestAppContext)
         assert!(
             panel.focus_handle(cx).is_focused(window),
             "Project panel should be focused after hovering the blank area below the entries"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_focus_follows_mouse_leaving_window(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.focus_follows_mouse = Some(settings::FocusFollowsMouse {
+                    enabled: Some(true),
+                    debounce_ms: Some(100),
+                });
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/root"), json!({ "a.txt": "" })).await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        workspace.open_panel::<ProjectPanel>(window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            let worktree_id = workspace.worktrees(cx).next().unwrap().read(cx).id();
+            let project_path = ProjectPath {
+                worktree_id,
+                path: rel_path("a.txt").into(),
+            };
+            workspace.open_path(project_path, None, true, window, cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            !panel.focus_handle(cx).is_focused(window),
+            "Editor should be focused after opening a file"
+        );
+    });
+
+    // Sweep the mouse across the project panel and off the window before the
+    // debounce elapses.
+    cx.simulate_mouse_move(point(px(1800.), px(600.)), None, Modifiers::none());
+    cx.simulate_event(MouseExitEvent::default());
+    cx.executor().advance_clock(Duration::from_millis(200));
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            !panel.focus_handle(cx).is_focused(window),
+            "Project panel should not be focused when the mouse left the window before the debounce elapsed"
         );
     });
 }

--- a/crates/workspace/src/focus_follows_mouse.rs
+++ b/crates/workspace/src/focus_follows_mouse.rs
@@ -60,6 +60,25 @@ pub trait FocusFollowsMouse<E: Focusable>: StatefulInteractiveElement {
                         handles: Some((window_handle, focus_handle)),
                         _debounce_task: Some(debounce_task),
                     });
+                } else {
+                    // The pointer can leave this element without entering another
+                    // focus-follows-mouse target, most notably when it leaves the window
+                    // entirely. Without this the pending focus would still be applied even
+                    // though the pointer never lingered here.
+                    //
+                    // Compare handles for equality rather than containment: hover
+                    // enter/exit handlers for different elements are not ordered within a
+                    // frame, so an ancestor's exit must never cancel a target a descendant
+                    // just scheduled.
+                    let focus_handle = this.focus_handle(cx);
+                    let is_pending_target = cx
+                        .try_global::<FfmState>()
+                        .and_then(|state| state.handles.as_ref())
+                        .is_some_and(|(_, pending)| *pending == focus_handle);
+
+                    if is_pending_target {
+                        cx.set_global(FfmState::default());
+                    }
                 }
             }))
         } else {


### PR DESCRIPTION
## Context

Closes #61748

With `focus_follows_mouse` enabled, sweeping the pointer from the editor across a docked panel and off the Zed window focused that panel once the debounce elapsed, even though the pointer never lingered there. Moving the mouse to another app (to scroll it while keeping Zed focused, for example) would silently change focus inside Zed.

`FocusFollowsMouse::focus_follows_mouse` only handled hover *enter*: it recorded a target in the `FfmState` global and spawned a debounce task to focus it. Hover *exit* was ignored, so a pending focus was only ever superseded by entering another focus-follows-mouse target, and leaving the window is not one of those. This adds an exit branch that cancels the pending focus.

Manual test before the fix :

https://github.com/user-attachments/assets/7aa7284b-b229-44fb-897a-e868edeb1129

Manual test after the fix :

https://github.com/user-attachments/assets/f51bb572-8be4-4449-ab7f-bd331176c7de

## How to Review

2 files changed. Read in this order:

**`crates/workspace/src/focus_follows_mouse.rs`**

The `on_hover` listener gains an `else` branch for hover exit. It reads `FfmState` via `try_global` and, if the recorded target is this element's own focus handle, replaces the global with `FfmState::default()`. That drops the stored `Task`, which cancels the debounce timer. No call site changes were needed: `Dock`, `Pane`, and `ProjectPanel` all route through this one trait method.

Handles are compared with `PartialEq` (`FocusHandle` compares by `FocusId`) rather than `FocusHandle::contains`, which the enter branch uses for its parent/child precedence rule. Hover enter/exit handlers for different elements are not ordered within a frame, so containment would let an ancestor's exit cancel a target its descendant just scheduled. That matters concretely for the project panel's `project-panel-blank-area`: it uses `block_mouse_except_scroll`, so the surrounding `Dock` un-hovers as the blank area hovers, and with containment the `Dock` exit could cancel the panel target the blank area had just set. Equality makes both orderings safe.

No GPUI change was required. `Div`'s hover listener already registers a `MouseExitEvent` handler that fires `on_hover(false)` when the pointer leaves the window, and every platform backend emits `PlatformInput::MouseExited` (macOS installs a whole-view `NSTrackingArea` with `NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways`).

**`crates/project_panel/src/project_panel_tests.rs`**

Adds `test_focus_follows_mouse_leaving_window` next to the existing `test_focus_follows_mouse_into_blank_area`, reusing its setup: a `MultiWorkspace` with a docked `ProjectPanel`, `a.txt` opened so the editor holds focus, and `focus_follows_mouse { enabled: true, debounce_ms: 100 }`. The test hovers the panel, dispatches `MouseExitEvent::default()` before the debounce elapses, advances the clock by 200ms, and asserts the panel did not take focus. `advance_clock` is required here; `run_until_parked` alone does not fire the debounce timer.

The test fails on `main` with `Project panel should not be focused when the mouse left the window before the debounce elapsed` and passes with the fix. `test_focus_follows_mouse_into_blank_area` still passes, which is the regression guard for the equality-versus-containment choice above.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed focus-follows-mouse focusing a panel when the mouse moved across it on the way out of the Zed window
