### PR TITLE
gpui: Render deferred overlays above native child views

### DIFF
--- a/crates/gpui/examples/README.md
+++ b/crates/gpui/examples/README.md
@@ -67,6 +67,9 @@ best starting point for new applications:
 - `active_state_bug` is a focused active-state reproduction.
 - `layer_shell` demonstrates Linux layer-shell windows.
 - `list_example` demonstrates bottom-aligned list state and scrollbar behavior.
+- `native_webview` demonstrates the macOS native-surface overlay API with a
+  directly hosted `WKWebView`, without depending on wry. It also demonstrates
+  click-anywhere overlay dismissal and native-focus handoff back to GPUI.
 - `ownership_post` supports the ownership and data-flow documentation.
 - `paths_bench` is a path rendering benchmark.
 - `tree` renders a deep tree of nested elements.

--- a/crates/gpui/examples/native_webview.html
+++ b/crates/gpui/examples/native_webview.html
@@ -68,6 +68,13 @@
       border-color: #5ac1fe;
       box-shadow: 0 0 0 3px rgba(90, 193, 254, .16);
     }
+    #keyboard-event {
+      grid-column: 1 / -1;
+      min-height: 16px;
+      color: #8a8986;
+      font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+      white-space: nowrap;
+    }
   </style>
 </head>
 <body>
@@ -86,6 +93,25 @@
       <div class="datum"><span>STATE</span><strong>INTERACTIVE</strong></div>
     </aside>
     <input autofocus value="Focus and type inside the native layer">
+    <div id="keyboard-event" aria-live="polite">Keyboard event: waiting for input</div>
   </main>
+  <script>
+    const keyboardEvent = document.querySelector("#keyboard-event");
+
+    function showKeyboardEvent(event) {
+      const modifiers = [
+        event.metaKey && "Meta",
+        event.ctrlKey && "Ctrl",
+        event.altKey && "Alt",
+        event.shiftKey && "Shift",
+      ].filter(Boolean).join("+") || "None";
+      const key = event.key === " " ? "Space" : event.key;
+      keyboardEvent.textContent =
+        `${event.type}: key=${key} · code=${event.code} · modifiers=${modifiers} · repeat=${event.repeat}`;
+    }
+
+    window.addEventListener("keydown", showKeyboardEvent, true);
+    window.addEventListener("keyup", showKeyboardEvent, true);
+  </script>
 </body>
 </html>

--- a/crates/gpui/examples/native_webview.html
+++ b/crates/gpui/examples/native_webview.html
@@ -4,16 +4,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: dark;
       font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #fcfcfc;
+      background: #0d1016;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
-      background: #fcfcfc;
-      color: #5c6166;
+      background: #0d1016;
+      color: #bfbdb6;
     }
     main {
       display: grid;
@@ -22,7 +22,7 @@
       padding: 42px 38px;
     }
     .eyebrow {
-      color: #3b9ee5;
+      color: #5ac1fe;
       font: 600 10px ui-monospace, SFMono-Regular, Menlo, monospace;
       letter-spacing: .16em;
       text-transform: uppercase;
@@ -38,7 +38,7 @@
     p {
       max-width: 390px;
       margin: 0;
-      color: #8b8e92;
+      color: #8a8986;
       font-size: 14px;
       line-height: 1.6;
     }
@@ -47,26 +47,26 @@
       display: flex;
       justify-content: space-between;
       padding: 12px 0;
-      border-bottom: 1px solid #cfd1d2;
-      color: #8b8e92;
+      border-bottom: 1px solid #3f4043;
+      color: #8a8986;
       font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
     }
