### PR TITLE
Model selector collapsible groups

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -221,6 +221,7 @@ pub struct AgentSettings {
     pub thread_summary_model: Option<LanguageModelSelection>,
     pub inline_alternatives: Vec<LanguageModelSelection>,
     pub favorite_models: Vec<LanguageModelSelection>,
+    pub collapsed_model_groups: Vec<String>,
     pub default_profile: AgentProfileId,
     pub profiles: IndexMap<AgentProfileId, AgentProfileSettings>,
 
@@ -281,6 +282,13 @@ impl AgentSettings {
         self.favorite_models
             .iter()
             .map(|sel| SharedString::from(format!("{}/{}", sel.provider.0, sel.model)))
+            .collect()
+    }
+
+    pub fn collapsed_model_group_names(&self) -> HashSet<SharedString> {
+        self.collapsed_model_groups
+            .iter()
+            .map(|group| SharedString::from(group.clone()))
             .collect()
     }
 }
@@ -772,6 +780,7 @@ impl Settings for AgentSettings {
             thread_summary_model: agent.thread_summary_model,
             inline_alternatives: agent.inline_alternatives.unwrap_or_default(),
             favorite_models: agent.favorite_models,
+            collapsed_model_groups: agent.collapsed_model_groups,
             default_profile: AgentProfileId(agent.default_profile.unwrap()),
             profiles: agent
                 .profiles

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -290,6 +290,7 @@ impl ManageProfilesModal {
                         );
                     }
                 },
+                fs.clone(),
                 false, // Do not use popover styles for the model picker
                 self.focus_handle.clone(),
                 window,

--- a/crates/agent_ui/src/agent_model_selector.rs
+++ b/crates/agent_ui/src/agent_model_selector.rs
@@ -60,6 +60,7 @@ impl AgentModelSelector {
                             );
                         }
                     },
