### PR TITLE
edit_prediction: Add inline-only edit prediction mode

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -2790,7 +2790,7 @@ impl EditPredictionStore {
         let related_files = self.context_for_project(&project, cx);
         let allow_jump = is_cloud_zeta && cx.has_flag::<EditPredictionJumpsFeatureFlag>();
         let mode = match all_language_settings(snapshot.file(), cx).edit_predictions_mode() {
-            EditPredictionsMode::Eager => PredictEditsMode::Eager,
+            EditPredictionsMode::Eager | EditPredictionsMode::InlineOnly => PredictEditsMode::Eager,
             EditPredictionsMode::Subtle => PredictEditsMode::Subtle,
         };
 

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -778,6 +778,7 @@ impl EditPredictionButton {
         let current_mode = settings.edit_predictions_mode();
         let subtle_mode = matches!(current_mode, EditPredictionsMode::Subtle);
         let eager_mode = matches!(current_mode, EditPredictionsMode::Eager);
+        let inline_only_mode = matches!(current_mode, EditPredictionsMode::InlineOnly);
 
         menu = menu
                 .separator()
@@ -815,6 +816,24 @@ impl EditPredictionButton {
                                     value = "subtle",
                                 );
                                 toggle_edit_prediction_mode(fs.clone(), EditPredictionsMode::Subtle, cx)
+                            }
+                        }),
+                )
+                .item(
+                    ContextMenuEntry::new("Inline Only")
+                        .toggleable(IconPosition::Start, inline_only_mode)
+                        .documentation_aside(DocumentationSide::Left, move |_| {
+                            Label::new("Only show ghost text at the cursor, accepted one line at a time. Predictions that need a diff popover are skipped.").into_any_element()
+                        })
+                        .handler({
+                            let fs = fs.clone();
+                            move |_, cx| {
+                                telemetry::event!(
+                                    "Edit Prediction Setting Changed",
+                                    setting = "mode",
+                                    value = "inline_only",
+                                );
+                                toggle_edit_prediction_mode(fs.clone(), EditPredictionsMode::InlineOnly, cx)
                             }
                         }),
                 );

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -13,6 +13,7 @@ pub fn make_suggestion_styles(cx: &App) -> EditPredictionStyles {
     }
 }
 
+#[derive(PartialEq)]
 pub(super) enum EditDisplayMode {
     TabAccept,
     DiffPopover,
@@ -586,7 +587,22 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.accept_partial_edit_prediction(EditPredictionGranularity::Full, window, cx);
+        // InlineOnly reveals a multi-line prediction a line at a time, so accepting
+        // takes the next line rather than the whole thing.
+        let granularity = if self.edit_predictions_mode_at_cursor(cx)
+            == Some(EditPredictionsMode::InlineOnly)
+        {
+            EditPredictionGranularity::Line
+        } else {
+            EditPredictionGranularity::Full
+        };
+        self.accept_partial_edit_prediction(granularity, window, cx);
+    }
+
+    fn edit_predictions_mode_at_cursor(&self, cx: &App) -> Option<EditPredictionsMode> {
+        let cursor = self.selections.newest_anchor().head();
+        let (buffer, _) = self.buffer.read(cx).text_anchor_for_position(cursor, cx)?;
+        Some(all_language_settings(buffer.read(cx).file(), cx).edit_predictions_mode())
     }
 
     pub fn has_active_edit_prediction(&self) -> bool {
@@ -985,6 +1001,15 @@ impl Editor {
             } else {
                 EditDisplayMode::DiffPopover
             };
+
+            // InlineOnly renders nothing but ghost text, and a replacement cannot be
+            // expressed as ghost text, so those predictions are skipped entirely.
+            if display_mode == EditDisplayMode::DiffPopover
+                && all_language_settings(buffer.read(cx).file(), cx).edit_predictions_mode()
+                    == EditPredictionsMode::InlineOnly
+            {
+                return None;
+            }
 
             let report_shown = match display_mode {
                 EditDisplayMode::DiffPopover | EditDisplayMode::Inline => {

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -1494,6 +1494,113 @@ async fn test_discard_clears_delegate_completion(cx: &mut gpui::TestAppContext) 
     });
 }
 
