### PR TITLE
Release decoded images for offscreen agent conversation entries

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -365,6 +365,12 @@ impl AssistantMessageChunk {
         }
     }
 
+    pub fn block(&self) -> &ContentBlock {
+        match self {
+            Self::Message { block, .. } | Self::Thought { block, .. } => block,
+        }
+    }
+
     fn to_markdown(&self, cx: &App) -> String {
         match self {
             Self::Message { block, .. } => block.to_markdown(cx).to_string(),
@@ -781,6 +787,34 @@ pub struct ContextCompactionUpdate {
 }
 
 impl AgentThreadEntry {
+    /// Every image this entry renders. Decoding an image caches its bitmap in
+    /// GPUI's asset cache, which is keyed by the `Arc<Image>` and only ever
+    /// grows, so callers that know an entry is off screen use this to release
+    /// the decoded bitmaps (see [`AcpThread::release_offscreen_images`]).
+    pub fn images(&self) -> impl Iterator<Item = &Arc<gpui::Image>> {
+        let blocks: Box<dyn Iterator<Item = Option<&Arc<gpui::Image>>>> = match self {
+            Self::UserMessage(message) => {
+                Box::new(std::iter::once(message.content.image().map(|(image, _)| image)))
+            }
+            Self::AssistantMessage(message) => Box::new(
+                message
+                    .chunks
+                    .iter()
+                    .map(|chunk| chunk.block().image().map(|(image, _)| image)),
+            ),
+            Self::ToolCall(tool_call) => Box::new(
+                tool_call
+                    .content
+                    .iter()
+                    .map(|content| content.image().map(|(image, _)| image)),
+            ),
+            Self::Elicitation(_) | Self::CompletedPlan(_) | Self::ContextCompaction(_) => {
+                Box::new(std::iter::empty())
+            }
+        };
+        blocks.flatten()
+    }
+
     pub fn is_indented(&self) -> bool {
         match self {
             Self::UserMessage(message) => message.indented,
@@ -2387,6 +2421,23 @@ impl AcpThread {
 
     pub fn entries(&self) -> &[AgentThreadEntry] {
         &self.entries
+    }
+
+    /// Drops the decoded bitmaps of every image outside `keep`.
+    ///
+    /// GPUI caches a decoded image per `Arc<Image>` and never evicts it, so in
+    /// a long conversation the bitmaps of every image ever scrolled past stay
+    /// resident -- a 705x1567 screenshot costs ~4.4MB decoded regardless of the
+    /// ~100KB it takes as PNG. Scrolling back re-decodes off the main thread.
+    pub fn release_offscreen_images(&self, keep: Range<usize>, cx: &mut App) {
+        for (index, entry) in self.entries.iter().enumerate() {
+            if keep.contains(&index) {
+                continue;
+            }
+            for image in entry.images() {
+                gpui::ImageSource::from(image.clone()).remove_asset(cx);
+            }
+        }
     }
 
     pub fn is_compacting(&self) -> bool {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -55,6 +55,9 @@ use super::*;
 
 const DATA_RETENTION_LEARN_MORE_URL: &str = "https://support.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models";
 
+/// How many entries beyond the viewport keep their decoded images resident.
+const OFFSCREEN_IMAGE_MARGIN: usize = 10;
+
 #[derive(Default)]
 struct ThreadFeedbackState {
     feedback: Option<ThreadFeedback>,
@@ -1059,9 +1062,10 @@ impl ThreadView {
         let thread_view = cx.entity().downgrade();
 
         this.list_state
-            .set_scroll_handler(move |_event, _window, cx| {
+            .set_scroll_handler(move |event, _window, cx| {
                 let list_state = list_state_for_scroll.clone();
                 let thread_view = thread_view.clone();
+                let visible_range = event.visible_range.clone();
                 // N.B. We must defer because the scroll handler is called while the
                 // ListState's RefCell is mutably borrowed. Reading logical_scroll_top()
                 // directly would panic from a double borrow.
@@ -1073,6 +1077,13 @@ impl ThreadView {
                                 thread.set_ui_scroll_position(Some(scroll_top));
                             });
                         }
+                        // Keep a margin around the viewport so small scrolls
+                        // don't thrash decoding of images at either edge.
+                        let keep = visible_range.start.saturating_sub(OFFSCREEN_IMAGE_MARGIN)
+                            ..visible_range.end + OFFSCREEN_IMAGE_MARGIN;
+                        this.thread.update(cx, |thread, cx| {
+                            thread.release_offscreen_images(keep, cx);
+                        });
                         this.schedule_save(cx);
                     });
                 });


### PR DESCRIPTION
GPUI caches one decoded bitmap per `Arc<Image>` in `App::loading_assets`. `fetch_asset` only ever inserts into that map, and nothing in the agent panel calls `remove_asset`, so every image a conversation has scrolled past stays resident for the lifetime of the process.

The cost is paid in decoded pixels rather than in the encoded source. Inspecting one long thread from my own `threads.db`:

- 3298 messages, 125MB of JSON (41.8MB zstd on disk)
- 140 distinct images, mostly screenshots pasted into the conversation or read via `read_file`
- **~395MB of BGRA** once all of them had been viewed — a 705x1567 screenshot is ~100KB as PNG but 4.4MB decoded

None of that is released while the thread stays open, and for native threads it is re-accumulated every time the thread is reloaded from the database.

## Change

`AcpThread::release_offscreen_images` drops the decoded bitmaps of entries outside a given range, and the list's scroll handler calls it with the visible range plus a margin, so small scrolls don't thrash decoding at either edge. Scrolling back re-decodes on the background executor, which is the path a first view already takes.

The call sits next to the existing scroll-position bookkeeping in the shared conversation view, outside the `as_native_thread` branch, so it applies to external ACP agents as well as the native one.

## Testing

`cargo check` and `cargo clippy` are clean for `acp_thread` and `agent_ui`. I have not measured the resident-set effect in a running Zed, so the ~395MB figure above is the size of what is eligible to be released rather than a measured delta — worth a second look from someone who can profile it.

Release Notes:

- Improved memory usage in long agent conversations containing images