+                    fs.clone(),
                     true, // Use popover styles for picker
                     focus_handle.clone(),
                     window,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -988,6 +988,7 @@ mod tests {
             thread_summary_model: None,
             inline_alternatives: vec![],
             favorite_models: vec![],
+            collapsed_model_groups: vec![],
             default_profile: AgentProfileId::default(),
             profiles: Default::default(),
             notify_when_agent_waiting: NotifyWhenAgentWaiting::default(),

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -21,6 +21,7 @@ mod language_model_selector;
 mod mention_set;
 mod message_editor;
 mod mode_selector;
+mod model_picker_sections;
 mod model_selector;
 mod model_selector_popover;
 mod profile_selector;

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1309,9 +1309,11 @@ impl ConversationView {
             // Fall back to dedicated mode/model selectors
             config_options_view = None;
             model_selector = connection.model_selector(&session_id).map(|selector| {
+                let fs = self.project.read(cx).fs().clone();
                 cx.new(|cx| {
                     ModelSelectorPopover::new(
                         selector,
+                        fs,
                         PopoverMenuHandle::default(),
                         self.focus_handle(cx),
                         window,

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -370,6 +370,42 @@ enum LanguageModelPickerEntry {
     },
 }
 
+enum PreviousSelection {
+    Header(SharedString),
+    Model {
+        provider_id: LanguageModelProviderId,
+        model_id: LanguageModelId,
+        section: Option<SharedString>,
+    },
+}
+
+/// The title of the section header (separator or group header) preceding `ix`.
+/// Favorited models appear under "Favorite" (and possibly "Recommended") as
+/// well as under their provider group; the section disambiguates which copy
+/// the cursor is on.
+fn section_title_of(entries: &[LanguageModelPickerEntry], ix: usize) -> Option<&SharedString> {
+    entries
+        .iter()
+        .take(ix + 1)
+        .rev()
+        .find_map(|entry| match entry {
+            LanguageModelPickerEntry::Separator(title)
+            | LanguageModelPickerEntry::GroupHeader { title, .. } => Some(title),
+            LanguageModelPickerEntry::Model(_) => None,
+        })
+}
+
+fn position_of_section(
+    entries: &[LanguageModelPickerEntry],
+    section: &SharedString,
+) -> Option<usize> {
+    entries.iter().position(|entry| match entry {
+        LanguageModelPickerEntry::Separator(title)
+        | LanguageModelPickerEntry::GroupHeader { title, .. } => title == section,
+        LanguageModelPickerEntry::Model(_) => false,
+    })
+}
+
 struct ModelMatcher {
     models: Vec<ModelInfo>,
     fg_executor: ForegroundExecutor,
@@ -531,14 +567,71 @@ impl PickerDelegate for LanguageModelPickerDelegate {
 
         let filtered_models = GroupedModels::new(all, recommended);
 
-        let collapsed_groups = query.is_empty().then(|| self.collapsed_groups.clone());
+        let browsing = query.is_empty();
+        let collapsed_groups = browsing.then(|| self.collapsed_groups.clone());
 
         cx.spawn_in(window, async move |this, cx| {
             this.update_in(cx, |this, window, cx| {
+                // The cursor falls back to the active model when the captured entry is gone.
+                let previous_selection = browsing
+                    .then(|| {
+                        let ix = this.delegate.selected_index;
+                        match this.delegate.filtered_entries.get(ix)? {
+                            LanguageModelPickerEntry::GroupHeader { title, .. } => {
+                                Some(PreviousSelection::Header(title.clone()))
+                            }
+                            LanguageModelPickerEntry::Model(model_info) => {
+                                Some(PreviousSelection::Model {
+                                    provider_id: model_info.model.provider_id(),
+                                    model_id: model_info.model.id(),
+                                    section: section_title_of(&this.delegate.filtered_entries, ix)
+                                        .cloned(),
+                                })
+                            }
+                            LanguageModelPickerEntry::Separator(_) => None,
+                        }
+                    })
+                    .flatten();
+
                 this.delegate.filtered_entries = filtered_models.entries(collapsed_groups.as_ref());
-                // Finds the currently selected model in the list
-                let new_index =
-                    Self::get_active_model_index(&this.delegate.filtered_entries, active_model);
+                let entries = &this.delegate.filtered_entries;
+                // Restore order: the same model in the same section, the same
+                // model in another section (it moved, e.g. was unfavorited),
+                // the section's own header (the model is gone but its section
+                // remains, e.g. the group collapsed under the cursor), and
+                // finally the active model.
+                let new_index = previous_selection
+                    .and_then(|previous| match previous {
+                        PreviousSelection::Header(section) => {
+                            position_of_section(entries, &section)
+                        }
+                        PreviousSelection::Model {
+                            provider_id,
+                            model_id,
+                            section,
+                        } => {
+                            let matches_model = |entry: &LanguageModelPickerEntry| {
+                                matches!(entry, LanguageModelPickerEntry::Model(model_info)
+                                    if model_info.model.provider_id() == provider_id
+                                        && model_info.model.id() == model_id)
+                            };
+                            entries
+                                .iter()
+                                .enumerate()
+                                .find_map(|(ix, entry)| {
+                                    (matches_model(entry)
+                                        && section_title_of(entries, ix) == section.as_ref())
+                                    .then_some(ix)
+                                })
+                                .or_else(|| entries.iter().position(|entry| matches_model(entry)))
+                                .or_else(|| {
+                                    section
+                                        .as_ref()
+                                        .and_then(|section| position_of_section(entries, section))
+                                })
+                        }
+                    })
+                    .unwrap_or_else(|| Self::get_active_model_index(entries, active_model));
                 this.set_selected_index(new_index, Some(picker::Direction::Down), true, window, cx);
                 cx.notify();
             })

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -471,10 +471,9 @@ impl PickerDelegate for LanguageModelPickerDelegate {
 
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
         match self.filtered_entries.get(ix) {
-            Some(LanguageModelPickerEntry::Model(_)) => true,
-            Some(LanguageModelPickerEntry::Separator(_))
-            | Some(LanguageModelPickerEntry::GroupHeader { .. })
-            | None => false,
+            Some(LanguageModelPickerEntry::Model(_))
+            | Some(LanguageModelPickerEntry::GroupHeader { .. }) => true,
+            Some(LanguageModelPickerEntry::Separator(_)) | None => false,
         }
     }
 
@@ -548,16 +547,24 @@ impl PickerDelegate for LanguageModelPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
-        if let Some(LanguageModelPickerEntry::Model(model_info)) =
-            self.filtered_entries.get(self.selected_index)
-        {
-            let model = model_info.model.clone();
-            (self.on_model_changed)(model.clone(), cx);
+        match self.filtered_entries.get(self.selected_index) {
+            Some(LanguageModelPickerEntry::Model(model_info)) => {
+                let model = model_info.model.clone();
+                (self.on_model_changed)(model.clone(), cx);
 
-            let current_index = self.selected_index;
-            self.set_selected_index(current_index, window, cx);
+                let current_index = self.selected_index;
+                self.set_selected_index(current_index, window, cx);
 
-            cx.emit(DismissEvent);
+                cx.emit(DismissEvent);
+            }
+            Some(LanguageModelPickerEntry::GroupHeader { title, .. }) => {
+                let group = title.clone();
+                self.toggle_group_collapsed(group, cx);
+                cx.defer_in(window, |picker, window, cx| {
+                    picker.refresh(window, cx);
+                });
+            }
+            _ => {}
         }
     }
 
@@ -576,19 +583,11 @@ impl PickerDelegate for LanguageModelPickerDelegate {
             LanguageModelPickerEntry::Separator(title) => {
                 Some(ModelSelectorHeader::new(title, ix > 1).into_any_element())
             }
-            LanguageModelPickerEntry::GroupHeader { title, collapsed } => {
-                let group = title.clone();
-                let on_toggle = cx.listener(move |picker, _, window, cx| {
-                    picker.delegate.toggle_group_collapsed(group.clone(), cx);
-                    picker.refresh(window, cx);
-                });
-
-                Some(
-                    ModelSelectorHeader::new(title.clone(), ix > 1)
-                        .collapsible(ix, *collapsed, on_toggle)
-                        .into_any_element(),
-                )
-            }
+            LanguageModelPickerEntry::GroupHeader { title, collapsed } => Some(
+                ModelSelectorHeader::new(title.clone(), ix > 1)
+                    .collapsible(ix, *collapsed, selected)
+                    .into_any_element(),
+            ),
             LanguageModelPickerEntry::Model(model_info) => {
                 let active_model = (self.get_active_model)(cx);
                 let active_provider_id = active_model.as_ref().map(|m| m.provider.id());

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -14,10 +14,11 @@ use language_model::{
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use settings::{Settings, SettingsStore, update_settings_file};
+use settings::{Settings, SettingsStore};
 use ui::prelude::*;
 use zed_actions::agent::OpenSettings;
 
+use crate::model_picker_sections::{self, PreviousSelection, SectionedEntry};
 use crate::ui::{ModelSelectorFooter, ModelSelectorHeader, ModelSelectorListItem};
 
 type OnModelChanged = Arc<dyn Fn(Arc<dyn LanguageModel>, &mut App) + 'static>;
@@ -224,19 +225,12 @@ impl LanguageModelPickerDelegate {
     }
 
     fn toggle_group_collapsed(&mut self, group: SharedString, cx: &mut Context<Picker<Self>>) {
-        let collapsed = !self.collapsed_groups.contains(&group);
-        if collapsed {
-            self.collapsed_groups.insert(group.clone());
-        } else {
-            self.collapsed_groups.remove(&group);
-        }
-
-        update_settings_file(self.fs.clone(), cx, move |settings, _cx| {
-            settings
-                .agent
-                .get_or_insert_default()
-                .set_model_group_collapsed(&group, collapsed);
-        });
+        model_picker_sections::toggle_group_collapsed(
+            &mut self.collapsed_groups,
+            group,
+            self.fs.clone(),
+            cx,
+        );
     }
 
     pub fn favorites_count(&self) -> usize {
@@ -370,40 +364,21 @@ enum LanguageModelPickerEntry {
     },
 }
 
-enum PreviousSelection {
-    Header(SharedString),
-    Model {
-        provider_id: LanguageModelProviderId,
-        model_id: LanguageModelId,
-        section: Option<SharedString>,
-    },
-}
-
-/// The title of the section header (separator or group header) preceding `ix`.
-/// Favorited models appear under "Favorite" (and possibly "Recommended") as
-/// well as under their provider group; the section disambiguates which copy
-/// the cursor is on.
-fn section_title_of(entries: &[LanguageModelPickerEntry], ix: usize) -> Option<&SharedString> {
-    entries
-        .iter()
-        .take(ix + 1)
-        .rev()
-        .find_map(|entry| match entry {
+impl SectionedEntry for LanguageModelPickerEntry {
+    fn section_title(&self) -> Option<&SharedString> {
+        match self {
             LanguageModelPickerEntry::Separator(title)
             | LanguageModelPickerEntry::GroupHeader { title, .. } => Some(title),
             LanguageModelPickerEntry::Model(_) => None,
-        })
-}
+        }
+    }
 
-fn position_of_section(
-    entries: &[LanguageModelPickerEntry],
-    section: &SharedString,
-) -> Option<usize> {
-    entries.iter().position(|entry| match entry {
-        LanguageModelPickerEntry::Separator(title)
-        | LanguageModelPickerEntry::GroupHeader { title, .. } => title == section,
-        LanguageModelPickerEntry::Model(_) => false,
-    })
+    fn group_header_title(&self) -> Option<&SharedString> {
+        match self {
+            LanguageModelPickerEntry::GroupHeader { title, .. } => Some(title),
+            LanguageModelPickerEntry::Separator(_) | LanguageModelPickerEntry::Model(_) => None,
+        }
+    }
 }
 
 struct ModelMatcher {
@@ -575,61 +550,29 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                 // The cursor falls back to the active model when the captured entry is gone.
                 let previous_selection = browsing
                     .then(|| {
-                        let ix = this.delegate.selected_index;
-                        match this.delegate.filtered_entries.get(ix)? {
-                            LanguageModelPickerEntry::GroupHeader { title, .. } => {
-                                Some(PreviousSelection::Header(title.clone()))
-                            }
-                            LanguageModelPickerEntry::Model(model_info) => {
-                                Some(PreviousSelection::Model {
-                                    provider_id: model_info.model.provider_id(),
-                                    model_id: model_info.model.id(),
-                                    section: section_title_of(&this.delegate.filtered_entries, ix)
-                                        .cloned(),
-                                })
-                            }
-                            LanguageModelPickerEntry::Separator(_) => None,
-                        }
+                        PreviousSelection::capture(
+                            &this.delegate.filtered_entries,
+                            this.delegate.selected_index,
+                            |entry| match entry {
+                                LanguageModelPickerEntry::Model(model_info) => Some((
+                                    model_info.model.provider_id(),
+                                    model_info.model.id(),
+                                )),
+                                _ => None,
+                            },
+                        )
                     })
                     .flatten();
 
                 this.delegate.filtered_entries = filtered_models.entries(collapsed_groups.as_ref());
                 let entries = &this.delegate.filtered_entries;
-                // Restore order: the same model in the same section, the same
-                // model in another section (it moved, e.g. was unfavorited),
-                // the section's own header (the model is gone but its section
-                // remains, e.g. the group collapsed under the cursor), and
-                // finally the active model.
                 let new_index = previous_selection
-                    .and_then(|previous| match previous {
-                        PreviousSelection::Header(section) => {
-                            position_of_section(entries, &section)
-                        }
-                        PreviousSelection::Model {
-                            provider_id,
-                            model_id,
-                            section,
-                        } => {
-                            let matches_model = |entry: &LanguageModelPickerEntry| {
-                                matches!(entry, LanguageModelPickerEntry::Model(model_info)
-                                    if model_info.model.provider_id() == provider_id
-                                        && model_info.model.id() == model_id)
-                            };
-                            entries
-                                .iter()
-                                .enumerate()
-                                .find_map(|(ix, entry)| {
-                                    (matches_model(entry)
-                                        && section_title_of(entries, ix) == section.as_ref())
-                                    .then_some(ix)
-                                })
-                                .or_else(|| entries.iter().position(|entry| matches_model(entry)))
-                                .or_else(|| {
-                                    section
-                                        .as_ref()
-                                        .and_then(|section| position_of_section(entries, section))
-                                })
-                        }
+                    .and_then(|previous| {
+                        previous.restore(entries, |entry, (provider_id, model_id)| {
+                            matches!(entry, LanguageModelPickerEntry::Model(model_info)
+                                if model_info.model.provider_id() == *provider_id
+                                    && model_info.model.id() == *model_id)
+                        })
                     })
                     .unwrap_or_else(|| Self::get_active_model_index(entries, active_model));
                 this.set_selected_index(new_index, Some(picker::Direction::Down), true, window, cx);

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -2,6 +2,7 @@ use std::{cmp::Reverse, sync::Arc};
 
 use agent_settings::AgentSettings;
 use collections::{HashMap, HashSet, IndexMap};
+use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     Action, AnyElement, App, BackgroundExecutor, DismissEvent, FocusHandle, ForegroundExecutor,
@@ -13,7 +14,7 @@ use language_model::{
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use settings::Settings;
+use settings::{Settings, SettingsStore, update_settings_file};
 use ui::prelude::*;
 use zed_actions::agent::OpenSettings;
 
@@ -29,6 +30,7 @@ pub fn language_model_selector(
     get_active_model: impl Fn(&App) -> Option<ConfiguredModel> + 'static,
     on_model_changed: impl Fn(Arc<dyn LanguageModel>, &mut App) + 'static,
     on_toggle_favorite: impl Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static,
+    fs: Arc<dyn Fs>,
     popover_styles: bool,
     focus_handle: FocusHandle,
     window: &mut Window,
@@ -38,6 +40,7 @@ pub fn language_model_selector(
         get_active_model,
         on_model_changed,
         on_toggle_favorite,
+        fs,
         popover_styles,
         focus_handle,
         window,
@@ -123,8 +126,10 @@ pub struct LanguageModelPickerDelegate {
     on_model_changed: OnModelChanged,
     get_active_model: GetActiveModel,
     on_toggle_favorite: OnToggleFavorite,
+    fs: Arc<dyn Fs>,
     all_models: Arc<GroupedModels>,
     filtered_entries: Vec<LanguageModelPickerEntry>,
+    collapsed_groups: HashSet<SharedString>,
     selected_index: usize,
     _subscriptions: Vec<Subscription>,
     popover_styles: bool,
@@ -136,6 +141,7 @@ impl LanguageModelPickerDelegate {
         get_active_model: impl Fn(&App) -> Option<ConfiguredModel> + 'static,
         on_model_changed: impl Fn(Arc<dyn LanguageModel>, &mut App) + 'static,
         on_toggle_favorite: impl Fn(Arc<dyn LanguageModel>, bool, &mut App) + 'static,
+        fs: Arc<dyn Fs>,
         popover_styles: bool,
         focus_handle: FocusHandle,
         window: &mut Window,
@@ -143,33 +149,49 @@ impl LanguageModelPickerDelegate {
     ) -> Self {
         let on_model_changed = Arc::new(on_model_changed);
         let models = all_models(cx);
-        let entries = models.entries();
+        let collapsed_groups = AgentSettings::get_global(cx).collapsed_model_group_names();
+        let entries = models.entries(Some(&collapsed_groups));
 
         Self {
             on_model_changed,
             all_models: Arc::new(models),
             selected_index: Self::get_active_model_index(&entries, get_active_model(cx)),
             filtered_entries: entries,
+            collapsed_groups,
+            fs,
             get_active_model: Arc::new(get_active_model),
             on_toggle_favorite: Arc::new(on_toggle_favorite),
-            _subscriptions: vec![cx.subscribe_in(
-                &LanguageModelRegistry::global(cx),
-                window,
-                |picker, _, event, window, cx| {
-                    match event {
-                        language_model::Event::ProviderStateChanged(_)
-                        | language_model::Event::AddedProvider(_)
-                        | language_model::Event::RemovedProvider(_) => {
-                            let query = picker.query(cx);
-                            picker.delegate.all_models = Arc::new(all_models(cx));
-                            // Update matches will automatically drop the previous task
-                            // if we get a provider event again
-                            picker.update_matches(query, window, cx)
+            _subscriptions: vec![
+                cx.subscribe_in(
+                    &LanguageModelRegistry::global(cx),
+                    window,
+                    |picker, _, event, window, cx| {
+                        match event {
+                            language_model::Event::ProviderStateChanged(_)
+                            | language_model::Event::AddedProvider(_)
+                            | language_model::Event::RemovedProvider(_) => {
+                                let query = picker.query(cx);
+                                picker.delegate.all_models = Arc::new(all_models(cx));
+                                // Update matches will automatically drop the previous task
+                                // if we get a provider event again
+                                picker.update_matches(query, window, cx)
+                            }
+                            _ => {}
                         }
-                        _ => {}
+                    },
+                ),
+                cx.observe_global_in::<SettingsStore>(window, |picker, window, cx| {
+                    // Toggling in this picker updates the local set first, so this only
+                    // fires a refresh when the settings change came from elsewhere
+                    // (settings.json edits or another picker instance).
+                    let new_collapsed_groups =
+                        AgentSettings::get_global(cx).collapsed_model_group_names();
+                    if new_collapsed_groups != picker.delegate.collapsed_groups {
+                        picker.delegate.collapsed_groups = new_collapsed_groups;
+                        picker.refresh(window, cx);
                     }
-                },
-            )],
+                }),
+            ],
             popover_styles,
             focus_handle,
         }
@@ -199,6 +221,22 @@ impl LanguageModelPickerDelegate {
 
     pub fn active_model(&self, cx: &App) -> Option<ConfiguredModel> {
         (self.get_active_model)(cx)
+    }
+
+    fn toggle_group_collapsed(&mut self, group: SharedString, cx: &mut Context<Picker<Self>>) {
+        let collapsed = !self.collapsed_groups.contains(&group);
+        if collapsed {
+            self.collapsed_groups.insert(group.clone());
+        } else {
+            self.collapsed_groups.remove(&group);
+        }
+
+        update_settings_file(self.fs.clone(), cx, move |settings, _cx| {
+            settings
+                .agent
+                .get_or_insert_default()
+                .set_model_group_collapsed(&group, collapsed);
+        });
     }
 
     pub fn favorites_count(&self) -> usize {
@@ -272,7 +310,12 @@ impl GroupedModels {
         }
     }
 
-    fn entries(&self) -> Vec<LanguageModelPickerEntry> {
+    /// `collapsed_groups` is `None` while searching, so that matches surface
+    /// from every group and headers render as plain, non-collapsible separators.
+    fn entries(
+        &self,
+        collapsed_groups: Option<&HashSet<SharedString>>,
+    ) -> Vec<LanguageModelPickerEntry> {
         let mut entries = Vec::new();
 
         if !self.favorites.is_empty() {
@@ -293,9 +336,22 @@ impl GroupedModels {
             if models.is_empty() {
                 continue;
             }
-            entries.push(LanguageModelPickerEntry::Separator(
-                models[0].model.provider_name().0,
-            ));
+            let provider_name = models[0].model.provider_name().0;
+            match collapsed_groups {
+                Some(collapsed_groups) => {
+                    let collapsed = collapsed_groups.contains(&provider_name);
+                    entries.push(LanguageModelPickerEntry::GroupHeader {
+                        title: provider_name,
+                        collapsed,
+                    });
+                    if collapsed {
+                        continue;
+                    }
+                }
+                None => {
+                    entries.push(LanguageModelPickerEntry::Separator(provider_name));
+                }
+            }
             for info in models {
                 entries.push(LanguageModelPickerEntry::Model(info.clone()));
             }
@@ -308,6 +364,10 @@ impl GroupedModels {
 enum LanguageModelPickerEntry {
     Model(ModelInfo),
     Separator(SharedString),
+    GroupHeader {
+        title: SharedString,
+        collapsed: bool,
+    },
 }
 
 struct ModelMatcher {
@@ -412,7 +472,9 @@ impl PickerDelegate for LanguageModelPickerDelegate {
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
         match self.filtered_entries.get(ix) {
             Some(LanguageModelPickerEntry::Model(_)) => true,
-            Some(LanguageModelPickerEntry::Separator(_)) | None => false,
+            Some(LanguageModelPickerEntry::Separator(_))
+            | Some(LanguageModelPickerEntry::GroupHeader { .. })
+            | None => false,
         }
     }
 
@@ -470,9 +532,11 @@ impl PickerDelegate for LanguageModelPickerDelegate {
 
         let filtered_models = GroupedModels::new(all, recommended);
 
+        let collapsed_groups = query.is_empty().then(|| self.collapsed_groups.clone());
+
         cx.spawn_in(window, async move |this, cx| {
             this.update_in(cx, |this, window, cx| {
-                this.delegate.filtered_entries = filtered_models.entries();
+                this.delegate.filtered_entries = filtered_models.entries(collapsed_groups.as_ref());
                 // Finds the currently selected model in the list
                 let new_index =
                     Self::get_active_model_index(&this.delegate.filtered_entries, active_model);
@@ -511,6 +575,19 @@ impl PickerDelegate for LanguageModelPickerDelegate {
         match self.filtered_entries.get(ix)? {
             LanguageModelPickerEntry::Separator(title) => {
                 Some(ModelSelectorHeader::new(title, ix > 1).into_any_element())
+            }
+            LanguageModelPickerEntry::GroupHeader { title, collapsed } => {
+                let group = title.clone();
+                let on_toggle = cx.listener(move |picker, _, window, cx| {
+                    picker.delegate.toggle_group_collapsed(group.clone(), cx);
+                    picker.refresh(window, cx);
+                });
+
+                Some(
+                    ModelSelectorHeader::new(title.clone(), ix > 1)
+                        .collapsible(ix, *collapsed, on_toggle)
+                        .into_any_element(),
+                )
             }
             LanguageModelPickerEntry::Model(model_info) => {
                 let active_model = (self.get_active_model)(cx);
@@ -820,7 +897,7 @@ mod tests {
         );
 
         let grouped_models = GroupedModels::new(all_models, recommended_models);
-        let entries = grouped_models.entries();
+        let entries = grouped_models.entries(Some(&HashSet::default()));
 
         assert!(matches!(
             entries.first(),
@@ -836,7 +913,7 @@ mod tests {
         let all_models = create_models(vec![("zed", "claude"), ("zed", "gemini")]);
 
         let grouped_models = GroupedModels::new(all_models, recommended_models);
-        let entries = grouped_models.entries();
+        let entries = grouped_models.entries(Some(&HashSet::default()));
 
         assert!(matches!(
             entries.first(),
@@ -844,6 +921,69 @@ mod tests {
         ));
 
         assert!(grouped_models.favorites.is_empty());
+    }
+
+    #[gpui::test]
+    fn test_collapsed_provider_group_hides_its_models(_cx: &mut TestAppContext) {
+        let all_models = create_models(vec![
+            ("openrouter", "model-a"),
+            ("openrouter", "model-b"),
+            ("zed", "claude"),
+        ]);
+
+        let grouped_models = GroupedModels::new(all_models, vec![]);
+        let collapsed_groups: HashSet<SharedString> =
+            [SharedString::from("openrouter")].into_iter().collect();
+        let entries = grouped_models.entries(Some(&collapsed_groups));
+
+        assert!(matches!(
+            entries.first(),
+            Some(LanguageModelPickerEntry::GroupHeader {
+                title,
+                collapsed: true,
+            }) if title == "openrouter"
+        ));
+
+        let model_ids: Vec<_> = entries
+            .iter()
+            .filter_map(|entry| match entry {
+                LanguageModelPickerEntry::Model(info) => Some(info.model.telemetry_id()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(model_ids, vec!["zed/claude"]);
+    }
+
+    #[gpui::test]
+    fn test_search_entries_ignore_collapsed_groups(_cx: &mut TestAppContext) {
+        let all_models = create_models(vec![
+            ("openrouter", "model-a"),
+            ("openrouter", "model-b"),
+            ("zed", "claude"),
+        ]);
+
+        let grouped_models = GroupedModels::new(all_models, vec![]);
+        // While searching, entries are built with no collapsed set, so models
+        // surface from every group and headers are plain separators.
+        let entries = grouped_models.entries(None);
+
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !matches!(entry, LanguageModelPickerEntry::GroupHeader { .. }))
+        );
+
+        let model_ids: Vec<_> = entries
+            .iter()
+            .filter_map(|entry| match entry {
+                LanguageModelPickerEntry::Model(info) => Some(info.model.telemetry_id()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            model_ids,
+            vec!["openrouter/model-a", "openrouter/model-b", "zed/claude"]
+        );
     }
 
     #[gpui::test]
@@ -856,7 +996,7 @@ mod tests {
         );
 
         let grouped_models = GroupedModels::new(all_models, recommended_models);
-        let entries = grouped_models.entries();
+        let entries = grouped_models.entries(Some(&HashSet::default()));
 
         for entry in &entries {
             if let LanguageModelPickerEntry::Model(info) = entry {

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -682,13 +682,16 @@ impl PickerDelegate for LanguageModelPickerDelegate {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use super::*;
     use futures::{future::BoxFuture, stream::BoxStream};
-    use gpui::{AsyncApp, TestAppContext};
+    use gpui::{AsyncApp, TestAppContext, UpdateGlobal, VisualTestContext};
     use language_model::{
         LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId,
         LanguageModelName, LanguageModelProviderId, LanguageModelProviderName,
-        LanguageModelRequest, LanguageModelToolChoice,
+        LanguageModelRequest, LanguageModelToolChoice, fake_provider::FakeLanguageModelProvider,
     };
     use ui::IconName;
 
@@ -1019,6 +1022,211 @@ mod tests {
             model_ids,
             vec!["openrouter/model-a", "openrouter/model-b", "zed/claude"]
         );
+    }
+
+    fn entry_labels(entries: &[LanguageModelPickerEntry]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|entry| match entry {
+                LanguageModelPickerEntry::Model(info) => info.model.name().0.to_string(),
+                LanguageModelPickerEntry::Separator(title)
+                | LanguageModelPickerEntry::GroupHeader { title, .. } => title.to_string(),
+            })
+            .collect()
+    }
+
+    fn register_provider(models: Vec<(&str, &str)>, cx: &mut App) {
+        let provider = models[0].0.to_string();
+        let models = models
+            .into_iter()
+            .map(|(provider, name)| {
+                Arc::new(TestLanguageModel::new(name, provider)) as Arc<dyn LanguageModel>
+            })
+            .collect();
+        LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+            registry.register_provider(
+                Arc::new(
+                    FakeLanguageModelProvider::new(
+                        LanguageModelProviderId::from(provider.clone()),
+                        LanguageModelProviderName::from(provider),
+                    )
+                    .with_models(models),
+                ),
+                cx,
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn confirming_group_header_toggles_collapse(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+            language_model::init(cx);
+
+            register_provider(vec![("alpha", "alpha/one"), ("alpha", "alpha/two")], cx);
+            register_provider(vec![("beta", "beta/one")], cx);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        let selected_models = Rc::new(RefCell::new(Vec::<String>::new()));
+        let window_handle = cx.add_window({
+            let selected_models = selected_models.clone();
+            move |window, cx| {
+                language_model_selector(
+                    |_| None,
+                    move |model, _| selected_models.borrow_mut().push(model.name().0.to_string()),
+                    |_, _, _| {},
+                    fs,
+                    true,
+                    cx.focus_handle(),
+                    window,
+                    cx,
+                )
+            }
+        });
+        cx.run_until_parked();
+
+        let picker = window_handle.root(cx).unwrap();
+        let dismiss_count = Rc::new(RefCell::new(0));
+        let _dismiss_subscription = cx.update(|cx| {
+            cx.subscribe(&picker, {
+                let dismiss_count = dismiss_count.clone();
+                move |_, _: &DismissEvent, _| *dismiss_count.borrow_mut() += 1
+            })
+        });
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(
+                    entry_labels(&picker.delegate.filtered_entries),
+                    vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
+                );
+
+                picker.delegate.set_selected_index(3, window, cx);
+                picker.delegate.confirm(false, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(
+                    entry_labels(&picker.delegate.filtered_entries),
+                    vec!["alpha", "alpha/one", "alpha/two", "beta"]
+                );
+                // The cursor stays on the toggled header instead of jumping
+                // back to the active model.
+                assert_eq!(picker.delegate.selected_index, 3);
+
+                // A later unrelated refresh must not move the cursor either.
+                picker.refresh(window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(picker.delegate.selected_index, 3);
+
+                // Confirming the collapsed header again expands the group.
+                picker.delegate.confirm(false, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(
+                    entry_labels(&picker.delegate.filtered_entries),
+                    vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
+                );
+                assert_eq!(picker.delegate.selected_index, 3);
+                // Toggling headers never selects a model or dismisses the picker.
+                assert!(selected_models.borrow().is_empty());
+                assert_eq!(*dismiss_count.borrow(), 0);
+
+                // Confirming a model does both.
+                picker.delegate.set_selected_index(1, window, cx);
+                picker.delegate.confirm(false, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(selected_models.borrow().as_slice(), ["alpha/one"]);
+        assert_eq!(*dismiss_count.borrow(), 1);
+    }
+
+    #[gpui::test]
+    fn settings_driven_collapse_keeps_cursor_anchored_to_provider(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+            language_model::init(cx);
+
+            // The same model id offered by two providers: cursor restoration
+            // must key on provider + model id, not model id alone.
+            register_provider(vec![("alpha", "claude")], cx);
+            register_provider(vec![("beta", "claude")], cx);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        let window_handle = cx.add_window(move |window, cx| {
+            language_model_selector(
+                |_| None,
+                |_, _| {},
+                |_, _, _| {},
+                fs,
+                true,
+                cx.focus_handle(),
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(
+                    entry_labels(&picker.delegate.filtered_entries),
+                    vec!["alpha", "claude", "beta", "claude"]
+                );
+                picker.delegate.set_selected_index(3, window, cx);
+            })
+            .unwrap();
+
+        // Collapse "beta" from outside this picker (a settings.json edit or
+        // another picker instance): the settings observer refreshes the list.
+        cx.update(|_window, cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .agent
+                        .get_or_insert_default()
+                        .set_model_group_collapsed("beta", true);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, _window, _cx| {
+                assert_eq!(
+                    entry_labels(&picker.delegate.filtered_entries),
+                    vec!["alpha", "claude", "beta"]
+                );
+                // The cursor was on beta's copy of "claude"; with beta's
+                // models hidden it must land on beta's own header rather than
+                // jump to alpha's same-id model.
+                assert_eq!(picker.delegate.selected_index, 2);
+            })
+            .unwrap();
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/model_picker_sections.rs
+++ b/crates/agent_ui/src/model_picker_sections.rs
@@ -1,0 +1,306 @@
+use std::sync::Arc;
+
+use collections::HashSet;
+use fs::Fs;
+use gpui::{App, SharedString};
+use settings::update_settings_file;
+
+/// A model picker entry viewed only through its section structure, so that
+/// both model pickers can share cursor-restoration policy without sharing
+/// entry payloads.
+pub trait SectionedEntry {
+    /// The title when this entry is a section header of any kind, collapsible
+    /// or not.
+    fn section_title(&self) -> Option<&SharedString>;
+
+    /// The title when this entry is a collapsible group header. Plain
+    /// separators return `None`.
+    fn group_header_title(&self) -> Option<&SharedString>;
+}
+
+/// The title of the section header (separator or group header) preceding `ix`.
+/// Favorited models appear under "Favorite" (and possibly "Recommended") as
+/// well as under their provider group; the section disambiguates which copy
+/// the cursor is on.
+fn section_title_of<E: SectionedEntry>(entries: &[E], ix: usize) -> Option<&SharedString> {
+    entries
+        .iter()
+        .take(ix + 1)
+        .rev()
+        .find_map(SectionedEntry::section_title)
+}
+
+fn position_of_section<E: SectionedEntry>(entries: &[E], section: &SharedString) -> Option<usize> {
+    entries
+        .iter()
+        .position(|entry| entry.section_title() == Some(section))
+}
+
+/// What the cursor was resting on before the entry list was rebuilt.
+///
+/// `Key` is the model identity used to find the entry again. The language
+/// model picker needs a composite (provider id, model id) key because the same
+/// model id can be offered by more than one provider; the ACP picker's model
+/// ids are globally unique.
+pub enum PreviousSelection<Key> {
+    Header(SharedString),
+    Model {
+        key: Key,
+        section: Option<SharedString>,
+    },
+}
+
+impl<Key> PreviousSelection<Key> {
+    /// Captures the entry at `ix`. `model_key` returns the identity of a
+    /// model entry and `None` for anything else; separators are never
+    /// captured because the cursor cannot rest on one.
+    pub fn capture<E: SectionedEntry>(
+        entries: &[E],
+        ix: usize,
+        model_key: impl FnOnce(&E) -> Option<Key>,
+    ) -> Option<Self> {
+        let entry = entries.get(ix)?;
+        if let Some(title) = entry.group_header_title() {
+            return Some(Self::Header(title.clone()));
+        }
+        Some(Self::Model {
+            key: model_key(entry)?,
+            section: section_title_of(entries, ix).cloned(),
+        })
+    }
+
+    /// Restore order: the same model in the same section, the same model in
+    /// another section (it moved, e.g. was unfavorited), then the section's
+    /// own header (the model is gone but its section remains, e.g. the group
+    /// collapsed under the cursor). Returns `None` when nothing survives so
+    /// the caller can apply its own final fallback, which differs per picker.
+    pub fn restore<E: SectionedEntry>(
+        &self,
+        entries: &[E],
+        is_model: impl Fn(&E, &Key) -> bool,
+    ) -> Option<usize> {
+        match self {
+            Self::Header(section) => position_of_section(entries, section),
+            Self::Model { key, section } => entries
+                .iter()
+                .enumerate()
+                .find_map(|(ix, entry)| {
+                    (is_model(entry, key) && section_title_of(entries, ix) == section.as_ref())
+                        .then_some(ix)
+                })
+                .or_else(|| entries.iter().position(|entry| is_model(entry, key)))
+                .or_else(|| {
+                    section
+                        .as_ref()
+                        .and_then(|section| position_of_section(entries, section))
+                }),
+        }
+    }
+}
+
+/// Flips `group` in the local set before persisting, because the pickers'
+/// settings observers compare the incoming settings against that local set to
+/// avoid refreshing for their own writes.
+pub fn toggle_group_collapsed(
+    collapsed_groups: &mut HashSet<SharedString>,
+    group: SharedString,
+    fs: Arc<dyn Fs>,
+    cx: &App,
+) {
+    let collapsed = !collapsed_groups.contains(&group);
+    if collapsed {
+        collapsed_groups.insert(group.clone());
+    } else {
+        collapsed_groups.remove(&group);
+    }
+
+    update_settings_file(fs, cx, move |settings, _cx| {
+        settings
+            .agent
+            .get_or_insert_default()
+            .set_model_group_collapsed(&group, collapsed);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    enum TestEntry {
+        Separator(SharedString),
+        GroupHeader(SharedString),
+        Model {
+            provider: &'static str,
+            id: &'static str,
+        },
+    }
+
+    impl SectionedEntry for TestEntry {
+        fn section_title(&self) -> Option<&SharedString> {
+            match self {
+                TestEntry::Separator(title) | TestEntry::GroupHeader(title) => Some(title),
+                TestEntry::Model { .. } => None,
+            }
+        }
+
+        fn group_header_title(&self) -> Option<&SharedString> {
+            match self {
+                TestEntry::GroupHeader(title) => Some(title),
+                TestEntry::Separator(_) | TestEntry::Model { .. } => None,
+            }
+        }
+    }
+
+    fn separator(title: &'static str) -> TestEntry {
+        TestEntry::Separator(title.into())
+    }
+
+    fn header(title: &'static str) -> TestEntry {
+        TestEntry::GroupHeader(title.into())
+    }
+
+    fn model(provider: &'static str, id: &'static str) -> TestEntry {
+        TestEntry::Model { provider, id }
+    }
+
+    type TestKey = (&'static str, &'static str);
+
+    fn capture(entries: &[TestEntry], ix: usize) -> Option<PreviousSelection<TestKey>> {
+        PreviousSelection::capture(entries, ix, |entry| match entry {
+            TestEntry::Model { provider, id } => Some((*provider, *id)),
+            _ => None,
+        })
+    }
+
+    fn restore(previous: &PreviousSelection<TestKey>, entries: &[TestEntry]) -> Option<usize> {
+        previous.restore(entries, |entry, (provider, id)| {
+            matches!(entry, TestEntry::Model { provider: p, id: i } if p == provider && i == id)
+        })
+    }
+
+    #[test]
+    fn capture_ignores_separators() {
+        let entries = [
+            separator("Favorite"),
+            model("zed", "claude"),
+            separator("zed"),
+        ];
+        assert!(capture(&entries, 0).is_none());
+        assert!(capture(&entries, 2).is_none());
+        // Index 3 is out of bounds.
+        assert!(capture(&entries, 3).is_none());
+    }
+
+    #[test]
+    fn restores_the_same_model_in_the_same_section() {
+        // The favorited model appears both under "Favorite" and under its
+        // provider group; the section anchor keeps the cursor on the group
+        // copy instead of the first id match.
+        let entries = [
+            separator("Favorite"),
+            model("zed", "claude"),
+            header("zed"),
+            model("zed", "claude"),
+            header("openai"),
+            model("openai", "gpt"),
+        ];
+        let previous = capture(&entries, 3).unwrap();
+        assert_eq!(restore(&previous, &entries), Some(3));
+    }
+
+    #[test]
+    fn follows_a_model_that_moved_to_another_section() {
+        let before = [
+            separator("Favorite"),
+            model("zed", "claude"),
+            header("zed"),
+            model("zed", "claude"),
+        ];
+        let previous = capture(&before, 1).unwrap();
+
+        // The model was unfavorited: the Favorite section is gone and only
+        // the group copy remains.
+        let after = [header("zed"), model("zed", "claude")];
+        assert_eq!(restore(&previous, &after), Some(1));
+    }
+
+    #[test]
+    fn prefers_the_model_anywhere_over_its_old_section_header() {
+        let before = [
+            separator("Favorite"),
+            model("zed", "claude"),
+            header("zed"),
+            model("zed", "claude"),
+        ];
+        let previous = capture(&before, 1).unwrap();
+
+        // The model left the Favorite section but the section itself remains:
+        // the cursor follows the model rather than staying on the section.
+        let after = [
+            separator("Favorite"),
+            model("zed", "gemini"),
+            header("zed"),
+            model("zed", "claude"),
+        ];
+        assert_eq!(restore(&previous, &after), Some(3));
+    }
+
+    #[test]
+    fn falls_back_to_the_section_header_when_the_model_is_gone() {
+        // Two providers offer the same model id, so the composite key must
+        // not treat the other provider's copy as a match.
+        let before = [
+            header("zed"),
+            model("zed", "gpt-5"),
+            header("openai"),
+            model("openai", "gpt-5"),
+        ];
+        let previous = capture(&before, 3).unwrap();
+
+        // The openai group collapsed under the cursor: its model is gone but
+        // its header remains, and zed's same-id model must not win.
+        let after = [header("zed"), model("zed", "gpt-5"), header("openai")];
+        assert_eq!(restore(&previous, &after), Some(2));
+    }
+
+    #[test]
+    fn falls_back_to_a_separator_section() {
+        // The section anchor can be a plain separator, not just a collapsible
+        // group header.
+        let before = [
+            separator("Favorite"),
+            model("zed", "claude"),
+            header("zed"),
+        ];
+        let previous = capture(&before, 1).unwrap();
+
+        let after = [separator("Favorite"), header("zed")];
+        assert_eq!(restore(&previous, &after), Some(0));
+    }
+
+    #[test]
+    fn returns_none_when_model_and_section_are_gone() {
+        let before = [header("zed"), model("zed", "claude")];
+        let previous = capture(&before, 1).unwrap();
+
+        let after = [header("openai"), model("openai", "gpt")];
+        assert_eq!(restore(&previous, &after), None);
+    }
+
+    #[test]
+    fn header_restores_to_its_section() {
+        let before = [
+            header("zed"),
+            model("zed", "claude"),
+            header("openai"),
+            model("openai", "gpt"),
+        ];
+        let previous = capture(&before, 2).unwrap();
+
+        let after = [header("openai"), header("zed")];
+        assert_eq!(restore(&previous, &after), Some(0));
+
+        let gone = [header("zed"), model("zed", "claude")];
+        assert_eq!(restore(&previous, &gone), None);
+    }
+}

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -50,6 +50,39 @@ enum ModelPickerEntry {
     Model(AgentModelInfo, bool),
 }
 
+enum PreviousSelection {
+    Header(SharedString),
+    Model {
+        id: AgentModelId,
+        section: Option<SharedString>,
+    },
+}
+
+/// The title of the section header (separator or group header) preceding `ix`.
+/// Favorited models appear both under "Favorite" and under their provider
+/// group; the section disambiguates which copy the cursor is on.
+fn section_title_of(entries: &[ModelPickerEntry], ix: usize) -> Option<&SharedString> {
+    entries
+        .iter()
+        .take(ix + 1)
+        .rev()
+        .find_map(|entry| match entry {
+            ModelPickerEntry::Separator(title) | ModelPickerEntry::GroupHeader { title, .. } => {
+                Some(title)
+            }
+            ModelPickerEntry::Model(_, _) => None,
+        })
+}
+
+fn position_of_section(entries: &[ModelPickerEntry], section: &SharedString) -> Option<usize> {
+    entries.iter().position(|entry| match entry {
+        ModelPickerEntry::Separator(title) | ModelPickerEntry::GroupHeader { title, .. } => {
+            title == section
+        }
+        ModelPickerEntry::Model(_, _) => false,
+    })
+}
+
 pub struct ModelPickerDelegate {
     selector: Rc<dyn AgentModelSelector>,
     fs: Arc<dyn Fs>,
@@ -262,7 +295,8 @@ impl PickerDelegate for ModelPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
         let favorites = self.favorites.clone();
-        let collapsed_groups = query.is_empty().then(|| self.collapsed_groups.clone());
+        let browsing = query.is_empty();
+        let collapsed_groups = browsing.then(|| self.collapsed_groups.clone());
 
         cx.spawn_in(window, async move |this, cx| {
             let filtered_models = match this
@@ -279,23 +313,65 @@ impl PickerDelegate for ModelPickerDelegate {
             };
 
             this.update_in(cx, |this, window, cx| {
+                // The cursor falls back to the selected model when the captured entry is gone.
+                let previous_selection = browsing
+                    .then(|| {
+                        let ix = this.delegate.selected_index;
+                        match this.delegate.filtered_entries.get(ix)? {
+                            ModelPickerEntry::GroupHeader { title, .. } => {
+                                Some(PreviousSelection::Header(title.clone()))
+                            }
+                            ModelPickerEntry::Model(model_info, _) => {
+                                Some(PreviousSelection::Model {
+                                    id: model_info.id.clone(),
+                                    section: section_title_of(&this.delegate.filtered_entries, ix)
+                                        .cloned(),
+                                })
+                            }
+                            ModelPickerEntry::Separator(_) => None,
+                        }
+                    })
+                    .flatten();
+
                 this.delegate.filtered_entries = info_list_to_picker_entries(
                     filtered_models,
                     &favorites,
                     collapsed_groups.as_ref(),
                 );
-                // Finds the currently selected model in the list
-                let new_index = this
-                    .delegate
-                    .selected_model
-                    .as_ref()
-                    .and_then(|selected| {
-                        this.delegate.filtered_entries.iter().position(|entry| {
-                            if let ModelPickerEntry::Model(model_info, _) = entry {
-                                model_info.id == selected.id
-                            } else {
-                                false
-                            }
+                let position_of_model = |entries: &[ModelPickerEntry], id: &AgentModelId| {
+                    entries.iter().position(|entry| {
+                        matches!(entry, ModelPickerEntry::Model(model_info, _) if model_info.id == *id)
+                    })
+                };
+                let entries = &this.delegate.filtered_entries;
+                // Restore order: the same model in the same section, the same
+                // model in another section (it moved, e.g. was unfavorited),
+                // the section's own header (the model is gone but its section
+                // remains, e.g. the group collapsed under the cursor), and
+                // finally the selected model.
+                let new_index = previous_selection
+                    .and_then(|previous| match previous {
+                        PreviousSelection::Header(section) => {
+                            position_of_section(entries, &section)
+                        }
+                        PreviousSelection::Model { id, section } => entries
+                            .iter()
+                            .enumerate()
+                            .find_map(|(ix, entry)| {
+                                (matches!(entry, ModelPickerEntry::Model(model_info, _) if model_info.id == id)
+                                    && section_title_of(entries, ix) == section.as_ref())
+                                .then_some(ix)
+                            })
+                            .or_else(|| position_of_model(entries, &id))
+                            .or_else(|| {
+                                section
+                                    .as_ref()
+                                    .and_then(|section| position_of_section(entries, section))
+                            }),
+                    })
+                    .or_else(|| {
+                        this.delegate.selected_model.as_ref().and_then(|selected| {
+                            position_of_model(&this.delegate.filtered_entries, &selected.id)
                         })
                     })
                     .unwrap_or(0);
@@ -711,7 +787,7 @@ mod tests {
                     vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
                 );
 
-                picker.delegate.set_selected_index(0, window, cx);
+                picker.delegate.set_selected_index(3, window, cx);
                 picker.delegate.confirm(false, window, cx);
             })
             .unwrap();
@@ -720,7 +796,21 @@ mod tests {
         window_handle
             .update(&mut cx, |picker, window, cx| {
                 let labels = get_entry_labels(&picker.delegate.filtered_entries);
-                assert_eq!(labels, vec!["alpha", "beta", "beta/one"]);
+                assert_eq!(labels, vec!["alpha", "alpha/one", "alpha/two", "beta"]);
+                // The cursor stays on the toggled header instead of jumping
+                // back to the active model.
+                assert_eq!(picker.delegate.selected_index, 3);
+
+                // A later unrelated refresh (e.g. from the model watch stream)
+                // must not move the cursor either.
+                picker.refresh(window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                assert_eq!(picker.delegate.selected_index, 3);
 
                 // Confirming the collapsed header again expands the group.
                 picker.delegate.confirm(false, window, cx);
@@ -735,6 +825,7 @@ mod tests {
                     labels,
                     vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
                 );
+                assert_eq!(picker.delegate.selected_index, 3);
 
                 // No model was selected by confirming headers.
                 assert!(model_selector.selected_models.borrow().is_empty());
@@ -742,9 +833,68 @@ mod tests {
             .unwrap();
     }
 
+    #[gpui::test]
+    fn refresh_keeps_cursor_on_group_copy_of_favorite(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        let model_selector = Rc::new(
+            TestModelSelector::with_list(create_model_list(vec![
+                ("alpha", vec!["alpha/one", "alpha/two"]),
+                ("beta", vec!["beta/one"]),
+            ]))
+            .with_favorites(vec!["alpha/two"]),
+        );
+
+        let window_handle = cx.add_window(move |window, cx| {
+            let selector: Rc<dyn AgentModelSelector> = model_selector;
+            acp_model_selector(selector, fs, cx.focus_handle(), window, cx)
+        });
+        cx.run_until_parked();
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                let labels = get_entry_labels(&picker.delegate.filtered_entries);
+                assert_eq!(
+                    labels,
+                    vec![
+                        "Favorite",
+                        "alpha/two",
+                        "alpha",
+                        "alpha/one",
+                        "alpha/two",
+                        "beta",
+                        "beta/one"
+                    ]
+                );
+
+                // Rest the cursor on the favorited model's copy inside its
+                // provider group, not the copy in the Favorite section.
+                picker.delegate.set_selected_index(4, window, cx);
+                picker.refresh(window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, _window, _cx| {
+                // The cursor stays on the group copy; matching by id alone
+                // would jump it to the Favorite section's copy at index 1.
+                assert_eq!(picker.delegate.selected_index, 4);
+            })
+            .unwrap();
+    }
+
     struct TestModelSelector {
         list: AgentModelList,
         models: Vec<AgentModelInfo>,
+        favorites: HashSet<AgentModelId>,
         selected_model: RefCell<AgentModelInfo>,
         selected_models: RefCell<Vec<AgentModelId>>,
     }
@@ -765,9 +915,15 @@ mod tests {
             Self {
                 list,
                 models,
+                favorites: HashSet::default(),
                 selected_model: RefCell::new(selected_model),
                 selected_models: RefCell::new(Vec::new()),
             }
+        }
+
+        fn with_favorites(mut self, favorites: Vec<&str>) -> Self {
+            self.favorites = create_favorites(favorites);
+            self
         }
 
         fn new() -> Self {
@@ -811,6 +967,10 @@ mod tests {
 
         fn selected_model(&self, _cx: &mut App) -> Task<Result<AgentModelInfo>> {
             Task::ready(Ok(self.selected_model.borrow().clone()))
+        }
+
+        fn favorite_model_ids(&self, _cx: &mut App) -> HashSet<AgentModelId> {
+            self.favorites.clone()
         }
     }
 

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -17,11 +17,12 @@ use gpui::{
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use settings::{Settings, SettingsStore, update_settings_file};
+use settings::{Settings, SettingsStore};
 use ui::{DocumentationAside, IntoElement, prelude::*};
 use util::ResultExt;
 use zed_actions::agent::OpenSettings;
 
+use crate::model_picker_sections::{self, PreviousSelection, SectionedEntry};
 use crate::ui::{
     ModelSelectorFooter, ModelSelectorHeader, ModelSelectorListItem, documentation_aside_side,
 };
@@ -50,37 +51,22 @@ enum ModelPickerEntry {
     Model(AgentModelInfo, bool),
 }
 
-enum PreviousSelection {
-    Header(SharedString),
-    Model {
-        id: AgentModelId,
-        section: Option<SharedString>,
-    },
-}
-
-/// The title of the section header (separator or group header) preceding `ix`.
-/// Favorited models appear both under "Favorite" and under their provider
-/// group; the section disambiguates which copy the cursor is on.
-fn section_title_of(entries: &[ModelPickerEntry], ix: usize) -> Option<&SharedString> {
-    entries
-        .iter()
-        .take(ix + 1)
-        .rev()
-        .find_map(|entry| match entry {
+impl SectionedEntry for ModelPickerEntry {
+    fn section_title(&self) -> Option<&SharedString> {
+        match self {
             ModelPickerEntry::Separator(title) | ModelPickerEntry::GroupHeader { title, .. } => {
                 Some(title)
             }
             ModelPickerEntry::Model(_, _) => None,
-        })
-}
-
-fn position_of_section(entries: &[ModelPickerEntry], section: &SharedString) -> Option<usize> {
-    entries.iter().position(|entry| match entry {
-        ModelPickerEntry::Separator(title) | ModelPickerEntry::GroupHeader { title, .. } => {
-            title == section
         }
-        ModelPickerEntry::Model(_, _) => false,
-    })
+    }
+
+    fn group_header_title(&self) -> Option<&SharedString> {
+        match self {
+            ModelPickerEntry::GroupHeader { title, .. } => Some(title),
+            ModelPickerEntry::Separator(_) | ModelPickerEntry::Model(_, _) => None,
+        }
+    }
 }
 
 pub struct ModelPickerDelegate {
@@ -177,19 +163,12 @@ impl ModelPickerDelegate {
     }
 
     fn toggle_group_collapsed(&mut self, group: SharedString, cx: &mut Context<Picker<Self>>) {
-        let collapsed = !self.collapsed_groups.contains(&group);
-        if collapsed {
-            self.collapsed_groups.insert(group.clone());
-        } else {
-            self.collapsed_groups.remove(&group);
-        }
-
-        update_settings_file(self.fs.clone(), cx, move |settings, _cx| {
-            settings
-                .agent
-                .get_or_insert_default()
-                .set_model_group_collapsed(&group, collapsed);
-        });
+        model_picker_sections::toggle_group_collapsed(
+            &mut self.collapsed_groups,
+            group,
+            self.fs.clone(),
+            cx,
+        );
     }
 
     pub fn active_model(&self) -> Option<&AgentModelInfo> {
@@ -316,20 +295,16 @@ impl PickerDelegate for ModelPickerDelegate {
                 // The cursor falls back to the selected model when the captured entry is gone.
                 let previous_selection = browsing
                     .then(|| {
-                        let ix = this.delegate.selected_index;
-                        match this.delegate.filtered_entries.get(ix)? {
-                            ModelPickerEntry::GroupHeader { title, .. } => {
-                                Some(PreviousSelection::Header(title.clone()))
-                            }
-                            ModelPickerEntry::Model(model_info, _) => {
-                                Some(PreviousSelection::Model {
-                                    id: model_info.id.clone(),
-                                    section: section_title_of(&this.delegate.filtered_entries, ix)
-                                        .cloned(),
-                                })
-                            }
-                            ModelPickerEntry::Separator(_) => None,
-                        }
+                        PreviousSelection::capture(
+                            &this.delegate.filtered_entries,
+                            this.delegate.selected_index,
+                            |entry| match entry {
+                                ModelPickerEntry::Model(model_info, _) => {
+                                    Some(model_info.id.clone())
+                                }
+                                _ => None,
+                            },
+                        )
                     })
                     .flatten();
 
@@ -338,40 +313,15 @@ impl PickerDelegate for ModelPickerDelegate {
                     &favorites,
                     collapsed_groups.as_ref(),
                 );
-                let position_of_model = |entries: &[ModelPickerEntry], id: &AgentModelId| {
-                    entries.iter().position(|entry| {
-                        matches!(entry, ModelPickerEntry::Model(model_info, _) if model_info.id == *id)
-                    })
+                let is_model = |entry: &ModelPickerEntry, id: &AgentModelId| {
+                    matches!(entry, ModelPickerEntry::Model(model_info, _) if model_info.id == *id)
                 };
                 let entries = &this.delegate.filtered_entries;
-                // Restore order: the same model in the same section, the same
-                // model in another section (it moved, e.g. was unfavorited),
-                // the section's own header (the model is gone but its section
-                // remains, e.g. the group collapsed under the cursor), and
-                // finally the selected model.
                 let new_index = previous_selection
-                    .and_then(|previous| match previous {
-                        PreviousSelection::Header(section) => {
-                            position_of_section(entries, &section)
-                        }
-                        PreviousSelection::Model { id, section } => entries
-                            .iter()
-                            .enumerate()
-                            .find_map(|(ix, entry)| {
-                                (matches!(entry, ModelPickerEntry::Model(model_info, _) if model_info.id == id)
-                                    && section_title_of(entries, ix) == section.as_ref())
-                                .then_some(ix)
-                            })
-                            .or_else(|| position_of_model(entries, &id))
-                            .or_else(|| {
-                                section
-                                    .as_ref()
-                                    .and_then(|section| position_of_section(entries, section))
-                            }),
-                    })
+                    .and_then(|previous| previous.restore(entries, is_model))
                     .or_else(|| {
                         this.delegate.selected_model.as_ref().and_then(|selected| {
-                            position_of_model(&this.delegate.filtered_entries, &selected.id)
+                            entries.iter().position(|entry| is_model(entry, &selected.id))
                         })
                     })
                     .unwrap_or(0);

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -4,8 +4,10 @@ use acp_thread::{
     AgentModelIcon, AgentModelId, AgentModelInfo, AgentModelList, AgentModelSelector,
 };
 
+use agent_settings::AgentSettings;
 use anyhow::Result;
 use collections::{HashSet, IndexMap};
+use fs::Fs;
 use futures::FutureExt;
 use fuzzy::{StringMatchCandidate, match_strings};
 use gpui::{
@@ -15,7 +17,7 @@ use gpui::{
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use settings::SettingsStore;
+use settings::{Settings, SettingsStore, update_settings_file};
 use ui::{DocumentationAside, IntoElement, prelude::*};
 use util::ResultExt;
 use zed_actions::agent::OpenSettings;
@@ -28,11 +30,12 @@ pub type ModelSelector = Picker<ModelPickerDelegate>;
 
 pub fn acp_model_selector(
     selector: Rc<dyn AgentModelSelector>,
+    fs: Arc<dyn Fs>,
     focus_handle: FocusHandle,
     window: &mut Window,
     cx: &mut Context<ModelSelector>,
 ) -> ModelSelector {
-    let delegate = ModelPickerDelegate::new(selector, focus_handle, window, cx);
+    let delegate = ModelPickerDelegate::new(selector, fs, focus_handle, window, cx);
     Picker::list(delegate, window, cx)
         .show_scrollbar(true)
         .initial_width(rems(20.))
@@ -40,17 +43,23 @@ pub fn acp_model_selector(
 
 enum ModelPickerEntry {
     Separator(SharedString),
+    GroupHeader {
+        title: SharedString,
+        collapsed: bool,
+    },
     Model(AgentModelInfo, bool),
 }
 
 pub struct ModelPickerDelegate {
     selector: Rc<dyn AgentModelSelector>,
+    fs: Arc<dyn Fs>,
     filtered_entries: Vec<ModelPickerEntry>,
     models: Option<AgentModelList>,
     selected_index: usize,
     selected_description: Option<(usize, SharedString)>,
     selected_model: Option<AgentModelInfo>,
     favorites: HashSet<AgentModelId>,
+    collapsed_groups: HashSet<SharedString>,
     _refresh_models_task: Task<()>,
     _settings_subscription: Subscription,
     focus_handle: FocusHandle,
@@ -59,6 +68,7 @@ pub struct ModelPickerDelegate {
 impl ModelPickerDelegate {
     fn new(
         selector: Rc<dyn AgentModelSelector>,
+        fs: Arc<dyn Fs>,
         focus_handle: FocusHandle,
         window: &mut Window,
         cx: &mut Context<ModelSelector>,
@@ -101,28 +111,52 @@ impl ModelPickerDelegate {
         let selector_for_subscription = selector.clone();
         let settings_subscription =
             cx.observe_global_in::<SettingsStore>(window, move |picker, window, cx| {
-                // Only refresh if the favorites actually changed to avoid redundant work
-                // when other settings are modified (e.g., user editing settings.json)
+                // Only refresh if the favorites or collapsed groups actually changed to avoid
+                // redundant work when other settings are modified (e.g., user editing settings.json)
                 let new_favorites = selector_for_subscription.favorite_model_ids(cx);
-                if new_favorites != picker.delegate.favorites {
+                let new_collapsed_groups =
+                    AgentSettings::get_global(cx).collapsed_model_group_names();
+                if new_favorites != picker.delegate.favorites
+                    || new_collapsed_groups != picker.delegate.collapsed_groups
+                {
                     picker.delegate.favorites = new_favorites;
+                    picker.delegate.collapsed_groups = new_collapsed_groups;
                     picker.refresh(window, cx);
                 }
             });
         let favorites = selector.favorite_model_ids(cx);
+        let collapsed_groups = AgentSettings::get_global(cx).collapsed_model_group_names();
 
         Self {
             selector,
+            fs,
             filtered_entries: Vec::new(),
             models: None,
             selected_model: None,
             selected_index: 0,
             selected_description: None,
             favorites,
+            collapsed_groups,
             _refresh_models_task: refresh_models_task,
             _settings_subscription: settings_subscription,
             focus_handle,
         }
+    }
+
+    fn toggle_group_collapsed(&mut self, group: SharedString, cx: &mut Context<Picker<Self>>) {
+        let collapsed = !self.collapsed_groups.contains(&group);
+        if collapsed {
+            self.collapsed_groups.insert(group.clone());
+        } else {
+            self.collapsed_groups.remove(&group);
+        }
+
+        update_settings_file(self.fs.clone(), cx, move |settings, _cx| {
+            settings
+                .agent
+                .get_or_insert_default()
+                .set_model_group_collapsed(&group, collapsed);
+        });
     }
 
     pub fn active_model(&self) -> Option<&AgentModelInfo> {
@@ -211,7 +245,9 @@ impl PickerDelegate for ModelPickerDelegate {
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
         match self.filtered_entries.get(ix) {
             Some(ModelPickerEntry::Model(_, _)) => true,
-            Some(ModelPickerEntry::Separator(_)) | None => false,
+            Some(ModelPickerEntry::Separator(_))
+            | Some(ModelPickerEntry::GroupHeader { .. })
+            | None => false,
         }
     }
 
@@ -226,6 +262,7 @@ impl PickerDelegate for ModelPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
         let favorites = self.favorites.clone();
+        let collapsed_groups = query.is_empty().then(|| self.collapsed_groups.clone());
 
         cx.spawn_in(window, async move |this, cx| {
             let filtered_models = match this
@@ -242,8 +279,11 @@ impl PickerDelegate for ModelPickerDelegate {
             };
 
             this.update_in(cx, |this, window, cx| {
-                this.delegate.filtered_entries =
-                    info_list_to_picker_entries(filtered_models, &favorites);
+                this.delegate.filtered_entries = info_list_to_picker_entries(
+                    filtered_models,
+                    &favorites,
+                    collapsed_groups.as_ref(),
+                );
                 // Finds the currently selected model in the list
                 let new_index = this
                     .delegate
@@ -298,6 +338,19 @@ impl PickerDelegate for ModelPickerDelegate {
         match self.filtered_entries.get(ix)? {
             ModelPickerEntry::Separator(title) => {
                 Some(ModelSelectorHeader::new(title, ix > 1).into_any_element())
+            }
+            ModelPickerEntry::GroupHeader { title, collapsed } => {
+                let group = title.clone();
+                let on_toggle = cx.listener(move |picker, _, window, cx| {
+                    picker.delegate.toggle_group_collapsed(group.clone(), cx);
+                    picker.refresh(window, cx);
+                });
+
+                Some(
+                    ModelSelectorHeader::new(title.clone(), ix > 1)
+                        .collapsible(ix, *collapsed, on_toggle)
+                        .into_any_element(),
+                )
             }
             ModelPickerEntry::Model(model_info, is_favorite) => {
                 let is_selected = Some(model_info) == self.selected_model.as_ref();
@@ -385,9 +438,12 @@ impl PickerDelegate for ModelPickerDelegate {
     }
 }
 
+/// `collapsed_groups` is `None` while searching, so that matches surface
+/// from every group and headers render as plain, non-collapsible separators.
 fn info_list_to_picker_entries(
     model_list: AgentModelList,
     favorites: &HashSet<AgentModelId>,
+    collapsed_groups: Option<&HashSet<SharedString>>,
 ) -> Vec<ModelPickerEntry> {
     let mut entries = Vec::new();
 
@@ -422,7 +478,21 @@ fn info_list_to_picker_entries(
         }
         AgentModelList::Grouped(index_map) => {
             for (group_name, models) in index_map {
-                entries.push(ModelPickerEntry::Separator(group_name.0));
+                match collapsed_groups {
+                    Some(collapsed_groups) => {
+                        let collapsed = collapsed_groups.contains(&group_name.0);
+                        entries.push(ModelPickerEntry::GroupHeader {
+                            title: group_name.0,
+                            collapsed,
+                        });
+                        if collapsed {
+                            continue;
+                        }
+                    }
+                    None => {
+                        entries.push(ModelPickerEntry::Separator(group_name.0));
+                    }
+                }
                 for model in models {
                     let is_favorite = favorites.contains(&model.id);
                     entries.push(ModelPickerEntry::Model(model, is_favorite));
@@ -570,6 +640,10 @@ mod tests {
             .collect()
     }
 
+    fn no_collapsed_groups() -> HashSet<SharedString> {
+        HashSet::default()
+    }
+
     #[gpui::test]
     fn confirming_model_selects_model(cx: &mut TestAppContext) {
         cx.update(|cx| {
@@ -579,13 +653,14 @@ mod tests {
             editor::init(cx);
         });
 
+        let fs = fs::FakeFs::new(cx.executor());
         let model_selector = Rc::new(TestModelSelector::new());
 
         let window_handle = cx.add_window({
             let model_selector = model_selector.clone();
             move |window, cx| {
                 let selector: Rc<dyn AgentModelSelector> = model_selector;
-                acp_model_selector(selector, cx.focus_handle(), window, cx)
+                acp_model_selector(selector, fs, cx.focus_handle(), window, cx)
             }
         });
         cx.run_until_parked();
@@ -665,6 +740,7 @@ mod tests {
             .map(|entry| match entry {
                 ModelPickerEntry::Model(info, _) => info.id.as_ref(),
                 ModelPickerEntry::Separator(s) => &s,
+                ModelPickerEntry::GroupHeader { title, .. } => &title,
             })
             .collect()
     }
@@ -708,7 +784,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
 
         assert!(matches!(
             entries.first(),
@@ -724,12 +800,74 @@ mod tests {
         let models = create_model_list(vec![("zed", vec!["zed/claude", "zed/gemini"])]);
         let favorites = create_favorites(vec![]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
 
         assert!(matches!(
             entries.first(),
-            Some(ModelPickerEntry::Separator(s)) if s == "zed"
+            Some(ModelPickerEntry::GroupHeader { title, .. }) if title == "zed"
         ));
+    }
+
+    #[gpui::test]
+    fn test_collapsed_group_hides_its_models(_cx: &mut TestAppContext) {
+        let models = create_model_list(vec![
+            ("openrouter", vec!["openrouter/a", "openrouter/b"]),
+            ("zed", vec!["zed/claude"]),
+        ]);
+        let favorites = create_favorites(vec![]);
+        let collapsed_groups: HashSet<SharedString> =
+            [SharedString::from("openrouter")].into_iter().collect();
+
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&collapsed_groups));
+        let labels = get_entry_labels(&entries);
+
+        // The collapsed group keeps its header but hides its models.
+        assert_eq!(labels, vec!["openrouter", "zed", "zed/claude"]);
+        assert!(matches!(
+            entries.first(),
+            Some(ModelPickerEntry::GroupHeader {
+                collapsed: true,
+                ..
+            })
+        ));
+        assert!(matches!(
+            entries.get(1),
+            Some(ModelPickerEntry::GroupHeader {
+                collapsed: false,
+                ..
+            })
+        ));
+    }
+
+    #[gpui::test]
+    fn test_search_entries_ignore_collapsed_groups(_cx: &mut TestAppContext) {
+        let models = create_model_list(vec![
+            ("openrouter", vec!["openrouter/a", "openrouter/b"]),
+            ("zed", vec!["zed/claude"]),
+        ]);
+        let favorites = create_favorites(vec![]);
+
+        // While searching, entries are built with no collapsed set, so models
+        // surface from every group and headers are plain separators.
+        let entries = info_list_to_picker_entries(models, &favorites, None);
+
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !matches!(entry, ModelPickerEntry::GroupHeader { .. }))
+        );
+
+        let labels = get_entry_labels(&entries);
+        assert_eq!(
+            labels,
+            vec![
+                "openrouter",
+                "openrouter/a",
+                "openrouter/b",
+                "zed",
+                "zed/claude"
+            ]
+        );
     }
 
     #[gpui::test]
@@ -740,7 +878,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/claude"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
 
         for entry in &entries {
             if let ModelPickerEntry::Model(info, is_favorite) = entry {
@@ -761,7 +899,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini", "openai/gpt-5"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
         let model_ids = get_entry_model_ids(&entries);
 
         assert_eq!(model_ids[0], "zed/gemini");
@@ -782,7 +920,7 @@ mod tests {
 
         let favorites = create_favorites(vec!["zed/claude"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
         let labels = get_entry_labels(&entries);
 
         assert_eq!(
@@ -828,7 +966,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
 
         assert!(matches!(
             entries.first(),
@@ -880,7 +1018,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["favorite-model"]);
 
-        let entries = info_list_to_picker_entries(models, &favorites);
+        let entries = info_list_to_picker_entries(models, &favorites, Some(&no_collapsed_groups()));
 
         for entry in &entries {
             if let ModelPickerEntry::Model(info, is_favorite) = entry {

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -244,10 +244,10 @@ impl PickerDelegate for ModelPickerDelegate {
 
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
         match self.filtered_entries.get(ix) {
-            Some(ModelPickerEntry::Model(_, _)) => true,
-            Some(ModelPickerEntry::Separator(_))
-            | Some(ModelPickerEntry::GroupHeader { .. })
-            | None => false,
+            Some(ModelPickerEntry::Model(_, _)) | Some(ModelPickerEntry::GroupHeader { .. }) => {
+                true
+            }
+            Some(ModelPickerEntry::Separator(_)) | None => false,
         }
     }
 
@@ -307,18 +307,25 @@ impl PickerDelegate for ModelPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
-        if let Some(ModelPickerEntry::Model(model_info, _)) =
-            self.filtered_entries.get(self.selected_index)
-            && model_info.disabled.is_none()
-        {
-            self.selector
-                .select_model(model_info.id.clone(), cx)
-                .detach_and_log_err(cx);
-            self.selected_model = Some(model_info.clone());
-            let current_index = self.selected_index;
-            self.set_selected_index(current_index, window, cx);
+        match self.filtered_entries.get(self.selected_index) {
+            Some(ModelPickerEntry::Model(model_info, _)) if model_info.disabled.is_none() => {
+                self.selector
+                    .select_model(model_info.id.clone(), cx)
+                    .detach_and_log_err(cx);
+                self.selected_model = Some(model_info.clone());
+                let current_index = self.selected_index;
+                self.set_selected_index(current_index, window, cx);
 
-            cx.emit(DismissEvent);
+                cx.emit(DismissEvent);
+            }
+            Some(ModelPickerEntry::GroupHeader { title, .. }) => {
+                let group = title.clone();
+                self.toggle_group_collapsed(group, cx);
+                cx.defer_in(window, |picker, window, cx| {
+                    picker.refresh(window, cx);
+                });
+            }
+            _ => {}
         }
     }
 
@@ -339,19 +346,11 @@ impl PickerDelegate for ModelPickerDelegate {
             ModelPickerEntry::Separator(title) => {
                 Some(ModelSelectorHeader::new(title, ix > 1).into_any_element())
             }
-            ModelPickerEntry::GroupHeader { title, collapsed } => {
-                let group = title.clone();
-                let on_toggle = cx.listener(move |picker, _, window, cx| {
-                    picker.delegate.toggle_group_collapsed(group.clone(), cx);
-                    picker.refresh(window, cx);
-                });
-
-                Some(
-                    ModelSelectorHeader::new(title.clone(), ix > 1)
-                        .collapsible(ix, *collapsed, on_toggle)
-                        .into_any_element(),
-                )
-            }
+            ModelPickerEntry::GroupHeader { title, collapsed } => Some(
+                ModelSelectorHeader::new(title.clone(), ix > 1)
+                    .collapsible(ix, *collapsed, selected)
+                    .into_any_element(),
+            ),
             ModelPickerEntry::Model(model_info, is_favorite) => {
                 let is_selected = Some(model_info) == self.selected_model.as_ref();
 
@@ -679,13 +678,98 @@ mod tests {
         );
     }
 
+    #[gpui::test]
+    fn confirming_group_header_toggles_collapse(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        let model_selector = Rc::new(TestModelSelector::with_list(create_model_list(vec![
+            ("alpha", vec!["alpha/one", "alpha/two"]),
+            ("beta", vec!["beta/one"]),
+        ])));
+
+        let window_handle = cx.add_window({
+            let model_selector = model_selector.clone();
+            move |window, cx| {
+                let selector: Rc<dyn AgentModelSelector> = model_selector;
+                acp_model_selector(selector, fs, cx.focus_handle(), window, cx)
+            }
+        });
+        cx.run_until_parked();
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                let labels = get_entry_labels(&picker.delegate.filtered_entries);
+                assert_eq!(
+                    labels,
+                    vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
+                );
+
+                picker.delegate.set_selected_index(0, window, cx);
+                picker.delegate.confirm(false, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, window, cx| {
+                let labels = get_entry_labels(&picker.delegate.filtered_entries);
+                assert_eq!(labels, vec!["alpha", "beta", "beta/one"]);
+
+                // Confirming the collapsed header again expands the group.
+                picker.delegate.confirm(false, window, cx);
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        window_handle
+            .update(&mut cx, |picker, _window, _cx| {
+                let labels = get_entry_labels(&picker.delegate.filtered_entries);
+                assert_eq!(
+                    labels,
+                    vec!["alpha", "alpha/one", "alpha/two", "beta", "beta/one"]
+                );
+
+                // No model was selected by confirming headers.
+                assert!(model_selector.selected_models.borrow().is_empty());
+            })
+            .unwrap();
+    }
+
     struct TestModelSelector {
+        list: AgentModelList,
         models: Vec<AgentModelInfo>,
         selected_model: RefCell<AgentModelInfo>,
         selected_models: RefCell<Vec<AgentModelId>>,
     }
 
     impl TestModelSelector {
+        fn with_list(list: AgentModelList) -> Self {
+            let models = match &list {
+                AgentModelList::Flat(models) => models.clone(),
+                AgentModelList::Grouped(groups) => {
+                    groups.values().flatten().cloned().collect::<Vec<_>>()
+                }
+            };
+            let selected_model = models
+                .first()
+                .expect("test model list must not be empty")
+                .clone();
+
+            Self {
+                list,
+                models,
+                selected_model: RefCell::new(selected_model),
+                selected_models: RefCell::new(Vec::new()),
+            }
+        }
+
         fn new() -> Self {
             let models = vec![
                 AgentModelInfo {
@@ -708,17 +792,13 @@ mod tests {
                 },
             ];
 
-            Self {
-                selected_model: RefCell::new(models[0].clone()),
-                models,
-                selected_models: RefCell::new(Vec::new()),
-            }
+            Self::with_list(AgentModelList::Flat(models))
         }
     }
 
     impl AgentModelSelector for TestModelSelector {
         fn list_models(&self, _cx: &mut App) -> Task<Result<AgentModelList>> {
-            Task::ready(Ok(AgentModelList::Flat(self.models.clone())))
+            Task::ready(Ok(self.list.clone()))
         }
 
         fn select_model(&self, model_id: AgentModelId, _cx: &mut App) -> Task<Result<()>> {

--- a/crates/agent_ui/src/model_selector_popover.rs
+++ b/crates/agent_ui/src/model_selector_popover.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
+use std::sync::Arc;
 
 use acp_thread::{AgentModelIcon, AgentModelInfo, AgentModelSelector};
+use fs::Fs;
 use gpui::{Entity, FocusHandle};
 use picker::popover_menu::PickerPopoverMenu;
 use ui::{PopoverMenuHandle, Tooltip, prelude::*};
@@ -16,6 +18,7 @@ pub struct ModelSelectorPopover {
 impl ModelSelectorPopover {
     pub(crate) fn new(
         selector: Rc<dyn AgentModelSelector>,
+        fs: Arc<dyn Fs>,
         menu_handle: PopoverMenuHandle<ModelSelector>,
         focus_handle: FocusHandle,
         window: &mut Window,
@@ -23,7 +26,7 @@ impl ModelSelectorPopover {
     ) -> Self {
         Self {
             selector: cx
-                .new(move |cx| acp_model_selector(selector, focus_handle.clone(), window, cx)),
+                .new(move |cx| acp_model_selector(selector, fs, focus_handle.clone(), window, cx)),
             menu_handle,
         }
     }

--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -20,7 +20,7 @@ pub struct ModelSelectorHeader {
 struct CollapsibleHeader {
     index: usize,
     collapsed: bool,
-    on_toggle: Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>,
+    focused: bool,
 }
 
 impl ModelSelectorHeader {
@@ -32,16 +32,11 @@ impl ModelSelectorHeader {
         }
     }
 
-    pub fn collapsible(
-        mut self,
-        index: usize,
-        collapsed: bool,
-        on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
-    ) -> Self {
+    pub fn collapsible(mut self, index: usize, collapsed: bool, focused: bool) -> Self {
         self.collapsible = Some(CollapsibleHeader {
             index,
             collapsed,
-            on_toggle: Box::new(on_toggle),
+            focused,
         });
         self
     }
@@ -70,8 +65,11 @@ impl RenderOnce for ModelSelectorHeader {
                         } else {
                             IconName::ChevronDown
                         };
-                        let on_toggle = collapsible.on_toggle;
 
+                        // Click handling is left to the picker's own per-entry
+                        // click handler, which routes through `confirm` — the
+                        // same path keyboard toggling uses. A handler here
+                        // would fire in addition to it and toggle twice.
                         this.child(
                             h_flex()
                                 .id(("model-selector-group-header", collapsible.index))
@@ -79,6 +77,10 @@ impl RenderOnce for ModelSelectorHeader {
                                 .gap_0p5()
                                 .pr_2()
                                 .justify_between()
+                                .rounded_sm()
+                                .when(collapsible.focused, |this| {
+                                    this.bg(cx.theme().colors().ghost_element_selected)
+                                })
                                 .cursor_pointer()
                                 .child(label)
                                 .child(
@@ -90,8 +92,7 @@ impl RenderOnce for ModelSelectorHeader {
                                     "Expand Section"
                                 } else {
                                     "Collapse Section"
-                                }))
-                                .on_click(move |event, window, cx| on_toggle(event, window, cx)),
+                                })),
                         )
                     }
                     None => this.child(label),

--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -14,6 +14,13 @@ enum ModelIcon {
 pub struct ModelSelectorHeader {
     title: SharedString,
     has_border: bool,
+    collapsible: Option<CollapsibleHeader>,
+}
+
+struct CollapsibleHeader {
+    index: usize,
+    collapsed: bool,
+    on_toggle: Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>,
 }
 
 impl ModelSelectorHeader {
@@ -21,7 +28,22 @@ impl ModelSelectorHeader {
         Self {
             title: title.into(),
             has_border,
+            collapsible: None,
         }
+    }
+
+    pub fn collapsible(
+        mut self,
+        index: usize,
+        collapsed: bool,
+        on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.collapsible = Some(CollapsibleHeader {
+            index,
+            collapsed,
+            on_toggle: Box::new(on_toggle),
+        });
+        self
     }
 }
 
@@ -36,11 +58,45 @@ impl RenderOnce for ModelSelectorHeader {
                     .border_t_1()
                     .border_color(cx.theme().colors().border_variant)
             })
-            .child(
-                Label::new(self.title)
+            .map(|this| {
+                let label = Label::new(self.title)
                     .size(LabelSize::XSmall)
-                    .color(Color::Muted),
-            )
+                    .color(Color::Muted);
+
+                match self.collapsible {
+                    Some(collapsible) => {
+                        let chevron = if collapsible.collapsed {
+                            IconName::ChevronRight
+                        } else {
+                            IconName::ChevronDown
+                        };
+                        let on_toggle = collapsible.on_toggle;
+
+                        this.child(
+                            h_flex()
+                                .id(("model-selector-group-header", collapsible.index))
+                                .w_full()
+                                .gap_0p5()
+                                .pr_2()
+                                .justify_between()
+                                .cursor_pointer()
+                                .child(label)
+                                .child(
+                                    Icon::new(chevron)
+                                        .size(IconSize::XSmall)
+                                        .color(Color::Muted),
+                                )
+                                .tooltip(Tooltip::text(if collapsible.collapsed {
+                                    "Expand Section"
+                                } else {
+                                    "Collapse Section"
+                                }))
+                                .on_click(move |event, window, cx| on_toggle(event, window, cx)),
+                        )
+                    }
+                    None => this.child(label),
+                }
+            })
     }
 }
 

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -240,6 +240,9 @@ pub struct AgentSettingsContent {
     /// Favorite models to show at the top of the model selector.
     #[serde(default)]
     pub favorite_models: Vec<LanguageModelSelection>,
+    /// Provider groups that are collapsed in the model selector.
+    #[serde(default)]
+    pub collapsed_model_groups: Vec<String>,
     /// Model to use for the inline assistant. Defaults to default_model when not specified.
     pub inline_assistant_model: Option<LanguageModelSelection>,
     /// Model to use for the inline assistant when streaming tools are enabled.
@@ -401,6 +404,16 @@ impl AgentSettingsContent {
     pub fn remove_favorite_model(&mut self, model: &LanguageModelSelection) {
         self.favorite_models
             .retain(|m| !(m.provider == model.provider && m.model == model.model));
+    }
+
+    pub fn set_model_group_collapsed(&mut self, group: &str, collapsed: bool) {
+        if collapsed {
+            if !self.collapsed_model_groups.iter().any(|g| g == group) {
+                self.collapsed_model_groups.push(group.to_string());
+            }
+        } else {
+            self.collapsed_model_groups.retain(|g| g != group);
+        }
     }
 
     pub fn update_favorite_model<F>(&mut self, provider: &str, model: &str, f: F)

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -171,6 +171,10 @@ You can mark specific models as favorites either through the model selector, by 
 
 Cycle through your favorites with {#kb agent::CycleFavoriteModels} without opening the model selector.
 
+### Collapsing Provider Groups
+
+Models in the model selector are grouped by provider, and you can collapse or expand a group by clicking its header, or by moving the selection to the header and pressing {#kb menu::Confirm}. Collapsed groups persist across restarts via the `agent.collapsed_model_groups` settings key, and searching always surfaces matches from every group, including collapsed ones.
+
 ## Using Tools and Profiles {#using-tools}
 
 The Agent Panel supports tool calling, which enables agentic editing. Zed includes [built-in tools](./tools.md) for searching your codebase, editing files, running terminal commands, and more.


### PR DESCRIPTION
Provider group headers in the Agent Panel and inline assistant model pickers can now be clicked to collapse/expand their models, with a chevron indicator. Collapsed state persists via the new `agent.collapsed_model_groups` setting. Search results ignore collapse state so all models remain findable.

# Objective

- Allow collapsing model providers. Provider aggregators like OpenRouter have many models, of which few will be used by the user, so hiding most models unless searching or favorited will make the UX better. See #61695 

## Solution

- Model provider headers are now clickable, to collapse the group and hide its models. Favorited models or models that match a search still appear.
- They are also selectable via keyboard. Selecting now also keeps the selection cursor at the same location, instead of resetting to index 0.
  - Intentional side effect: cursor position is now stable across any list refresh, for example if a provider finishes loading while you're arrowing through models, it doesn't snap to index 0.
- Cursor-restoration policy is shared by both pickers via a new `model_picker_sections` module, so the two delegates don't drift.
- Added a "Collapsing Provider Groups" section to the Agent Panel docs.

## Testing

- Tested by manually interacting with UI (macOS 26).
- Also added gpui unit tests covering collapse toggling via click/keyboard confirm, cursor restoration across refreshes and external settings changes, and the restore-priority ladder in `model_picker_sections`.
- Test it yourself by simply having a provider set up in the model picker

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>


https://github.com/user-attachments/assets/73b1cfc1-a98f-423f-8fc1-eb719474337f



</details>

---

Release Notes:

- Added provider collapse/expand functionality in the model picker