+async fn inline_only_test_context(
+    cx: &mut gpui::TestAppContext,
+) -> (EditorTestContext, Entity<FakeEditPredictionDelegate>) {
+    init_test(cx, |_| {});
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode =
+            Some(EditPredictionsMode::InlineOnly);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    (cx, provider)
+}
+
+#[gpui::test]
+async fn test_inline_only_accepts_one_line_per_tab(cx: &mut gpui::TestAppContext) {
+    let (mut cx, provider) = inline_only_test_context(cx).await;
+    cx.set_state("fn main() {\nˇ\n}");
+
+    propose_edits(
+        &provider,
+        vec![(12..12, "one();\ntwo();\nthree();")],
+        &mut cx,
+    );
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    // The whole suggestion is offered as ghost text, not chopped into pieces.
+    assert_editor_active_edit_completion(&mut cx, |_, edits| {
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].1.as_ref(), "one();\ntwo();\nthree();");
+    });
+
+    // Accepting takes only the first line of it.
+    accept_completion(&mut cx);
+    cx.run_until_parked();
+    cx.assert_editor_state("fn main() {\none();\nˇ\n}");
+}
+
+#[gpui::test]
+async fn test_inline_only_requests_next_prediction_after_accepting(cx: &mut gpui::TestAppContext) {
+    let (mut cx, provider) = inline_only_test_context(cx).await;
+    cx.set_state("fn main() {\nˇ\n}");
+
+    propose_edits(
+        &provider,
+        vec![(12..12, "one();\ntwo();\nthree();")],
+        &mut cx,
+    );
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    let refreshes_before = provider.read_with(&cx.cx, |provider, _| {
+        provider.refresh_count.load(atomic::Ordering::SeqCst)
+    });
+
+    accept_completion(&mut cx);
+    cx.run_until_parked();
+
+    let refreshes_after = provider.read_with(&cx.cx, |provider, _| {
+        provider.refresh_count.load(atomic::Ordering::SeqCst)
+    });
+    assert!(
+        refreshes_after > refreshes_before,
+        "provider was never asked what comes after the accepted line \
+         (before: {refreshes_before}, after: {refreshes_after})"
+    );
+}
+
+#[gpui::test]
+async fn test_inline_only_skips_predictions_needing_a_diff_popover(cx: &mut gpui::TestAppContext) {
+    let (mut cx, provider) = inline_only_test_context(cx).await;
+    cx.set_state("let pi = ˇ\"foo\";");
+
+    // A replacement cannot be drawn as ghost text, so InlineOnly declines it.
+    propose_edits(&provider, vec![(9..14, "3.14159")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.active_edit_prediction.is_none(),
+            "replacement prediction should be skipped in InlineOnly mode"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_eager_mode_still_accepts_whole_prediction(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("fn main() {\nˇ\n}");
+
+    propose_edits(
+        &provider,
+        vec![(12..12, "one();\ntwo();\nthree();")],
+        &mut cx,
+    );
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    accept_completion(&mut cx);
+    cx.run_until_parked();
+    cx.assert_editor_state("fn main() {\none();\ntwo();\nthree();ˇ\n}");
+}
+
+
 fn accept_completion(cx: &mut EditorTestContext) {
     cx.update_editor(|editor, window, cx| {
         editor.accept_edit_prediction(&crate::AcceptEditPrediction, window, cx)
@@ -1748,6 +1855,7 @@ impl CompletionProvider for FakeCompletionMenuProvider {
 pub struct FakeEditPredictionDelegate {
     pub completion: Option<edit_prediction_types::EditPrediction>,
     pub refresh_count: Arc<AtomicUsize>,
+    pub accept_count: Arc<AtomicUsize>,
 }
 
 impl FakeEditPredictionDelegate {
@@ -1804,7 +1912,11 @@ impl EditPredictionDelegate for FakeEditPredictionDelegate {
         self.refresh_count.fetch_add(1, atomic::Ordering::SeqCst);
     }
 
-    fn accept(&mut self, _cx: &mut gpui::Context<Self>) {}
+    fn accept(&mut self, _cx: &mut gpui::Context<Self>) {
+        self.accept_count.fetch_add(1, atomic::Ordering::SeqCst);
+        // Mirrors the real delegates, which take their current prediction on accept.
+        self.completion.take();
+    }
 
     fn discard(
         &mut self,

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -336,6 +336,10 @@ pub enum EditPredictionsMode {
     #[default]
     #[serde(alias = "eager_preview")]
     Eager,
+    /// Only display predictions that can be shown as ghost text at the cursor,
+    /// and accept them one line at a time. Predictions that would need a diff
+    /// popover are skipped.
+    InlineOnly,
 }
 
 /// Controls the soft-wrapping behavior in the editor.

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -39,16 +39,17 @@ The free plan includes 2,000 Zeta predictions per month. The [Pro plan](../accou
 
 ### Switching Modes {#switching-modes}
 
-Edit Prediction has two display modes:
+Edit Prediction has three display modes:
 
 1. `eager` (default): predictions are displayed inline as long as they don't conflict with language server completions
 2. `subtle`: predictions only appear inline when holding a modifier key (`alt` by default)
+3. `inline_only`: only predictions that can be drawn as ghost text at the cursor are shown, and accepting takes one line at a time rather than the whole prediction. Predictions that would require a diff popover are skipped.
 
 Toggle between them via the `mode` key:
 
 ```json [settings]
 "edit_predictions": {
-  "mode": "eager" // or "subtle"
+  "mode": "eager" // or "subtle", or "inline_only"
 },
 ```
 


### PR DESCRIPTION
The Issue: https://github.com/zed-industries/zed/issues/60091


# Objective

Edit predictions currently have two modes, `eager` and `subtle`, and both accept
the entire prediction on a single `tab`. When a prediction spans several lines,
that means taking all of it or none of it, and multi-line predictions that touch
existing code are surfaced as a diff popover rather than inline.


## Solution

Adds `inline_only` as a third value for the `edit_predictions.mode` setting.

<img width="500" height="250" alt="Screenshot 2026-07-28 at 11 21 40 AM" src="https://github.com/user-attachments/assets/c33cb004-3784-4eee-afa9-59a7324ddc9c" />



Two behavior changes, both scoped to this mode:

- Predictions that would render as a diff popover are skipped. A replacement
  can't be expressed as ghost text at the cursor, so rather than falling back to
  a popover, those predictions are not shown at all.
- `tab` accepts the next line rather than the whole prediction, by routing
  through the existing `EditPredictionGranularity::Line` path already used by
  `editor::AcceptNextLineEditPrediction` (`alt-j` / `ctrl-cmd-down`).

Reusing the existing line-granularity path means no new state is added to
`Editor` — the net diff to `editor.rs` is zero. The mode is also added to the
edit prediction status bar menu, and requests are issued the same way as in
`eager` mode.

## Testing

Automated: 888 editor tests pass, including four new tests covering this mode
(one line per accept, a follow-up prediction being requested after each accept,
diff-popover predictions being skipped) and a regression test confirming `eager`
still accepts the whole prediction in one go. `./script/clippy` is clean.

Manual: tested on macOS against Zed's own prediction provider while writing
Python. Not tested on Linux or Windows, and not with Copilot as the provider —
worth a look from someone who uses it.

For reviewers: set `"edit_predictions": { "mode": "inline_only" }` or pick
**Inline Only** from the edit prediction status bar menu, then trigger a
multi-line prediction. `tab` should insert one line at a time, with a fresh
suggestion following each accept.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="500" height="250" alt="Screenshot 2026-07-28 at 10 40 51 AM" src="https://github.com/user-attachments/assets/60680fc8-0c1f-43c4-b0e6-4211a106e98e" />


<img width="500" height="250" alt="Screenshot 2026-07-28 at 10 41 00 AM" src="https://github.com/user-attachments/assets/01bbe267-e5da-4e45-9288-dd9ab85a8abd" />


---

Release Notes:

- Added `inline_only` edit prediction mode, which shows only ghost-text predictions and accepts them one line at a time
