### PR TITLE
editor: Keep the cursor before text inserted by on-type formatting

### DIFF
--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -378,9 +378,9 @@ impl InlineAssistant {
                 continue;
             }
 
-            let latest_selection = newest_selection.get_or_insert_with(|| selection.clone());
+            let latest_selection = newest_selection.get_or_insert_with(|| selection);
             if selection.id > latest_selection.id {
-                *latest_selection = selection.clone();
+                *latest_selection = selection;
             }
             selections.push(selection);
         }

--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -389,7 +389,7 @@ impl Editor {
 
                 let (start_buffer, start, _, end, _newest_selection) = editor
                     .update(cx, |editor, cx| {
-                        let newest_selection = editor.selections.newest_anchor().clone();
+                        let newest_selection = *editor.selections.newest_anchor();
                         if newest_selection.head().diff_base_anchor().is_some() {
                             return None;
                         }

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -218,6 +218,16 @@ impl Editor {
         // If this is not the host, append its history with new edits.
         let push_to_client_history = project.read(cx).is_via_collab();
 
+        let on_type_formatting = project.update(cx, |project, cx| {
+            project.on_type_format(
+                buffer.clone(),
+                buffer_position,
+                input,
+                push_to_lsp_host_history,
+                cx,
+            )
+        })?;
+
         // Cursors are right-biased, so text the server inserts exactly at a cursor would push it
         // along. Keep a left-biased copy to restore afterwards, keyed by the anchor the editor
         // holds now so that cursors the user moved during the request are left alone.
@@ -230,23 +240,18 @@ impl Editor {
             .map(|selection| (selection.head(), snapshot.anchor_before(selection.head())))
             .collect::<HashMap<_, _>>();
 
-        let on_type_formatting = project.update(cx, |project, cx| {
-            project.on_type_format(
-                buffer.clone(),
-                buffer_position,
-                input,
-                push_to_lsp_host_history,
-                cx,
-            )
-        });
         Some(cx.spawn_in(window, async move |editor, cx| {
             if let Some(transaction) = on_type_formatting.await? {
-                if push_to_client_history {
-                    buffer.update(cx, |buffer, _| {
+                let (formatted_buffer_id, formatted_ranges) = buffer.update(cx, |buffer, _| {
+                    let formatted_ranges = buffer
+                        .edited_ranges_for_transaction::<usize>(&transaction)
+                        .collect::<Vec<_>>();
+                    if push_to_client_history {
                         buffer.push_transaction(transaction, Instant::now());
                         buffer.finalize_last_transaction();
-                    });
-                }
+                    }
+                    (buffer.remote_id(), formatted_ranges)
+                });
                 editor.update_in(cx, |editor, window, cx| {
                     let snapshot = editor.buffer.read(cx).snapshot(cx);
                     let mut any_cursor_pushed = false;
@@ -258,11 +263,45 @@ impl Editor {
                             if selection.start != selection.end {
                                 return selection.clone();
                             }
-                            let Some(&cursor) = cursors_to_pin.get(&selection.head()) else {
+                            let head = selection.head();
+                            let Some(&cursor) = cursors_to_pin.get(&head) else {
                                 return selection.clone();
                             };
-                            any_cursor_pushed |= cursor.to_offset(&snapshot)
-                                != selection.head().to_offset(&snapshot);
+                            let Some((buffer_cursor, buffer_snapshot)) =
+                                snapshot.anchor_to_buffer_anchor(cursor)
+                            else {
+                                return selection.clone();
+                            };
+                            let Some((buffer_head, head_buffer_snapshot)) =
+                                snapshot.anchor_to_buffer_anchor(head)
+                            else {
+                                return selection.clone();
+                            };
+                            if buffer_snapshot.remote_id() != formatted_buffer_id
+                                || head_buffer_snapshot.remote_id() != formatted_buffer_id
+                            {
+                                return selection.clone();
+                            }
+
+                            let cursor_offset = buffer_cursor.to_offset(buffer_snapshot);
+                            let head_offset = buffer_head.to_offset(head_buffer_snapshot);
+                            // Only rewind when formatter edits cover the displacement without gaps
+                            // that could contain edits made while the request was in flight.
+                            let mut formatted_end = cursor_offset;
+                            for range in &formatted_ranges {
+                                if range.end <= formatted_end {
+                                    continue;
+                                }
+                                if range.start > formatted_end || range.end > head_offset {
+                                    break;
+                                }
+                                formatted_end = range.end;
+                            }
+                            if cursor_offset == head_offset || formatted_end != head_offset {
+                                return selection.clone();
+                            }
+
+                            any_cursor_pushed = true;
                             Selection {
                                 start: cursor,
                                 end: cursor,

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -218,6 +218,18 @@ impl Editor {
         // If this is not the host, append its history with new edits.
         let push_to_client_history = project.read(cx).is_via_collab();
 
+        // Cursors are right-biased, so text the server inserts exactly at a cursor would push it
+        // along. Keep a left-biased copy to restore afterwards, keyed by the anchor the editor
+        // holds now so that cursors the user moved during the request are left alone.
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let cursors_to_pin = self
+            .selections
+            .disjoint_anchors()
+            .iter()
+            .filter(|selection| selection.start == selection.end)
+            .map(|selection| (selection.head(), snapshot.anchor_before(selection.head())))
+            .collect::<HashMap<_, _>>();
+
         let on_type_formatting = project.update(cx, |project, cx| {
             project.on_type_format(
                 buffer.clone(),
@@ -235,7 +247,34 @@ impl Editor {
                         buffer.finalize_last_transaction();
                     });
                 }
-                editor.update(cx, |editor, cx| {
+                editor.update_in(cx, |editor, window, cx| {
+                    let snapshot = editor.buffer.read(cx).snapshot(cx);
+                    let mut any_cursor_pushed = false;
+                    let pinned = editor
+                        .selections
+                        .disjoint_anchors()
+                        .iter()
+                        .map(|selection| {
+                            if selection.start != selection.end {
+                                return selection.clone();
+                            }
+                            let Some(&cursor) = cursors_to_pin.get(&selection.head()) else {
+                                return selection.clone();
+                            };
+                            any_cursor_pushed |= cursor.to_offset(&snapshot)
+                                != selection.head().to_offset(&snapshot);
+                            Selection {
+                                start: cursor,
+                                end: cursor,
+                                ..selection.clone()
+                            }
+                        })
+                        .collect();
+                    if any_cursor_pushed {
+                        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                            s.select_anchors(pinned)
+                        });
+                    }
                     editor.refresh_document_highlights(cx);
                 })?;
             }

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -226,16 +226,91 @@ impl Editor {
                 push_to_lsp_host_history,
                 cx,
             )
-        });
+        })?;
+
+        // Cursors are right-biased, so an edit inserting text at one drags it along. Pin a
+        // left-biased copy, keyed by the current anchor so cursors the user moves are skipped.
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let cursors_to_pin = self
+            .selections
+            .disjoint_anchors()
+            .iter()
+            .filter(|selection| selection.start == selection.end)
+            .map(|selection| (selection.head(), snapshot.anchor_before(selection.head())))
+            .collect::<HashMap<_, _>>();
+
         Some(cx.spawn_in(window, async move |editor, cx| {
             if let Some(transaction) = on_type_formatting.await? {
-                if push_to_client_history {
-                    buffer.update(cx, |buffer, _| {
+                let (formatted_buffer_id, formatted_ranges) = buffer.update(cx, |buffer, _| {
+                    let formatted_ranges = buffer
+                        .edited_ranges_for_transaction::<usize>(&transaction)
+                        .collect::<Vec<_>>();
+                    if push_to_client_history {
                         buffer.push_transaction(transaction, Instant::now());
                         buffer.finalize_last_transaction();
-                    });
-                }
-                editor.update(cx, |editor, cx| {
+                    }
+                    (buffer.remote_id(), formatted_ranges)
+                });
+                editor.update_in(cx, |editor, window, cx| {
+                    let snapshot = editor.buffer.read(cx).snapshot(cx);
+                    let pinned_cursor = |selection: &Selection<Anchor>| {
+                        if selection.start != selection.end {
+                            return None;
+                        }
+                        let head = selection.head();
+                        let &cursor = cursors_to_pin.get(&head)?;
+                        let (buffer_cursor, cursor_snapshot) =
+                            snapshot.anchor_to_buffer_anchor(cursor)?;
+                        let (buffer_head, head_snapshot) =
+                            snapshot.anchor_to_buffer_anchor(head)?;
+                        if cursor_snapshot.remote_id() != formatted_buffer_id
+                            || head_snapshot.remote_id() != formatted_buffer_id
+                        {
+                            return None;
+                        }
+                        let cursor_offset = buffer_cursor.to_offset(cursor_snapshot);
+                        let head_offset = buffer_head.to_offset(head_snapshot);
+                        if cursor_offset == head_offset {
+                            return None;
+                        }
+                        // A gap in the formatter's edits means something else, such as a user edit
+                        // while the request was in flight, moved the cursor.
+                        let mut formatted_end = cursor_offset;
+                        for range in &formatted_ranges {
+                            if range.end <= formatted_end {
+                                continue;
+                            }
+                            if range.start > formatted_end || range.end > head_offset {
+                                break;
+                            }
+                            formatted_end = range.end;
+                        }
+                        (formatted_end == head_offset).then_some(cursor)
+                    };
+
+                    let mut restored_any_cursor = false;
+                    let pinned = editor
+                        .selections
+                        .disjoint_anchors()
+                        .iter()
+                        .map(|selection| match pinned_cursor(selection) {
+                            Some(cursor) => {
+                                restored_any_cursor = true;
+                                Selection {
+                                    start: cursor,
+                                    end: cursor,
+                                    goal: SelectionGoal::None,
+                                    ..selection.clone()
+                                }
+                            }
+                            None => selection.clone(),
+                        })
+                        .collect();
+                    if restored_any_cursor {
+                        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                            s.select_anchors(pinned)
+                        });
+                    }
                     editor.refresh_document_highlights(cx);
                 })?;
             }

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -300,10 +300,10 @@ impl Editor {
                                     start: cursor,
                                     end: cursor,
                                     goal: SelectionGoal::None,
-                                    ..selection.clone()
+                                    ..*selection
                                 }
                             }
-                            None => selection.clone(),
+                            None => *selection,
                         })
                         .collect();
                     if restored_any_cursor {

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -305,6 +305,7 @@ impl Editor {
                             Selection {
                                 start: cursor,
                                 end: cursor,
+                                goal: SelectionGoal::None,
                                 ..selection.clone()
                             }
                         })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3527,7 +3527,7 @@ impl Editor {
 
         let provider = self.semantics_provider.clone()?;
         let buffer = self.buffer.read(cx);
-        let newest_selection = self.selections.newest_anchor().clone();
+        let newest_selection = *self.selections.newest_anchor();
         let cursor_position = newest_selection.head();
         let (cursor_buffer, cursor_buffer_position) =
             buffer.text_anchor_for_position(cursor_position, cx)?;
@@ -7784,7 +7784,7 @@ impl Editor {
             return None;
         }
         let provider = self.semantics_provider.clone()?;
-        let selection = self.selections.newest_anchor().clone();
+        let selection = *self.selections.newest_anchor();
         let cursor = self.rename_target_anchor(&selection, cx);
         let (cursor_buffer, cursor_buffer_position) =
             self.buffer.read(cx).text_anchor_for_position(cursor, cx)?;
@@ -11525,14 +11525,14 @@ fn consume_contiguous_rows(
     display_map: &DisplaySnapshot,
     selections: &mut Peekable<std::slice::Iter<Selection<Point>>>,
 ) -> (MultiBufferRow, MultiBufferRow) {
-    contiguous_row_selections.push(selection.clone());
+    contiguous_row_selections.push(*selection);
     let start_row = starting_row(selection, display_map);
     let mut end_row = ending_row(selection, display_map);
 
     while let Some(next_selection) = selections.peek() {
         if next_selection.start.row <= end_row.0 {
             end_row = ending_row(next_selection, display_map);
-            contiguous_row_selections.push(selections.next().unwrap().clone());
+            contiguous_row_selections.push(*selections.next().unwrap());
         } else {
             break;
         }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24308,6 +24308,20 @@ async fn test_on_type_formatting_is_applied_after_autoindent(cx: &mut TestAppCon
 }
 
 #[gpui::test]
+async fn test_on_type_formatting_not_scheduled_without_server_support(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(lsp::ServerCapabilities::default(), cx).await;
+    cx.set_state("let a = bˇ;\n");
+
+    let task = cx.update_editor(|editor, window, cx| {
+        editor.trigger_on_type_formatting(".".to_owned(), window, cx)
+    });
+
+    assert!(task.is_none());
+}
+
+#[gpui::test]
 async fn test_on_type_formatting_preserves_cursor_position(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
@@ -24342,6 +24356,50 @@ async fn test_on_type_formatting_preserves_cursor_position(cx: &mut TestAppConte
 
     cx.assert_editor_state("let a = b.ˇc;\n");
     assert!(request.next().await.is_some());
+}
+
+#[gpui::test]
+async fn test_on_type_formatting_does_not_rewind_over_intervening_edits(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
+                first_trigger_character: ".".to_string(),
+                more_trigger_character: None,
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("let a = bˇ;\n");
+
+    let (request_started_tx, request_started_rx) = oneshot::channel();
+    let (respond_tx, respond_rx) = oneshot::channel();
+    let mut request_started_tx = Some(request_started_tx);
+    let mut respond_rx = Some(respond_rx);
+    let _request =
+        cx.set_request_handler::<lsp::request::OnTypeFormatting, _, _>(move |_, _, _| {
+            request_started_tx.take().unwrap().send(()).unwrap();
+            let respond_rx = respond_rx.take().unwrap();
+            async move {
+                respond_rx.await.unwrap();
+                Ok(Some(vec![lsp::TextEdit {
+                    range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 10)),
+                    new_text: "c".to_string(),
+                }]))
+            }
+        });
+
+    cx.simulate_keystroke(".");
+    request_started_rx.await.unwrap();
+    cx.update_buffer(|buffer, cx| buffer.edit([(10..10, "x")], None, cx));
+    respond_tx.send(()).unwrap();
+    cx.run_until_parked();
+
+    cx.assert_editor_state("let a = b.cxˇ;\n");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24346,8 +24346,8 @@ async fn test_on_type_formatting_preserves_cursor_position(cx: &mut TestAppConte
                 lsp::Position::new(0, 10)
             );
             Ok(Some(vec![lsp::TextEdit {
-                range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 10)),
-                new_text: "c".to_string(),
+                range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 11)),
+                new_text: "c;".to_string(),
             }]))
         });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24308,6 +24308,101 @@ async fn test_on_type_formatting_is_applied_after_autoindent(cx: &mut TestAppCon
 }
 
 #[gpui::test]
+async fn test_on_type_formatting_not_scheduled_without_server_support(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(lsp::ServerCapabilities::default(), cx).await;
+    cx.set_state("let a = bˇ;\n");
+
+    let task = cx.update_editor(|editor, window, cx| {
+        editor.trigger_on_type_formatting(".".to_owned(), window, cx)
+    });
+
+    assert!(task.is_none());
+}
+
+#[gpui::test]
+async fn test_on_type_formatting_preserves_cursor_position(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
+                first_trigger_character: ".".to_string(),
+                more_trigger_character: None,
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("let a = bˇ;\n");
+
+    let mut request =
+        cx.set_request_handler::<lsp::request::OnTypeFormatting, _, _>(|_, params, _| async move {
+            assert_eq!(
+                params.text_document_position.position,
+                lsp::Position::new(0, 10)
+            );
+            Ok(Some(vec![lsp::TextEdit {
+                range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 11)),
+                new_text: "c;".to_string(),
+            }]))
+        });
+
+    cx.simulate_keystroke(".");
+    cx.run_until_parked();
+
+    cx.assert_editor_state("let a = b.ˇc;\n");
+    assert!(request.next().await.is_some());
+}
+
+#[gpui::test]
+async fn test_on_type_formatting_does_not_rewind_over_intervening_edits(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
+                first_trigger_character: ".".to_string(),
+                more_trigger_character: None,
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("let a = bˇ;\n");
+
+    let (request_started_tx, request_started_rx) = oneshot::channel();
+    let (respond_tx, respond_rx) = oneshot::channel();
+    let mut request_started_tx = Some(request_started_tx);
+    let mut respond_rx = Some(respond_rx);
+    let _request =
+        cx.set_request_handler::<lsp::request::OnTypeFormatting, _, _>(move |_, _, _| {
+            request_started_tx.take().unwrap().send(()).unwrap();
+            let respond_rx = respond_rx.take().unwrap();
+            async move {
+                respond_rx.await.unwrap();
+                Ok(Some(vec![lsp::TextEdit {
+                    range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 10)),
+                    new_text: "c".to_string(),
+                }]))
+            }
+        });
+
+    cx.simulate_keystroke(".");
+    request_started_rx.await.unwrap();
+    cx.update_buffer(|buffer, cx| buffer.edit([(10..10, "x")], None, cx));
+    respond_tx.send(()).unwrap();
+    cx.run_until_parked();
+
+    cx.assert_editor_state("let a = b.cxˇ;\n");
+}
+
+#[gpui::test]
 async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24308,6 +24308,43 @@ async fn test_on_type_formatting_is_applied_after_autoindent(cx: &mut TestAppCon
 }
 
 #[gpui::test]
+async fn test_on_type_formatting_preserves_cursor_position(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
+                first_trigger_character: ".".to_string(),
+                more_trigger_character: None,
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("let a = bˇ;\n");
+
+    let mut request =
+        cx.set_request_handler::<lsp::request::OnTypeFormatting, _, _>(|_, params, _| async move {
+            assert_eq!(
+                params.text_document_position.position,
+                lsp::Position::new(0, 10)
+            );
+            Ok(Some(vec![lsp::TextEdit {
+                range: lsp::Range::new(lsp::Position::new(0, 10), lsp::Position::new(0, 10)),
+                new_text: "c".to_string(),
+            }]))
+        });
+
+    cx.simulate_keystroke(".");
+    cx.run_until_parked();
+
+    cx.assert_editor_state("let a = b.ˇc;\n");
+    assert!(request.next().await.is_some());
+}
+
+#[gpui::test]
 async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -843,7 +843,7 @@ impl EditorElement {
                             .eq(&Ordering::Greater))
                 {
                     let drag_cursor_layout = SelectionLayout::new(
-                        drop_cursor.clone(),
+                        *drop_cursor,
                         false,
                         editor.cursor_offset_on_selection,
                         CursorShape::Bar,

--- a/crates/editor/src/element/mouse.rs
+++ b/crates/editor/src/element/mouse.rs
@@ -633,7 +633,7 @@ impl EditorElement {
             let selection = newest_anchor.map(|anchor| anchor.to_display_point(&snapshot));
             if point_for_position.intersects_selection(&selection) {
                 editor.selection_drag_state = SelectionDragState::ReadyToDrag {
-                    selection: newest_anchor.clone(),
+                    selection: *newest_anchor,
                     click_position: event.position,
                     mouse_down_time: Instant::now(),
                 };
@@ -1081,7 +1081,7 @@ impl EditorElement {
                             goal: SelectionGoal::None,
                         };
                         editor.selection_drag_state = SelectionDragState::Dragging {
-                            selection: selection.clone(),
+                            selection: *selection,
                             drop_cursor,
                             hide_drop_cursor: false,
                         };

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -511,13 +511,13 @@ pub(crate) fn handle_from(
                     let Some(selection_buffer_offset_head) =
                         multi_buffer_snapshot.point_to_buffer_offset(selection.head())
                     else {
-                        base_selections.push(selection.clone());
+                        base_selections.push(*selection);
                         continue;
                     };
                     let Some(selection_buffer_offset_tail) =
                         multi_buffer_snapshot.point_to_buffer_offset(selection.tail())
                     else {
-                        base_selections.push(selection.clone());
+                        base_selections.push(*selection);
                         continue;
                     };
 
@@ -525,7 +525,7 @@ pub(crate) fn handle_from(
                         == buffer_id
                         && selection_buffer_offset_tail.0.remote_id() == buffer_id;
                     if !is_entirely_in_buffer {
-                        base_selections.push(selection.clone());
+                        base_selections.push(*selection);
                         continue;
                     }
 
@@ -533,7 +533,7 @@ pub(crate) fn handle_from(
                     let selection_buffer_offset_tail = selection_buffer_offset_tail.1;
                     buffer_selection_map.insert(
                         (selection_buffer_offset_head, selection_buffer_offset_tail),
-                        (selection.clone(), None),
+                        (*selection, None),
                     );
                 }
             }
@@ -578,8 +578,8 @@ pub(crate) fn handle_from(
 
                 base_selections.extend(buffer_selection_map.values().map(|selection| {
                     match &selection.1 {
-                        Some(left_biased_selection) => left_biased_selection.clone(),
-                        None => selection.0.clone(),
+                        Some(left_biased_selection) => *left_biased_selection,
+                        None => selection.0,
                     }
                 }));
 

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -107,7 +107,7 @@ impl MouseContextMenu {
             }
         });
 
-        let selection_init = editor.selections.newest_anchor().clone();
+        let selection_init = *editor.selections.newest_anchor();
 
         let _cursor_move_subscription = cx.subscribe_in(
             &cx.entity(),

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -637,7 +637,7 @@ impl Editor {
                     }
                     new_selection
                 }
-                None => selection.clone(),
+                None => *selection,
             })
             .collect::<Vec<_>>();
 
@@ -855,7 +855,7 @@ impl Editor {
                         reversed: selection.reversed,
                     }
                 } else {
-                    selection.clone()
+                    *selection
                 }
             })
             .collect::<Vec<_>>();
@@ -913,7 +913,7 @@ impl Editor {
                         reversed: selection.reversed,
                     }
                 } else {
-                    selection.clone()
+                    *selection
                 }
             })
             .collect::<Vec<_>>();
