### PR TITLE
csv_preview: #9 Allow copying cell and column header content

### DIFF
--- a/crates/csv_preview/src/renderer/table_cell.rs
+++ b/crates/csv_preview/src/renderer/table_cell.rs
@@ -1,7 +1,7 @@
 //! Table Cell Rendering
 
-use gpui::{AnyElement, ElementId};
-use ui::{SharedString, Tooltip, div, prelude::*};
+use gpui::{AnyElement, ClipboardItem, ElementId, MouseButton};
+use ui::{Color, Divider, Label, LabelSize, SharedString, Tooltip, div, prelude::*};
 
 use crate::{CsvPreviewView, settings::VerticalAlignment, types::DisplayCellId};
 
@@ -40,12 +40,25 @@ fn create_table_cell(
             VerticalAlignment::Center => div.items_center(),
         })
         .font_buffer(cx)
+        .on_mouse_down(MouseButton::Right, {
+            let text = cell_content.clone();
+            move |_event, _window, cx| {
+                cx.stop_propagation();
+                cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
+            }
+        })
         .tooltip(Tooltip::element({
             let text = cell_content.clone();
             move |_window, cx| {
-                div()
-                    .font_buffer(cx)
-                    .child(text.clone())
+                v_flex()
+                    .gap_1()
+                    .child(div().font_buffer(cx).child(text.clone()))
+                    .child(Divider::horizontal())
+                    .child(
+                        Label::new("Right click to copy content")
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    )
                     .into_any_element()
             }
         }))

--- a/crates/csv_preview/src/renderer/table_cell.rs
+++ b/crates/csv_preview/src/renderer/table_cell.rs
@@ -31,7 +31,6 @@ fn create_table_cell(
             format!("csv-display-cell-{}", *display_cell_id.row).into(),
             *display_cell_id.col as u64,
         ))
-        .cursor_pointer()
         .flex()
         .h_full()
         .px_1()
@@ -41,6 +40,14 @@ fn create_table_cell(
             VerticalAlignment::Center => div.items_center(),
         })
         .font_buffer(cx)
-        .tooltip(Tooltip::text(cell_content.clone()))
+        .tooltip(Tooltip::element({
+            let text = cell_content.clone();
+            move |_window, cx| {
+                div()
+                    .font_buffer(cx)
+                    .child(text.clone())
+                    .into_any_element()
+            }
+        }))
         .child(div().child(cell_content))
 }

--- a/crates/csv_preview/src/renderer/table_cell.rs
+++ b/crates/csv_preview/src/renderer/table_cell.rs
@@ -1,9 +1,34 @@
 //! Table Cell Rendering
 
-use gpui::{AnyElement, ClipboardItem, ElementId, MouseButton};
+use gpui::{AnyElement, ClipboardItem, ElementId, MouseButton, StatefulInteractiveElement};
 use ui::{Color, Divider, Label, LabelSize, SharedString, Tooltip, div, prelude::*};
 
 use crate::{CsvPreviewView, settings::VerticalAlignment, types::DisplayCellId};
