### PR TITLE
editor: Respect `auto_indent` setting in `NewlineBelow` and `NewlineAbove`

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13217,6 +13217,110 @@ async fn test_autoindent_syntax_aware_applies_syntax_indent(cx: &mut TestAppCont
 }
 
 #[gpui::test]
+async fn test_newline_below_auto_indent_none(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::None)
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        hello
+            indented lineˇ
+        world
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline_below(&NewlineBelow, window, cx);
+    });
+
+    cx.assert_editor_state(indoc! {"
+        hello
+            indented line
+        ˇ
+        world
+    "});
+}
+
+#[gpui::test]
+async fn test_newline_below_auto_indent_preserve(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent)
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        hello
+            indented lineˇ
+        world
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline_below(&NewlineBelow, window, cx);
+    });
+
+    cx.assert_editor_state(indoc! {"
+        hello
+            indented line
+            ˇ
+        world
+    "});
+}
+
+#[gpui::test]
+async fn test_newline_above_auto_indent_none(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::None)
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        hello
+            indented lineˇ
+        world
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline_above(&NewlineAbove, window, cx);
+    });
+
+    cx.assert_editor_state(indoc! {"
+        hello
+        ˇ
+            indented line
+        world
+    "});
+}
+
+#[gpui::test]
+async fn test_newline_above_auto_indent_preserve(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent)
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        hello
+            indented lineˇ
+        world
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline_above(&NewlineAbove, window, cx);
+    });
+
+    cx.assert_editor_state(indoc! {"
+        hello
+            ˇ
+            indented line
+        world
+    "});
+}
+
+#[gpui::test]
 async fn test_autoindent_disabled_with_nested_language(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::SyntaxAware);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13222,24 +13222,42 @@ async fn test_newline_below_auto_indent_none(cx: &mut TestAppContext) {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::None)
     });
 
-    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                brackets: BracketPairConfig {
+                    pairs: vec![BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: false,
+                        surround: false,
+                        newline: false,
+                    }],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
 
-    cx.set_state(indoc! {"
-        hello
-            indented lineˇ
-        world
-    "});
+    let buffer =
+        cx.new(|cx| Buffer::local("fn foo() {\n}", cx).with_language(language.clone(), cx));
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
 
-    cx.update_editor(|editor, window, cx| {
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([MultiBufferOffset(10)..MultiBufferOffset(10)])
+        });
         editor.newline_below(&NewlineBelow, window, cx);
+        assert_eq!(editor.text(cx), "fn foo() {\n\n}");
     });
-
-    cx.assert_editor_state(indoc! {"
-        hello
-            indented line
-        ˇ
-        world
-    "});
 }
 
 #[gpui::test]
@@ -13248,24 +13266,43 @@ async fn test_newline_below_auto_indent_preserve(cx: &mut TestAppContext) {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent)
     });
 
-    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                brackets: BracketPairConfig {
+                    pairs: vec![BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: false,
+                        surround: false,
+                        newline: false,
+                    }],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
 
-    cx.set_state(indoc! {"
-        hello
-            indented lineˇ
-        world
-    "});
-
-    cx.update_editor(|editor, window, cx| {
-        editor.newline_below(&NewlineBelow, window, cx);
+    let buffer = cx.new(|cx| {
+        Buffer::local("fn outer() {\n    fn inner() {\n    }\n}", cx).with_language(language.clone(), cx)
     });
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
 
-    cx.assert_editor_state(indoc! {"
-        hello
-            indented line
-            ˇ
-        world
-    "});
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([MultiBufferOffset(29)..MultiBufferOffset(29)])
+        });
+        editor.newline_below(&NewlineBelow, window, cx);
+        assert_eq!(editor.text(cx), "fn outer() {\n    fn inner() {\n    \n    }\n}");
+    });
 }
 
 #[gpui::test]
@@ -13274,24 +13311,42 @@ async fn test_newline_above_auto_indent_none(cx: &mut TestAppContext) {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::None)
     });
 
-    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                brackets: BracketPairConfig {
+                    pairs: vec![BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: false,
+                        surround: false,
+                        newline: false,
+                    }],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
 
-    cx.set_state(indoc! {"
-        hello
-            indented lineˇ
-        world
-    "});
+    let buffer =
+        cx.new(|cx| Buffer::local("fn foo() {\n}", cx).with_language(language.clone(), cx));
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
 
-    cx.update_editor(|editor, window, cx| {
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([MultiBufferOffset(11)..MultiBufferOffset(11)])
+        });
         editor.newline_above(&NewlineAbove, window, cx);
+        assert_eq!(editor.text(cx), "fn foo() {\n\n}");
     });
-
-    cx.assert_editor_state(indoc! {"
-        hello
-        ˇ
-            indented line
-        world
-    "});
 }
 
 #[gpui::test]
@@ -13300,24 +13355,43 @@ async fn test_newline_above_auto_indent_preserve(cx: &mut TestAppContext) {
         settings.defaults.auto_indent = Some(settings::AutoIndentMode::PreserveIndent)
     });
 
