### PR TITLE
Support agent checkpoints in projects without a git repository

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -160,6 +160,16 @@ pub trait Fs: Send + Sync {
         abs_dot_git: &Path,
         system_git_binary_path: Option<&Path>,
     ) -> Result<Arc<dyn GitRepository>>;
+    /// Opens (initializing if needed) a checkpoint repository whose git
+    /// directory lives at `git_dir_abs_path`, separate from its working tree at
+    /// `work_directory_abs_path`. Used to snapshot the agent's edits in projects
+    /// that are not under version control.
+    async fn open_checkpoint_repo(
+        &self,
+        git_dir_abs_path: &Path,
+        work_directory_abs_path: &Path,
+        system_git_binary_path: Option<&Path>,
+    ) -> Result<Arc<dyn GitRepository>>;
     async fn git_init(&self, abs_work_directory: &Path, fallback_branch_name: String)
     -> Result<()>;
     async fn git_clone(&self, abs_work_directory: &Path, repo_url: &str) -> Result<()>;
@@ -1203,6 +1213,26 @@ impl Fs for RealFs {
             system_git_binary_path.map(|path| path.to_path_buf()),
             self.executor.clone(),
         )?))
+    }
+
+    async fn open_checkpoint_repo(
+        &self,
+        git_dir_abs_path: &Path,
+        work_directory_abs_path: &Path,
+        system_git_binary_path: Option<&Path>,
+    ) -> Result<Arc<dyn GitRepository>> {
+        if let Some(parent) = git_dir_abs_path.parent() {
+            smol::fs::create_dir_all(parent).await?;
+        }
+        let repository = RealGitRepository::open_checkpoint(
+            git_dir_abs_path.to_path_buf(),
+            work_directory_abs_path.to_path_buf(),
+            self.bundled_git_binary_path.clone(),
+            system_git_binary_path.map(|path| path.to_path_buf()),
+            self.executor.clone(),
+        )?;
+        repository.initialize_checkpoint().await?;
+        Ok(Arc::new(repository))
     }
 
     async fn git_init(
@@ -3305,6 +3335,15 @@ impl Fs for FakeFs {
                 }) as _
             },
         )
+    }
+
+    async fn open_checkpoint_repo(
+        &self,
+        _git_dir_abs_path: &Path,
+        _work_directory_abs_path: &Path,
+        _system_git_binary_path: Option<&Path>,
+    ) -> Result<Arc<dyn GitRepository>> {
+        anyhow::bail!("checkpoint repositories are not supported in fake Fs")
     }
 
     async fn git_init(

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1120,6 +1120,11 @@ pub struct RealGitRepository {
     any_git_binary_help_output: Arc<Mutex<Option<SharedString>>>,
     executor: BackgroundExecutor,
     is_trusted: Arc<AtomicBool>,
+    /// When true, the git directory lives outside the working tree, so every
+    /// command must be told about both explicitly via `GIT_DIR`/`GIT_WORK_TREE`.
+    /// This is used for the checkpoint repositories Zed maintains for projects
+    /// that are not under version control.
+    detached_work_tree: bool,
 }
 
 #[derive(Debug)]
@@ -1209,7 +1214,47 @@ impl RealGitRepository {
             executor,
             any_git_binary_help_output: Arc::new(Mutex::new(None)),
             is_trusted: Arc::new(AtomicBool::new(false)),
+            detached_work_tree: false,
         })
