### PR TITLE
docs: Show badges for Nightly and Preview channels

### DIFF
--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -680,6 +680,20 @@ fn load_all_actions() -> ActionManifest {
     }
 }
 
+fn replace_docs_channel_badge(contents: &str, docs_channel: &str) -> String {
+    let badge = match docs_channel {
+        "nightly" => {
+            r#"<span class="docs-channel-badge" title="You’re viewing the Nightly docs for Zed">Nightly</span>"#
+        }
+        "preview" => {
+            r#"<span class="docs-channel-badge" title="You’re viewing the Preview docs for Zed">Preview</span>"#
+        }
+        _ => "",
+    };
+
+    contents.replace("#docs-channel-badge#", badge)
+}
+
 fn handle_postprocessing() -> Result<()> {
     let logger = zlog::scoped!("render");
     let mut ctx = mdbook::renderer::RenderContext::from_json(io::stdin())?;
@@ -807,6 +821,7 @@ fn handle_postprocessing() -> Result<()> {
         let contents = contents.replace("#amplitude_key#", &amplitude_key);
         let contents = contents.replace("#consent_io_instance#", &consent_io_instance);
         let contents = contents.replace("#noindex#", noindex);
+        let contents = replace_docs_channel_badge(&contents, &docs_channel);
         let contents = rewrite_docs_links(&contents, &site_url);
         let contents = add_markdown_alternate_link(&contents, file, &root_dir, &site_url);
         let contents = title_regex()

--- a/crates/docs_preprocessor/src/tests.rs
+++ b/crates/docs_preprocessor/src/tests.rs
@@ -2,6 +2,24 @@ use super::*;
 use serde_json::json;
 
 #[test]
+fn test_replace_docs_channel_badge_only_renders_prerelease_channels() {
+    let template = "<header>#docs-channel-badge#</header>";
+
+    assert_eq!(
+        replace_docs_channel_badge(template, "nightly"),
+        "<header><span class=\"docs-channel-badge\" title=\"You’re viewing the Nightly docs for Zed\">Nightly</span></header>"
+    );
+    assert_eq!(
+        replace_docs_channel_badge(template, "preview"),
+        "<header><span class=\"docs-channel-badge\" title=\"You’re viewing the Preview docs for Zed\">Preview</span></header>"
+    );
+    assert_eq!(
+        replace_docs_channel_badge(template, "stable"),
+        "<header></header>"
+    );
+}
+
+#[test]
 fn test_find_binding_prefers_exact_match_over_parameterized() {
     let keymap: KeymapFile = serde_json::from_value(json!([
         {

--- a/docs/theme/css/chrome.css
+++ b/docs/theme/css/chrome.css
@@ -17,6 +17,20 @@ a > .hljs {
   display: block;
 }
 
+.docs-channel-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 6px;
+  background: var(--search-btn-bg);
+  border: 1px solid var(--search-btn-border);
+  border-radius: 4px;
+  color: var(--icons);
+  font-size: 1.1rem;
+  line-height: 1;
+  user-select: none;
+}
+
 .icon-button {
   position: relative;
   height: 28px;

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -96,6 +96,7 @@
                 <a href="/" class="logo-nav">
                     <img src="https://zed.dev/logo_icon.webp" class="icon-logo-img" alt="Zed Industries" style="height: 26px;">
                 </a>
+                #docs-channel-badge#
                 <button id="sidebar-toggle" class="icon-button ib-hidden-desktop" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar" aria-expanded="false">
                     <i class="fa fa-bars"></i>
                 </button>


### PR DESCRIPTION
We’ve had separate docs for a while now, so it also makes sense to advertise (or at least make it clear) to our users about the existence of this. Should be easier/possible to share our [preview docs](https://zed.dev/docs/preview) in release notes now.

| Stable | Nightly | Preview |
|--------|--------|--------|
| <img width="362" height="106" alt="image" src="https://github.com/user-attachments/assets/5e6c2b9d-68cb-463e-a1a7-1fbe16ec127a" /> | <img width="434" height="103" alt="image" src="https://github.com/user-attachments/assets/1d33bf8e-e7ee-494a-9bad-71773f37afb7" /> | <img width="408" height="101" alt="image" src="https://github.com/user-attachments/assets/c53ab84b-efd2-4a52-992e-04eb9a3cf5a1" /> | 

<img width="386" height="54" alt="image" src="https://github.com/user-attachments/assets/1807bd6c-2950-4fc1-a47a-ae63934ea4be" />

^Maybe it gets a bit too crowded on mobile? 😅

---

Release Notes:

- Make it easier to identify the Nightly and Preview channels of Zed docs

