### PR TITLE
Send Git diff review feedback to agent threads

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -66,7 +66,7 @@ use chrono::{DateTime, Utc};
 use client::UserStore;
 use cloud_api_types::Plan;
 use collections::HashMap;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, ReviewFeedback};
 use extension_host::ExtensionStore;
 use feature_flags::{CreateThreadToolFeatureFlag, FeatureFlagAppExt as _};
 
@@ -4078,6 +4078,21 @@ impl AgentPanel {
     pub fn active_thread_view(&self, cx: &App) -> Option<Entity<ThreadView>> {
         let server_view = self.active_conversation_view()?;
         server_view.read(cx).root_thread_view()
+    }
+
+    pub fn send_review_feedback(
+        &mut self,
+        feedback: Vec<ReviewFeedback>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<bool> {
+        let Some(thread_view) = self.active_thread_view(cx) else {
+            return Ok(false);
+        };
+        thread_view.update(cx, |thread_view, cx| {
+            thread_view.send_review_feedback(feedback, window, cx)
+        })?;
+        Ok(true)
     }
 
     pub fn active_agent_thread(&self, cx: &App) -> Option<Entity<AcpThread>> {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -4233,6 +4233,122 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_review_feedback_preserves_paused_queue_order(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("first", window, cx);
+        });
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |view, window, cx| view.send(window, cx));
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.add_to_queue(
+                vec![acp::ContentBlock::Text(acp::TextContent::new(
+                    "queued first".to_string(),
+                ))],
+                vec![],
+                window,
+                cx,
+            );
+        });
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |thread, _window, cx| thread.cancel_generation(cx));
+        cx.run_until_parked();
+
+        let result = active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.send_review_feedback(
+                vec![editor::ReviewFeedback {
+                    worktree_name: Some("zed".to_string()),
+                    file_path: "crates/editor/src/git.rs".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                    excerpt: "example".to_string(),
+                    comment: "Address this".to_string(),
+                }],
+                window,
+                cx,
+            )
+        });
+        assert!(result.is_ok(), "review feedback should be accepted");
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).read_with(cx, |thread, _cx| {
+            assert_eq!(thread.message_queue.len(), 1);
+            let remaining_text = thread
+                .message_queue
+                .first()
+                .and_then(|entry| entry.content.first())
+                .and_then(|content| match content {
+                    acp::ContentBlock::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                });
+            assert!(
+                remaining_text.is_some_and(|text| text.contains("Address this")),
+                "review feedback should remain behind the previously queued message"
+            );
+        });
+
+        let session_id = conversation_view.read_with(cx, |view, cx| {
+            view.active_thread()
+                .expect("active thread")
+                .read(cx)
+                .thread
+                .read(cx)
+                .session_id()
+                .clone()
+        });
+        connection.end_turn(session_id, acp::StopReason::EndTurn);
+        cx.run_until_parked();
+
+        let queue_len = active_thread(&conversation_view, cx)
+            .read_with(cx, |thread, _cx| thread.message_queue.len());
+        assert_eq!(queue_len, 0, "review feedback should auto-send next");
+    }
+
+    #[gpui::test]
+    async fn test_review_feedback_queues_while_message_content_is_loading(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let result = active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.is_loading_contents = true;
+            thread.send_review_feedback(
+                vec![editor::ReviewFeedback {
+                    worktree_name: Some("zed".to_string()),
+                    file_path: "crates/editor/src/git.rs".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                    excerpt: "example".to_string(),
+                    comment: "Address this".to_string(),
+                }],
+                window,
+                cx,
+            )
+        });
+        assert!(result.is_ok(), "review feedback should be accepted");
+
+        active_thread(&conversation_view, cx).read_with(cx, |thread, cx| {
+            assert_eq!(thread.thread.read(cx).status(), ThreadStatus::Idle);
+            assert_eq!(
+                thread.message_queue.len(),
+                1,
+                "review feedback should wait for the in-flight content to start its turn"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_notification_for_error(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -19,7 +19,7 @@ use agent::{
 use agent_settings::UserAgentsMd;
 use agent_skills::MAX_SKILL_DESCRIPTION_LEN;
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
-use editor::actions::OpenExcerpts;
+use editor::{ReviewFeedback, actions::OpenExcerpts};
 use sandbox::{SandboxFsPolicy, SandboxNetPolicy, SandboxPolicy};
 
 use crate::completion_provider::{AvailableSkill, PromptLocalCommand, pluralize};
@@ -1550,6 +1550,39 @@ impl ThreadView {
 
         cx.emit(AcpThreadViewEvent::Interacted);
         self.send_impl(message_editor, window, cx)
+    }
+
+    pub fn send_review_feedback(
+        &mut self,
+        feedback: Vec<ReviewFeedback>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<()> {
+        let payload = serde_json::to_string_pretty(&feedback)?;
+        let content = vec![acp::ContentBlock::Text(acp::TextContent::new(format!(
+            "Address the following human-authored review feedback. Each item is anchored to a local diff and includes its worktree, file, one-based line range, and selected excerpt.\n\n```json\n{payload}\n```"
+        )))];
+        let can_send_immediately =
+            self.thread.read(cx).status() == ThreadStatus::Idle && !self.is_loading_contents;
+        if can_send_immediately && self.message_queue.is_empty() {
+            cx.emit(AcpThreadViewEvent::Interacted);
+            self.send_content(
+                Task::ready(Ok(Some((content, Vec::new())))),
+                false,
+                window,
+                cx,
+            );
+        } else {
+            self.add_to_queue(content, Vec::new(), window, cx);
+            if can_send_immediately {
+                if let Some(id) = self.message_queue.first_id() {
+                    self.send_queued_message_now(id, window, cx);
+                }
+            } else {
+                cx.emit(AcpThreadViewEvent::Interacted);
+            }
+        }
+        Ok(())
     }
 
     /// Sends a bare `/command` turn and queues everything the user typed after

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -109,8 +109,8 @@ pub use element::{
 pub use git::blame::BlameRenderer;
 pub use git::{
     DiffHunkDelegate, ResolvedDiffHunk, ResolvedDiffHunks, RestoreOnlyDiffHunkDelegate,
-    RestoreOnlyUnstagedDiffHunkDelegate, UncommittedDiffHunkDelegate, render_diff_hunk_controls,
-    set_blame_renderer,
+    RestoreOnlyUnstagedDiffHunkDelegate, ReviewFeedback, UncommittedDiffHunkDelegate,
+    render_diff_hunk_controls, set_blame_renderer,
 };
 pub(crate) use git::{DiffHunkKey, StoredReviewComment};
 use git::{

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -40042,6 +40042,40 @@ fn test_review_comment_take_all(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_review_feedback_preserves_anchor_metadata_until_cleared(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| Editor::single_line(window, cx));
+
+    let result = editor.update(cx, |editor, window, cx| {
+        editor.set_text("first\nsecond\n", window, cx);
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let start = snapshot.anchor_before(Point::new(0, 0));
+        let end = snapshot.anchor_after(Point::new(1, 6));
+        editor.add_review_comment(
+            test_hunk_key_with_anchor("src/example.rs", start),
+            "Handle this edge case".to_string(),
+            start..end,
+            cx,
+        );
+
+        let feedback = editor.review_feedback(cx);
+        assert_eq!(feedback.len(), 1);
+        assert_eq!(feedback[0].worktree_name, None);
+        assert_eq!(feedback[0].file_path, "src/example.rs");
+        assert_eq!(feedback[0].start_line, 1);
+        assert_eq!(feedback[0].end_line, 2);
+        assert_eq!(feedback[0].excerpt, "first\nsecond");
+        assert_eq!(feedback[0].comment, "Handle this edge case");
+
+        editor.clear_review_feedback(cx);
+        assert!(editor.review_feedback(cx).is_empty());
+        assert_eq!(editor.total_review_comment_count(), 0);
+    });
+    assert!(result.is_ok(), "editor window should remain available");
+}
+
+#[gpui::test]
 fn test_diff_review_overlay_show_and_dismiss(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -298,6 +298,16 @@ pub(super) struct DiffHunkKey {
     pub(super) hunk_start_anchor: Anchor,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct ReviewFeedback {
+    pub worktree_name: Option<String>,
+    pub file_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub excerpt: String,
+    pub comment: String,
+}
+
 /// A review comment stored locally before being sent to the Agent panel.
 #[derive(Clone)]
 pub(super) struct StoredReviewComment {
@@ -882,6 +892,59 @@ impl Editor {
             .iter()
             .map(|(_, v)| v.len())
             .sum()
+    }
+
+    pub fn review_feedback(&self, cx: &App) -> Vec<ReviewFeedback> {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        self.stored_review_comments
+            .iter()
+            .flat_map(|(hunk, comments)| {
+                comments.iter().filter_map(|comment| {
+                    let start_point = comment.range.start.to_point(&snapshot);
+                    let end_point = comment.range.end.to_point(&snapshot);
+                    let buffer_ranges = snapshot.range_to_buffer_ranges(start_point..end_point);
+                    let (Some((first_buffer, first_range, _)), Some((last_buffer, last_range, _))) =
+                        (buffer_ranges.first(), buffer_ranges.last())
+                    else {
+                        log::debug!(
+                            "Skipping review comment {} for {} because its buffer range could not be resolved ({start_point:?}..{end_point:?})",
+                            comment.id,
+                            hunk.file_path.as_unix_str(),
+                        );
+                        return None;
+                    };
+                    let start_line = first_buffer.offset_to_point(first_range.start.0).row;
+                    let end_line = last_buffer.offset_to_point(last_range.end.0).row;
+                    let worktree_name = snapshot
+                        .file_at(start_point)
+                        .and_then(|file| {
+                            self.project
+                                .as_ref()?
+                                .read(cx)
+                                .worktree_for_id(file.worktree_id(cx), cx)
+                        })
+                        .map(|worktree| worktree.read(cx).root_name().as_unix_str().to_string());
+                    Some(ReviewFeedback {
+                        worktree_name,
+                        file_path: hunk.file_path.as_unix_str().to_string(),
+                        start_line: start_line.saturating_add(1),
+                        end_line: end_line.saturating_add(1),
+                        excerpt: snapshot
+                            .text_for_range(start_point..end_point)
+                            .collect::<String>(),
+                        comment: comment.comment.clone(),
+                    })
+                })
+            })
+            .collect()
+    }
+
+    pub fn clear_review_feedback(&mut self, cx: &mut Context<Self>) {
+        self.dismiss_all_diff_review_overlays(cx);
+        self.stored_review_comments.clear();
+        self.next_review_comment_id = 0;
+        cx.emit(EditorEvent::ReviewCommentsChanged { total_count: 0 });
+        cx.notify();
     }
 
     /// Adds a new review comment to a specific hunk.

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -1,12 +1,13 @@
 use crate::{
     diff_multibuffer::DiffMultibuffer,
     git_panel::{GitPanel, GitPanelAddon, GitStatusEntry},
+    project_diff::render_send_review_to_agent_button,
 };
 use anyhow::{Context as _, Result};
 use buffer_diff::DiffHunkStatus;
 use editor::{
     DiffHunkDelegate, Editor, EditorEvent, ResolvedDiffHunks, SplittableEditor,
-    actions::{GoToHunk, GoToPreviousHunk},
+    actions::{GoToHunk, GoToPreviousHunk, SendReviewToAgent},
 };
 use git::{Commit, UnstageAll, UnstageAndNext};
 use gpui::{
@@ -635,6 +636,7 @@ impl Render for StagedDiffToolbar {
         let diff = staged_diff.read(cx).diff.read(cx);
         let (additions, deletions) = diff.calculate_changed_lines(cx);
         let is_multibuffer_empty = diff.multibuffer().read(cx).is_empty();
+        let review_count = diff.total_review_comment_count();
 
         h_flex()
             .my_neg_1()
@@ -649,6 +651,16 @@ impl Render for StagedDiffToolbar {
                     deletions as usize,
                 ))
                 .child(Divider::vertical().ml_1())
+            })
+            .when(review_count > 0, |this| {
+                this.child(
+                    render_send_review_to_agent_button(review_count, &focus_handle).on_click(
+                        cx.listener(|this, _, window, cx| {
+                            this.dispatch_action(&SendReviewToAgent, window, cx)
+                        }),
+                    ),
+                )
+                .child(Divider::vertical())
             })
             // n.b. the only reason these arrows are here is because we don't
             // support "undo" for staging so we need a way to go back.

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -1,12 +1,13 @@
 use crate::{
     diff_multibuffer::DiffMultibuffer,
     git_panel::{GitPanel, GitPanelAddon, GitStatusEntry},
+    project_diff::render_send_review_to_agent_button,
 };
 use anyhow::{Context as _, Result};
 use buffer_diff::DiffHunkStatus;
 use editor::{
     DiffHunkDelegate, Editor, EditorEvent, ResolvedDiffHunks, SplittableEditor,
-    actions::{GoToHunk, GoToPreviousHunk},
+    actions::{GoToHunk, GoToPreviousHunk, SendReviewToAgent},
 };
 use git::{StageAll, StageAndNext};
 use gpui::{
@@ -741,6 +742,7 @@ impl Render for UnstagedDiffToolbar {
         let diff = unstaged_diff.read(cx).diff.read(cx);
         let (additions, deletions) = diff.calculate_changed_lines(cx);
         let is_multibuffer_empty = diff.multibuffer().read(cx).is_empty();
+        let review_count = diff.total_review_comment_count();
 
         h_flex()
             .my_neg_1()
@@ -755,6 +757,16 @@ impl Render for UnstagedDiffToolbar {
                     deletions as usize,
                 ))
                 .child(Divider::vertical().ml_1())
+            })
+            .when(review_count > 0, |this| {
+                this.child(
+                    render_send_review_to_agent_button(review_count, &focus_handle).on_click(
+                        cx.listener(|this, _, window, cx| {
+                            this.dispatch_action(&SendReviewToAgent, window, cx)
+                        }),
+                    ),
+                )
+                .child(Divider::vertical())
             })
             // n.b. the only reason these arrows are here is because we don't
             // support "undo" for staging so we need a way to go back.

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -25,7 +25,7 @@ use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
 use debugger_ui::debugger_panel::DebugPanel;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, actions::SendReviewToAgent};
 use extension_host::ExtensionStore;
 use feature_flags::{FeatureFlagAppExt as _, PanicFeatureFlag};
 use fs::Fs;
@@ -912,6 +912,46 @@ fn register_actions(
 ) {
     workspace
         .register_action(|_, _: &OpenDocs, _, cx| cx.open_url(DOCS_URL))
+        .register_action(
+            |workspace: &mut Workspace,
+             _: &SendReviewToAgent,
+             window: &mut Window,
+             cx: &mut Context<Workspace>| {
+                let Some(review_editor) = workspace
+                    .active_item(cx)
+                    .and_then(|item| item.act_as::<Editor>(cx))
+                else {
+                    return;
+                };
+                let feedback = review_editor.read(cx).review_feedback(cx);
+                if feedback.is_empty() {
+                    return;
+                }
+                let Some(agent_panel) = workspace.panel::<agent_ui::AgentPanel>(cx) else {
+                    workspace.show_error(
+                        "Open or create an agent thread before sending review feedback.",
+                        cx,
+                    );
+                    return;
+                };
+                match agent_panel.update(cx, |panel, cx| {
+                    panel.send_review_feedback(feedback, window, cx)
+                }) {
+                    Ok(true) => {
+                        review_editor.update(cx, |editor, cx| {
+                            editor.clear_review_feedback(cx);
+                        });
+                        workspace.reveal_panel::<agent_ui::AgentPanel>(window, cx);
+                    }
+                    Ok(false) => workspace.show_error(
+                        "Open or create an agent thread before sending review feedback.",
+                        cx,
+                    ),
+                    Err(error) => workspace
+                        .show_error(format!("Failed to send review feedback: {error}"), cx),
+                }
+            },
+        )
         .register_action(|_, _: &OpenStatusPage, _, cx| cx.open_url(STATUS_URL))
         .register_action(|_, _: &GetMerch, _, cx| cx.open_url(MERCH_URL))
         .register_action(


### PR DESCRIPTION
# Objective

- Connect the existing local Git diff review comments to the active agent thread.
- Keep the feedback model independent from GitHub pull requests and other hosting platforms so local, staged, unstaged, project, and branch diffs share one path.
- Scope the platform-neutral part of the MVP validated in https://github.com/zixiao-labs/Kaltsit-Esperanta/pull/43 for upstream review.

Related to #59157

## Solution

- Add a serializable `ReviewFeedback` model containing worktree, file path, one-based line range, selected excerpt, and the human comment while retaining editor anchors until submission.
- Route `SendReviewToAgent` through the active item existing `Item::act_as::<Editor>` implementation instead of adding accessors to every diff item type.
- Submit structured JSON to the active native or external agent thread without replacing the composer draft. Busy threads and messages whose content is still resolving use the existing queue.
- Preserve FIFO ordering when a manually stopped thread has queued messages, and clear diff comments only after the feedback has been accepted by the thread.
- Reuse the existing send-review toolbar control for staged and unstaged diff views.

### Downstream compatibility and adding connectors

This PR intentionally excludes connector accounts, OAuth flows, avatars, Wuling settings, GitHub settings, and other ZetaCode-specific code from the downstream MVP. The shared diff-to-agent path is upstream-owned, while provider authentication and account UI remain downstream-owned.

Using `Item::act_as::<Editor>` also avoids parallel edits to `ProjectDiff`, `BranchDiff`, `StagedDiff`, and `UnstagedDiff` merely to find the review editor. After this lands, ZetaCode can rebase on upstream and drop its overlapping review-feedback hunks in `editor`, `agent_ui`, `git_ui`, and `zed`, leaving only provider-specific changes.

To add another downstream connector:

1. Keep connector IDs, account data, credentials, API clients, settings, and branding in the downstream connector crate.
2. Register connector UI and actions from the downstream application composition layer rather than adding provider variants to this upstream model.
3. Convert any provider-specific review context to the upstream `ReviewFeedback` boundary only when sending it to an agent, and reuse `SendReviewToAgent` instead of patching each diff type.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- `cargo test -p editor test_review_feedback_preserves_anchor_metadata_until_cleared -- --nocapture`
- `cargo test -p agent_ui test_review_feedback_ -- --nocapture`
- `cargo check -p git_ui -p agent_ui -p zed`
- `./script/clippy -p editor -p agent_ui -p zed` was attempted, but the all-features run is currently blocked before the changed crates by existing spell-check errors for `scap` in `crates/gpui/src/platform/scap_screen_capture.rs`.

Tested on macOS.

## Self-Review Checklist:

- [x] I have reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks are not introduced
- [x] The content adheres to Zed UI standards by reusing the existing toolbar control
- [x] Tests cover the new and changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The existing send-review control now appears when comments exist in staged and unstaged diff toolbars. No new visual component or interaction pattern is introduced.

## Suggested .rules additions

- For Git diff actions that operate on the displayed right-hand editor, resolve the active pane item through `Item::act_as::<Editor>` instead of adding equivalent accessors to each diff item type.

> The English description above was prepared with AI-assisted translation from the Chinese implementation notes below.
>
> 本次改动把下游 MVP 中与平台无关的本地差异审阅反馈模型和发送链路迁移到上游。Wuling、GitHub OAuth、账户头像和其他 ZetaCode 专属连接器仍保留在下游。下游在上游改动合入后应删除 `editor`、`agent_ui`、`git_ui` 和 `zed` 中重叠的审阅反馈补丁，并在应用组合层注册自己的连接器，避免再次修改每一种差异视图。

---

Release Notes:

- Added the ability to send Git diff review comments to the active agent thread.