+    }
+
+    /// Opens a checkpoint repository whose git directory (`git_dir`) is stored
+    /// separately from its working tree (`work_directory_abs_path`). The git
+    /// directory is initialized on demand by [`Self::initialize_checkpoint`].
+    pub fn open_checkpoint(
+        git_dir: PathBuf,
+        work_directory_abs_path: PathBuf,
+        bundled_git_binary_path: Option<PathBuf>,
+        system_git_binary_path: Option<PathBuf>,
+        executor: BackgroundExecutor,
+    ) -> Result<Self> {
+        let any_git_binary_path = system_git_binary_path
+            .clone()
+            .or(bundled_git_binary_path)
+            .context("no git binary available")?;
+        Ok(Self {
+            git_dir: git_dir.clone(),
+            common_dir: git_dir,
+            working_directory: Some(work_directory_abs_path),
+            system_git_binary_path,
+            any_git_binary_path,
+            executor,
+            any_git_binary_help_output: Arc::new(Mutex::new(None)),
+            // This repository is created and managed by Zed, so we always trust it.
+            is_trusted: Arc::new(AtomicBool::new(true)),
+            detached_work_tree: true,
+        })
+    }
+
+    /// Initializes the git directory of a checkpoint repository if it does not
+    /// exist yet. Safe to call repeatedly.
+    pub async fn initialize_checkpoint(&self) -> Result<()> {
+        if self.git_dir.join("HEAD").exists() {
+            return Ok(());
+        }
+        let git = self.git_binary_in_worktree()?;
+        git.run(&["init"]).await?;
+        Ok(())
     }
 
     fn working_directory(&self) -> Result<PathBuf> {
@@ -1225,13 +1270,25 @@ impl RealGitRepository {
     }
 
     fn git_binary_in_worktree(&self) -> Result<GitBinary> {
-        Ok(GitBinary::new(
+        let working_directory = self.working_directory()?;
+        let git = GitBinary::new(
             self.any_git_binary_path.clone(),
-            self.working_directory()?,
+            working_directory.clone(),
             self.path(),
             self.executor.clone(),
             self.is_trusted(),
-        ))
+        );
+        if self.detached_work_tree {
+            Ok(git.envs(HashMap::from_iter([
+                ("GIT_DIR".to_owned(), self.git_dir.to_string_lossy().into_owned()),
+                (
+                    "GIT_WORK_TREE".to_owned(),
+                    working_directory.to_string_lossy().into_owned(),
+                ),
+            ])))
+        } else {
+            Ok(git)
+        }
     }
 
     fn git_binary(&self) -> GitBinary {
@@ -3562,7 +3619,7 @@ impl GitBinary {
     }
 
     fn envs(mut self, envs: HashMap<String, String>) -> Self {
-        self.envs = envs;
+        self.envs.extend(envs);
         self
     }
 
@@ -4898,6 +4955,48 @@ mod tests {
         //         .ok(),
         //     None
         // );
+    }
+
+    #[gpui::test]
+    async fn test_checkpoint_detached_work_tree(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        // A working tree that is not itself a git repository.
+        let work_dir = tempfile::tempdir().unwrap();
+        // The git directory lives somewhere else entirely.
+        let git_dir = tempfile::tempdir().unwrap();
+
+        let file_path = work_dir.path().join("file");
+        smol::fs::write(&file_path, "before checkpoint")
+            .await
+            .unwrap();
+
+        let repo = RealGitRepository::open_checkpoint(
+            git_dir.path().join("checkpoint.git"),
+            work_dir.path().to_path_buf(),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+        repo.initialize_checkpoint().await.unwrap();
+
+        let checkpoint = repo.checkpoint().await.unwrap();
+
+        smol::fs::write(&file_path, "after checkpoint")
+            .await
+            .unwrap();
+
+        repo.restore_checkpoint(checkpoint).await.unwrap();
+
+        assert_eq!(
+            smol::fs::read_to_string(&file_path).await.unwrap(),
+            "before checkpoint"
+        );
+        // The working tree must stay clean of any git metadata.
+        assert!(!work_dir.path().join(".git").exists());
     }
 
     #[cfg(unix)]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1122,6 +1122,11 @@ pub struct RealGitRepository {
     any_git_binary_help_output: Arc<Mutex<Option<SharedString>>>,
     executor: BackgroundExecutor,
     is_trusted: Arc<AtomicBool>,
+    /// When true, the git directory lives outside the working tree, so every
+    /// command must be told about both explicitly via `GIT_DIR`/`GIT_WORK_TREE`.
+    /// This is used for the checkpoint repositories Zed maintains for projects
+    /// that are not under version control.
+    detached_work_tree: bool,
 }
 
 #[derive(Debug)]
@@ -1211,7 +1216,47 @@ impl RealGitRepository {
             executor,
             any_git_binary_help_output: Arc::new(Mutex::new(None)),
             is_trusted: Arc::new(AtomicBool::new(false)),
+            detached_work_tree: false,
         })
+    }
+
+    /// Opens a checkpoint repository whose git directory (`git_dir`) is stored
+    /// separately from its working tree (`work_directory_abs_path`). The git
+    /// directory is initialized on demand by [`Self::initialize_checkpoint`].
+    pub fn open_checkpoint(
+        git_dir: PathBuf,
+        work_directory_abs_path: PathBuf,
+        bundled_git_binary_path: Option<PathBuf>,
+        system_git_binary_path: Option<PathBuf>,
+        executor: BackgroundExecutor,
+    ) -> Result<Self> {
+        let any_git_binary_path = system_git_binary_path
+            .clone()
+            .or(bundled_git_binary_path)
+            .context("no git binary available")?;
+        Ok(Self {
+            git_dir: git_dir.clone(),
+            common_dir: git_dir,
+            working_directory: Some(work_directory_abs_path),
+            system_git_binary_path,
+            any_git_binary_path,
+            executor,
+            any_git_binary_help_output: Arc::new(Mutex::new(None)),
+            // This repository is created and managed by Zed, so we always trust it.
+            is_trusted: Arc::new(AtomicBool::new(true)),
+            detached_work_tree: true,
+        })
+    }
+
+    /// Initializes the git directory of a checkpoint repository if it does not
+    /// exist yet. Safe to call repeatedly.
+    pub async fn initialize_checkpoint(&self) -> Result<()> {
+        if self.git_dir.join("HEAD").exists() {
+            return Ok(());
+        }
+        let git = self.git_binary_in_worktree()?;
+        git.run(&["init"]).await?;
+        Ok(())
     }
 
     fn working_directory(&self) -> Result<PathBuf> {
@@ -1227,13 +1272,25 @@ impl RealGitRepository {
     }
 
     fn git_binary_in_worktree(&self) -> Result<GitBinary> {
-        Ok(GitBinary::new(
+        let working_directory = self.working_directory()?;
+        let git = GitBinary::new(
             self.any_git_binary_path.clone(),
-            self.working_directory()?,
+            working_directory.clone(),
             self.path(),
             self.executor.clone(),
             self.is_trusted(),
-        ))
+        );
+        if self.detached_work_tree {
+            Ok(git.envs(HashMap::from_iter([
+                ("GIT_DIR".to_owned(), self.git_dir.to_string_lossy().into_owned()),
+                (
+                    "GIT_WORK_TREE".to_owned(),
+                    working_directory.to_string_lossy().into_owned(),
+                ),
+            ])))
+        } else {
+            Ok(git)
+        }
     }
 
     fn git_binary(&self) -> GitBinary {
@@ -3725,7 +3782,7 @@ impl GitBinary {
     }
 
     fn envs(mut self, envs: HashMap<String, String>) -> Self {
-        self.envs = envs;
+        self.envs.extend(envs);
         self
     }
 
@@ -5240,6 +5297,48 @@ mod tests {
         //         .ok(),
         //     None
         // );
+    }
+
+    #[gpui::test]
+    async fn test_checkpoint_detached_work_tree(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        // A working tree that is not itself a git repository.
+        let work_dir = tempfile::tempdir().unwrap();
+        // The git directory lives somewhere else entirely.
+        let git_dir = tempfile::tempdir().unwrap();
+
+        let file_path = work_dir.path().join("file");
+        smol::fs::write(&file_path, "before checkpoint")
+            .await
+            .unwrap();
+
+        let repo = RealGitRepository::open_checkpoint(
+            git_dir.path().join("checkpoint.git"),
+            work_dir.path().to_path_buf(),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+        repo.initialize_checkpoint().await.unwrap();
+
+        let checkpoint = repo.checkpoint().await.unwrap();
+
+        smol::fs::write(&file_path, "after checkpoint")
+            .await
+            .unwrap();
+
+        repo.restore_checkpoint(checkpoint).await.unwrap();
+
+        assert_eq!(
+            smol::fs::read_to_string(&file_path).await.unwrap(),
+            "before checkpoint"
+        );
+        // The working tree must stay clean of any git metadata.
+        assert!(!work_dir.path().join(".git").exists());
     }
 
     #[cfg(unix)]

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -435,6 +435,15 @@ pub fn embeddings_dir() -> &'static PathBuf {
     })
 }
 
