### PR TITLE
language_tools: Add copy button to language server status message

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -22,7 +22,8 @@ use project::{
 };
 use settings::{Settings as _, SettingsStore};
 use ui::{
-    ContextMenu, ContextMenuEntry, Indicator, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
+    ContextMenu, ContextMenuEntry, CopyButton, Indicator, PopoverMenu, PopoverMenuHandle, Tooltip,
+    prelude::*,
 };
 
 use util::{ResultExt, paths::PathExt, rel_path::RelPath};
@@ -375,6 +376,7 @@ impl LanguageServerState {
             let server_message = message.clone();
 
             let submenu_server_name = server_info.name.clone();
+            let submenu_server_id = server_info.id.0;
             let submenu_server_info = server_info.clone();
 
             menu = menu.submenu_with_colored_icon(
@@ -584,6 +586,8 @@ impl LanguageServerState {
                             let binary_path = binary_path.clone();
                             let server_version = server_version.clone();
                             let server_message = server_message.clone();
+                            let server_name = submenu_server_name.clone();
+                            let server_id = submenu_server_id;
                             let process_memory_cache = process_memory_cache.clone();
                             move |_, cx| {
                                 let memory_usage = process_id.map(|pid| {
@@ -607,6 +611,44 @@ impl LanguageServerState {
                                 let separator_color =
                                     cx.theme().colors().icon_disabled.opacity(0.8);
 
+                                let status_details = h_flex()
+                                    .ml_neg_1()
+                                    .gap_1()
+                                    .child(
+                                        Icon::new(IconName::Circle)
+                                            .color(status_color)
+                                            .size(IconSize::Small),
+                                    )
+                                    .child(
+                                        Label::new(status_label)
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted),
+                                    )
+                                    .when_some(version_label.as_ref(), |row, version| {
+                                        row.child(
+                                            Icon::new(IconName::Dash)
+                                                .color(Color::Custom(separator_color))
+                                                .size(IconSize::XSmall),
+                                        )
+                                        .child(
+                                            Label::new(version)
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted),
+                                        )
+                                    })
+                                    .when_some(memory_label.as_ref(), |row, memory| {
+                                        row.child(
+                                            Icon::new(IconName::Dash)
+                                                .color(Color::Custom(separator_color))
+                                                .size(IconSize::XSmall),
+                                        )
+                                        .child(
+                                            Label::new(memory)
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted),
+                                        )
+                                    });
+
                                 v_flex()
                                     .id("metadata-container")
                                     .gap_1()
@@ -615,40 +657,19 @@ impl LanguageServerState {
                                     })
                                     .child(
                                         h_flex()
-                                            .ml_neg_1()
-                                            .gap_1()
-                                            .child(
-                                                Icon::new(IconName::Circle)
-                                                    .color(status_color)
-                                                    .size(IconSize::Small),
-                                            )
-                                            .child(
-                                                Label::new(status_label)
-                                                    .size(LabelSize::Small)
-                                                    .color(Color::Muted),
-                                            )
-                                            .when_some(version_label.as_ref(), |row, version| {
-                                                row.child(
-                                                    Icon::new(IconName::Dash)
-                                                        .color(Color::Custom(separator_color))
-                                                        .size(IconSize::XSmall),
-                                                )
-                                                .child(
-                                                    Label::new(version)
-                                                        .size(LabelSize::Small)
-                                                        .color(Color::Muted),
-                                                )
+                                            .when_some(server_message.as_ref(), |row, _| {
+                                                row.w_full().justify_between()
                                             })
-                                            .when_some(memory_label.as_ref(), |row, memory| {
+                                            .child(status_details)
+                                            .when_some(server_message.clone(), |row, message| {
                                                 row.child(
-                                                    Icon::new(IconName::Dash)
-                                                        .color(Color::Custom(separator_color))
-                                                        .size(IconSize::XSmall),
-                                                )
-                                                .child(
-                                                    Label::new(memory)
-                                                        .size(LabelSize::Small)
-                                                        .color(Color::Muted),
+                                                    CopyButton::new(
+                                                        ("copy-lsp-server-message", server_id),
+                                                        format!(
+                                                            "Language server {server_name}:\n\n{message}"
+                                                        ),
+                                                    )
+                                                    .tooltip_label("Copy Message"),
                                                 )
                                             }),
                                     )


### PR DESCRIPTION
Sometimes a language server fails, and the error message shown in the language server status popover can't be copied or selected. Menu text isn't mouse selectable, so there's no way to get it out other than opening "View Message" and copying from the buffer it creates.

## Solution

Add a copy button to the right of the status row, laid out with justify-between against the existing status dot, version and memory group. It copies the same "Language server {name}:\n\n{message}" text that "View Message" writes into its buffer, so the server name travels with the error.

The button and the row's width constraint are both gated on a message being present, so a healthy server's row is unchanged.

## Testing

- Built locally on macOS and manually verified: opened the language server status popover for a server with a failed/error message, clicked the copy button, and confirmed the clipboard contains `Language server {name}:\n\n{message}`, matching what "View Message" produces.
- Confirmed a healthy server (no message) renders its status row unchanged, with no copy button and no width constraint.
- Verified `cargo check --workspace --all-targets` is clean.
- Reviewers can test by triggering a language server error (e.g. misconfiguring a server's binary path) and confirming the copy button appears next to that server's status row and copies the correct text.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Here is a screenshot of the changes and the copy button it would produce:

<img width="2240" height="1258" alt="warya_wayne_zed_ide_add_lsp_error_copy_button" src="https://github.com/user-attachments/assets/9d7123e0-8f45-4c3b-978b-ae9cf10400e7" />

Here is a screenshot of a healthy server with no issues and no copy button:

<img width="2240" height="1258" alt="warya_wayne_zed_ide_add_lsp_error_copy_button-no-error" src="https://github.com/user-attachments/assets/84560d1e-0764-4807-9f9f-b56e5f45a6ef" />


---

Release Notes:

- Added a copy button to the language server status popover for copying a server's error message