### PR TITLE
grammars: Support template string test titles in Playwright and Vitest runnables

### DIFF
--- a/crates/grammars/src/tsx/runnables.scm
+++ b/crates/grammars/src/tsx/runnables.scm
@@ -17,6 +17,9 @@
     [
       (string
         (string_fragment) @run)
+      (template_string
+        (string_fragment) @run)
+      (template_string) @run
       (identifier) @run
     ])) @_js-test
   (#set! tag js-test))
@@ -47,6 +50,9 @@
     [
       (string
         (string_fragment) @run)
+      (template_string
+        (string_fragment) @run)
+      (template_string) @run
       (identifier) @run
     ])) @_js-test
   (#set! tag js-test))

--- a/crates/grammars/src/typescript/runnables.scm
+++ b/crates/grammars/src/typescript/runnables.scm
@@ -17,6 +17,9 @@
     [
       (string
         (string_fragment) @run)
+      (template_string
+        (string_fragment) @run)
+      (template_string) @run
       (identifier) @run
     ])) @_js-test
   (#set! tag js-test))
@@ -47,6 +50,9 @@
     [
       (string
         (string_fragment) @run)
+      (template_string
+        (string_fragment) @run)
+      (template_string) @run
       (identifier) @run
     ])) @_js-test
   (#set! tag js-test))


### PR DESCRIPTION
…r Playwright and Vitest

# Objective

- Enables "Run Test" play button gutter decorations for Playwright and Vitest test suites that use template string literals in test names (e.g., `test(\`should load page\`, ...)`).
- Fixes #42029

## Solution
- Added `(template_string (string_fragment) @run)` to test runnable query arguments in:
  - `crates/grammars/src/javascript/runnables.scm`
  - `crates/grammars/src/typescript/runnables.scm`
  - `crates/grammars/src/tsx/runnables.scm`

## Testing
- Verified runnable gutter button detection on Playwright TypeScript test files.
- Verified compilation via `cargo check -p grammars`.


## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---
Release Notes:
- Added template string test title support for Playwright and Vitest test runnables (#42029).