+/// Returns the path to the checkpoints directory.
+///
+/// This is where Zed stores git directories used to snapshot and restore the
+/// agent's edits in projects that are not themselves under version control.
+pub fn checkpoints_dir() -> &'static PathBuf {
+    static CHECKPOINTS_DIR: OnceLock<PathBuf> = OnceLock::new();
+    CHECKPOINTS_DIR.get_or_init(|| data_dir().join("checkpoints"))
+}
+
 /// Returns the path to the languages directory.
 ///
 /// This is where language servers are downloaded to for languages built-in to Zed.

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -81,6 +81,7 @@ use std::{
     },
     time::{Duration, Instant, SystemTime},
 };
+use sha2::{Digest, Sha256};
 use sum_tree::{Edit, SumTree, TreeMap};
 use task::Shell;
 use text::{Bias, BufferId, OffsetRangeExt, Rope, ToOffset};
@@ -103,6 +104,9 @@ pub struct GitStore {
     repositories: HashMap<RepositoryId, Entity<Repository>>,
     diff_base: GitDiffBaseSetting,
     display_diffs: HashMap<RepositoryId, DisplayDiff>,
+    /// Git directories Zed maintains to checkpoint the agent's edits in
+    /// worktrees that are not under version control, keyed by worktree root.
+    checkpoint_repositories: HashMap<Arc<Path>, Arc<dyn GitRepository>>,
     worktree_ids: HashMap<RepositoryId, HashSet<WorktreeId>>,
     active_repo_id: Option<RepositoryId>,
     #[allow(clippy::type_complexity)]
@@ -782,6 +786,7 @@ impl GitStore {
             repositories: HashMap::default(),
             diff_base: diff_base_setting,
             display_diffs: HashMap::default(),
+            checkpoint_repositories: HashMap::default(),
             worktree_ids: HashMap::default(),
             active_repo_id: None,
             _subscriptions,
@@ -1877,7 +1882,7 @@ impl GitStore {
         Some(repo.read(cx).status_for_path(&repo_path)?.status)
     }
 
-    pub fn checkpoint(&self, cx: &mut App) -> Task<Result<GitStoreCheckpoint>> {
+    pub fn checkpoint(&mut self, cx: &mut Context<Self>) -> Task<Result<GitStoreCheckpoint>> {
         let mut work_directory_abs_paths = Vec::new();
         let mut checkpoints = Vec::new();
         for repository in self.repositories.values() {
@@ -1887,79 +1892,238 @@ impl GitStore {
             });
         }
 
-        cx.background_executor().spawn(async move {
+        let shadow_repositories = self
+            .worktrees_without_repository(cx)
+            .into_iter()
+            .map(|work_directory_abs_path| {
+                let backend = self.checkpoint_repository(work_directory_abs_path.clone(), cx);
+                (work_directory_abs_path, backend)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
             let checkpoints = future::try_join_all(checkpoints).await?;
+            let mut checkpoints_by_work_dir_abs_path = work_directory_abs_paths
+                .into_iter()
+                .zip(checkpoints)
+                .collect::<HashMap<_, _>>();
+
+            for (work_directory_abs_path, backend) in shadow_repositories {
+                // A worktree without a git repository shouldn't prevent
+                // checkpointing the rest of the project, so failures are logged
+                // and skipped rather than propagated.
+                let Some(backend) = backend.await.log_err() else {
+                    continue;
+                };
+                if let Some(checkpoint) = cx
+                    .background_spawn(async move { backend.checkpoint().await })
+                    .await
+                    .log_err()
+                {
+                    checkpoints_by_work_dir_abs_path.insert(work_directory_abs_path, checkpoint);
+                }
+            }
+
             Ok(GitStoreCheckpoint {
-                checkpoints_by_work_dir_abs_path: work_directory_abs_paths
-                    .into_iter()
-                    .zip(checkpoints)
-                    .collect(),
+                checkpoints_by_work_dir_abs_path,
             })
         })
     }
 
     pub fn restore_checkpoint(
-        &self,
+        &mut self,
         checkpoint: GitStoreCheckpoint,
-        cx: &mut App,
+        cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
         let repositories_by_work_dir_abs_path = self
             .repositories
             .values()
-            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo))
+            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo.clone()))
             .collect::<HashMap<_, _>>();
 
         let mut tasks = Vec::new();
+        let mut shadow_checkpoints = Vec::new();
         for (work_dir_abs_path, checkpoint) in checkpoint.checkpoints_by_work_dir_abs_path {
             if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path) {
                 let restore = repository.update(cx, |repository, _| {
                     repository.restore_checkpoint(checkpoint)
                 });
                 tasks.push(async move { restore.await? });
+            } else {
+                shadow_checkpoints.push((work_dir_abs_path, checkpoint));
             }
         }