@@ -1229,7 +1229,7 @@ impl Editor {
         };
 
         self.change_selections(effects, window, cx, |s| {
-            s.set_pending(pending_selection.clone(), pending_mode);
+            s.set_pending(pending_selection, pending_mode);
             s.set_is_extending(true);
         });
     }
@@ -1425,7 +1425,7 @@ impl Editor {
             }
 
             self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                s.set_pending(pending.clone(), mode);
+                s.set_pending(pending, mode);
             });
         } else {
             log::error!("update_selection dispatched with no pending selection");
@@ -1873,7 +1873,7 @@ impl Editor {
 
     fn pending_selection_and_mode(&self) -> Option<(Selection<Anchor>, SelectMode)> {
         Some((
-            self.selections.pending_anchor()?.clone(),
+            *self.selections.pending_anchor()?,
             self.selections.pending_mode()?,
         ))
     }
@@ -2348,7 +2348,7 @@ impl Editor {
             .iter()
             .map(|selection| {
                 if !selection.is_empty() {
-                    return selection.clone();
+                    return *selection;
                 }
 
                 let selection_pos = selection.head();
@@ -2395,7 +2395,7 @@ impl Editor {
                     &buffer,
                 );
 
-                let mut new_selection = selection.clone();
+                let mut new_selection = *selection;
                 new_selection.set_head(new_pos, SelectionGoal::None);
                 new_selection
             })

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -330,7 +330,7 @@ impl SelectionsCollection {
     pub fn first_anchor(&self) -> Selection<Anchor> {
         self.pending
             .as_ref()
-            .map(|pending| pending.selection.clone())
+            .map(|pending| pending.selection)
             .unwrap_or_else(|| self.disjoint.first().cloned().unwrap())
     }
 
@@ -772,7 +772,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
             return true;
         }
 
-        let mut oldest = self.oldest_anchor().clone();
+        let mut oldest = *self.oldest_anchor();
         if self.count() > 1 {
             self.collection.disjoint = Arc::from([oldest]);
             self.selections_changed = true;
@@ -999,7 +999,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         let selections = selections
             .into_iter()
             .map(|selection| {
-                let mut moved_selection = selection.clone();
+                let mut moved_selection = selection;
                 move_selection(&display_map, &mut moved_selection);
                 if selection != moved_selection {
                     changed = true;
@@ -1024,7 +1024,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
             .all::<MultiBufferOffset>(&display_map)
             .into_iter()
             .map(|selection| {
-                let mut moved_selection = selection.clone();
+                let mut moved_selection = selection;
                 move_selection(self.snapshot, &mut moved_selection);
                 if selection != moved_selection {
                     changed = true;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6255,11 +6255,14 @@ impl LspStore {
                         buffer.wait_for_edits(Some(position.timestamp()))
                     })
                     .await?;
-                this.update(cx, |this, cx| {
+                let Some(on_type_formatting) = this.update(cx, |this, cx| {
                     let position = position.to_point_utf16(buffer.read(cx));
                     this.on_type_format(buffer, position, trigger, false, cx)
                 })?
-                .await
+                else {
+                    return Ok(None);
+                };
+                on_type_formatting.await
             })
         } else {
             Task::ready(Err(anyhow!("No upstream client or local language server")))
@@ -6273,9 +6276,17 @@ impl LspStore {
         trigger: String,
         push_to_history: bool,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Option<Transaction>>> {
+    ) -> Option<Task<Result<Option<Transaction>>>> {
+        if !self.check_if_capable_for_proto_request(
+            &buffer,
+            |capabilities| OnTypeFormatting::supports_on_type_formatting(&trigger, capabilities),
+            cx,
+        ) {
+            return None;
+        }
+
         let position = position.to_point_utf16(buffer.read(cx));
-        self.on_type_format_impl(buffer, position, trigger, push_to_history, cx)
+        Some(self.on_type_format_impl(buffer, position, trigger, push_to_history, cx))
     }
 
     fn on_type_format_impl(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4631,7 +4631,7 @@ impl Project {
         trigger: String,
         push_to_history: bool,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Option<Transaction>>> {
+    ) -> Option<Task<Result<Option<Transaction>>>> {
         self.lsp_store.update(cx, |lsp_store, cx| {
             lsp_store.on_type_format(buffer, position, trigger, push_to_history, cx)
         })

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -14,7 +14,7 @@ pub enum SelectionGoal {
     WrappedHorizontalPosition((u32, f32)),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Selection<T> {
     pub id: usize,
     pub start: T,

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -2366,13 +2366,7 @@ impl Vim {
                 .newest_display(&editor.display_snapshot(cx));
             let text_layout_details = editor.text_layout_details(window, cx);
             let (mut range, _) = motion
-                .range(
-                    &snapshot,
-                    start.clone(),
-                    times,
-                    &text_layout_details,
-                    forced_motion,
-                )
+                .range(&snapshot, start, times, &text_layout_details, forced_motion)
                 .unwrap_or((start.range(), MotionKind::Exclusive));
             if range.start != start.start {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
@@ -2414,7 +2408,7 @@ impl Vim {
                 .selections
                 .newest_display(&editor.display_snapshot(cx));
             let range = object
-                .range(&snapshot, start.clone(), around, None)
+                .range(&snapshot, start, around, None)
                 .unwrap_or(start.range());
             if range.start != start.start {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -960,7 +960,7 @@ impl Vim {
                     new_end -= ch.len_utf8();
                 }
 
-                let mut new_selection = selection.clone();
+                let mut new_selection = *selection;
                 new_selection.start = new_start;
                 new_selection.end = new_end;
                 trimmed.push(new_selection);

--- a/crates/vim/src/helix/select.rs
+++ b/crates/vim/src/helix/select.rs
@@ -17,13 +17,10 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |map, selection| {
-                    let Some(range) = object
-                        .helix_range(map, selection.clone(), around)
-                        .unwrap_or({
-                            let vim_range = object.range(map, selection.clone(), around, None);
-                            vim_range.filter(|r| r.start <= cursor_range(selection, map).start)
-                        })
-                    else {
+                    let Some(range) = object.helix_range(map, *selection, around).unwrap_or({
+                        let vim_range = object.range(map, *selection, around, None);
+                        vim_range.filter(|r| r.start <= cursor_range(selection, map).start)
+                    }) else {
                         return;
                     };
 
@@ -46,8 +43,7 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |map, selection| {
-                    let Ok(Some(range)) = object.helix_next_range(map, selection.clone(), around)
-                    else {
+                    let Ok(Some(range)) = object.helix_next_range(map, *selection, around) else {
                         return;
                     };
 
@@ -70,8 +66,7 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |map, selection| {
-                    let Ok(Some(range)) =
-                        object.helix_previous_range(map, selection.clone(), around)
+                    let Ok(Some(range)) = object.helix_previous_range(map, *selection, around)
                     else {
                         return;
                     };

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1477,13 +1477,8 @@ impl Motion {
         text_layout_details: &TextLayoutDetails,
         forced_motion: bool,
     ) -> Option<MotionKind> {
-        let (range, kind) = self.range(
-            map,
-            selection.clone(),
-            times,
-            text_layout_details,
-            forced_motion,
-        )?;
+        let (range, kind) =
+            self.range(map, *selection, times, text_layout_details, forced_motion)?;
         selection.start = range.start;
         selection.end = range.end;
         Some(kind)

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -788,7 +788,7 @@ impl Object {
         around: bool,
         times: Option<usize>,
     ) -> bool {
-        if let Some(range) = self.range(map, selection.clone(), around, times) {
+        if let Some(range) = self.range(map, *selection, around, times) {
             selection.start = range.start;
             selection.end = range.end;
             true

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -109,13 +109,13 @@ impl Vim {
                 for selection in &display_selections {
                     let range = match &target {
                         SurroundsType::Object(object, around) => {
-                            object.range(&display_map, selection.clone(), *around, None)
+                            object.range(&display_map, *selection, *around, None)
                         }
                         SurroundsType::Motion(motion) => {
                             motion
                                 .range(
                                     &display_map,
-                                    selection.clone(),
+                                    *selection,
                                     count,
                                     &text_layout_details,
                                     forced_motion,
@@ -210,9 +210,7 @@ impl Vim {
 
                 for selection in &display_selections {
                     let start = selection.start.to_offset(&display_map, Bias::Left);
-                    if let Some(range) =
-                        pair_object.range(&display_map, selection.clone(), true, None)
-                    {
+                    if let Some(range) = pair_object.range(&display_map, *selection, true, None) {
                         // If the current parenthesis object is single-line,
                         // then we need to filter whether it is the current line or not
                         if !pair_object.is_multiline() {
@@ -420,13 +418,14 @@ impl Vim {
 
                     for selection in &selections {
                         let start = selection.start.to_offset(&display_map, Bias::Left);
-                        let in_range = object
-                            .range(&display_map, selection.clone(), true, None)
-                            .filter(|range| {
-                                object.is_multiline()
-                                    || (selection.start.row() == range.start.row()
-                                        && selection.end.row() == range.end.row())
-                            });
+                        let in_range =
+                            object
+                                .range(&display_map, *selection, true, None)
+                                .filter(|range| {
+                                    object.is_multiline()
+                                        || (selection.start.row() == range.start.row()
+                                            && selection.end.row() == range.end.row())
+                                });
                         let Some(range) = in_range else {
                             updated_cursor_ranges.push(start..start);
                             matched_pair_anchors.push(None);
@@ -559,7 +558,7 @@ impl Vim {
                 // For now, only primary selection is used to select the bracket/quote pair. It might be weird
                 // if multi-select resulted in different quote kinds being replaced for different selections.
                 // any_pair uses the same logic, so this should be consistent across {Any,Mini}{Quotes,Brackets}
-                let selection = selections.first()?.clone();
+                let selection = *selections.first()?;
                 let range = object.range(&display_map, selection, true, None)?;
                 let start_offset = range.start.to_offset(&display_map, Bias::Left);
                 let (pair_char, _) = display_map.buffer_chars_at(start_offset).next()?;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2004,7 +2004,7 @@ impl Vim {
             return;
         }
 
-        let newest = editor.read(cx).selections.newest_anchor().clone();
+        let newest = *editor.read(cx).selections.newest_anchor();
         let is_multicursor = editor.read(cx).selections.count() > 1;
         if self.mode == Mode::Insert && self.current_tx.is_some() {
             if let Some(current_anchor) = &self.current_anchor {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -435,7 +435,7 @@ impl Vim {
             self.update_editor(cx, |_, editor, cx| {
                 editor.change_selections(Default::default(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
-                        let mut mut_selection = selection.clone();
+                        let mut mut_selection = *selection;
 
                         // all our motions assume that the current character is
                         // after the cursor; however in the case of a visual selection
@@ -463,7 +463,7 @@ impl Vim {
                                         && object.always_expands_both_ways()
                                     {
                                         if let Some(range) =
-                                            object.range(map, selection.clone(), around, count)
+                                            object.range(map, *selection, around, count)
                                         {
                                             selection.start = range.start;
                                             selection.end = range.end;
@@ -782,7 +782,7 @@ impl Vim {
 
                 let mut edits = Vec::new();
                 for selection in selections.iter() {
-                    let selection = selection.clone();
+                    let selection = *selection;
                     for row_range in
                         movement::split_display_range_by_lines(&display_map, selection.range())
                     {


### PR DESCRIPTION
## Why

`textDocument/onTypeFormatting` edits that insert or replace text at an empty cursor use its right bias and move it past the new text. In paired tags, pressing Enter can therefore leave the cursor on the closing tag instead of between the tags.

## What

- Capture a left-biased pin for each empty cursor before requesting on-type formatting.
- Skip cursor tracking unless a matching language server advertises the trigger.
- Restore only unchanged empty cursors whose displacement is fully covered by formatting transaction ranges, so intervening user edits are preserved.
- Reset vertical movement state when restoring a cursor.

## Testing

- `cargo test -p editor test_on_type_formatting` (5 passed)
- `./script/clippy -p editor`

## References

- Fixes https://github.com/zed-industries/zed/issues/61574

Release Notes:

- Fixed the cursor being moved past text inserted or replaced at its position during on-type formatting.