### PR TITLE
sidebar: Show the worktree name for subdirectory workspaces

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -633,6 +633,12 @@ impl WorkspaceMenuWorktreeLabel {
     }
 }
 
+fn path_file_name(path: &Path) -> SharedString {
+    path.file_name()
+        .map(|name| SharedString::from(name.to_string_lossy().to_string()))
+        .unwrap_or_default()
+}
+
 fn workspace_menu_worktree_labels(
     workspace: &Entity<Workspace>,
     cx: &App,
@@ -651,27 +657,31 @@ fn workspace_menu_worktree_labels(
         .into_iter()
         .map(|root_path| {
             let root_path = root_path.as_ref();
-            let folder_name = root_path
-                .file_name()
-                .map(|name| SharedString::from(name.to_string_lossy().to_string()))
-                .unwrap_or_default();
+            let folder_name = path_file_name(root_path);
+            // The opened folder is often a subdirectory of a worktree rather
+            // than its root, so resolve the repository by longest containing
+            // path instead of requiring an exact match. Requiring an exact
+            // match labeled every worktree's `example` subdirectory as a bare
+            // `example`, leaving them indistinguishable in the switcher.
             let repository_snapshot = repository_snapshots
                 .iter()
-                .find(|snapshot| snapshot.work_directory_abs_path.as_ref() == root_path);
+                .filter(|snapshot| root_path.starts_with(snapshot.work_directory_abs_path.as_ref()))
+                .max_by_key(|snapshot| snapshot.work_directory_abs_path.components().count());
 
             if let Some(snapshot) = repository_snapshot {
+                let work_directory = snapshot.work_directory_abs_path.as_ref();
                 let worktree_name = if snapshot.is_linked_worktree() {
                     snapshot
                         .main_worktree_abs_path()
                         .and_then(|main_worktree_path| {
-                            project::linked_worktree_short_name(main_worktree_path, root_path)
+                            project::linked_worktree_short_name(main_worktree_path, work_directory)
                         })
-                        .unwrap_or_else(|| folder_name.clone())
+                        .unwrap_or_else(|| path_file_name(work_directory))
                 } else {
                     "main".into()
                 };
 
-                if show_folder_name {
+                if show_folder_name || work_directory != root_path {
                     WorkspaceMenuWorktreeLabel {
                         icon: Some(IconName::GitWorktree),
                         primary_name: folder_name,

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -14912,3 +14912,80 @@ fn test_split_leading_icon_char() {
     assert_eq!(trimmed.as_ref(), "abc");
     assert_eq!(positions, vec![0, 1]);
 }
+
+async fn workspace_menu_labels_for_root(
+    fs: &Arc<FakeFs>,
+    root_path: &str,
+    cx: &mut TestAppContext,
+) -> Vec<String> {
+    let project = project::Project::test(fs.clone(), [root_path.as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let window = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let workspace = window.root(cx).unwrap();
+    cx.run_until_parked();
+
+    cx.update(|cx| {
+        workspace_menu_worktree_labels(&workspace, cx)
+            .iter()
+            .map(|label| match &label.secondary_name {
+                Some(secondary_name) => format!("{} / {}", label.primary_name, secondary_name),
+                None => label.primary_name.to_string(),
+            })
+            .collect()
+    })
+}
+
+#[gpui::test]
+async fn test_workspace_menu_labels_for_worktree_subdirectory(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "example": {},
+        }),
+    )
+    .await;
+
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/worktrees/sedge-beacon"),
+            ref_name: Some("refs/heads/sedge-beacon".into()),
+            sha: "aaa".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    fs.create_dir(Path::new("/worktrees/sedge-beacon/example"))
+        .await
+        .unwrap();
+
+    cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+    // Opening a subdirectory of a linked worktree keeps the folder name as the
+    // primary label and names the worktree it belongs to.
+    assert_eq!(
+        workspace_menu_labels_for_root(&fs, "/worktrees/sedge-beacon/example", cx).await,
+        vec!["example / sedge-beacon".to_string()],
+    );
+
+    // The same subdirectory in the main checkout stays distinguishable.
+    assert_eq!(
+        workspace_menu_labels_for_root(&fs, "/project/example", cx).await,
+        vec!["example / main".to_string()],
+    );
+
+    // Opening a worktree root still shows just the worktree name.
+    assert_eq!(
+        workspace_menu_labels_for_root(&fs, "/worktrees/sedge-beacon", cx).await,
+        vec!["sedge-beacon".to_string()],
+    );
+}


### PR DESCRIPTION
Addresses the workspace-switcher half of #58091.

## Problem

`workspace_menu_worktree_labels` resolved a workspace's repository with an exact path comparison:

```rust
.find(|snapshot| snapshot.work_directory_abs_path.as_ref() == root_path)
```

That only matches when the opened folder *is* the worktree root. Opening a subdirectory of a monorepo — the common case the issue describes — matched no repository, so the entry fell back to the bare folder name. With the same subdirectory open from several linked worktrees, every entry in the switcher read `example`, with nothing to tell them apart.

## Fix

Resolve the repository by longest containing path instead, which is what `git_ui::worktree_service::classify_worktrees` already does for the same problem:

```rust
.filter(|snapshot| root_path.starts_with(snapshot.work_directory_abs_path.as_ref()))
.max_by_key(|snapshot| snapshot.work_directory_abs_path.components().count())
```

`linked_worktree_short_name` is then given the repository's work directory rather than the opened root, and the folder name stays the primary label whenever the opened path sits below that work directory — so the worktree name is shown next to it instead of replacing it.

Worktree roots keep their existing single-label rendering; only subdirectory workspaces change.

## Before / after

Opening `example/` from the main checkout and from two linked worktrees:

| | Before | After |
| --- | --- | --- |
| main checkout | `example` | `example / main` |
| worktree `sedge-beacon` | `example` | `example / sedge-beacon` |
| worktree `plush-marten` | `example` | `example / plush-marten` |

## Testing

- New `test_workspace_menu_labels_for_worktree_subdirectory` covers all three cases: a subdirectory of a linked worktree, the same subdirectory in the main checkout, and a worktree root (which must keep the plain worktree name).
- `cargo test -p sidebar` — 142 passed, 0 failed.
- `cargo clippy -p sidebar --all-targets -- --deny warnings` — clean.
- Manually verified against a real repository with two linked worktrees, with the fix reverted and applied, confirming the switcher entries go from three identical `example` rows to the labels in the table above.

## Not covered here

The issue also asks for the worktree name in the chat-list subtitle. That path goes through `WorktreePaths` persisted in the threads database, so it is left for a separate change rather than folded into this one.

Release Notes:

- Fixed the workspace switcher showing indistinguishable entries when the same subdirectory is open from multiple git worktrees.
