### PR TITLE
markdown_preview: Exclude hidden link destinations from search

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -731,6 +731,13 @@ impl Markdown {
         &self.source
     }
 
+    pub fn search_snapshot(&self) -> (SharedString, Vec<Range<usize>>) {
+        (
+            self.parsed_markdown.source.clone(),
+            searchable_source_ranges(&self.parsed_markdown.events),
+        )
+    }
+
     pub fn first_code_block_language(&self) -> Option<Arc<Language>> {
         self.parsed_markdown.events.iter().find_map(|(_, event)| {
             let MarkdownEvent::Start(MarkdownTag::CodeBlock { kind, .. }) = event else {
@@ -1240,6 +1247,37 @@ pub struct ParsedMarkdown {
     pub(crate) mermaid_diagrams: BTreeMap<usize, ParsedMarkdownMermaidDiagram>,
     pub heading_slugs: HashMap<SharedString, usize>,
     pub footnote_definitions: HashMap<SharedString, usize>,
+}
+
+fn searchable_source_ranges(events: &[(Range<usize>, MarkdownEvent)]) -> Vec<Range<usize>> {
+    let mut searchable_ranges: Vec<Range<usize>> = Vec::new();
+
+    for (range, event) in events {
+        if !matches!(
+            event,
+            MarkdownEvent::Text
+                | MarkdownEvent::SubstitutedText(_)
+                | MarkdownEvent::Code
+                | MarkdownEvent::SubstitutedCode(_)
+                | MarkdownEvent::Html
+                | MarkdownEvent::InlineHtml
+                | MarkdownEvent::FootnoteReference(_)
+                | MarkdownEvent::SoftBreak
+                | MarkdownEvent::HardBreak
+        ) {
+            continue;
+        }
+
+        if let Some(previous_range) = searchable_ranges.last_mut()
+            && range.start <= previous_range.end
+        {
+            previous_range.end = previous_range.end.max(range.end);
+        } else {
+            searchable_ranges.push(range.clone());
+        }
+    }
+
+    searchable_ranges
 }
 
 impl ParsedMarkdown {
@@ -4204,6 +4242,35 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[test]
+    fn searchable_source_ranges_exclude_link_destinations() {
+        let source = concat!(
+            "([#61784](https://github.com/zed-industries/zed/pull/61784))\n",
+            "([#61784](https://github.com/zed-industries/zed/pull/61784))\n",
+            "([#61784](https://github.com/zed-industries/zed/pull/61784))",
+        );
+        let parsed = parse_markdown_with_options(source, true, true, true);
+        let searchable_ranges = searchable_source_ranges(&parsed.events);
+        let occurrences = source
+            .match_indices("61784")
+            .map(|(start, occurrence)| start..start + occurrence.len())
+            .collect::<Vec<_>>();
+
+        assert_eq!(occurrences.len(), 6);
+        assert_eq!(
+            occurrences
+                .iter()
+                .filter(
+                    |occurrence| searchable_ranges.iter().any(|searchable_range| {
+                        searchable_range.start <= occurrence.start
+                            && occurrence.end <= searchable_range.end
+                    })
+                )
+                .count(),
+            3
+        );
+    }
 
     struct TestWindow;
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -1791,8 +1791,18 @@ impl SearchableItem for MarkdownPreviewView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Vec<Self::Match>> {
-        let source = self.markdown.read(cx).source().to_string();
-        cx.background_spawn(async move { query.search_str(&source) })
+        let (source, searchable_ranges) = self.markdown.read(cx).search_snapshot();
+        cx.background_spawn(async move {
+            query
+                .search_str(&source)
+                .into_iter()
+                .filter(|matched| {
+                    searchable_ranges
+                        .iter()
+                        .any(|range| range.start <= matched.start && matched.end <= range.end)
+                })
+                .collect()
+        })
     }
 
     fn active_match_index(


### PR DESCRIPTION
Filter Markdown Preview matches against rendered text ranges so hidden link URLs no longer inflate search result counts.

# Objective

fixed https://github.com/zed-industries/zed/issues/61909

## Solution

Added a Markdown search snapshot containing the parsed source and the source ranges that correspond to rendered text.
- Filtered Markdown Preview search results to matches fully contained within those rendered text ranges.
- This preserves existing search options and source offsets while excluding hidden Markdown content such as link destinations.

## Testing

- Added a regression test verifying that three visible pull request links produce three results instead of six matches from both labels and URLs.
- Ran `cargo test -p markdown searchable_source_ranges_exclude_link_destinations`.
- Ran `cargo check -p markdown_preview`.
- Ran `cargo fmt -p markdown -p markdown_preview -- --check`.

---

Release Notes:

- N/A or Added/Fixed/Improved ...
