### PR TITLE
Fix MCP servers not being populated sometimes in settings UI

### DIFF
--- a/crates/settings_ui/src/pages/external_agents_page.rs
+++ b/crates/settings_ui/src/pages/external_agents_page.rs
@@ -62,10 +62,7 @@ fn get_agent_server_store(
     settings_window: &SettingsWindow,
     cx: &App,
 ) -> Option<Entity<AgentServerStore>> {
-    let original_window = settings_window.original_window.as_ref()?;
-    let multi_workspace = original_window.read(cx).ok()?;
-    let workspace = multi_workspace.workspaces().next()?;
-    let project = workspace.read(cx).project().clone();
+    let project = settings_window.active_project(cx)?;
     Some(project.read(cx).agent_server_store().clone())
 }
 
@@ -886,13 +883,7 @@ fn open_new_custom_agent_in_settings(original_window: WindowHandle<MultiWorkspac
     cx.activate(true);
     original_window
         .update(cx, |multi_workspace, window, cx| {
-            // Use the workspace handed to us by the update closure rather than
-            // `Workspace::for_window`, which would read the `MultiWorkspace`
-            // entity that this closure is already updating (a double borrow).
-            let Some(workspace) = multi_workspace.workspaces().next() else {
-                return;
-            };
-            let workspace = workspace.downgrade();
+            let workspace = multi_workspace.workspace().downgrade();
             window.activate_window();
             window
                 .spawn(cx, async move |cx| {

--- a/crates/settings_ui/src/pages/mcp_servers_page.rs
+++ b/crates/settings_ui/src/pages/mcp_servers_page.rs
@@ -95,10 +95,7 @@ fn get_context_server_store(
     settings_window: &SettingsWindow,
     cx: &App,
 ) -> Option<Entity<ContextServerStore>> {
-    let original_window = settings_window.original_window.as_ref()?;
-    let multi_workspace = original_window.read(cx).ok()?;
-    let workspace = multi_workspace.workspaces().next()?;
-    let project = workspace.read(cx).project().clone();
+    let project = settings_window.active_project(cx)?;
     Some(project.read(cx).context_server_store())
 }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -4409,6 +4409,12 @@ impl SettingsWindow {
         cx.notify();
     }
 
+    pub(crate) fn active_project(&self, cx: &App) -> Option<Entity<Project>> {
+        let original_window = self.original_window.as_ref()?;
+        let multi_workspace = original_window.read(cx).ok()?;
+        Some(multi_workspace.workspace().read(cx).project().clone())
+    }
+
     fn focus_file_at_index(&mut self, index: usize, window: &mut Window, cx: &mut App) {
         if let Some((_, handle)) = self.files.get(index) {
             handle.focus(window, cx);


### PR DESCRIPTION
The MCP server list was always populated from the first workspace in the `MultiWorkspace`. If Zed is configured to `"restore_on_startup": "launchpad"`, the first workspace will always be the 'launchpad' workspace which has no worktees in it. Since there are no worktrees in this workspace, the MCP store is not populated, so the settings UI did not show any MCP servers.

---

Release Notes:

- Fixed an issue where the settings UI would sometimes not show the list of configured MCP servers