-    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                brackets: BracketPairConfig {
+                    pairs: vec![BracketPair {
+                        start: "{".to_string(),
+                        end: "}".to_string(),
+                        close: false,
+                        surround: false,
+                        newline: false,
+                    }],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
 
-    cx.set_state(indoc! {"
-        hello
-            indented lineˇ
-        world
-    "});
-
-    cx.update_editor(|editor, window, cx| {
-        editor.newline_above(&NewlineAbove, window, cx);
+    let buffer = cx.new(|cx| {
+        Buffer::local("fn foo() {\n        let x = 1;\n}", cx).with_language(language.clone(), cx)
     });
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
 
-    cx.assert_editor_state(indoc! {"
-        hello
-            ˇ
-            indented line
-        world
-    "});
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([MultiBufferOffset(29)..MultiBufferOffset(29)])
+        });
+        editor.newline_above(&NewlineAbove, window, cx);
+        assert_eq!(editor.text(cx), "fn foo() {\n        \n        let x = 1;\n}");
+    });
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -830,23 +830,10 @@ impl Editor {
                 });
             });
 
-            let mut indent_edits = Vec::new();
             let multibuffer_snapshot = editor.buffer.read(cx).snapshot(cx);
-            for row in rows {
-                let indents = multibuffer_snapshot.suggested_indents(row..row + 1, cx);
-                for (row, indent) in indents {
-                    if indent.len == 0 {
-                        continue;
-                    }
-
-                    let text = match indent.kind {
-                        IndentKind::Space => " ".repeat(indent.len as usize),
-                        IndentKind::Tab => "\t".repeat(indent.len as usize),
-                    };
-                    let point = Point::new(row.0, 0);
-                    indent_edits.push((point..point, text));
-                }
-            }
+            let indent_edits = indent_edits_for_new_lines(&multibuffer_snapshot, &rows, |row| {
+                Some(row + 1)
+            }, cx);
             editor.edit(indent_edits, cx);
             if let Some(format) = editor.trigger_on_type_formatting("\n".to_owned(), window, cx) {
                 format.detach_and_log_err(cx);
@@ -914,23 +901,13 @@ impl Editor {
                 });
             });
 
-            let mut indent_edits = Vec::new();
             let multibuffer_snapshot = editor.buffer.read(cx).snapshot(cx);
-            for row in rows.into_iter().flatten() {
-                let indents = multibuffer_snapshot.suggested_indents(row..row + 1, cx);
-                for (row, indent) in indents {
-                    if indent.len == 0 {
-                        continue;
-                    }
-
-                    let text = match indent.kind {
-                        IndentKind::Space => " ".repeat(indent.len as usize),
-                        IndentKind::Tab => "\t".repeat(indent.len as usize),
-                    };
-                    let point = Point::new(row.0, 0);
-                    indent_edits.push((point..point, text));
-                }
-            }
+            let indent_edits = indent_edits_for_new_lines(
+                &multibuffer_snapshot,
+                &rows.into_iter().flatten().collect::<Vec<_>>(),
+                |row| row.checked_sub(1),
+                cx,
+            );
             editor.edit(indent_edits, cx);
             if let Some(format) = editor.trigger_on_type_formatting("\n".to_owned(), window, cx) {
                 format.detach_and_log_err(cx);
@@ -2223,6 +2200,54 @@ impl Editor {
 
         self.insert_snippet(&insertion_ranges, snippet, window, cx)
     }
+}
+
+fn indent_edits_for_new_lines(
+    snapshot: &MultiBufferSnapshot,
+    rows: &[u32],
+    preserve_indent_source_row: impl Fn(u32) -> Option<u32>,
+    cx: &App,
+) -> Vec<(Range<Point>, String)> {
+    let mut indent_edits = Vec::new();
+    for row in rows {
+        let auto_indent_mode = snapshot
+            .language_settings_at(Point::new(*row, 0), cx)
+            .auto_indent;
+        match auto_indent_mode {
+            language::AutoIndentMode::None => {}
+            language::AutoIndentMode::PreserveIndent => {
+                let Some(source_row) = preserve_indent_source_row(*row) else {
+                    continue;
+                };
+                let line_indent = snapshot.line_indent_for_row(MultiBufferRow(source_row));
+                if line_indent.raw_len() == 0 {
+                    continue;
+                }
+                let text = format!(
+                    "{}{}",
+                    "\t".repeat(line_indent.tabs as usize),
+                    " ".repeat(line_indent.spaces as usize)
+                );
+                let point = Point::new(*row, 0);
+                indent_edits.push((point..point, text));
+            }
+            language::AutoIndentMode::SyntaxAware => {
+                let indents = snapshot.suggested_indents(*row..*row + 1, cx);
+                for (row, indent) in indents {
+                    if indent.len == 0 {
+                        continue;
+                    }
+                    let text = match indent.kind {
+                        IndentKind::Space => " ".repeat(indent.len as usize),
+                        IndentKind::Tab => "\t".repeat(indent.len as usize),
+                    };
+                    let point = Point::new(row.0, 0);
+                    indent_edits.push((point..point, text));
+                }
+            }
+        }
+    }
+    indent_edits
 }
 
 #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
Closes #61839

Release Notes:

- Fixed `NewlineBelow` and `NewlineAbove` ignoring the `auto_indent` setting

<img width="800" height="430" alt="screenrecording-2026-07-29_20-38-53" src="https://github.com/user-attachments/assets/141582fe-5516-470c-9ea0-7b5b8781864e" />