### PR TITLE
languages: Register Tailwind CSS LSP adapter for Angular and Django templates

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -270,8 +270,10 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
     // This can be driven by the `language_servers` setting once we have a way for
     // extensions to provide their own default value for that setting.
     let tailwind_languages = [
+        "Angular",
         "Astro",
         "CSS",
+        "Django",
         "ERB",
         "HTML+ERB",
         "HEEx",


### PR DESCRIPTION
…ango languages

# Objective
- Enables Tailwind CSS IntelliSense and auto-completion for Angular HTML templates (`Angular` language) and Django templates (`Django` language).
- Fixes #39507
## Solution
- Added `"Angular"` and `"Django"` to the default `tailwind_languages` array in `crates/languages/src/lib.rs`.


## Testing
- Tested Tailwind LSP adapter registration logic across registered language servers.
- Verified compilation via `cargo check -p languages` inside `crates/languages`.
- Tested on Linux (x86_64).


## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---
Release Notes:
- Added Tailwind CSS IntelliSense support for Angular and Django templates (#39507).