### PR TITLE
Fix X11 redraws after workspace switches

### DIFF
--- a/.github/workflows/nix_build.yml
+++ b/.github/workflows/nix_build.yml
@@ -91,6 +91,45 @@ jobs:
         fi
     timeout-minutes: 60
     continue-on-error: true
+  i3_workspace_redraw:
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && ((github.event.action == 'labeled' && github.event.label.name == 'run-nix') || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-nix')))
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    env:
+      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+      ZED_MINIDUMP_ENDPOINT: ${{ secrets.ZED_SENTRY_MINIDUMP_ENDPOINT }}
+      ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON: ${{ secrets.ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON }}
+      GIT_LFS_SKIP_SMUDGE: '1'
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: nix_build::build_nix::install_nix
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: nix_build::build_nix::cachix_action
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: nix_build::build_nix::build
+      run: nix build .#checks.x86_64-linux.i3-workspace-redraw -L --accept-flake-config
+    - name: nix_build::i3_workspace_redraw_job
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: i3-workspace-redraw-artifacts
+        path: result/gpui-i3-artifacts
+        if-no-files-found: warn
+        retention-days: '14'
+    timeout-minutes: 60
+    continue-on-error: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -265,5 +265,9 @@ name = "a11y"
 path = "examples/a11y.rs"
 
 [[example]]
+name = "x11_workspace_redraw"
+path = "examples/x11_workspace_redraw.rs"
+
+[[example]]
 name = "view_example"
 path = "examples/view_example/view_example_main.rs"

--- a/crates/gpui/examples/x11_workspace_redraw.rs
+++ b/crates/gpui/examples/x11_workspace_redraw.rs
@@ -41,6 +41,8 @@ impl Render for Fixture {
         div()
             .size_full()
             .flex()
+            .gap_8()
+            .p_8()
             .bg(rgb(background))
             .child(div().w_1_4().h_full().bg(rgb(left)))
             .child(
@@ -49,6 +51,7 @@ impl Render for Fixture {
                     .h_full()
                     .flex()
                     .flex_col()
+                    .gap_8()
                     .child(div().h_1_2().w_full().bg(rgb(upper)))
                     .child(div().flex_1().w_full().bg(rgb(lower))),
             )

--- a/crates/gpui/examples/x11_workspace_redraw.rs
+++ b/crates/gpui/examples/x11_workspace_redraw.rs
@@ -34,6 +34,17 @@ struct Fixture {
     palette: Palette,
 }
 
+#[derive(Clone)]
+struct FixtureWindow {
+    title: String,
+    palette: Palette,
+}
+
+struct Arguments {
+    primary: FixtureWindow,
+    secondary: Option<FixtureWindow>,
+}
+
 impl Render for Fixture {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         let [background, left, upper, lower, right] = self.palette.colors();
@@ -59,9 +70,11 @@ impl Render for Fixture {
     }
 }
 
-fn parse_arguments() -> Result<(String, Palette), String> {
+fn parse_arguments() -> Result<Arguments, String> {
     let mut title = "GPUI X11 Workspace Redraw".to_string();
     let mut palette = Palette::Target;
+    let mut secondary_title = None;
+    let mut secondary_palette = Palette::Alternate;
     let mut arguments = std::env::args().skip(1);
 
     while let Some(argument) = arguments.next() {
@@ -78,11 +91,53 @@ fn parse_arguments() -> Result<(String, Palette), String> {
                 palette =
                     Palette::from_name(&name).ok_or_else(|| format!("unknown palette: {name}"))?;
             }
+            "--secondary-title" => {
+                secondary_title = Some(
+                    arguments
+                        .next()
+                        .ok_or_else(|| "--secondary-title requires a value".to_string())?,
+                );
+            }
+            "--secondary-palette" => {
+                let name = arguments
+                    .next()
+                    .ok_or_else(|| "--secondary-palette requires a value".to_string())?;
+                secondary_palette =
+                    Palette::from_name(&name).ok_or_else(|| format!("unknown palette: {name}"))?;
+            }
             _ => return Err(format!("unknown argument: {argument}")),
         }
     }
 
-    Ok((title, palette))
+    Ok(Arguments {
+        primary: FixtureWindow { title, palette },
+        secondary: secondary_title.map(|title| FixtureWindow {
+            title,
+            palette: secondary_palette,
+        }),
+    })
+}
+
+fn open_fixture_window(cx: &mut App, fixture: FixtureWindow) -> anyhow::Result<()> {
+    let bounds = Bounds::centered(None, size(px(600.0), px(700.0)), cx);
+    cx.open_window(
+        WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            titlebar: Some(gpui::TitlebarOptions {
+                title: Some(fixture.title.into()),
+                ..Default::default()
+            }),
+            window_background: WindowBackgroundAppearance::Opaque,
+            app_id: Some("gpui-x11-workspace-redraw".to_string()),
+            ..Default::default()
+        },
+        |_, cx| {
+            cx.new(|_| Fixture {
+                palette: fixture.palette,
+            })
+        },
+    )?;
+    Ok(())
 }
 
 fn main() {
@@ -90,7 +145,7 @@ fn main() {
         .filter_level(log::LevelFilter::Info)
         .init();
 
-    let (title, palette) = match parse_arguments() {
+    let arguments = match parse_arguments() {
         Ok(arguments) => arguments,
         Err(error) => {
             eprintln!("error: {error}");
@@ -99,20 +154,13 @@ fn main() {
     };
 
     application().run(move |cx: &mut App| {
-        let bounds = Bounds::centered(None, size(px(600.0), px(700.0)), cx);
-        if let Err(error) = cx.open_window(
-            WindowOptions {
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
-                titlebar: Some(gpui::TitlebarOptions {
-                    title: Some(title.clone().into()),
-                    ..Default::default()
-                }),
-                window_background: WindowBackgroundAppearance::Opaque,
-                app_id: Some("gpui-x11-workspace-redraw".to_string()),
-                ..Default::default()
-            },
-            |_, cx| cx.new(|_| Fixture { palette }),
-        ) {
+        let result = open_fixture_window(cx, arguments.primary.clone()).and_then(|_| {
+            if let Some(secondary) = arguments.secondary.clone() {
+                open_fixture_window(cx, secondary)?;
+            }
+            Ok(())
+        });
+        if let Err(error) = result {
             eprintln!("failed to open fixture window: {error:#}");
             cx.quit();
         }

--- a/crates/gpui/examples/x11_workspace_redraw.rs
+++ b/crates/gpui/examples/x11_workspace_redraw.rs
@@ -1,0 +1,117 @@
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBackgroundAppearance, WindowBounds, WindowOptions,
+    div, prelude::*, px, rgb, size,
+};
+use gpui_platform::application;
+
+#[derive(Clone, Copy)]
+enum Palette {
+    Target,
+    Helper,
+    Alternate,
+}
+
+impl Palette {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "target" => Some(Self::Target),
+            "helper" => Some(Self::Helper),
+            "alternate" => Some(Self::Alternate),
+            _ => None,
+        }
+    }
+
+    fn colors(self) -> [u32; 5] {
+        match self {
+            Self::Target => [0x172554, 0x06b6d4, 0xfacc15, 0xef4444, 0x22c55e],
+            Self::Helper => [0x3b0764, 0xa855f7, 0xf0abfc, 0x7e22ce, 0xc084fc],
+            Self::Alternate => [0x450a0a, 0xf97316, 0xfef08a, 0xdc2626, 0xfb923c],
+        }
+    }
+}
+
+struct Fixture {
+    palette: Palette,
+}
+
+impl Render for Fixture {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let [background, left, upper, lower, right] = self.palette.colors();
+
+        div()
+            .size_full()
+            .flex()
+            .bg(rgb(background))
+            .child(div().w_1_4().h_full().bg(rgb(left)))
+            .child(
+                div()
+                    .flex_1()
+                    .h_full()
+                    .flex()
+                    .flex_col()
+                    .child(div().h_1_2().w_full().bg(rgb(upper)))
+                    .child(div().flex_1().w_full().bg(rgb(lower))),
+            )
+            .child(div().w_1_4().h_full().bg(rgb(right)))
+    }
+}
+
+fn parse_arguments() -> Result<(String, Palette), String> {
+    let mut title = "GPUI X11 Workspace Redraw".to_string();
+    let mut palette = Palette::Target;
+    let mut arguments = std::env::args().skip(1);
+
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--title" => {
+                title = arguments
+                    .next()
+                    .ok_or_else(|| "--title requires a value".to_string())?;
+            }
+            "--palette" => {
+                let name = arguments
+                    .next()
+                    .ok_or_else(|| "--palette requires a value".to_string())?;
+                palette =
+                    Palette::from_name(&name).ok_or_else(|| format!("unknown palette: {name}"))?;
+            }
+            _ => return Err(format!("unknown argument: {argument}")),
+        }
+    }
+
+    Ok((title, palette))
+}
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let (title, palette) = match parse_arguments() {
+        Ok(arguments) => arguments,
+        Err(error) => {
+            eprintln!("error: {error}");
+            std::process::exit(2);
+        }
+    };
+
+    application().run(move |cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(600.0), px(700.0)), cx);
+        if let Err(error) = cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                titlebar: Some(gpui::TitlebarOptions {
+                    title: Some(title.clone().into()),
+                    ..Default::default()
+                }),
+                window_background: WindowBackgroundAppearance::Opaque,
+                app_id: Some("gpui-x11-workspace-redraw".to_string()),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| Fixture { palette }),
+        ) {
+            eprintln!("failed to open fixture window: {error:#}");
+            cx.quit();
+        }
+    });
+}

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -380,7 +380,14 @@ impl X11Client {
             .reply()
             .context("Failed to get XCB atoms")?;
 
-        let root = xcb_connection.setup().roots[0].root;
+        let root = xcb_connection.setup().roots[x_root_index].root;
+        check_reply(
+            || "Failed to subscribe to X11 desktop changes",
+            xcb_connection.change_window_attributes(
+                root,
+                &ChangeWindowAttributesAux::new().event_mask(EventMask::PROPERTY_CHANGE),
+            ),
+        )?;
         let compositor_present = check_compositor_present(&xcb_connection, root);
         let gtk_frame_extents_supported =
             check_gtk_frame_extents_supported(&xcb_connection, &atoms, root);
@@ -951,6 +958,70 @@ impl X11Client {
                     .log_err();
             }
             Event::PropertyNotify(event) => {
+                let desktop_changed = {
+                    let state = self.0.borrow();
+                    let root = state.xcb_connection.setup().roots[state.x_root_index].root;
+                    event.window == root && event.atom == state.atoms._NET_CURRENT_DESKTOP
+                };
+                if desktop_changed {
+                    // i3 maps its ancestor frame rather than the client window when
+                    // switching workspaces, so no Expose event reaches the client.
+                    let mut attempts_remaining = 8;
+                    let mut viewable_windows = HashSet::new();
+                    let mut refreshed_windows = HashSet::new();
+                    self.0
+                        .borrow()
+                        .loop_handle
+                        .insert_source(
+                            calloop::timer::Timer::from_duration(Duration::from_millis(16)),
+                            move |_, (), client| {
+                                let (xcb_connection, windows) = {
+                                    let state = client.0.borrow();
+                                    let windows = state
+                                        .windows
+                                        .iter()
+                                        .map(|(x_window, window)| {
+                                            (*x_window, window.window.clone())
+                                        })
+                                        .collect::<Vec<_>>();
+                                    (state.xcb_connection.clone(), windows)
+                                };
+                                for (x_window, window) in windows {
+                                    if refreshed_windows.contains(&x_window) {
+                                        continue;
+                                    }
+                                    let is_viewable = get_reply(
+                                        || "Failed to get X11 window attributes",
+                                        xcb_connection.get_window_attributes(x_window),
+                                    )
+                                    .map(|attributes| {
+                                        attributes.map_state == xproto::MapState::VIEWABLE
+                                    })
+                                    .log_err()
+                                    .unwrap_or(false);
+                                    // Give the compositor one frame after the window becomes
+                                    // viewable before presenting its new contents.
+                                    if is_viewable && !viewable_windows.insert(x_window) {
+                                        refreshed_windows.insert(x_window);
+                                        window.refresh(RequestFrameOptions {
+                                            require_presentation: true,
+                                            force_render: true,
+                                        });
+                                    }
+                                }
+                                attempts_remaining -= 1;
+                                if attempts_remaining == 0 {
+                                    calloop::timer::TimeoutAction::Drop
+                                } else {
+                                    calloop::timer::TimeoutAction::ToDuration(
+                                        Duration::from_millis(16),
+                                    )
+                                }
+                            },
+                        )
+                        .log_err();
+                    return Some(());
+                }
                 let window = self.get_window(event.window)?;
                 window
                     .property_notify(event)

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -124,13 +124,15 @@ enum RefreshState {
 struct WorkspaceRedrawWindowState {
     viewable_since: Option<Instant>,
     refresh_rate: Duration,
+    warn_on_timeout: bool,
 }
 
 impl WorkspaceRedrawWindowState {
-    fn new(refresh_rate: Duration) -> Self {
+    fn new(refresh_rate: Duration, candidate: WorkspaceRedrawCandidate) -> Self {
         Self {
             viewable_since: None,
             refresh_rate,
+            warn_on_timeout: candidate == WorkspaceRedrawCandidate::Expected,
         }
     }
 
@@ -147,6 +149,41 @@ impl WorkspaceRedrawWindowState {
                 false
             }
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkspaceRedrawCandidate {
+    Expected,
+    Fallback,
+}
+
+#[derive(Default)]
+struct WorkspaceRedrawGeneration(u64);
+
+impl WorkspaceRedrawGeneration {
+    fn advance(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(1);
+        self.0
+    }
+
+    fn is_current(&self, generation: u64) -> bool {
+        self.0 == generation
+    }
+}
+
+fn workspace_redraw_candidate(
+    current_desktop: Option<u32>,
+    window_desktop: Option<u32>,
+) -> Option<WorkspaceRedrawCandidate> {
+    match (current_desktop, window_desktop) {
+        (Some(current_desktop), Some(window_desktop))
+            if window_desktop != current_desktop && window_desktop != u32::MAX =>
+        {
+            None
+        }
+        (Some(_), Some(_)) => Some(WorkspaceRedrawCandidate::Expected),
+        _ => Some(WorkspaceRedrawCandidate::Fallback),
     }
 }
 
@@ -232,7 +269,7 @@ pub struct X11ClientState {
     pub(crate) atoms: XcbAtoms,
     pub(crate) windows: HashMap<xproto::Window, WindowRef>,
     workspace_redraw_timer: Option<RegistrationToken>,
-    workspace_redraw_generation: u64,
+    workspace_redraw_generation: WorkspaceRedrawGeneration,
     pub(crate) mouse_focused_window: Option<xproto::Window>,
     pub(crate) keyboard_focused_window: Option<xproto::Window>,
     pub(crate) xkb: xkbc::State,
@@ -584,7 +621,7 @@ impl X11Client {
             atoms,
             windows: HashMap::default(),
             workspace_redraw_timer: None,
-            workspace_redraw_generation: 0,
+            workspace_redraw_generation: WorkspaceRedrawGeneration::default(),
             mouse_focused_window: None,
             keyboard_focused_window: None,
             xkb: xkb_state,
@@ -614,25 +651,107 @@ impl X11Client {
     }
 
     fn start_workspace_redraw_timer(&self) {
-        let (loop_handle, generation, mut window_states) = {
+        let (
+            loop_handle,
+            generation,
+            xcb_connection,
+            root,
+            current_desktop_atom,
+            window_desktop_atom,
+            windows,
+        ) = {
             let mut state = self.0.borrow_mut();
             if let Some(timer) = state.workspace_redraw_timer.take() {
                 state.loop_handle.remove(timer);
             }
-            state.workspace_redraw_generation = state.workspace_redraw_generation.wrapping_add(1);
-            let generation = state.workspace_redraw_generation;
-            let window_states = state
+            let generation = state.workspace_redraw_generation.advance();
+            let root = state.xcb_connection.setup().roots[state.x_root_index].root;
+            let windows = state
                 .windows
                 .iter()
-                .map(|(x_window, window)| {
-                    (
-                        *x_window,
-                        WorkspaceRedrawWindowState::new(window.refresh_rate()),
-                    )
-                })
-                .collect::<HashMap<_, _>>();
-            (state.loop_handle.clone(), generation, window_states)
+                .map(|(x_window, window)| (*x_window, window.refresh_rate()))
+                .collect::<Vec<_>>();
+            (
+                state.loop_handle.clone(),
+                generation,
+                state.xcb_connection.clone(),
+                root,
+                state.atoms._NET_CURRENT_DESKTOP,
+                state.atoms._NET_WM_DESKTOP,
+                windows,
+            )
         };
+
+        let current_desktop_request = xcb_connection.get_property(
+            false,
+            root,
+            current_desktop_atom,
+            xproto::AtomEnum::CARDINAL,
+            0,
+            1,
+        );
+
+        let mut desktop_requests = Vec::with_capacity(windows.len());
+        let mut windows_without_desktop_request = Vec::new();
+        for (x_window, refresh_rate) in windows {
+            match xcb_connection.get_property(
+                false,
+                x_window,
+                window_desktop_atom,
+                xproto::AtomEnum::CARDINAL,
+                0,
+                1,
+            ) {
+                Ok(request) => desktop_requests.push((x_window, refresh_rate, request)),
+                Err(error) => {
+                    log::debug!(
+                        "Failed to request _NET_WM_DESKTOP for workspace redraw: {error:?}"
+                    );
+                    windows_without_desktop_request.push((x_window, refresh_rate));
+                }
+            }
+        }
+
+        let current_desktop = match current_desktop_request {
+            Ok(request) => match request.reply() {
+                Ok(reply) => reply.value32().and_then(|mut values| values.next()),
+                Err(error) => {
+                    log::debug!(
+                        "Failed to get _NET_CURRENT_DESKTOP for workspace redraw: {error:?}"
+                    );
+                    None
+                }
+            },
+            Err(error) => {
+                log::debug!(
+                    "Failed to request _NET_CURRENT_DESKTOP for workspace redraw: {error:?}"
+                );
+                None
+            }
+        };
+
+        let mut window_states = HashMap::default();
+        for (x_window, refresh_rate, request) in desktop_requests {
+            let window_desktop = match request.reply() {
+                Ok(reply) => reply.value32().and_then(|mut values| values.next()),
+                Err(error) => {
+                    log::debug!("Failed to get _NET_WM_DESKTOP for workspace redraw: {error:?}");
+                    None
+                }
+            };
+            if let Some(candidate) = workspace_redraw_candidate(current_desktop, window_desktop) {
+                window_states.insert(
+                    x_window,
+                    WorkspaceRedrawWindowState::new(refresh_rate, candidate),
+                );
+            }
+        }
+        for (x_window, refresh_rate) in windows_without_desktop_request {
+            window_states.insert(
+                x_window,
+                WorkspaceRedrawWindowState::new(refresh_rate, WorkspaceRedrawCandidate::Fallback),
+            );
+        }
 
         if window_states.is_empty() {
             return;
@@ -647,7 +766,7 @@ impl X11Client {
             let now = Instant::now();
             let (xcb_connection, pending_windows) = {
                 let state = client.0.borrow();
-                if state.workspace_redraw_generation != generation {
+                if !state.workspace_redraw_generation.is_current(generation) {
                     return calloop::timer::TimeoutAction::Drop;
                 }
                 window_states.retain(|x_window, _| state.windows.contains_key(x_window));
@@ -701,7 +820,7 @@ impl X11Client {
 
             let windows_to_refresh = {
                 let state = client.0.borrow();
-                if state.workspace_redraw_generation != generation {
+                if !state.workspace_redraw_generation.is_current(generation) {
                     return calloop::timer::TimeoutAction::Drop;
                 }
                 windows_to_refresh
@@ -723,16 +842,28 @@ impl X11Client {
 
             let timed_out = Instant::now() >= deadline;
             if timed_out && !window_states.is_empty() {
-                log::warn!(
-                    "Timed out waiting for {} X11 window(s) to become viewable after a \
-                     workspace change",
-                    window_states.len()
-                );
+                let expected_windows = window_states
+                    .values()
+                    .filter(|window| window.warn_on_timeout)
+                    .count();
+                let fallback_windows = window_states.len() - expected_windows;
+                if expected_windows > 0 {
+                    log::warn!(
+                        "Timed out waiting for {expected_windows} X11 window(s) on the current \
+                         desktop to become viewable after a workspace change"
+                    );
+                }
+                if fallback_windows > 0 {
+                    log::debug!(
+                        "Stopped polling {fallback_windows} X11 window(s) whose desktop could not \
+                         be determined after a workspace change"
+                    );
+                }
             }
 
             if window_states.is_empty() || timed_out {
                 let mut state = client.0.borrow_mut();
-                if state.workspace_redraw_generation == generation {
+                if state.workspace_redraw_generation.is_current(generation) {
                     state.workspace_redraw_timer = None;
                 }
                 calloop::timer::TimeoutAction::Drop
@@ -744,7 +875,7 @@ impl X11Client {
         match registration {
             Ok(registration) => {
                 let mut state = self.0.borrow_mut();
-                if state.workspace_redraw_generation == generation {
+                if state.workspace_redraw_generation.is_current(generation) {
                     state.workspace_redraw_timer = Some(registration);
                 } else {
                     state.loop_handle.remove(registration);
@@ -3007,7 +3138,10 @@ mod tests {
 
     fn workspace_redraw_observations(observations: &[(u64, bool)]) -> Vec<bool> {
         let start = Instant::now();
-        let mut state = WorkspaceRedrawWindowState::new(Duration::from_millis(16));
+        let mut state = WorkspaceRedrawWindowState::new(
+            Duration::from_millis(16),
+            WorkspaceRedrawCandidate::Expected,
+        );
         observations
             .iter()
             .map(|(milliseconds, is_viewable)| {
@@ -3042,6 +3176,39 @@ mod tests {
             workspace_redraw_observations(&[(0, false), (100, false), (200, true), (216, true),]),
             [false, false, false, true],
         );
+    }
+
+    #[test]
+    fn workspace_redraw_limits_candidates_to_the_current_desktop() {
+        assert_eq!(
+            workspace_redraw_candidate(Some(2), Some(2)),
+            Some(WorkspaceRedrawCandidate::Expected)
+        );
+        assert_eq!(
+            workspace_redraw_candidate(Some(2), Some(u32::MAX)),
+            Some(WorkspaceRedrawCandidate::Expected)
+        );
+        assert_eq!(workspace_redraw_candidate(Some(2), Some(3)), None);
+        assert_eq!(
+            workspace_redraw_candidate(Some(2), None),
+            Some(WorkspaceRedrawCandidate::Fallback)
+        );
+        assert_eq!(
+            workspace_redraw_candidate(None, Some(2)),
+            Some(WorkspaceRedrawCandidate::Fallback)
+        );
+    }
+
+    #[test]
+    fn workspace_redraw_generation_invalidates_older_timers() {
+        let mut generation = WorkspaceRedrawGeneration::default();
+        let first = generation.advance();
+        let second = generation.advance();
+        let third = generation.advance();
+
+        assert!(!generation.is_current(first));
+        assert!(!generation.is_current(second));
+        assert!(generation.is_current(third));
     }
 
     fn test_keymap(layouts: &str) -> xkbc::Keymap {

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -77,6 +77,9 @@ pub(crate) const XINPUT_ALL_DEVICES: xinput::DeviceId = 0;
 pub(crate) const XINPUT_ALL_DEVICE_GROUPS: xinput::DeviceId = 1;
 
 const GPUI_X11_SCALE_FACTOR_ENV: &str = "GPUI_X11_SCALE_FACTOR";
+const WORKSPACE_REDRAW_POLL_INTERVAL: Duration = Duration::from_millis(16);
+const WORKSPACE_REDRAW_DEADLINE: Duration = Duration::from_millis(500);
+const DEFAULT_REFRESH_RATE: Duration = Duration::from_micros(1_000_000 / 60);
 
 pub(crate) struct WindowRef {
     window: X11WindowStatePtr,
@@ -89,6 +92,14 @@ pub(crate) struct WindowRef {
 impl WindowRef {
     pub fn handle(&self) -> AnyWindowHandle {
         self.window.state.borrow().handle
+    }
+
+    fn refresh_rate(&self) -> Duration {
+        match &self.refresh_state {
+            Some(RefreshState::Hidden { refresh_rate })
+            | Some(RefreshState::PeriodicRefresh { refresh_rate, .. }) => *refresh_rate,
+            None => DEFAULT_REFRESH_RATE,
+        }
     }
 }
 
@@ -108,6 +119,35 @@ enum RefreshState {
         refresh_rate: Duration,
         event_loop_token: RegistrationToken,
     },
+}
+
+struct WorkspaceRedrawWindowState {
+    viewable_since: Option<Instant>,
+    refresh_rate: Duration,
+}
+
+impl WorkspaceRedrawWindowState {
+    fn new(refresh_rate: Duration) -> Self {
+        Self {
+            viewable_since: None,
+            refresh_rate,
+        }
+    }
+
+    fn observe(&mut self, is_viewable: bool, now: Instant) -> bool {
+        if !is_viewable {
+            self.viewable_since = None;
+            return false;
+        }
+
+        match self.viewable_since {
+            Some(viewable_since) => now.duration_since(viewable_since) >= self.refresh_rate,
+            None => {
+                self.viewable_since = Some(now);
+                false
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -191,6 +231,8 @@ pub struct X11ClientState {
     pub(crate) resource_database: Database,
     pub(crate) atoms: XcbAtoms,
     pub(crate) windows: HashMap<xproto::Window, WindowRef>,
+    workspace_redraw_timer: Option<RegistrationToken>,
+    workspace_redraw_generation: u64,
     pub(crate) mouse_focused_window: Option<xproto::Window>,
     pub(crate) keyboard_focused_window: Option<xproto::Window>,
     pub(crate) xkb: xkbc::State,
@@ -541,6 +583,8 @@ impl X11Client {
             resource_database,
             atoms,
             windows: HashMap::default(),
+            workspace_redraw_timer: None,
+            workspace_redraw_generation: 0,
             mouse_focused_window: None,
             keyboard_focused_window: None,
             xkb: xkb_state,
@@ -567,6 +611,149 @@ impl X11Client {
             clipboard_item: None,
             xdnd_state: Xdnd::default(),
         }))))
+    }
+
+    fn start_workspace_redraw_timer(&self) {
+        let (loop_handle, generation, mut window_states) = {
+            let mut state = self.0.borrow_mut();
+            if let Some(timer) = state.workspace_redraw_timer.take() {
+                state.loop_handle.remove(timer);
+            }
+            state.workspace_redraw_generation = state.workspace_redraw_generation.wrapping_add(1);
+            let generation = state.workspace_redraw_generation;
+            let window_states = state
+                .windows
+                .iter()
+                .map(|(x_window, window)| {
+                    (
+                        *x_window,
+                        WorkspaceRedrawWindowState::new(window.refresh_rate()),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            (state.loop_handle.clone(), generation, window_states)
+        };
+
+        if window_states.is_empty() {
+            return;
+        }
+
+        // Some window managers remap an ancestor frame without sending Expose
+        // or MapNotify to the client. Poll long enough to cover delayed remaps,
+        // then wait one measured display refresh after each client is viewable.
+        let deadline = Instant::now() + WORKSPACE_REDRAW_DEADLINE;
+        let timer = calloop::timer::Timer::immediate();
+        let registration = loop_handle.insert_source(timer, move |_, (), client| {
+            let now = Instant::now();
+            let (xcb_connection, pending_windows) = {
+                let state = client.0.borrow();
+                if state.workspace_redraw_generation != generation {
+                    return calloop::timer::TimeoutAction::Drop;
+                }
+                window_states.retain(|x_window, _| state.windows.contains_key(x_window));
+                (
+                    state.xcb_connection.clone(),
+                    window_states.keys().copied().collect::<Vec<_>>(),
+                )
+            };
+
+            let mut attribute_requests = Vec::with_capacity(pending_windows.len());
+            let mut failed_windows = Vec::new();
+            for x_window in pending_windows {
+                match xcb_connection.get_window_attributes(x_window) {
+                    Ok(request) => attribute_requests.push((x_window, request)),
+                    Err(error) => {
+                        log::warn!(
+                            "Failed to request X11 window attributes for workspace redraw: \
+                             {error:?}"
+                        );
+                        failed_windows.push(x_window);
+                    }
+                }
+            }
+
+            let mut windows_to_refresh = Vec::new();
+            for (x_window, request) in attribute_requests {
+                match request.reply() {
+                    Ok(attributes) => {
+                        let is_viewable = attributes.map_state == xproto::MapState::VIEWABLE;
+                        if let Some(window_state) = window_states.get_mut(&x_window)
+                            && window_state.observe(is_viewable, now)
+                        {
+                            windows_to_refresh.push(x_window);
+                        }
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "Failed to get X11 window attributes for workspace redraw: {error:?}"
+                        );
+                        failed_windows.push(x_window);
+                    }
+                }
+            }
+
+            for x_window in failed_windows
+                .into_iter()
+                .chain(windows_to_refresh.iter().copied())
+            {
+                window_states.remove(&x_window);
+            }
+
+            let windows_to_refresh = {
+                let state = client.0.borrow();
+                if state.workspace_redraw_generation != generation {
+                    return calloop::timer::TimeoutAction::Drop;
+                }
+                windows_to_refresh
+                    .into_iter()
+                    .filter_map(|x_window| {
+                        state
+                            .windows
+                            .get(&x_window)
+                            .map(|window| window.window.clone())
+                    })
+                    .collect::<Vec<_>>()
+            };
+            for window in windows_to_refresh {
+                window.refresh(RequestFrameOptions {
+                    require_presentation: true,
+                    force_render: true,
+                });
+            }
+
+            let timed_out = Instant::now() >= deadline;
+            if timed_out && !window_states.is_empty() {
+                log::warn!(
+                    "Timed out waiting for {} X11 window(s) to become viewable after a \
+                     workspace change",
+                    window_states.len()
+                );
+            }
+
+            if window_states.is_empty() || timed_out {
+                let mut state = client.0.borrow_mut();
+                if state.workspace_redraw_generation == generation {
+                    state.workspace_redraw_timer = None;
+                }
+                calloop::timer::TimeoutAction::Drop
+            } else {
+                calloop::timer::TimeoutAction::ToDuration(WORKSPACE_REDRAW_POLL_INTERVAL)
+            }
+        });
+
+        match registration {
+            Ok(registration) => {
+                let mut state = self.0.borrow_mut();
+                if state.workspace_redraw_generation == generation {
+                    state.workspace_redraw_timer = Some(registration);
+                } else {
+                    state.loop_handle.remove(registration);
+                }
+            }
+            Err(error) => {
+                log::error!("Failed to initialize X11 workspace redraw timer: {error:?}");
+            }
+        }
     }
 
     pub fn process_x11_events(
@@ -964,62 +1151,7 @@ impl X11Client {
                     event.window == root && event.atom == state.atoms._NET_CURRENT_DESKTOP
                 };
                 if desktop_changed {
-                    // i3 maps its ancestor frame rather than the client window when
-                    // switching workspaces, so no Expose event reaches the client.
-                    let mut attempts_remaining = 8;
-                    let mut viewable_windows = HashSet::new();
-                    let mut refreshed_windows = HashSet::new();
-                    self.0
-                        .borrow()
-                        .loop_handle
-                        .insert_source(
-                            calloop::timer::Timer::from_duration(Duration::from_millis(16)),
-                            move |_, (), client| {
-                                let (xcb_connection, windows) = {
-                                    let state = client.0.borrow();
-                                    let windows = state
-                                        .windows
-                                        .iter()
-                                        .map(|(x_window, window)| {
-                                            (*x_window, window.window.clone())
-                                        })
-                                        .collect::<Vec<_>>();
-                                    (state.xcb_connection.clone(), windows)
-                                };
-                                for (x_window, window) in windows {
-                                    if refreshed_windows.contains(&x_window) {
-                                        continue;
-                                    }
-                                    let is_viewable = get_reply(
-                                        || "Failed to get X11 window attributes",
-                                        xcb_connection.get_window_attributes(x_window),
-                                    )
-                                    .map(|attributes| {
-                                        attributes.map_state == xproto::MapState::VIEWABLE
-                                    })
-                                    .log_err()
-                                    .unwrap_or(false);
-                                    // Give the compositor one frame after the window becomes
-                                    // viewable before presenting its new contents.
-                                    if is_viewable && !viewable_windows.insert(x_window) {
-                                        refreshed_windows.insert(x_window);
-                                        window.refresh(RequestFrameOptions {
-                                            require_presentation: true,
-                                            force_render: true,
-                                        });
-                                    }
-                                }
-                                attempts_remaining -= 1;
-                                if attempts_remaining == 0 {
-                                    calloop::timer::TimeoutAction::Drop
-                                } else {
-                                    calloop::timer::TimeoutAction::ToDuration(
-                                        Duration::from_millis(16),
-                                    )
-                                }
-                            },
-                        )
-                        .log_err();
+                    self.start_workspace_redraw_timer();
                     return Some(());
                 }
                 let window = self.get_window(event.window)?;
@@ -2021,7 +2153,7 @@ impl X11ClientState {
                             "Failed to get screen mode info from xrandr, \
                             defaulting to 60hz refresh rate."
                         );
-                        Duration::from_micros(1_000_000 / 60)
+                        DEFAULT_REFRESH_RATE
                     }
                 };
 
@@ -2872,6 +3004,45 @@ fn xkb_state_for_key_event(xkb: &xkbc::State, event_state: xproto::KeyButMask) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn workspace_redraw_observations(observations: &[(u64, bool)]) -> Vec<bool> {
+        let start = Instant::now();
+        let mut state = WorkspaceRedrawWindowState::new(Duration::from_millis(16));
+        observations
+            .iter()
+            .map(|(milliseconds, is_viewable)| {
+                state.observe(*is_viewable, start + Duration::from_millis(*milliseconds))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn workspace_redraw_waits_one_refresh_after_becoming_viewable() {
+        assert_eq!(
+            workspace_redraw_observations(&[(0, false), (16, false), (32, true), (48, true),]),
+            [false, false, false, true],
+        );
+    }
+
+    #[test]
+    fn workspace_redraw_resets_after_becoming_unviewable() {
+        assert_eq!(
+            workspace_redraw_observations(&[(0, true), (16, false), (32, true), (48, true),]),
+            [false, false, false, true],
+        );
+        assert_eq!(
+            workspace_redraw_observations(&[(0, true), (16, false), (32, true), (48, false),]),
+            [false, false, false, false],
+        );
+    }
+
+    #[test]
+    fn workspace_redraw_allows_delayed_remaps() {
+        assert_eq!(
+            workspace_redraw_observations(&[(0, false), (100, false), (200, true), (216, true),]),
+            [false, false, false, true],
+        );
+    }
 
     fn test_keymap(layouts: &str) -> xkbc::Keymap {
         test_keymap_with_variant(layouts, "")

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -68,6 +68,7 @@ x11rb::atom_manager! {
         _NET_WM_STATE_HIDDEN,
         _NET_WM_STATE_FOCUSED,
         _NET_ACTIVE_WINDOW,
+        _NET_CURRENT_DESKTOP,
         _NET_WM_SYNC_REQUEST,
         _NET_WM_SYNC_REQUEST_COUNTER,
         _NET_WM_BYPASS_COMPOSITOR,

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -69,6 +69,7 @@ x11rb::atom_manager! {
         _NET_WM_STATE_FOCUSED,
         _NET_ACTIVE_WINDOW,
         _NET_CURRENT_DESKTOP,
+        _NET_WM_DESKTOP,
         _NET_WM_SYNC_REQUEST,
         _NET_WM_SYNC_REQUEST_COUNTER,
         _NET_WM_BYPASS_COMPOSITOR,

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -22,6 +22,9 @@
         a11y-test = import ../tests/a11y.nix {
           inherit pkgs inputs;
         };
+        i3-workspace-redraw = import ../tests/i3_workspace_redraw.nix {
+          inherit pkgs inputs;
+        };
       }
       // import ../tests/sandboxing { inherit pkgs inputs; };
     };

--- a/nix/tests/i3_workspace_redraw.nix
+++ b/nix/tests/i3_workspace_redraw.nix
@@ -1,0 +1,308 @@
+# NixOS VM integration test for GPUI X11 presentation across i3 workspaces.
+#
+# Automated:
+#   nix build .#checks.x86_64-linux.i3-workspace-redraw -L
+#
+# Interactive:
+#   nix run .#checks.x86_64-linux.i3-workspace-redraw.driverInteractive
+{
+  pkgs,
+  inputs,
+}:
+let
+  lib = pkgs.lib;
+
+  rustBin = inputs.rust-overlay.lib.mkRustBin { } pkgs;
+  rustToolchain = rustBin.fromRustupToolchainFile ../../rust-toolchain.toml;
+  craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+  fixture =
+    let
+      src = builtins.path {
+        path = ../../.;
+        filter =
+          path: _type:
+          let
+            root = toString ../../. + "/";
+            relativePath = lib.removePrefix root path;
+            firstComponent = builtins.head (lib.path.subpath.components relativePath);
+          in
+          builtins.elem firstComponent [
+            "crates"
+            "assets"
+            "extensions"
+            "script"
+            "tooling"
+            "Cargo.toml"
+            ".config"
+            ".cargo"
+          ];
+        name = "gpui-i3-workspace-redraw-source";
+      };
+      commonArgs = {
+        pname = "gpui-i3-workspace-redraw-fixture";
+        version = "0.0.0";
+        inherit src;
+        cargoLock = ../../Cargo.lock;
+        cargoExtraArgs = "-p gpui --example x11_workspace_redraw --locked --features=gpui_platform/x11";
+        CARGO_PROFILE = "dev";
+
+        nativeBuildInputs = with pkgs; [
+          cmake
+          pkg-config
+          rustPlatform.bindgenHook
+        ];
+
+        buildInputs = with pkgs; [
+          alsa-lib
+          fontconfig
+          freetype
+          libdrm
+          libgbm
+          libglvnd
+          libx11
+          libxcb
+          libxcomposite
+          libxdamage
+          libxext
+          libxfixes
+          libxkbcommon
+          libxrandr
+          openssl
+          vulkan-loader
+          wayland
+          zlib
+          zstd
+        ];
+
+        cargoVendorDir = craneLib.vendorCargoDeps {
+          inherit src;
+          cargoLock = ../../Cargo.lock;
+        };
+
+        env = {
+          ZSTD_SYS_USE_PKG_CONFIG = true;
+          FONTCONFIG_FILE = pkgs.makeFontsConf {
+            fontDirectories = [
+              ../../assets/fonts/lilex
+              ../../assets/fonts/ibm-plex-sans
+            ];
+          };
+        };
+
+        doCheck = false;
+
+        stdenv =
+          let
+            base = pkgs.llvmPackages.stdenv;
+            addBinTools = old: {
+              cc = old.cc.override {
+                inherit (pkgs.llvmPackages) bintools;
+              };
+            };
+          in
+          lib.pipe base [
+            (stdenv: stdenv.override addBinTools)
+            pkgs.stdenvAdapters.useMoldLinker
+          ];
+      };
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+    in
+    craneLib.buildPackage (
+      lib.recursiveUpdate commonArgs {
+        inherit cargoArtifacts;
+        dontUseCmakeConfigure = true;
+
+        installPhase = ''
+          runHook preInstall
+          install -D -m 755 \
+            target/debug/examples/x11_workspace_redraw \
+            $out/bin/gpui-i3-workspace-redraw-fixture
+          runHook postInstall
+        '';
+
+        NIX_LDFLAGS = "-rpath ${
+          lib.makeLibraryPath [
+            pkgs.vulkan-loader
+            pkgs.wayland
+          ]
+        }";
+        dontPatchELF = true;
+
+        meta = {
+          description = "Deterministic GPUI X11 workspace redraw fixture";
+          platforms = lib.platforms.linux;
+        };
+      }
+    );
+
+  testScript = pkgs.writeShellApplication {
+    name = "test-i3-workspace-redraw";
+    runtimeInputs = with pkgs; [
+      bash
+      coreutils
+      gawk
+      gnugrep
+      i3
+      imagemagick
+      jq
+      xdotool
+      xorg.xprop
+    ];
+    text = builtins.readFile ../../script/test-i3-workspace-redraw;
+  };
+
+  i3Config = pkgs.writeText "gpui-i3-workspace-redraw-config" ''
+    set $mod Mod4
+    font pango:monospace 8
+    focus_follows_mouse no
+    mouse_warping none
+    workspace_auto_back_and_forth no
+    focus_wrapping no
+    default_border none
+    default_floating_border none
+  '';
+
+  lavapipeIcd = "${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.${pkgs.stdenv.hostPlatform.linuxArch}.json";
+in
+pkgs.testers.nixosTest {
+  name = "gpui-i3-workspace-redraw-x11";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.xserver = {
+        enable = true;
+        displayManager.lightdm.enable = true;
+        windowManager.i3 = {
+          enable = true;
+          configFile = i3Config;
+          extraPackages = [ ];
+        };
+      };
+      services.displayManager = {
+        defaultSession = "none+i3";
+        autoLogin = {
+          enable = true;
+          user = "gpui-test";
+        };
+      };
+
+      hardware.graphics = {
+        enable = true;
+        package = pkgs.mesa;
+      };
+
+      fonts.packages = [ pkgs.dejavu_fonts ];
+
+      environment.systemPackages = [
+        fixture
+        testScript
+        pkgs.gawk
+        pkgs.i3
+        pkgs.imagemagick
+        pkgs.jq
+        pkgs.mesa-demos
+        pkgs.vulkan-loader
+        pkgs.vulkan-tools
+        pkgs.xdotool
+        pkgs.xorg.xprop
+        pkgs.xorg.xwininfo
+      ];
+
+      environment.variables = {
+        LIBGL_ALWAYS_SOFTWARE = "1";
+        RUST_BACKTRACE = "1";
+        VK_DRIVER_FILES = lavapipeIcd;
+        WGPU_BACKEND = "vulkan";
+        XDG_SESSION_TYPE = "x11";
+      };
+
+      users.users.gpui-test = {
+        isNormalUser = true;
+        password = "gpui-test";
+        extraGroups = [
+          "render"
+          "video"
+        ];
+      };
+
+      virtualisation = {
+        memorySize = 4096;
+        cores = 2;
+        resolution = {
+          x = 1280;
+          y = 800;
+        };
+        qemu.options = [ "-vga virtio" ];
+      };
+    };
+
+  testScript = ''
+    import os
+
+    machine.wait_for_x()
+    machine.wait_for_unit("graphical.target")
+    machine.wait_until_succeeds(
+        "runuser -u gpui-test -- env DISPLAY=:0 "
+        "XAUTHORITY=/home/gpui-test/.Xauthority i3-msg -t get_version",
+        timeout=30,
+    )
+
+    machine.succeed("install -d -o gpui-test -g users /tmp/gpui-i3-artifacts")
+    machine.succeed(
+        "runuser -u gpui-test -- env "
+        "VK_DRIVER_FILES=${lavapipeIcd} "
+        "vulkaninfo --summary > /tmp/gpui-i3-artifacts/vulkaninfo.txt 2>&1"
+    )
+    machine.succeed(
+        "{ "
+        "i3 --version; "
+        "Xorg -version 2>&1 | head -n 2; "
+        "convert -version | head -n 1; "
+        "} > /tmp/gpui-i3-artifacts/package-versions.txt"
+    )
+
+    status, output = machine.execute(
+        "runuser -u gpui-test -- env "
+        "DISPLAY=:0 "
+        "XAUTHORITY=/home/gpui-test/.Xauthority "
+        "XDG_RUNTIME_DIR=/run/user/1000 "
+        "XDG_SESSION_TYPE=x11 "
+        "WAYLAND_DISPLAY= "
+        "LIBGL_ALWAYS_SOFTWARE=1 "
+        "VK_DRIVER_FILES=${lavapipeIcd} "
+        "WGPU_BACKEND=vulkan "
+        "RUST_LOG=gpui_linux=info,gpui_wgpu=info "
+        "test-i3-workspace-redraw "
+        "--candidate ${fixture}/bin/gpui-i3-workspace-redraw-fixture "
+        "--iterations 5 "
+        "--settle 0.5 "
+        "--threshold 0.01 "
+        "--artifacts /tmp/gpui-i3-artifacts",
+        timeout=300,
+    )
+    print(output)
+
+    machine.execute(
+        "cp /var/log/X.0.log /tmp/gpui-i3-artifacts/Xorg.0.log 2>/dev/null || true"
+    )
+    machine.execute(
+        "journalctl --no-pager -b > /tmp/gpui-i3-artifacts/system-journal.log"
+    )
+    machine.copy_from_vm("/tmp/gpui-i3-artifacts", os.environ["out"])
+
+    if status != 0:
+        machine.log("fixture log tail:")
+        print(machine.execute("tail -n 100 /tmp/gpui-i3-artifacts/candidate-target.log")[1])
+        machine.log("i3 journal tail:")
+        print(machine.execute("journalctl --no-pager -b -n 100 | tail -n 100")[1])
+        raise Exception(f"workspace redraw test failed with status {status}")
+
+    machine.succeed(
+        "grep -E 'Selected GPU.*llvmpipe.*Vulkan' "
+        "/tmp/gpui-i3-artifacts/candidate-target.log"
+    )
+    machine.fail("pgrep -f gpui-i3-workspace-redraw-fixture")
+  '';
+}

--- a/nix/tests/i3_workspace_redraw.nix
+++ b/nix/tests/i3_workspace_redraw.nix
@@ -262,6 +262,11 @@ pkgs.testers.nixosTest {
         "convert -version | head -n 1; "
         "} > /tmp/gpui-i3-artifacts/package-versions.txt"
     )
+    machine.succeed(
+        "runuser -u gpui-test -- env "
+        "DISPLAY=:0 XAUTHORITY=/home/gpui-test/.Xauthority "
+        "i3-msg 'shmlog on'"
+    )
 
     status, output = machine.execute(
         "runuser -u gpui-test -- env "
@@ -289,6 +294,11 @@ pkgs.testers.nixosTest {
     )
     machine.execute(
         "journalctl --no-pager -b > /tmp/gpui-i3-artifacts/system-journal.log"
+    )
+    machine.execute(
+        "runuser -u gpui-test -- env "
+        "DISPLAY=:0 XAUTHORITY=/home/gpui-test/.Xauthority "
+        "i3-dump-log > /tmp/gpui-i3-artifacts/i3.log 2>&1"
     )
     machine.copy_from_vm("/tmp/gpui-i3-artifacts", os.environ["out"])
 

--- a/nix/tests/i3_workspace_redraw.nix
+++ b/nix/tests/i3_workspace_redraw.nix
@@ -259,10 +259,10 @@ pkgs.testers.nixosTest {
         "{ "
         "i3 --version; "
         "Xorg -version 2>&1 | head -n 2; "
-        "convert -version | head -n 1; "
+        "magick -version | head -n 1; "
         "} > /tmp/gpui-i3-artifacts/package-versions.txt"
     )
-    machine.succeed(
+    machine.execute(
         "runuser -u gpui-test -- env "
         "DISPLAY=:0 XAUTHORITY=/home/gpui-test/.Xauthority "
         "i3-msg 'shmlog on'"

--- a/script/test-i3-workspace-redraw
+++ b/script/test-i3-workspace-redraw
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+#
+# Screenshot regression test for GPUI redraws after i3 switches X11 workspaces.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  script/test-i3-workspace-redraw --candidate FIXTURE [options]
+
+Options:
+  --candidate PATH      GPUI fixture containing the proposed fix (required).
+  --baseline PATH       Optional unpatched fixture to measure first.
+  --iterations N        Workspace round trips per variant (default: 5).
+  --settle SECONDS      Delay before screenshots (default: 0.5).
+  --threshold RMSE      Maximum normalized RMSE (default: 0.01).
+  --artifacts DIR       Output directory (default: a new /tmp directory).
+  -h, --help            Show this help.
+
+The current i3 workspace and focused container are restored on exit. The target
+is never focused between returning to its workspace and taking the return image.
+EOF
+}
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 2
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 ||
+        fail "required command not found: $1"
+}
+
+resolve_executable() {
+    local executable=$1
+
+    if [[ "$executable" == */* ]]; then
+        [[ -x "$executable" ]] || fail "not an executable: $executable"
+        readlink -f "$executable"
+    else
+        command -v "$executable" ||
+            fail "executable not found in PATH: $executable"
+    fi
+}
+
+i3_quote() {
+    jq -Rrn --arg value "$1" '$value | @json'
+}
+
+candidate=
+baseline=
+iterations=5
+settle=0.5
+threshold=0.01
+artifact_dir=
+
+while (($#)); do
+    case "$1" in
+        --candidate)
+            (($# >= 2)) || fail "--candidate requires a value"
+            candidate=$2
+            shift 2
+            ;;
+        --baseline)
+            (($# >= 2)) || fail "--baseline requires a value"
+            baseline=$2
+            shift 2
+            ;;
+        --iterations)
+            (($# >= 2)) || fail "--iterations requires a value"
+            iterations=$2
+            shift 2
+            ;;
+        --settle)
+            (($# >= 2)) || fail "--settle requires a value"
+            settle=$2
+            shift 2
+            ;;
+        --threshold)
+            (($# >= 2)) || fail "--threshold requires a value"
+            threshold=$2
+            shift 2
+            ;;
+        --artifacts)
+            (($# >= 2)) || fail "--artifacts requires a value"
+            artifact_dir=$2
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ -n "$candidate" ]] || {
+    usage >&2
+    fail "--candidate is required"
+}
+[[ "$iterations" =~ ^[1-9][0-9]*$ ]] ||
+    fail "--iterations must be a positive integer"
+[[ "$settle" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+    fail "--settle must be a non-negative number"
+[[ "$threshold" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+    fail "--threshold must be a non-negative number"
+[[ -n "${DISPLAY:-}" ]] || fail "DISPLAY is not set"
+[[ "${XDG_SESSION_TYPE:-x11}" == x11 ]] || fail "an X11 session is required"
+[[ -z "${WAYLAND_DISPLAY:-}" ]] || fail "WAYLAND_DISPLAY must be unset"
+
+for command in awk compare convert grep i3-msg import jq readlink seq xdotool xprop; do
+    require_command "$command"
+done
+
+candidate=$(resolve_executable "$candidate")
+if [[ -n "$baseline" ]]; then
+    baseline=$(resolve_executable "$baseline")
+fi
+
+if [[ -z "$artifact_dir" ]]; then
+    artifact_dir=$(mktemp -d "${TMPDIR:-/tmp}/gpui-i3-redraw.XXXXXX")
+else
+    mkdir -p "$artifact_dir"
+    artifact_dir=$(readlink -f "$artifact_dir")
+fi
+
+run_id="$$-$(date +%s)"
+original_workspace=$(i3-msg -t get_workspaces |
+    jq -er '.[] | select(.focused).name')
+original_con_id=$(i3-msg -t get_tree |
+    jq -r '.. | objects |
+        select(.focused? == true and .window? != null) | .id' |
+    head -n 1)
+test_pids=()
+test_cons=()
+
+stop_test_processes() {
+    local con_id pid
+
+    for con_id in "${test_cons[@]}"; do
+        i3-msg "[con_id=${con_id}] kill" >/dev/null 2>&1 || true
+    done
+    for pid in "${test_pids[@]}"; do
+        kill "$pid" >/dev/null 2>&1 || true
+        wait "$pid" >/dev/null 2>&1 || true
+    done
+
+    test_cons=()
+    test_pids=()
+}
+
+cleanup() {
+    stop_test_processes
+    i3-msg "workspace $(i3_quote "$original_workspace")" \
+        >/dev/null 2>&1 || true
+    if [[ -n "$original_con_id" ]]; then
+        i3-msg "[con_id=${original_con_id}] focus" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+window_for_pid_and_title() {
+    local pid=$1
+    local title=$2
+    local window_id window_pid
+
+    for _ in $(seq 1 150); do
+        while read -r window_id; do
+            [[ -n "$window_id" ]] || continue
+            window_pid=$(xdotool getwindowpid "$window_id" 2>/dev/null || true)
+            if [[ "$window_pid" == "$pid" ]] &&
+                xprop -id "$window_id" _NET_WM_NAME 2>/dev/null |
+                    grep -Fq "\"${title}\""; then
+                printf '%s\n' "$window_id"
+                return 0
+            fi
+        done < <(xdotool search --pid "$pid" --name "^${title}$" 2>/dev/null || true)
+        sleep 0.1
+    done
+
+    return 1
+}
+
+container_for_window() {
+    local window_id=$1
+    local con_id
+
+    for _ in $(seq 1 100); do
+        con_id=$(i3-msg -t get_tree |
+            jq -er --argjson window_id "$window_id" \
+                '.. | objects |
+                select(.window? == $window_id) | .id' |
+            head -n 1) || true
+        if [[ -n "$con_id" ]]; then
+            printf '%s\n' "$con_id"
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    return 1
+}
+
+launch_fixture() {
+    local executable=$1
+    local title=$2
+    local palette=$3
+    local log_file=$4
+    local window_id
+
+    "$executable" --title "$title" --palette "$palette" >"$log_file" 2>&1 &
+    launched_pid=$!
+    test_pids+=("$launched_pid")
+
+    if ! window_id=$(window_for_pid_and_title "$launched_pid" "$title"); then
+        printf 'fixture did not create its X11 window; log tail:\n' >&2
+        tail -n 80 "$log_file" >&2 || true
+        printf 'i3 tree:\n' >&2
+        i3-msg -t get_tree | jq '.. | objects | select(.window? != null)' >&2 || true
+        fail "timed out waiting for fixture: $title"
+    fi
+
+    launched_con=$(container_for_window "$window_id") ||
+        fail "i3 container not found for window ${window_id} (${title})"
+    test_cons+=("$launched_con")
+    xprop -id "$window_id" _NET_WM_PID _NET_WM_NAME WM_CLASS \
+        >"${log_file%.log}.xprop" 2>&1
+}
+
+capture_container() {
+    local con_id=$1
+    local output=$2
+    local geometry x y width height
+
+    geometry=$(i3-msg -t get_tree |
+        jq -er --argjson con_id "$con_id" \
+            '.. | objects | select(.id? == $con_id) |
+            [
+                (.rect.x + .window_rect.x),
+                (.rect.y + .window_rect.y),
+                .window_rect.width,
+                .window_rect.height
+            ] | @tsv')
+    IFS=$'\t' read -r x y width height <<<"$geometry"
+    ((width > 0 && height > 0)) ||
+        fail "invalid target geometry: ${width}x${height}+${x}+${y}"
+
+    import -window root "${output}.root.png"
+    convert "${output}.root.png" \
+        -crop "${width}x${height}+${x}+${y}" +repage "${output}.png"
+    rm -f "${output}.root.png"
+}
+
+normalized_rmse() {
+    local metric value
+
+    metric=$(compare -metric RMSE "$1" "$2" null: 2>&1 || true)
+    value=$(awk -F '[()]' 'NF >= 3 { print $(NF - 1) }' <<<"$metric")
+    [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+        fail "could not parse ImageMagick RMSE output: $metric"
+    printf '%s\n' "$value"
+}
+
+rmse_is_acceptable() {
+    awk -v value="$1" -v limit="$threshold" \
+        'BEGIN { exit !(value <= limit) }'
+}
+
+run_variant() {
+    local label=$1
+    local executable=$2
+    local workspace_a="gpui_i3_e2e_${run_id}_${label}_a"
+    local workspace_b="gpui_i3_e2e_${run_id}_${label}_b"
+    local target_title="GPUI_I3_E2E_${run_id}_${label}_TARGET"
+    local helper_title="GPUI_I3_E2E_${run_id}_${label}_HELPER"
+    local alternate_title="GPUI_I3_E2E_${run_id}_${label}_ALTERNATE"
+    local target_con helper_con alternate_con focused_con iteration
+    local return_rmse control_rmse failures=0
+
+    i3-msg "workspace $(i3_quote "$workspace_a")" >/dev/null
+    launch_fixture "$executable" "$target_title" target \
+        "${artifact_dir}/${label}-target.log"
+    target_con=$launched_con
+    launch_fixture "$executable" "$helper_title" helper \
+        "${artifact_dir}/${label}-helper.log"
+    helper_con=$launched_con
+
+    i3-msg "[con_id=${helper_con}] focus" >/dev/null
+    sleep "$settle"
+    capture_container "$target_con" "${artifact_dir}/${label}-reference"
+
+    i3-msg "workspace $(i3_quote "$workspace_b")" >/dev/null
+    launch_fixture "$executable" "$alternate_title" alternate \
+        "${artifact_dir}/${label}-alternate.log"
+    alternate_con=$launched_con
+    i3-msg "[con_id=${alternate_con}] focus" >/dev/null
+    sleep "$settle"
+
+    printf '\nvariant=%s executable=%s\n' "$label" "$executable"
+    for iteration in $(seq 1 "$iterations"); do
+        i3-msg "workspace $(i3_quote "$workspace_b")" >/dev/null
+        sleep "$settle"
+        i3-msg "workspace $(i3_quote "$workspace_a")" >/dev/null
+        i3-msg "[con_id=${helper_con}] focus" >/dev/null
+        sleep "$settle"
+
+        focused_con=$(i3-msg -t get_tree |
+            jq -er '.. | objects | select(.focused? == true) | .id' |
+            head -n 1)
+        [[ "$focused_con" == "$helper_con" ]] ||
+            fail "target workspace returned with the wrong focused container"
+
+        capture_container "$target_con" \
+            "${artifact_dir}/${label}-return-${iteration}"
+        return_rmse=$(normalized_rmse \
+            "${artifact_dir}/${label}-reference.png" \
+            "${artifact_dir}/${label}-return-${iteration}.png")
+        if ! rmse_is_acceptable "$return_rmse"; then
+            ((failures += 1))
+        fi
+
+        i3-msg "[con_id=${target_con}] focus" >/dev/null
+        sleep "$settle"
+        i3-msg "[con_id=${helper_con}] focus" >/dev/null
+        sleep "$settle"
+        capture_container "$target_con" \
+            "${artifact_dir}/${label}-control-${iteration}"
+        control_rmse=$(normalized_rmse \
+            "${artifact_dir}/${label}-reference.png" \
+            "${artifact_dir}/${label}-control-${iteration}.png")
+
+        printf '%s\t%d\t%s\t%s\n' \
+            "$label" "$iteration" "$return_rmse" "$control_rmse" |
+            tee -a "${artifact_dir}/results.tsv"
+    done
+
+    stop_test_processes
+    variant_failures=$failures
+    if ((failures == 0)); then
+        printf 'result=%s PASS (%d/%d at or below %s)\n' \
+            "$label" "$iterations" "$iterations" "$threshold"
+    else
+        printf 'result=%s FAIL (%d/%d exceeded %s)\n' \
+            "$label" "$failures" "$iterations" "$threshold"
+    fi
+}
+
+{
+    printf 'display=%s\n' "$DISPLAY"
+    printf 'i3=%s\n' "$(i3-msg -t get_version | jq -er '.human_readable')"
+    printf 'imagemagick=%s\n' "$(convert -version | head -n 1)"
+    printf 'iterations=%s\nsettle=%s\nthreshold=%s\n' \
+        "$iterations" "$settle" "$threshold"
+    printf 'candidate=%s\nbaseline=%s\n' "$candidate" "${baseline:-none}"
+} | tee "${artifact_dir}/environment.txt"
+printf 'variant\titeration\treturn_rmse\tcontrol_rmse\n' \
+    >"${artifact_dir}/results.tsv"
+printf 'artifacts=%s\n' "$artifact_dir"
+
+if [[ -n "$baseline" ]]; then
+    run_variant baseline "$baseline"
+fi
+
+run_variant candidate "$candidate"
+candidate_failures=$variant_failures
+
+if ((candidate_failures > 0)); then
+    exit 1
+fi

--- a/script/test-i3-workspace-redraw
+++ b/script/test-i3-workspace-redraw
@@ -213,8 +213,9 @@ launch_fixture() {
     local palette=$3
     local log_file=$4
     local window_id
+    shift 4
 
-    "$executable" --title "$title" --palette "$palette" >"$log_file" 2>&1 &
+    "$executable" --title "$title" --palette "$palette" "$@" >"$log_file" 2>&1 &
     launched_pid=$!
     test_pids+=("$launched_pid")
 
@@ -229,7 +230,7 @@ launch_fixture() {
     launched_con=$(container_for_window "$window_id") ||
         fail "i3 container not found for window ${window_id} (${title})"
     test_cons+=("$launched_con")
-    xprop -id "$window_id" _NET_WM_PID _NET_WM_NAME WM_CLASS \
+    xprop -id "$window_id" _NET_WM_PID _NET_WM_NAME _NET_WM_DESKTOP WM_CLASS \
         >"${log_file%.log}.xprop" 2>&1
 }
 
@@ -369,8 +370,22 @@ run_variant() {
 
     i3-msg "workspace $(i3_quote "$workspace_a")" >/dev/null
     launch_fixture "$executable" "$target_title" target \
-        "${artifact_dir}/${label}-target.log"
+        "${artifact_dir}/${label}-target.log" \
+        --secondary-title "$alternate_title" --secondary-palette alternate
+    local target_pid=$launched_pid
     target_con=$launched_con
+    local alternate_window
+    alternate_window=$(window_for_pid_and_title "$target_pid" "$alternate_title") ||
+        fail "timed out waiting for secondary fixture: $alternate_title"
+    alternate_con=$(container_for_window "$alternate_window") ||
+        fail "i3 container not found for secondary fixture window ${alternate_window}"
+    test_cons+=("$alternate_con")
+    i3-msg "[con_id=${alternate_con}] move container to workspace $(i3_quote "$workspace_b")" \
+        >/dev/null
+    xprop -id "$alternate_window" \
+        _NET_WM_PID _NET_WM_NAME _NET_WM_DESKTOP WM_CLASS \
+        >"${artifact_dir}/${label}-alternate.xprop" 2>&1
+
     launch_fixture "$executable" "$helper_title" helper \
         "${artifact_dir}/${label}-helper.log"
     helper_con=$launched_con
@@ -386,9 +401,6 @@ run_variant() {
         fail "${label} reference image does not contain the expected target palette"
 
     i3-msg "workspace $(i3_quote "$workspace_b")" >/dev/null
-    launch_fixture "$executable" "$alternate_title" alternate \
-        "${artifact_dir}/${label}-alternate.log"
-    alternate_con=$launched_con
     i3-msg "[con_id=${alternate_con}] focus" >/dev/null
     sleep "$settle"
 
@@ -445,6 +457,11 @@ run_variant() {
             tee -a "${artifact_dir}/results.tsv"
     done
 
+    if grep -Fq "Timed out waiting for" "${artifact_dir}/${label}-target.log"; then
+        tail -n 80 "${artifact_dir}/${label}-target.log" >&2 || true
+        fail "${label} emitted a workspace redraw timeout warning"
+    fi
+
     stop_test_processes
     variant_failures=$failures
     if ((failures == 0)); then
@@ -459,7 +476,7 @@ run_variant() {
 {
     printf 'display=%s\n' "$DISPLAY"
     printf 'i3=%s\n' "$(i3-msg -t get_version | jq -er '.human_readable')"
-    printf 'imagemagick=%s\n' "$(convert -version | head -n 1)"
+    printf 'imagemagick=%s\n' "$(magick -version | head -n 1)"
     printf 'iterations=%s\nsettle=%s\nthreshold=%s\n' \
         "$iterations" "$settle" "$threshold"
     printf 'candidate=%s\nbaseline=%s\n' "$candidate" "${baseline:-none}"

--- a/script/test-i3-workspace-redraw
+++ b/script/test-i3-workspace-redraw
@@ -112,7 +112,7 @@ done
 [[ "${XDG_SESSION_TYPE:-x11}" == x11 ]] || fail "an X11 session is required"
 [[ -z "${WAYLAND_DISPLAY:-}" ]] || fail "WAYLAND_DISPLAY must be unset"
 
-for command in awk compare convert grep i3-msg import jq readlink seq xdotool xprop; do
+for command in awk compare grep i3-msg identify import jq magick readlink seq xdotool xprop; do
     require_command "$command"
 done
 
@@ -137,6 +137,8 @@ original_con_id=$(i3-msg -t get_tree |
     head -n 1)
 test_pids=()
 test_cons=()
+captured_width=
+captured_height=
 
 stop_test_processes() {
     local con_id pid
@@ -250,9 +252,11 @@ capture_container() {
         fail "invalid target geometry: ${width}x${height}+${x}+${y}"
 
     import -window root "${output}.root.png"
-    convert "${output}.root.png" \
+    magick "${output}.root.png" \
         -crop "${width}x${height}+${x}+${y}" +repage "${output}.png"
     rm -f "${output}.root.png"
+    captured_width=$width
+    captured_height=$height
 }
 
 normalized_rmse() {
@@ -270,6 +274,87 @@ rmse_is_acceptable() {
         'BEGIN { exit !(value <= limit) }'
 }
 
+validate_target_palette() {
+    local image=$1
+    local expected_width=$2
+    local expected_height=$3
+    local oracle_name=$4
+    local dimensions width height histogram minimum_pixels color count
+    local index x y expected_pixel pixel_metric pixel_rmse
+    local failed=0
+    local colors=(172554 06b6d4 facc15 ef4444 22c55e)
+    local samples=(
+        "2 2"
+        "$((expected_width / 8)) $((expected_height / 2))"
+        "$((expected_width / 2)) $((expected_height / 4))"
+        "$((expected_width / 2)) $((expected_height * 3 / 4))"
+        "$((expected_width * 7 / 8)) $((expected_height / 2))"
+    )
+
+    dimensions=$(identify -format '%w %h' "$image")
+    IFS=' ' read -r width height <<<"$dimensions"
+    if [[ "$width" != "$expected_width" || "$height" != "$expected_height" ]]; then
+        printf 'oracle error: %s has size %sx%s, expected %sx%s\n' \
+            "$image" "$width" "$height" "$expected_width" "$expected_height" >&2
+        failed=1
+    fi
+    if ((width < 200 || height < 200)); then
+        printf 'oracle error: %s is too small for the fixture pattern: %sx%s\n' \
+            "$image" "$width" "$height" >&2
+        failed=1
+    fi
+
+    histogram="${image%.png}.histogram.txt"
+    magick "$image" -alpha off -depth 8 -format %c histogram:info:- >"$histogram"
+    minimum_pixels=$((expected_width * expected_height / 20))
+    for color in "${colors[@]}"; do
+        count=$(awk -v color="$color" '
+            index(toupper($0), "#" toupper(color)) {
+                sub(":", "", $1)
+                total += $1
+            }
+            END { print total + 0 }
+        ' "$histogram")
+        if ((count < minimum_pixels)); then
+            printf 'oracle error: %s has %d pixels of #%s, expected at least %d\n' \
+                "$image" "$count" "$color" "$minimum_pixels" >&2
+            failed=1
+        fi
+    done
+
+    for index in "${!colors[@]}"; do
+        color=${colors[$index]}
+        IFS=' ' read -r x y <<<"${samples[$index]}"
+        expected_pixel="${artifact_dir}/expected-${color}.png"
+        if [[ ! -f "$expected_pixel" ]]; then
+            magick -size 1x1 "xc:#${color}" "$expected_pixel"
+        fi
+        pixel_metric=$(
+            magick "$image" -crop "1x1+${x}+${y}" +repage miff:- |
+                compare -metric RMSE miff:- "$expected_pixel" null: 2>&1 || true
+        )
+        pixel_rmse=$(awk -F '[()]' 'NF >= 3 { print $(NF - 1) }' <<<"$pixel_metric")
+        if [[ ! "$pixel_rmse" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] ||
+            ! rmse_is_acceptable "$pixel_rmse"; then
+            printf 'oracle error: %s pixel %s,%s does not match #%s: %s\n' \
+                "$image" "$x" "$y" "$color" "$pixel_metric" >&2
+            failed=1
+        fi
+    done
+
+    if ((failed == 0)); then
+        printf '%s\t%s\t%sx%s\tpass\n' \
+            "$oracle_name" "$image" "$width" "$height" |
+            tee -a "${artifact_dir}/oracle.tsv"
+        return 0
+    fi
+
+    printf '%s\t%s\t%sx%s\tfail\n' \
+        "$oracle_name" "$image" "$width" "$height" |
+        tee -a "${artifact_dir}/oracle.tsv"
+    return 1
+}
+
 run_variant() {
     local label=$1
     local executable=$2
@@ -279,7 +364,8 @@ run_variant() {
     local helper_title="GPUI_I3_E2E_${run_id}_${label}_HELPER"
     local alternate_title="GPUI_I3_E2E_${run_id}_${label}_ALTERNATE"
     local target_con helper_con alternate_con focused_con iteration
-    local return_rmse control_rmse failures=0
+    local reference_width reference_height return_rmse control_rmse
+    local control_palette iteration_failed failures=0
 
     i3-msg "workspace $(i3_quote "$workspace_a")" >/dev/null
     launch_fixture "$executable" "$target_title" target \
@@ -292,6 +378,12 @@ run_variant() {
     i3-msg "[con_id=${helper_con}] focus" >/dev/null
     sleep "$settle"
     capture_container "$target_con" "${artifact_dir}/${label}-reference"
+    reference_width=$captured_width
+    reference_height=$captured_height
+    validate_target_palette \
+        "${artifact_dir}/${label}-reference.png" \
+        "$reference_width" "$reference_height" "${label}-reference" ||
+        fail "${label} reference image does not contain the expected target palette"
 
     i3-msg "workspace $(i3_quote "$workspace_b")" >/dev/null
     launch_fixture "$executable" "$alternate_title" alternate \
@@ -319,8 +411,9 @@ run_variant() {
         return_rmse=$(normalized_rmse \
             "${artifact_dir}/${label}-reference.png" \
             "${artifact_dir}/${label}-return-${iteration}.png")
+        iteration_failed=0
         if ! rmse_is_acceptable "$return_rmse"; then
-            ((failures += 1))
+            iteration_failed=1
         fi
 
         i3-msg "[con_id=${target_con}] focus" >/dev/null
@@ -332,9 +425,23 @@ run_variant() {
         control_rmse=$(normalized_rmse \
             "${artifact_dir}/${label}-reference.png" \
             "${artifact_dir}/${label}-control-${iteration}.png")
+        control_palette=pass
+        if ! rmse_is_acceptable "$control_rmse"; then
+            iteration_failed=1
+        fi
+        if ! validate_target_palette \
+            "${artifact_dir}/${label}-control-${iteration}.png" \
+            "$reference_width" "$reference_height" \
+            "${label}-control-${iteration}"; then
+            control_palette=fail
+            iteration_failed=1
+        fi
+        if ((iteration_failed != 0)); then
+            ((failures += 1))
+        fi
 
-        printf '%s\t%d\t%s\t%s\n' \
-            "$label" "$iteration" "$return_rmse" "$control_rmse" |
+        printf '%s\t%d\t%s\t%s\t%s\n' \
+            "$label" "$iteration" "$return_rmse" "$control_rmse" "$control_palette" |
             tee -a "${artifact_dir}/results.tsv"
     done
 
@@ -357,8 +464,9 @@ run_variant() {
         "$iterations" "$settle" "$threshold"
     printf 'candidate=%s\nbaseline=%s\n' "$candidate" "${baseline:-none}"
 } | tee "${artifact_dir}/environment.txt"
-printf 'variant\titeration\treturn_rmse\tcontrol_rmse\n' \
+printf 'variant\titeration\treturn_rmse\tcontrol_rmse\tcontrol_palette\n' \
     >"${artifact_dir}/results.tsv"
+printf 'oracle\timage\tsize\tresult\n' >"${artifact_dir}/oracle.tsv"
 printf 'artifacts=%s\n' "$artifact_dir"
 
 if [[ -n "$baseline" ]]; then

--- a/tooling/xtask/src/tasks/workflows/nix_build.rs
+++ b/tooling/xtask/src/tasks/workflows/nix_build.rs
@@ -1,6 +1,9 @@
 use crate::tasks::workflows::{
     runners::{Arch, Platform},
-    steps::{CommonJobConditions, CommonPermissionSets, DEFAULT_REPOSITORY_OWNER_GUARD, NamedJob},
+    steps::{
+        CommonJobConditions, CommonPermissionSets, DEFAULT_REPOSITORY_OWNER_GUARD, IfNoFilesFound,
+        NamedJob,
+    },
 };
 
 use super::{runners, steps, steps::named, vars};
@@ -12,6 +15,7 @@ use gh_workflow::*;
 /// them twice.
 pub fn nix_build() -> Workflow {
     let [nix_linux_x86_64, nix_mac_aarch64] = nix_pr_jobs(&["run-nix", "run-bundling"]);
+    let i3_workspace_redraw = i3_workspace_redraw_job();
     named::workflow()
         .with_minimal_permissions()
         .on(Event::default().pull_request(
@@ -27,6 +31,37 @@ pub fn nix_build() -> Workflow {
         .add_env(("RUST_BACKTRACE", "1"))
         .add_job(nix_linux_x86_64.name, nix_linux_x86_64.job)
         .add_job(nix_mac_aarch64.name, nix_mac_aarch64.job)
+        .add_job(i3_workspace_redraw.name, i3_workspace_redraw.job)
+}
+
+/// Runs the Linux-only graphical VM regression when maintainers opt a PR into
+/// Nix testing. Keeping this behind `run-nix` avoids adding a costly VM to the
+/// required checks while ensuring that the check does not silently rot.
+fn i3_workspace_redraw_job() -> NamedJob {
+    let mut job = build_nix(
+        Platform::Linux,
+        Arch::X86_64,
+        "checks.x86_64-linux.i3-workspace-redraw",
+        None,
+        &[],
+    );
+    job.name = "i3_workspace_redraw".to_owned();
+    job.job = job
+        .job
+        .continue_on_error(false)
+        .cond(Expression::new(format!(
+            "{DEFAULT_REPOSITORY_OWNER_GUARD} && \
+            ((github.event.action == 'labeled' && github.event.label.name == 'run-nix') || \
+            (github.event.action == 'synchronize' && \
+            contains(github.event.pull_request.labels.*.name, 'run-nix')))"
+        )))
+        .add_step(
+            steps::upload_artifact("i3-workspace-redraw-artifacts", "result/gpui-i3-artifacts")
+                .if_no_files_found(IfNoFilesFound::Warn)
+                .retention_days(14)
+                .if_condition(Expression::new("always()")),
+        );
+    job
 }
 
 /// Builds the pair of PR Nix jobs (Linux x86_64 + macOS aarch64), each gated so


### PR DESCRIPTION
## Summary

- subscribe to EWMH `_NET_CURRENT_DESKTOP` changes on X11
- replace any previous workspace-redraw timer and reject callbacks from obsolete generations
- use `_NET_CURRENT_DESKTOP` and `_NET_WM_DESKTOP` to poll only windows on the newly selected desktop, including sticky windows
- wait until each candidate is continuously viewable for its measured display refresh interval, with a 500 ms deadline
- force one render and presentation after the window manager has remapped the ancestor frame
- add a reproducible headless i3/X11 screenshot regression test as the Linux-only flake check `i3-workspace-redraw`
- run that VM check as an opt-in, non-allowed-to-fail `run-nix` CI job and upload its artifacts

## Root cause

i3 unmaps and maps its own frame window when switching workspaces while the client window remains mapped. As a result, Zed receives neither `MapNotify` nor `Expose` for the client window and its hidden refresh loop has no event that requests a new presentation.

#20535 handles workspace switches that produce `Expose`, but it cannot handle this ancestor-frame path. This fixes the i3 workspace-switch reproduction reported in #56735 and is a follow-up to #18184 and #20535.

## Recovery state machine

`_NET_CURRENT_DESKTOP` remains the portable EWMH signal; no i3 IPC is used in production. Each desktop change now:

1. removes the previous calloop `RegistrationToken`
2. advances a generation counter
3. snapshots the current GPUI windows and their measured refresh intervals
4. batches the root `_NET_CURRENT_DESKTOP` request and every window's `_NET_WM_DESKTOP` request before collecting replies
5. keeps only windows on the current desktop plus EWMH sticky windows (`0xFFFFFFFF`)
6. batches all candidate `GetWindowAttributes` requests before collecting replies
7. resets a window's viewable state whenever it is `UNVIEWABLE`
8. refreshes it once only after it has remained `VIEWABLE` for a full refresh interval
9. stops early when all candidates are handled, or stops at a 500 ms deadline

If either desktop property is unavailable, the implementation retains that window as a compatibility fallback. A timeout for a known current-desktop candidate remains a warning; an indeterminate fallback candidate is diagnostic-only at debug level. This avoids warnings and up to roughly 31 unnecessary polls for normal windows left on another workspace.

The callback checks its generation before querying and again before refreshing, so an obsolete timer cannot affect a newer workspace state. Destroyed and failed windows are removed from the candidate set. Unit tests cover continuous viewability, `VIEWABLE → UNVIEWABLE → VIEWABLE`, no-refresh transitions, a 200 ms delayed remap, current/sticky/other/unknown desktop selection, and generation invalidation.

## Headless regression test

The check uses `pkgs.testers.nixosTest`, following the existing `a11y-test` structure, instead of an ad-hoc host `Xvfb` wrapper. Nix fixes Xorg, i3, a 1280x800 display, ImageMagick, X11 inspection tools, Mesa Lavapipe, the Vulkan loader, and the Rust/Cargo toolchain from the existing flake lock and `rust-toolchain.toml`. LightDM auto-logs into a dedicated i3 user with focus-follows-mouse and workspace auto-back-and-forth disabled. No external compositor is configured.

A small opaque GPUI fixture is used instead of full Zed because the defect is in `gpui_linux`, while session restore, sockets, trust prompts, settings, and project state would make full-Zed screenshots nondeterministic. The fixture uses `gpui_platform::application`, so it reaches the same `gpui_linux` X11 and wgpu presentation path as production. It renders five fixed opaque color regions with visible background gaps: no text, transparency, animation, clock, or cursor.

`script/test-i3-workspace-redraw` remains reusable in a real i3/X11 session. It identifies windows by PID, exact unique `_NET_WM_NAME`, and the i3 tree window ID. The fixture now creates the target and alternate window in one process. The script leaves the target on workspace A and moves the same-process alternate to workspace B, which directly covers multiple GPUI windows on different workspaces. The captured xprop data confirms the same `_NET_WM_PID` with `_NET_WM_DESKTOP` values 0 and 1.

For each variant the script captures a reference, switches to the visibly different B window, returns to A while focusing a helper rather than the target, and crops only the target client region. It also fails if the candidate fixture emits a workspace-redraw timeout warning.

The screenshot oracle verifies more than self-similarity:

- exact target dimensions, with a minimum useful size
- all five expected colors occupying at least 5% of the image each
- representative background, left, upper-center, lower-center, and right pixels
- `return RMSE <= threshold`
- `control RMSE <= threshold`
- the expected palette in both reference and every focus-control image

Cleanup kills all fixture containers/processes and restores the original workspace and focus. The NixOS test separately verifies that no fixture process remains. i3 shared-memory logging is diagnostic-only and best-effort.

Run it with:

```sh
nix build .#checks.x86_64-linux.i3-workspace-redraw -L
```

For interactive VM debugging:

```sh
nix run .#checks.x86_64-linux.i3-workspace-redraw.driverInteractive
```

The successful Nix result contains `gpui-i3-artifacts/` with the reference image, every return and focus-control image, palette histograms, `results.tsv`, `oracle.tsv`, fixture logs and xprop data, `i3.log`, `Xorg.0.log`, the system journal, `vulkaninfo.txt`, and package versions.

## Regression sensitivity and threshold

I ran the current test-only changes in two source trees: this PR and its parent `c97b7c0ea4` without the production redraw fix. No fault injection or test-only production behavior was used.

| build | return RMSE, iterations 1-5 | focus-control RMSE, iterations 1-5 | absolute oracle | result at 0.01 |
| --- | --- | --- | --- | --- |
| patched | `0, 0, 0, 0, 0` | `0, 0, 0, 0, 0` | reference + 5 controls pass | 5/5 pass |
| unpatched | `0, 0.493583, 0.493583, 0.493583, 0.493583` | `0, 0, 0, 0, 0` | reference + 5 controls pass | check fails (4/5 stale) |

The normalized RMSE threshold is `0.01`. The observed patched maximum is `0`; every stale unpatched image measured `0.493583`, about 49x the threshold. One unpatched iteration happened to redraw normally, but the check fails if any iteration exceeds the threshold. The focus controls returning to exact equality show that focus repairs each stale frame, while the absolute oracle proves that neither reference nor controls are a stable but incorrect image.

The final patched run also recorded no workspace-redraw timeout warning with the same process owning windows on both workspaces.

The VM recorded i3 4.24, X.Org 1.21.1.21, ImageMagick 7.1.2-12, and Mesa 25.3.4. `VK_DRIVER_FILES` points explicitly at Lavapipe, `LIBGL_ALWAYS_SOFTWARE=1`, `WGPU_BACKEND=vulkan`, `XDG_SESSION_TYPE=x11`, and `WAYLAND_DISPLAY` is empty. The check requires the fixture log to match `Selected GPU.*llvmpipe.*Vulkan`, and `vulkaninfo.txt` independently records the llvmpipe adapter and Mesa driver.

The VM is the primary reproducible automated regression guard for the no-compositor Xorg/i3 path. It does not cover hardware Vulkan drivers, host-specific GPU behavior, or compositor effects such as picom blur. The existing real Arch Linux/i3 measurements remain the primary confirmation for those external GPU/compositor variants. One diagnostic nuance is that GPUI's current compositor heuristic also considers `_NET_SUPPORTING_WM_CHECK`, so its log reports a compositor as present under i3 even though this VM starts no compositor process; the fixture is opaque and borderless, so that heuristic does not affect the compared pixels.

## CI

The generated `nix_build` workflow has a Linux-only `i3_workspace_redraw` job. It runs only when maintainers opt the PR into `run-nix`; `run-bundling` does not trigger the VM. The job is not allowed to fail and uploads `result/gpui-i3-artifacts` for 14 days. The final local KVM test script took 51.55 seconds after derivations were built; total job time depends mainly on the Nix/Crane cache. This avoids making a graphical VM a new required check for every community PR while preventing the test from silently rotting.

## Validation

- Reproduced with Zed stable on Arch Linux/i3/X11: 5/5 workspace returns showed stale contents both with picom enabled and disabled; focusing the window repaired every return.
- Built a patched GPUI X11 application and repeated the same screenshot-based workspace-switch test. With picom disabled, all 5/5 unfocused returns matched the reference exactly (RMSE 0). With picom enabled, all 5/5 returned with correct application contents; only the sample window's transparent-background blur differed.
- `nix build .#checks.x86_64-linux.i3-workspace-redraw -L` (current patched source: 5/5 pass, all RMSE 0, reference and controls pass the absolute oracle, no timeout warning)
- the same check on parent `c97b7c0ea4` plus the current test-only changes (unpatched: check fails; 4/5 stale at RMSE 0.493583, focus controls 5/5 recover at RMSE 0)
- `nix flake show --no-write-lock-file`
- `nix fmt -- <changed files> --ci` (treefmt 2.4 syntax)
- `bash -n script/test-i3-workspace-redraw`
- `shellcheck script/test-i3-workspace-redraw`
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check --locked -p gpui --example x11_workspace_redraw`
- `cargo +1.95.0 test --locked -p gpui_linux --no-default-features --features x11 --lib` (26 passed)
- `./script/clippy --locked -p gpui_linux`
- `cargo +1.95.0 xtask workflows`

`nix flake check --no-build` was also attempted in the isolated local container, but repo-wide evaluation stopped in the pre-existing `a11y-test` because its `gpui-a11y-source` store path was not registered. The new check itself evaluated in `flake show` and completed full patched and unpatched NixOS VM runs.

Release Notes:

- Fixed stale window contents after switching X11 workspaces in tiling window managers such as i3.
