### PR TITLE
language: Fix block auto-indent when the pasted block starts with a blank line

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3004,6 +3004,15 @@ impl Buffer {
                     } = &mode
                     {
                         original_indent_column = Some(if new_text.starts_with('\n') {
+                            // Keep the last blank line so the range stays within the edit.
+                            while let Some((line, rest)) =
+                                new_text[range_of_insertion_to_indent.clone()].split_once('\n')
+                                && !rest.is_empty()
+                                && line.chars().all(char::is_whitespace)
+                            {
+                                range_of_insertion_to_indent.start += line.len() + 1;
+                            }
+
                             indent_size_for_text(
                                 new_text[range_of_insertion_to_indent.clone()].chars(),
                             )

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2927,6 +2927,19 @@ impl Buffer {
                     } = &mode
                     {
                         original_indent_column = Some(if new_text.starts_with('\n') {
+                            // Blank lines have no indentation to compare against, so measure
+                            // the block's original indent on its first line with content. A
+                            // wholly blank block has none, and skipping it would indent the
+                            // line after the edit.
+                            while let Some((blank_line, rest)) =
+                                new_text[range_of_insertion_to_indent.clone()].split_once('\n')
+                            {
+                                if rest.is_empty() || !blank_line.chars().all(char::is_whitespace) {
+                                    break;
+                                }
+                                range_of_insertion_to_indent.start += blank_line.len() + 1;
+                            }
+
                             indent_size_for_text(
                                 new_text[range_of_insertion_to_indent.clone()].chars(),
                             )

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2664,6 +2664,33 @@ fn test_autoindent_block_mode_with_newline(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_autoindent_block_mode_with_blank_first_line(cx: &mut App) {
+    init_settings(cx, |_| {});
+
+    for (inserted, expected) in [
+        ("\n\n    c();", "fn a() {\n    b();\n\n    c();\n}\n"),
+        (
+            "\n    \n        c();",
+            "fn a() {\n    b();\n    \n    c();\n}\n",
+        ),
+    ] {
+        cx.new(|cx| {
+            let mut buffer =
+                Buffer::local("fn a() {\n    b();\n}\n", cx).with_language(rust_lang(), cx);
+            buffer.edit(
+                [(Point::new(1, 8)..Point::new(1, 8), inserted)],
+                Some(AutoindentMode::Block {
+                    original_indent_columns: vec![Some(0)],
+                }),
+                cx,
+            );
+            assert_eq!(buffer.text(), expected);
+            buffer
+        });
+    }
+}
+
+#[gpui::test]
 fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
     init_settings(cx, |_| {});
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2503,6 +2503,46 @@ fn test_autoindent_block_mode_with_newline(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_autoindent_block_mode_with_blank_first_line(cx: &mut App) {
+    init_settings(cx, |_| {});
+
+    cx.new(|cx| {
+        let text = "fn a() {\n    b();\n}\n";
+        let mut buffer = Buffer::local(text, cx).with_language(rust_lang(), cx);
+
+        // Vim's linewise `p` prepends a newline, so yanking a block whose first
+        // line is blank yields text that starts with two newlines.
+        buffer.edit(
+            [(Point::new(1, 8)..Point::new(1, 8), "\n\n    c();")],
+            Some(AutoindentMode::Block {
+                original_indent_columns: vec![Some(4)],
+            }),
+            cx,
+        );
+
+        // The blank line has no indentation to serve as the block's basis, so
+        // the block is inserted verbatim instead of being shifted right.
+        assert_eq!(buffer.text(), "fn a() {\n    b();\n\n    c();\n}\n");
+
+        // A line holding nothing but whitespace is blank as well.
+        buffer.edit(
+            [(Point::new(3, 8)..Point::new(3, 8), "\n\u{a0}\n    d();")],
+            Some(AutoindentMode::Block {
+                original_indent_columns: vec![Some(4)],
+            }),
+            cx,
+        );
+
+        assert_eq!(
+            buffer.text(),
+            "fn a() {\n    b();\n\n    c();\n\u{a0}\n    d();\n}\n"
+        );
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
     init_settings(cx, |_| {});
 

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -808,6 +808,34 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_paste_auto_indent_blank_first_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state(
+            indoc! {"
+                fn main() {
+                ˇ
+                    a();
+                }
+                "},
+            Mode::Normal,
+        );
+        // See https://github.com/zed-industries/zed/issues/55881
+        cx.simulate_keystrokes("shift-v j y p");
+        cx.assert_state(
+            indoc! {"
+                fn main() {
+
+                ˇ
+                    a();
+                    a();
+                }
+                "},
+            Mode::Normal,
+        );
+    }
+
+    #[gpui::test]
     async fn test_paste_count(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
 


### PR DESCRIPTION
# Objective

Fixes #55881

Vim linewise `p` prepends a newline, so pasting a block whose first line is blank inserts two newlines in a row. Block auto-indent skipped only the first one and then used the blank line as the block indentation basis. Its original indent measured zero while the destination suggested the enclosing block indent, so every following line shifted right and the blank line gained whitespace.

## Solution

Skip leading blank lines so both indents are measured on the first line with content and the blank lines stay outside the auto-indented range. A line containing only whitespace is blank too, since its whitespace is not the block indent. This applies only to block mode. `AutoindentMode::EachLine` keeps indenting blank lines created by pressing Enter.

## Testing

- `cargo test -p language test_autoindent_block_mode_with_blank_first_line` (passed)
- `cargo fmt --all -- --check` (passed)
- `./script/clippy -p language` (passed)
- `test_paste_auto_indent_blank_first_line` covers the Vim repro. Local execution is blocked by the existing `webrtc-sys` arm64 Linux C++ build failure; GitHub CI covers this target.

## Self-Review Checklist:

- [x] I have reviewed the diff for quality, security, and reliability
- [x] Unsafe blocks, if any, have justifying comments
- [x] The content adheres to Zed UI standards
- [x] Tests cover the changed behavior
- [x] Performance impact has been considered and is acceptable

## Suggested .rules additions

> In `Buffer::did_edit`, scope changes to `range_of_insertion_to_indent` to the applicable auto-indent mode. Changing it before the mode check also changes `AutoindentMode::EachLine` newline behavior.

Release Notes:

- Fixed extra indentation when pasting lines whose first line is blank