-    .datum strong { color: #313435; font-weight: 600; }
+    .datum strong { color: #bfbdb6; font-weight: 600; }
     input {
       grid-column: 1 / -1;
       width: 100%;
       margin-top: 8px;
       padding: 13px 14px;
-      border: 1px solid #cfd1d2;
+      border: 1px solid #3f4043;
       border-radius: 7px;
       outline: none;
-      background: #ffffff;
-      color: #5c6166;
+      background: #1f2127;
+      color: #bfbdb6;
       font: 13px ui-monospace, SFMono-Regular, Menlo, monospace;
     }
     input:focus {
-      border-color: #3b9ee5;
-      box-shadow: 0 0 0 3px rgba(59, 158, 229, .13);
+      border-color: #5ac1fe;
+      box-shadow: 0 0 0 3px rgba(90, 193, 254, .16);
     }
   </style>
 </head>

--- a/crates/gpui/examples/native_webview.html
+++ b/crates/gpui/examples/native_webview.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #fcfcfc;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #fcfcfc;
+      color: #5c6166;
+    }
+    main {
+      display: grid;
+      grid-template-columns: 1.2fr .8fr;
+      gap: 28px;
+      padding: 42px 38px;
+    }
+    .eyebrow {
+      color: #3b9ee5;
+      font: 600 10px ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: .16em;
+      text-transform: uppercase;
+    }
+    h1 {
+      max-width: 360px;
+      margin: 14px 0;
+      font-size: 34px;
+      font-weight: 590;
+      letter-spacing: -.035em;
+      line-height: 1.06;
+    }
+    p {
+      max-width: 390px;
+      margin: 0;
+      color: #8b8e92;
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    .details { display: grid; gap: 10px; align-content: start; }
+    .datum {
+      display: flex;
+      justify-content: space-between;
+      padding: 12px 0;
+      border-bottom: 1px solid #cfd1d2;
+      color: #8b8e92;
+      font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .datum strong { color: #313435; font-weight: 600; }
+    input {
+      grid-column: 1 / -1;
+      width: 100%;
+      margin-top: 8px;
+      padding: 13px 14px;
+      border: 1px solid #cfd1d2;
+      border-radius: 7px;
+      outline: none;
+      background: #ffffff;
+      color: #5c6166;
+      font: 13px ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    input:focus {
+      border-color: #3b9ee5;
+      box-shadow: 0 0 0 3px rgba(59, 158, 229, .13);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section>
+      <div class="eyebrow">Native surface / live</div>
+      <h1>A real browser inside GPUI’s scene.</h1>
+      <p>
+        This page is rendered by WKWebView. GPUI owns the surfaces
+        below and above it, while AppKit composes all three.
+      </p>
+    </section>
+    <aside class="details">
+      <div class="datum"><span>ENGINE</span><strong>WEBKIT</strong></div>
+      <div class="datum"><span>HOST</span><strong>NSVIEW</strong></div>
+      <div class="datum"><span>STATE</span><strong>INTERACTIVE</strong></div>
+    </aside>
+    <input autofocus value="Focus and type inside the native layer">
+  </main>
+</body>
+</html>

--- a/crates/gpui/examples/native_webview.rs
+++ b/crates/gpui/examples/native_webview.rs
@@ -9,7 +9,7 @@ mod macos {
 
     use cocoa::{
         appkit::NSView,
-        base::{id, nil},
+        base::{YES, id, nil},
         foundation::{NSPoint, NSRect, NSSize, NSString},
     };
     use gpui::{
@@ -56,6 +56,21 @@ mod macos {
                     let _: () = msg_send![configuration, release];
                     anyhow::bail!("failed to create WKWebView");
                 }
+
+                let _: () = msg_send![view, setWantsLayer: YES];
+                let layer: id = msg_send![view, layer];
+                let border_color: id = msg_send![
+                    class!(NSColor),
+                    colorWithSRGBRed: 63. / 255.
+                    green: 64. / 255.
+                    blue: 67. / 255.
+                    alpha: 1.
+                ];
+                let border_color: id = msg_send![border_color, CGColor];
+                let _: () = msg_send![layer, setMasksToBounds: YES];
+                let _: () = msg_send![layer, setCornerRadius: 8.];
+                let _: () = msg_send![layer, setBorderWidth: 1.];
+                let _: () = msg_send![layer, setBorderColor: border_color];
 
                 let html = NSString::alloc(nil).init_str(PAGE);
                 let _: id = msg_send![view, loadHTMLString: html baseURL: nil];
@@ -178,12 +193,12 @@ mod macos {
             .py_2()
             .rounded_md()
             .border_1()
-            .border_color(rgb(0xcfd1d2))
-            .bg(rgb(0xececed))
-            .text_color(rgb(0x5c6166))
+            .border_color(rgb(0x3f4043))
+            .bg(rgb(0x1f2127))
+            .text_color(rgb(0xbfbdb6))
             .text_sm()
             .cursor_pointer()
-            .hover(|style| style.bg(rgb(0xdfe0e1)).border_color(rgb(0xcfd0d2)))
+            .hover(|style| style.bg(rgb(0x2d2f34)).border_color(rgb(0x3e4043)))
             .child(label)
     }
 
@@ -194,10 +209,10 @@ mod macos {
             .gap_2()
             .py_2()
             .border_b_1()
-            .border_color(rgb(0xcfd1d2))
+            .border_color(rgb(0x3f4043))
             .child(div().w_1().h_5().rounded_sm().bg(color))
-            .child(div().text_color(rgb(0xa9acae)).w(px(18.)).child(index))
-            .child(div().text_color(rgb(0x5c6166)).child(label))
+            .child(div().text_color(rgb(0x696a6a)).w(px(18.)).child(index))
+            .child(div().text_color(rgb(0xbfbdb6)).child(label))
     }
 
     impl Render for NativeWebViewExample {
@@ -209,8 +224,8 @@ mod macos {
                 .gap_6()
                 .size_full()
                 .p_7()
-                .bg(rgb(0xdcddde))
-                .text_color(rgb(0x5c6166))
+                .bg(rgb(0x313337))
+                .text_color(rgb(0xbfbdb6))
                 // While a deferred overlay is visible, the transparent GPUI
                 // NSView captures the whole window. This handler therefore
                 // also dismisses clicks geometrically over the WKWebView.
@@ -235,7 +250,7 @@ mod macos {
                                 .child(
                                     div()
                                         .text_xs()
-                                        .text_color(rgb(0xf1ad49))
+                                        .text_color(rgb(0xfeb454))
                                         .child("GPUI / LAB 04"),
                                 )
                                 .child(
@@ -249,7 +264,7 @@ mod macos {
                                     div()
                                         .mt_3()
                                         .text_sm()
-                                        .text_color(rgb(0x8b8e92))
+                                        .text_color(rgb(0x8a8986))
                                         .child("Three surfaces.\nOne visual stack."),
                                 ),
                         )
@@ -259,9 +274,9 @@ mod macos {
                                 .flex_col()
                                 .gap_1()
                                 .text_xs()
-                                .child(layer_row("03", "GPUI overlay", rgb(0xf1ad49)))
-                                .child(layer_row("02", "WKWebView", rgb(0x3b9ee5)))
-                                .child(layer_row("01", "GPUI base", rgb(0x8b8e92))),
+                                .child(layer_row("03", "GPUI overlay", rgb(0xfeb454)))
+                                .child(layer_row("02", "WKWebView", rgb(0x5ac1fe)))
+                                .child(layer_row("01", "GPUI base", rgb(0x8a8986))),
                         ),
                 )
                 .child(
@@ -282,7 +297,7 @@ mod macos {
                                         .child(
                                             div()
                                                 .text_xs()
-                                                .text_color(rgb(0x8b8e92))
+                                                .text_color(rgb(0x8a8986))
                                                 .child("COMPOSITION TARGET"),
                                         )
                                         .child(
@@ -315,21 +330,9 @@ mod macos {
                                         )),
                                 ),
                         )
-                        .child(
-                            div()
-                                .flex_1()
-                                .min_h_0()
-                                .p(px(6.))
-                                .rounded_xl()
-                                .border_1()
-                                .border_color(rgb(0xcfd1d2))
-                                .bg(rgb(0xececed))
-                                .shadow_xl()
-                                .overflow_hidden()
-                                .child(NativeWebViewElement {
-                                    webview: self.webview.clone(),
-                                }),
-                        ),
+                        .child(div().flex_1().min_h_0().child(NativeWebViewElement {
+                            webview: self.webview.clone(),
+                        })),
                 )
                 .when(self.popover_open, |root| {
                     root.child(
@@ -343,13 +346,13 @@ mod macos {
                                 .rounded_lg()
                                 .shadow_xl()
                                 .border_1()
-                                .border_color(rgb(0xcfd1d2))
-                                .bg(rgb(0xececed))
-                                .text_color(rgb(0x5c6166))
+                                .border_color(rgb(0x3f4043))
+                                .bg(rgb(0x1f2127))
+                                .text_color(rgb(0xbfbdb6))
                                 .child(
                                     div()
                                         .text_xs()
-                                        .text_color(rgb(0xf1ad49))
+                                        .text_color(rgb(0xfeb454))
                                         .child("SURFACE 03"),
                                 )
                                 .child(
@@ -358,7 +361,7 @@ mod macos {
                                         .font_weight(gpui::FontWeight::SEMIBOLD)
                                         .child("Deferred GPUI popover"),
                                 )
-                                .child(div().mt_2().text_sm().text_color(rgb(0x8b8e92)).child(
+                                .child(div().mt_2().text_sm().text_color(rgb(0x8a8986)).child(
                                     "Painted after the native WebView without changing its \
                                          AppKit z-order.",
                                 )),
@@ -375,7 +378,7 @@ mod macos {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .bg(rgb(0x5c6166).opacity(0.38))
+                                .bg(rgb(0x0d1016).opacity(0.72))
                                 .child(
                                     div()
                                         .w(px(500.))
@@ -383,9 +386,9 @@ mod macos {
                                         .rounded_xl()
                                         .shadow_xl()
                                         .border_1()
-                                        .border_color(rgb(0xcfd1d2))
-                                        .bg(rgb(0xececed))
-                                        .text_color(rgb(0x5c6166))
+                                        .border_color(rgb(0x3f4043))
+                                        .bg(rgb(0x1f2127))
+                                        .text_color(rgb(0xbfbdb6))
                                         .child(
                                             div()
                                                 .flex()
@@ -394,7 +397,7 @@ mod macos {
                                                 .child(
                                                     div()
                                                         .text_xs()
-                                                        .text_color(rgb(0xf1ad49))
+                                                        .text_color(rgb(0xfeb454))
                                                         .child("SURFACE 03 / GPUI OVERLAY"),
                                                 )
                                                 .child(
@@ -402,9 +405,9 @@ mod macos {
                                                         .px_2()
                                                         .py_1()
                                                         .rounded_md()
-                                                        .bg(rgb(0xdfe0e1))
+                                                        .bg(rgb(0x2d2f34))
                                                         .text_xs()
-                                                        .text_color(rgb(0x8b8e92))
+                                                        .text_color(rgb(0x8a8986))
                                                         .child("LIVE"),
                                                 ),
                                         )
@@ -417,12 +420,12 @@ mod macos {
                                                     "The native layer stays exactly where it is.",
                                                 ),
                                         )
-                                        .child(div().mt_3().text_color(rgb(0x8b8e92)).child(
+                                        .child(div().mt_3().text_color(rgb(0x8a8986)).child(
                                             "GPUI splits its scene before deferred draws. \
                                                      AppKit places WKWebView between the base and \
                                                      this transparent overlay surface.",
                                         ))
-                                        .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0xcfd1d2)))
+                                        .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0x3f4043)))
                                         .child(
                                             button("close-dialog", "Close").mt_5().on_mouse_down(
                                                 MouseButton::Left,

--- a/crates/gpui/examples/native_webview.rs
+++ b/crates/gpui/examples/native_webview.rs
@@ -1,0 +1,584 @@
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("The native_webview example is only available on macOS.");
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::rc::Rc;
+
+    use cocoa::{
+        appkit::NSView,
+        base::{id, nil},
+        foundation::{NSPoint, NSRect, NSSize, NSString},
+    };
+    use gpui::{
+        App, Bounds, Context, Div, Element, ElementId, GlobalElementId, IntoElement, LayoutId,
+        MouseButton, Pixels, Stateful, Style, Window, WindowBounds, WindowOptions, deferred, div,
+        prelude::*, px, rgb, size,
+    };
+    use gpui_platform::application;
+    use objc::{class, msg_send, sel, sel_impl};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    #[link(name = "WebKit", kind = "framework")]
+    unsafe extern "C" {}
+
+    const WEBVIEW_WIDTH: Pixels = px(660.);
+    const WEBVIEW_HEIGHT: Pixels = px(410.);
+
+    const PAGE: &str = r#"
+        <!doctype html>
+        <html>
+        <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            :root {
+              color-scheme: dark;
+              font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+              background: #11151b;
+            }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              min-height: 100vh;
+              background: #11151b;
+              color: #eef2f7;
+            }
+            header {
+              height: 48px;
+              display: flex;
+              align-items: center;
+              gap: 14px;
+              padding: 0 18px;
+              border-bottom: 1px solid #2a313b;
+              background: #181d25;
+            }
+            .lights { display: flex; gap: 7px; }
+            .lights i {
+              width: 9px;
+              height: 9px;
+              border-radius: 50%;
+              background: #46505d;
+            }
+            .lights i:first-child { background: #ff7147; }
+            .address {
+              flex: 1;
+              padding: 7px 12px;
+              border: 1px solid #303844;
+              border-radius: 6px;
+              background: #0d1117;
+              color: #98a5b6;
+              font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+            }
+            main {
+              display: grid;
+              grid-template-columns: 1.2fr .8fr;
+              gap: 28px;
+              padding: 34px;
+            }
+            .eyebrow {
+              color: #ff7147;
+              font: 600 10px ui-monospace, SFMono-Regular, Menlo, monospace;
+              letter-spacing: .16em;
+              text-transform: uppercase;
+            }
+            h1 {
+              max-width: 360px;
+              margin: 14px 0;
+              font-size: 34px;
+              font-weight: 590;
+              letter-spacing: -.035em;
+              line-height: 1.06;
+            }
+            p {
+              max-width: 390px;
+              margin: 0;
+              color: #95a1b1;
+              font-size: 14px;
+              line-height: 1.6;
+            }
+            .details { display: grid; gap: 10px; align-content: start; }
+            .datum {
+              display: flex;
+              justify-content: space-between;
+              padding: 12px 0;
+              border-bottom: 1px solid #2a313b;
+              color: #818d9d;
+              font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
+            }
+            .datum strong { color: #dce3ec; font-weight: 500; }
+            input {
+              grid-column: 1 / -1;
+              width: 100%;
+              margin-top: 8px;
+              padding: 13px 14px;
+              border: 1px solid #394451;
+              border-radius: 7px;
+              outline: none;
+              background: #0b0f14;
+              color: #eef2f7;
+              font: 13px ui-monospace, SFMono-Regular, Menlo, monospace;
+            }
+            input:focus {
+              border-color: #ff7147;
+              box-shadow: 0 0 0 3px rgba(255, 113, 71, .13);
+            }
+          </style>
+        </head>
+        <body>
+          <header>
+            <div class="lights"><i></i><i></i><i></i></div>
+            <div class="address">native://webkit/composition-surface</div>
+          </header>
+          <main>
+            <section>
+              <div class="eyebrow">Native surface / live</div>
+              <h1>A real browser inside GPUI’s scene.</h1>
+              <p>
+                This page is rendered by WKWebView. GPUI owns the surfaces
+                below and above it, while AppKit composes all three.
+              </p>
+            </section>
+            <aside class="details">
+              <div class="datum"><span>ENGINE</span><strong>WEBKIT</strong></div>
+              <div class="datum"><span>HOST</span><strong>NSVIEW</strong></div>
+              <div class="datum"><span>STATE</span><strong>INTERACTIVE</strong></div>
+            </aside>
+            <input autofocus value="Focus and type inside the native layer">
+          </main>
+        </body>
+        </html>
+    "#;
+
+    struct NativeWebView {
+        parent: id,
+        view: id,
+    }
+
+    impl NativeWebView {
+        fn new(window: &Window) -> anyhow::Result<Self> {
+            let window_handle = HasWindowHandle::window_handle(window).map_err(|error| {
+                anyhow::anyhow!("failed to get AppKit window handle: {error:?}")
+            })?;
+            let parent = match window_handle.as_raw() {
+                RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
+                _ => anyhow::bail!("native_webview requires an AppKit window"),
+            };
+
+            unsafe {
+                let configuration: id = msg_send![class!(WKWebViewConfiguration), new];
+                let view: id = msg_send![class!(WKWebView), alloc];
+                let view: id = msg_send![
+                    view,
+                    initWithFrame: NSRect::new(
+                        NSPoint::new(0., 0.),
+                        NSSize::new(
+                            f64::from(WEBVIEW_WIDTH),
+                            f64::from(WEBVIEW_HEIGHT),
+                        ),
+                    )
+                    configuration: configuration
+                ];
+                anyhow::ensure!(!view.is_null(), "failed to create WKWebView");
+
+                let html = NSString::alloc(nil).init_str(PAGE);
+                let _: id = msg_send![view, loadHTMLString: html baseURL: nil];
+                parent.addSubview_(view);
+
+                let _: () = msg_send![html, release];
+                let _: () = msg_send![configuration, release];
+
+                Ok(Self { parent, view })
+            }
+        }
+
+        fn set_bounds(&self, bounds: Bounds<Pixels>) {
+            unsafe {
+                let parent_bounds = NSView::bounds(self.parent);
+                let frame = NSRect::new(
+                    NSPoint::new(
+                        f64::from(bounds.origin.x),
+                        parent_bounds.size.height
+                            - f64::from(bounds.origin.y)
+                            - f64::from(bounds.size.height),
+                    ),
+                    NSSize::new(f64::from(bounds.size.width), f64::from(bounds.size.height)),
+                );
+                let _: () = msg_send![self.view, setFrame: frame];
+            }
+        }
+
+        fn focus_parent(&self) {
+            unsafe {
+                let window: id = msg_send![self.view, window];
+                if !window.is_null() {
+                    let _: bool = msg_send![window, makeFirstResponder: self.parent];
+                }
+            }
+        }
+    }
+
+    impl Drop for NativeWebView {
+        fn drop(&mut self) {
+            unsafe {
+                NSView::removeFromSuperview(self.view);
+                let _: () = msg_send![self.view, release];
+            }
+        }
+    }
+
+    struct NativeWebViewElement {
+        webview: Rc<NativeWebView>,
+    }
+
+    impl IntoElement for NativeWebViewElement {
+        type Element = Self;
+
+        fn into_element(self) -> Self::Element {
+            self
+        }
+    }
+
+    impl Element for NativeWebViewElement {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            None
+        }
+
+        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&gpui::InspectorElementId>,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> (LayoutId, Self::RequestLayoutState) {
+            let mut style = Style::default();
+            style.size.width = WEBVIEW_WIDTH.into();
+            style.size.height = WEBVIEW_HEIGHT.into();
+            (window.request_layout(style, [], cx), ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&gpui::InspectorElementId>,
+            bounds: Bounds<Pixels>,
+            _request_layout: &mut Self::RequestLayoutState,
+            _window: &mut Window,
+            _cx: &mut App,
+        ) -> Self::PrepaintState {
+            self.webview.set_bounds(bounds);
+        }
+
+        fn paint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&gpui::InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut Self::RequestLayoutState,
+            _prepaint: &mut Self::PrepaintState,
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+        }
+    }
+
+    struct NativeWebViewExample {
+        webview: Rc<NativeWebView>,
+        dialog_open: bool,
+        popover_open: bool,
+    }
+
+    fn button(id: &'static str, label: &'static str) -> Stateful<Div> {
+        div()
+            .id(id)
+            .px_4()
+            .py_2()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(0x35404d))
+            .bg(rgb(0x171c23))
+            .text_color(rgb(0xdce3ec))
+            .text_sm()
+            .cursor_pointer()
+            .hover(|style| style.bg(rgb(0x202731)).border_color(rgb(0x566273)))
+            .child(label)
+    }
+
+    fn layer_row(index: &'static str, label: &'static str, color: gpui::Rgba) -> Div {
+        div()
+            .flex()
+            .items_center()
+            .gap_2()
+            .py_2()
+            .border_b_1()
+            .border_color(rgb(0x242c35))
+            .child(div().w_1().h_5().rounded_sm().bg(color))
+            .child(div().text_color(rgb(0x687586)).w(px(18.)).child(index))
+            .child(div().text_color(rgb(0xaeb8c5)).child(label))
+    }
+
+    impl Render for NativeWebViewExample {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("native-webview-example")
+                .relative()
+                .flex()
+                .gap_6()
+                .size_full()
+                .p_7()
+                .bg(rgb(0x090c10))
+                .text_color(rgb(0xe7edf6))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, _, cx| {
+                        this.webview.focus_parent();
+                        this.popover_open = false;
+                        this.dialog_open = false;
+                        cx.notify();
+                    }),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .justify_between()
+                        .w(px(150.))
+                        .py_1()
+                        .child(
+                            div()
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(rgb(0xff7147))
+                                        .child("GPUI / LAB 04"),
+                                )
+                                .child(
+                                    div()
+                                        .mt_3()
+                                        .text_2xl()
+                                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                                        .child("Native\ncomposition"),
+                                )
+                                .child(
+                                    div()
+                                        .mt_3()
+                                        .text_sm()
+                                        .text_color(rgb(0x788597))
+                                        .child("Three surfaces.\nOne visual stack."),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .flex_col()
+                                .gap_1()
+                                .text_xs()
+                                .child(layer_row("03", "GPUI overlay", rgb(0xff7147)))
+                                .child(layer_row("02", "WKWebView", rgb(0x5ea7ff)))
+                                .child(layer_row("01", "GPUI base", rgb(0x667080))),
+                        ),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_4()
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .child(
+                                    div()
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(rgb(0x788597))
+                                                .child("COMPOSITION TARGET"),
+                                        )
+                                        .child(
+                                            div().mt_1().text_lg().child("WebView overlay proof"),
+                                        ),
+                                )
+                                .child(
+                                    div()
+                                        .flex()
+                                        .gap_2()
+                                        .child(button("toggle-popover", "Show popover").on_click(
+                                            cx.listener(|this, _, _, cx| {
+                                                cx.stop_propagation();
+                                                this.webview.focus_parent();
+                                                this.popover_open = !this.popover_open;
+                                                cx.notify();
+                                            }),
+                                        ))
+                                        .child(button("open-dialog", "Open dialog").on_click(
+                                            cx.listener(|this, _, _, cx| {
+                                                cx.stop_propagation();
+                                                this.webview.focus_parent();
+                                                this.dialog_open = true;
+                                                cx.notify();
+                                            }),
+                                        )),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .p(px(6.))
+                                .rounded_xl()
+                                .border_1()
+                                .border_color(rgb(0x2b3440))
+                                .bg(rgb(0x12171d))
+                                .shadow_xl()
+                                .overflow_hidden()
+                                .child(NativeWebViewElement {
+                                    webview: self.webview.clone(),
+                                }),
+                        ),
+                )
+                .when(self.popover_open, |root| {
+                    root.child(
+                        deferred(
+                            div()
+                                .absolute()
+                                .top(px(92.))
+                                .right(px(42.))
+                                .w(px(300.))
+                                .p_4()
+                                .rounded_lg()
+                                .shadow_xl()
+                                .border_1()
+                                .border_color(rgb(0x384452))
+                                .bg(rgb(0x171d24))
+                                .text_color(rgb(0xe7edf6))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(rgb(0xff7147))
+                                        .child("SURFACE 03"),
+                                )
+                                .child(
+                                    div()
+                                        .mt_2()
+                                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                                        .child("Deferred GPUI popover"),
+                                )
+                                .child(div().mt_2().text_sm().text_color(rgb(0x94a0b0)).child(
+                                    "Painted after the native WebView without changing its \
+                                         AppKit z-order.",
+                                )),
+                        )
+                        .priority(1),
+                    )
+                })
+                .when(self.dialog_open, |root| {
+                    root.child(
+                        deferred(
+                            div()
+                                .absolute()
+                                .inset_0()
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .bg(gpui::black().opacity(0.62))
+                                .child(
+                                    div()
+                                        .w(px(500.))
+                                        .p_7()
+                                        .rounded_xl()
+                                        .shadow_xl()
+                                        .border_1()
+                                        .border_color(rgb(0x3b4654))
+                                        .bg(rgb(0x151a21))
+                                        .text_color(rgb(0xe7edf6))
+                                        .child(
+                                            div()
+                                                .flex()
+                                                .items_center()
+                                                .justify_between()
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(rgb(0xff7147))
+                                                        .child("SURFACE 03 / GPUI OVERLAY"),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .px_2()
+                                                        .py_1()
+                                                        .rounded_md()
+                                                        .bg(rgb(0x202731))
+                                                        .text_xs()
+                                                        .text_color(rgb(0x94a0b0))
+                                                        .child("LIVE"),
+                                                ),
+                                        )
+                                        .child(
+                                            div()
+                                                .mt_5()
+                                                .text_2xl()
+                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .child(
+                                                    "The native layer stays exactly where it is.",
+                                                ),
+                                        )
+                                        .child(div().mt_3().text_color(rgb(0x94a0b0)).child(
+                                            "GPUI splits its scene before deferred draws. \
+                                                     AppKit places WKWebView between the base and \
+                                                     this transparent overlay surface.",
+                                        ))
+                                        .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0x2c3541)))
+                                        .child(button("close-dialog", "Close").mt_5().on_click(
+                                            cx.listener(|this, _, _, cx| {
+                                                this.dialog_open = false;
+                                                cx.notify();
+                                            }),
+                                        )),
+                                ),
+                        )
+                        .priority(2),
+                    )
+                })
+        }
+    }
+
+    pub fn run() {
+        application().run(|cx: &mut App| {
+            let bounds = Bounds::centered(None, size(px(900.), px(640.)), cx);
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |window, cx| {
+                    let webview = Rc::new(NativeWebView::new(window).unwrap());
+
+                    // Insert the transparent GPUI overlay after the native
+                    // WebView so AppKit places it above the browser view.
+                    window.enable_scene_overlay().unwrap();
+
+                    cx.new(|_| NativeWebViewExample {
+                        webview,
+                        dialog_open: true,
+                        popover_open: false,
+                    })
+                },
+            )
+            .unwrap();
+            cx.activate(true);
+        });
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos::run();
+}

--- a/crates/gpui/examples/native_webview.rs
+++ b/crates/gpui/examples/native_webview.rs
@@ -15,7 +15,7 @@ mod macos {
     use gpui::{
         App, Bounds, Context, Div, Element, ElementId, GlobalElementId, IntoElement, LayoutId,
         MouseButton, Pixels, Stateful, Style, Window, WindowBounds, WindowOptions, deferred, div,
-        prelude::*, px, rgb, size,
+        prelude::*, px, relative, rgb, size,
     };
     use gpui_platform::application;
     use objc::{class, msg_send, sel, sel_impl};
@@ -24,132 +24,7 @@ mod macos {
     #[link(name = "WebKit", kind = "framework")]
     unsafe extern "C" {}
 
-    const WEBVIEW_WIDTH: Pixels = px(660.);
-    const WEBVIEW_HEIGHT: Pixels = px(410.);
-
-    const PAGE: &str = r#"
-        <!doctype html>
-        <html>
-        <head>
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          <style>
-            :root {
-              color-scheme: dark;
-              font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-              background: #11151b;
-            }
-            * { box-sizing: border-box; }
-            body {
-              margin: 0;
-              min-height: 100vh;
-              background: #11151b;
-              color: #eef2f7;
-            }
-            header {
-              height: 48px;
-              display: flex;
-              align-items: center;
-              gap: 14px;
-              padding: 0 18px;
-              border-bottom: 1px solid #2a313b;
-              background: #181d25;
-            }
-            .lights { display: flex; gap: 7px; }
-            .lights i {
-              width: 9px;
-              height: 9px;
-              border-radius: 50%;
-              background: #46505d;
-            }
-            .lights i:first-child { background: #ff7147; }
-            .address {
-              flex: 1;
-              padding: 7px 12px;
-              border: 1px solid #303844;
-              border-radius: 6px;
-              background: #0d1117;
-              color: #98a5b6;
-              font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
-            }
-            main {
-              display: grid;
-              grid-template-columns: 1.2fr .8fr;
-              gap: 28px;
-              padding: 34px;
-            }
-            .eyebrow {
-              color: #ff7147;
-              font: 600 10px ui-monospace, SFMono-Regular, Menlo, monospace;
-              letter-spacing: .16em;
-              text-transform: uppercase;
-            }
-            h1 {
-              max-width: 360px;
-              margin: 14px 0;
-              font-size: 34px;
-              font-weight: 590;
-              letter-spacing: -.035em;
-              line-height: 1.06;
-            }
-            p {
-              max-width: 390px;
-              margin: 0;
-              color: #95a1b1;
-              font-size: 14px;
-              line-height: 1.6;
-            }
-            .details { display: grid; gap: 10px; align-content: start; }
-            .datum {
-              display: flex;
-              justify-content: space-between;
-              padding: 12px 0;
-              border-bottom: 1px solid #2a313b;
-              color: #818d9d;
-              font: 11px ui-monospace, SFMono-Regular, Menlo, monospace;
-            }
-            .datum strong { color: #dce3ec; font-weight: 500; }
-            input {
-              grid-column: 1 / -1;
-              width: 100%;
-              margin-top: 8px;
-              padding: 13px 14px;
-              border: 1px solid #394451;
-              border-radius: 7px;
-              outline: none;
-              background: #0b0f14;
-              color: #eef2f7;
-              font: 13px ui-monospace, SFMono-Regular, Menlo, monospace;
-            }
-            input:focus {
-              border-color: #ff7147;
-              box-shadow: 0 0 0 3px rgba(255, 113, 71, .13);
-            }
-          </style>
-        </head>
-        <body>
-          <header>
-            <div class="lights"><i></i><i></i><i></i></div>
-            <div class="address">native://webkit/composition-surface</div>
-          </header>
-          <main>
-            <section>
-              <div class="eyebrow">Native surface / live</div>
-              <h1>A real browser inside GPUI’s scene.</h1>
-              <p>
-                This page is rendered by WKWebView. GPUI owns the surfaces
-                below and above it, while AppKit composes all three.
-              </p>
-            </section>
-            <aside class="details">
-              <div class="datum"><span>ENGINE</span><strong>WEBKIT</strong></div>
-              <div class="datum"><span>HOST</span><strong>NSVIEW</strong></div>
-              <div class="datum"><span>STATE</span><strong>INTERACTIVE</strong></div>
-            </aside>
-            <input autofocus value="Focus and type inside the native layer">
-          </main>
-        </body>
-        </html>
-    "#;
+    const PAGE: &str = include_str!("native_webview.html");
 
     struct NativeWebView {
         parent: id,
@@ -173,14 +48,14 @@ mod macos {
                     view,
                     initWithFrame: NSRect::new(
                         NSPoint::new(0., 0.),
-                        NSSize::new(
-                            f64::from(WEBVIEW_WIDTH),
-                            f64::from(WEBVIEW_HEIGHT),
-                        ),
+                        NSSize::new(0., 0.),
                     )
                     configuration: configuration
                 ];
-                anyhow::ensure!(!view.is_null(), "failed to create WKWebView");
+                if view.is_null() {
+                    let _: () = msg_send![configuration, release];
+                    anyhow::bail!("failed to create WKWebView");
+                }
 
                 let html = NSString::alloc(nil).init_str(PAGE);
                 let _: id = msg_send![view, loadHTMLString: html baseURL: nil];
@@ -260,8 +135,8 @@ mod macos {
             cx: &mut App,
         ) -> (LayoutId, Self::RequestLayoutState) {
             let mut style = Style::default();
-            style.size.width = WEBVIEW_WIDTH.into();
-            style.size.height = WEBVIEW_HEIGHT.into();
+            style.size.width = relative(1.).into();
+            style.size.height = relative(1.).into();
             (window.request_layout(style, [], cx), ())
         }
 
@@ -303,12 +178,12 @@ mod macos {
             .py_2()
             .rounded_md()
             .border_1()
-            .border_color(rgb(0x35404d))
-            .bg(rgb(0x171c23))
-            .text_color(rgb(0xdce3ec))
+            .border_color(rgb(0xcfd1d2))
+            .bg(rgb(0xececed))
+            .text_color(rgb(0x5c6166))
             .text_sm()
             .cursor_pointer()
-            .hover(|style| style.bg(rgb(0x202731)).border_color(rgb(0x566273)))
+            .hover(|style| style.bg(rgb(0xdfe0e1)).border_color(rgb(0xcfd0d2)))
             .child(label)
     }
 
@@ -319,10 +194,10 @@ mod macos {
             .gap_2()
             .py_2()
             .border_b_1()
-            .border_color(rgb(0x242c35))
+            .border_color(rgb(0xcfd1d2))
             .child(div().w_1().h_5().rounded_sm().bg(color))
-            .child(div().text_color(rgb(0x687586)).w(px(18.)).child(index))
-            .child(div().text_color(rgb(0xaeb8c5)).child(label))
+            .child(div().text_color(rgb(0xa9acae)).w(px(18.)).child(index))
+            .child(div().text_color(rgb(0x5c6166)).child(label))
     }
 
     impl Render for NativeWebViewExample {
@@ -334,8 +209,11 @@ mod macos {
                 .gap_6()
                 .size_full()
                 .p_7()
-                .bg(rgb(0x090c10))
-                .text_color(rgb(0xe7edf6))
+                .bg(rgb(0xdcddde))
+                .text_color(rgb(0x5c6166))
+                // While a deferred overlay is visible, the transparent GPUI
+                // NSView captures the whole window. This handler therefore
+                // also dismisses clicks geometrically over the WKWebView.
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(|this, _, _, cx| {
@@ -357,7 +235,7 @@ mod macos {
                                 .child(
                                     div()
                                         .text_xs()
-                                        .text_color(rgb(0xff7147))
+                                        .text_color(rgb(0xf1ad49))
                                         .child("GPUI / LAB 04"),
                                 )
                                 .child(
@@ -371,7 +249,7 @@ mod macos {
                                     div()
                                         .mt_3()
                                         .text_sm()
-                                        .text_color(rgb(0x788597))
+                                        .text_color(rgb(0x8b8e92))
                                         .child("Three surfaces.\nOne visual stack."),
                                 ),
                         )
@@ -381,15 +259,18 @@ mod macos {
                                 .flex_col()
                                 .gap_1()
                                 .text_xs()
-                                .child(layer_row("03", "GPUI overlay", rgb(0xff7147)))
-                                .child(layer_row("02", "WKWebView", rgb(0x5ea7ff)))
-                                .child(layer_row("01", "GPUI base", rgb(0x667080))),
+                                .child(layer_row("03", "GPUI overlay", rgb(0xf1ad49)))
+                                .child(layer_row("02", "WKWebView", rgb(0x3b9ee5)))
+                                .child(layer_row("01", "GPUI base", rgb(0x8b8e92))),
                         ),
                 )
                 .child(
                     div()
                         .flex()
                         .flex_col()
+                        .flex_1()
+                        .min_w_0()
+                        .h_full()
                         .gap_4()
                         .child(
                             div()
@@ -401,7 +282,7 @@ mod macos {
                                         .child(
                                             div()
                                                 .text_xs()
-                                                .text_color(rgb(0x788597))
+                                                .text_color(rgb(0x8b8e92))
                                                 .child("COMPOSITION TARGET"),
                                         )
                                         .child(
@@ -412,15 +293,19 @@ mod macos {
                                     div()
                                         .flex()
                                         .gap_2()
-                                        .child(button("toggle-popover", "Show popover").on_click(
-                                            cx.listener(|this, _, _, cx| {
-                                                cx.stop_propagation();
-                                                this.webview.focus_parent();
-                                                this.popover_open = !this.popover_open;
-                                                cx.notify();
-                                            }),
-                                        ))
-                                        .child(button("open-dialog", "Open dialog").on_click(
+                                        .child(
+                                            button("toggle-popover", "Show popover").on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|this, _, _, cx| {
+                                                    cx.stop_propagation();
+                                                    this.webview.focus_parent();
+                                                    this.popover_open = !this.popover_open;
+                                                    cx.notify();
+                                                }),
+                                            ),
+                                        )
+                                        .child(button("open-dialog", "Open dialog").on_mouse_down(
+                                            MouseButton::Left,
                                             cx.listener(|this, _, _, cx| {
                                                 cx.stop_propagation();
                                                 this.webview.focus_parent();
@@ -432,11 +317,13 @@ mod macos {
                         )
                         .child(
                             div()
+                                .flex_1()
+                                .min_h_0()
                                 .p(px(6.))
                                 .rounded_xl()
                                 .border_1()
-                                .border_color(rgb(0x2b3440))
-                                .bg(rgb(0x12171d))
+                                .border_color(rgb(0xcfd1d2))
+                                .bg(rgb(0xececed))
                                 .shadow_xl()
                                 .overflow_hidden()
                                 .child(NativeWebViewElement {
@@ -456,13 +343,13 @@ mod macos {
                                 .rounded_lg()
                                 .shadow_xl()
                                 .border_1()
-                                .border_color(rgb(0x384452))
-                                .bg(rgb(0x171d24))
-                                .text_color(rgb(0xe7edf6))
+                                .border_color(rgb(0xcfd1d2))
+                                .bg(rgb(0xececed))
+                                .text_color(rgb(0x5c6166))
                                 .child(
                                     div()
                                         .text_xs()
-                                        .text_color(rgb(0xff7147))
+                                        .text_color(rgb(0xf1ad49))
                                         .child("SURFACE 03"),
                                 )
                                 .child(
@@ -471,7 +358,7 @@ mod macos {
                                         .font_weight(gpui::FontWeight::SEMIBOLD)
                                         .child("Deferred GPUI popover"),
                                 )
-                                .child(div().mt_2().text_sm().text_color(rgb(0x94a0b0)).child(
+                                .child(div().mt_2().text_sm().text_color(rgb(0x8b8e92)).child(
                                     "Painted after the native WebView without changing its \
                                          AppKit z-order.",
                                 )),
@@ -488,7 +375,7 @@ mod macos {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .bg(gpui::black().opacity(0.62))
+                                .bg(rgb(0x5c6166).opacity(0.38))
                                 .child(
                                     div()
                                         .w(px(500.))
@@ -496,9 +383,9 @@ mod macos {
                                         .rounded_xl()
                                         .shadow_xl()
                                         .border_1()
-                                        .border_color(rgb(0x3b4654))
-                                        .bg(rgb(0x151a21))
-                                        .text_color(rgb(0xe7edf6))
+                                        .border_color(rgb(0xcfd1d2))
+                                        .bg(rgb(0xececed))
+                                        .text_color(rgb(0x5c6166))
                                         .child(
                                             div()
                                                 .flex()
@@ -507,7 +394,7 @@ mod macos {
                                                 .child(
                                                     div()
                                                         .text_xs()
-                                                        .text_color(rgb(0xff7147))
+                                                        .text_color(rgb(0xf1ad49))
                                                         .child("SURFACE 03 / GPUI OVERLAY"),
                                                 )
                                                 .child(
@@ -515,9 +402,9 @@ mod macos {
                                                         .px_2()
                                                         .py_1()
                                                         .rounded_md()
-                                                        .bg(rgb(0x202731))
+                                                        .bg(rgb(0xdfe0e1))
                                                         .text_xs()
-                                                        .text_color(rgb(0x94a0b0))
+                                                        .text_color(rgb(0x8b8e92))
                                                         .child("LIVE"),
                                                 ),
                                         )
@@ -530,18 +417,23 @@ mod macos {
                                                     "The native layer stays exactly where it is.",
                                                 ),
                                         )
-                                        .child(div().mt_3().text_color(rgb(0x94a0b0)).child(
+                                        .child(div().mt_3().text_color(rgb(0x8b8e92)).child(
                                             "GPUI splits its scene before deferred draws. \
                                                      AppKit places WKWebView between the base and \
                                                      this transparent overlay surface.",
                                         ))
-                                        .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0x2c3541)))
-                                        .child(button("close-dialog", "Close").mt_5().on_click(
-                                            cx.listener(|this, _, _, cx| {
-                                                this.dialog_open = false;
-                                                cx.notify();
-                                            }),
-                                        )),
+                                        .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0xcfd1d2)))
+                                        .child(
+                                            button("close-dialog", "Close").mt_5().on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|this, _, _, cx| {
+                                                    cx.stop_propagation();
+                                                    this.webview.focus_parent();
+                                                    this.dialog_open = false;
+                                                    cx.notify();
+                                                }),
+                                            ),
+                                        ),
                                 ),
                         )
                         .priority(2),
@@ -567,7 +459,7 @@ mod macos {
 
                     cx.new(|_| NativeWebViewExample {
                         webview,
-                        dialog_open: true,
+                        dialog_open: false,
                         popover_open: false,
                     })
                 },

--- a/crates/gpui/examples/native_webview.rs
+++ b/crates/gpui/examples/native_webview.rs
@@ -182,7 +182,9 @@ mod macos {
 
     struct NativeWebViewExample {
         webview: Rc<NativeWebView>,
+        about_active: bool,
         dialog_open: bool,
+        menu_open: bool,
         popover_open: bool,
     }
 
@@ -199,6 +201,33 @@ mod macos {
             .text_sm()
             .cursor_pointer()
             .hover(|style| style.bg(rgb(0x2d2f34)).border_color(rgb(0x3e4043)))
+            .child(label)
+    }
+
+    fn tab(id: &'static str, label: &'static str, active: bool) -> Stateful<Div> {
+        div()
+            .id(id)
+            .px_3()
+            .py_2()
+            .border_b_2()
+            .border_color(if active { rgb(0x5ac1fe) } else { rgb(0x313337) })
+            .text_color(if active { rgb(0xbfbdb6) } else { rgb(0x8a8986) })
+            .text_sm()
+            .cursor_pointer()
+            .hover(|style| style.text_color(rgb(0xbfbdb6)))
+            .child(label)
+    }
+
+    fn menu_item(id: &'static str, label: &'static str) -> Stateful<Div> {
+        div()
+            .id(id)
+            .px_2()
+            .py_1()
+            .rounded_md()
+            .text_xs()
+            .text_color(rgb(0xbfbdb6))
+            .cursor_pointer()
+            .hover(|style| style.bg(rgb(0x2d2f34)))
             .child(label)
     }
 
@@ -235,6 +264,7 @@ mod macos {
                         this.webview.focus_parent();
                         this.popover_open = false;
                         this.dialog_open = false;
+                        this.menu_open = false;
                         cx.notify();
                     }),
                 )
@@ -243,30 +273,20 @@ mod macos {
                         .flex()
                         .flex_col()
                         .justify_between()
-                        .w(px(150.))
-                        .py_1()
+                        .w(px(180.))
                         .child(
                             div()
                                 .child(
                                     div()
-                                        .text_xs()
-                                        .text_color(rgb(0xfeb454))
-                                        .child("GPUI / LAB 04"),
-                                )
-                                .child(
-                                    div()
-                                        .mt_3()
-                                        .text_2xl()
+                                        .mt(px(-2.))
+                                        .text_lg()
                                         .font_weight(gpui::FontWeight::SEMIBOLD)
-                                        .child("Native\ncomposition"),
+                                        .text_color(rgb(0xfeb454))
+                                        .child("GPUI NATIVE WEBVIEW"),
                                 )
-                                .child(
-                                    div()
-                                        .mt_3()
-                                        .text_sm()
-                                        .text_color(rgb(0x8a8986))
-                                        .child("Three surfaces.\nOne visual stack."),
-                                ),
+                                .child(div().mt_2().text_sm().text_color(rgb(0x8a8986)).child(
+                                    "Native composition.\nThree surfaces, one visual stack.",
+                                )),
                         )
                         .child(
                             div()
@@ -315,6 +335,7 @@ mod macos {
                                                     cx.stop_propagation();
                                                     this.webview.focus_parent();
                                                     this.popover_open = !this.popover_open;
+                                                    this.menu_open = false;
                                                     cx.notify();
                                                 }),
                                             ),
@@ -325,14 +346,171 @@ mod macos {
                                                 cx.stop_propagation();
                                                 this.webview.focus_parent();
                                                 this.dialog_open = true;
+                                                this.menu_open = false;
                                                 cx.notify();
                                             }),
                                         )),
                                 ),
                         )
-                        .child(div().flex_1().min_h_0().child(NativeWebViewElement {
-                            webview: self.webview.clone(),
-                        })),
+                        .child(
+                            div()
+                                .relative()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .border_b_1()
+                                .border_color(rgb(0x3f4043))
+                                .child(
+                                    div()
+                                        .flex()
+                                        .child(
+                                            tab("webview-tab", "WebView", !self.about_active)
+                                                .on_mouse_down(
+                                                    MouseButton::Left,
+                                                    cx.listener(|this, _, _, cx| {
+                                                        cx.stop_propagation();
+                                                        this.about_active = false;
+                                                        this.popover_open = false;
+                                                        this.dialog_open = false;
+                                                        this.menu_open = false;
+                                                        cx.notify();
+                                                    }),
+                                                ),
+                                        )
+                                        .child(
+                                            tab("about-tab", "About", self.about_active)
+                                                .on_mouse_down(
+                                                    MouseButton::Left,
+                                                    cx.listener(|this, _, _, cx| {
+                                                        cx.stop_propagation();
+                                                        this.webview.focus_parent();
+                                                        this.about_active = true;
+                                                        this.popover_open = false;
+                                                        this.dialog_open = false;
+                                                        this.menu_open = false;
+                                                        cx.notify();
+                                                    }),
+                                                ),
+                                        ),
+                                )
+                                .child(
+                                    div()
+                                        .id("popup-menu-trigger")
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .w(px(28.))
+                                        .h(px(28.))
+                                        .rounded_md()
+                                        .text_base()
+                                        .text_color(rgb(0x8a8986))
+                                        .cursor_pointer()
+                                        .hover(|style| {
+                                            style.bg(rgb(0x2d2f34)).text_color(rgb(0xbfbdb6))
+                                        })
+                                        .on_mouse_down(
+                                            MouseButton::Left,
+                                            cx.listener(|this, _, _, cx| {
+                                                cx.stop_propagation();
+                                                this.webview.focus_parent();
+                                                this.menu_open = !this.menu_open;
+                                                cx.notify();
+                                            }),
+                                        )
+                                        .child("…"),
+                                )
+                                .when(self.menu_open, |tab_bar| {
+                                    tab_bar.child(
+                                        deferred(
+                                            div()
+                                                .absolute()
+                                                .top(px(34.))
+                                                .right_0()
+                                                .w(px(180.))
+                                                .p_1()
+                                                .rounded_lg()
+                                                .border_1()
+                                                .border_color(rgb(0x3f4043))
+                                                .bg(rgb(0x1f2127))
+                                                .shadow_xl()
+                                                .child(menu_item(
+                                                    "popup-menu-reload",
+                                                    "Reload WebView",
+                                                ))
+                                                .child(menu_item(
+                                                    "popup-menu-inspect",
+                                                    "Inspect native surface",
+                                                ))
+                                                .child(div().my_1().h(px(1.)).bg(rgb(0x3f4043)))
+                                                .child(menu_item(
+                                                    "popup-menu-about",
+                                                    "About this example",
+                                                ))
+                                                .on_mouse_down(
+                                                    MouseButton::Left,
+                                                    cx.listener(|this, _, _, cx| {
+                                                        cx.stop_propagation();
+                                                        this.menu_open = false;
+                                                        cx.notify();
+                                                    }),
+                                                ),
+                                        )
+                                        .priority(2),
+                                    )
+                                }),
+                        )
+                        .child(
+                            div()
+                                .relative()
+                                .flex_1()
+                                .min_h_0()
+                                .child(NativeWebViewElement {
+                                    webview: self.webview.clone(),
+                                })
+                                .when(self.about_active, |content| {
+                                    content.child(
+                                        deferred(
+                                            div()
+                                                .absolute()
+                                                .inset_0()
+                                                .flex()
+                                                .flex_col()
+                                                .justify_center()
+                                                .p_10()
+                                                .rounded_lg()
+                                                .bg(rgb(0x0d1016))
+                                                .text_color(rgb(0xbfbdb6))
+                                                .child(
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(rgb(0x5ac1fe))
+                                                        .child("GPUI OVERLAY CONTENT"),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .mt_3()
+                                                        .text_3xl()
+                                                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                        .child("A regular rendered view"),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .mt_4()
+                                                        .max_w(px(520.))
+                                                        .text_color(rgb(0x8a8986))
+                                                        .line_height(relative(1.6))
+                                                        .child(
+                                                            "This tab is rendered by GPUI above \
+                                                             the native WebView. It verifies that \
+                                                             non-popup content can replace and \
+                                                             fully occlude a native surface.",
+                                                        ),
+                                                ),
+                                        )
+                                        .priority(1),
+                                    )
+                                }),
+                        ),
                 )
                 .when(self.popover_open, |root| {
                     root.child(
@@ -366,7 +544,7 @@ mod macos {
                                          AppKit z-order.",
                                 )),
                         )
-                        .priority(1),
+                        .priority(3),
                     )
                 })
                 .when(self.dialog_open, |root| {
@@ -426,8 +604,8 @@ mod macos {
                                                      this transparent overlay surface.",
                                         ))
                                         .child(div().mt_5().h(px(1.)).w_full().bg(rgb(0x3f4043)))
-                                        .child(
-                                            button("close-dialog", "Close").mt_5().on_mouse_down(
+                                        .child(div().mt_5().flex().child(
+                                            button("close-dialog", "Close").on_mouse_down(
                                                 MouseButton::Left,
                                                 cx.listener(|this, _, _, cx| {
                                                     cx.stop_propagation();
@@ -436,10 +614,10 @@ mod macos {
                                                     cx.notify();
                                                 }),
                                             ),
-                                        ),
+                                        )),
                                 ),
                         )
-                        .priority(2),
+                        .priority(4),
                     )
                 })
         }
@@ -462,7 +640,9 @@ mod macos {
 
                     cx.new(|_| NativeWebViewExample {
                         webview,
+                        about_active: false,
                         dialog_open: false,
+                        menu_open: false,
                         popover_open: false,
                     })
                 },

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -782,8 +782,6 @@ pub enum PlatformInput {
     FileDrop(FileDropEvent),
     /// A raw touch event on a touch screen.
     Touch(TouchEvent),
-    /// Keyboard focus moved to a native child view outside GPUI's view tree.
-    NativeViewFocus,
 }
 
 impl PlatformInput {
@@ -801,7 +799,6 @@ impl PlatformInput {
             PlatformInput::Pinch(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
             PlatformInput::Touch(_) => None,
-            PlatformInput::NativeViewFocus => None,
         }
     }
 
@@ -819,7 +816,6 @@ impl PlatformInput {
             PlatformInput::Pinch(_) => None,
             PlatformInput::FileDrop(_) => None,
             PlatformInput::Touch(_) => None,
-            PlatformInput::NativeViewFocus => None,
         }
     }
 

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -782,6 +782,8 @@ pub enum PlatformInput {
     FileDrop(FileDropEvent),
     /// A raw touch event on a touch screen.
     Touch(TouchEvent),
+    /// Keyboard focus moved to a native child view outside GPUI's view tree.
+    NativeViewFocus,
 }
 
 impl PlatformInput {
@@ -799,6 +801,7 @@ impl PlatformInput {
             PlatformInput::Pinch(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
             PlatformInput::Touch(_) => None,
+            PlatformInput::NativeViewFocus => None,
         }
     }
 
@@ -816,6 +819,7 @@ impl PlatformInput {
             PlatformInput::Pinch(_) => None,
             PlatformInput::FileDrop(_) => None,
             PlatformInput::Touch(_) => None,
+            PlatformInput::NativeViewFocus => None,
         }
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -837,6 +837,12 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>);
     fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult>);
     fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>);
+    /// Registers a callback for when a native child view outside GPUI's view
+    /// hierarchy acquires keyboard focus.
+    ///
+    /// Native surface hosts use this to keep GPUI's logical focus tree in sync
+    /// with the platform responder chain.
+    fn on_native_view_focus(&self, _callback: Box<dyn FnMut()>) {}
     fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool)>);
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>);
     fn on_moved(&self, callback: Box<dyn FnMut()>);

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -64,12 +64,25 @@ use std::io::Cursor;
 use std::ops;
 use std::time::Duration;
 use std::{
+    any::Any,
     fmt::{self, Debug},
     ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
 };
+
+/// A platform-native surface inserted between GPUI's base and overlay scene
+/// planes.
+pub trait PlatformNativeSurface {
+    /// Updates the native surface geometry in device pixels.
+    fn set_bounds(&self, bounds: Bounds<DevicePixels>) -> Result<()>;
+    /// Updates whether the native surface participates in composition.
+    fn set_visible(&self, visible: bool) -> Result<()>;
+    /// Returns the platform attachment object, such as an
+    /// `IDCompositionVisual` on Windows.
+    fn platform_handle(&self) -> Box<dyn Any>;
+}
 use strum::EnumIter;
 use uuid::Uuid;
 
@@ -860,6 +873,10 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     /// surfaces between GPUI's base and deferred-overlay paint planes.
     fn enable_scene_overlay(&self) -> anyhow::Result<()> {
         anyhow::bail!("layered GPUI scenes are not supported on this platform")
+    }
+    /// Creates a native surface slot between GPUI's base and overlay planes.
+    fn create_native_surface(&self) -> Result<Rc<dyn PlatformNativeSurface>> {
+        anyhow::bail!("native surface portals are not supported on this platform")
     }
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -837,12 +837,6 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>);
     fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult>);
     fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>);
-    /// Registers a callback for when a native child view outside GPUI's view
-    /// hierarchy acquires keyboard focus.
-    ///
-    /// Native surface hosts use this to keep GPUI's logical focus tree in sync
-    /// with the platform responder chain.
-    fn on_native_view_focus(&self, _callback: Box<dyn FnMut()>) {}
     fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool)>);
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>);
     fn on_moved(&self, callback: Box<dyn FnMut()>);

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -846,6 +846,21 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
     fn draw(&self, scene: &Scene);
+    /// Draws a scene with primitives at and after `overlay_start` on a platform
+    /// overlay surface when one has been enabled.
+    ///
+    /// Platforms without layered scene support fall back to drawing the complete
+    /// scene on their primary surface.
+    fn draw_layered(&self, scene: &Scene, _overlay_start: usize) {
+        self.draw(scene);
+    }
+    /// Enables a transparent GPUI surface above native child views.
+    ///
+    /// This is currently an experimental capability for embedding native
+    /// surfaces between GPUI's base and deferred-overlay paint planes.
+    fn enable_scene_overlay(&self) -> anyhow::Result<()> {
+        anyhow::bail!("layered GPUI scenes are not supported on this platform")
+    }
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -72,6 +72,22 @@ impl Scene {
         self.paint_operations.len()
     }
 
+    /// Returns whether the scene contains no drawable primitives.
+    ///
+    /// A scene may have paint operations that only open and close empty layers,
+    /// so `len() == 0` is not equivalent to having no visible/input-relevant
+    /// overlay content.
+    pub fn is_empty(&self) -> bool {
+        self.shadows.is_empty()
+            && self.quads.is_empty()
+            && self.paths.is_empty()
+            && self.underlines.is_empty()
+            && self.monochrome_sprites.is_empty()
+            && self.subpixel_sprites.is_empty()
+            && self.polychrome_sprites.is_empty()
+            && self.surfaces.is_empty()
+    }
+
     pub fn push_layer(&mut self, bounds: Bounds<ScaledPixels>) {
         let order = self.primitive_bounds.insert(bounds);
         self.layer_stack.push(order);
@@ -188,6 +204,68 @@ impl Scene {
             surfaces_start: 0,
             surfaces_iter: self.surfaces.iter().peekable(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_layers_do_not_make_a_scene_drawable() {
+        let mut scene = Scene::default();
+        let bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: ScaledPixels::from(100.),
+                height: ScaledPixels::from(100.),
+            },
+        };
+
+        scene.push_layer(bounds);
+        scene.pop_layer();
+
+        assert_ne!(scene.len(), 0);
+        assert!(scene.is_empty());
+    }
+
+    #[test]
+    fn drawable_primitives_make_a_scene_non_empty() {
+        let mut scene = Scene::default();
+        let bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: ScaledPixels::from(100.),
+                height: ScaledPixels::from(100.),
+            },
+        };
+
+        scene.insert_primitive(Quad {
+            bounds,
+            content_mask: ContentMask { bounds },
+            ..Default::default()
+        });
+
+        assert!(!scene.is_empty());
+    }
+
+    #[test]
+    fn replay_preserves_scene_emptiness() {
+        let mut source = Scene::default();
+        let bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: ScaledPixels::from(100.),
+                height: ScaledPixels::from(100.),
+            },
+        };
+        source.push_layer(bounds);
+        source.pop_layer();
+
+        let mut replayed = Scene::default();
+        replayed.replay(0..source.len(), &source);
+
+        assert!(replayed.is_empty());
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1736,14 +1736,6 @@ impl Window {
                     .log_err();
             }
         }));
