### PR TITLE
vim: Fix helix duplicate selection landing on wrong column

### DIFF
--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -98,15 +98,33 @@ fn find_next_valid_duplicate_space(
                 if candidate.end.row() >= map.max_point().row() {
                     return None;
                 }
-                *candidate.start.row_mut() += 1;
-                *candidate.end.row_mut() += 1;
+
+                candidate = map.start_of_relative_buffer_row(
+                    DisplayPoint::new(candidate.start.row(), candidate.start.column()),
+                    1,
+                )
+                    ..map.start_of_relative_buffer_row(
+                        DisplayPoint::new(candidate.end.row(), candidate.end.column()),
+                        1,
+                    );
+                // *candidate.start.row_mut() += 1;
+                // *candidate.end.row_mut() += 1;
             }
             Direction::Above => {
                 if candidate.start.row() == DisplayPoint::zero().row() {
                     return None;
                 }
-                *candidate.start.row_mut() = candidate.start.row().0.saturating_sub(1);
-                *candidate.end.row_mut() = candidate.end.row().0.saturating_sub(1);
+
+                candidate = map.start_of_relative_buffer_row(
+                    DisplayPoint::new(candidate.start.row(), candidate.start.column()),
+                    -1,
+                )
+                    ..map.start_of_relative_buffer_row(
+                        DisplayPoint::new(candidate.end.row(), candidate.start.column()),
+                        -1,
+                    );
+                // *candidate.start.row_mut() = candidate.start.row().0.saturating_sub(1);
+                // *candidate.end.row_mut() = candidate.end.row().0.saturating_sub(1);
             }
         }
 
@@ -429,16 +447,22 @@ let y: i32 = 2;",
 
         cx.set_state(
             indoc! {"
-                «1ˇ»234567890121
+                «1ˇ»2345678901234567890
+                12345678901234567890
+                12345678901234567890
+                12345678901234567890
             "},
             Mode::HelixNormal,
         );
 
-        cx.simulate_keystrokes("C");
+        cx.simulate_keystrokes("3 C");
 
         cx.assert_state(
             indoc! {"
-                «1ˇ»23456789012«1ˇ»
+                «1ˇ»2345678901234567890
+                «1ˇ»2345678901234567890
+                «1ˇ»2345678901234567890
+                «1ˇ»2345678901234567890
             "},
             Mode::HelixNormal,
         );

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -512,6 +512,51 @@ let xyz: i32 = 2;",
     }
 
     #[gpui::test]
+    async fn test_selection_duplication_with_tab_and_inlay_hint(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.update_global(|settings: &mut SettingsStore, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.hard_tabs = Some(true);
+            });
+        });
+
+        cx.set_state(
+            indoc! {"
+                \t12345«6ˇ»
+                \t\t56"},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, window, cx| {
+            let buffer = &editor.snapshot(window, cx).buffer;
+            editor.splice_inlays(
+                &[],
+                vec![
+                    Inlay::mock_hint(0, buffer.anchor_after(MultiBufferOffset(6)), ": foo"),
+                    Inlay::mock_hint(1, buffer.anchor_after(MultiBufferOffset(11)), ": foo"),
+                ],
+                cx,
+            );
+        });
+
+        assert_eq!(
+            cx.display_text(),
+            "    12345: foo6
+        5: foo6"
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+                \t12345«6ˇ»
+                \t\t5«6ˇ»"},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
     async fn test_selection_duplication_with_softwrap(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.enable_helix();

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -410,4 +410,37 @@ let y: i32 = 2;",
             Mode::HelixNormal,
         );
     }
