### PR TITLE
Don't cancel renames or dismiss Go to Line when the window is deactivated

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -354,10 +354,9 @@ impl CollabPanel {
                 &channel_name_editor,
                 window,
                 |this: &mut Self, _, event, window, cx| {
-                    if let editor::EditorEvent::Blurred = event {
-                        if !window.is_window_active() {
-                            return;
-                        }
+                    if let editor::EditorEvent::Blurred = event
+                        && window.is_window_active()
+                    {
                         if let Some(state) = &this.channel_editing_state
                             && state.pending_name().is_some()
                         {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -355,6 +355,9 @@ impl CollabPanel {
                 window,
                 |this: &mut Self, _, event, window, cx| {
                     if let editor::EditorEvent::Blurred = event {
+                        if !window.is_window_active() {
+                            return;
+                        }
                         if let Some(state) = &this.channel_editing_state
                             && state.pending_name().is_some()
                         {

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -167,13 +167,15 @@ impl GoToLine {
         &mut self,
         _: &Entity<Editor>,
         event: &editor::EditorEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         match event {
             editor::EditorEvent::Blurred => {
-                self.prev_scroll_position.take();
-                cx.emit(DismissEvent)
+                if window.is_window_active() {
+                    self.prev_scroll_position.take();
+                    cx.emit(DismissEvent)
+                }
             }
             editor::EditorEvent::BufferEdited => self.highlight_current_line(cx),
             _ => {}

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -171,11 +171,9 @@ impl GoToLine {
         cx: &mut Context<Self>,
     ) {
         match event {
-            editor::EditorEvent::Blurred => {
-                if window.is_window_active() {
-                    self.prev_scroll_position.take();
-                    cx.emit(DismissEvent)
-                }
+            editor::EditorEvent::Blurred if window.is_window_active() => {
+                self.prev_scroll_position.take();
+                cx.emit(DismissEvent)
             }
             editor::EditorEvent::BufferEdited => self.highlight_current_line(cx),
             _ => {}

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -797,13 +797,12 @@ impl ProjectPanel {
                     EditorEvent::SelectionsChanged { .. } => {
                         project_panel.autoscroll(cx);
                     }
-                    EditorEvent::Blurred => {
-                        if window.is_window_active()
-                            && project_panel
-                                .state
-                                .edit_state
-                                .as_ref()
-                                .is_some_and(|state| state.processing_filename.is_none())
+                    EditorEvent::Blurred if window.is_window_active() => {
+                        if project_panel
+                            .state
+                            .edit_state
+                            .as_ref()
+                            .is_some_and(|state| state.processing_filename.is_none())
                         {
                             match project_panel.confirm_edit(false, window, cx) {
                                 Some(task) => {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -798,11 +798,12 @@ impl ProjectPanel {
                         project_panel.autoscroll(cx);
                     }
                     EditorEvent::Blurred => {
-                        if project_panel
-                            .state
-                            .edit_state
-                            .as_ref()
-                            .is_some_and(|state| state.processing_filename.is_none())
+                        if window.is_window_active()
+                            && project_panel
+                                .state
+                                .edit_state
+                                .as_ref()
+                                .is_some_and(|state| state.processing_filename.is_none())
                         {
                             match project_panel.confirm_edit(false, window, cx) {
                                 Some(task) => {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4659,6 +4659,38 @@ async fn test_rename_with_hide_root(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_rename_survives_window_deactivation(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", json!({ "file1.txt": "content" }))
+        .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    select_path(&panel, "root/file1.txt", cx);
+    panel.update_in(cx, |panel, window, cx| panel.rename(&Rename, window, cx));
+    assert!(
+        panel.read_with(cx, |panel, _| panel.state.edit_state.is_some()),
+        "Rename should have started"
+    );
+
+    cx.deactivate_window();
+
+    assert!(
+        panel.read_with(cx, |panel, _| panel.state.edit_state.is_some()),
+        "Rename should not be cancelled when the window is deactivated, e.g. by a keyboard layout switcher grabbing keyboard focus"
+    );
+}
+
+#[gpui::test]
 async fn test_multiple_marked_entries(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
     let fs = FakeFs::new(cx.executor());


### PR DESCRIPTION
Closes #39286

## Problem

Switching the keyboard layout on Wayland (e.g. GNOME's Super+Space) makes the compositor briefly grab the keyboard, which deactivates the Zed window. GPUI reports window deactivation as a blur of the focused element (`WindowFocusEvent` is emitted with an empty `current_focus_path`), so controls that dismiss or cancel on blur treated it as the user abandoning them. The same happens when switching to another app window. As discussed in #39286 with @MrSubidubi, the desired behavior is to keep these controls open and focused across window deactivation.

## Fix

Guard the blur-driven cancel/dismiss handlers with `window.is_window_active()`, following the pattern established for pickers in #41320:

- Project panel: in-progress rename / new file / new directory inputs are no longer cancelled when the window is deactivated
- Collab panel: in-progress channel rename is no longer cancelled
- Go to Line: the dialog is no longer dismissed

In-window focus changes (clicking elsewhere, Escape) keep the existing commit/cancel semantics. The terminal tab rename needed no change: it re-checks `FocusHandle::is_focused`, which reads `window.focus` and that survives deactivation. Command palette, file finder, and outline were already fixed by #41320.

Added a regression test (`test_rename_survives_window_deactivation`) that starts a rename, deactivates the window via the test platform, and asserts the edit state survives.

Two milder siblings were left unchanged to keep this PR focused, flagging them for a maintainer decision: the notebook markdown cell exits edit mode on blur (`crates/repl/src/notebook/cell.rs`), and the diagnostics view prunes diagnosticless buffers on blur (`crates/diagnostics/src/diagnostics.rs`).

Longer term it may be worth carrying the blur cause in the event itself (e.g. a `FocusMoved` vs `WindowDeactivated` reason on `FocusOutEvent` and `EditorEvent::Blurred`), so each handler has to state which causes it handles instead of relying on an opt-in guard; happy to file a separate issue for that.

## Before


https://github.com/user-attachments/assets/9eec1bb5-1881-4b3a-80ef-a287e23219ca

## After


https://github.com/user-attachments/assets/49b8775c-175a-4882-835d-871432c0b315

## Suggested .rules additions

> Handlers that cancel or dismiss UI on blur (`EditorEvent::Blurred`, `on_blur`, `on_focus_out`) must check `window.is_window_active()` first: GPUI reports window deactivation (app switch, layout switcher grabbing the keyboard) as a blur of the focused element, and dismissing there loses user input.

Release Notes:

- Fixed in-progress file renames, channel renames, and the Go to Line dialog being cancelled when the window is deactivated, e.g. by a keyboard layout switch on Wayland or by switching to another application ([#39286](https://github.com/zed-industries/zed/issues/39286)).
