### PR TITLE
lsp: Kill language server process trees on shutdown

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -19,7 +19,7 @@ use postage::{barrier, prelude::Stream};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json, value::RawValue};
-use util::command::{Child, Stdio};
+use util::process::Child;
 
 use gpui_util::{ResultExt, TryFutureExt};
 use std::path::Path;
@@ -32,6 +32,7 @@ use std::{
     ops::DerefMut,
     path::PathBuf,
     pin::Pin,
+    process::Stdio,
     sync::{
         Arc, Weak,
         atomic::{AtomicI32, Ordering::SeqCst},
@@ -450,19 +451,16 @@ impl LanguageServer {
             working_dir,
             binary.arguments
         );
-        let mut command = util::command::new_command(&binary.path);
+        let mut command = util::command::new_std_command(&binary.path);
         command
             .current_dir(working_dir)
             .args(&binary.arguments)
-            .envs(binary.env.clone().unwrap_or_default())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
+            .envs(binary.env.clone().unwrap_or_default());
 
-        let mut server = command
-            .spawn()
-            .with_context(|| format!("failed to spawn command {command:?}",))?;
+        // Spawn through `util::process`, which puts the server in its own
+        // process group on Unix and a job object on Windows, so that anything
+        // the server spawns is torn down with it instead of being orphaned.
+        let mut server = Child::spawn(command, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
 
         let stdin = server.stdin.take().unwrap();
         let stdout = server.stdout.take().unwrap();
@@ -1159,7 +1157,10 @@ impl LanguageServer {
             Self::notify_internal::<notification::Exit>(&notification_serializers, ()).ok();
             notification_serializers.close();
             output_done.recv().await;
-            server.lock().take().map(|mut child| child.kill());
+            server
+                .lock()
+                .take()
+                .map(|mut child| child.kill().log_err());
             drop(tasks);
             log::debug!("language server shutdown finished");
             Some(())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -19,7 +19,7 @@ use postage::{barrier, prelude::Stream};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json, value::RawValue};
-use util::command::{Child, Stdio};
+use util::process::Child;
 
 use gpui_util::{ResultExt, TryFutureExt};
 use std::path::Path;
@@ -32,6 +32,7 @@ use std::{
     ops::DerefMut,
     path::PathBuf,
     pin::Pin,
+    process::Stdio,
     sync::{
         Arc, Weak,
         atomic::{AtomicI32, Ordering::SeqCst},
@@ -434,19 +435,16 @@ impl LanguageServer {
             working_dir,
             &binary.arguments
         );
-        let mut command = util::command::new_command(&binary.path);
+        let mut command = util::command::new_std_command(&binary.path);
         command
             .current_dir(working_dir)
             .args(&binary.arguments)
-            .envs(binary.env.clone().unwrap_or_default())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
+            .envs(binary.env.clone().unwrap_or_default());
 
-        let mut server = command
-            .spawn()
-            .with_context(|| format!("failed to spawn command {command:?}",))?;
+        // Spawn through `util::process`, which puts the server in its own
+        // process group on Unix and a job object on Windows, so that anything
+        // the server spawns is torn down with it instead of being orphaned.
+        let mut server = Child::spawn(command, Stdio::piped(), Stdio::piped(), Stdio::piped())?;
 
         let stdin = server.stdin.take().unwrap();
         let stdout = server.stdout.take().unwrap();
@@ -1143,7 +1141,10 @@ impl LanguageServer {
             Self::notify_internal::<notification::Exit>(&notification_serializers, ()).ok();
             notification_serializers.close();
             output_done.recv().await;
-            server.lock().take().map(|mut child| child.kill());
+            server
+                .lock()
+                .take()
+                .map(|mut child| child.kill().log_err());
             drop(tasks);
             log::debug!("language server shutdown finished");
             Some(())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1157,10 +1157,7 @@ impl LanguageServer {
             Self::notify_internal::<notification::Exit>(&notification_serializers, ()).ok();
             notification_serializers.close();
             output_done.recv().await;
-            server
-                .lock()
-                .take()
-                .map(|mut child| child.kill().log_err());
+            server.lock().take().map(|mut child| child.kill().log_err());
             drop(tasks);
             log::debug!("language server shutdown finished");
             Some(())

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1141,10 +1141,7 @@ impl LanguageServer {
             Self::notify_internal::<notification::Exit>(&notification_serializers, ()).ok();
             notification_serializers.close();
             output_done.recv().await;
-            server
-                .lock()
-                .take()
-                .map(|mut child| child.kill().log_err());
+            server.lock().take().map(|mut child| child.kill().log_err());
             drop(tasks);
             log::debug!("language server shutdown finished");
             Some(())

--- a/crates/util/src/process.rs
+++ b/crates/util/src/process.rs
@@ -5,14 +5,49 @@ use std::process::Stdio;
 /// are killed when the process is terminated: on Unix by using process
 /// groups, and on Windows by using job objects.
 ///
-/// On Windows, dropping this struct closes the job object handle, which
-/// terminates all processes in the job. This also applies when the Zed
-/// process exits for any reason (including crashes), since the OS closes
-/// its handles, so spawned process trees can never outlive Zed.
+/// Dropping this struct terminates the whole process tree on both platforms:
+/// on Unix by signalling the child's process group, and on Windows by closing
+/// the job object handle, which terminates all processes in the job.
+///
+/// On Windows that also applies when the Zed process exits for any reason
+/// (including crashes), since the OS closes its handles, so spawned process
+/// trees can never outlive Zed. Unix has no equivalent guarantee: a Zed
+/// process that is killed outright never runs `Drop`, so its children's
+/// process groups survive.
 pub struct Child {
+    /// Held for its `Drop`, never read.
+    ///
+    /// Declared before `process` deliberately: fields drop in declaration
+    /// order, and dropping `process` synchronously reaps the child if it has
+    /// already exited, which releases its pid. Signalling the group first
+    /// means the pid we pass to `killpg` is still held by `process`.
+    #[cfg(not(windows))]
+    _process_group: ProcessGroup,
     process: smol::process::Child,
     #[cfg(windows)]
     job: Option<windows_job::JobObject>,
+}
+
+/// Kills a child's process group when dropped, so descendants the child
+/// spawned do not outlive it.
+///
+/// This mirrors what the job object does on Windows. It is a separate guard
+/// rather than a `Drop` impl on [`Child`] so that [`Child::output`] can still
+/// move `process` out of `self`, which a `Drop` impl would forbid.
+#[cfg(not(windows))]
+struct ProcessGroup(u32);
+
+#[cfg(not(windows))]
+impl Drop for ProcessGroup {
+    fn drop(&mut self) {
+        // SAFETY: `killpg` takes no pointers and cannot fail in a way we can
+        // act on. `Child::spawn` puts the child in its own session, and
+        // therefore its own process group, so the group id is the child's pid
+        // and this can never signal Zed's own process group.
+        unsafe {
+            libc::killpg(self.0 as i32, libc::SIGKILL);
+        }
+    }
 }
 
 impl std::ops::Deref for Child {
@@ -50,7 +85,11 @@ impl Child {
                     crate::redact::redact_command(&format!("{command:?}"))
                 )
             })?;
-        Ok(Self { process })
+        let _process_group = ProcessGroup(process.id());
+        Ok(Self {
+            process,
+            _process_group,
+        })
     }
 
     #[cfg(windows)]
@@ -105,9 +144,11 @@ impl Child {
     /// exit, then returns the collected output.
     pub async fn output(self) -> Result<std::process::Output> {
         // NOTE: Keep `self` alive across this await, do not destructure it to
-        // pull `process` out first. On Windows that drops the job object early,
-        // which triggers `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and kills the
-        // child before `output()` finishes collecting its stdout/stderr.
+        // pull `process` out first. That drops the teardown guard early and
+        // kills the child before `output()` finishes collecting its
+        // stdout/stderr: on Windows by triggering
+        // `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, and on Unix by signalling the
+        // child's process group.
         Ok(self.process.output().await?)
     }
 
@@ -198,6 +239,92 @@ mod windows_job {
                 CloseHandle(self.0).log_err();
             }
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    /// Spawns a process tree `sh -> sleep` via `Child::spawn` and returns the
+    /// `Child` along with the pid of the grandchild (`sleep`).
+    fn spawn_process_tree(temp_dir: &std::path::Path) -> (Child, u32) {
+        let pid_file = temp_dir.join("grandchild_pid");
+        let mut command = std::process::Command::new("/bin/sh");
+        command.arg("-c").arg(format!(
+            "sleep 60 & echo $! > '{}'; wait",
+            pid_file.display()
+        ));
+        let child = Child::spawn(command, Stdio::null(), Stdio::null(), Stdio::null())
+            .expect("failed to spawn sh");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let grandchild_pid = loop {
+            if let Ok(contents) = std::fs::read_to_string(&pid_file)
+                && let Ok(pid) = contents.trim().parse::<u32>()
+            {
+                break pid;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for grandchild pid file"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        };
+        assert!(
+            process_is_alive(grandchild_pid),
+            "grandchild should be alive after spawning"
+        );
+        (child, grandchild_pid)
+    }
+
+    /// Signal 0 performs error checking without sending a signal. Only
+    /// `ESRCH` means the process is gone: `EPERM` means it is still there and
+    /// merely not ours to signal, so treating any error as "exited" would let
+    /// these tests pass without the process group being torn down.
+    fn process_is_alive(pid: u32) -> bool {
+        // SAFETY: `kill` with signal 0 takes no pointers and only probes
+        // whether the pid exists.
+        let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        result != -1 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    fn assert_process_exits(pid: u32, message: &str) {
+        // The grandchild is reparented to init once its parent dies, so this
+        // waits on init reaping it. Matches `wait_until_gone` in
+        // `crate::command::darwin`.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while process_is_alive(pid) {
+            assert!(Instant::now() < deadline, "{message} (pid {pid})");
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    #[test]
+    fn test_kill_terminates_grandchildren() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (mut child, grandchild_pid) = spawn_process_tree(temp_dir.path());
+
+        child.kill().expect("failed to kill child");
+
+        assert_process_exits(
+            grandchild_pid,
+            "grandchild should be terminated after killing the child",
+        );
+    }
+
+    #[test]
+    fn test_drop_terminates_grandchildren() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (child, grandchild_pid) = spawn_process_tree(temp_dir.path());
+
+        drop(child);
+
+        assert_process_exits(
+            grandchild_pid,
+            "grandchild should be terminated after dropping the child",
+        );
     }
 }
 


### PR DESCRIPTION
# Objective

Language servers leave their child processes running after Zed exits. People
in #43864 report `node`, `tsgo`, `tsgolint`, `java`, and `lua-language-server`
still running and eating CPU and RAM hours later.

Worth separating this from the `<defunct>` zombie problem that #59156 already
fixed. Those were dead entries sitting in the process table waiting to be
reaped. These processes are alive and doing work with no parent left.

`crates/lsp` spawns language servers through `util::command::Child`. That is
`smol::process::Child` on Linux and Windows, and a `posix_spawn` wrapper on
macOS. Killing it kills the language server and nothing else, so whatever the
server spawned gets reparented to PID 1 and keeps running.

Zed already has the wrapper that handles this. `util::process::Child` puts
children in their own process group on Unix and a job object on Windows, and
#45902 moved the ACP and agent servers onto it. The LSP path never got moved.

## Solution

Two changes.

First, `util::process::Child` gets a Unix teardown guard, so dropping it kills
the child's process group the way the Windows job object already does on drop.
I made it a separate `ProcessGroup` guard field instead of a `Drop` impl on
`Child`, because a `Drop` impl stops `Child::output` from moving `process` out
of `self` (E0509).

Second, `crates/lsp` spawns through `util::process::Child`.

On touching a shared type: in #48749 reflectronic wrote that the way forward
was to "re-design `Child` so that it kills the process tree when it is
dropped", and that it "would be useful to add to other places around Zed".
That is what the first change does, for the Unix half that was missing.

I checked the drop change against every existing user of
`util::process::Child`. All of them already kill in their own `Drop`:
`agent_servers/src/acp.rs`, `context_server/src/transport/stdio_transport.rs`,
both impls in `dap/src/transport.rs`, and
`repl/src/kernels/native_kernel.rs`. The fifth is
`terminal/src/terminal.rs`, where `SubprocessHandle` is documented as
"Dropping this kills the child". That was true on Windows and false on Unix.
Now it is true on both.

This covers macOS, Linux, and Windows.

### Tradeoffs

Moving off `util::command::darwin` means macOS language servers lose
`posix_spawnattr_setexceptionports_np(EXC_MASK_ALL, MACH_PORT_NULL)` and
`POSIX_SPAWN_CLOEXEC_DEFAULT`. So a crashing language server's Mach exception
can reach Zed's crash handler, and children can inherit non-CLOEXEC fds.
`agent_servers`, `dap`, `context_server`, `repl`, and `terminal` all already
spawn this way on macOS, so it is not new exposure, but it is a real change
for LSPs specifically.

There is a third macOS difference I want to flag rather than bury.
`darwin.rs` resolves a bare program name itself, with `which_in` against the
`PATH` in the command's own env and the child's working directory, because
`posix_spawnp` would otherwise resolve against the parent's.
`std::process::Command` does not do that. So if any
`LanguageServerBinary.path` is a bare name rather than an absolute path,
and the adapter passes a custom `PATH`
(version manager shims being the obvious case), it could resolve differently
on macOS now. Linux and Windows both went from a std `Command` to a std
`Command`, so they are unaffected. I have not audited every adapter to
confirm whether a bare name ever reaches here.

Happy to `cfg`-gate macOS back to `util::command` if you would rather keep
any of this.

`setsid` also means a language server no longer gets SIGINT or SIGHUP sent to
Zed's foreground process group. If you Ctrl-C a terminal-launched Zed, Zed
dies without running `Drop` and the server now survives where it used to die.
That is the same tradeoff #45902 shipped for agent servers.

Unix gets no guarantee if Zed is killed outright, since nothing runs `Drop`
and the process groups survive. Windows job objects do not have that hole.
The same limit applies to `remote_server`, so the SSH reparenting reported in
the thread is only fixed on clean shutdown.

I am not marking this "Closes #43864". The thread has a second cause that
aviatesk separated out and that is still undiagnosed. This fixes the orphan
half.

## Testing

Added `unix_tests` in `crates/util/src/process.rs`, mirroring the
`windows_tests` that are already there. Both spawn an `sh -> sleep` tree and
check the grandchild is gone, one after `kill()` and one after `drop()`.

Windows:

- `cargo test -p util` (108 passed, including the two `windows_tests`)
- `cargo test -p lsp` (9 passed)
- `cargo clippy -p util -p lsp --all-targets -- -D warnings`

Linux (x86_64-unknown-linux-gnu):

- `cargo test -p util` (107 passed, including the two new `unix_tests`)
- `cargo clippy -p util --all-targets -- -D warnings`

I checked that the drop test actually fails without the fix. With the
`killpg` call in `ProcessGroup::drop` stubbed out,
`test_drop_terminates_grandchildren` fails with "grandchild should be
terminated after dropping the child" after its 10 second deadline, and passes
again once the call is restored.

Worth being precise about what each test covers.
`test_drop_terminates_grandchildren` is the one that exercises the new guard.
`test_kill_terminates_grandchildren` passes with or without it, because
`kill()` already called `killpg` directly and this PR leaves `kill()` alone.
I kept it anyway to mirror `windows_tests`.

I have not run the macOS tests, and I have not done a full end to end check
with a real language server, so the macOS notes above are reasoning from the
code rather than something I observed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards (no UI changes)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed language servers leaving orphaned child processes running after Zed
  exits.
