### PR TITLE
grammars: Support `*_test` suffix function names in Pytest runnables

### DIFF
--- a/crates/grammars/src/python/runnables.scm
+++ b/crates/grammars/src/python/runnables.scm
@@ -30,7 +30,7 @@
 ((module
   (function_definition
     name: (identifier) @run @_pytest_method_name
-    (#match? @_pytest_method_name "^test_")) @_python-pytest-method)
+    (#match? @_pytest_method_name "^test_|_test$")) @_python-pytest-method)
   (#set! tag python-pytest-method))
 
 ; decorated pytest functions
@@ -39,7 +39,7 @@
     (decorator)+ @_decorator
     definition: (function_definition
       name: (identifier) @run @_pytest_method_name
-      (#match? @_pytest_method_name "^test_"))) @_python-pytest-method)
+      (#match? @_pytest_method_name "^test_|_test$"))) @_python-pytest-method)
   (#set! tag python-pytest-method))
 
 ; pytest classes


### PR DESCRIPTION
…query

# Objective
- Enables "Run Test" play button decorations in the gutter for pytest functions that use the `*_test` suffix naming convention (e.g. `def login_test():`).

## Solution
- Updated `crates/grammars/src/python/runnables.scm`:
  - Updated `_pytest_method_name` regex pattern from `"^test_"` to `"^test_|_test$"`.


## Testing
- Tested test runnable detection on Python pytest files containing `test_*` and `*_test` functions.
- Verified grammar compilation via `cargo check -p grammars`.
- Tested on Linux (x86_64).

## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---


Release Notes:
- Added support for `*_test` suffix function names in Python pytest test runnables.