-        cx.background_spawn(async move {
+
+        let shadow_repositories = shadow_checkpoints
+            .into_iter()
+            .map(|(work_dir_abs_path, checkpoint)| {
+                let backend = self.checkpoint_repository(work_dir_abs_path, cx);
+                (backend, checkpoint)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
             future::try_join_all(tasks).await?;
+            for (backend, checkpoint) in shadow_repositories {
+                let backend = backend.await?;
+                cx.background_spawn(async move { backend.restore_checkpoint(checkpoint).await })
+                    .await?;
+            }
             Ok(())
         })
     }
 
     /// Compares two checkpoints, returning true if they are equal.
     pub fn compare_checkpoints(
-        &self,
+        &mut self,
         left: GitStoreCheckpoint,
         mut right: GitStoreCheckpoint,
-        cx: &mut App,
+        cx: &mut Context<Self>,
     ) -> Task<Result<bool>> {
         let repositories_by_work_dir_abs_path = self
             .repositories
             .values()
-            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo))
+            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo.clone()))
             .collect::<HashMap<_, _>>();
 
         let mut tasks = Vec::new();
+        let mut shadow_checkpoints = Vec::new();
         for (work_dir_abs_path, left_checkpoint) in left.checkpoints_by_work_dir_abs_path {
-            if let Some(right_checkpoint) = right
+            let Some(right_checkpoint) = right
                 .checkpoints_by_work_dir_abs_path
                 .remove(&work_dir_abs_path)
-            {
-                if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path)
-                {
-                    let compare = repository.update(cx, |repository, _| {
-                        repository.compare_checkpoints(left_checkpoint, right_checkpoint)
-                    });
-
-                    tasks.push(async move { compare.await? });
-                }
-            } else {
+            else {
                 return Task::ready(Ok(false));
+            };
+            if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path) {
+                let compare = repository.update(cx, |repository, _| {
+                    repository.compare_checkpoints(left_checkpoint, right_checkpoint)
+                });
+
+                tasks.push(async move { compare.await? });
+            } else {
+                shadow_checkpoints.push((work_dir_abs_path, left_checkpoint, right_checkpoint));
             }
         }