+
+/// Adds a right-click-to-copy handler and a tooltip showing `text` plus `hint`
+/// (e.g. "Right click to copy content") to a `Stateful` element.
+pub(crate) fn with_copy_on_right_click<E: StatefulInteractiveElement>(
+    element: E,
+    text: SharedString,
+    hint: &'static str,
+) -> E {
+    element
+        .on_mouse_down(MouseButton::Right, {
+            let text_to_copy = text.clone();
+            move |_event, _window, cx| {
+                cx.stop_propagation();
+                cx.write_to_clipboard(ClipboardItem::new_string(text_to_copy.to_string()));
+            }
+        })
+        .tooltip(Tooltip::element(move |_window, cx| {
+            v_flex()
+                .gap_1()
+                .child(div().font_buffer(cx).child(text.clone()))
+                .child(Divider::horizontal())
+                .child(Label::new(hint).size(LabelSize::Small).color(Color::Muted))
+                .into_any_element()
+        }))
+}
 
 impl CsvPreviewView {
     /// Create selectable table cell with mouse event handlers.
@@ -26,7 +51,7 @@ fn create_table_cell(
     vertical_alignment: VerticalAlignment,
     cx: &Context<'_, CsvPreviewView>,
 ) -> gpui::Stateful<Div> {
-    div()
+    let cell = div()
         .id(ElementId::NamedInteger(
             format!("csv-display-cell-{}", *display_cell_id.row).into(),
             *display_cell_id.col as u64,
@@ -39,28 +64,7 @@ fn create_table_cell(
             VerticalAlignment::Top => div.items_start(),
             VerticalAlignment::Center => div.items_center(),
         })
-        .font_buffer(cx)
-        .on_mouse_down(MouseButton::Right, {
-            let text = cell_content.clone();
-            move |_event, _window, cx| {
-                cx.stop_propagation();
-                cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
-            }
-        })
-        .tooltip(Tooltip::element({
-            let text = cell_content.clone();
-            move |_window, cx| {
-                v_flex()
-                    .gap_1()
-                    .child(div().font_buffer(cx).child(text.clone()))
-                    .child(Divider::horizontal())
-                    .child(
-                        Label::new("Right click to copy content")
-                            .size(LabelSize::Small)
-                            .color(Color::Muted),
-                    )
-                    .into_any_element()
-            }
-        }))
+        .font_buffer(cx);
+    with_copy_on_right_click(cell, cell_content.clone(), "Right click to copy content")
         .child(div().child(cell_content))
 }

--- a/crates/csv_preview/src/renderer/table_header.rs
+++ b/crates/csv_preview/src/renderer/table_header.rs
@@ -12,12 +12,13 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate};
 use ui::{
-    Color, Divider, GradientFade, HighlightedLabel, Icon, IconButton, IconName, IconSize, Label,
-    LabelSize, ListItem, ListItemSpacing, PopoverMenu, Tooltip, prelude::*,
+    Color, GradientFade, HighlightedLabel, Icon, IconButton, IconName, IconSize, Label, LabelSize,
+    ListItem, ListItemSpacing, PopoverMenu, Tooltip, prelude::*,
 };
 
 use crate::{
     CsvPreviewView,
+    renderer::table_cell::with_copy_on_right_click,
     settings::FilterSortOrder,
     table_data_engine::{
         filtering_by_column::{FilterEntry, FilterEntryState},
@@ -546,8 +547,8 @@ impl CsvPreviewView {
             .items_center()
             .font_buffer(cx)
             .text_buffer(cx)
-            .child(
-                div()
+            .child({
+                let header_text_cell = div()
                     .id(ElementId::NamedInteger(
                         "csv-col-header-text".into(),
                         col_idx.get() as u64,
@@ -555,31 +556,14 @@ impl CsvPreviewView {
                     .flex_1()
                     .min_w_0()
                     .overflow_hidden()
-                    .whitespace_nowrap()
-                    .on_mouse_down(MouseButton::Right, {
-                        let text = header_text.clone();
-                        move |_event, _window, cx| {
-                            cx.stop_propagation();
-                            cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
-                        }
-                    })
-                    .tooltip(Tooltip::element({
-                        let text = header_text.clone();
-                        move |_window, cx| {
-                            v_flex()
-                                .gap_1()
-                                .child(div().font_buffer(cx).child(text.clone()))
-                                .child(Divider::horizontal())
-                                .child(
-                                    Label::new("Right click to copy column name")
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted),
-                                )
-                                .into_any_element()
-                        }
-                    }))
-                    .child(header_text),
-            )
+                    .whitespace_nowrap();
+                with_copy_on_right_click(
+                    header_text_cell,
+                    header_text.clone(),
+                    "Right click to copy column name",
+                )
+                .child(header_text)
+            })
             .child(
                 GradientFade::new(base_bg, base_bg, base_bg)
                     .width(grad_width)

--- a/crates/csv_preview/src/renderer/table_header.rs
+++ b/crates/csv_preview/src/renderer/table_header.rs
@@ -12,8 +12,8 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate};
 use ui::{
-    Color, GradientFade, HighlightedLabel, Icon, IconButton, IconName, IconSize, Label, LabelSize,
-    ListItem, ListItemSpacing, PopoverMenu, Tooltip, prelude::*,
+    Color, Divider, GradientFade, HighlightedLabel, Icon, IconButton, IconName, IconSize, Label,
+    LabelSize, ListItem, ListItemSpacing, PopoverMenu, Tooltip, prelude::*,
 };
 
 use crate::{
@@ -548,10 +548,36 @@ impl CsvPreviewView {
             .text_buffer(cx)
             .child(
                 div()
+                    .id(ElementId::NamedInteger(
+                        "csv-col-header-text".into(),
+                        col_idx.get() as u64,
+                    ))
                     .flex_1()
                     .min_w_0()
                     .overflow_hidden()
                     .whitespace_nowrap()
+                    .on_mouse_down(MouseButton::Right, {
+                        let text = header_text.clone();
+                        move |_event, _window, cx| {
+                            cx.stop_propagation();
+                            cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
+                        }
+                    })
+                    .tooltip(Tooltip::element({
+                        let text = header_text.clone();
+                        move |_window, cx| {
+                            v_flex()
+                                .gap_1()
+                                .child(div().font_buffer(cx).child(text.clone()))
+                                .child(Divider::horizontal())
+                                .child(
+                                    Label::new("Right click to copy column name")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .into_any_element()
+                        }
+                    }))
                     .child(header_text),
             )
             .child(


### PR DESCRIPTION
# Objective

- There was no way to copy a cell's or a column header's text out of the CSV preview table (at all).

## Solution

- Right-clicking a table cell now copies its full content to the clipboard; the cell tooltip shows the content plus a "Right click to copy content" hint.
- Right-clicking a column header name copies the column name to the clipboard, with the same tooltip pattern ("Right click to copy column name").

## Testing

- Right-click a cell: content is copied, tooltip shows the hint.
- Right-click a column header: column name is copied, tooltip shows the hint.

## Demo

<img width="994" height="241" alt="image" src="https://github.com/user-attachments/assets/827a0356-e152-4bfd-84ea-5745e638f13c" />


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added copy-to-clipboard on right-click for CSV preview cells and column headers
