### PR TITLE
Make Install script reject 32-bit Linux architectures

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -27,10 +27,10 @@ main() {
     fi
 
     case "$platform-$arch" in
-        macos-arm64* | linux-arm64* | linux-armhf | linux-aarch64)
+        macos-arm64* | linux-arm64* | linux-aarch64)
             arch="aarch64"
             ;;
-        macos-x86* | linux-x86* | linux-i686*)
+        macos-x86* | linux-x86*)
             arch="x86_64"
             ;;
         *)


### PR DESCRIPTION
# Objective

Prevent successful installations on 32-bit Linux architectures where the `zed` binary will **fail to execute** post-installation. Rather, fail at installation time with a proper verdict. 

`script/install.sh` maps `uname -m` onto the two architectures Zed publishes builds for. Two of the matchers named 32-bit userlands and mapped them onto a 64-bit tarball:

- `linux-armhf` mapped to `aarch64`
- `linux-i686*` mapped to `x86_64`

Neither can execute the binary it selected. Tested on i386 Debian Trixie container: the installer downloaded, unpacked, symlinked and reported success, and the failure surfaced later as an exec error -- see [Showcase](##showcase).

Thus the installer's correct behavior would be to reject the 32-bit architecture and terminate with an "unsupported" verdict.


## Solution

Remove the case-statement-based mapping of `linux-armhf` to `aarch64`, and of `linux-i686*` to `x86_64`.


## Testing

Tested in isolation, simulating supported and unsupported platforms, and supported and unsupported architectures:

| Platform | `uname -m` | Outcome |
| --- | --- | --- |
| Linux | `x86_64` | ✅ Installed — resolves to `x86_64`, symlink created |
| Linux | `i386` | ❌ Unsupported — `i386` doesn't match glob `x86*` (no case handles plain i386 anyway |
| Linux | `i686` | ❌ Unsupported — same reason |
| Linux | `aarch64` | ✅ Installed — resolves to `aarch64` |
| Linux | `arm64` | ✅ Installed — resolves to `aarch64` |
| Linux | `armv7l` | ❌ Unsupported — no 32-bit ARM case |
| Linux | `riscv64` | ❌ Unsupported |
| Darwin | `arm64` | ✅ Installed — resolves to `aarch64`, copied to real `/Applications/Zed.app`, symlink created; |
| Darwin | `x86_64` | ✅ Installed — resolves to `x86_64`, copied to real `/Applications/Zed.app`, symlink created |
| Darwin | `i386` | ❌ Unsupported — no case for macOS 32-bit |
| FreeBSD | `x86_64` | ❌ Unsupported platform - expected |

This is all correct behavior. Successful installations are expected to work. Unsupported architectures are detected and rejected as unsupported during installation.

## Showcase

```plaintext
~# file /usr/bin/dash  # a sample executable showing the 32-bit arch
/usr/bin/dash: ELF 32-bit LSB pie executable, Intel i386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=7e2e8652114c8c2ae595b6f78798716a9ba07671, for GNU/Linux 3.2.0, stripped

~# file .local/zed.app/bin/zed
.local/zed.app/bin/zed: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=e550eeb1d97f0cdac2460de672bfa36e9e3f6e25, not stripped

~# .local/zed.app/bin/zed
bash: .local/zed.app/bin/zed: cannot execute: required file not found
# It cannot find  ELF 64-bit interpreter /lib64/ld-linux-x86-64.so.2 -- this is
# a 32-bit container on a 64-bit host. On a genuine 32-bit host it would fail with:
# `Exec format error`.
```


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Locally conducted tests cover the new/changed behavior

---

Release Notes:

- N/A