-        cx.background_spawn(async move {
-            Ok(future::try_join_all(tasks)
+
+        let shadow_repositories = shadow_checkpoints
+            .into_iter()
+            .map(|(work_dir_abs_path, left_checkpoint, right_checkpoint)| {
+                let backend = self.checkpoint_repository(work_dir_abs_path, cx);
+                (backend, left_checkpoint, right_checkpoint)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
+            let mut equal = future::try_join_all(tasks)
                 .await?
                 .into_iter()
-                .all(|result| result))
+                .all(|result| result);
+            for (backend, left_checkpoint, right_checkpoint) in shadow_repositories {
+                if !equal {
+                    break;
+                }
+                let backend = backend.await?;
+                equal = cx
+                    .background_spawn(async move {
+                        backend
+                            .compare_checkpoints(left_checkpoint, right_checkpoint)
+                            .await
+                    })
+                    .await?;
+            }
+            Ok(equal)
+        })
+    }
+
+    /// Returns the roots of visible worktrees that are not covered by any git
+    /// repository, so the agent can still checkpoint them.
+    fn worktrees_without_repository(&self, cx: &App) -> Vec<Arc<Path>> {
+        if !matches!(self.state, GitStoreState::Local { .. }) {
+            return Vec::new();
+        }
+        let repository_work_dirs = self
+            .repositories
+            .values()
+            .map(|repo| repo.read(cx).snapshot.work_directory_abs_path.clone())
+            .collect::<Vec<_>>();
+        self.worktree_store
+            .read(cx)
+            .visible_worktrees(cx)
+            .filter_map(|worktree| {
+                let root_dir = worktree.read(cx).root_dir()?;
+                let covered = repository_work_dirs
+                    .iter()
+                    .any(|work_dir| root_dir.starts_with(work_dir.as_ref()));
+                if covered { None } else { Some(root_dir) }
+            })
+            .collect()
+    }
+
+    /// Returns the git directory Zed uses to checkpoint edits in the given
+    /// worktree, creating and initializing it on first use.
+    fn checkpoint_repository(
+        &mut self,
+        work_directory_abs_path: Arc<Path>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Arc<dyn GitRepository>>> {
+        if let Some(backend) = self.checkpoint_repositories.get(&work_directory_abs_path) {
+            return Task::ready(Ok(backend.clone()));
+        }
+        let GitStoreState::Local {
+            fs,
+            project_environment,
+            ..
+        } = &self.state
+        else {
+            return Task::ready(Err(anyhow!(
+                "checkpoints without a git repository are only supported in local projects"
+            )));
+        };
+        let fs = fs.clone();
+        let environment = project_environment.update(cx, |project_environment, cx| {
+            project_environment.local_directory_environment(
+                &Shell::System,
+                work_directory_abs_path.clone(),
+                cx,
+            )
+        });
+        let mut hasher = Sha256::new();
+        hasher.update(work_directory_abs_path.to_string_lossy().as_bytes());
+        let git_dir_abs_path = paths::checkpoints_dir().join(format!("{:x}", hasher.finalize()));
+
+        cx.spawn(async move |this, cx| {
+            let environment = environment.await.unwrap_or_default();
+            let search_paths = environment.get("PATH").map(|value| value.to_owned());
+            let backend = cx
+                .background_spawn({
+                    let fs = fs.clone();
+                    let work_directory_abs_path = work_directory_abs_path.clone();
+                    async move {
+                        let system_git_binary_path = search_paths
+                            .and_then(|search_paths| {
+                                which::which_in(
+                                    "git",
+                                    Some(search_paths),
+                                    work_directory_abs_path.as_ref(),
+                                )
+                                .ok()
+                            })
+                            .or_else(|| which::which("git").ok());
+                        fs.open_checkpoint_repo(
+                            &git_dir_abs_path,
+                            &work_directory_abs_path,
+                            system_git_binary_path.as_deref(),
+                        )
+                        .await
+                    }
+                })
+                .await?;
+            this.update(cx, |this, _| {
+                this.checkpoint_repositories
+                    .insert(work_directory_abs_path, backend.clone());
+                backend
+            })
         })
     }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -81,6 +81,7 @@ use std::{
     },
     time::{Duration, Instant, SystemTime},
 };
+use sha2::{Digest, Sha256};
 use sum_tree::{Edit, SumTree, TreeMap};
 use task::Shell;
 use text::{Bias, BufferId, OffsetRangeExt, Rope, ToOffset};
@@ -101,6 +102,9 @@ pub struct GitStore {
     buffer_store: Entity<BufferStore>,
     worktree_store: Entity<WorktreeStore>,
     repositories: HashMap<RepositoryId, Entity<Repository>>,
+    /// Git directories Zed maintains to checkpoint the agent's edits in
+    /// worktrees that are not under version control, keyed by worktree root.
+    checkpoint_repositories: HashMap<Arc<Path>, Arc<dyn GitRepository>>,
     worktree_ids: HashMap<RepositoryId, HashSet<WorktreeId>>,
     active_repo_id: Option<RepositoryId>,
     #[allow(clippy::type_complexity)]
@@ -758,6 +762,7 @@ impl GitStore {
             buffer_store,
             worktree_store,
             repositories: HashMap::default(),
+            checkpoint_repositories: HashMap::default(),
             worktree_ids: HashMap::default(),
             active_repo_id: None,
             _subscriptions,
@@ -1813,7 +1818,7 @@ impl GitStore {
         Some(repo.read(cx).status_for_path(&repo_path)?.status)
     }
 
-    pub fn checkpoint(&self, cx: &mut App) -> Task<Result<GitStoreCheckpoint>> {
+    pub fn checkpoint(&mut self, cx: &mut Context<Self>) -> Task<Result<GitStoreCheckpoint>> {
         let mut work_directory_abs_paths = Vec::new();
         let mut checkpoints = Vec::new();
         for repository in self.repositories.values() {
@@ -1823,79 +1828,238 @@ impl GitStore {
             });
         }
 
-        cx.background_executor().spawn(async move {
+        let shadow_repositories = self
+            .worktrees_without_repository(cx)
+            .into_iter()
+            .map(|work_directory_abs_path| {
+                let backend = self.checkpoint_repository(work_directory_abs_path.clone(), cx);
+                (work_directory_abs_path, backend)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
             let checkpoints = future::try_join_all(checkpoints).await?;
+            let mut checkpoints_by_work_dir_abs_path = work_directory_abs_paths
+                .into_iter()
+                .zip(checkpoints)
+                .collect::<HashMap<_, _>>();
+
+            for (work_directory_abs_path, backend) in shadow_repositories {
+                // A worktree without a git repository shouldn't prevent
+                // checkpointing the rest of the project, so failures are logged
+                // and skipped rather than propagated.
+                let Some(backend) = backend.await.log_err() else {
+                    continue;
+                };
+                if let Some(checkpoint) = cx
+                    .background_spawn(async move { backend.checkpoint().await })
+                    .await
+                    .log_err()
+                {
+                    checkpoints_by_work_dir_abs_path.insert(work_directory_abs_path, checkpoint);
+                }
+            }
+
             Ok(GitStoreCheckpoint {
-                checkpoints_by_work_dir_abs_path: work_directory_abs_paths
-                    .into_iter()
-                    .zip(checkpoints)
-                    .collect(),
+                checkpoints_by_work_dir_abs_path,
             })
         })
     }
 
     pub fn restore_checkpoint(
-        &self,
+        &mut self,
         checkpoint: GitStoreCheckpoint,
-        cx: &mut App,
+        cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
         let repositories_by_work_dir_abs_path = self
             .repositories
             .values()
-            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo))
+            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo.clone()))
             .collect::<HashMap<_, _>>();
 
         let mut tasks = Vec::new();
+        let mut shadow_checkpoints = Vec::new();
         for (work_dir_abs_path, checkpoint) in checkpoint.checkpoints_by_work_dir_abs_path {
             if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path) {
                 let restore = repository.update(cx, |repository, _| {
                     repository.restore_checkpoint(checkpoint)
                 });
                 tasks.push(async move { restore.await? });
+            } else {
+                shadow_checkpoints.push((work_dir_abs_path, checkpoint));
             }
         }
-        cx.background_spawn(async move {
+
+        let shadow_repositories = shadow_checkpoints
+            .into_iter()
+            .map(|(work_dir_abs_path, checkpoint)| {
+                let backend = self.checkpoint_repository(work_dir_abs_path, cx);
+                (backend, checkpoint)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
             future::try_join_all(tasks).await?;
+            for (backend, checkpoint) in shadow_repositories {
+                let backend = backend.await?;
+                cx.background_spawn(async move { backend.restore_checkpoint(checkpoint).await })
+                    .await?;
+            }
             Ok(())
         })
     }
 
     /// Compares two checkpoints, returning true if they are equal.
     pub fn compare_checkpoints(
-        &self,
+        &mut self,
         left: GitStoreCheckpoint,
         mut right: GitStoreCheckpoint,
-        cx: &mut App,
+        cx: &mut Context<Self>,
     ) -> Task<Result<bool>> {
         let repositories_by_work_dir_abs_path = self
             .repositories
             .values()
-            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo))
+            .map(|repo| (repo.read(cx).snapshot.work_directory_abs_path.clone(), repo.clone()))
             .collect::<HashMap<_, _>>();
 
         let mut tasks = Vec::new();
+        let mut shadow_checkpoints = Vec::new();
         for (work_dir_abs_path, left_checkpoint) in left.checkpoints_by_work_dir_abs_path {
-            if let Some(right_checkpoint) = right
+            let Some(right_checkpoint) = right
                 .checkpoints_by_work_dir_abs_path
                 .remove(&work_dir_abs_path)
-            {
-                if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path)
-                {
-                    let compare = repository.update(cx, |repository, _| {
-                        repository.compare_checkpoints(left_checkpoint, right_checkpoint)
-                    });
-
-                    tasks.push(async move { compare.await? });
-                }
-            } else {
+            else {
                 return Task::ready(Ok(false));
+            };
+            if let Some(repository) = repositories_by_work_dir_abs_path.get(&work_dir_abs_path) {
+                let compare = repository.update(cx, |repository, _| {
+                    repository.compare_checkpoints(left_checkpoint, right_checkpoint)
+                });
+
+                tasks.push(async move { compare.await? });
+            } else {
+                shadow_checkpoints.push((work_dir_abs_path, left_checkpoint, right_checkpoint));
             }
         }
-        cx.background_spawn(async move {
-            Ok(future::try_join_all(tasks)
+
+        let shadow_repositories = shadow_checkpoints
+            .into_iter()
+            .map(|(work_dir_abs_path, left_checkpoint, right_checkpoint)| {
+                let backend = self.checkpoint_repository(work_dir_abs_path, cx);
+                (backend, left_checkpoint, right_checkpoint)
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn(async move |_, cx| {
+            let mut equal = future::try_join_all(tasks)
                 .await?
                 .into_iter()
-                .all(|result| result))
+                .all(|result| result);
+            for (backend, left_checkpoint, right_checkpoint) in shadow_repositories {
+                if !equal {
+                    break;
+                }
+                let backend = backend.await?;
+                equal = cx
+                    .background_spawn(async move {
+                        backend
+                            .compare_checkpoints(left_checkpoint, right_checkpoint)
+                            .await
+                    })
+                    .await?;
+            }
+            Ok(equal)
+        })
+    }
+
+    /// Returns the roots of visible worktrees that are not covered by any git
+    /// repository, so the agent can still checkpoint them.
+    fn worktrees_without_repository(&self, cx: &App) -> Vec<Arc<Path>> {
+        if !matches!(self.state, GitStoreState::Local { .. }) {
+            return Vec::new();
+        }
+        let repository_work_dirs = self
+            .repositories
+            .values()
+            .map(|repo| repo.read(cx).snapshot.work_directory_abs_path.clone())
+            .collect::<Vec<_>>();
+        self.worktree_store
+            .read(cx)
+            .visible_worktrees(cx)
+            .filter_map(|worktree| {
+                let root_dir = worktree.read(cx).root_dir()?;
+                let covered = repository_work_dirs
+                    .iter()
+                    .any(|work_dir| root_dir.starts_with(work_dir.as_ref()));
+                if covered { None } else { Some(root_dir) }
+            })
+            .collect()
+    }
+
+    /// Returns the git directory Zed uses to checkpoint edits in the given
+    /// worktree, creating and initializing it on first use.
+    fn checkpoint_repository(
+        &mut self,
+        work_directory_abs_path: Arc<Path>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Arc<dyn GitRepository>>> {
+        if let Some(backend) = self.checkpoint_repositories.get(&work_directory_abs_path) {
+            return Task::ready(Ok(backend.clone()));
+        }
+        let GitStoreState::Local {
+            fs,
+            project_environment,
+            ..
+        } = &self.state
+        else {
+            return Task::ready(Err(anyhow!(
+                "checkpoints without a git repository are only supported in local projects"
+            )));
+        };
+        let fs = fs.clone();
+        let environment = project_environment.update(cx, |project_environment, cx| {
+            project_environment.local_directory_environment(
+                &Shell::System,
+                work_directory_abs_path.clone(),
+                cx,
+            )
+        });
+        let mut hasher = Sha256::new();
+        hasher.update(work_directory_abs_path.to_string_lossy().as_bytes());
+        let git_dir_abs_path = paths::checkpoints_dir().join(format!("{:x}", hasher.finalize()));
+
+        cx.spawn(async move |this, cx| {
+            let environment = environment.await.unwrap_or_default();
+            let search_paths = environment.get("PATH").map(|value| value.to_owned());
+            let backend = cx
+                .background_spawn({
+                    let fs = fs.clone();
+                    let work_directory_abs_path = work_directory_abs_path.clone();
+                    async move {
+                        let system_git_binary_path = search_paths
+                            .and_then(|search_paths| {
+                                which::which_in(
+                                    "git",
+                                    Some(search_paths),
+                                    work_directory_abs_path.as_ref(),
+                                )
+                                .ok()
+                            })
+                            .or_else(|| which::which("git").ok());
+                        fs.open_checkpoint_repo(
+                            &git_dir_abs_path,
+                            &work_directory_abs_path,
+                            system_git_binary_path.as_deref(),
+                        )
+                        .await
+                    }
+                })
+                .await?;
+            this.update(cx, |this, _| {
+                this.checkpoint_repositories
+                    .insert(work_directory_abs_path, backend.clone());
+                backend
+            })
         })
     }
 


### PR DESCRIPTION
This is a bit of a big PR, specially compared to my previous ones. If there's
any doubts feel free to ask!

Agent checkpoints were only created for detected git repositories. In a
project that is not under version control, the "Restore Checkpoint" button
never appeared and rewinding a thread left the files on disk untouched. This
is model-agnostic; it was reported by a user running llama.cpp with Qwen who
assumed checkpoints were a model feature.

Resolves #61951

For each visible worktree not covered by a git repository, Zed now keeps a
git directory under its support directory (`checkpoints/<hash>`) using the
worktree as a detached work tree (`GIT_DIR` + `GIT_WORK_TREE`). The existing
checkpoint, restore, and compare code runs against it unchanged, so the
user's project stays free of any git metadata.

Local projects only. Remote and single-file worktrees are left as they were.


Release Notes:

- Improved agent checkpoints so they work in projects that are not git repositories
