### PR TITLE
worktree: Ignore invalid .git directories

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -9448,7 +9448,9 @@ mod tests {
         .await
         .unwrap();
         cx.run_until_parked();
-        fs.create_dir(Path::new(path!("/test/.git"))).await.unwrap();
+        fs.git_init(Path::new(path!("/test")), "main".to_string())
+            .await
+            .unwrap();
         cx.run_until_parked();
 
         complete_tx.send(()).unwrap();

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -2183,6 +2183,7 @@ mod tests {
                 "This is file2.rs".as_bytes().to_vec(),
             )
             .await;
+        cx.run_until_parked();
 
         // Base document with {ABS} placeholder for absolute path prefix.
         // Each test case replaces a specific line to add cursor (ˇ) or highlight («»ˇ) markers.
@@ -2352,6 +2353,7 @@ Sentence ending file2.rs.
                     .to_vec(),
             )
             .await;
+        cx.run_until_parked();
 
         // file2.rs:5:3 should be highlighted and clickable
         cx.set_state(indoc! {"
@@ -2428,6 +2430,7 @@ Sentence ending file2.rs.
                     .to_vec(),
             )
             .await;
+        cx.run_until_parked();
 
         // file2.rs:3 should be highlighted and clickable
         cx.set_state(indoc! {"
@@ -2485,6 +2488,7 @@ Sentence ending file2.rs.
                 "line 1\nline 2\nline 3\n".as_bytes().to_vec(),
             )
             .await;
+        cx.run_until_parked();
 
         // file2.rs:2:in should resolve to file2.rs line 2 (like Ruby backtraces)
         cx.set_state(indoc! {"
@@ -2543,6 +2547,7 @@ Sentence ending file2.rs.
                     .to_vec(),
             )
             .await;
+        cx.run_until_parked();
 
         // Markdown link [text](file2.rs:3:2) should highlight only the inner link,
         // not the surrounding markdown syntax.
@@ -2615,6 +2620,7 @@ Sentence ending file2.rs.
         fs.as_fake()
             .insert_file("/root/dir/file2.rs", "This is file2.rs".as_bytes().to_vec())
             .await;
+        cx.run_until_parked();
 
         cx.set_state(indoc! {"
             You can't open ../diˇr because it's a directory.

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -41,7 +41,7 @@ use smol::io::AsyncWriteExt;
 #[cfg(feature = "test-support")]
 use std::path::Component;
 use std::{
-    io::{self, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -49,6 +49,7 @@ use std::{
 };
 use tempfile::TempDir;
 use text::LineEnding;
+use util::ResultExt as _;
 
 #[cfg(feature = "test-support")]
 mod fake_git_repo;
@@ -92,6 +93,175 @@ impl From<PathEvent> for PathBuf {
     fn from(event: PathEvent) -> Self {
         event.path
     }
+}
+
+/// Resolves a `.git` entry — a directory, or a gitfile pointing elsewhere — to its
+/// validated `(repository_dir, common_dir)`, mirroring git's discovery. Worktree
+/// discovery and identity resolution share it (the sync git backend shares only the
+/// grammar helpers), so they agree on what a repository is and where its dirs are.
+/// The two dirs differ only for a linked worktree, whose `HEAD` is per-worktree while
+/// the object/ref stores live in the shared common dir. The layout being validated is
+/// documented in gitrepository-layout(5) and git-worktree(1).
+///
+/// * `Ok(Some(_))` — fully resolved and structurally valid.
+/// * `Ok(None)` — confirmed *not* a repository (absent, malformed/empty gitfile,
+///   broken gitfile/`commondir` target, or a leftover/empty `.git`).
+/// * `Err(_)` — the answer is indeterminate because an I/O operation failed (a
+///   permission or other read error); a caller holding a registration must preserve it
+///   rather than remove it. This "confirmed gone" vs "couldn't read it" distinction is
+///   why the return type is `Result<Option<_>>`.
+pub async fn resolve_git_repository(
+    dot_git_path: &Path,
+    fs: &dyn Fs,
+) -> Result<Option<(PathBuf, PathBuf)>> {
+    let Some(metadata) = fs.metadata(dot_git_path).await? else {
+        return Ok(None);
+    };
+
+    let repository_dir = if metadata.is_dir {
+        // A plain `.git` or bare directory keeps its own identity; git does not
+        // canonicalize it during discovery.
+        dot_git_path.to_path_buf()
+    } else {
+        // A gitfile: the `.git` of a linked worktree or a separate-git-dir checkout.
+        // Confirmed-absent content (dangling symlink, TOCTOU delete) is non-repo,
+        // not a transient failure — same tri-state as `canonicalize_existing`.
+        let Some(contents) = load_bytes_existing(fs, dot_git_path).await? else {
+            return Ok(None);
+        };
+        let Some(target) = git::parse_gitfile(&contents).log_err() else {
+            return Ok(None);
+        };
+        // `Path::join` replaces the base for an absolute gitdir pointer.
+        let target = dot_git_path.parent().unwrap_or(Path::new("")).join(target);
+        // A gitfile pointing at a nonexistent directory is a broken worktree link;
+        // a transient error propagates so an existing registration is preserved.
+        let Some(resolved) = canonicalize_existing(fs, &target).await? else {
+            return Ok(None);
+        };
+        resolved
+    };
+
+    let Some(common_dir) = resolve_common_dir(&repository_dir, fs).await? else {
+        return Ok(None);
+    };
+
+    Ok(fs
+        .is_git_repository(&repository_dir, &common_dir)
+        .await?
+        .then_some((repository_dir, common_dir)))
+}
+
+/// Canonicalizes a path, distinguishing a confirmed-missing target (`Ok(None)`, a
+/// broken link) from a transient permission/I/O failure (`Err`) that a caller holding
+/// a registration must not treat as a deletion.
+async fn canonicalize_existing(fs: &dyn Fs, path: &Path) -> Result<Option<PathBuf>> {
+    match fs.canonicalize(path).await {
+        Ok(path) => Ok(Some(path)),
+        Err(error) if io_error_is_absence(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Loads file bytes, mapping confirmed absence to `Ok(None)` the same way
+/// [`canonicalize_existing`] does, so a missing gitfile/commondir is not treated as a
+/// transient I/O failure that would preserve a stale registration.
+async fn load_bytes_existing(fs: &dyn Fs, path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs.load_bytes(path).await {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if io_error_is_absence(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Whether `error` is confirmed path absence (`NotFound` / `NotADirectory`) rather
+/// than an indeterminate I/O failure. This is the absence half of the resolver's
+/// tri-state contract; shared so callers cannot drift from each other.
+pub fn io_error_is_absence(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<io::Error>().is_some_and(|error| {
+        matches!(
+            error.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+        )
+    })
+}
+
+/// Resolves the common directory for `repository_dir`, following a `commondir` file
+/// when present (git's `get_common_dir_noenv`). Returns `Ok(None)` when a `commondir`
+/// is present but broken (a directory, or a target that is missing or not a directory);
+/// git does not silently fall back to `repository_dir` in that case.
+async fn resolve_common_dir(repository_dir: &Path, fs: &dyn Fs) -> Result<Option<PathBuf>> {
+    let commondir_path = repository_dir.join(git::COMMONDIR);
+    let Some(metadata) = fs.metadata(&commondir_path).await? else {
+        // No `commondir`: the repository is its own common dir (normal or bare repo).
+        return Ok(Some(repository_dir.to_path_buf()));
+    };
+    if metadata.is_dir {
+        return Ok(None);
+    }
+    let Some(contents) = load_bytes_existing(fs, &commondir_path).await? else {
+        return Ok(None);
+    };
+    let Some(target) = git::parse_commondir(&contents).log_err() else {
+        return Ok(None);
+    };
+    let target = repository_dir.join(target);
+    let Some(resolved) = canonicalize_existing(fs, &target).await? else {
+        return Ok(None);
+    };
+    Ok(dir_exists(fs, &resolved).await?.then_some(resolved))
+}
+
+/// Whether `path` is an existing directory, distinguishing confirmed absence
+/// (`Ok(false)`) from a transient I/O error (`Err`). `Fs::metadata` already maps
+/// `NotFound`/`NotADirectory` to `Ok(None)`.
+async fn dir_exists<F: Fs + ?Sized>(fs: &F, path: &Path) -> Result<bool> {
+    Ok(fs
+        .metadata(path)
+        .await?
+        .is_some_and(|metadata| metadata.is_dir))
+}
+
+/// Whether the common dir holds git's object and ref stores (`objects` and `refs`).
+/// git's `is_git_directory` requires both; reftable repos still create `refs/`, so
+/// there is no "reftable instead of refs" branch. A missing store is `Ok(false)`; a
+/// transient I/O error propagates as `Err` so a valid repository is not spuriously
+/// unregistered.
+async fn common_dir_has_stores<F: Fs + ?Sized>(fs: &F, common_dir: &Path) -> Result<bool> {
+    Ok(dir_exists(fs, &common_dir.join(git::OBJECTS_DIR)).await?
+        && dir_exists(fs, &common_dir.join(git::REFS_DIR)).await?)
+}
+
+/// Path-aware `HEAD` validation, faithful to git's `validate_headref`: a symlink
+/// `HEAD` is validated by its link text without being followed (an unborn or
+/// packed-only target is legal), while a regular `HEAD` is validated from its
+/// first bytes. Returns `Err` only for transient I/O failures.
+async fn git_head_is_valid<F: Fs + ?Sized>(fs: &F, head_path: &Path) -> Result<bool> {
+    let Some(metadata) = fs.metadata(head_path).await? else {
+        return Ok(false);
+    };
+    // Symlink first: a symlink-to-directory is validated by link text, not rejected
+    // as a directory HEAD. Directory HEAD is confirmed-invalid (git rejects it).
+    if metadata.is_symlink {
+        return match fs.read_link(head_path).await {
+            Ok(target) => Ok(git::head_symlink_target_is_valid(target.as_os_str())),
+            Err(error) if io_error_is_absence(&error) => Ok(false),
+            Err(error) => Err(error),
+        };
+    }
+    if metadata.is_dir {
+        return Ok(false);
+    }
+    // git reads a fixed 255-byte buffer; HEAD is tiny, and the bound keeps a
+    // pathological large file from forcing a full read.
+    let reader = match fs.open_sync(head_path).await {
+        Ok(reader) => reader,
+        Err(error) if io_error_is_absence(&error) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let mut contents = Vec::new();
+    reader.take(255).read_to_end(&mut contents)?;
+    Ok(git::regular_head_contents_are_valid(&contents))
 }
 
 #[async_trait::async_trait]
@@ -164,6 +334,27 @@ pub trait Fs: Send + Sync {
     -> Result<()>;
     async fn git_clone(&self, abs_work_directory: &Path, repo_url: &str) -> Result<()>;
     async fn git_config(&self, abs_work_directory: &Path, args: Vec<String>) -> Result<String>;
+
+    /// Whether the resolved `(repository_dir, common_dir)` is a valid git repository.
+    /// A leftover/empty `.git` directory isn't one: git walks up to the parent, and so
+    /// must discovery, or the phantom shadows the real parent. A gitfile pointing at a
+    /// non-repository is a fatal discovery error in git; discovery here deliberately
+    /// walks up instead so the phantom cannot shadow the real parent. Returns `Err`
+    /// for a transient I/O failure so callers can preserve an existing registration
+    /// rather than remove it. Most callers should use [`resolve_git_repository`], which
+    /// also resolves the dirs; this hook exists so `FakeFs` can consult its in-memory
+    /// model.
+    async fn is_git_repository(&self, repository_dir: &Path, common_dir: &Path) -> Result<bool> {
+        // The structural shape git's `is_git_directory` looks for: a valid `HEAD` in the
+        // repository dir plus `objects` and `refs` stores in the common dir (which
+        // differs from the repository dir only for a linked worktree). Existence is
+        // checked by type, not git's `X_OK` access check.
+        Ok(
+            git_head_is_valid(self, &repository_dir.join(git::HEAD)).await?
+                && common_dir_has_stores(self, common_dir).await?,
+        )
+    }
+
     fn is_fake(&self) -> bool;
     async fn is_case_sensitive(&self) -> bool;
     fn subscribe_to_jobs(&self) -> JobEventReceiver;
@@ -1134,7 +1325,7 @@ impl Fs for RealFs {
         Pin<Box<dyn Send + Stream<Item = Vec<PathEvent>>>>,
         Arc<dyn Watcher>,
     ) {
-        use util::{ResultExt as _, paths::SanitizedPath};
+        use util::paths::SanitizedPath;
         let executor = self.executor.clone();
 
         let (tx, rx) = async_channel::unbounded();
@@ -1977,6 +2168,7 @@ impl FakeFs {
             tree: serde_json::Value,
         ) -> futures::future::BoxFuture<'a, ()> {
             async move {
+                let is_dir = matches!(tree, Object(_) | Null);
                 match tree {
                     Object(map) => {
                         this.create_dir(&path).await.unwrap();
@@ -1995,6 +2187,15 @@ impl FakeFs {
                     _ => {
                         panic!("JSON object must contain only objects, strings, or null");
                     }
+                }
+                // A directory named `.git` models a git repository, so mark it as an
+                // initialized repository (in-memory state, no files) — repository
+                // discovery recognizes it via `is_git_repository`. A `.git` created
+                // directly via `create_dir` deliberately stays uninitialized, so tests
+                // can model an invalid/phantom `.git`.
+                if is_dir && path.file_name() == Some(*FS_DOT_GIT) {
+                    this.with_git_state(&path, false, |_| {})
+                        .expect("just-created .git dir should accept git state");
                 }
             }
             .boxed()
@@ -2066,11 +2267,7 @@ impl FakeFs {
             let path = match git_dir_path {
                 Some(path) => path,
                 None => {
-                    let path = std::str::from_utf8(content)
-                        .ok()
-                        .and_then(|content| content.strip_prefix("gitdir:"))
-                        .context("not a valid gitfile")?
-                        .trim();
+                    let path = git::parse_gitfile(content)?;
                     git_dir_path.insert(normalize_path(&dot_git.parent().unwrap().join(path)))
                 }
             }
@@ -2087,14 +2284,11 @@ impl FakeFs {
                 anyhow::bail!("gitfile points to a non-directory")
             };
             let common_dir = if let Some(child) = entries.get("commondir") {
-                let raw = std::str::from_utf8(child.file_content("commondir".as_ref())?)
-                    .context("commondir content")?
-                    .trim();
-                let raw_path = Path::new(raw);
+                let raw_path = git::parse_commondir(child.file_content("commondir".as_ref())?)?;
                 if raw_path.is_relative() {
-                    normalize_path(&canonical_path.join(raw_path))
+                    normalize_path(&canonical_path.join(&raw_path))
                 } else {
-                    raw_path.to_owned()
+                    raw_path
                 }
             } else {
                 canonical_path.clone()
@@ -3144,10 +3338,14 @@ impl Fs for FakeFs {
         let path = normalize_path(path);
         self.simulate_random_delay().await;
         let state = self.state.lock();
-        let canonical_path = state
-            .canonicalize(&path, true)
-            .with_context(|| format!("path does not exist: {path:?}"))?;
-        Ok(canonical_path)
+        // Real `io::Error` so `io_error_is_absence` downcasts like RealFs (an
+        // `Option` + `.with_context` does not put `io::Error` in the chain).
+        state.canonicalize(&path, true).ok_or_else(|| {
+            anyhow::anyhow!(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("path does not exist: {path:?}")
+            ))
+        })
     }
 
     async fn is_file(&self, path: &Path) -> bool {
@@ -3218,9 +3416,12 @@ impl Fs for FakeFs {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
         let mut state = self.state.lock();
-        let (entry, _) = state
-            .try_entry(&path, false)
-            .with_context(|| format!("path does not exist: {path:?}"))?;
+        let Some((entry, _)) = state.try_entry(&path, false) else {
+            return Err(anyhow::anyhow!(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("path does not exist: {path:?}")
+            )));
+        };
         if let FakeFsEntry::Symlink { target } = entry {
             Ok(target.clone())
         } else {
@@ -3312,7 +3513,10 @@ impl Fs for FakeFs {
         abs_work_directory_path: &Path,
         _fallback_branch_name: String,
     ) -> Result<()> {
-        self.create_dir(&abs_work_directory_path.join(".git")).await
+        let dot_git = abs_work_directory_path.join(".git");
+        self.create_dir(&dot_git).await?;
+        self.with_git_state(&dot_git, false, |_| {})?;
+        Ok(())
     }
 
     async fn git_clone(&self, _abs_work_directory: &Path, _repo_url: &str) -> Result<()> {
@@ -3321,6 +3525,31 @@ impl Fs for FakeFs {
 
     async fn git_config(&self, _abs_work_directory: &Path, _args: Vec<String>) -> Result<String> {
         anyhow::bail!("Git config is not supported in fake Fs")
+    }
+
+    async fn is_git_repository(&self, repository_dir: &Path, common_dir: &Path) -> Result<bool> {
+        // A fake repository is modeled either in memory (git state attached to the
+        // common dir — `insert_tree` on a `.git` dir, `git_init`, and the
+        // `set_*_for_repo` helpers all initialize it) or by literal files in the fixture
+        // (e.g. bare-backed linked worktrees, which write `HEAD`/`objects`/`refs`). A
+        // bare `create_dir` does neither, so tests can model an empty/leftover `.git`.
+        let has_git_state = matches!(
+            self.state.lock().try_entry(common_dir, false),
+            Some((
+                FakeFsEntry::Dir {
+                    git_repo_state: Some(_),
+                    ..
+                },
+                _
+            ))
+        );
+        // In-memory state lives on the common dir. It vouches for the whole repository
+        // only when the dirs coincide; for a split layout (linked worktree) the
+        // per-worktree `HEAD` is still validated from files so an invalidated gitfile is
+        // not masked, and the state can vouch only for the shared object/ref stores.
+        let head_is_valid = (repository_dir == common_dir && has_git_state)
+            || git_head_is_valid(self, &repository_dir.join(git::HEAD)).await?;
+        Ok(head_is_valid && (has_git_state || common_dir_has_stores(self, common_dir).await?))
     }
 
     fn is_fake(&self) -> bool {

--- a/crates/fs/tests/integration/fake_git_repo_tests.rs
+++ b/crates/fs/tests/integration/fake_git_repo_tests.rs
@@ -194,3 +194,32 @@ async fn test_checkpoints(executor: BackgroundExecutor) {
     assert!(diff.contains("b"), "diff should mention changed file 'b'");
     assert!(diff.contains("c"), "diff should mention added file 'c'");
 }
+
+#[gpui::test]
+async fn test_is_git_repository(cx: &mut TestAppContext) {
+    let fs = FakeFs::new(cx.executor());
+
+    // A `.git` via `insert_tree` and one via `git_init` are both initialized
+    // repositories; a `.git` created directly with `create_dir` models an
+    // empty/leftover `.git` (the phantom-repository bug case) and is not one.
+    fs.insert_tree("/repo", json!({".git": {}, "file.txt": "content"}))
+        .await;
+    fs.create_dir(Path::new("/repo2")).await.unwrap();
+    fs.git_init(Path::new("/repo2"), "main".to_string())
+        .await
+        .unwrap();
+    fs.create_dir(Path::new("/phantom/.git")).await.unwrap();
+
+    for (git_dir, expected) in [
+        ("/repo/.git", true),
+        ("/repo2/.git", true),
+        ("/phantom/.git", false),
+    ] {
+        let git_dir = Path::new(git_dir);
+        assert_eq!(
+            fs.is_git_repository(git_dir, git_dir).await.unwrap(),
+            expected,
+            "is_git_repository({git_dir:?})"
+        );
+    }
+}

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -431,6 +431,248 @@ async fn test_copy_recursive_with_ignoring(executor: BackgroundExecutor) {
 }
 
 #[gpui::test]
+async fn test_realfs_is_git_repository(executor: BackgroundExecutor) {
+    // Exercises the production `Fs::is_git_repository` default impl against real
+    // on-disk `.git` layouts (FakeFs overrides it with an in-memory bit, so this is
+    // the only coverage of the actual HEAD/objects/refs parsing).
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    const VALID_HEAD: &str = "ref: refs/heads/main\n";
+    const DETACHED_HEAD: &str = "0123456789abcdef0123456789abcdef01234567\n";
+
+    let git_dir = |name: &str, head: Option<&str>, stores: &[&str]| {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(head) = head {
+            std::fs::write(dir.join("HEAD"), head).unwrap();
+        }
+        for store in stores {
+            std::fs::create_dir_all(dir.join(store)).unwrap();
+        }
+        dir
+    };
+
+    let cases: &[(&str, Option<&str>, &[&str], bool)] = &[
+        ("valid", Some(VALID_HEAD), &["objects", "refs"], true),
+        ("detached", Some(DETACHED_HEAD), &["objects", "refs"], true),
+        // What `git init --ref-format=reftable` creates: reftable *and* refs.
+        (
+            "reftable_with_refs",
+            Some(VALID_HEAD),
+            &["objects", "refs", "reftable"],
+            true,
+        ),
+        // Phantom shape git rejects (no refs); must not register as a repository.
+        (
+            "reftable_without_refs",
+            Some(VALID_HEAD),
+            &["objects", "reftable"],
+            false,
+        ),
+        ("empty", None, &[], false), // the phantom-repository bug
+        ("no_objects", Some(VALID_HEAD), &["refs"], false),
+        ("no_refs", Some(VALID_HEAD), &["objects"], false),
+        ("bad_head", Some("garbage\n"), &["objects", "refs"], false),
+    ];
+    for (name, head, stores, expected) in cases {
+        let dir = git_dir(name, *head, stores);
+        assert_eq!(
+            fs.is_git_repository(&dir, &dir).await.unwrap(),
+            *expected,
+            "is_git_repository({name})"
+        );
+    }
+
+    // Linked-worktree shape: HEAD is checked in the repository (per-worktree) dir, while
+    // objects/refs are checked in the shared common dir — exactly as git does.
+    let common_dir = git_dir("wt_common", None, &["objects", "refs"]);
+    let worktree_git_dir = git_dir("wt_repo", Some(VALID_HEAD), &[]);
+    assert!(
+        fs.is_git_repository(&worktree_git_dir, &common_dir)
+            .await
+            .unwrap()
+    );
+    // A leftover worktree admin dir whose own HEAD is gone is not a repository.
+    let worktree_without_head = git_dir("wt_repo_no_head", None, &[]);
+    assert!(
+        !fs.is_git_repository(&worktree_without_head, &common_dir)
+            .await
+            .unwrap()
+    );
+
+    // A symlink HEAD is validated by its link text without being followed (git's
+    // legacy symref form): `refs/…` is accepted even if the target is unborn, while a
+    // link to a non-`refs/` path is rejected regardless of what it points at.
+    #[cfg(unix)]
+    {
+        let symref = git_dir("symref", None, &["objects", "refs"]);
+        std::os::unix::fs::symlink("refs/heads/unborn", symref.join("HEAD")).unwrap();
+        assert!(fs.is_git_repository(&symref, &symref).await.unwrap());
+
+        let bad_symref = git_dir("bad_symref", None, &["objects", "refs"]);
+        std::fs::write(bad_symref.join("ORIG_HEAD"), DETACHED_HEAD).unwrap();
+        std::os::unix::fs::symlink("ORIG_HEAD", bad_symref.join("HEAD")).unwrap();
+        assert!(
+            !fs.is_git_repository(&bad_symref, &bad_symref)
+                .await
+                .unwrap()
+        );
+    }
+}
+
+#[gpui::test]
+async fn test_realfs_resolve_git_repository(executor: BackgroundExecutor) {
+    // The canonical resolver: turns a `.git` entry (directory or gitfile) into its
+    // validated `(repository_dir, common_dir)`, or `Ok(None)` when it is not a repo.
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    const VALID_HEAD: &str = "ref: refs/heads/main\n";
+
+    // A normal repository directory resolves to itself.
+    let repo = root.join("repo/.git");
+    std::fs::create_dir_all(repo.join("objects")).unwrap();
+    std::fs::create_dir_all(repo.join("refs")).unwrap();
+    std::fs::write(repo.join("HEAD"), VALID_HEAD).unwrap();
+    // A plain `.git` directory keeps its own (un-canonicalized) identity.
+    let resolved = resolve_git_repository(&repo, &fs).await.unwrap();
+    assert_eq!(resolved, Some((repo.clone(), repo.clone())));
+    let repo_canonical = std::fs::canonicalize(&repo).unwrap();
+
+    // A linked worktree: `.git` is a gitfile pointing at the per-worktree admin dir,
+    // whose `commondir` points back at the shared repository.
+    let worktree_admin = repo.join("worktrees/wt");
+    std::fs::create_dir_all(&worktree_admin).unwrap();
+    std::fs::write(worktree_admin.join("HEAD"), VALID_HEAD).unwrap();
+    std::fs::write(worktree_admin.join("commondir"), "../..\n").unwrap();
+    let worktree = root.join("wt");
+    std::fs::create_dir_all(&worktree).unwrap();
+    std::fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", worktree_admin.display()),
+    )
+    .unwrap();
+    let (repository_dir, common_dir) = resolve_git_repository(&worktree.join(".git"), &fs)
+        .await
+        .unwrap()
+        .expect("linked worktree resolves");
+    assert_eq!(
+        repository_dir,
+        std::fs::canonicalize(&worktree_admin).unwrap()
+    );
+    assert_eq!(common_dir, repo_canonical);
+
+    // A gitfile without the literal `gitdir: ` (git rejects a missing space), a gitfile
+    // pointing nowhere, a `commondir` pointing nowhere, and a leftover empty `.git` are
+    // all confirmed non-repositories (`Ok(None)`), not errors.
+    let none_cases: &[(&str, &str)] = &[
+        ("no_space", "gitdir:/nowhere\n"),
+        ("bad_target", "gitdir: /does/not/exist\n"),
+        ("garbage", "not a gitfile\n"),
+    ];
+    for (name, contents) in none_cases {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".git"), contents).unwrap();
+        assert_eq!(
+            resolve_git_repository(&dir.join(".git"), &fs)
+                .await
+                .unwrap(),
+            None,
+            "resolve({name})"
+        );
+    }
+    let empty = root.join("empty/.git");
+    std::fs::create_dir_all(&empty).unwrap();
+    assert_eq!(resolve_git_repository(&empty, &fs).await.unwrap(), None);
+
+    // A present-but-broken `commondir` (target missing) rejects the whole repository
+    // rather than silently falling back to the repository dir.
+    let broken = root.join("broken/.git");
+    std::fs::create_dir_all(broken.join("objects")).unwrap();
+    std::fs::create_dir_all(broken.join("refs")).unwrap();
+    std::fs::write(broken.join("HEAD"), VALID_HEAD).unwrap();
+    std::fs::write(broken.join("commondir"), "/does/not/exist\n").unwrap();
+    assert_eq!(resolve_git_repository(&broken, &fs).await.unwrap(), None);
+
+    // An absent `.git` is `Ok(None)`.
+    assert_eq!(
+        resolve_git_repository(&root.join("missing/.git"), &fs)
+            .await
+            .unwrap(),
+        None
+    );
+
+    // A dangling-symlink `.git` is confirmed non-repo (`Ok(None)`), not a transient
+    // read error: RealFs reports the symlink's own metadata when the target is gone,
+    // so the path is treated as a gitfile whose content load then hits absence.
+    #[cfg(unix)]
+    {
+        let dangling = root.join("dangling");
+        std::fs::create_dir_all(&dangling).unwrap();
+        std::os::unix::fs::symlink("/does/not/exist", dangling.join(".git")).unwrap();
+        assert_eq!(
+            resolve_git_repository(&dangling.join(".git"), &fs)
+                .await
+                .unwrap(),
+            None,
+            "dangling-symlink .git must resolve to Ok(None), not Err"
+        );
+    }
+
+    // A directory `HEAD` is confirmed-invalid (`Ok(None)`). A symlink HEAD to
+    // `refs/…` remains valid, guarding the is_symlink-before-is_dir branch order.
+    let dir_head = root.join("dir_head/.git");
+    std::fs::create_dir_all(dir_head.join("objects")).unwrap();
+    std::fs::create_dir_all(dir_head.join("refs")).unwrap();
+    std::fs::create_dir_all(dir_head.join("HEAD")).unwrap();
+    assert_eq!(
+        resolve_git_repository(&dir_head, &fs).await.unwrap(),
+        None,
+        "directory HEAD must resolve to Ok(None)"
+    );
+
+    #[cfg(unix)]
+    {
+        let symlink_head = root.join("symlink_head/.git");
+        std::fs::create_dir_all(symlink_head.join("objects")).unwrap();
+        std::fs::create_dir_all(symlink_head.join("refs")).unwrap();
+        // Target is a directory so metadata is both symlink and dir; validating by
+        // link text (not rejecting as directory HEAD) requires is_symlink before is_dir.
+        std::fs::create_dir_all(symlink_head.join("refs/heads/main")).unwrap();
+        std::os::unix::fs::symlink("refs/heads/main", symlink_head.join("HEAD")).unwrap();
+        let resolved = resolve_git_repository(&symlink_head, &fs)
+            .await
+            .unwrap()
+            .expect("symlink HEAD to refs/… remains valid");
+        assert_eq!(resolved, (symlink_head.clone(), symlink_head));
+    }
+}
+
+#[gpui::test]
+async fn test_fakefs_resolve_missing_gitfile_target_is_ok_none(executor: BackgroundExecutor) {
+    // FakeFs must classify absence with a real io::Error so it downcasts like RealFs.
+    let fake_fs = FakeFs::new(executor);
+    fake_fs
+        .insert_tree(
+            path!("/linked"),
+            json!({
+                ".git": "gitdir: /does/not/exist\n",
+                "file.txt": "content",
+            }),
+        )
+        .await;
+    let fake_result = resolve_git_repository(Path::new(path!("/linked/.git")), fake_fs.as_ref())
+        .await
+        .expect("FakeFs: missing gitfile target must not be Err");
+    assert_eq!(
+        fake_result, None,
+        "FakeFs: missing gitfile target must be Ok(None)"
+    );
+}
+
+#[gpui::test]
 async fn test_realfs_atomic_write(executor: BackgroundExecutor) {
     // With the file handle still open, the file should be replaced
     // https://github.com/zed-industries/zed/issues/30054

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -8,18 +8,21 @@ pub mod status;
 
 pub use crate::hosting_provider::*;
 pub use crate::remote::*;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use gpui::{Action, actions};
 pub use repository::RemoteCommandOutput;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::fmt::{self, Write as _};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 pub const DOT_GIT: &str = ".git";
 pub const GITIGNORE: &str = ".gitignore";
 pub const FSMONITOR_DAEMON: &str = "fsmonitor--daemon";
 pub const LFS_DIR: &str = "lfs";
+pub const HEAD: &str = "HEAD";
 pub const OBJECTS_DIR: &str = "objects";
 pub const REFS_DIR: &str = "refs";
 pub const REFTABLE_DIR: &str = "reftable";
@@ -36,6 +39,7 @@ pub const BISECT_LOG: &str = "BISECT_LOG";
 pub const GC_PID: &str = "gc.pid";
 pub const INFO_DIR: &str = "info";
 pub const REPO_EXCLUDE: &str = "info/exclude";
+pub const COMMONDIR: &str = "commondir";
 
 actions!(
     git,
@@ -162,6 +166,89 @@ const SHA256_BYTE_LENGTH: usize = 32;
 const SHA1_HEX_LENGTH: usize = SHA1_BYTE_LENGTH * 2;
 const SHA256_HEX_LENGTH: usize = SHA256_BYTE_LENGTH * 2;
 const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+/// Whether the raw contents of a regular `.git/HEAD` file denote a valid git head,
+/// mirroring git's `validate_headref` (setup.c) for the non-symlink case:
+///
+/// * a symbolic ref `ref:` (at byte zero, no leading whitespace) whose target —
+///   after skipping only space, tab, LF, CR (git's `sane isspace`) — begins with
+///   `refs/`. git does not validate the refname further, so neither do we; and
+/// * otherwise a detached object id, accepted when the contents begin with at
+///   least 40 ASCII hex digits. git parses "any supported algorithm, longest
+///   first" and never checks the trailing byte, so 40 hex (SHA-1), 64 hex
+///   (SHA-256), and any longer/junk-suffixed hex prefix all pass; this keeps
+///   git's forward compatibility with future, longer hashes. Fewer than 40 hex
+///   is rejected. `Oid::from_str` is deliberately not used here — it accepts
+///   abbreviated (<40) ids, which git's HEAD check does not.
+///
+/// An empty or leftover `.git` has no valid `HEAD`, so this returns `false`.
+/// Operates on bytes so a non-UTF-8 suffix after an otherwise-valid prefix (which
+/// git accepts) is not spuriously rejected. `HEAD`'s forms are documented in
+/// gitrepository-layout(5).
+pub fn regular_head_contents_are_valid(contents: &[u8]) -> bool {
+    if let Some(mut target) = contents.strip_prefix(b"ref:") {
+        while let [first, rest @ ..] = target
+            && matches!(*first, b' ' | b'\t' | b'\n' | b'\r')
+        {
+            target = rest;
+        }
+        return target.starts_with(b"refs/");
+    }
+    contents
+        .get(..SHA1_HEX_LENGTH)
+        .is_some_and(|prefix| prefix.iter().all(u8::is_ascii_hexdigit))
+}
+
+/// Whether a symlink `HEAD`'s raw link text denotes a valid git head. git's
+/// `validate_headref` inspects the symlink target *without following it* and
+/// accepts it iff the link text begins with `refs/` (an unborn or packed-only
+/// target is legal). Pass the raw `readlink` result; it is never resolved.
+pub fn head_symlink_target_is_valid(target: &OsStr) -> bool {
+    target.as_encoded_bytes().starts_with(b"refs/")
+}
+
+/// Parses a `.git` *gitfile* (the `.git` of a linked worktree or a separate
+/// git-dir checkout), returning the referenced git directory path. Mirrors git's
+/// `read_gitfile_gently`: the contents must begin with the literal `gitdir: `
+/// (including the single space); only trailing CR/LF is stripped, so any further
+/// spaces or tabs are part of the path. The returned path may be relative — the
+/// caller resolves it against the gitfile's parent. Non-UTF-8 paths are preserved
+/// on Unix. The gitfile and `commondir` files are documented in
+/// gitrepository-layout(5).
+pub fn parse_gitfile(contents: &[u8]) -> Result<PathBuf> {
+    let path = contents
+        .strip_prefix(b"gitdir: ")
+        .context("gitfile must begin with `gitdir: `")?;
+    let path = strip_trailing_crlf(path);
+    anyhow::ensure!(!path.is_empty(), "gitfile has an empty gitdir path");
+    Ok(bytes_to_path(path))
+}
+
+/// Parses a git `commondir` file, returning the referenced common directory path.
+/// Mirrors git's `get_common_dir_noenv`: a zero-byte file is invalid, but after
+/// stripping trailing CR/LF the remainder may be empty — git treats that as an empty
+/// relative path, which the caller resolves back to the repository directory. The
+/// returned path may be relative.
+pub fn parse_commondir(contents: &[u8]) -> Result<PathBuf> {
+    anyhow::ensure!(!contents.is_empty(), "commondir file is empty");
+    Ok(bytes_to_path(strip_trailing_crlf(contents)))
+}
+
+fn strip_trailing_crlf(mut bytes: &[u8]) -> &[u8] {
+    while let [rest @ .., last] = bytes
+        && matches!(*last, b'\n' | b'\r')
+    {
+        bytes = rest;
+    }
+    bytes
+}
+
+fn bytes_to_path(bytes: &[u8]) -> PathBuf {
+    // Unix: raw bytes; Windows: WTF-8. Lossy conversion is only reachable for
+    // genuinely malformed metadata, which resolution then rejects downstream.
+    <PathBuf as util::paths::PathExt>::try_from_bytes(bytes)
+        .unwrap_or_else(|_| PathBuf::from(String::from_utf8_lossy(bytes).into_owned()))
+}
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Oid {
@@ -358,6 +445,99 @@ impl From<Oid> for usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validates_head_contents() {
+        let valid = |head: &str| regular_head_contents_are_valid(head.as_bytes());
+
+        // Symbolic refs must point under `refs/`, mirroring git's `validate_headref`.
+        assert!(valid("ref: refs/heads/main\n"));
+        assert!(valid("ref: refs/heads/main")); // no trailing newline
+        assert!(valid("ref: refs/heads/feature/x\r\n")); // CRLF
+        assert!(valid("ref:refs/heads/main")); // no space after `ref:`
+        assert!(valid("ref:\trefs/heads/main")); // tab after `ref:`
+        assert!(valid("ref: refs/heads/.invalid")); // reftable stub HEAD (git creates this)
+        assert!(!valid("ref: HEAD")); // not under `refs/`
+        assert!(!valid("ref: ../evil")); // not under `refs/`
+        assert!(!valid("ref: ")); // empty target
+        assert!(!valid("ref:")); // empty target
+        // git skips only ASCII space/tab/LF/CR after `ref:`, not other whitespace.
+        assert!(!valid("ref:\x0brefs/heads/main")); // vertical tab
+        assert!(!valid("ref:\x0crefs/heads/main")); // form feed
+        assert!(!valid("ref:\u{a0}refs/heads/main")); // NBSP
+
+        // Detached HEADs are accepted when the contents begin with >= 40 hex.
+        let sha1 = "0123456789abcdef0123456789abcdef01234567";
+        let sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert_eq!(sha1.len(), SHA1_HEX_LENGTH);
+        assert_eq!(sha256.len(), SHA256_HEX_LENGTH);
+        assert!(valid(sha1));
+        assert!(valid(&format!("{sha1}\n")));
+        assert!(valid(sha256));
+        // git parses a >= 40-hex prefix and ignores the suffix (forward-hash rule).
+        assert!(valid(&format!("{sha1}garbage"))); // 40 hex + junk
+        assert!(valid(&"a".repeat(50))); // 41..63 hex
+        assert!(valid(&"a".repeat(65))); // > 64 hex
+        // A non-UTF-8 suffix after a valid 40-hex prefix is still accepted.
+        let mut bytes = sha1.as_bytes().to_vec();
+        bytes.push(0xff);
+        assert!(regular_head_contents_are_valid(&bytes));
+
+        // Junk / empty / truncated / non-hex is not a valid HEAD.
+        assert!(!valid(""));
+        assert!(!valid("   "));
+        assert!(!valid("garbage"));
+        assert!(!valid("0123456789abcdef")); // too short for any oid
+        assert!(!valid(&"a".repeat(39))); // 39 hex, one short of SHA-1
+        assert!(!valid(&"z".repeat(SHA1_HEX_LENGTH))); // right length, non-hex
+        assert!(!valid(&format!(" {sha1}"))); // leading whitespace
+    }
+
+    #[test]
+    fn validates_head_symlink_target() {
+        assert!(head_symlink_target_is_valid(OsStr::new("refs/heads/main")));
+        assert!(head_symlink_target_is_valid(OsStr::new(
+            "refs/heads/unborn"
+        ))); // target need not exist
+        assert!(!head_symlink_target_is_valid(OsStr::new("ORIG_HEAD")));
+        assert!(!head_symlink_target_is_valid(OsStr::new("HEAD.saved")));
+        assert!(!head_symlink_target_is_valid(OsStr::new(
+            "../refs/heads/main"
+        )));
+    }
+
+    #[test]
+    fn parses_gitfile_and_commondir() {
+        // Requires the literal `gitdir: ` prefix (with the space), like git.
+        assert_eq!(
+            parse_gitfile(b"gitdir: /repo/.git/worktrees/wt\n").unwrap(),
+            PathBuf::from("/repo/.git/worktrees/wt"),
+        );
+        assert_eq!(
+            parse_gitfile(b"gitdir: ../relative\r\n").unwrap(),
+            PathBuf::from("../relative"),
+        );
+        // Spaces beyond the required one are part of the path (git strips only CR/LF).
+        assert_eq!(
+            parse_gitfile(b"gitdir: /has spaces/x\n").unwrap(),
+            PathBuf::from("/has spaces/x"),
+        );
+        assert!(parse_gitfile(b"gitdir:/no-space").is_err()); // git rejects a missing space
+        assert!(parse_gitfile(b"gitdir: \n").is_err()); // empty path
+        assert!(parse_gitfile(b"not a gitfile").is_err());
+
+        assert_eq!(
+            parse_commondir(b"/repo/.git\n").unwrap(),
+            PathBuf::from("/repo/.git"),
+        );
+        assert_eq!(
+            parse_commondir(b"../..\r\n").unwrap(),
+            PathBuf::from("../..")
+        );
+        assert!(parse_commondir(b"").is_err()); // a zero-byte file is invalid
+        // git accepts newline-only content as an empty relative path (→ repository dir).
+        assert_eq!(parse_commondir(b"\n").unwrap(), PathBuf::new());
+    }
 
     #[test]
     fn parses_short_sha1_oid_by_padding_trailing_nibbles() {

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -5389,45 +5389,82 @@ mod tests {
         let commits = generate_random_commit_dag(&mut rng, 10, false);
         fs.set_graph_commits(Path::new("/project/.git"), commits.clone());
 
-        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        // Build the project WITHOUT a worktree so no repository exists yet, then
+        // install the git-store subscription BEFORE the initial scan. With the
+        // in-memory `is_git_repository` fast path the whole initial scan can otherwise
+        // complete inside `Project::test`, so a subscription installed afterwards would
+        // miss the initial `RepositoryAdded`/`HeadChanged`.
+        let project = Project::test(fs.clone(), [] as [&Path; 0], cx).await;
+
         let observed_repository_events = Arc::new(Mutex::new(Vec::new()));
         project.update(cx, |project, cx| {
             let observed_repository_events = observed_repository_events.clone();
-            cx.subscribe(project.git_store(), move |_, _, event, _| {
-                if let GitStoreEvent::RepositoryUpdated(_, repository_event, true) = event {
-                    observed_repository_events
-                        .lock()
-                        .expect("repository event mutex should be available")
-                        .push(repository_event.clone());
-                }
-            })
+            cx.subscribe(
+                project.git_store(),
+                move |_, git_store, event, cx| match event {
+                    // `RepositoryAdded` is emitted synchronously the moment the repository
+                    // is first registered, at `scan_id == 0`, BEFORE the git worker runs
+                    // `compute_snapshot`. Kicking off the graph-data load here is the only
+                    // deterministic way to guarantee the initial graph data exists before
+                    // the initial scan's `HeadChanged` (which fires at `scan_id == 1`),
+                    // independent of how fast the repository-validity check is.
+                    GitStoreEvent::RepositoryAdded => {
+                        if let Some(repo) =
+                            git_store.read(cx).repositories().values().next().cloned()
+                        {
+                            repo.update(cx, |repo, cx| {
+                                repo.graph_data(
+                                    LogSource::default(),
+                                    LogOrder::default(),
+                                    0..usize::MAX,
+                                    cx,
+                                );
+                            });
+                        }
+                    }
+                    GitStoreEvent::RepositoryUpdated(_, repository_event, true) => {
+                        observed_repository_events
+                            .lock()
+                            .expect("repository event mutex should be available")
+                            .push(repository_event.clone());
+                    }
+                    _ => {}
+                },
+            )
             .detach();
         });
+
+        // Registering the worktree triggers the initial repository scan.
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(Path::new("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        // The initial scan must actually have emitted `HeadChanged` (scan_id -> 1);
+        // otherwise the guard this test protects was never exercised.
+        {
+            let observed_repository_events = observed_repository_events
+                .lock()
+                .expect("repository event mutex should be available");
+            assert!(
+                observed_repository_events
+                    .iter()
+                    .any(|event| matches!(event, RepositoryEvent::HeadChanged)),
+                "initial repository scan should emit HeadChanged"
+            );
+        }
 
         let repository = project.read_with(cx, |project, cx| {
             project
                 .active_repository(cx)
                 .expect("should have a repository")
         });
-
-        repository.update(cx, |repo, cx| {
-            repo.graph_data(LogSource::default(), LogOrder::default(), 0..usize::MAX, cx);
-        });
-
-        project
-            .update(cx, |project, cx| project.git_scans_complete(cx))
-            .await;
-        cx.run_until_parked();
-
-        let observed_repository_events = observed_repository_events
-            .lock()
-            .expect("repository event mutex should be available");
-        assert!(
-            observed_repository_events
-                .iter()
-                .any(|event| matches!(event, RepositoryEvent::HeadChanged)),
-            "initial repository scan should emit HeadChanged"
-        );
         let commit_count_after = repository.read_with(cx, |repo, _| {
             repo.get_graph_data(LogSource::default(), LogOrder::default())
                 .map(|data| data.commit_data.len())

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -13358,16 +13358,21 @@ async fn test_project_group_keys_match_for_bare_repo_linked_worktrees(
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
                     "HEAD": "ref: refs/heads/main\n",
+                    "objects": {},
+                    "refs": {},
                     "worktrees": {
                         "main": {
+                            "HEAD": "ref: refs/heads/main\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/main/.git",
                         },
                         "feature-a": {
+                            "HEAD": "ref: refs/heads/feature-a\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/feature-a/.git",
                         },
                         "feature-b": {
+                            "HEAD": "ref: refs/heads/feature-b\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/feature-b/.git",
                         },
@@ -14627,16 +14632,20 @@ async fn test_git_worktrees_and_submodules(cx: &mut gpui::TestAppContext) {
                 "worktrees": {
                     "some-worktree": {
                         "commondir": "../..\n",
-                        // For is_git_dir
-                        "HEAD": "",
+                        // A linked worktree's object/ref stores live in the common dir
+                        // (this `.git`); only HEAD is per-worktree.
+                        "HEAD": "ref: refs/heads/some-worktree\n",
                         "config": ""
                     }
                 },
                 "modules": {
                     "subdir": {
+                        // A submodule's git dir is a full repository: valid HEAD plus its
+                        // own object/ref stores.
                         "some-submodule": {
-                            // For is_git_dir
-                            "HEAD": "",
+                            "HEAD": "ref: refs/heads/main\n",
+                            "objects": {},
+                            "refs": {},
                             "config": "",
                         }
                     }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3069,6 +3069,16 @@ impl LocalSnapshot {
         let mut new_ignores = Vec::new();
         let mut repo_excludes = Vec::new();
         let mut repo_root = None;
+        // Deepest registered work dir covering this path — already validated at
+        // registration, so `reload_entries_for_paths` can skip a full resolve on the
+        // hot path (thousands of event paths per checkout). Invalid `.git` never
+        // enters `git_repositories`, so a phantom cannot win as a registered root.
+        let covering_registered = self
+            .git_repositories
+            .values()
+            .filter(|repo| abs_path.starts_with(repo.work_directory_abs_path.as_ref()))
+            .max_by_key(|repo| repo.work_directory_abs_path.as_os_str().len())
+            .map(|repo| repo.work_directory_abs_path.clone());
         for (index, ancestor) in abs_path.ancestors().enumerate() {
             if index > 0 {
                 if let Some((ignore, _)) = self.ignores_by_parent_abs_path.get(ancestor) {
@@ -3085,11 +3095,29 @@ impl LocalSnapshot {
                 repo_excludes.push(repo_exclude.clone());
             }
 
-            if repo_root.is_none() {
-                let metadata = fs.metadata(&ancestor.join(DOT_GIT)).await.ok().flatten();
-                if metadata.is_some() {
-                    repo_root = Some(Arc::from(ancestor));
-                }
+            // Anchor the ignore root at a *validated* repository, so an invalid nested
+            // `.git` cannot shadow the real parent's excludes/ignore rooting.
+            if repo_root.is_some() {
+                continue;
+            }
+
+            // Covering registered root: free, no filesystem.
+            if covering_registered
+                .as_ref()
+                .is_some_and(|root| root.as_ref() == ancestor)
+            {
+                repo_root = covering_registered.clone();
+                continue;
+            }
+
+            // Deeper than the covering registration, or nothing registered yet: resolve.
+            // `reload_entries_for_paths` runs before `update_git_repositories`, so a
+            // newly-appeared nested repo may not be registered yet and must still win.
+            if discover_valid_git_repository(&ancestor.join(DOT_GIT), fs)
+                .await
+                .is_some()
+            {
+                repo_root = Some(Arc::from(ancestor));
             }
         }
 
@@ -3548,13 +3576,15 @@ impl BackgroundScannerState {
         .log_err();
     }
 
+    /// Registers a validated git repository for `work_directory`, returning whether a
+    /// repository was inserted (`Ok(false)` when the `.git` entry is not a repository).
     async fn insert_git_repository_for_path(
         &mut self,
         work_directory: WorkDirectory,
         dot_git_abs_path: Arc<Path>,
         fs: &dyn Fs,
         watcher: &dyn Watcher,
-    ) -> Result<LocalRepositoryEntry> {
+    ) -> Result<bool> {
         let work_dir_entry = self
             .snapshot
             .entry_for_path(&work_directory.path_key().0)
@@ -3569,8 +3599,13 @@ impl BackgroundScannerState {
             })?;
         let work_directory_abs_path = self.snapshot.work_directory_abs_path(&work_directory);
 
-        let (repository_dir_abs_path, common_dir_abs_path) =
-            discover_git_paths(&dot_git_abs_path, fs).await;
+        // Bail before setting up any watches if the `.git` entry isn't a real repository.
+        let Some((repository_dir_abs_path, common_dir_abs_path)) =
+            discover_valid_git_repository(&dot_git_abs_path, fs).await
+        else {
+            return Ok(false);
+        };
+
         watcher
             .add(&common_dir_abs_path)
             .context("failed to add common directory to watcher")
@@ -3604,22 +3639,21 @@ impl BackgroundScannerState {
             .get(&work_directory_id)
             .map_or(0, |existing_repository| existing_repository.git_dir_scan_id);
 
-        let local_repository = LocalRepositoryEntry {
+        self.snapshot.git_repositories.insert(
             work_directory_id,
-            work_directory,
-            work_directory_abs_path: work_directory_abs_path.as_path().into(),
-            git_dir_scan_id,
-            dot_git_abs_path,
-            common_dir_abs_path,
-            repository_dir_abs_path,
-        };
-
-        self.snapshot
-            .git_repositories
-            .insert(work_directory_id, local_repository.clone());
+            LocalRepositoryEntry {
+                work_directory_id,
+                work_directory,
+                work_directory_abs_path: work_directory_abs_path.as_path().into(),
+                git_dir_scan_id,
+                dot_git_abs_path,
+                common_dir_abs_path,
+                repository_dir_abs_path,
+            },
+        );
 
         log::trace!("inserting new local git repository");
-        Ok(local_repository)
+        Ok(true)
     }
 }
 
@@ -4369,7 +4403,8 @@ impl BackgroundScanner {
             && self.track_git_repositories
         {
             maybe!(async {
-                self.state
+                let inserted = self
+                    .state
                     .lock()
                     .await
                     .insert_git_repository_for_path(
@@ -4379,8 +4414,10 @@ impl BackgroundScanner {
                         self.watcher.as_ref(),
                     )
                     .await
+                    // Bail on both an error and an invalid `.git` (`Ok(false)`), so a
+                    // non-repository is never reported as the containing repo.
                     .log_err()?;
-                Some(ancestor_dot_git)
+                inserted.then_some(ancestor_dot_git)
             })
             .await
         } else {
@@ -5320,6 +5357,9 @@ impl BackgroundScanner {
 
         if let Some(path) = child_paths.first()
             && path.ends_with(DOT_GIT)
+            && discover_valid_git_repository(path, self.fs.as_ref())
+                .await
+                .is_some()
         {
             ignore_stack.repo_root = Some(job.abs_path.clone());
         }
@@ -5945,8 +5985,11 @@ impl BackgroundScanner {
             return;
         };
 
-        if let Ok(Some(metadata)) = self.fs.metadata(&job.abs_path.join(DOT_GIT)).await
-            && metadata.is_dir
+        // Anchor the ignore root at a *validated* repository (a `.git` directory or a
+        // linked-worktree gitfile), so an invalid/leftover `.git` doesn't shadow it.
+        if discover_valid_git_repository(&job.abs_path.join(DOT_GIT), self.fs.as_ref())
+            .await
+            .is_some()
         {
             ignore_stack.repo_root = Some(job.abs_path.clone());
         }
@@ -6209,7 +6252,13 @@ async fn discover_ancestor_git_repo(
                 ancestor_dot_git.clone()
             };
             let dot_git_abs_path: Arc<Path> = dot_git_abs_path.as_path().into();
-            let (_, common_dir_abs_path) = discover_git_paths(&dot_git_abs_path, fs.as_ref()).await;
+
+            // Keep walking up past an invalid `.git`.
+            let Some((_, common_dir_abs_path)) =
+                discover_valid_git_repository(&dot_git_abs_path, fs.as_ref()).await
+            else {
+                continue;
+            };
 
             let repo_exclude_abs_path = common_dir_abs_path.join(REPO_EXCLUDE);
             if let Ok(repo_exclude) =
@@ -7001,33 +7050,6 @@ impl CreatedEntry {
     }
 }
 
-fn parse_gitfile(content: &str) -> anyhow::Result<&Path> {
-    let path = content
-        .strip_prefix("gitdir:")
-        .with_context(|| format!("parsing gitfile content {content:?}"))?;
-    Ok(Path::new(path.trim()))
-}
-
-fn resolve_gitfile_path(dot_git_abs_path: &Path, gitfile_path: &Path) -> PathBuf {
-    if gitfile_path.is_absolute() {
-        gitfile_path.into()
-    } else {
-        dot_git_abs_path
-            .parent()
-            .unwrap_or_else(|| Path::new(""))
-            .join(gitfile_path)
-    }
-}
-
-fn resolve_commondir_path(repository_dir_abs_path: &Path, commondir_path: &str) -> PathBuf {
-    let commondir_path = Path::new(commondir_path.trim());
-    if commondir_path.is_absolute() {
-        commondir_path.into()
-    } else {
-        repository_dir_abs_path.join(commondir_path)
-    }
-}
-
 pub async fn discover_root_repo_common_dir(root_abs_path: &Path, fs: &dyn Fs) -> Option<Arc<Path>> {
     discover_root_repo_metadata(root_abs_path, fs)
         .await
@@ -7038,43 +7060,27 @@ async fn discover_root_repo_metadata(
     root_abs_path: &Path,
     fs: &dyn Fs,
 ) -> Option<(Arc<Path>, bool)> {
-    let root_dot_git = root_abs_path.join(DOT_GIT);
-    if !fs.metadata(&root_dot_git).await.is_ok_and(|m| m.is_some()) {
-        return None;
-    }
-    let dot_git_path: Arc<Path> = root_dot_git.into();
-    let (repository_dir, common_dir) = discover_git_paths(&dot_git_path, fs).await;
+    let (repository_dir, common_dir) =
+        discover_valid_git_repository(&root_abs_path.join(DOT_GIT), fs).await?;
     let is_linked_worktree = repository_dir != common_dir;
     Some((common_dir, is_linked_worktree))
 }
 
-async fn discover_git_paths(dot_git_abs_path: &Arc<Path>, fs: &dyn Fs) -> (Arc<Path>, Arc<Path>) {
-    let mut repository_dir_abs_path = dot_git_abs_path.clone();
-    let mut common_dir_abs_path = dot_git_abs_path.clone();
-
-    if let Some(path) = fs
-        .load(dot_git_abs_path)
-        .await
-        .ok()
-        .as_ref()
-        .and_then(|contents| parse_gitfile(contents).log_err())
-    {
-        let path = resolve_gitfile_path(dot_git_abs_path, path);
-        if let Some(path) = fs.canonicalize(&path).await.log_err() {
-            repository_dir_abs_path = Path::new(&path).into();
-            common_dir_abs_path = repository_dir_abs_path.clone();
-
-            if let Some(commondir_contents) = fs.load(&path.join("commondir")).await.ok()
-                && let Some(commondir_path) = fs
-                    .canonicalize(&resolve_commondir_path(&path, &commondir_contents))
-                    .await
-                    .log_err()
-            {
-                common_dir_abs_path = commondir_path.as_path().into();
-            }
+/// Adapts [`fs::resolve_git_repository`] to the `Arc<Path>` identities discovery stores.
+/// A transient I/O error is collapsed to `None` here (a later rescan retries) — discovery
+/// either registers a repository or moves on, it holds no registration to preserve.
+async fn discover_valid_git_repository(
+    dot_git_abs_path: &Path,
+    fs: &dyn Fs,
+) -> Option<(Arc<Path>, Arc<Path>)> {
+    match fs::resolve_git_repository(dot_git_abs_path, fs).await {
+        Ok(Some((repository_dir, common_dir))) => Some((repository_dir.into(), common_dir.into())),
+        Ok(None) => None,
+        Err(error) => {
+            log::debug!("failed to resolve git repository at {dot_git_abs_path:?}: {error:#}");
+            None
         }
-    };
-    (repository_dir_abs_path, common_dir_abs_path)
+    }
 }
 
 struct NullWatcher;

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -3617,6 +3617,107 @@ async fn test_repository_above_root(executor: BackgroundExecutor, cx: &mut TestA
 }
 
 #[gpui::test]
+async fn test_invalid_nested_git_dir_is_not_registered_as_repository(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "nested": {
+                "file.txt": "content",
+            },
+        }),
+    )
+    .await;
+    // A leftover, empty `.git` directory (no HEAD/objects/refs) is not a real
+    // repository: git ignores it and walks up to the parent, and so must we. If it
+    // were registered, it would shadow the parent repo for `nested/`'s files and
+    // load an empty diff base, rendering them as wholly added.
+    fs.create_dir(Path::new(path!("/root/nested/.git")))
+        .await
+        .unwrap();
+
+    let worktree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    let repos = worktree.update(cx, |worktree, _| {
+        worktree.as_local().unwrap().repositories()
+    });
+    pretty_assertions::assert_eq!(repos, [Path::new(path!("/root")).into()]);
+}
+
+#[gpui::test]
+async fn test_gitfile_pointing_at_non_repository_is_not_registered(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "nested": {
+                // A `.git` *file* (gitfile) pointing at a directory that isn't a git
+                // repository — the same phantom-shadowing bug as an empty `.git`
+                // directory, but reached via gitfile indirection. Real git rejects it,
+                // so `nested/`'s files belong to the `/root` repo.
+                ".git": "gitdir: /root/phantom_gitdir\n",
+                "file.txt": "content",
+            },
+            // The gitfile's target exists but is not a valid repository (no
+            // HEAD/objects/refs), so it must not register `nested` as its own repo.
+            "phantom_gitdir": {},
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    let repos = worktree.update(cx, |worktree, _| {
+        worktree.as_local().unwrap().repositories()
+    });
+    pretty_assertions::assert_eq!(repos, [Path::new(path!("/root")).into()]);
+}
+
+#[gpui::test]
 async fn test_global_gitignore(executor: BackgroundExecutor, cx: &mut TestAppContext) {
     init_test(cx);
 
@@ -3745,11 +3846,17 @@ async fn test_repo_exclude_in_worktree(executor: BackgroundExecutor, cx: &mut Te
         path!("/repo"),
         json!({
             ".git": {
+                "HEAD": "ref: refs/heads/main\n",
+                "objects": {},
+                "refs": {},
                 "info": {
                     "exclude": ".env.*"
                 },
                 "worktrees": {
                     "my-worktree": {
+                        // A real linked worktree has its own per-worktree HEAD; the
+                        // shared object/ref stores live in the common dir (`../..`).
+                        "HEAD": "ref: refs/heads/main\n",
                         "commondir": "../.."
                     }
                 }


### PR DESCRIPTION
# Objective

An empty or leftover `.git` directory (no HEAD/objects/refs), or a `.git` gitfile pointing at
a non-repository, is registered as a phantom git repository. Nested inside a real checkout it
shadows the real parent for its files ("deepest work-dir wins") and loads an empty diff base,
so those files render as wholly added and the uncommitted-diff counts are inflated.

## Solution

Repository discovery previously answered "is this `.git` a repository?" from mere presence.
This introduces one validated resolver and routes worktree discovery through it:

- Pure git grammar in the `git` crate: gitfile/commondir parsing and `HEAD` validation
  following git's `read_gitfile_gently` and `validate_headref` (symbolic `ref: refs/...`,
  detached >=40-hex prefix, and a symlink `HEAD` validated by its link text without following
  it).
- `fs::resolve_git_repository` resolves a `.git` directory or gitfile to its
  `(repository_dir, common_dir)` and checks what git's `is_git_directory` checks — a valid
  `HEAD` plus the `objects` and `refs` stores. Its `Result<Option<_>>` distinguishes a
  confirmed non-repository from an indeterminate I/O failure.
- Worktree discovery bails before registering (and before adding watches) when the `.git`
  entry is not a repository, anchors ignore/exclude rooting only at validated repositories,
  and keeps walking up past an invalid `.git` when locating an ancestor repository. A
  repository that becomes invalid *after* registration is deliberately out of scope here
  (behavior unchanged from main); a follow-up PR revalidates registrations on fs events.
- `FakeFs` models validity in memory: `insert_tree` and `git_init` initialize git state for
  `.git` directories, while a bare `create_dir` deliberately does not, so tests can model a
  phantom `.git`.

## Testing

- New grammar unit tests (`git`), resolver tests (`fs`), and worktree tests covering: a
  phantom nested `.git` dir / gitfile is not registered and does not shadow the parent.
- A few editor hover-link tests insert a file and immediately hover; they now park the
  executor in between. Resolution adds await points to the scanner's event path, which
  shifted the deterministic test interleaving and exposed the missing synchronization
  (the hover lookup is one-shot and raced the scan; the worktree state itself is correct).
- The resolver and grammar code is ported unchanged from #61156, where its behavior was
  compared against git 2.54 across layouts (empty `.git`, broken gitfiles, missing
  `objects`/`refs`, symlink HEADs, linked worktrees, submodules, bare/reftable); the unit
  tests encode what that comparison established.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed an empty or invalid nested `.git` directory shadowing the real repository, which showed incorrect uncommitted-diff counts and rendered files as wholly added.

