### PR TITLE
ui: Fix scrollbar animation timing on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19845,6 +19845,7 @@ dependencies = [
  "theme",
  "theme_settings",
  "ui_macros",
+ "web-time",
  "windows 0.61.3",
 ]
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -29,6 +29,7 @@ smallvec.workspace = true
 strum.workspace = true
 theme.workspace = true
 ui_macros.workspace = true
+web-time.workspace = true
 gpui_util.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -1,9 +1,5 @@
-use std::{
-    any::Any,
-    fmt::Debug,
-    ops::Not,
-    time::{Duration, Instant},
-};
+use std::{any::Any, fmt::Debug, ops::Not, time::Duration};
+use web_time::Instant;
 
 use gpui::{
     Along, Anchor, App, AppContext as _, Axis as ScrollbarAxis, BorderStyle, Bounds, ContentMask,


### PR DESCRIPTION
Use `web_time::Instant` instead of `std::time::Instant` when advancing scrollbar animations. This uses the web platform's compatible clock in WASM builds.

Release Notes:
- N/A
