### PR TITLE
editor: Stop opt-left on the right side of punctuation between words

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -306,8 +306,8 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
         return word_start;
     };
 
-    let punctuation_is_single = chars_before_word
-        .next()
+    let char_before_punctuation = chars_before_word.next();
+    let punctuation_is_single = char_before_punctuation
         .is_none_or(|character| !classifier.is_punctuation(character));
     let punctuation_prefixes_word = buffer_snapshot
         .chars_at(word_start_offset)
@@ -321,7 +321,14 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
 
     // Forward movement treats a single punctuation prefix as part of the following word.
     // Include it when moving back from the word's end so `|@word` and `@word|` are symmetric.
-    if cursor_is_at_word_end && punctuation_is_single && punctuation_prefixes_word {
+    // Only do this when the punctuation is a true prefix (not preceded by a word char),
+    // otherwise `a-b-c|` would jump to `a-b|-c` instead of `a-b-|c`.
+    let punctuation_is_prefix = char_before_punctuation
+        .is_none_or(|character| !classifier.is_word(character));
+    if cursor_is_at_word_end
+        && punctuation_is_single
+        && punctuation_prefixes_word
+        && punctuation_is_prefix {
         let mut punctuation_offset = word_start_offset;
         punctuation_offset -= punctuation.len_utf8();
         punctuation_offset.to_display_point(map)
@@ -1125,6 +1132,14 @@ mod tests {
         assert("foo ..ˇbarˇ baz", cx);
         assert("ˇ.helloˇ", cx);
         assert("[2001:4860:4860::8888ˇ] ˇ", cx);
+        // Punctuation between words is a separator, not a prefix.
+        // opt-left should stop to the right of the punctuation, not the left.
+        assert("a-b-ˇcˇ", cx);
+        assert("a.b.ˇcˇ", cx);
+        assert("foo.ˇbarˇ", cx);
+        assert("a@ˇbˇ", cx);
+        // Punctuation at start of buffer (or after whitespace) is a true prefix.
+        assert("ˇ@wordˇ", cx);
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

`previous_word_start` has post-processing that pulls a single punctuation prefix into the following word so `@word|` jumps to `|@word` (symmetric with forward movement). But it fired even when the punctuation sat between two word characters, so `a-b-c|` jumped to `a-b|-c` instead of `a-b-|c`.

The fix adds a check: only treat the punctuation as a prefix when it is **not** preceded by a word character (i.e. at buffer start or after whitespace/punctuation). This preserves the `@word` / `.hello` prefix behavior while fixing the separator case.

- `a-b-c|` → `a-b-|c` (was `a-b|-c`)
- `foo.bar|` → `foo.|bar` (was `foo|.bar`)
- `@word|` → `|@word` (unchanged)
- `.hello|` → `|.hello` (unchanged)

Closes #61884.

## Test plan

- [x] `cargo test -p editor --lib movement::` — all 9 tests pass
- [x] `./script/clippy --package editor --lib` — clean
- [x] New test cases added to `test_previous_word_start`:
  - `a-b-ˇcˇ`, `a.b.ˇcˇ`, `foo.ˇbarˇ`, `a@ˇbˇ` (separator cases)
  - `ˇ@wordˇ` (prefix case, unchanged behavior)

Release Notes:

- Fixed Option+Left stopping to the left of punctuation between words (e.g. `a-b-c|` now stops at `a-b-|c` instead of `a-b|-c`)