-        platform_window.on_native_view_focus(Box::new({
-            let mut cx = cx.to_async();
-            move || {
-                handle
-                    .update(&mut cx, |_, window, _| window.blur())
-                    .log_err();
-            }
-        }));
         platform_window.on_hover_status_change(Box::new({
             let mut cx = cx.to_async();
             move |active| {
@@ -5025,6 +5017,10 @@ impl Window {
                 }
             },
             PlatformInput::Touch(touch) => PlatformInput::Touch(touch),
+            PlatformInput::NativeViewFocus => {
+                self.blur();
+                PlatformInput::NativeViewFocus
+            }
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -912,6 +912,8 @@ pub(crate) struct Frame {
     pub(crate) mouse_listeners: Vec<Option<AnyMouseListener>>,
     pub(crate) dispatch_tree: DispatchTree,
     pub(crate) scene: Scene,
+    /// First paint operation that belongs on the GPUI overlay surface.
+    pub(crate) overlay_scene_start: usize,
     pub(crate) hitboxes: Vec<Hitbox>,
     pub(crate) window_control_hitboxes: Vec<(WindowControlArea, Hitbox)>,
     pub(crate) deferred_draws: Vec<DeferredDraw>,
@@ -958,6 +960,7 @@ impl Frame {
             mouse_listeners: Vec::new(),
             dispatch_tree,
             scene: Scene::default(),
+            overlay_scene_start: 0,
             hitboxes: Vec::new(),
             window_control_hitboxes: Vec::new(),
             deferred_draws: Vec::new(),
@@ -983,6 +986,7 @@ impl Frame {
         self.mouse_listeners.clear();
         self.dispatch_tree.clear();
         self.scene.clear();
+        self.overlay_scene_start = 0;
         self.input_handlers.clear();
         self.tooltip_requests.clear();
         self.cursor_styles.clear();
@@ -2012,6 +2016,15 @@ impl Window {
         self.handle
     }
 
+    /// Enables an experimental transparent GPUI scene plane above native child
+    /// views hosted by this window.
+    ///
+    /// The root scene remains on the primary surface. Deferred elements and
+    /// window-level overlays are rendered on the transparent plane.
+    pub fn enable_scene_overlay(&self) -> anyhow::Result<()> {
+        self.platform_window.enable_scene_overlay()
+    }
+
     /// Mark the window as dirty, scheduling it to be redrawn on the next frame.
     pub fn refresh(&mut self) {
         if self.invalidator.not_drawing() {
@@ -2959,7 +2972,10 @@ impl Window {
 
     #[profiling::function]
     fn present(&mut self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
+        self.platform_window.draw_layered(
+            &self.rendered_frame.scene,
+            self.rendered_frame.overlay_scene_start,
+        );
         #[cfg(feature = "input-latency-histogram")]
         self.input_latency_tracker.record_frame_presented();
         self.needs_present.set(false);
@@ -3059,6 +3075,12 @@ impl Window {
 
         #[cfg(any(feature = "inspector", debug_assertions))]
         self.paint_inspector(inspector_element, cx);
+
+        // Native surfaces are composited after the root scene and before all
+        // deferred/window-level overlays. Platform backends with layered scene
+        // support use this boundary to render the remainder on a transparent
+        // surface above native children such as WebViews.
+        self.next_frame.overlay_scene_start = self.next_frame.scene.len();
 
         self.paint_deferred_draws(cx);
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1737,19 +1737,11 @@ impl Window {
             }
         }));
         platform_window.on_native_view_focus(Box::new({
-            let cx = cx.to_async();
-            let foreground_executor = cx.foreground_executor().clone();
+            let mut cx = cx.to_async();
             move || {
-                let mut cx = cx.clone();
-                // AppKit responder changes can be synchronous with a GPUI
-                // pointer dispatch, so update logical focus on the next task.
-                foreground_executor
-                    .spawn(async move {
-                        handle
-                            .update(&mut cx, |_, window, _| window.blur())
-                            .log_err();
-                    })
-                    .detach();
+                handle
+                    .update(&mut cx, |_, window, _| window.blur())
+                    .log_err();
             }
         }));
         platform_window.on_hover_status_change(Box::new({

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7114,5 +7114,4 @@ mod tests {
             .unwrap();
         assert_eq!(b_focus_count.get(), 1);
     }
-
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5017,10 +5017,6 @@ impl Window {
                 }
             },
             PlatformInput::Touch(touch) => PlatformInput::Touch(touch),
-            PlatformInput::NativeViewFocus => {
-                self.blur();
-                PlatformInput::NativeViewFocus
-            }
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 
@@ -7119,23 +7115,4 @@ mod tests {
         assert_eq!(b_focus_count.get(), 1);
     }
 
-    #[gpui::test]
-    fn native_view_focus_clears_gpui_focus(cx: &mut TestAppContext) {
-        let window = cx.add_window(|_, cx| FocusForwarder {
-            a: cx.focus_handle(),
-            b: cx.focus_handle(),
-        });
-
-        window
-            .update(cx, |this, window, cx| {
-                window.focus(&this.a, cx);
-                assert!(this.a.is_focused(window));
-
-                window.dispatch_event(crate::PlatformInput::NativeViewFocus, cx);
-
-                assert!(window.focused(cx).is_none());
-                assert!(!this.a.is_focused(window));
-            })
-            .unwrap();
-    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1736,6 +1736,22 @@ impl Window {
                     .log_err();
             }
         }));
+        platform_window.on_native_view_focus(Box::new({
+            let cx = cx.to_async();
+            let foreground_executor = cx.foreground_executor().clone();
+            move || {
+                let mut cx = cx.clone();
+                // AppKit responder changes can be synchronous with a GPUI
+                // pointer dispatch, so update logical focus on the next task.
+                foreground_executor
+                    .spawn(async move {
+                        handle
+                            .update(&mut cx, |_, window, _| window.blur())
+                            .log_err();
+                    })
+                    .detach();
+            }
+        }));
         platform_window.on_hover_status_change(Box::new({
             let mut cx = cx.to_async();
             move |active| {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7118,4 +7118,24 @@ mod tests {
             .unwrap();
         assert_eq!(b_focus_count.get(), 1);
     }
+
+    #[gpui::test]
+    fn native_view_focus_clears_gpui_focus(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, cx| FocusForwarder {
+            a: cx.focus_handle(),
+            b: cx.focus_handle(),
+        });
+
+        window
+            .update(cx, |this, window, cx| {
+                window.focus(&this.a, cx);
+                assert!(this.a.is_focused(window));
+
+                window.dispatch_event(crate::PlatformInput::NativeViewFocus, cx);
+
+                assert!(window.focused(cx).is_none());
+                assert!(!this.a.is_focused(window));
+            })
+            .unwrap();
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2025,6 +2025,12 @@ impl Window {
         self.platform_window.enable_scene_overlay()
     }
 
+    /// Creates a native surface slot between the root scene and GPUI's
+    /// deferred/window-level overlay scene.
+    pub fn create_native_surface(&self) -> anyhow::Result<Rc<dyn crate::PlatformNativeSurface>> {
+        self.platform_window.create_native_surface()
+    }
+
     /// Mark the window as dirty, scheduling it to be redrawn on the next frame.
     pub fn refresh(&mut self) {
         if self.invalidator.not_drawing() {

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -152,6 +152,22 @@ pub struct PathRasterizationVertex {
 }
 
 impl MetalRenderer {
+    /// Creates a new MetalRenderer with a CAMetalLayer for window-based rendering.
+    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
+        let device = Self::create_device();
+        // Support direct-to-display rendering if the window is not transparent
+        // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
+        let layer = Self::new_layer(&device, transparent);
+
+        Self::new_internal(
+            device,
+            Some(layer),
+            !transparent,
+            instance_buffer_pool,
+            None,
+        )
+    }
+
     fn new_layer(device: &metal::Device, transparent: bool) -> metal::MetalLayer {
         let layer = metal::MetalLayer::new();
         layer.set_device(device);
@@ -170,22 +186,6 @@ impl MetalRenderer {
             ];
         }
         layer
-    }
-
-    /// Creates a new MetalRenderer with a CAMetalLayer for window-based rendering.
-    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
-        let device = Self::create_device();
-        // Support direct-to-display rendering if the window is not transparent
-        // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
-        let layer = Self::new_layer(&device, transparent);
-
-        Self::new_internal(
-            device,
-            Some(layer),
-            !transparent,
-            instance_buffer_pool,
-            None,
-        )
     }
 
     fn new_sharing_atlas(

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -53,6 +53,10 @@ pub(crate) unsafe fn new_renderer(
     MetalRenderer::new(context, transparent)
 }
 
+pub(crate) fn new_overlay_renderer(context: self::Context, base: &Renderer) -> Renderer {
+    base.new_sharing_atlas(context, true)
+}
+
 pub(crate) struct InstanceBufferPool {
     buffer_size: usize,
     buffers: Vec<metal::Buffer>,
@@ -148,18 +152,12 @@ pub struct PathRasterizationVertex {
 }
 
 impl MetalRenderer {
-    /// Creates a new MetalRenderer with a CAMetalLayer for window-based rendering.
-    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
-        let device = Self::create_device();
-
+    fn new_layer(device: &metal::Device, transparent: bool) -> metal::MetalLayer {
         let layer = metal::MetalLayer::new();
-        layer.set_device(&device);
+        layer.set_device(device);
         layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
-        // Support direct-to-display rendering if the window is not transparent
-        // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
         layer.set_opaque(!transparent);
         layer.set_maximum_drawable_count(3);
-        // Allow texture reading for visual tests (captures screenshots without ScreenCaptureKit)
         #[cfg(any(test, feature = "test-support"))]
         layer.set_framebuffer_only(false);
         unsafe {
@@ -171,8 +169,39 @@ impl MetalRenderer {
                     | AutoresizingMask::HEIGHT_SIZABLE
             ];
         }
+        layer
+    }
 
-        Self::new_internal(device, Some(layer), !transparent, instance_buffer_pool)
+    /// Creates a new MetalRenderer with a CAMetalLayer for window-based rendering.
+    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
+        let device = Self::create_device();
+        // Support direct-to-display rendering if the window is not transparent
+        // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
+        let layer = Self::new_layer(&device, transparent);
+
+        Self::new_internal(
+            device,
+            Some(layer),
+            !transparent,
+            instance_buffer_pool,
+            None,
+        )
+    }
+
+    fn new_sharing_atlas(
+        &self,
+        instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
+        transparent: bool,
+    ) -> Self {
+        let device = self.device.clone();
+        let layer = Self::new_layer(&device, transparent);
+        Self::new_internal(
+            device,
+            Some(layer),
+            !transparent,
+            instance_buffer_pool,
+            Some(self.sprite_atlas.clone()),
+        )
     }
 
     /// Creates a new headless MetalRenderer for offscreen rendering without a window.
@@ -182,7 +211,7 @@ impl MetalRenderer {
     #[cfg(any(test, feature = "test-support"))]
     pub fn new_headless(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>) -> Self {
         let device = Self::create_device();
-        Self::new_internal(device, None, true, instance_buffer_pool)
+        Self::new_internal(device, None, true, instance_buffer_pool, None)
     }
 
     fn create_device() -> metal::Device {
@@ -212,6 +241,7 @@ impl MetalRenderer {
         layer: Option<metal::MetalLayer>,
         opaque: bool,
         instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
+        shared_sprite_atlas: Option<Arc<MetalAtlas>>,
     ) -> Self {
         #[cfg(feature = "runtime_shaders")]
         let library = device
@@ -324,7 +354,8 @@ impl MetalRenderer {
         );
 
         let command_queue = device.new_command_queue();
-        let sprite_atlas = Arc::new(MetalAtlas::new(device.clone(), is_apple_gpu));
+        let sprite_atlas = shared_sprite_atlas
+            .unwrap_or_else(|| Arc::new(MetalAtlas::new(device.clone(), is_apple_gpu)));
         let core_video_texture_cache =
             CVMetalTextureCache::new(None, device.clone(), None).unwrap();
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -439,6 +439,10 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
             make_first_responder as extern "C" fn(&Object, Sel, id) -> BOOL,
         );
         decl.add_method(
+            sel!(sendEvent:),
+            send_event as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
             sel!(windowDidResize:),
             window_did_resize as extern "C" fn(&Object, Sel, id),
         );
@@ -2286,6 +2290,43 @@ extern "C" fn make_first_responder(this: &Object, _: Sel, responder: id) -> BOOL
         }
 
         accepted
+    }
+}
+
+extern "C" fn send_event(this: &Object, _: Sel, event: id) {
+    unsafe {
+        if matches!(
+            event.eventType(),
+            NSEventType::NSLeftMouseDown
+                | NSEventType::NSRightMouseDown
+                | NSEventType::NSOtherMouseDown
+        ) {
+            let content_view: id = msg_send![this, contentView];
+            let location: NSPoint = msg_send![event, locationInWindow];
+            let location: NSPoint = msg_send![content_view, convertPoint: location fromView: nil];
+            let hit_view: id = msg_send![content_view, hitTest: location];
+
+            if hit_view != nil {
+                let window_state = get_window_state(this);
+                let mut state = window_state.lock();
+                let native_view = state.native_view.as_ptr() as id;
+                let in_gpui_view: BOOL = msg_send![hit_view, isDescendantOf: native_view];
+                let in_overlay_view = state.overlay_view.is_some_and(|overlay_view| {
+                    let in_overlay: BOOL =
+                        msg_send![hit_view, isDescendantOf: overlay_view.as_ptr()];
+                    in_overlay == YES
+                });
+
+                if in_gpui_view == NO
+                    && !in_overlay_view
+                    && let Some(callback) = state.native_view_focus_callback.as_mut()
+                {
+                    callback();
+                }
+            }
+        }
+
+        let _: () = msg_send![super(this, class!(NSWindow)), sendEvent: event];
     }
 }
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -583,7 +583,6 @@ struct MacWindowState {
     request_frame_callback: Option<Box<dyn FnMut(RequestFrameOptions)>>,
     event_callback: Option<Box<dyn FnMut(PlatformInput) -> gpui::DispatchEventResult>>,
     activate_callback: Option<Box<dyn FnMut(bool)>>,
-    native_view_focus_callback: Option<Box<dyn FnMut()>>,
     resize_callback: Option<Box<dyn FnMut(Size<Pixels>, f32)>>,
     moved_callback: Option<Box<dyn FnMut()>>,
     should_close_callback: Option<Box<dyn FnMut() -> bool>>,
@@ -990,7 +989,6 @@ impl MacWindow {
                 request_frame_callback: None,
                 event_callback: None,
                 activate_callback: None,
-                native_view_focus_callback: None,
                 resize_callback: None,
                 moved_callback: None,
                 should_close_callback: None,
@@ -1751,10 +1749,6 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().activate_callback = Some(callback);
     }
 
-    fn on_native_view_focus(&self, callback: Box<dyn FnMut()>) {
-        self.0.as_ref().lock().native_view_focus_callback = Some(callback);
-    }
-
     fn on_hover_status_change(&self, _: Box<dyn FnMut(bool)>) {}
 
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>) {
@@ -2276,12 +2270,13 @@ extern "C" fn make_first_responder(this: &Object, _: Sel, responder: id) -> BOOL
         }
 
         let window_state = get_window_state(this);
-        let mut state = window_state.lock();
+        let state = window_state.lock();
         let native_view = state.native_view.as_ptr() as id;
         let belongs_to_gpui = responder == native_view;
+        drop(state);
 
-        if !belongs_to_gpui && let Some(callback) = state.native_view_focus_callback.as_mut() {
-            callback();
+        if !belongs_to_gpui {
+            dispatch_native_view_focus(&window_state);
         }
 
         accepted
@@ -2303,25 +2298,31 @@ extern "C" fn send_event(this: &Object, _: Sel, event: id) {
 
             if hit_view != nil {
                 let window_state = get_window_state(this);
-                let mut state = window_state.lock();
+                let state = window_state.lock();
                 let native_view = state.native_view.as_ptr() as id;
                 let in_overlay_view = state.overlay_view.is_some_and(|overlay_view| {
                     let in_overlay: BOOL =
                         msg_send![hit_view, isDescendantOf: overlay_view.as_ptr()];
                     in_overlay == YES
                 });
+                drop(state);
 
-                if hit_view != native_view
-                    && !in_overlay_view
-                    && let Some(callback) = state.native_view_focus_callback.as_mut()
-                {
-                    callback();
+                if hit_view != native_view && !in_overlay_view {
+                    dispatch_native_view_focus(&window_state);
                 }
             }
         }
 
         let _: () = msg_send![super(this, class!(NSWindow)), sendEvent: event];
     }
+}
+
+fn dispatch_native_view_focus(window_state: &Arc<Mutex<MacWindowState>>) {
+    let mut callback = window_state.lock().event_callback.take();
+    if let Some(callback) = callback.as_mut() {
+        callback(PlatformInput::NativeViewFocus);
+    }
+    window_state.lock().event_callback = callback;
 }
 
 extern "C" fn dealloc_view(this: &Object, _: Sel) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -612,6 +612,13 @@ struct MacWindowState {
 }
 
 impl MacWindowState {
+    fn set_presents_with_transaction(&mut self, enabled: bool) {
+        self.renderer.set_presents_with_transaction(enabled);
+        if let Some(renderer) = self.overlay_renderer.as_mut() {
+            renderer.set_presents_with_transaction(enabled);
+        }
+    }
+
     fn move_traffic_light(&mut self) {
         if let Some(traffic_light_position) = self.traffic_light_position {
             if self.is_fullscreen() {
@@ -2859,14 +2866,14 @@ extern "C" fn window_did_change_key_status(this: &Object, selector: Sel, _: id) 
 
         if lock.activated_least_once {
             if let Some(mut callback) = lock.request_frame_callback.take() {
-                lock.renderer.set_presents_with_transaction(true);
+                lock.set_presents_with_transaction(true);
                 lock.stop_display_link();
                 drop(lock);
                 callback(Default::default());
 
                 let mut lock = window_state.lock();
                 lock.request_frame_callback = Some(callback);
-                lock.renderer.set_presents_with_transaction(false);
+                lock.set_presents_with_transaction(false);
                 lock.start_display_link();
             }
         } else {
@@ -2976,14 +2983,14 @@ extern "C" fn display_layer(this: &Object, _: Sel, _: id) {
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.lock();
     if let Some(mut callback) = lock.request_frame_callback.take() {
-        lock.renderer.set_presents_with_transaction(true);
+        lock.set_presents_with_transaction(true);
         lock.stop_display_link();
         drop(lock);
         callback(Default::default());
 
         let mut lock = window_state.lock();
         lock.request_frame_callback = Some(callback);
-        lock.renderer.set_presents_with_transaction(false);
+        lock.set_presents_with_transaction(false);
         lock.start_display_link();
     }
 }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -435,6 +435,10 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
             yes as extern "C" fn(&Object, Sel) -> BOOL,
         );
         decl.add_method(
+            sel!(makeFirstResponder:),
+            make_first_responder as extern "C" fn(&Object, Sel, id) -> BOOL,
+        );
+        decl.add_method(
             sel!(windowDidResize:),
             window_did_resize as extern "C" fn(&Object, Sel, id),
         );
@@ -575,6 +579,7 @@ struct MacWindowState {
     request_frame_callback: Option<Box<dyn FnMut(RequestFrameOptions)>>,
     event_callback: Option<Box<dyn FnMut(PlatformInput) -> gpui::DispatchEventResult>>,
     activate_callback: Option<Box<dyn FnMut(bool)>>,
+    native_view_focus_callback: Option<Box<dyn FnMut()>>,
     resize_callback: Option<Box<dyn FnMut(Size<Pixels>, f32)>>,
     moved_callback: Option<Box<dyn FnMut()>>,
     should_close_callback: Option<Box<dyn FnMut() -> bool>>,
@@ -981,6 +986,7 @@ impl MacWindow {
                 request_frame_callback: None,
                 event_callback: None,
                 activate_callback: None,
+                native_view_focus_callback: None,
                 resize_callback: None,
                 moved_callback: None,
                 should_close_callback: None,
@@ -1741,6 +1747,10 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().activate_callback = Some(callback);
     }
 
+    fn on_native_view_focus(&self, callback: Box<dyn FnMut()>) {
+        self.0.as_ref().lock().native_view_focus_callback = Some(callback);
+    }
+
     fn on_hover_status_change(&self, _: Box<dyn FnMut(bool)>) {}
 
     fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>) {
@@ -2250,6 +2260,32 @@ extern "C" fn dealloc_window(this: &Object, _: Sel) {
     unsafe {
         drop_window_state(this);
         let _: () = msg_send![super(this, class!(NSWindow)), dealloc];
+    }
+}
+
+extern "C" fn make_first_responder(this: &Object, _: Sel, responder: id) -> BOOL {
+    unsafe {
+        let accepted: BOOL =
+            msg_send![super(this, class!(NSWindow)), makeFirstResponder: responder];
+        if accepted == NO || responder == nil {
+            return accepted;
+        }
+
+        let window_state = get_window_state(this);
+        let mut state = window_state.lock();
+        let native_view = state.native_view.as_ptr() as id;
+        let is_view: BOOL = msg_send![responder, isKindOfClass: class!(NSView)];
+        let belongs_to_gpui = responder == native_view
+            || (is_view == YES && {
+                let is_descendant: BOOL = msg_send![responder, isDescendantOf: native_view];
+                is_descendant == YES
+            });
+
+        if !belongs_to_gpui && let Some(callback) = state.native_view_focus_callback.as_mut() {
+            callback();
+        }
+
+        accepted
     }
 }
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -2278,12 +2278,7 @@ extern "C" fn make_first_responder(this: &Object, _: Sel, responder: id) -> BOOL
         let window_state = get_window_state(this);
         let mut state = window_state.lock();
         let native_view = state.native_view.as_ptr() as id;
-        let is_view: BOOL = msg_send![responder, isKindOfClass: class!(NSView)];
-        let belongs_to_gpui = responder == native_view
-            || (is_view == YES && {
-                let is_descendant: BOOL = msg_send![responder, isDescendantOf: native_view];
-                is_descendant == YES
-            });
+        let belongs_to_gpui = responder == native_view;
 
         if !belongs_to_gpui && let Some(callback) = state.native_view_focus_callback.as_mut() {
             callback();
@@ -2310,14 +2305,13 @@ extern "C" fn send_event(this: &Object, _: Sel, event: id) {
                 let window_state = get_window_state(this);
                 let mut state = window_state.lock();
                 let native_view = state.native_view.as_ptr() as id;
-                let in_gpui_view: BOOL = msg_send![hit_view, isDescendantOf: native_view];
                 let in_overlay_view = state.overlay_view.is_some_and(|overlay_view| {
                     let in_overlay: BOOL =
                         msg_send![hit_view, isDescendantOf: overlay_view.as_ptr()];
                     in_overlay == YES
                 });
 
-                if in_gpui_view == NO
+                if hit_view != native_view
                     && !in_overlay_view
                     && let Some(callback) = state.native_view_focus_callback.as_mut()
                 {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -435,14 +435,6 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
             yes as extern "C" fn(&Object, Sel) -> BOOL,
         );
         decl.add_method(
-            sel!(makeFirstResponder:),
-            make_first_responder as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
-        decl.add_method(
-            sel!(sendEvent:),
-            send_event as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
             sel!(windowDidResize:),
             window_did_resize as extern "C" fn(&Object, Sel, id),
         );
@@ -2259,70 +2251,6 @@ extern "C" fn dealloc_window(this: &Object, _: Sel) {
         drop_window_state(this);
         let _: () = msg_send![super(this, class!(NSWindow)), dealloc];
     }
-}
-
-extern "C" fn make_first_responder(this: &Object, _: Sel, responder: id) -> BOOL {
-    unsafe {
-        let accepted: BOOL =
-            msg_send![super(this, class!(NSWindow)), makeFirstResponder: responder];
-        if accepted == NO || responder == nil {
-            return accepted;
-        }
-
-        let window_state = get_window_state(this);
-        let state = window_state.lock();
-        let native_view = state.native_view.as_ptr() as id;
-        let belongs_to_gpui = responder == native_view;
-        drop(state);
-
-        if !belongs_to_gpui {
-            dispatch_native_view_focus(&window_state);
-        }
-
-        accepted
-    }
-}
-
-extern "C" fn send_event(this: &Object, _: Sel, event: id) {
-    unsafe {
-        if matches!(
-            event.eventType(),
-            NSEventType::NSLeftMouseDown
-                | NSEventType::NSRightMouseDown
-                | NSEventType::NSOtherMouseDown
-        ) {
-            let content_view: id = msg_send![this, contentView];
-            let location: NSPoint = msg_send![event, locationInWindow];
-            let location: NSPoint = msg_send![content_view, convertPoint: location fromView: nil];
-            let hit_view: id = msg_send![content_view, hitTest: location];
-
-            if hit_view != nil {
-                let window_state = get_window_state(this);
-                let state = window_state.lock();
-                let native_view = state.native_view.as_ptr() as id;
-                let in_overlay_view = state.overlay_view.is_some_and(|overlay_view| {
-                    let in_overlay: BOOL =
-                        msg_send![hit_view, isDescendantOf: overlay_view.as_ptr()];
-                    in_overlay == YES
-                });
-                drop(state);
-
-                if hit_view != native_view && !in_overlay_view {
-                    dispatch_native_view_focus(&window_state);
-                }
-            }
-        }
-
-        let _: () = msg_send![super(this, class!(NSWindow)), sendEvent: event];
-    }
-}
-
-fn dispatch_native_view_focus(window_state: &Arc<Mutex<MacWindowState>>) {
-    let mut callback = window_state.lock().event_callback.take();
-    if let Some(callback) = callback.as_mut() {
-        callback(PlatformInput::NativeViewFocus);
-    }
-    window_state.lock().event_callback = callback;
 }
 
 extern "C" fn dealloc_view(this: &Object, _: Sel) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -75,10 +75,12 @@ use std::{
 };
 
 const WINDOW_STATE_IVAR: &str = "windowState";
+const OVERLAY_INPUT_IVAR: &str = "overlayInputActive";
 
 static mut WINDOW_CLASS: *const Class = ptr::null();
 static mut PANEL_CLASS: *const Class = ptr::null();
 static mut VIEW_CLASS: *const Class = ptr::null();
+static mut OVERLAY_VIEW_CLASS: *const Class = ptr::null();
 static mut BLURRED_VIEW_CLASS: *const Class = ptr::null();
 
 #[allow(non_upper_case_globals)]
@@ -113,6 +115,27 @@ const NSDragOperationCopy: NSDragOperation = 1;
 const NSDragOperationMove: NSDragOperation = 16;
 const NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION: NSInteger = 0;
 const NSDRAGGING_CONTEXT_WITHIN_APPLICATION: NSInteger = 1;
+
+extern "C" fn overlay_hit_test(this: &Object, _: Sel, _: NSPoint) -> id {
+    let active = unsafe {
+        let raw: *mut c_void = *this.get_ivar(OVERLAY_INPUT_IVAR);
+        &*(raw as *const AtomicBool)
+    };
+    if active.load(Ordering::Acquire) {
+        this as *const Object as id
+    } else {
+        nil
+    }
+}
+
+extern "C" fn handle_overlay_event(this: &Object, selector: Sel, native_event: id) {
+    let window_state = unsafe { get_window_state(this) };
+    let native_view = window_state.lock().native_view;
+    unsafe {
+        handle_view_event(native_view.as_ref(), selector, native_event);
+    }
+}
+
 #[derive(PartialEq)]
 pub enum UserTabbingPreference {
     Never,
@@ -298,6 +321,42 @@ unsafe fn build_classes() {
                 sel!(characterIndexForPoint:),
                 character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
             );
+            decl.register()
+        };
+        OVERLAY_VIEW_CLASS = {
+            let mut decl = ClassDecl::new("GPUIOverlayView", class!(NSView)).unwrap();
+            decl.add_ivar::<*mut c_void>(WINDOW_STATE_IVAR);
+            decl.add_ivar::<*mut c_void>(OVERLAY_INPUT_IVAR);
+            decl.add_method(
+                sel!(dealloc),
+                dealloc_overlay_view as extern "C" fn(&Object, Sel),
+            );
+            decl.add_method(
+                sel!(hitTest:),
+                overlay_hit_test as extern "C" fn(&Object, Sel, NSPoint) -> id,
+            );
+            for selector in [
+                sel!(mouseDown:),
+                sel!(mouseUp:),
+                sel!(rightMouseDown:),
+                sel!(rightMouseUp:),
+                sel!(otherMouseDown:),
+                sel!(otherMouseUp:),
+                sel!(mouseMoved:),
+                sel!(mouseExited:),
+                sel!(mouseDragged:),
+                sel!(rightMouseDragged:),
+                sel!(otherMouseDragged:),
+                sel!(scrollWheel:),
+                sel!(magnifyWithEvent:),
+                sel!(swipeWithEvent:),
+                sel!(pressureChangeWithEvent:),
+            ] {
+                decl.add_method(
+                    selector,
+                    handle_overlay_event as extern "C" fn(&Object, Sel, id),
+                );
+            }
             decl.register()
         };
         BLURRED_VIEW_CLASS = {
@@ -503,12 +562,16 @@ struct MacWindowState {
     background_executor: BackgroundExecutor,
     native_window: id,
     native_view: NonNull<Object>,
+    overlay_view: Option<NonNull<Object>>,
+    overlay_input_active: Arc<AtomicBool>,
     blurred_view: Option<id>,
     background_appearance: WindowBackgroundAppearance,
     cursor_style: CursorStyle,
     cursor_visible: Arc<AtomicBool>,
     frame_source: Option<WindowFrameSource>,
     renderer: renderer::Renderer,
+    overlay_renderer: Option<renderer::Renderer>,
+    renderer_context: renderer::Context,
     request_frame_callback: Option<Box<dyn FnMut(RequestFrameOptions)>>,
     event_callback: Option<Box<dyn FnMut(PlatformInput) -> gpui::DispatchEventResult>>,
     activate_callback: Option<Box<dyn FnMut(bool)>>,
@@ -899,18 +962,22 @@ impl MacWindow {
                 background_executor,
                 native_window,
                 native_view: NonNull::new_unchecked(native_view),
+                overlay_view: None,
+                overlay_input_active: Arc::new(AtomicBool::new(false)),
                 blurred_view: None,
                 background_appearance: WindowBackgroundAppearance::Opaque,
                 cursor_style: CursorStyle::Arrow,
                 cursor_visible,
                 frame_source: None,
                 renderer: renderer::new_renderer(
-                    renderer_context,
+                    renderer_context.clone(),
                     native_window as *mut _,
                     native_view as *mut _,
                     bounds.size.map(|pixels| pixels.as_f32()),
                     false,
                 ),
+                overlay_renderer: None,
+                renderer_context,
                 request_frame_callback: None,
                 event_callback: None,
                 activate_callback: None,
@@ -1760,6 +1827,84 @@ impl PlatformWindow for MacWindow {
         this.renderer.draw(scene);
     }
 
+    fn draw_layered(&self, scene: &gpui::Scene, overlay_start: usize) {
+        let mut this = self.0.lock();
+        if this.overlay_renderer.is_none() {
+            this.renderer.draw(scene);
+            return;
+        }
+
+        let split = overlay_start.min(scene.len());
+        let mut base_scene = gpui::Scene::default();
+        base_scene.replay(0..split, scene);
+        base_scene.finish();
+
+        let mut overlay_scene = gpui::Scene::default();
+        overlay_scene.replay(split..scene.len(), scene);
+        overlay_scene.finish();
+
+        this.overlay_input_active
+            .store(!overlay_scene.is_empty(), Ordering::Release);
+        this.renderer.draw(&base_scene);
+        this.overlay_renderer
+            .as_mut()
+            .expect("overlay renderer checked above")
+            .draw(&overlay_scene);
+    }
+
+    fn enable_scene_overlay(&self) -> anyhow::Result<()> {
+        let window_state = self.0.clone();
+        let mut this = self.0.lock();
+        if this.overlay_renderer.is_some() {
+            return Ok(());
+        }
+
+        unsafe {
+            let native_view = this.native_view.as_ptr() as id;
+            let frame = NSView::bounds(native_view);
+            let overlay_view: id = msg_send![OVERLAY_VIEW_CLASS, alloc];
+            let overlay_view = NSView::initWithFrame_(overlay_view, frame);
+            anyhow::ensure!(
+                !overlay_view.is_null(),
+                "failed to create GPUI overlay NSView"
+            );
+            (*overlay_view).set_ivar(
+                WINDOW_STATE_IVAR,
+                Arc::into_raw(window_state) as *const c_void,
+            );
+            (*overlay_view).set_ivar(
+                OVERLAY_INPUT_IVAR,
+                Arc::into_raw(this.overlay_input_active.clone()) as *const c_void,
+            );
+
+            let mut overlay_renderer =
+                renderer::new_overlay_renderer(this.renderer_context.clone(), &this.renderer);
+            let scale_factor = this.scale_factor();
+            overlay_renderer
+                .update_drawable_size(this.content_size().to_device_pixels(scale_factor));
+            if let Some(layer) = overlay_renderer.layer() {
+                let _: () = msg_send![layer, setContentsScale: scale_factor as f64];
+            }
+
+            overlay_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable);
+            overlay_view.setWantsLayer(YES);
+            let _: () = msg_send![overlay_view, setLayer: overlay_renderer.layer_ptr()];
+            let _: () = msg_send![
+                overlay_view,
+                setLayerContentsRedrawPolicy: NSViewLayerContentsRedrawDuringViewResize
+            ];
+
+            // wry has already inserted WKWebView by the time this API is called.
+            // Adding the overlay last places it above the WebView in AppKit's
+            // back-to-front subview order.
+            native_view.addSubview_(overlay_view.autorelease());
+            this.overlay_view = NonNull::new(overlay_view);
+            this.overlay_renderer = Some(overlay_renderer);
+        }
+
+        Ok(())
+    }
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.0.lock().renderer.sprite_atlas().clone()
     }
@@ -2111,6 +2256,15 @@ extern "C" fn dealloc_window(this: &Object, _: Sel) {
 extern "C" fn dealloc_view(this: &Object, _: Sel) {
     unsafe {
         drop_window_state(this);
+        let _: () = msg_send![super(this, class!(NSView)), dealloc];
+    }
+}
+
+extern "C" fn dealloc_overlay_view(this: &Object, _: Sel) {
+    unsafe {
+        drop_window_state(this);
+        let raw: *mut c_void = *this.get_ivar(OVERLAY_INPUT_IVAR);
+        drop(Arc::from_raw(raw as *const AtomicBool));
         let _: () = msg_send![super(this, class!(NSView)), dealloc];
     }
 }
@@ -2628,6 +2782,14 @@ fn update_window_scale_factor(window_state: &Arc<Mutex<MacWindowState>>) {
     }
 
     lock.renderer.update_drawable_size(drawable_size);
+    if let Some(renderer) = lock.overlay_renderer.as_mut() {
+        if let Some(layer) = renderer.layer() {
+            unsafe {
+                let _: () = msg_send![layer, setContentsScale: scale_factor as f64];
+            }
+        }
+        renderer.update_drawable_size(drawable_size);
+    }
 
     if let Some(mut callback) = lock.resize_callback.take() {
         let content_size = lock.content_size();
@@ -2797,6 +2959,9 @@ extern "C" fn set_frame_size(this: &Object, _: Sel, size: NSSize) {
     let scale_factor = lock.scale_factor();
     let drawable_size = new_size.to_device_pixels(scale_factor);
     lock.renderer.update_drawable_size(drawable_size);
+    if let Some(renderer) = lock.overlay_renderer.as_mut() {
+        renderer.update_drawable_size(drawable_size);
+    }
 
     if let Some(mut callback) = lock.resize_callback.take() {
         let content_size = lock.content_size();

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1147,7 +1147,7 @@ impl PlatformNativeSurface for DirectCompositionPortal {
     }
 
     fn set_visible(&self, visible: bool) -> Result<()> {
-        if self.visible.replace(visible) != visible {
+        if self.visible.get() != visible {
             unsafe {
                 if visible {
                     self.container.AddVisual(&self.visual, true, None)?;
@@ -1156,6 +1156,7 @@ impl PlatformNativeSurface for DirectCompositionPortal {
                 }
                 self.comp_device.Commit()?;
             }
+            self.visible.set(visible);
         }
         Ok(())
     }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -124,7 +124,11 @@ impl Drop for Annotation<'_> {
 
 struct DirectComposition {
     comp_device: IDCompositionDevice,
+    // Keep these COM objects alive for the lifetime of the visual tree. They
+    // are not otherwise read after the tree is attached to the target.
+    #[allow(dead_code)]
     comp_target: IDCompositionTarget,
+    #[allow(dead_code)]
     root_visual: IDCompositionVisual,
     base_visual: IDCompositionVisual,
     portal_container: IDCompositionVisual,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -432,12 +432,16 @@ impl DirectXRenderer {
                 .as_ref()
                 .context("resources missing")?
                 .swap_chain
-                .Present(0, DXGI_PRESENT(0))?;
+                .Present(0, DXGI_PRESENT(0))
+                .ok()
+                .context("presenting base swap chain")?;
             self.overlay_resources
                 .as_ref()
                 .context("overlay resources missing")?
                 .swap_chain
-                .Present(0, DXGI_PRESENT(0))?;
+                .Present(0, DXGI_PRESENT(0))
+                .ok()
+                .context("presenting overlay swap chain")?;
         }
         Ok(())
     }
@@ -1141,7 +1145,11 @@ impl PlatformNativeSurface for DirectCompositionPortal {
     fn set_visible(&self, visible: bool) -> Result<()> {
         if self.visible.replace(visible) != visible {
             unsafe {
-                self.visual.SetOpacity2(if visible { 1.0 } else { 0.0 })?;
+                if visible {
+                    self.container.AddVisual(&self.visual, true, None)?;
+                } else {
+                    self.container.RemoveVisual(&self.visual)?;
+                }
                 self.comp_device.Commit()?;
             }
         }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1,4 +1,6 @@
 use std::{
+    cell::Cell,
+    rc::Rc,
     slice,
     sync::{Arc, OnceLock},
 };
@@ -40,6 +42,7 @@ pub(crate) struct DirectXRenderer {
     atlas: Arc<DirectXAtlas>,
     devices: Option<DirectXRendererDevices>,
     resources: Option<DirectXResources>,
+    overlay_resources: Option<OverlayResources>,
     globals: DirectXGlobalElements,
     pipelines: DirectXRenderPipelines,
     direct_composition: Option<DirectComposition>,
@@ -82,6 +85,12 @@ struct DirectXResources {
     viewport: D3D11_VIEWPORT,
 }
 
+struct OverlayResources {
+    swap_chain: IDXGISwapChain1,
+    render_target: Option<ID3D11Texture2D>,
+    render_target_view: Option<ID3D11RenderTargetView>,
+}
+
 struct DirectXRenderPipelines {
     shadow_pipeline: PipelineState<Shadow>,
     quad_pipeline: PipelineState<Quad>,
@@ -116,7 +125,18 @@ impl Drop for Annotation<'_> {
 struct DirectComposition {
     comp_device: IDCompositionDevice,
     comp_target: IDCompositionTarget,
-    comp_visual: IDCompositionVisual,
+    root_visual: IDCompositionVisual,
+    base_visual: IDCompositionVisual,
+    portal_container: IDCompositionVisual,
+    overlay_visual: IDCompositionVisual,
+}
+
+struct DirectCompositionPortal {
+    comp_device: IDCompositionDevice,
+    container: IDCompositionVisual,
+    visual: IDCompositionVisual,
+    clip: IDCompositionRectangleClip,
+    visible: Cell<bool>,
 }
 
 impl DirectXRendererDevices {
@@ -185,6 +205,7 @@ impl DirectXRenderer {
             atlas,
             devices: Some(devices),
             resources: Some(resources),
+            overlay_resources: None,
             globals,
             pipelines,
             direct_composition,
@@ -199,7 +220,11 @@ impl DirectXRenderer {
         self.atlas.clone()
     }
 
-    fn pre_draw(&self, clear_color: &[f32; 4]) -> Result<()> {
+    fn pre_draw(
+        &self,
+        render_target_view: &Option<ID3D11RenderTargetView>,
+        clear_color: &[f32; 4],
+    ) -> Result<()> {
         let resources = self.resources.as_ref().expect("resources missing");
         let device_context = &self
             .devices
@@ -220,14 +245,12 @@ impl DirectXRenderer {
         )?;
         unsafe {
             device_context.ClearRenderTargetView(
-                resources
-                    .render_target_view
+                render_target_view
                     .as_ref()
                     .context("missing render target view")?,
                 clear_color,
             );
-            device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+            device_context.OMSetRenderTargets(Some(slice::from_ref(render_target_view)), None);
             device_context.RSSetViewports(Some(slice::from_ref(&resources.viewport)));
         }
         Ok(())
@@ -254,6 +277,7 @@ impl DirectXRenderer {
 
     fn handle_device_lost_impl(&mut self, directx_devices: &DirectXDevices) -> Result<()> {
         let disable_direct_composition = self.direct_composition.is_none();
+        let overlay_enabled = self.overlay_resources.is_some();
 
         unsafe {
             #[cfg(debug_assertions)]
@@ -264,6 +288,7 @@ impl DirectXRenderer {
             }
 
             self.resources.take();
+            self.overlay_resources.take();
             if let Some(devices) = &self.devices {
                 devices.device_context.OMSetRenderTargets(None, None);
                 devices.device_context.ClearState();
@@ -301,6 +326,16 @@ impl DirectXRenderer {
             composition.set_swap_chain(&resources.swap_chain)?;
             Some(composition)
         };
+        let overlay_resources = if overlay_enabled {
+            let overlay = OverlayResources::new(&devices, self.width, self.height)?;
+            direct_composition
+                .as_ref()
+                .context("DirectComposition missing for overlay")?
+                .set_overlay_swap_chain(&overlay.swap_chain)?;
+            Some(overlay)
+        } else {
+            None
+        };
 
         self.atlas
             .handle_device_lost(&devices.device, &devices.device_context);
@@ -312,6 +347,7 @@ impl DirectXRenderer {
         }
         self.devices = Some(devices);
         self.resources = Some(resources);
+        self.overlay_resources = overlay_resources;
         self.globals = globals;
         self.pipelines = pipelines;
         self.direct_composition = direct_composition;
@@ -329,13 +365,109 @@ impl DirectXRenderer {
             // and so likely do not have the textures anymore that are required for drawing
             return Ok(());
         }
-        self.pre_draw(&match background_appearance {
-            WindowBackgroundAppearance::Opaque => [1.0f32; 4],
-            _ => [0.0f32; 4],
-        })?;
+        let render_target_view = self
+            .resources
+            .as_ref()
+            .context("resources missing")?
+            .render_target_view
+            .clone();
+        self.pre_draw(
+            &render_target_view,
+            &match background_appearance {
+                WindowBackgroundAppearance::Opaque => [1.0f32; 4],
+                _ => [0.0f32; 4],
+            },
+        )?;
+        self.draw_scene(scene)?;
+        self.present()
+    }
 
+    pub(crate) fn draw_layered(
+        &mut self,
+        scene: &Scene,
+        overlay_start: usize,
+        background_appearance: WindowBackgroundAppearance,
+    ) -> Result<()> {
+        if self.overlay_resources.is_none() {
+            return self.draw(scene, background_appearance);
+        }
+        if self.skip_draws {
+            return Ok(());
+        }
+
+        let split = overlay_start.min(scene.len());
+        let mut base_scene = Scene::default();
+        base_scene.replay(0..split, scene);
+        base_scene.finish();
+        let mut overlay_scene = Scene::default();
+        overlay_scene.replay(split..scene.len(), scene);
+        overlay_scene.finish();
+
+        let base_view = self
+            .resources
+            .as_ref()
+            .context("resources missing")?
+            .render_target_view
+            .clone();
+        self.pre_draw(
+            &base_view,
+            &match background_appearance {
+                WindowBackgroundAppearance::Opaque => [1.0; 4],
+                _ => [0.0; 4],
+            },
+        )?;
+        self.draw_scene(&base_scene)?;
+
+        let overlay_view = self
+            .overlay_resources
+            .as_ref()
+            .context("overlay resources missing")?
+            .render_target_view
+            .clone();
+        self.pre_draw(&overlay_view, &[0.0; 4])?;
+        self.draw_scene(&overlay_scene)?;
+
+        unsafe {
+            self.resources
+                .as_ref()
+                .context("resources missing")?
+                .swap_chain
+                .Present(0, DXGI_PRESENT(0))?;
+            self.overlay_resources
+                .as_ref()
+                .context("overlay resources missing")?
+                .swap_chain
+                .Present(0, DXGI_PRESENT(0))?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn enable_scene_overlay(&mut self) -> Result<()> {
+        if self.overlay_resources.is_some() {
+            return Ok(());
+        }
+        let devices = self.devices.as_ref().context("devices missing")?;
+        let overlay = OverlayResources::new(devices, self.width, self.height)?;
+        self.direct_composition
+            .as_ref()
+            .context("DirectComposition is disabled")?
+            .set_overlay_swap_chain(&overlay.swap_chain)?;
+        self.overlay_resources = Some(overlay);
+        Ok(())
+    }
+
+    pub(crate) fn create_native_surface(&mut self) -> Result<Rc<dyn PlatformNativeSurface>> {
+        self.enable_scene_overlay()?;
+        Ok(Rc::new(
+            self.direct_composition
+                .as_ref()
+                .context("DirectComposition is disabled")?
+                .create_portal()?,
+        ))
+    }
+
+    fn draw_scene(&mut self, scene: &Scene) -> Result<()> {
         self.upload_scene_buffers(scene)?;
-
         let annotation = self
             .devices
             .as_ref()
@@ -380,7 +512,7 @@ impl DirectXRenderer {
                 )
             })?;
         }
-        self.present()
+        Ok(())
     }
 
     pub(crate) fn resize(&mut self, new_size: Size<DevicePixels>) -> Result<()> {
@@ -417,6 +549,10 @@ impl DirectXRenderer {
         }
 
         resources.recreate_resources(devices, width, height)?;
+
+        if let Some(overlay) = self.overlay_resources.as_mut() {
+            overlay.resize(devices, width, height)?;
+        }
 
         unsafe {
             devices
@@ -927,21 +1063,142 @@ impl DirectComposition {
     pub fn new(dxgi_device: &IDXGIDevice, hwnd: HWND) -> Result<Self> {
         let comp_device = get_comp_device(dxgi_device)?;
         let comp_target = unsafe { comp_device.CreateTargetForHwnd(hwnd, true) }?;
-        let comp_visual = unsafe { comp_device.CreateVisual() }?;
+        let root_visual = unsafe { comp_device.CreateVisual() }?;
+        let base_visual = unsafe { comp_device.CreateVisual() }?;
+        let portal_container = unsafe { comp_device.CreateVisual() }?;
+        let overlay_visual = unsafe { comp_device.CreateVisual() }?;
+
+        unsafe {
+            root_visual.AddVisual(&base_visual, false, None)?;
+            root_visual.AddVisual(&portal_container, true, &base_visual)?;
+            root_visual.AddVisual(&overlay_visual, true, &portal_container)?;
+            comp_target.SetRoot(&root_visual)?;
+            comp_device.Commit()?;
+        }
 
         Ok(Self {
             comp_device,
             comp_target,
-            comp_visual,
+            root_visual,
+            base_visual,
+            portal_container,
+            overlay_visual,
         })
     }
 
     pub fn set_swap_chain(&self, swap_chain: &IDXGISwapChain1) -> Result<()> {
         unsafe {
-            self.comp_visual.SetContent(swap_chain)?;
-            self.comp_target.SetRoot(&self.comp_visual)?;
+            self.base_visual.SetContent(swap_chain)?;
             self.comp_device.Commit()?;
         }
+        Ok(())
+    }
+
+    pub fn set_overlay_swap_chain(&self, swap_chain: &IDXGISwapChain1) -> Result<()> {
+        unsafe {
+            self.overlay_visual.SetContent(swap_chain)?;
+            self.comp_device.Commit()?;
+        }
+        Ok(())
+    }
+
+    fn create_portal(&self) -> Result<DirectCompositionPortal> {
+        let visual = unsafe { self.comp_device.CreateVisual() }?;
+        let clip = unsafe { self.comp_device.CreateRectangleClip() }?;
+        unsafe {
+            visual.SetClip(&clip)?;
+            self.portal_container.AddVisual(&visual, true, None)?;
+            self.comp_device.Commit()?;
+        }
+        Ok(DirectCompositionPortal {
+            comp_device: self.comp_device.clone(),
+            container: self.portal_container.clone(),
+            visual,
+            clip,
+            visible: Cell::new(true),
+        })
+    }
+}
+
+impl PlatformNativeSurface for DirectCompositionPortal {
+    fn set_bounds(&self, bounds: Bounds<DevicePixels>) -> Result<()> {
+        let x = bounds.origin.x.0 as f32;
+        let y = bounds.origin.y.0 as f32;
+        let width = bounds.size.width.0.max(0) as f32;
+        let height = bounds.size.height.0.max(0) as f32;
+        unsafe {
+            self.visual.SetOffsetX2(x)?;
+            self.visual.SetOffsetY2(y)?;
+            self.clip.SetLeft2(0.0)?;
+            self.clip.SetTop2(0.0)?;
+            self.clip.SetRight2(width)?;
+            self.clip.SetBottom2(height)?;
+            self.comp_device.Commit()?;
+        }
+        Ok(())
+    }
+
+    fn set_visible(&self, visible: bool) -> Result<()> {
+        if self.visible.replace(visible) != visible {
+            unsafe {
+                self.visual.SetOpacity2(if visible { 1.0 } else { 0.0 })?;
+                self.comp_device.Commit()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn platform_handle(&self) -> Box<dyn std::any::Any> {
+        Box::new(
+            self.visual
+                .cast::<windows::core::IUnknown>()
+                .expect("IDCompositionVisual must implement IUnknown"),
+        )
+    }
+}
+
+impl Drop for DirectCompositionPortal {
+    fn drop(&mut self) {
+        unsafe {
+            self.container.RemoveVisual(&self.visual).ok();
+            self.comp_device.Commit().ok();
+        }
+    }
+}
+
+impl OverlayResources {
+    fn new(devices: &DirectXRendererDevices, width: u32, height: u32) -> Result<Self> {
+        let swap_chain = create_swap_chain_for_composition(
+            &devices.dxgi_factory,
+            &devices.device,
+            width,
+            height,
+        )?;
+        let (render_target, render_target_view) =
+            create_render_target_and_its_view(&swap_chain, &devices.device)?;
+        Ok(Self {
+            swap_chain,
+            render_target: Some(render_target),
+            render_target_view,
+        })
+    }
+
+    fn resize(&mut self, devices: &DirectXRendererDevices, width: u32, height: u32) -> Result<()> {
+        self.render_target.take();
+        self.render_target_view.take();
+        unsafe {
+            self.swap_chain.ResizeBuffers(
+                BUFFER_COUNT as u32,
+                width,
+                height,
+                RENDER_TARGET_FORMAT,
+                DXGI_SWAP_CHAIN_FLAG(0),
+            )?;
+        }
+        let (render_target, render_target_view) =
+            create_render_target_and_its_view(&self.swap_chain, &devices.device)?;
+        self.render_target = Some(render_target);
+        self.render_target_view = render_target_view;
         Ok(())
     }
 }

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -355,8 +355,8 @@ impl WindowsPlatform {
     }
 }
 
-fn translate_accelerator(msg: &MSG) -> Option<()> {
-    if msg.message != WM_KEYDOWN && msg.message != WM_SYSKEYDOWN {
+fn translate_accelerator(msg: &MSG, is_gpui_window: bool) -> Option<()> {
+    if !is_gpui_window || (msg.message != WM_KEYDOWN && msg.message != WM_SYSKEYDOWN) {
         return None;
     }
 
@@ -419,7 +419,12 @@ impl Platform for WindowsPlatform {
         let mut msg = MSG::default();
         unsafe {
             while GetMessageW(&mut msg, None, 0, 0).as_bool() {
-                if translate_accelerator(&msg).is_none() {
+                let is_gpui_window = self
+                    .raw_window_handles
+                    .read()
+                    .iter()
+                    .any(|handle| handle.as_raw() == msg.hwnd);
+                if translate_accelerator(&msg, is_gpui_window).is_none() {
                     _ = TranslateMessage(&msg);
                     DispatchMessageW(&msg);
                 }
@@ -1010,8 +1015,17 @@ impl WindowsPlatformInner {
                     // then quit out of foreground work to allow us to process other gpui events first before returning back to foreground task work
                     // if we don't we might not for example process window quit events
                     let mut msg = MSG::default();
-                    let process_message = |msg: &_| {
-                        if translate_accelerator(msg).is_none() {
+                    let process_message = |msg: &MSG| {
+                        let is_gpui_window = self
+                            .raw_window_handles
+                            .upgrade()
+                            .is_some_and(|handles| {
+                                handles
+                                    .read()
+                                    .iter()
+                                    .any(|handle| handle.as_raw() == msg.hwnd)
+                            });
+                        if translate_accelerator(msg, is_gpui_window).is_none() {
                             _ = unsafe { TranslateMessage(msg) };
                             unsafe { DispatchMessageW(msg) };
                         }

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -355,8 +355,11 @@ impl WindowsPlatform {
     }
 }
 
-fn translate_accelerator(msg: &MSG, is_gpui_window: bool) -> Option<()> {
-    if !is_gpui_window || (msg.message != WM_KEYDOWN && msg.message != WM_SYSKEYDOWN) {
+fn translate_accelerator(msg: &MSG, is_gpui_window: impl FnOnce() -> bool) -> Option<()> {
+    if msg.message != WM_KEYDOWN && msg.message != WM_SYSKEYDOWN {
+        return None;
+    }
+    if !is_gpui_window() {
         return None;
     }
 
@@ -419,12 +422,14 @@ impl Platform for WindowsPlatform {
         let mut msg = MSG::default();
         unsafe {
             while GetMessageW(&mut msg, None, 0, 0).as_bool() {
-                let is_gpui_window = self
-                    .raw_window_handles
-                    .read()
-                    .iter()
-                    .any(|handle| handle.as_raw() == msg.hwnd);
-                if translate_accelerator(&msg, is_gpui_window).is_none() {
+                if translate_accelerator(&msg, || {
+                    self.raw_window_handles
+                        .read()
+                        .iter()
+                        .any(|handle| handle.as_raw() == msg.hwnd)
+                })
+                .is_none()
+                {
                     _ = TranslateMessage(&msg);
                     DispatchMessageW(&msg);
                 }
@@ -1016,16 +1021,16 @@ impl WindowsPlatformInner {
                     // if we don't we might not for example process window quit events
                     let mut msg = MSG::default();
                     let process_message = |msg: &MSG| {
-                        let is_gpui_window = self
-                            .raw_window_handles
-                            .upgrade()
-                            .is_some_and(|handles| {
+                        if translate_accelerator(msg, || {
+                            self.raw_window_handles.upgrade().is_some_and(|handles| {
                                 handles
                                     .read()
                                     .iter()
                                     .any(|handle| handle.as_raw() == msg.hwnd)
-                            });
-                        if translate_accelerator(msg, is_gpui_window).is_none() {
+                            })
+                        })
+                        .is_none()
+                        {
                             _ = unsafe { TranslateMessage(msg) };
                             unsafe { DispatchMessageW(msg) };
                         }

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -996,6 +996,22 @@ impl PlatformWindow for WindowsWindow {
             .log_err();
     }
 
+    fn draw_layered(&self, scene: &Scene, overlay_start: usize) {
+        self.state
+            .renderer
+            .borrow_mut()
+            .draw_layered(scene, overlay_start, self.state.background_appearance.get())
+            .log_err();
+    }
+
+    fn enable_scene_overlay(&self) -> anyhow::Result<()> {
+        self.state.renderer.borrow_mut().enable_scene_overlay()
+    }
+
+    fn create_native_surface(&self) -> anyhow::Result<Rc<dyn PlatformNativeSurface>> {
+        self.state.renderer.borrow_mut().create_native_surface()
+    }
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.state.renderer.borrow().sprite_atlas()
     }


### PR DESCRIPTION
## Why

Native child views such as `WKWebView` and Windows composition visuals are hosted outside GPUI's normal scene. A native view placed above GPUI's primary render surface also covers deferred GPUI content, so popovers, dialogs, menus, and other window-level overlays cannot appear above it.

## From a production workaround to a GPUI primitive

This is not a hypothetical integration problem. In June 2024, before Zed's broader [WebView discussion](https://github.com/zed-industries/zed/issues/21208) was opened, I have added [Wry-backed WebView support to gpui-component](https://github.com/longbridge/gpui-component/pull/2) and maintained a small [GPUI patch](https://github.com/huacnlee/zed/pull/6) that exposed the raw window handle Wry needed.

That workaround was driven by a production requirement at Longbridge: the login flow required a WebView to complete CAPTCHA verification, so shipping without one was not an option. It proved that a native WebView could be attached to a GPUI window and was sufficient to unblock the product.

It also exposed the architectural problem that attaching a WebView alone does not solve. As documented in [the original #21208 comment](https://github.com/zed-industries/zed/issues/21208#issuecomment-2500885428), the WebView always rendered above GPUI elements. The application therefore had to confine it to carefully controlled Drawer or Modal layouts where no `PopupMenu`, tooltip, or other GPUI overlay would need to cross its bounds. This made the integration viable for a few essential flows, but too constrained to become a general GPUI capability.

The continuing requests on #21208—for previews, interactive documents, extension UI, and local HTML artifacts—show why the workaround is not enough. The missing piece has not been the ability to instantiate a WebView; it has been a composition model that allows native content and GPUI content to participate in the same interface without sacrificing GPUI's overlay system.

This PR supplies that missing layer. It turns the production workaround into an explicit GPUI rendering primitive: native content remains independently rendered, while GPUI retains a base plane below it and an interactive overlay plane above it. WebView lifecycle and an extension-facing API remain separate follow-up concerns, but the fundamental z-order limitation is removed on macOS and Windows.

This PR introduces an opt-in three-plane composition model:

```text
                  Front / closest to the user

  ┌─────────────────────────────────────────────────────┐
  │ GPUI overlay surface (transparent)                  │
  │ deferred draws: Popover, Dialog, menus, tooltips    │
  ├────────────── overlay_scene_start ──────────────────┤
  │ Native surface                                     │
  │ WKWebView / IDCompositionVisual                     │
  ├─────────────────────────────────────────────────────┤
  │ GPUI base surface                                   │
  │ root scene, layout, editor chrome                   │
  └─────────────────────────────────────────────────────┘

                  Back / window background
```

The root UI remains on the existing renderer, while deferred and window-level draws are replayed onto the transparent surface above the native content.

## Show case

```bash
cargo run -p gpui --example native_webview
```

https://github.com/user-attachments/assets/ed174ed4-7bc3-4843-9d06-c0e9cddc39e3

For Windows support, this just used GPUI Component webview to test, not included to GPUI example:

https://github.com/user-attachments/assets/f2763554-3a56-4c83-ae82-7aa635dcdd20

## Industry context

Embedding web content remains a recurring gap in GPU-rendered Rust UI frameworks. The difficult part is not obtaining a native window handle or placing a WebView beside the framework's render surface; it is preserving one coherent visual stack in which framework-rendered popovers, dialogs, menus, and tooltips can still appear above that independently rendered native content.

Public discussions in comparable projects show the same boundary:

- [egui's WebView/iframe discussion](https://github.com/emilk/egui/issues/441) points toward handing a native window handle to an external WebView, while noting that integrating its separate rendering pipeline may be a problem.
- [iced's WebView request](https://github.com/iced-rs/iced/issues/742) concluded that an officially supported WebView widget was not planned in the short term and would likely need to live in a separate crate.
- [Slint's WebView discussion](https://github.com/slint-ui/slint/issues/3930#issuecomment-1976039803) describes the exact trade-off addressed here: embedding an external web engine as a native window comes with “the inability to easily place controls on top of the web view,” while importing engine-produced GPU buffers could provide perfect composition but is platform-specific.
- Slint's ongoing [Servo integration work](https://github.com/slint-ui/slint/issues/8735) further illustrates the alternative's complexity: bridging a browser engine's OpenGL output into another renderer is explicitly described as a hard task, with platform and graphics-API constraints.

GPUI already owns a sophisticated GPU-rendered application shell, so replacing parts of that shell with web UI or forcing every embedded engine through an off-screen texture path would be a poor fit. This PR establishes a third option: keep the platform WebView on its native, hardware-accelerated path, while splitting GPUI presentation into base and transparent overlay planes around it.

That is the architectural significance of this change. It does not merely add a WebView example; it gives GPUI a reusable composition primitive that resolves the z-order conflict which makes native embedded surfaces feel incompatible with self-rendered UI frameworks. On macOS and Windows, the PR demonstrates that GPUI can retain ownership of overlays and interaction while independently rendered native content remains live in the middle of the stack.

## Why this is significant

This change is significant because it gives GPUI a general composition boundary for content that GPUI does not render itself. GPUI can continue to own the application shell, layout, commands, and overlays, while a specialized native surface renders in the middle of the same visual stack.

A WebView is the first concrete use case, but the same architecture can provide a foundation for other embedded surfaces, for example:

- richer Markdown Preview and other HTML-based previews
- native video, audio visualization, or camera playback surfaces
- PDF and platform document viewers
- maps and other SDK-provided native views
- GPU, 3D, or data-visualization canvases with their own rendering pipeline
- platform-specific tools, third-party SDK UI, or extension-provided surfaces

This PR does not make all of those integrations complete by itself; each one still needs its own lifecycle, input, focus, and platform adapter. The important first step is now demonstrated: GPUI and an independently rendered native surface can work as one composed interface, including GPUI content both below and above it.

If this foundation proves reliable, Zed could build on it to embed WebView-backed experiences such as a richer Markdown Preview and other HTML preview surfaces. macOS and Windows both have mature WebView implementations that make this direction practical. Linux is likely to require more platform work because its display-server, desktop, toolkit, and WebKit environments are more varied. That makes Linux support harder, but not a fundamental blocker; it can be solved in follow-up work.

Ref #21208

## API

- `Window::enable_scene_overlay()` enables layered scene presentation for a window. Without this opt-in, platforms continue using the existing single-surface draw path.
- `Window::create_native_surface()` creates a platform-native slot between the GPUI base and overlay planes. The initial implementation exposes this portal on Windows.
- `PlatformNativeSurface` is the platform-neutral handle for a native slot:
  - `set_bounds` synchronizes its geometry in device pixels.
  - `set_visible` includes or excludes it from composition.
  - `platform_handle` exposes the platform attachment object, such as an `IDCompositionVisual`.

## Key implementation points

- `Frame::overlay_scene_start` records the scene boundary immediately before deferred draws are painted.
- `PlatformWindow::draw_layered(scene, overlay_start)` presents the base and overlay ranges separately. Its default implementation preserves the previous single-surface behavior on unsupported platforms.
- `Scene::is_empty()` checks for drawable primitives rather than bookkeeping operations. The macOS overlay uses this to capture input only while visible overlay content exists; otherwise events pass through to the native view.
- macOS `new_overlay_renderer` creates a transparent `CAMetalLayer` renderer that shares the base renderer's Metal device and sprite atlas. AppKit places this layer above native child views.
- Windows builds a DirectComposition tree ordered as base visual, native portal container, and overlay visual. The overlay has its own transparent swap chain, while `DirectCompositionPortal` implements `PlatformNativeSurface`.

## Example

`cargo run -p gpui --example native_webview`

The macOS-only example embeds `WKWebView` directly, without adding a `wry` dependency to GPUI. It demonstrates:

- GPUI Popover and Dialog content above the live WebView
- outside-click dismissal even when the click is geometrically over the WebView
- focus transfer between GPUI and WebView keyboard input
- WebView resizing with the window
- native CALayer border and rounded clipping

Companion component integration and documentation: https://github.com/longbridge/gpui-component/pull/2626

## Current scope

- macOS: layered GPUI overlay with a directly hosted native child view
- Windows: DirectComposition native-surface portal and layered renderer support
- Linux: deferred because current `wry`/WebKitGTK integration is not suitable for this iteration

WebView-specific focus and clipboard behavior remains in the embedding component so the GPUI API stays focused on rendering and native-surface composition.

## Test Plan

- `cargo test -p gpui scene::tests --lib`
- `cargo check -p gpui -p gpui_macos`
- `cargo check -p gpui --example native_webview`
- manually verified Popover and Dialog rendering above a live WKWebView
- manually verified overlay dismissal from clicks over the WebView
- manually verified focus transfer and keyboard input between GPUI and WKWebView
- manually verified native WebView resizing, border, and rounded clipping

Release Notes:

- N/A