+
+    #[gpui::test]
+    async fn test_selection_duplication_with_softwrap(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.update_global(|settings: &mut SettingsStore, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.soft_wrap =
+                    Some(settings::SoftWrap::Bounded);
+                settings
+                    .project
+                    .all_languages
+                    .defaults
+                    .preferred_line_length = Some(12);
+            });
+        });
+
+        cx.set_state(
+            indoc! {"
+                «1ˇ»234567890121
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+                «1ˇ»23456789012«1ˇ»
+            "},
+            Mode::HelixNormal,
+        );
+    }
 }

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -107,8 +107,6 @@ fn find_next_valid_duplicate_space(
                         DisplayPoint::new(candidate.end.row(), candidate.end.column()),
                         1,
                     );
-                // *candidate.start.row_mut() += 1;
-                // *candidate.end.row_mut() += 1;
             }
             Direction::Above => {
                 if candidate.start.row() == DisplayPoint::zero().row() {
@@ -123,8 +121,6 @@ fn find_next_valid_duplicate_space(
                         DisplayPoint::new(candidate.end.row(), candidate.start.column()),
                         -1,
                     );
-                // *candidate.start.row_mut() = candidate.start.row().0.saturating_sub(1);
-                // *candidate.end.row_mut() = candidate.end.row().0.saturating_sub(1);
             }
         }
 
@@ -455,7 +451,7 @@ let y: i32 = 2;",
             Mode::HelixNormal,
         );
 
