### PR TITLE
markdown_preview: Add setting to open the preview by defaultAlways open preview markdown

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -125,6 +125,9 @@
     // The maximum width, in pixels, of the rendered markdown content when
     // limit_content_width is enabled.
     "max_width": 800,
+    // Whether opening a markdown file opens a markdown preview tab instead
+    // of a text editor.
+    "open_preview_on_file_open": false,
   },
   // Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
   //

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10175,6 +10175,14 @@ impl Editor {
                                 Some(editor)
                             })
                             .flatten()
+                            .or_else(|| {
+                                // An alternate opener (e.g. markdown preview) may claim
+                                // this buffer; its item exposes the backing editor via
+                                // `act_as`, so selection handling below still applies.
+                                workspace
+                                    .open_alternate_item_for_buffer(&pane, &buffer, window, cx)
+                                    .and_then(|item| item.act_as::<Editor>(cx))
+                            })
                             .unwrap_or_else(|| {
                                 let keep_old_preview = PreviewTabsSettings::get_global(cx)
                                     .enable_keep_preview_on_code_navigation;

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -6,7 +6,9 @@ pub mod markdown_preview_view;
 
 pub use zed_actions::preview::markdown::{OpenPreview, OpenPreviewToTheSide};
 
+use crate::markdown_preview_settings::MarkdownPreviewSettings;
 use crate::markdown_preview_view::MarkdownPreviewView;
+use settings::Settings as _;
 
 actions!(
     markdown,
@@ -32,12 +34,30 @@ actions!(
         /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview,
         /// Closes the markdown preview and returns focus to the source editor.
-        CloseAndReturnToEditor
+        CloseAndReturnToEditor,
+        /// Opens the source file of the markdown preview in a text editor.
+        OpenSource
     ]
 );
 
 pub fn init(cx: &mut App) {
     workspace::register_serializable_item::<MarkdownPreviewView>(cx);
+    workspace::register_project_item::<MarkdownPreviewView>(cx);
+    workspace::register_alternate_buffer_item_opener(cx, |workspace, pane, buffer, window, cx| {
+        if !MarkdownPreviewSettings::get_global(cx).open_preview_on_file_open {
+            return None;
+        }
+
+        if buffer.read(cx).language()?.name().as_ref() != "Markdown" {
+            return None;
+        }
+
+        let preview = MarkdownPreviewView::open_preview_for_buffer_in_pane(
+            workspace, pane, buffer, window, cx,
+        )?;
+
+        Some(Box::new(preview))
+    });
 
     cx.observe_new(|workspace: &mut Workspace, window, cx| {
         let Some(window) = window else {

--- a/crates/markdown_preview/src/markdown_preview_settings.rs
+++ b/crates/markdown_preview/src/markdown_preview_settings.rs
@@ -7,6 +7,9 @@ pub struct MarkdownPreviewSettings {
     /// The maximum width of the rendered markdown content, or `None` to render
     /// content edge to edge.
     pub max_width: Option<Pixels>,
+    /// Whether opening a markdown file opens a markdown preview tab instead
+    /// of a text editor.
+    pub open_preview_on_file_open: bool,
 }
 
 impl Settings for MarkdownPreviewSettings {
@@ -17,6 +20,9 @@ impl Settings for MarkdownPreviewSettings {
         } else {
             None
         };
-        Self { max_width }
+        Self {
+            max_width,
+            open_preview_on_file_open: content.open_preview_on_file_open.unwrap_or(false),
+        }
     }
 }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -1489,19 +1489,17 @@ fn open_markdown_link_in_preview(
                 Editor::for_buffer(buffer, Some(workspace.project().clone()), window, cx)
             });
             let preview = MarkdownPreviewView::create_markdown_view(workspace, editor, window, cx);
-            // With open_preview_on_file_open enabled, previews are the user's
-            // markdown tabs: this link-opened preview is the file's only tab,
-            // so it takes over the editor tab's responsibilities (entry claim,
-            // dirty state). With the setting off, keep the pre-existing
-            // behavior where opening the path still opens a text editor.
+
             if MarkdownPreviewSettings::get_global(cx).open_preview_on_file_open {
                 preview.update(cx, |preview, _| preview.replaces_editor = true);
             }
+
             let pane = source_view
                 .as_ref()
                 .and_then(|view| view.upgrade())
                 .and_then(|view| workspace.pane_for(&view))
                 .unwrap_or_else(|| workspace.active_pane().clone());
+
             pane.update(cx, |pane, cx| {
                 pane.add_item(Box::new(preview.clone()), true, true, None, window, cx);
             });

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -10,17 +10,18 @@ use anyhow::{Context as _, Result};
 use editor::scroll::Autoscroll;
 use editor::{Editor, EditorEvent, MultiBufferOffset, SelectionEffects};
 use gpui::{
-    App, ClipboardItem, Context, Entity, EventEmitter, FocusHandle, Focusable, ImageSource,
-    InteractiveElement, IntoElement, IsZero, Pixels, Render, Resource, RetainAllImageCache,
-    ScrollHandle, SharedString, SharedUri, Subscription, Task, WeakEntity, Window, point, px,
+    App, ClipboardItem, Context, Entity, EntityId, EventEmitter, FocusHandle, Focusable,
+    ImageSource, InteractiveElement, IntoElement, IsZero, Pixels, Render, Resource,
+    RetainAllImageCache, ScrollHandle, SharedString, SharedUri, Subscription, Task, WeakEntity,
+    Window, point, px,
 };
-use language::{LanguageRegistry, Point};
+use language::{Buffer, LanguageRegistry, Point};
 use markdown::{
     CodeBlockRenderer, CopyButtonVisibility, Markdown, MarkdownElement, MarkdownFont,
     MarkdownOptions, MarkdownStyle,
 };
 use project::search::SearchQuery;
-use project::{Project, ProjectPath};
+use project::{Project, ProjectEntryId, ProjectPath};
 use settings::{SeedQuerySetting, Settings, update_settings_file};
 use theme::{SystemAppearance, Theme, ThemeRegistry};
 use theme_settings::ThemeSettings;
@@ -40,8 +41,8 @@ use zed_actions::{DecreaseBufferFontSize, IncreaseBufferFontSize, ResetBufferFon
 
 use crate::markdown_preview_settings::MarkdownPreviewSettings;
 use crate::{
-    CloseAndReturnToEditor, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollDown,
-    ScrollDownByItem,
+    CloseAndReturnToEditor, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, OpenSource,
+    ScrollDown, ScrollDownByItem,
 };
 use crate::{ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ScrollUp, ScrollUpByItem};
 
@@ -275,6 +276,26 @@ impl MarkdownPreviewView {
         cx: &mut App,
     ) -> Entity<Self> {
         cx.new(|cx| {
+            Self::build(
+                mode,
+                active_editor,
+                workspace,
+                language_registry,
+                window,
+                cx,
+            )
+        })
+    }
+
+    fn build(
+        mode: MarkdownPreviewMode,
+        active_editor: Entity<Editor>,
+        workspace: WeakEntity<Workspace>,
+        language_registry: Arc<LanguageRegistry>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        {
             let markdown = cx.new(|cx| {
                 Markdown::new_with_options(
                     SharedString::default(),
@@ -342,7 +363,7 @@ impl MarkdownPreviewView {
             }
 
             this
-        })
+        }
     }
 
     fn workspace_updated(
@@ -397,6 +418,48 @@ impl MarkdownPreviewView {
         .detach();
     }
 
+    /// Opens (or activates) a preview tab for the given singleton buffer in the
+    /// given pane. Used when jumping to markdown files from multibuffer excerpts
+    /// while `open_preview_on_file_open` is enabled.
+    pub fn open_preview_for_buffer_in_pane(
+        workspace: &mut Workspace,
+        pane: &Entity<Pane>,
+        buffer: &Entity<Buffer>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Option<Entity<Self>> {
+        let existing = pane.read(cx).items().enumerate().find_map(|(index, item)| {
+            let view = item.downcast::<MarkdownPreviewView>()?;
+            let view_read = view.read(cx);
+
+            (view_read.mode == MarkdownPreviewMode::Default
+                && view_read
+                    .active_editor
+                    .as_ref()
+                    .and_then(|state| state.editor.read(cx).buffer().read(cx).as_singleton())
+                    .as_ref()
+                    == Some(buffer))
+            .then_some((index, view))
+        });
+
+        if let Some((index, view)) = existing {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(index, true, true, window, cx);
+            });
+            return Some(view);
+        }
+
+        let project = workspace.project().clone();
+        let editor = cx.new(|cx| Editor::for_buffer(buffer.clone(), Some(project), window, cx));
+        let preview = Self::create_markdown_view(workspace, editor, window, cx);
+
+        pane.update(cx, |pane, cx| {
+            pane.add_item(Box::new(preview.clone()), true, true, None, window, cx);
+        });
+
+        Some(preview)
+    }
+
     pub fn is_markdown_file(editor: &Entity<Editor>, cx: &App) -> bool {
         let buffer = editor.read(cx).buffer().read(cx);
         if let Some(buffer) = buffer.as_singleton()
@@ -440,11 +503,12 @@ impl MarkdownPreviewView {
                                 (index, focused)
                             });
                         if let Some(selection_start) = selection_start {
-                            this.sync_preview_to_source_index(
-                                selection_start,
-                                editor_is_focused,
-                                cx,
-                            );
+                            // Also reveal when the preview itself is focused: the backing
+                            // editor may be hidden (preview-only tabs), in which case
+                            // selection changes come from programmatic navigation like
+                            // jumping to a multibuffer excerpt.
+                            let reveal = editor_is_focused || this.focus_handle.is_focused(window);
+                            this.sync_preview_to_source_index(selection_start, reveal, cx);
                             cx.notify();
                         }
                     }
@@ -835,6 +899,29 @@ impl MarkdownPreviewView {
         cx.notify();
     }
 
+    fn open_source(&mut self, _: &OpenSource, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(editor) = self
+            .active_editor
+            .as_ref()
+            .map(|state| state.editor.clone())
+        else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+
+        // Defer for the same reason as `close_and_return_to_editor`: we're a pane
+        // item ourselves, and manipulating the pane reentrantly would panic.
+        window.defer(cx, move |window, cx| {
+            workspace.update(cx, |workspace, cx| {
+                if !workspace.activate_item(&editor, true, true, window, cx) {
+                    workspace.add_item_to_active_pane(Box::new(editor), None, true, window, cx);
+                }
+            });
+        });
+    }
+
     fn close_and_return_to_editor(
         &mut self,
         _: &CloseAndReturnToEditor,
@@ -1028,6 +1115,82 @@ impl MarkdownPreviewView {
                 this.update_markdown_from_active_editor(false, false, window, cx);
             });
         }
+    }
+}
+
+/// A thin project-item wrapper around a markdown buffer. Registering
+/// `MarkdownPreviewView` with its own item type (instead of `Buffer`) keeps it
+/// from clobbering the `Buffer` -> `Editor` mapping in the project item
+/// registry, while still letting the preview claim markdown paths when
+/// `open_preview_on_file_open` is enabled.
+pub struct MarkdownPreviewBuffer(pub Entity<Buffer>);
+
+impl project::ProjectItem for MarkdownPreviewBuffer {
+    fn try_open(
+        project: &Entity<Project>,
+        path: &ProjectPath,
+        cx: &mut App,
+    ) -> Option<Task<Result<Entity<Self>>>> {
+        if !MarkdownPreviewSettings::get_global(cx).open_preview_on_file_open {
+            return None;
+        }
+        let languages = project.read(cx).languages().clone();
+        let markdown = languages.available_language_for_name("Markdown")?;
+        if languages.language_for_file_path(path.path.as_std_path()) != Some(markdown.id()) {
+            return None;
+        }
+        let open_buffer = project.update(cx, |project, cx| project.open_buffer(path.clone(), cx));
+        Some(cx.spawn(async move |cx| {
+            let buffer = open_buffer.await?;
+            Ok(cx.new(|_| Self(buffer)))
+        }))
+    }
+
+    fn entry_id(&self, cx: &App) -> Option<ProjectEntryId> {
+        project::ProjectItem::entry_id(self.0.read(cx), cx)
+    }
+
+    fn project_path(&self, cx: &App) -> Option<ProjectPath> {
+        project::ProjectItem::project_path(self.0.read(cx), cx)
+    }
+
+    fn is_dirty(&self) -> bool {
+        // Can't read the buffer entity without a context; this wrapper only
+        // exists transiently while the registry builds the preview view.
+        false
+    }
+}
+
+impl workspace::item::ProjectItem for MarkdownPreviewView {
+    type Item = MarkdownPreviewBuffer;
+
+    fn for_project_item(
+        project: Entity<Project>,
+        pane: Option<&Pane>,
+        item: Entity<MarkdownPreviewBuffer>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let buffer = item.read(cx).0.clone();
+        let workspace = pane
+            .map(|pane| pane.workspace().clone())
+            .or_else(|| {
+                window
+                    .root::<Workspace>()
+                    .flatten()
+                    .map(|workspace| workspace.downgrade())
+            })
+            .unwrap_or_else(WeakEntity::new_invalid);
+        let language_registry = project.read(cx).languages().clone();
+        let editor = cx.new(|cx| Editor::for_buffer(buffer, Some(project), window, cx));
+        Self::build(
+            MarkdownPreviewMode::Default,
+            editor,
+            workspace,
+            language_registry,
+            window,
+            cx,
+        )
     }
 }
 
@@ -1372,6 +1535,22 @@ impl Item for MarkdownPreviewView {
         ItemBufferKind::Singleton
     }
 
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
+    ) {
+        if let Some(state) = &self.active_editor {
+            state.editor.read(cx).for_each_project_item(cx, f);
+        }
+    }
+
+    fn is_dirty(&self, cx: &App) -> bool {
+        self.active_editor
+            .as_ref()
+            .is_some_and(|state| state.editor.read(cx).is_dirty(cx))
+    }
+
     fn as_searchable(
         &self,
         handle: &Entity<Self>,
@@ -1390,7 +1569,8 @@ impl Render for MarkdownPreviewView {
             .unwrap_or_else(|| cx.theme().colors().editor_background);
         let preview_font_size = ThemeSettings::get_global(cx).markdown_preview_font_size(cx);
         let hovered_url = self.hovered_url.clone();
-        div()
+
+        v_flex()
             .image_cache(self.image_cache.clone())
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")
@@ -1409,6 +1589,7 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_to_top))
             .on_action(cx.listener(MarkdownPreviewView::scroll_to_bottom))
             .on_action(cx.listener(MarkdownPreviewView::close_and_return_to_editor))
+            .on_action(cx.listener(MarkdownPreviewView::open_source))
             .on_action(cx.listener(MarkdownPreviewView::increase_font_size))
             .on_action(cx.listener(MarkdownPreviewView::decrease_font_size))
             .on_action(cx.listener(MarkdownPreviewView::reset_font_size))
@@ -1418,81 +1599,117 @@ impl Render for MarkdownPreviewView {
             .relative()
             .bg(bg_color)
             .child(
-                WithRemSize::new(preview_font_size).size_full().child(
-                    div()
-                        .id("markdown-preview-scroll-container")
-                        .size_full()
-                        .overflow_y_scroll()
-                        .track_scroll(&self.scroll_handle)
-                        .p_4()
-                        .child({
-                            let markdown_element =
-                                self.render_markdown_element(&preview_theme, window, cx);
-                            let markdown = self.markdown.clone();
-                            let max_width = MarkdownPreviewSettings::get_global(cx).max_width;
-                            let content = right_click_menu("markdown-preview-context-menu")
-                                .trigger(move |_, _, _| markdown_element)
-                                .maybe_menu(move |window, cx| {
-                                    let focus = window.focused(cx);
-                                    let markdown = markdown.read(cx);
-                                    let context_menu_link = markdown.context_menu_link().cloned();
-                                    let selected_text =
-                                        markdown.context_menu_selected_text().cloned();
-                                    let selected_markdown =
-                                        markdown.context_menu_selected_markdown().cloned();
-                                    if context_menu_link.is_none()
-                                        && selected_text.is_none()
-                                        && selected_markdown.is_none()
-                                    {
-                                        return None;
-                                    }
-                                    Some(ContextMenu::build(window, cx, move |menu, _, _cx| {
-                                        menu.when_some(focus, |menu, focus| menu.context(focus))
-                                            .when_some(selected_text, |menu, text| {
-                                                menu.entry(
-                                                    "Copy",
-                                                    Some(Box::new(markdown::Copy)),
-                                                    move |_, cx| {
-                                                        cx.write_to_clipboard(
-                                                            ClipboardItem::new_string(
-                                                                text.to_string(),
-                                                            ),
-                                                        );
-                                                    },
-                                                )
-                                            })
-                                            .when_some(selected_markdown, |menu, text| {
-                                                menu.entry(
-                                                    "Copy as Markdown",
-                                                    Some(Box::new(markdown::CopyAsMarkdown)),
-                                                    move |_, cx| {
-                                                        cx.write_to_clipboard(
-                                                            ClipboardItem::new_string(
-                                                                text.to_string(),
-                                                            ),
-                                                        );
-                                                    },
-                                                )
-                                            })
-                                            .when_some(context_menu_link, |menu, url| {
-                                                menu.entry("Copy Link", None, move |_, cx| {
-                                                    cx.write_to_clipboard(
-                                                        ClipboardItem::new_string(url.to_string()),
-                                                    );
-                                                })
-                                            })
-                                    }))
-                                });
-                            div()
-                                .w_full()
-                                .when_some(max_width, |this, max_width| {
-                                    this.max_w(max_width).mx_auto()
-                                })
-                                .child(content)
-                        }),
+                h_flex().px_2().pt_2().child(
+                    Button::new("open-markdown-source", "Markdown")
+                        .label_size(LabelSize::Small)
+                        .start_icon(
+                            Icon::new(IconName::File)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.open_source(&OpenSource, window, cx);
+                        })),
                 ),
             )
-            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
+            .child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .relative()
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx)
+                    .child(
+                        WithRemSize::new(preview_font_size).size_full().child(
+                            div()
+                                .id("markdown-preview-scroll-container")
+                                .size_full()
+                                .overflow_y_scroll()
+                                .track_scroll(&self.scroll_handle)
+                                .p_4()
+                                .child({
+                                    let markdown_element =
+                                        self.render_markdown_element(&preview_theme, window, cx);
+                                    let markdown = self.markdown.clone();
+                                    let max_width =
+                                        MarkdownPreviewSettings::get_global(cx).max_width;
+                                    let content = right_click_menu("markdown-preview-context-menu")
+                                        .trigger(move |_, _, _| markdown_element)
+                                        .maybe_menu(move |window, cx| {
+                                            let focus = window.focused(cx);
+                                            let markdown = markdown.read(cx);
+                                            let context_menu_link =
+                                                markdown.context_menu_link().cloned();
+                                            let selected_text =
+                                                markdown.context_menu_selected_text().cloned();
+                                            let selected_markdown =
+                                                markdown.context_menu_selected_markdown().cloned();
+                                            if context_menu_link.is_none()
+                                                && selected_text.is_none()
+                                                && selected_markdown.is_none()
+                                            {
+                                                return None;
+                                            }
+                                            Some(ContextMenu::build(
+                                                window,
+                                                cx,
+                                                move |menu, _, _cx| {
+                                                    menu.when_some(focus, |menu, focus| {
+                                                        menu.context(focus)
+                                                    })
+                                                    .when_some(selected_text, |menu, text| {
+                                                        menu.entry(
+                                                            "Copy",
+                                                            Some(Box::new(markdown::Copy)),
+                                                            move |_, cx| {
+                                                                cx.write_to_clipboard(
+                                                                    ClipboardItem::new_string(
+                                                                        text.to_string(),
+                                                                    ),
+                                                                );
+                                                            },
+                                                        )
+                                                    })
+                                                    .when_some(selected_markdown, |menu, text| {
+                                                        menu.entry(
+                                                            "Copy as Markdown",
+                                                            Some(Box::new(
+                                                                markdown::CopyAsMarkdown,
+                                                            )),
+                                                            move |_, cx| {
+                                                                cx.write_to_clipboard(
+                                                                    ClipboardItem::new_string(
+                                                                        text.to_string(),
+                                                                    ),
+                                                                );
+                                                            },
+                                                        )
+                                                    })
+                                                    .when_some(context_menu_link, |menu, url| {
+                                                        menu.entry(
+                                                            "Copy Link",
+                                                            None,
+                                                            move |_, cx| {
+                                                                cx.write_to_clipboard(
+                                                                    ClipboardItem::new_string(
+                                                                        url.to_string(),
+                                                                    ),
+                                                                );
+                                                            },
+                                                        )
+                                                    })
+                                                },
+                                            ))
+                                        });
+                                    div()
+                                        .w_full()
+                                        .when_some(max_width, |this, max_width| {
+                                            this.max_w(max_width).mx_auto()
+                                        })
+                                        .child(content)
+                                }),
+                        ),
+                    ),
+            )
             .when_some(hovered_url, |this, hovered_url| {
                 this.child(
                     div()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -898,7 +898,12 @@ impl MarkdownPreviewView {
         cx.notify();
     }
 
-    fn open_source(&mut self, _: &OpenSource, window: &mut Window, cx: &mut Context<Self>) {
+    fn open_markdown_file_source(
+        &mut self,
+        _: &OpenSource,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let Some(editor) = self
             .active_editor
             .as_ref()
@@ -1591,7 +1596,7 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_to_top))
             .on_action(cx.listener(MarkdownPreviewView::scroll_to_bottom))
             .on_action(cx.listener(MarkdownPreviewView::close_and_return_to_editor))
-            .on_action(cx.listener(MarkdownPreviewView::open_source))
+            .on_action(cx.listener(MarkdownPreviewView::open_markdown_file_source))
             .on_action(cx.listener(MarkdownPreviewView::increase_font_size))
             .on_action(cx.listener(MarkdownPreviewView::decrease_font_size))
             .on_action(cx.listener(MarkdownPreviewView::reset_font_size))
@@ -1610,7 +1615,7 @@ impl Render for MarkdownPreviewView {
                                 .color(Color::Muted),
                         )
                         .on_click(cx.listener(|this, _, window, cx| {
-                            this.open_source(&OpenSource, window, cx);
+                            this.open_markdown_file_source(&OpenSource, window, cx);
                         })),
                 ),
             )

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -295,75 +295,74 @@ impl MarkdownPreviewView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        {
-            let markdown = cx.new(|cx| {
-                Markdown::new_with_options(
-                    SharedString::default(),
-                    Some(language_registry),
-                    None,
-                    MarkdownOptions {
-                        parse_html: true,
-                        render_mermaid_diagrams: true,
-                        parse_heading_slugs: true,
-                        render_metadata_blocks: true,
-                        ..Default::default()
-                    },
-                    cx,
-                )
-            });
-            let mut this = Self {
-                active_editor: None,
-                focus_handle: cx.focus_handle(),
-                workspace: workspace.clone(),
-                _markdown_subscription: cx.observe(
-                    &markdown,
-                    |this: &mut Self, _: Entity<Markdown>, cx| {
-                        this.sync_active_root_block(cx);
-                    },
-                ),
-                markdown,
-                active_source_index: None,
-                scroll_handle: ScrollHandle::new(),
-                image_cache: RetainAllImageCache::new(cx),
-                base_directory: None,
-                pending_update_task: None,
-                hovered_url: None,
-                mode,
-            };
+        let markdown = cx.new(|cx| {
+            Markdown::new_with_options(
+                SharedString::default(),
+                Some(language_registry),
+                None,
+                MarkdownOptions {
+                    parse_html: true,
+                    render_mermaid_diagrams: true,
+                    parse_heading_slugs: true,
+                    render_metadata_blocks: true,
+                    ..Default::default()
+                },
+                cx,
+            )
+        });
 
-            this.set_editor(active_editor, window, cx);
+        let mut this = Self {
+            active_editor: None,
+            focus_handle: cx.focus_handle(),
+            workspace: workspace.clone(),
+            _markdown_subscription: cx.observe(
+                &markdown,
+                |this: &mut Self, _: Entity<Markdown>, cx| {
+                    this.sync_active_root_block(cx);
+                },
+            ),
+            markdown,
+            active_source_index: None,
+            scroll_handle: ScrollHandle::new(),
+            image_cache: RetainAllImageCache::new(cx),
+            base_directory: None,
+            pending_update_task: None,
+            hovered_url: None,
+            mode,
+        };
 
-            match mode {
-                MarkdownPreviewMode::Follow => {
-                    if let Some(workspace) = &workspace.upgrade() {
-                        cx.observe_in(workspace, window, |this, workspace, window, cx| {
-                            let item = workspace.read(cx).active_item(cx);
-                            this.workspace_updated(item, window, cx);
-                        })
-                        .detach();
-                    } else {
-                        log::error!("Failed to listen to workspace updates");
-                    }
-                }
-                MarkdownPreviewMode::Default => {
-                    // After workspace restoration the bound editor may be an orphan that
-                    // wraps the right buffer but isn't the canonical Editor instance in
-                    // any pane. Re-binding to the workspace's editor for our buffer is
-                    // what restores cursor-driven scroll sync — `SelectionsChanged` only
-                    // fires from the editor the user actually interacts with.
-                    //
-                    // Subscribing to `workspace::Event` (rather than `observe`) keeps the
-                    // rebind check off the cursor-move hot path; `observe` would fire on
-                    // every workspace `cx.notify`.
-                    if let Some(workspace) = &workspace.upgrade() {
-                        cx.subscribe_in(workspace, window, Self::on_workspace_event)
-                            .detach();
-                    }
+        this.set_editor(active_editor, window, cx);
+
+        match mode {
+            MarkdownPreviewMode::Follow => {
+                if let Some(workspace) = &workspace.upgrade() {
+                    cx.observe_in(workspace, window, |this, workspace, window, cx| {
+                        let item = workspace.read(cx).active_item(cx);
+                        this.workspace_updated(item, window, cx);
+                    })
+                    .detach();
+                } else {
+                    log::error!("Failed to listen to workspace updates");
                 }
             }
-
-            this
+            MarkdownPreviewMode::Default => {
+                // After workspace restoration the bound editor may be an orphan that
+                // wraps the right buffer but isn't the canonical Editor instance in
+                // any pane. Re-binding to the workspace's editor for our buffer is
+                // what restores cursor-driven scroll sync — `SelectionsChanged` only
+                // fires from the editor the user actually interacts with.
+                //
+                // Subscribing to `workspace::Event` (rather than `observe`) keeps the
+                // rebind check off the cursor-move hot path; `observe` would fire on
+                // every workspace `cx.notify`.
+                if let Some(workspace) = &workspace.upgrade() {
+                    cx.subscribe_in(workspace, window, Self::on_workspace_event)
+                        .detach();
+                }
+            }
         }
+
+        this
     }
 
     fn workspace_updated(
@@ -1136,7 +1135,10 @@ impl project::ProjectItem for MarkdownPreviewBuffer {
         }
         let languages = project.read(cx).languages().clone();
         let markdown = languages.available_language_for_name("Markdown")?;
-        if languages.language_for_file_path(path.path.as_std_path()) != Some(markdown.id()) {
+        // Match against the absolute path: for single-file worktrees the
+        // worktree-relative path is empty and has no extension to match on.
+        let abs_path = project.read(cx).absolute_path(path, cx)?;
+        if languages.language_for_file_path(&abs_path) != Some(markdown.id()) {
             return None;
         }
         let open_buffer = project.update(cx, |project, cx| project.open_buffer(path.clone(), cx));
@@ -2018,10 +2020,10 @@ mod persistence {
 
 #[cfg(test)]
 mod tests {
-    use crate::CloseAndReturnToEditor;
     use crate::markdown_preview_view::ImageSource;
     use crate::markdown_preview_view::Resource;
     use crate::markdown_preview_view::resolve_preview_image;
+    use crate::{CloseAndReturnToEditor, OpenSource};
     use buffer_diff::BufferDiff;
     use editor::Editor;
     use fs::FakeFs;
@@ -2029,6 +2031,7 @@ mod tests {
     use language::{Buffer, DiskState, Point};
     use project::Project;
     use serde_json::json;
+    use settings::SettingsStore;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
@@ -3019,6 +3022,287 @@ mod tests {
             MarkdownPreviewView::get_folder_for_active_editor(editor, cx)
         });
         assert_eq!(folder, Some(PathBuf::from("/remote/project/docs")));
+    }
+
+    #[gpui::test]
+    async fn open_preview_on_file_open_opens_preview_instead_of_editor(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state.languages.add(markdown_language());
+        set_open_preview_on_file_open(cx, true);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/dir"),
+                json!({
+                    "a.md": "# A\n",
+                    "b.md": "# B\n"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/dir"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let workspace = multi_workspace
+            .update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let worktree_id = workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+        });
+
+        let item = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path((worktree_id, rel_path("a.md")), None, true, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap();
+        assert!(
+            item.downcast::<MarkdownPreviewView>().is_some(),
+            "opening a markdown file with the setting enabled should open a preview"
+        );
+        workspace.read_with(cx, |workspace, cx| {
+            assert_eq!(
+                workspace.active_pane().read(cx).items_len(),
+                1,
+                "no editor tab should open alongside the preview"
+            );
+        });
+
+        // Reopening the same path must activate the existing preview, not
+        // stack a duplicate.
+        multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path((worktree_id, rel_path("a.md")), None, true, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap();
+        workspace.read_with(cx, |workspace, cx| {
+            assert_eq!(workspace.active_pane().read(cx).items_len(), 1);
+        });
+
+        // With the setting disabled, markdown files open as regular editors again.
+        set_open_preview_on_file_open(cx, false);
+        let item = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path((worktree_id, rel_path("b.md")), None, true, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap();
+        assert!(
+            cx.update(|cx| item.act_as::<Editor>(cx)).is_some(),
+            "with the setting disabled, markdown files should open in an editor"
+        );
+    }
+
+    #[gpui::test]
+    async fn open_source_action_opens_editor_tab_alongside_preview(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state.languages.add(markdown_language());
+        set_open_preview_on_file_open(cx, true);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/dir"), json!({ "a.md": "# A\n" }))
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/dir"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let workspace = multi_workspace
+            .update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let worktree_id = workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id()
+        });
+        let preview = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path((worktree_id, rel_path("a.md")), None, true, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap()
+            .downcast::<MarkdownPreviewView>()
+            .expect("markdown file should open as a preview");
+
+        multi_workspace
+            .update(cx, |_, window, cx| {
+                assert!(
+                    preview.read(cx).focus_handle.contains_focused(window, cx),
+                    "preview must be focused for the action to dispatch to it"
+                );
+                window.dispatch_action(Box::new(OpenSource), cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        // Regression test for pane dedup: the editor and the preview share a
+        // project entry, but must coexist as separate tabs.
+        workspace.read_with(cx, |workspace, cx| {
+            assert_eq!(
+                workspace.active_pane().read(cx).items_len(),
+                2,
+                "the source editor should open as a second tab next to the preview"
+            );
+            let editor = workspace
+                .active_item_as::<Editor>(cx)
+                .expect("source editor should be the active item");
+            let source_path = editor
+                .read(cx)
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .map(|buffer| buffer.read(cx).file().unwrap().path().clone());
+            assert_eq!(
+                source_path.as_deref(),
+                Some(rel_path("a.md")),
+                "the editor should show the preview's source file"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn alternate_buffer_opener_claims_only_markdown_buffers(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state.languages.add(markdown_language());
+        set_open_preview_on_file_open(cx, true);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/dir"),
+                json!({
+                    "a.md": "# A\n",
+                    "b.txt": "plain text"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/dir"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let workspace = multi_workspace
+            .update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
+        let markdown_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/a.md"), cx)
+            })
+            .await
+            .unwrap();
+        let text_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/b.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    let pane = workspace.active_pane().clone();
+                    let item = workspace
+                        .open_alternate_item_for_buffer(&pane, &markdown_buffer, window, cx)
+                        .expect("opener should claim markdown buffers");
+                    assert!(item.downcast::<MarkdownPreviewView>().is_some());
+                    assert!(
+                        workspace
+                            .open_alternate_item_for_buffer(&pane, &text_buffer, window, cx)
+                            .is_none(),
+                        "opener should decline non-markdown buffers"
+                    );
+                });
+            })
+            .unwrap();
+    }
+
+    fn markdown_language() -> Arc<language::Language> {
+        Arc::new(language::Language::new(
+            language::LanguageConfig {
+                name: "Markdown".into(),
+                matcher: Arc::new(language::LanguageMatcher {
+                    path_suffixes: vec!["md".to_string()],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            None,
+        ))
+    }
+
+    fn set_open_preview_on_file_open(cx: &mut TestAppContext, enabled: bool) {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .markdown_preview
+                    .get_or_insert_default()
+                    .open_preview_on_file_open = Some(enabled);
+            });
+        });
     }
 
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -456,14 +456,8 @@ impl MarkdownPreviewView {
             let view = item.downcast::<MarkdownPreviewView>()?;
             let view_read = view.read(cx);
 
-            (view_read.mode == MarkdownPreviewMode::Default
-                && view_read
-                    .active_editor
-                    .as_ref()
-                    .and_then(|state| state.editor.read(cx).buffer().read(cx).as_singleton())
-                    .as_ref()
-                    == Some(buffer))
-            .then_some((index, view))
+            (view_read.mode == MarkdownPreviewMode::Default && view_read.is_previewing(buffer, cx))
+                .then_some((index, view))
         });
 
         if let Some((index, view)) = existing {
@@ -1206,11 +1200,10 @@ impl project::ProjectItem for MarkdownPreviewBuffer {
             return None;
         }
         let languages = project.read(cx).languages().clone();
-        let markdown = languages.available_language_for_name("Markdown")?;
         // Match against the absolute path: for single-file worktrees the
         // worktree-relative path is empty and has no extension to match on.
         let abs_path = project.read(cx).absolute_path(path, cx)?;
-        if languages.language_for_file_path(&abs_path) != Some(markdown.id()) {
+        if !MarkdownPreviewView::is_markdown_path(&abs_path, &languages) {
             return None;
         }
         let open_buffer = project.update(cx, |project, cx| project.open_buffer(path.clone(), cx));
@@ -1496,6 +1489,14 @@ fn open_markdown_link_in_preview(
                 Editor::for_buffer(buffer, Some(workspace.project().clone()), window, cx)
             });
             let preview = MarkdownPreviewView::create_markdown_view(workspace, editor, window, cx);
+            // With open_preview_on_file_open enabled, previews are the user's
+            // markdown tabs: this link-opened preview is the file's only tab,
+            // so it takes over the editor tab's responsibilities (entry claim,
+            // dirty state). With the setting off, keep the pre-existing
+            // behavior where opening the path still opens a text editor.
+            if MarkdownPreviewSettings::get_global(cx).open_preview_on_file_open {
+                preview.update(cx, |preview, _| preview.replaces_editor = true);
+            }
             let pane = source_view
                 .as_ref()
                 .and_then(|view| view.upgrade())
@@ -2299,7 +2300,9 @@ mod tests {
         )
         .await;
         let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
-        register_markdown_language(&project, cx);
+        register_markdown_language(
+            &project.read_with(cx, |project, _| project.languages().clone()),
+        );
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
         let workspace =
@@ -2448,7 +2451,9 @@ mod tests {
         )
         .await;
         let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
-        register_markdown_language(&project, cx);
+        register_markdown_language(
+            &project.read_with(cx, |project, _| project.languages().clone()),
+        );
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
         let workspace =
@@ -2678,7 +2683,9 @@ mod tests {
         fs.insert_tree(path!("/project"), json!({ "notes.md": notes }))
             .await;
         let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
-        register_markdown_language(&project, cx);
+        register_markdown_language(
+            &project.read_with(cx, |project, _| project.languages().clone()),
+        );
         let (multi_workspace, cx) =
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
         let workspace =
@@ -3644,7 +3651,7 @@ mod tests {
     #[gpui::test]
     async fn open_preview_on_file_open_opens_preview_instead_of_editor(cx: &mut TestAppContext) {
         let app_state = init_test(cx);
-        app_state.languages.add(markdown_language());
+        register_markdown_language(&app_state.languages);
         set_open_preview_on_file_open(cx, true);
         app_state
             .fs
@@ -3745,7 +3752,7 @@ mod tests {
     #[gpui::test]
     async fn open_source_action_opens_editor_tab_alongside_preview(cx: &mut TestAppContext) {
         let app_state = init_test(cx);
-        app_state.languages.add(markdown_language());
+        register_markdown_language(&app_state.languages);
         set_open_preview_on_file_open(cx, true);
         app_state
             .fs
@@ -3832,7 +3839,7 @@ mod tests {
     #[gpui::test]
     async fn alternate_buffer_opener_claims_only_markdown_buffers(cx: &mut TestAppContext) {
         let app_state = init_test(cx);
-        app_state.languages.add(markdown_language());
+        register_markdown_language(&app_state.languages);
         set_open_preview_on_file_open(cx, true);
         app_state
             .fs
@@ -3967,18 +3974,74 @@ mod tests {
             .unwrap();
     }
 
-    fn markdown_language() -> Arc<language::Language> {
-        Arc::new(language::Language::new(
-            language::LanguageConfig {
-                name: "Markdown".into(),
-                matcher: Arc::new(language::LanguageMatcher {
-                    path_suffixes: vec!["md".to_string()],
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            None,
-        ))
+    #[gpui::test]
+    async fn link_opened_preview_replaces_editor_when_setting_enabled(cx: &mut TestAppContext) {
+        init_test(cx);
+        set_open_preview_on_file_open(cx, true);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({ "notes.md": "# Notes\n" }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        register_markdown_language(
+            &project.read_with(cx, |project, _| project.languages().clone()),
+        );
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+        let workspace_weak = workspace.downgrade();
+
+        multi_workspace.update_in(cx, |_, window, cx| {
+            open_preview_url(
+                "notes.md".into(),
+                None,
+                Some(PathBuf::from(path!("/project"))),
+                None,
+                &workspace_weak,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let preview = workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .items_of_type::<MarkdownPreviewView>(cx)
+                .next()
+                .expect("link should open a preview")
+        });
+
+        // With the setting on, the link-opened preview is the file's tab:
+        // opening the same path must activate it instead of opening an editor
+        // alongside it.
+        let project_path = workspace.read_with(cx, |workspace, cx| {
+            let worktree_id = workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .id();
+            project::ProjectPath::from((worktree_id, rel_path("notes.md")))
+        });
+        let item = multi_workspace
+            .update_in(cx, |_, window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path(project_path, None, true, window, cx)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            item.item_id(),
+            preview.entity_id(),
+            "opening the path should activate the link-opened preview"
+        );
+        workspace.read_with(cx, |workspace, cx| {
+            assert_eq!(workspace.active_pane().read(cx).items_len(), 1);
+        });
     }
 
     fn set_open_preview_on_file_open(cx: &mut TestAppContext, enabled: bool) {
@@ -4001,8 +4064,7 @@ mod tests {
         })
     }
 
-    fn register_markdown_language(project: &Entity<Project>, cx: &mut TestAppContext) {
-        let languages = project.read_with(cx, |project, _| project.languages().clone());
+    fn register_markdown_language(languages: &Arc<language::LanguageRegistry>) {
         languages.add(Arc::new(language::Language::new(
             language::LanguageConfig {
                 name: "Markdown".into(),

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -61,6 +61,13 @@ pub struct MarkdownPreviewView {
     pending_update_task: Option<Task<Result<()>>>,
     hovered_url: Option<SharedString>,
     mode: MarkdownPreviewMode,
+    /// True when the preview tab opens by default (via `open_preview_on_file_open`),
+    /// making it the file's only tab. Such previews take over the editor tab's responsibilities: claiming the
+    /// file's project entry (so reopening the path activates them) and
+    /// reporting dirty state. Companion previews opened next to an editor tab
+    /// must not claim the entry, or opening the file's path would activate
+    /// the preview instead of an editor.
+    replaces_editor: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -72,17 +79,22 @@ pub enum MarkdownPreviewMode {
 }
 
 impl MarkdownPreviewMode {
-    fn to_db(self) -> i64 {
-        match self {
-            Self::Default => 0,
-            Self::Follow => 1,
+    // 2 encodes "Default + replaces-editor" so file-open previews survive
+    // workspace restoration without a schema migration; 0 and 1 keep their
+    // old meanings and must not be repurposed.
+    fn to_db(self, replaces_editor: bool) -> i64 {
+        match (self, replaces_editor) {
+            (Self::Default, false) => 0,
+            (Self::Follow, _) => 1,
+            (Self::Default, true) => 2,
         }
     }
 
-    fn from_db(value: i64) -> Self {
+    fn from_db(value: i64) -> (Self, bool) {
         match value {
-            1 => Self::Follow,
-            _ => Self::Default,
+            1 => (Self::Follow, false),
+            2 => (Self::Default, true),
+            _ => (Self::Default, false),
         }
     }
 }
@@ -329,6 +341,7 @@ impl MarkdownPreviewView {
             pending_update_task: None,
             hovered_url: None,
             mode,
+            replaces_editor: false,
         };
 
         this.set_editor(active_editor, window, cx);
@@ -451,6 +464,7 @@ impl MarkdownPreviewView {
         let project = workspace.project().clone();
         let editor = cx.new(|cx| Editor::for_buffer(buffer.clone(), Some(project), window, cx));
         let preview = Self::create_markdown_view(workspace, editor, window, cx);
+        preview.update(cx, |preview, _| preview.replaces_editor = true);
 
         pane.update(cx, |pane, cx| {
             pane.add_item(Box::new(preview.clone()), true, true, None, window, cx);
@@ -1190,14 +1204,16 @@ impl workspace::item::ProjectItem for MarkdownPreviewView {
             .unwrap_or_else(WeakEntity::new_invalid);
         let language_registry = project.read(cx).languages().clone();
         let editor = cx.new(|cx| Editor::for_buffer(buffer, Some(project), window, cx));
-        Self::build(
+        let mut this = Self::build(
             MarkdownPreviewMode::Default,
             editor,
             workspace,
             language_registry,
             window,
             cx,
-        )
+        );
+        this.replaces_editor = true;
+        this
     }
 }
 
@@ -1547,15 +1563,20 @@ impl Item for MarkdownPreviewView {
         cx: &App,
         f: &mut dyn FnMut(EntityId, &dyn project::ProjectItem),
     ) {
+        if !self.replaces_editor {
+            return;
+        }
         if let Some(state) = &self.active_editor {
             state.editor.read(cx).for_each_project_item(cx, f);
         }
     }
 
     fn is_dirty(&self, cx: &App) -> bool {
-        self.active_editor
-            .as_ref()
-            .is_some_and(|state| state.editor.read(cx).is_dirty(cx))
+        self.replaces_editor
+            && self
+                .active_editor
+                .as_ref()
+                .is_some_and(|state| state.editor.read(cx).is_dirty(cx))
     }
 
     fn as_searchable(
@@ -1605,20 +1626,22 @@ impl Render for MarkdownPreviewView {
             .min_h_0()
             .relative()
             .bg(bg_color)
-            .child(
-                h_flex().px_2().pt_2().child(
-                    Button::new("open-markdown-source", "Markdown")
-                        .label_size(LabelSize::Small)
-                        .start_icon(
-                            Icon::new(IconName::File)
-                                .size(IconSize::Small)
-                                .color(Color::Muted),
-                        )
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            this.open_markdown_file_source(&OpenSource, window, cx);
-                        })),
-                ),
-            )
+            .when(self.replaces_editor, |this| {
+                this.child(
+                    h_flex().px_2().pt_2().child(
+                        Button::new("open-markdown-source", "Markdown")
+                            .label_size(LabelSize::Small)
+                            .start_icon(
+                                Icon::new(IconName::File)
+                                    .size(IconSize::Small)
+                                    .color(Color::Muted),
+                            )
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.open_markdown_file_source(&OpenSource, window, cx);
+                            })),
+                    ),
+                )
+            })
             .child(
                 div()
                     .flex_1()
@@ -1896,7 +1919,7 @@ impl SerializableItem for MarkdownPreviewView {
             let (abs_path, mode_value) = db
                 .get_preview(item_id, workspace_id)?
                 .context("No markdown preview entry found")?;
-            let mode = MarkdownPreviewMode::from_db(mode_value);
+            let (mode, replaces_editor) = MarkdownPreviewMode::from_db(mode_value);
 
             let (worktree, relative_path) = project
                 .update(cx, |project, cx| {
@@ -1919,7 +1942,16 @@ impl SerializableItem for MarkdownPreviewView {
                 let language_registry = project.read(cx).languages().clone();
                 let editor =
                     cx.new(|cx| Editor::for_buffer(buffer, Some(project.clone()), window, cx));
-                MarkdownPreviewView::new(mode, editor, workspace, language_registry, window, cx)
+                let view = MarkdownPreviewView::new(
+                    mode,
+                    editor,
+                    workspace,
+                    language_registry,
+                    window,
+                    cx,
+                );
+                view.update(cx, |view, _| view.replaces_editor = replaces_editor);
+                view
             })
         })
     }
@@ -1953,7 +1985,7 @@ impl SerializableItem for MarkdownPreviewView {
             .worktree_for_id(worktree_id, cx)?
             .read(cx)
             .absolutize(file.path());
-        let mode = self.mode.to_db();
+        let mode = self.mode.to_db(self.replaces_editor);
         let db = persistence::MarkdownPreviewDb::global(cx);
         Some(cx.background_spawn(async move {
             db.save_preview(item_id, workspace_id, abs_path, mode).await
@@ -3281,6 +3313,76 @@ mod tests {
                         "opener should decline non-markdown buffers"
                     );
                 });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn opening_path_with_classic_preview_open_opens_editor_not_preview(
+        cx: &mut TestAppContext,
+    ) {
+        let (multi_workspace, editor) = open_markdown_file(cx, "note.md", "# Note\n").await;
+        let _preview = open_preview_for_active_editor(cx, &multi_workspace);
+        cx.run_until_parked();
+
+        let project_path = multi_workspace
+            .update(cx, |_, _, cx| {
+                editor
+                    .read(cx)
+                    .buffer()
+                    .read(cx)
+                    .as_singleton()
+                    .unwrap()
+                    .read(cx)
+                    .file()
+                    .map(|file| project::ProjectPath {
+                        worktree_id: file.worktree_id(cx),
+                        path: file.path().clone(),
+                    })
+                    .unwrap()
+            })
+            .unwrap();
+
+        // Leave only the preview tab open, then re-open the file's path.
+        multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    workspace.active_pane().update(cx, |pane, cx| {
+                        pane.close_item_by_id(editor.entity_id(), SaveIntent::Skip, window, cx)
+                    })
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Regression test: classic previews must not report the file's project
+        // entry, or `Pane::open_item` would match the preview tab and opening
+        // the path via the file finder or project panel would activate the
+        // preview instead of opening an editor.
+        let item = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    workspace.open_path(project_path, None, true, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .unwrap();
+        assert!(
+            item.downcast::<Editor>().is_some(),
+            "opening the file's path should open an editor, not activate the preview"
+        );
+        multi_workspace
+            .update(cx, |multi_workspace, _, cx| {
+                let workspace = multi_workspace.workspace().read(cx);
+                assert_eq!(
+                    workspace.active_pane().read(cx).items_len(),
+                    2,
+                    "the preview tab should remain open alongside the new editor"
+                );
             })
             .unwrap();
     }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1211,6 +1211,11 @@ pub struct MarkdownPreviewSettingsContent {
     ///
     /// Default: 800
     pub max_width: Option<f32>,
+    /// Whether opening a markdown file opens a markdown preview tab instead
+    /// of a text editor.
+    ///
+    /// Default: false
+    pub open_preview_on_file_open: Option<bool>,
 }
 
 /// The settings for the image viewer.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -9939,7 +9939,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
         ]
     }
 
-    fn global_only_miscellaneous_sub_section() -> [SettingsPageItem; 3] {
+    fn global_only_miscellaneous_sub_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Image Viewer",
@@ -10018,6 +10018,29 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                         metadata: None,
                     }],
                 ],
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Open Markdown Preview On File Open",
+                description: "Whether opening a markdown file opens a markdown preview tab instead of a text editor.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("markdown_preview.open_preview_on_file_open"),
+                    pick: |settings_content| {
+                        settings_content
+                            .markdown_preview
+                            .as_ref()?
+                            .open_preview_on_file_open
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .markdown_preview
+                            .get_or_insert_default()
+                            .open_preview_on_file_open = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Drop Size Target",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -896,6 +896,10 @@ impl Pane {
         &self.nav_history
     }
 
+    pub fn workspace(&self) -> &WeakEntity<Workspace> {
+        &self.workspace
+    }
+
     pub fn nav_history_mut(&mut self) -> &mut NavHistory {
         &mut self.nav_history
     }
@@ -1282,7 +1286,12 @@ impl Pane {
         let existing_item_index = self.items.iter().position(|existing_item| {
             if existing_item.item_id() == item.item_id() {
                 true
-            } else if existing_item.buffer_kind(cx) == ItemBufferKind::Singleton {
+            } else if existing_item.buffer_kind(cx) == ItemBufferKind::Singleton
+                // Different views of the same file (e.g. an editor and a
+                // markdown preview) aren't duplicates; only dedupe items of
+                // the same view type.
+                && existing_item.to_any_view().entity_type() == item.to_any_view().entity_type()
+            {
                 existing_item
                     .project_entry_ids(cx)
                     .first()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -958,6 +958,42 @@ type WorkspaceItemBuilder =
 
 impl Global for ProjectItemRegistry {}
 
+type AlternateBufferItemOpener = Arc<
+    dyn Fn(
+        &mut Workspace,
+        &Entity<Pane>,
+        &Entity<Buffer>,
+        &mut Window,
+        &mut Context<Workspace>,
+    ) -> Option<Box<dyn ItemHandle>>,
+>;
+
+#[derive(Default)]
+struct AlternateBufferItemOpeners(Vec<AlternateBufferItemOpener>);
+
+impl Global for AlternateBufferItemOpeners {}
+
+/// Registers a callback that can open a singleton buffer as a non-editor
+/// workspace item (e.g. a markdown preview). Callers that open buffers
+/// directly (bypassing path-based project item builders) consult these
+/// openers via [`Workspace::open_alternate_item_for_buffer`]; an opener
+/// declines by returning `None`.
+pub fn register_alternate_buffer_item_opener(
+    cx: &mut App,
+    opener: impl Fn(
+        &mut Workspace,
+        &Entity<Pane>,
+        &Entity<Buffer>,
+        &mut Window,
+        &mut Context<Workspace>,
+    ) -> Option<Box<dyn ItemHandle>>
+    + 'static,
+) {
+    cx.default_global::<AlternateBufferItemOpeners>()
+        .0
+        .push(Arc::new(opener));
+}
+
 /// Registers a [ProjectItem] for the app. When opening a file, all the registered
 /// items will get a chance to open the file, starting from the project item that
 /// was added last.
@@ -4990,6 +5026,22 @@ impl Workspace {
             cx,
         );
         item
+    }
+
+    /// Gives registered alternate buffer item openers a chance to open this
+    /// buffer as a non-editor item in the given pane. Returns `None` when no
+    /// opener claims the buffer.
+    pub fn open_alternate_item_for_buffer(
+        &mut self,
+        pane: &Entity<Pane>,
+        buffer: &Entity<Buffer>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Box<dyn ItemHandle>> {
+        let openers = cx.try_global::<AlternateBufferItemOpeners>()?.0.clone();
+        openers
+            .iter()
+            .find_map(|opener| opener(self, pane, buffer, window, cx))
     }
 
     pub fn open_shared_screen(

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3153,6 +3153,54 @@ Configuration for various AI model providers including API URLs and authenticati
 
 `boolean` values
 
+## Markdown Preview
+
+- Description: Settings for the markdown preview
+- Setting: `markdown_preview`
+- Default:
+
+```json [settings]
+{
+  "markdown_preview": {
+    "limit_content_width": true,
+    "max_width": 800,
+    "open_preview_on_file_open": false
+  }
+}
+```
+
+**Options**
+
+### Limit Content Width
+
+- Description: Whether to limit the maximum width of the rendered markdown content
+- Setting: `limit_content_width`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Max Width
+
+- Description: The maximum width, in pixels, of the rendered markdown content when `limit_content_width` is enabled
+- Setting: `max_width`
+- Default: `800`
+
+**Options**
+
+Positive `number` values
+
+### Open Preview On File Open
+
+- Description: Whether opening a markdown file opens a markdown preview tab instead of a text editor
+- Setting: `open_preview_on_file_open`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
 ## Max Tabs
 
 - Description: Maximum number of tabs to show in the tab bar


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/10966

This PR adds the `open_preview_on_file_open` setting under `markdown_preview` essentially making every Markdown file open the preview tab first instead of a regular buffer. Opening the buffer is still possible with the setting turned on through a button that's displayed in the preview tab.

Release Notes:

- Added a new setting that allows Markdown Previews to be opened by default when opening any Markdown file.
