### PR TITLE
editor: Fix collapsed multibuffer header revealing content underneath

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8740,28 +8740,6 @@ impl Element for EditorElement {
                         }
                     }
 
-                    let sticky_buffer_header = if self.should_show_buffer_headers() {
-                        sticky_header_excerpt.map(|sticky_header_excerpt| {
-                            window.with_element_namespace("blocks", |window| {
-                                self.layout_sticky_buffer_header(
-                                    sticky_header_excerpt,
-                                    scroll_position,
-                                    line_height,
-                                    right_margin,
-                                    &snapshot,
-                                    &hitbox,
-                                    &selected_buffer_ids,
-                                    &blocks,
-                                    &latest_selection_anchors,
-                                    window,
-                                    cx,
-                                )
-                            })
-                        })
-                    } else {
-                        None
-                    };
-
                     let scroll_max: gpui::Point<ScrollPixelOffset> = point(
                         ScrollPixelOffset::from(
                             ((scroll_width - editor_width) / em_layout_width).max(0.0),
@@ -9251,6 +9229,31 @@ impl Element for EditorElement {
                     window.with_element_namespace("expand_toggles", |window| {
                         self.prepaint_expand_toggles(&mut expand_toggles, window, cx)
                     });
+
+                    // Laid out after the gutter toggles so its hitbox is registered last and
+                    // wins hit-testing: `block_mouse_except_scroll` on the header only masks
+                    // hitboxes registered before it.
+                    let sticky_buffer_header = if self.should_show_buffer_headers() {
+                        sticky_header_excerpt.map(|sticky_header_excerpt| {
+                            window.with_element_namespace("blocks", |window| {
+                                self.layout_sticky_buffer_header(
+                                    sticky_header_excerpt,
+                                    scroll_position,
+                                    line_height,
+                                    right_margin,
+                                    &snapshot,
+                                    &hitbox,
+                                    &selected_buffer_ids,
+                                    &blocks,
+                                    &latest_selection_anchors,
+                                    window,
+                                    cx,
+                                )
+                            })
+                        })
+                    } else {
+                        None
+                    };
 
                     let wrap_guides = self.layout_wrap_guides(
                         em_advance,
@@ -10762,6 +10765,117 @@ mod tests {
                 NavigationOverlayPaintCommand::Label(label) => label,
             })
             .collect()
+    }
+
+    #[gpui::test]
+    async fn test_sticky_multibuffer_header_blocks_hidden_expand_toggle(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let window = cx.add_window(|window, cx| {
+            let multi_buffer = MultiBuffer::build_multi(
+                [
+                    ("zero\none\ntwo\nthree\n", vec![Point::row_range(0..1)]),
+                    ("four\nfive\nsix\nseven\n", vec![Point::row_range(1..2)]),
+                ],
+                cx,
+            );
+            Editor::new(EditorMode::full(), multi_buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).expect("expected an editor root");
+        let line_height = window
+            .update(cx, |editor, window, cx| {
+                editor
+                    .style(cx)
+                    .text
+                    .line_height_in_pixels(window.rem_size())
+            })
+            .expect("expected the editor window to remain open");
+        let viewport_size = size(px(500.), line_height * 3.5);
+
+        let excerpt_contexts = |cx: &mut VisualTestContext| {
+            editor.update(cx, |editor, cx| {
+                editor
+                    .buffer()
+                    .read(cx)
+                    .snapshot(cx)
+                    .excerpts()
+                    .collect::<Vec<_>>()
+            })
+        };
+
+        let draw_window = |cx: &mut VisualTestContext| {
+            cx.update(|window, cx| {
+                window.refresh();
+                window.draw(cx).clear(cx);
+            });
+        };
+
+        cx.simulate_resize(viewport_size);
+        cx.run_until_parked();
+        draw_window(cx);
+        editor.update_in(cx, |editor, window, cx| {
+            editor.set_scroll_position(point(0., 2.25), window, cx);
+        });
+        draw_window(cx);
+        let covered_toggle_bounds = cx
+            .debug_bounds("ICON-ExpandDown")
+            .expect("expected an expand toggle underneath the sticky buffer header");
+        // Aim at the header's bare padding, clear of its own fold-toggle button. The
+        // header's child buttons are prepainted after the expand toggle and would swallow
+        // the click on their own; this is the only spot where `block_mouse_except_scroll`
+        // is what keeps the click from reaching the toggle underneath.
+        let covered_toggle_position = point(
+            covered_toggle_bounds.left() + px(0.5),
+            covered_toggle_bounds.center().y,
+        );
+        let scroll_position_before_wheel =
+            editor.update(cx, |editor, cx| editor.scroll_position(cx));
+        cx.simulate_event(gpui::ScrollWheelEvent {
+            position: covered_toggle_position,
+            delta: gpui::ScrollDelta::Lines(point(0., 0.5)),
+            ..Default::default()
+        });
+        assert_ne!(
+            editor.update(cx, |editor, cx| editor.scroll_position(cx)),
+            scroll_position_before_wheel,
+            "scrolling over the sticky buffer header should remain functional"
+        );
+        editor.update_in(cx, |editor, window, cx| {
+            editor.set_scroll_position(scroll_position_before_wheel, window, cx);
+        });
+        draw_window(cx);
+        let contexts_before_click = excerpt_contexts(cx);
+
+        cx.simulate_mouse_move(covered_toggle_position, None, gpui::Modifiers::none());
+        draw_window(cx);
+        cx.simulate_click(covered_toggle_position, gpui::Modifiers::none());
+
+        assert_eq!(
+            excerpt_contexts(cx),
+            contexts_before_click,
+            "the sticky buffer header should block the covered expand toggle"
+        );
+
+        editor.update_in(cx, |editor, window, cx| {
+            editor.set_scroll_position(point(0., 0.), window, cx);
+        });
+        cx.simulate_resize(size(px(500.), line_height * 8.));
+        draw_window(cx);
+        let visible_toggle_bounds = cx
+            .debug_bounds("ICON-ExpandDown")
+            .expect("expected a visible expand toggle");
+        let visible_toggle_position = visible_toggle_bounds.center();
+
+        cx.simulate_mouse_move(visible_toggle_position, None, gpui::Modifiers::none());
+        draw_window(cx);
+        cx.simulate_click(visible_toggle_position, gpui::Modifiers::none());
+
+        assert_ne!(
+            excerpt_contexts(cx),
+            contexts_before_click,
+            "an uncovered expand toggle should remain interactive"
+        );
     }
 
     const fn placeholder_hitbox() -> Hitbox {

--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -9,7 +9,7 @@ use gpui::{
     CursorStyle, DefiniteLength, Entity, Focusable as _, Hitbox, HitboxBehavior, Hsla, IntoElement,
     Length, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, ParentElement, Pixels,
     ShapedLine, SharedString, Styled, TextAlign, Window, WindowBackgroundAppearance, div, fill,
-    linear_color_stop, linear_gradient, point, px, size,
+    point, px, size,
 };
 use language::language_settings::ShowWhitespaceSetting;
 use multi_buffer::{Anchor, ExcerptBoundaryInfo, MultiBuffer};
@@ -169,14 +169,13 @@ impl EditorElement {
             .w_full()
             .relative()
             .child(
+                // Opaque rather than a gradient: this backs the padding around the header
+                // bar, and is all that masks the excerpt scrolling underneath. A
+                // translucent edge leaks that text through the padding strip.
                 div()
                     .w(available_width)
                     .h(FILE_HEADER_HEIGHT as f32 * line_height)
-                    .bg(linear_gradient(
-                        0.,
-                        linear_color_stop(editor_bg_color.opacity(0.), 0.),
-                        linear_color_stop(editor_bg_color, 0.6),
-                    ))
+                    .bg(editor_bg_color)
                     .absolute()
                     .top_0(),
             )
@@ -708,6 +707,7 @@ pub(crate) fn render_buffer_header(
         .p(BUFFER_HEADER_PADDING)
         .w_full()
         .h(FILE_HEADER_HEIGHT as f32 * window.line_height())
+        .when(is_sticky, |header| header.block_mouse_except_scroll())
         .child(
             h_flex()
                 .group("buffer-header-group")

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -5,7 +5,7 @@ use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, Context, DragMoveEvent, Element,
     Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement, LayoutId, Length,
     ParentElement, Pixels, StatefulInteractiveElement, Styled, TextStyleRefinement, Window, div,
-    linear_color_stop, linear_gradient, point, px, size,
+    point, px, size,
 };
 use multi_buffer::{Anchor, ExcerptBoundaryInfo};
 use smallvec::smallvec;
@@ -557,14 +557,13 @@ impl SplitBufferHeadersElement {
             .w(available_width)
             .relative()
             .child(
+                // Opaque rather than a gradient: this backs the padding around the header
+                // bar, and is all that masks the excerpt scrolling underneath. A
+                // translucent edge leaks that text through the padding strip.
                 div()
                     .w(available_width)
                     .h(FILE_HEADER_HEIGHT as f32 * line_height)
-                    .bg(linear_gradient(
-                        0.,
-                        linear_color_stop(editor_bg_color.opacity(0.), 0.),
-                        linear_color_stop(editor_bg_color, 0.6),
-                    ))
+                    .bg(editor_bg_color)
                     .absolute()
                     .top_0(),
             )


### PR DESCRIPTION
## Context

Closes #34363

When a buffer in a multibuffer is scrolled until it collapses, its sticky header stops occluding the excerpt passing beneath it. Hovering the header lights up hover affordances that belong to the content underneath, its buttons stay clickable through to that content, and a thin strip of buffer text remains visible below the header bar even with the pointer away.

Two independent causes:

**Hit testing.** The sticky header registered no blocking hitbox, and it was laid out before the gutter toggles, so anything underneath won hit testing. In gpui, prepaint order decides hit test priority and the last registration wins.

**Rendering.** The header's backdrop was a linear gradient running from transparent to opaque. The header bar itself is inset by `BUFFER_HEADER_PADDING`, so the gradient's transparent end was the only thing covering the padding strip at the bottom of the header band, and excerpt text showed through it.

The rendering half was confirmed by measuring rendered pixels rather than by eye: before the change, a match highlight scrolled under the header showed 117 pixels of leakage in that strip; after, zero, while content sitting legitimately below the band renders identically.

Manual test before the changes:


https://github.com/user-attachments/assets/accc5384-ec5a-41db-bf90-b0c92d3aa656



Manual test after the changes :


https://github.com/user-attachments/assets/b30a07a4-598f-4816-a77c-a9b55c074fed



## How to Review

3 files changed. Read in this order:

**`crates/editor/src/element/header.rs`**

`render_buffer_header` now applies `block_mouse_except_scroll()` when `is_sticky`, so the header occludes mouse events for everything behind it while still passing the scroll wheel through, keeping scrolling over a pinned header working. Its own child buttons register after it, so the fold toggle and open file button stay interactive. Separately, the backdrop in `layout_sticky_buffer_header` becomes a solid `editor_background` instead of the gradient. The soft edge below the header already comes from the `shadow_md` on the inner bar, so dropping the gradient does not flatten that transition.

**`crates/editor/src/element.rs`**

The `layout_sticky_buffer_header` call moves from just before `scroll_max` to just after `prepaint_expand_toggles`, so the header's hitbox is registered last and wins hit testing. The call reads only `scroll_position.y`, which is untouched between the two sites (only `.x` is clamped, autoscrolled and pixel snapped in that range), so the move changes nothing but ordering. Floating UI is unaffected: completion menus, hover popovers, signature help, blame popovers and the mouse context menu all go through `defer_draw` or `deferred()` and therefore prepaint after every normal element regardless.

`test_sticky_multibuffer_header_blocks_hidden_expand_toggle` scrolls a two buffer multibuffer until an expand toggle sits beneath the pinned header, then asserts that clicking there leaves the excerpts untouched, that the wheel still scrolls over the header, and that an uncovered toggle in a taller viewport stays clickable. The click deliberately targets the header's bare padding: the header's own buttons prepaint after the toggle and would swallow a centered click on their own, so the padding is the only position where the blocking hitbox is what the test actually exercises.

**`crates/editor/src/split_editor_view.rs`**

The same gradient, duplicated for the side by side diff header, is replaced the same way. This view also builds its headers with `is_sticky = true`, so it picks up the occlusion fix from `header.rs` as well. Its header element is a sibling prepainted after both editors, so the blocking hitbox takes effect there without needing the `element.rs` reordering.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed collapsed multibuffer headers revealing the buffer content underneath them