-        cx.simulate_keystrokes("3 C");
+        cx.simulate_keystrokes("8 C");
 
         cx.assert_state(
             indoc! {"

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -1,13 +1,16 @@
 use std::ops::Range;
 
 use editor::{
-    DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot, movement::TextLayoutDetails,
+    DisplayPoint, MultiBufferOffset,
+    display_map::{DisplaySnapshot, FoldPoint},
+    movement::TextLayoutDetails,
 };
 use gpui::Context;
-use text::Bias;
+use multi_buffer::MultiBufferRow;
+use text::{Bias, SelectionGoal};
 use ui::Window;
 
-use crate::Vim;
+use crate::{Vim, motion::up_down_buffer_rows};
 
 #[derive(Copy, Clone)]
 enum Direction {
@@ -88,51 +91,110 @@ fn find_next_valid_duplicate_space(
     direction: Direction,
     text_layout_details: &TextLayoutDetails,
 ) -> Option<Range<DisplayPoint>> {
+    // records which soft-wrap sub-row the origin start/end are on
+    let wrapped_row_for = |point: DisplayPoint| {
+        let fold_point = map.display_point_to_fold_point(point, Bias::Left);
+        let begin_folded_line = map.fold_point_to_display_point(
+            map.fold_snapshot()
+                .clip_point(FoldPoint::new(fold_point.row(), 0), Bias::Left),
+        );
+        point.row().0 - begin_folded_line.row().0
+    };
+
+    let start_wrapped_row = wrapped_row_for(origin.start);
+    let end_wrapped_row = wrapped_row_for(origin.end);
+
     let start_x = map.x_for_display_point(origin.start, text_layout_details);
     let end_x = map.x_for_display_point(origin.end, text_layout_details);
 
-    let mut candidate = origin;
+    let times = match direction {
+        Direction::Above => -1,
+        Direction::Below => 1,
+    };
+
+    let mut candidate = origin.clone();
+    let mut start_goal = SelectionGoal::None;
+    let mut end_goal = SelectionGoal::None;
+
+    // If the pos is in a `inlay_hint`, preserve the buffer column across inlays
+    let preserve_buffer_column_across_inlays =
+        |origin: DisplayPoint, candidate: DisplayPoint, bias: Bias| {
+            let origin_buffer_point = map.display_point_to_point(origin, bias);
+            let candidate_buffer_point = map.display_point_to_point(candidate, bias);
+
+            let origin_inlay_point = map.inlay_snapshot().to_inlay_point(origin_buffer_point);
+            let candidate_inlay_point = map.inlay_snapshot().to_inlay_point(candidate_buffer_point);
+
+            let has_inlay_before_origin = origin_inlay_point.0.column > origin_buffer_point.column;
+            let has_inlay_before_candidate =
+                candidate_inlay_point.0.column > candidate_buffer_point.column;
+
+            if origin_buffer_point.column == candidate_buffer_point.column
+                || !(has_inlay_before_origin || has_inlay_before_candidate)
+            {
+                return candidate;
+            }
+
+            // FIXME: This fallback compares/assigns raw buffer columns (byte offsets),
+            // not tab-expanded (visual) columns. If either the origin or candidate line
+            // contains tabs whose expansion width differs before this column, falling
+            // back to "same raw buffer column" can land on a visually misaligned
+            // position, the same class of bug the pixel-based (`up_down_buffer_rows`)
+            // path is otherwise designed to avoid. This case isn't currently covered by
+            // tests (existing tests exercise inlays and tabs separately, not combined
+            // on the same line/column).
+            let mut target_buffer_point = candidate_buffer_point;
+            target_buffer_point.column = origin_buffer_point.column.min(
+                map.buffer_snapshot()
+                    .line_len(MultiBufferRow(target_buffer_point.row)),
+            );
+            map.point_to_display_point(target_buffer_point, bias)
+        };
+
     loop {
-        match direction {
-            Direction::Below => {
-                if candidate.end.row() >= map.max_point().row() {
-                    return None;
-                }
+        let previous_boundary = match direction {
+            Direction::Above => candidate.start,
+            Direction::Below => candidate.end,
+        };
+        let (candidate_start, next_start_goal) =
+            up_down_buffer_rows(map, candidate.start, start_goal, times, text_layout_details);
+        let (candidate_end, next_end_goal) =
+            up_down_buffer_rows(map, candidate.end, end_goal, times, text_layout_details);
 
-                candidate = map.start_of_relative_buffer_row(
-                    DisplayPoint::new(candidate.start.row(), candidate.start.column()),
-                    1,
-                )
-                    ..map.start_of_relative_buffer_row(
-                        DisplayPoint::new(candidate.end.row(), candidate.end.column()),
-                        1,
-                    );
-            }
-            Direction::Above => {
-                if candidate.start.row() == DisplayPoint::zero().row() {
-                    return None;
-                }
+        let candidate_start =
+            preserve_buffer_column_across_inlays(origin.start, candidate_start, Bias::Left);
+        let candidate_end =
+            preserve_buffer_column_across_inlays(origin.end, candidate_end, Bias::Right);
+        candidate = candidate_start..candidate_end;
 
-                candidate = map.start_of_relative_buffer_row(
-                    DisplayPoint::new(candidate.start.row(), candidate.start.column()),
-                    -1,
-                )
-                    ..map.start_of_relative_buffer_row(
-                        DisplayPoint::new(candidate.end.row(), candidate.start.column()),
-                        -1,
-                    );
-            }
+        start_goal = next_start_goal;
+        end_goal = next_end_goal;
+
+        let boundary = match direction {
+            Direction::Above => candidate.start,
+            Direction::Below => candidate.end,
+        };
+
+        if map
+            .display_point_to_fold_point(previous_boundary, Bias::Left)
+            .row()
+            == map.display_point_to_fold_point(boundary, Bias::Left).row()
+        {
+            return None;
         }
 
-        let start_row = candidate.start.row();
-        let end_row = candidate.end.row();
+        if wrapped_row_for(candidate.start) != start_wrapped_row
+            || wrapped_row_for(candidate.end) != end_wrapped_row
+        {
+            continue;
+        }
 
         let start_row_end_x = map.x_for_display_point(
-            DisplayPoint::new(start_row, map.line_len(start_row)),
+            DisplayPoint::new(candidate.start.row(), map.line_len(candidate.start.row())),
             text_layout_details,
         );
         let end_row_end_x = map.x_for_display_point(
-            DisplayPoint::new(end_row, map.line_len(end_row)),
+            DisplayPoint::new(candidate.end.row(), map.line_len(candidate.end.row())),
             text_layout_details,
         );
 
@@ -140,17 +202,7 @@ fn find_next_valid_duplicate_space(
             continue;
         }
 
-        let start_col = map.display_column_for_x(start_row, start_x, text_layout_details);
-        let end_col = map.display_column_for_x(end_row, end_x, text_layout_details);
-
-        let candidate_start = DisplayPoint::new(start_row, start_col);
-        let candidate_end = DisplayPoint::new(end_row, end_col);
-
-        if map.clip_point(candidate_start, Bias::Left) == candidate_start
-            && map.clip_point(candidate_end, Bias::Right) == candidate_end
-        {
-            return Some(candidate_start..candidate_end);
-        }
+        return Some(candidate);
     }
 }
 
@@ -370,6 +422,40 @@ let y: i32 = 2;",
                let y = «2ˇ»;"},
             Mode::HelixNormal,
         );
+
+        cx.set_state(
+            indoc! {"
+               let x «=ˇ» 1;
+               let xyz = 2;"},
+            Mode::HelixNormal,
+        );
+
+        cx.update_editor(|editor, window, cx| {
+            let buffer = &editor.snapshot(window, cx).buffer;
+            editor.splice_inlays(
+                &[],
+                vec![
+                    Inlay::mock_hint(0, buffer.anchor_after(MultiBufferOffset(5)), ": i32"),
+                    Inlay::mock_hint(1, buffer.anchor_after(MultiBufferOffset(18)), ": i32"),
+                ],
+                cx,
+            );
+        });
+
+        cx.simulate_keystrokes("C");
+
+        assert_eq!(
+            cx.display_text(),
+            "let x: i32 = 1;
+let xyz: i32 = 2;",
+        );
+
+        cx.assert_state(
+            indoc! {"
+               let x «=ˇ» 1;
+               let xy«zˇ» = 2;"},
+            Mode::HelixNormal,
+        );
     }
 
     #[gpui::test]
@@ -443,7 +529,8 @@ let y: i32 = 2;",
 
         cx.set_state(
             indoc! {"
-                «1ˇ»2345678901234567890
+                12345678901234567890
+                1234567890123«4ˇ»567890
                 12345678901234567890
                 12345678901234567890
                 12345678901234567890
@@ -455,10 +542,24 @@ let y: i32 = 2;",
 
         cx.assert_state(
             indoc! {"
-                «1ˇ»2345678901234567890
-                «1ˇ»2345678901234567890
-                «1ˇ»2345678901234567890
-                «1ˇ»2345678901234567890
+                12345678901234567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("alt-C");
+
+        cx.assert_state(
+            indoc! {"
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
+                1234567890123«4ˇ»567890
             "},
             Mode::HelixNormal,
         );

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -1,9 +1,9 @@
 use std::ops::Range;
 
-use editor::{DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot};
+use editor::{
+    DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot, movement::TextLayoutDetails,
+};
 use gpui::Context;
-use language::PointUtf16;
-use multi_buffer::{MultiBufferPoint, MultiBufferRow};
 use text::Bias;
 use ui::Window;
 
@@ -50,6 +50,7 @@ impl Vim {
             let mut selections = Vec::new();
             let map = editor.display_snapshot(cx);
             let mut original_selections = editor.selections.all_display(&map);
+            let text_layout_details = editor.text_layout_details(window, cx);
             // The order matters, because it is recorded when the selections are added.
             if matches!(direction, Direction::Above) {
                 original_selections.reverse();
@@ -60,9 +61,12 @@ impl Vim {
                 selections.push(display_point_range_to_offset_range(&origin, &map));
                 let mut last_origin = origin;
                 for _ in 1..=times {
-                    if let Some(duplicate) =
-                        find_next_valid_duplicate_space(last_origin.clone(), &map, direction)
-                    {
+                    if let Some(duplicate) = find_next_valid_duplicate_space(
+                        last_origin.clone(),
+                        &map,
+                        direction,
+                        &text_layout_details,
+                    ) {
                         selections.push(display_point_range_to_offset_range(&duplicate, &map));
                         last_origin = duplicate;
                     } else {
@@ -82,12 +86,10 @@ fn find_next_valid_duplicate_space(
     origin: Range<DisplayPoint>,
     map: &DisplaySnapshot,
     direction: Direction,
+    text_layout_details: &TextLayoutDetails,
 ) -> Option<Range<DisplayPoint>> {
-    let buffer = map.buffer_snapshot();
-    let start_col_utf16 = buffer
-        .point_to_point_utf16(origin.start.to_point(map))
-        .column;
-    let end_col_utf16 = buffer.point_to_point_utf16(origin.end.to_point(map)).column;
+    let start_x = map.x_for_display_point(origin.start, text_layout_details);
+    let end_x = map.x_for_display_point(origin.end, text_layout_details);
 
     let mut candidate = origin;
     loop {
@@ -108,28 +110,27 @@ fn find_next_valid_duplicate_space(
             }
         }
 
-        let start_row = DisplayPoint::new(candidate.start.row(), 0)
-            .to_point(map)
-            .row;
-        let end_row = DisplayPoint::new(candidate.end.row(), 0).to_point(map).row;
+        let start_row = candidate.start.row();
+        let end_row = candidate.end.row();
 
-        if start_col_utf16 > buffer.line_len_utf16(MultiBufferRow(start_row))
-            || end_col_utf16 > buffer.line_len_utf16(MultiBufferRow(end_row))
-        {
+        let start_row_end_x = map.x_for_display_point(
+            DisplayPoint::new(start_row, map.line_len(start_row)),
+            text_layout_details,
+        );
+        let end_row_end_x = map.x_for_display_point(
+            DisplayPoint::new(end_row, map.line_len(end_row)),
+            text_layout_details,
+        );
+
+        if start_x > start_row_end_x || end_x > end_row_end_x {
             continue;
         }
 
-        let start_col = buffer
-            .point_utf16_to_point(PointUtf16::new(start_row, start_col_utf16))
-            .column;
-        let end_col = buffer
-            .point_utf16_to_point(PointUtf16::new(end_row, end_col_utf16))
-            .column;
+        let start_col = map.display_column_for_x(start_row, start_x, text_layout_details);
+        let end_col = map.display_column_for_x(end_row, end_x, text_layout_details);
 
-        let candidate_start =
-            map.point_to_display_point(MultiBufferPoint::new(start_row, start_col), Bias::Left);
-        let candidate_end =
-            map.point_to_display_point(MultiBufferPoint::new(end_row, end_col), Bias::Right);
+        let candidate_start = DisplayPoint::new(start_row, start_col);
+        let candidate_end = DisplayPoint::new(end_row, end_col);
 
         if map.clip_point(candidate_start, Bias::Left) == candidate_start
             && map.clip_point(candidate_end, Bias::Right) == candidate_end

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -149,8 +149,11 @@ fn display_point_range_to_offset_range(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZero;
+
     use db::indoc;
     use editor::{Inlay, MultiBufferOffset};
+    use settings::SettingsStore;
 
     use crate::{state::Mode, test::VimTestContext};
 
@@ -351,6 +354,59 @@ let y: i32 = 2;",
             indoc! {"
                let x = «1ˇ»;
                let y = «2ˇ»;"},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_selection_duplication_with_tab(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.update_global(|settings: &mut SettingsStore, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.hard_tabs = Some(true);
+            });
+        });
+
+        cx.set_state(
+            indoc! {"
+                \t1234«5ˇ»
+                \t\t5
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+                \t1234«5ˇ»
+                \t\t«5ˇ»
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.update_global(|settings: &mut SettingsStore, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.tab_size = NonZero::new(1);
+            });
+        });
+
+        cx.set_state(
+            indoc! {"
+                \t1«2ˇ»345
+                \t\t2
+            "},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+                \t1«2ˇ»345
+                \t\t«2ˇ»
+            "},
             Mode::HelixNormal,
         );
     }

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -135,7 +135,7 @@ fn find_next_valid_duplicate_space(
                 return candidate;
             }
 
-            // FIXME: This byte-column fallback can misalign tabs before the endpoint.
+            // NOTE: This byte-column fallback can misalign tabs before the endpoint.
             let mut target_buffer_point = candidate_buffer_point;
             target_buffer_point.column = origin_buffer_point.column.min(
                 map.buffer_snapshot()

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -91,7 +91,7 @@ fn find_next_valid_duplicate_space(
     direction: Direction,
     text_layout_details: &TextLayoutDetails,
 ) -> Option<Range<DisplayPoint>> {
-    // records which soft-wrap sub-row the origin start/end are on
+    // Keep each endpoint on the same soft-wrapped subrow as the original.
     let wrapped_row_for = |point: DisplayPoint| {
         let fold_point = map.display_point_to_fold_point(point, Bias::Left);
         let begin_folded_line = map.fold_point_to_display_point(
@@ -116,7 +116,7 @@ fn find_next_valid_duplicate_space(
     let mut start_goal = SelectionGoal::None;
     let mut end_goal = SelectionGoal::None;
 
-    // If the pos is in a `inlay_hint`, preserve the buffer column across inlays
+    // Rendered x includes inlay text, so preserve the buffer column when inlays shift it.
     let preserve_buffer_column_across_inlays =
         |origin: DisplayPoint, candidate: DisplayPoint, bias: Bias| {
             let origin_buffer_point = map.display_point_to_point(origin, bias);
@@ -135,14 +135,7 @@ fn find_next_valid_duplicate_space(
                 return candidate;
             }
 
-            // FIXME: This fallback compares/assigns raw buffer columns (byte offsets),
-            // not tab-expanded (visual) columns. If either the origin or candidate line
-            // contains tabs whose expansion width differs before this column, falling
-            // back to "same raw buffer column" can land on a visually misaligned
-            // position, the same class of bug the pixel-based (`up_down_buffer_rows`)
-            // path is otherwise designed to avoid. This case isn't currently covered by
-            // tests (existing tests exercise inlays and tabs separately, not combined
-            // on the same line/column).
+            // FIXME: This byte-column fallback can misalign tabs before the endpoint.
             let mut target_buffer_point = candidate_buffer_point;
             target_buffer_point.column = origin_buffer_point.column.min(
                 map.buffer_snapshot()

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1539,7 +1539,7 @@ fn wrapping_right_single(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayP
     }
 }
 
-fn up_down_buffer_rows(
+pub(crate) fn up_down_buffer_rows(
     map: &DisplaySnapshot,
     mut point: DisplayPoint,
     mut goal: SelectionGoal,


### PR DESCRIPTION
# Objective

- Fixes #57956 

## Solution

-  Previously, we aligned selections using the UTF-16 character offset (`point_to_point_utf16` / `point_utf16_to_point`) of the origin selection within its buffer line.
- This works fine for plain text, but breaks down whenever a line contains tab characters; a `\t` always counts as a single UTF-16 character (regardless of how many display columns it expands to)
- This PR rewrite instead reuses `up_down_buffer_rows` to move between rows, since it's already correct for tabs and multibyte text.
- A small `preserve_buffer_column_across_inlays` correction is layered on top to fall back to the origin's raw buffer column when **Vertical movement produced a different buffer column** or **An inlay is mapped before that endpoint on either the origin or candidate row**, `test_selection_duplication_with_tab_and_inlay_hint` covers tabs plus boundary-aligned hints.

## Testing

- Added regression test for tab, soft-wrap and....

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Related

- This may make #57666 obsolete — this PR should supersede it.

---

Release Notes:

- Fixed `Shift+C` cursor column alignment in helix mode