### PR TITLE
language_models: Stop logging noisy ChatGPT Subscription auth errors on startup

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use credentials_provider::CredentialsProvider;
 use futures::future::Shared;
 use gpui::{App, Context, Entity, SharedString, Task, Window};
@@ -89,17 +89,11 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
                 if is_auth {
                     Ok(())
                 } else {
-                    Err(anyhow!(
-                        "Sign in with your ChatGPT Plus or Pro subscription to use this provider."
-                    )
-                    .into())
+                    Err(AuthenticateError::CredentialsNotFound)
                 }
             })
         } else {
-            Task::ready(Err(anyhow!(
-                "Sign in with your ChatGPT Plus or Pro subscription to use this provider."
-            )
-            .into()))
+            Task::ready(Err(AuthenticateError::CredentialsNotFound))
         }
     }
 


### PR DESCRIPTION
# Objective

- On every startup (and whenever the agent panel initializes), Zed authenticates all visible language model providers in the background to populate the model selector. For every other credential-based provider, "not signed in yet" is reported as `AuthenticateError::CredentialsNotFound`, which is explicitly treated as expected and not logged. The ChatGPT Subscription provider instead returned a generic `anyhow` error, so it logged an `ERROR [agent] Failed to authenticate provider: ChatGPT Subscription: ...` on every launch, even for users who have never configured or used it.
- Fixes #60237


> **AI disclosure:** I used Claude (Anthropic) to investigate this error, write the fix, and draft this PR description, based on a `Failed to authenticate provider: ChatGPT Subscription` line I noticed in my own Zed logs. I reviewed the diff and the reasoning below, ran the tests myself, and understand and take responsibility for the change, per Zed's [AI Policy](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#ai-policy).

## Solution

- `OpenAiSubscribedProvider::authenticate` now returns `AuthenticateError::CredentialsNotFound` (instead of a generic `anyhow!(...)` wrapped into `AuthenticateError::Other`) when no ChatGPT credentials are found after the initial load, matching how every sibling provider (e.g. Anthropic's `ApiKeyState::load_if_needed`) signals "not configured."
- The user-facing sign-in prompt in the settings UI (`SUBSCRIPTION_DESCRIPTION`) is unchanged — this only affects the background authentication sweep's error handling, not what the user sees when opening provider settings.

## Testing

- `cargo test -p language_models -p openai_subscribed` — all 108 tests pass, including `provider::openai_subscribed::tests::test_authenticate_awaits_initial_load`, which exercises this exact code path.
- `cargo check -p language_models` — compiles cleanly.
- Manually confirmed the log line no longer appears when starting Zed without ChatGPT Subscription configured.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before (this fix): startup log ends with a spurious `ERROR` even though ChatGPT Subscription was never configured.

```
2026-07-30T21:37:46+05:30 INFO  [zed] ========== starting zed version 1.15.0+dev.b90735ff317b83c4ec62ab3d73dd5385bbe1624d, sha b90735f ==========
2026-07-30T21:37:48+05:30 WARN  [zed::reliability::hang_detection] debug build, only reporting hangs longer then 5s
2026-07-30T21:37:48+05:30 WARN  [zed::reliability] Minidump endpoint not set
2026-07-30T21:37:48+05:30 INFO  [zed::reliability] memory usage: resident 98 MiB, virtual 426367 MiB
2026-07-30T21:37:48+05:30 INFO  [extension_host] extensions updated. loading 2, reloading 0, unloading 0
2026-07-30T21:37:48+05:30 INFO  [prompt_store::rules_to_skills_migration] Rules-to-skills migration already marked done; skipping startup migration
2026-07-30T21:37:49+05:30 INFO  [zed::reliability] worktree diagnostics: stores 0, slots 0, live 0, visible 0, strong 0, dead weak 0, loading 0, entries 0, visible entries 0, largest none
2026-07-30T21:37:49+05:30 INFO  [workspace] Rendered first frame
2026-07-30T21:37:50+05:30 ERROR [agent] Failed to authenticate provider: ChatGPT Subscription: Sign in with your ChatGPT Plus or Pro subscription to use this provider.
```

After this fix: the same startup sequence completes with no `ERROR` line.

```
2026-07-30T22:11:38+05:30 INFO  [zed] ========== starting zed version 1.15.0+dev.a8491e63b54bf1881e10fe78bb3e7b1f8a5a2cac, sha a8491e6 ==========
2026-07-30T22:11:38+05:30 WARN  [zed::reliability::hang_detection] debug build, only reporting hangs longer then 5s
2026-07-30T22:11:38+05:30 WARN  [zed::reliability] Minidump endpoint not set
2026-07-30T22:11:38+05:30 INFO  [zed::reliability] memory usage: resident 104 MiB, virtual 426360 MiB
2026-07-30T22:11:38+05:30 INFO  [extension_host] extensions updated. loading 2, reloading 0, unloading 0
2026-07-30T22:11:39+05:30 INFO  [prompt_store::rules_to_skills_migration] Rules-to-skills migration already marked done; skipping startup migration
2026-07-30T22:11:39+05:30 INFO  [zed::reliability] worktree diagnostics: stores 0, slots 0, live 0, visible 0, strong 0, dead weak 0, loading 0, entries 0, visible entries 0, largest none
2026-07-30T22:11:39+05:30 INFO  [workspace] Rendered first frame
2026-07-30T22:11:40+05:30 INFO  [git::repository] opening git repository at ".../zed/.git" using git binary "/usr/bin/git"
```

Release Notes:

- Fixed a noisy "Failed to authenticate provider: ChatGPT Subscription" error being logged on every startup for users who have not configured the ChatGPT Subscription provider
