### PR TITLE
docs: Clarify `window_decorations` currently only works on Linux

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -229,10 +229,12 @@
   //
   // Default: true
   "zoomed_padding": true,
-  // What draws Zed's window decorations (titlebar):
-  // 1. Client application (Zed) draws its own window decorations
+  // On Linux, what draws Zed's window decorations (titlebar).
+  // This setting has no effect on other platforms:
+  // 1. Zed draws its own window decorations.
   //    "client"
-  // 2. Display server draws the window decorations. Not supported by GNOME Wayland.
+  // 2. The window manager or compositor draws the window decorations.
+  //    Not supported by GNOME Wayland.
   //    "server"
   //
   // This requires restarting Zed for changes to take effect.

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1832,7 +1832,7 @@ pub struct WindowOptions {
     /// Window minimum size
     pub window_min_size: Option<Size<Pixels>>,
 
-    /// Whether to use client- or server-side decorations on X11 and Wayland.
+    /// Whether to use client or server-side decorations on X11 and Wayland.
     /// The platform may ignore requests it cannot satisfy.
     pub window_decorations: Option<WindowDecorations>,
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1832,8 +1832,8 @@ pub struct WindowOptions {
     /// Window minimum size
     pub window_min_size: Option<Size<Pixels>>,
 
-    /// Whether to use client or server side decorations. Wayland only
-    /// Note that this may be ignored.
+    /// Whether to use client- or server-side decorations on X11 and Wayland.
+    /// The platform may ignore requests it cannot satisfy.
     pub window_decorations: Option<WindowDecorations>,
 
     /// Icon image (X11 only)

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -133,7 +133,8 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: false
     pub close_panel_on_toggle: Option<bool>,
-    /// What draws window decorations/titlebar, the client application (Zed) or display server
+    /// Controls whether Zed or the window manager or compositor draws window decorations on Linux.
+    ///
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
     /// Whether the focused panel follows the mouse location

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -357,8 +357,8 @@ pub enum WindowDecorations {
     /// Zed draws its own window decorations/titlebar (client-side decoration).
     #[default]
     Client,
-    /// The window manager or compositor draws the window decorations
-    /// (server-side decoration; not supported by GNOME Wayland).
+    /// The window manager or compositor draws the server-side window
+    /// decorations (not supported by GNOME Wayland).
     Server,
 }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -337,6 +337,8 @@ pub enum BottomDockLayout {
     RightAligned,
 }
 
+/// Configures what draws Zed's window decorations on Linux.
+/// This setting has no effect on other platforms.
 #[derive(
     Copy,
     Clone,
@@ -352,10 +354,11 @@ pub enum BottomDockLayout {
 )]
 #[serde(rename_all = "snake_case")]
 pub enum WindowDecorations {
-    /// Zed draws its own window decorations/titlebar (client-side decoration)
+    /// Zed draws its own window decorations/titlebar (client-side decoration).
     #[default]
     Client,
-    /// Show system's window titlebar (server-side decoration; not supported by GNOME Wayland)
+    /// The window manager or compositor draws the window decorations
+    /// (server-side decoration; not supported by GNOME Wayland).
     Server,
 }
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4996,6 +4996,32 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 - `show_menus`: Whether to show the menus in the titlebar
 - `button_layout`: The layout of window control buttons in the title bar (Linux only). Can be set to `"platform_default"` to follow the system setting, `"standard"` to use Zed's built-in layout, or a custom format like `"close:minimize,maximize"`
 
+## Window Decorations
+
+- Description: Controls whether Zed or the window manager or compositor draws window decorations on Linux. This setting has no effect on other platforms.
+- Setting: `window_decorations`
+- Default: `"client"`
+
+**Options**
+
+1. To have Zed draw its own window decorations, use `"client"`:
+
+```json [settings]
+{
+  "window_decorations": "client"
+}
+```
+
+2. To have the window manager or compositor draw the window decorations, use `"server"`:
+
+```json [settings]
+{
+  "window_decorations": "server"
+}
+```
+
+GNOME Wayland does not support server-side decorations. This setting requires restarting Zed.
+
 ## Vim
 
 - Description: Whether or not to enable vim mode.

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -130,7 +130,7 @@ Non-negative `float` values
 }
 ```
 
-Note: This setting has no effect in Vim mode, as rewrap is already allowed everywhere.
+> Note: This setting has no effect in Vim mode, as rewrap is already allowed everywhere.
 
 ## Auto Indent
 
@@ -500,7 +500,7 @@ left and right padding of the central pane from the workspace when the centered 
 
 When enabled, this setting will automatically close tabs for files that have been deleted from the file system. This is particularly useful for workflows involving temporary or scratch files that are frequently created and deleted. When disabled (default), deleted files remain open with a strikethrough through their tab title.
 
-Note: Dirty files (files with unsaved changes) will not be automatically closed even when this setting is enabled, ensuring you don't lose unsaved work.
+> Note: Dirty files (files with unsaved changes) will not be automatically closed even when this setting is enabled, ensuring you don't lose unsaved work.
 
 ## Code Lens
 
@@ -4998,7 +4998,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 ## Window Decorations
 
-- Description: Controls whether Zed or the window manager or compositor draws window decorations on Linux. This setting has no effect on other platforms.
+- Description: Controls whether Zed or the window manager or compositor draws window decorations.
 - Setting: `window_decorations`
 - Default: `"client"`
 
@@ -5020,7 +5020,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 }
 ```
 
-GNOME Wayland does not support server-side decorations. This setting requires restarting Zed.
+> Note: This setting only affects Linux. GNOME Wayland does not support server-side decorations. Changes only apply to newly created windows. Restart Zed to apply the setting to all windows.
 
 ## Vim
 


### PR DESCRIPTION
Also add the setting to our docs at https://zed.dev/docs -- it’s currently missing. Updated a stale comment as well -- window decorations were [always supported on X11](https://github.com/zed-industries/zed/pull/13611)? 

Closes #61788.

---

Release Notes:

- N/A
