### PR TITLE
Add settings UI for running MCP servers on remote hosts

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -35,6 +35,7 @@ enum ConfigurationTarget {
     Existing {
         id: ContextServerId,
         command: ContextServerCommand,
+        remote: bool,
     },
     ExistingHttp {
         id: ContextServerId,
@@ -47,6 +48,7 @@ enum ConfigurationTarget {
         id: ContextServerId,
         repository_url: Option<SharedString>,
         installation: Option<extension::ContextServerConfiguration>,
+        remote: bool,
     },
 }
 
@@ -59,6 +61,7 @@ enum ConfigurationSource {
     Existing {
         editor: Entity<Editor>,
         server_type: ExistingServerType,
+        remote: bool,
     },
     Extension {
         id: ContextServerId,
@@ -66,6 +69,7 @@ enum ConfigurationSource {
         repository_url: Option<SharedString>,
         installation_instructions: Option<Entity<markdown::Markdown>>,
         settings_validator: Option<jsonschema::Validator>,
+        remote: bool,
     },
 }
 
@@ -100,7 +104,11 @@ impl ConfigurationSource {
         }
 
         match target {
-            ConfigurationTarget::Existing { id, command } => ConfigurationSource::Existing {
+            ConfigurationTarget::Existing {
+                id,
+                command,
+                remote,
+            } => ConfigurationSource::Existing {
                 editor: create_editor(
                     context_server_input(Some((id, command))),
                     jsonc_language,
@@ -108,6 +116,7 @@ impl ConfigurationSource {
                     cx,
                 ),
                 server_type: ExistingServerType::Local,
+                remote,
             },
             ConfigurationTarget::ExistingHttp {
                 id,
@@ -122,12 +131,14 @@ impl ConfigurationSource {
                     cx,
                 ),
                 server_type: ExistingServerType::Remote,
+                remote: false,
             },
 
             ConfigurationTarget::Extension {
                 id,
                 repository_url,
                 installation,
+                remote,
             } => {
                 let settings_validator = installation.as_ref().and_then(|installation| {
                     jsonschema::validator_for(&installation.settings_schema)
@@ -152,6 +163,7 @@ impl ConfigurationSource {
                     editor: installation.map(|installation| {
                         create_editor(installation.default_settings, jsonc_language, window, cx)
                     }),
+                    remote,
                 }
             }
         }
@@ -162,6 +174,7 @@ impl ConfigurationSource {
             ConfigurationSource::Existing {
                 editor,
                 server_type,
+                remote,
             } => match *server_type {
                 ExistingServerType::Remote => {
                     parse_http_input(&editor.read(cx).text(cx)).map(|(id, url, auth, oauth)| {
@@ -183,7 +196,7 @@ impl ConfigurationSource {
                             id,
                             ContextServerSettings::Stdio {
                                 enabled: true,
-                                remote: false,
+                                remote: *remote,
                                 command,
                             },
                         )
@@ -194,6 +207,7 @@ impl ConfigurationSource {
                 id,
                 editor,
                 settings_validator,
+                remote,
                 ..
             } => {
                 let text = editor
@@ -211,7 +225,7 @@ impl ConfigurationSource {
                     id.clone(),
                     ContextServerSettings::Extension {
                         enabled: true,
-                        remote: false,
+                        remote: *remote,
                         settings,
                     },
                 ))
@@ -370,6 +384,7 @@ fn parse_http_input(
 fn resolve_context_server_extension(
     id: ContextServerId,
     worktree_store: Entity<WorktreeStore>,
+    remote: bool,
     cx: &mut App,
 ) -> Task<Option<ConfigurationTarget>> {
     let registry = ContextServerDescriptorRegistry::default_global(cx).read(cx);
@@ -397,6 +412,7 @@ fn resolve_context_server_extension(
             repository_url: extension
                 .and_then(|(_, manifest)| manifest.repository.clone().map(SharedString::from)),
             installation,
+            remote,
         })
     })
 }
@@ -488,10 +504,11 @@ impl ConfigureContextServerModal {
                 ContextServerSettings::Stdio {
                     enabled: _,
                     command,
-                    ..
+                    remote,
                 } => Some(ConfigurationTarget::Existing {
                     id: server_id,
                     command,
+                    remote,
                 }),
                 ContextServerSettings::Http {
                     enabled: _,
@@ -506,12 +523,13 @@ impl ConfigureContextServerModal {
                     oauth,
                 }),
 
-                ContextServerSettings::Extension { .. } => {
+                ContextServerSettings::Extension { remote, .. } => {
                     match workspace
                         .update(cx, |workspace, cx| {
                             resolve_context_server_extension(
                                 server_id,
                                 workspace.project().read(cx).worktree_store(),
+                                remote,
                                 cx,
                             )
                         })

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -917,11 +917,10 @@ impl ContextServerStore {
         id: ContextServerId,
         configuration: Arc<ContextServerConfiguration>,
         cx: &mut AsyncApp,
-    ) -> Result<(Arc<ContextServer>, Arc<ContextServerConfiguration>)> {
-        let remote = configuration.remote();
+    ) -> Result<Arc<ContextServer>> {
         let needs_remote_command = match configuration.as_ref() {
             ContextServerConfiguration::Custom { .. }
-            | ContextServerConfiguration::Extension { .. } => remote,
+            | ContextServerConfiguration::Extension { .. } => configuration.remote(),
             ContextServerConfiguration::Http { .. } => false,
         };
 
@@ -939,7 +938,7 @@ impl ContextServerStore {
         let root_path: Option<Arc<Path>> =
             this.update(cx, |this, cx| this.resolve_root_path(cx))?;
 
-        let configuration = if let Some((project_id, upstream_client)) = remote_state {
+        let remote_spawn_command = if let Some((project_id, upstream_client)) = remote_state {
             let root_dir = root_path.as_ref().map(|p| p.display().to_string());
 
             let response = upstream_client
@@ -965,16 +964,14 @@ impl ContextServerStore {
                 )
             })?;
 
-            let command = ContextServerCommand {
+            Some(ContextServerCommand {
                 path: remote_command.program.into(),
                 args: remote_command.args,
                 env: Some(remote_command.env.into_iter().collect()),
-                timeout: None,
-            };
-
-            Arc::new(ContextServerConfiguration::Custom { command, remote })
+                timeout: configuration.command().and_then(|command| command.timeout),
+            })
         } else {
-            configuration
+            None
         };
 
         if let Some(server) = this.update(cx, |this, _| {
@@ -982,7 +979,7 @@ impl ContextServerStore {
                 .as_ref()
                 .map(|factory| factory(id.clone(), configuration.clone()))
         })? {
-            return Ok((server, configuration));
+            return Ok(server);
         }
 
         let cached_token_provider: Option<Arc<dyn oauth::OAuthTokenProvider>> =
@@ -1042,10 +1039,13 @@ impl ContextServerStore {
                     )))
                 }
                 _ => {
-                    let mut command = configuration
-                        .command()
-                        .context("Missing command configuration for stdio context server")?
-                        .clone();
+                    let mut command = match remote_spawn_command {
+                        Some(command) => command,
+                        None => configuration
+                            .command()
+                            .context("Missing command configuration for stdio context server")?
+                            .clone(),
+                    };
                     command.timeout = Some(
                         command
                             .timeout
@@ -1064,7 +1064,7 @@ impl ContextServerStore {
             }
         })??;
 
-        Ok((server, configuration))
+        Ok(server)
     }
 
     async fn handle_get_context_server_command(
@@ -1837,8 +1837,8 @@ impl ContextServerStore {
         })??;
 
         for (id, config, working_directory) in servers_to_start {
-            match Self::create_context_server(this.clone(), id.clone(), config, cx).await {
-                Ok((server, config)) => {
+            match Self::create_context_server(this.clone(), id.clone(), config.clone(), cx).await {
+                Ok(server) => {
                     this.update(cx, |this, cx| {
                         this.server_working_directories
                             .insert(id.clone(), working_directory);

--- a/crates/settings_ui/src/pages/mcp_servers_page.rs
+++ b/crates/settings_ui/src/pages/mcp_servers_page.rs
@@ -733,6 +733,7 @@ pub(crate) struct McpServerForm {
     oauth_client_id: Entity<Editor>,
     env: Vec<KeyValueRow>,
     headers: Vec<KeyValueRow>,
+    run_on_remote_host: bool,
     error: Option<SharedString>,
 }
 
@@ -754,13 +755,17 @@ impl McpServerForm {
         let mut oauth_initial = None;
         let mut env = Vec::new();
         let mut headers = Vec::new();
+        let mut run_on_remote_host = false;
 
         // Pre-fill from the raw settings so invalid values (e.g. a malformed URL
         // the user typed directly into settings.json) still load into the form
         // for correction, rather than being dropped during resolution.
         if let Some(settings) = settings.as_ref() {
             match settings {
-                ContextServerSettings::Stdio { command, .. } => {
+                ContextServerSettings::Stdio {
+                    command, remote, ..
+                } => {
+                    run_on_remote_host = *remote;
                     command_initial = Some(command.path.to_string_lossy().to_string());
                     if !command.args.is_empty() {
                         args_initial = Some(command.args.join(" "));
@@ -811,6 +816,7 @@ impl McpServerForm {
             ),
             env,
             headers,
+            run_on_remote_host,
             error: None,
         }
     }
@@ -938,6 +944,11 @@ fn render_mcp_server_form_page(
                     "How long to wait for the server to respond before timing out.",
                     &form.timeout,
                     cx,
+                ))
+                .child(render_run_on_remote_host_switch(
+                    settings_window,
+                    form.run_on_remote_host,
+                    cx,
                 )),
             McpTransport::Http => this
                 .child(render_form_field(
@@ -1003,6 +1014,42 @@ fn input_box(editor: &Entity<Editor>, cx: &App) -> impl IntoElement {
         .track_focus(&focus_handle)
         .focus(|style| style.border_color(colors.border_focused))
         .child(editor.clone())
+}
+
+fn render_run_on_remote_host_switch(
+    settings_window: &SettingsWindow,
+    run_on_remote_host: bool,
+    cx: &mut Context<SettingsWindow>,
+) -> AnyElement {
+    let control = Switch::new(
+        "mcp-run-on-remote-host",
+        if run_on_remote_host {
+            ToggleState::Selected
+        } else {
+            ToggleState::Unselected
+        },
+    )
+    .tab_index(0isize)
+    .on_click(cx.listener(|this, state, _window, cx| {
+        if let Some(form) = this.mcp_server_form.as_mut() {
+            form.run_on_remote_host = *state == ToggleState::Selected;
+        }
+        cx.notify();
+    }))
+    .into_any_element();
+
+    crate::render_settings_item_layout(
+        settings_window,
+        "Run on Remote Machine",
+        "Run this server on the remote machine in SSH, dev container, and WSL projects.",
+        control,
+        None,
+        None,
+        None,
+        false,
+        cx,
+    )
+    .into_any_element()
 }
 
 fn render_form_field(
@@ -1201,6 +1248,7 @@ struct McpServerFormValues {
     oauth_client_id: String,
     env: Vec<(String, String)>,
     headers: Vec<(String, String)>,
+    run_on_remote_host: bool,
 }
 
 fn build_settings_from_form(
@@ -1225,6 +1273,7 @@ fn build_settings_from_form(
         oauth_client_id: form.oauth_client_id.read(cx).text(cx),
         env: read_kv(&form.env, cx),
         headers: read_kv(&form.headers, cx),
+        run_on_remote_host: form.run_on_remote_host,
     };
     build_settings_from_values(&values)
 }
@@ -1266,7 +1315,7 @@ fn build_settings_from_values(
             let env = collect_kv(&values.env, "environment variable")?;
             ContextServerSettingsContent::Stdio {
                 enabled: true,
-                remote: false,
+                remote: values.run_on_remote_host,
                 command: ContextServerCommand {
                     path: command.into(),
                     args,
@@ -1376,6 +1425,7 @@ mod tests {
             oauth_client_id: String::new(),
             env: Vec::new(),
             headers: Vec::new(),
+            run_on_remote_host: false,
         }
     }
 
@@ -1502,6 +1552,29 @@ mod tests {
                     args: vec!["--flag".into(), "value".into()],
                     env: Some(expected_env),
                     timeout: Some(30),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn builds_local_server_that_runs_on_remote_host() {
+        let mut values = values(McpTransport::Stdio);
+        values.name = "remote-stdio".into();
+        values.command = "/usr/bin/server".into();
+        values.run_on_remote_host = true;
+
+        let (_, _, content) = build_settings_from_values(&values).unwrap();
+        assert_eq!(
+            content,
+            ContextServerSettingsContent::Stdio {
+                enabled: true,
+                remote: true,
+                command: ContextServerCommand {
+                    path: "/usr/bin/server".into(),
+                    args: Vec::new(),
+                    env: None,
+                    timeout: None,
                 },
             }
         );


### PR DESCRIPTION
Release Notes:

- The ability to configure whether MCP servers on remote hosts when using remote development has been added to the MCP settings UI.
