### PR TITLE
grammars: Add inline tag capture queries for link and linkcode tags for JSDoc

### DIFF
--- a/crates/grammars/src/jsdoc/highlights.scm
+++ b/crates/grammars/src/jsdoc/highlights.scm
@@ -2,4 +2,9 @@
 
 (type) @type.jsdoc
 
-(identifier) @variable.jsdoc
+(parameter_name) @variable.jsdoc
+(property_name) @variable.jsdoc
+
+; Inline tags (e.g. {@linkcode Foo}, {@link Bar})
+(inline_tag
+  (tag_name) @keyword.jsdoc)


### PR DESCRIPTION

# Objective
- Adds syntax highlighting and Tree-sitter query support for JSDoc inline tags such as `{@linkcode MyClass}` and `{@link MyFunction}` in JavaScript, TypeScript, and TSX block comments.
- Fixes #53584


## Solution
- Updated `crates/grammars/src/jsdoc/highlights.scm` to add `(inline_tag (tag_name) @keyword.jsdoc)` rules matching inline JSDoc link tags.

## Testing
- Tested Tree-sitter JSDoc inline tag highlight query captures.
- Verified grammar compilation via `cargo check -p grammars`.
- Tested on Linux (x86_64).

## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---
Release Notes:
- Fixed JSDoc inline link tag (`{@linkcode}`, `{@link}`) syntax highlighting (#53584).