### PR TITLE
gpui_openharmony: Add OpenHarmony host foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7982,6 +7982,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui_openharmony"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "collections",
+ "futures 0.3.32",
+ "gpui",
+ "gpui_wgpu",
+ "libc",
+ "log",
+ "parking_lot",
+ "pollster 0.4.0",
+ "raw-window-handle",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "smol",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "gpui_platform"
 version = "0.1.0"
 dependencies = [
@@ -7989,6 +8011,7 @@ dependencies = [
  "gpui",
  "gpui_linux",
  "gpui_macos",
+ "gpui_openharmony",
  "gpui_web",
  "gpui_windows",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
     "crates/google_ai",
     "crates/grammars",
     "crates/gpui",
+    "crates/gpui_openharmony",
     "crates/gpui_shared_string",
     "crates/gpui_linux",
     "crates/gpui_macos",
@@ -351,6 +352,7 @@ go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }
 grammars = { path = "crates/grammars" }
 gpui = { path = "crates/gpui", default-features = false }
+gpui_openharmony = { path = "crates/gpui_openharmony", default-features = false }
 gpui_shared_string = { path = "crates/gpui_shared_string" }
 gpui_linux = { path = "crates/gpui_linux", default-features = false }
 gpui_macos = { path = "crates/gpui_macos", default-features = false }

--- a/crates/gpui_openharmony/Cargo.toml
+++ b/crates/gpui_openharmony/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "gpui_openharmony"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "Apache-2.0"
+description = "OpenHarmony host foundation for GPUI (surface/event contracts; no fake renderer)"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/gpui_openharmony.rs"
+doctest = false
+
+[features]
+default = []
+host-foundation = []
+test-support = ["gpui/test-support"]
+
+[dependencies]
+anyhow.workspace = true
+collections.workspace = true
+futures.workspace = true
+gpui.workspace = true
+parking_lot.workspace = true
+raw-window-handle.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[target.'cfg(target_env = "ohos")'.dependencies]
+gpui_wgpu.workspace = true
+libc.workspace = true
+log.workspace = true
+pollster.workspace = true
+smol.workspace = true
+smallvec.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }

--- a/crates/gpui_openharmony/build.rs
+++ b/crates/gpui_openharmony/build.rs
@@ -1,0 +1,45 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/clipboard.rs");
+    println!("cargo:rerun-if-changed=src/display_info.rs");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_env == "ohos" {
+        // Add the OHOS sysroot lib directory to the linker search path.
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let target_triple = format!("{}-unknown-linux-ohos", target_arch);
+
+        // Try CC_<triple> env var first (set by user for cross-compilation).
+        let cc_env = format!("CC_{}", target_triple.replace('-', "_"));
+        let mut search_path = None;
+        if let Ok(cc) = std::env::var(&cc_env) {
+            if let Ok(output) = std::process::Command::new(&cc)
+                .arg("--print-sysroot")
+                .output()
+            {
+                let sysroot = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !sysroot.is_empty() {
+                    search_path = Some(format!("{}/usr/lib/{}", sysroot, target_triple));
+                }
+            }
+        }
+        // Fallback: OHOS_NDK_HOME.
+        if search_path.is_none() {
+            if let Ok(ndk) = std::env::var("OHOS_NDK_HOME") {
+                search_path = Some(format!(
+                    "{}/sysroot/usr/lib/{}",
+                    ndk, target_triple
+                ));
+            }
+        }
+        if let Some(path) = search_path {
+            println!("cargo:rustc-link-search=native={}", path);
+        }
+
+        // Clipboard: libpasteboard.so (system pasteboard) + libudmf.so (UDMF)
+        println!("cargo:rustc-link-lib=dylib=pasteboard");
+        println!("cargo:rustc-link-lib=dylib=udmf");
+        // Display: libnative_display_manager.so
+        println!("cargo:rustc-link-lib=dylib=native_display_manager");
+    }
+}

--- a/crates/gpui_openharmony/examples/minimal.rs
+++ b/crates/gpui_openharmony/examples/minimal.rs
@@ -1,0 +1,16 @@
+fn main() {
+    #[cfg(target_env = "ohos")]
+    {
+        use gpui::Platform;
+        use gpui_openharmony::OpenHarmonyPlatform;
+        use std::rc::Rc;
+
+        let platform: Rc<OpenHarmonyPlatform> = OpenHarmonyPlatform::new();
+        let displays = platform.displays();
+        println!("OpenHarmony platform created; displays: {}", displays.len());
+    }
+    #[cfg(not(target_env = "ohos"))]
+    {
+        println!("This example only runs on OpenHarmony");
+    }
+}

--- a/crates/gpui_openharmony/src/clipboard.rs
+++ b/crates/gpui_openharmony/src/clipboard.rs
@@ -1,0 +1,185 @@
+//! Clipboard integration via the OpenHarmony Pasteboard and UDMF APIs.
+//!
+//! Uses `OH_Pasteboard` (system pasteboard) with UDMF records to read and
+//! write plain-text data.  Requires the process to have the
+//! `ohos.permission.READ_PASTEBOARD` and `ohos.permission.WRITE_PASTEBOARD`
+//! capabilities declared in its `module.json5`.
+
+use gpui::ClipboardItem;
+use log::warn;
+use std::ffi::{CStr, CString};
+
+// UDMF (database/udmf/uds.h + database/udmf/udmf.h)
+#[allow(non_camel_case_types)]
+type OH_UdsPlainText = std::ffi::c_void;
+#[allow(non_camel_case_types)]
+type OH_UdmfRecord = std::ffi::c_void;
+#[allow(non_camel_case_types)]
+type OH_UdmfData = std::ffi::c_void;
+#[allow(non_camel_case_types)]
+type OH_Pasteboard = std::ffi::c_void;
+
+#[link(name = "pasteboard", kind = "dylib")]
+#[link(name = "udmf", kind = "dylib")]
+#[allow(non_snake_case, non_camel_case_types)]
+unsafe extern "C" {
+    fn OH_Pasteboard_Create() -> *mut OH_Pasteboard;
+    fn OH_Pasteboard_Destroy(pasteboard: *mut OH_Pasteboard);
+    fn OH_Pasteboard_HasData(pasteboard: *mut OH_Pasteboard) -> bool;
+    fn OH_Pasteboard_GetData(pasteboard: *mut OH_Pasteboard, status: *mut i32) -> *mut OH_UdmfData;
+    fn OH_Pasteboard_SetData(pasteboard: *mut OH_Pasteboard, data: *mut OH_UdmfData) -> i32;
+    fn OH_Pasteboard_ClearData(pasteboard: *mut OH_Pasteboard) -> i32;
+
+    // UDMF data
+    fn OH_UdmfData_Create() -> *mut OH_UdmfData;
+    fn OH_UdmfData_Destroy(data: *mut OH_UdmfData);
+    fn OH_UdmfData_AddRecord(data: *mut OH_UdmfData, record: *mut OH_UdmfRecord) -> i32;
+    fn OH_UdmfData_GetPrimaryPlainText(data: *mut OH_UdmfData, plain_text: *mut OH_UdsPlainText) -> i32;
+
+    // UDMF record
+    fn OH_UdmfRecord_Create() -> *mut OH_UdmfRecord;
+    fn OH_UdmfRecord_Destroy(record: *mut OH_UdmfRecord);
+    fn OH_UdmfRecord_AddPlainText(record: *mut OH_UdmfRecord, plain_text: *mut OH_UdsPlainText) -> i32;
+
+    // UDS plain text
+    fn OH_UdsPlainText_Create() -> *mut OH_UdsPlainText;
+    fn OH_UdsPlainText_Destroy(plain_text: *mut OH_UdsPlainText);
+    fn OH_UdsPlainText_SetContent(plain_text: *mut OH_UdsPlainText, content: *const std::ffi::c_char) -> i32;
+    fn OH_UdsPlainText_GetContent(plain_text: *mut OH_UdsPlainText) -> *const std::ffi::c_char;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+pub(crate) fn read_from_clipboard() -> Option<ClipboardItem> {
+    unsafe {
+        let pasteboard = OH_Pasteboard_Create();
+        if pasteboard.is_null() {
+            return None;
+        }
+
+        let _guard = PasteboardGuard(pasteboard);
+
+        if !OH_Pasteboard_HasData(pasteboard) {
+            return None;
+        }
+
+        let mut status: i32 = 0;
+        let data = OH_Pasteboard_GetData(pasteboard, &mut status as *mut i32);
+        if data.is_null() {
+            warn!("OH_Pasteboard_GetData failed, status={status}");
+            return None;
+        }
+        let _data_guard = UdmfDataGuard(data);
+
+        let mut pt: *mut OH_UdsPlainText = std::ptr::null_mut();
+        if OH_UdmfData_GetPrimaryPlainText(data, std::ptr::addr_of_mut!(pt).cast()) != 0 || pt.is_null() {
+            // No plain-text record in clipboard.
+            return None;
+        }
+        let _pt_guard = UdsPlainTextGuard(pt);
+
+        let raw = OH_UdsPlainText_GetContent(pt);
+        if raw.is_null() {
+            return None;
+        }
+        let text = CStr::from_ptr(raw).to_string_lossy().into_owned();
+        if text.is_empty() {
+            return None;
+        }
+        Some(ClipboardItem::new_string(text))
+    }
+}
+
+pub(crate) fn write_to_clipboard(item: &ClipboardItem) {
+    let Some(text) = item.text() else {
+        return;
+    };
+
+    let Ok(c_text) = CString::new(text) else {
+        return;
+    };
+
+    unsafe {
+        let pt = OH_UdsPlainText_Create();
+        if pt.is_null() {
+            return;
+        }
+        let _pt_guard = UdsPlainTextGuard(pt);
+
+        if OH_UdsPlainText_SetContent(pt, c_text.as_ptr()) != 0 {
+            warn!("OH_UdsPlainText_SetContent failed");
+            return;
+        }
+
+        let record = OH_UdmfRecord_Create();
+        if record.is_null() {
+            return;
+        }
+        let _rec_guard = UdmfRecordGuard(record);
+
+        if OH_UdmfRecord_AddPlainText(record, pt) != 0 {
+            warn!("OH_UdmfRecord_AddPlainText failed");
+            return;
+        }
+
+        let data = OH_UdmfData_Create();
+        if data.is_null() {
+            return;
+        }
+        let _data_guard = UdmfDataGuard(data);
+
+        if OH_UdmfData_AddRecord(data, record) != 0 {
+            warn!("OH_UdmfData_AddRecord failed");
+            return;
+        }
+
+        let pasteboard = OH_Pasteboard_Create();
+        if pasteboard.is_null() {
+            return;
+        }
+        let _pb_guard = PasteboardGuard(pasteboard);
+
+        OH_Pasteboard_ClearData(pasteboard);
+        if OH_Pasteboard_SetData(pasteboard, data) != 0 {
+            warn!("OH_Pasteboard_SetData failed");
+        }
+    }
+}
+
+// ── RAII guards for OHOS heap allocations ─────────────────────────────────────
+
+struct PasteboardGuard(*mut OH_Pasteboard);
+impl Drop for PasteboardGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { OH_Pasteboard_Destroy(self.0) }
+        }
+    }
+}
+
+struct UdmfDataGuard(*mut OH_UdmfData);
+impl Drop for UdmfDataGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { OH_UdmfData_Destroy(self.0) }
+        }
+    }
+}
+
+struct UdmfRecordGuard(*mut OH_UdmfRecord);
+impl Drop for UdmfRecordGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { OH_UdmfRecord_Destroy(self.0) }
+        }
+    }
+}
+
+struct UdsPlainTextGuard(*mut OH_UdsPlainText);
+impl Drop for UdsPlainTextGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { OH_UdsPlainText_Destroy(self.0) }
+        }
+    }
+}

--- a/crates/gpui_openharmony/src/dispatcher.rs
+++ b/crates/gpui_openharmony/src/dispatcher.rs
@@ -1,0 +1,125 @@
+use gpui::{PlatformDispatcher, Priority, PriorityQueueReceiver, RunnableVariant};
+use parking_lot::Mutex;
+use std::{
+    collections::VecDeque,
+    mem::MaybeUninit,
+    sync::Arc,
+    thread::{self, ThreadId},
+    time::Duration,
+};
+
+pub(crate) struct OpenHarmonyDispatcher {
+    main_thread_id: ThreadId,
+    main_queue: Arc<Mutex<VecDeque<(Priority, RunnableVariant)>>>,
+    background_sender: gpui::PriorityQueueSender<RunnableVariant>,
+    _background_threads: Vec<thread::JoinHandle<()>>,
+    _timer_thread: thread::JoinHandle<()>,
+    timer_sender: std::sync::mpsc::Sender<TimerAfter>,
+    wake: Arc<dyn Fn() + Send + Sync>,
+}
+
+struct TimerAfter {
+    duration: Duration,
+    runnable: RunnableVariant,
+}
+
+const MIN_THREADS: usize = 2;
+
+impl OpenHarmonyDispatcher {
+    pub fn new(wake: Arc<dyn Fn() + Send + Sync>) -> Self {
+        let main_thread_id = thread::current().id();
+        let main_queue = Arc::new(Mutex::new(VecDeque::new()));
+
+        let (background_sender, background_receiver) = PriorityQueueReceiver::new();
+        let thread_count = std::thread::available_parallelism()
+            .map_or(MIN_THREADS, |i| i.get().max(MIN_THREADS));
+
+        let mut background_threads = Vec::with_capacity(thread_count);
+        for _ in 0..thread_count {
+            let receiver: PriorityQueueReceiver<RunnableVariant> = background_receiver.clone();
+            background_threads.push(
+                thread::Builder::new()
+                    .name("openharmony-worker".to_string())
+                    .spawn(move || {
+                        for runnable in receiver.iter() {
+                            runnable.run();
+                        }
+                    })
+                    .expect("failed to spawn background worker"),
+            );
+        }
+
+        let (timer_sender, timer_receiver) = std::sync::mpsc::channel::<TimerAfter>();
+        let main_queue_for_timer = main_queue.clone();
+        let wake_for_timer = wake.clone();
+        let timer_thread = thread::Builder::new()
+            .name("openharmony-timer".to_string())
+            .spawn(move || {
+                for timer in timer_receiver {
+                    thread::sleep(timer.duration);
+                    main_queue_for_timer
+                        .lock()
+                        .push_back((Priority::Medium, timer.runnable));
+                    wake_for_timer();
+                }
+            })
+            .expect("failed to spawn timer thread");
+
+        Self {
+            main_thread_id,
+            main_queue,
+            background_sender,
+            _background_threads: background_threads,
+            _timer_thread: timer_thread,
+            timer_sender,
+            wake,
+        }
+    }
+
+    pub fn process_main_thread_queue(&self) {
+        while let Some((_, runnable)) = self.main_queue.lock().pop_front() {
+            runnable.run();
+        }
+    }
+}
+
+impl PlatformDispatcher for OpenHarmonyDispatcher {
+    fn is_main_thread(&self) -> bool {
+        thread::current().id() == self.main_thread_id
+    }
+
+    fn dispatch(&self, runnable: RunnableVariant, priority: Priority) {
+        if self.background_sender.send(priority, runnable).is_err() {
+            log::debug!("background dispatcher disconnected");
+        }
+    }
+
+    fn dispatch_on_main_thread(&self, runnable: RunnableVariant, priority: Priority) {
+        self.main_queue.lock().push_back((priority, runnable));
+        (self.wake)();
+    }
+
+    fn dispatch_after(&self, duration: Duration, runnable: RunnableVariant) {
+        if self.timer_sender.send(TimerAfter { duration, runnable }).is_err() {
+            log::debug!("timer dispatcher disconnected");
+        }
+    }
+
+    fn spawn_realtime(&self, f: Box<dyn FnOnce() + Send>) {
+        thread::spawn(move || {
+            let thread_id = unsafe { libc::pthread_self() };
+            let policy = libc::SCHED_FIFO;
+            let sched_priority = 65;
+
+            let mut sched_param =
+                unsafe { MaybeUninit::<libc::sched_param>::zeroed().assume_init() };
+            sched_param.sched_priority = sched_priority;
+            let result = unsafe { libc::pthread_setschedparam(thread_id, policy, &sched_param) };
+            if result != 0 {
+                log::warn!("failed to set realtime thread priority");
+            }
+
+            f();
+        });
+    }
+}

--- a/crates/gpui_openharmony/src/display.rs
+++ b/crates/gpui_openharmony/src/display.rs
@@ -1,0 +1,61 @@
+use gpui::{Bounds, DisplayId, Pixels, PlatformDisplay, Size, point, px};
+use std::cell::Cell;
+use std::fmt;
+use uuid::Uuid;
+
+pub(crate) struct OpenHarmonyDisplay {
+    id: DisplayId,
+    bounds: Cell<Bounds<Pixels>>,
+    scale_factor: Cell<f32>,
+}
+
+impl OpenHarmonyDisplay {
+    pub fn new(id: DisplayId, size: Size<Pixels>, scale_factor: f32) -> Self {
+        Self {
+            id,
+            bounds: Cell::new(Bounds::new(point(px(0.), px(0.)), size)),
+            scale_factor: Cell::new(scale_factor),
+        }
+    }
+
+    pub fn set_size(&self, size: Size<Pixels>) {
+        let mut bounds = self.bounds.get();
+        bounds.size = size;
+        self.bounds.set(bounds);
+    }
+
+    pub fn set_scale_factor(&self, scale_factor: f32) {
+        self.scale_factor.set(scale_factor);
+    }
+
+    pub fn scale_factor(&self) -> f32 {
+        self.scale_factor.get()
+    }
+}
+
+impl fmt::Debug for OpenHarmonyDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenHarmonyDisplay")
+            .field("id", &self.id)
+            .field("bounds", &self.bounds.get())
+            .finish()
+    }
+}
+
+impl PlatformDisplay for OpenHarmonyDisplay {
+    fn id(&self) -> DisplayId {
+        self.id
+    }
+
+    fn uuid(&self) -> anyhow::Result<Uuid> {
+        Ok(Uuid::from_u64_pair(u64::from(self.id), 0))
+    }
+
+    fn bounds(&self) -> Bounds<Pixels> {
+        self.bounds.get()
+    }
+
+    fn visible_bounds(&self) -> Bounds<Pixels> {
+        self.bounds.get()
+    }
+}

--- a/crates/gpui_openharmony/src/display_info.rs
+++ b/crates/gpui_openharmony/src/display_info.rs
@@ -1,0 +1,127 @@
+//! Display properties via the OpenHarmony DisplayManager NDK.
+//!
+//! Queries the default display's width, height, density DPI, and rotation
+//! through `OH_NativeDisplayManager` APIs.  Falls back to surface-provided
+//! dimensions when the service is unavailable.
+
+use log::warn;
+
+// ── OHOS NDK FFI ──────────────────────────────────────────────────────────────
+
+#[allow(non_camel_case_types)]
+type NativeDisplayManager_ErrorCode = i32;
+
+const DISPLAY_MANAGER_OK: NativeDisplayManager_ErrorCode = 0;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct NativeDisplayManager_DisplayInfo {
+    id: u32,
+    name: [std::ffi::c_char; 33], // OH_DISPLAY_NAME_LENGTH + 1
+    is_alive: bool,
+    width: i32,
+    height: i32,
+    physical_width: i32,
+    physical_height: i32,
+    refresh_rate: u32,
+    available_width: u32,
+    available_height: u32,
+    density_dpi: f32,
+    density_pixels: f32,
+    scaled_density: f32,
+    x_dpi: f32,
+    y_dpi: f32,
+    rotation: i32, // NativeDisplayManager_Rotation
+    state: i32,    // NativeDisplayManager_DisplayState
+    orientation: i32, // NativeDisplayManager_Orientation
+}
+
+// Provided by libnative_display_manager.so (build.rs emits the link directive).
+#[link(name = "native_display_manager", kind = "dylib")]
+#[allow(non_snake_case, non_camel_case_types)]
+unsafe extern "C" {
+    fn OH_NativeDisplayManager_GetDefaultDisplayWidth(display_width: *mut i32) -> i32;
+    fn OH_NativeDisplayManager_GetDefaultDisplayHeight(display_height: *mut i32) -> i32;
+    fn OH_NativeDisplayManager_GetDefaultDisplayDensityInfo(density: *mut f32) -> i32;
+    fn OH_NativeDisplayManager_GetDefaultDisplayInfo(
+        display_info: *mut NativeDisplayManager_DisplayInfo,
+    ) -> i32;
+}
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// Display properties queried from the OHOS DisplayManager service.
+#[derive(Clone, Debug)]
+pub struct DisplayProperties {
+    /// Display width in physical pixels.
+    pub width: u32,
+    /// Display height in physical pixels.
+    pub height: u32,
+    /// Display density in DPI (typically 160, 240, 320, 480).
+    pub density_dpi: f32,
+    /// Current rotation (0, 90, 180, 270).
+    pub rotation_degrees: u32,
+}
+
+impl DisplayProperties {
+    /// Scale factor relative to a 160 DPI baseline.
+    pub fn scale_factor(&self) -> f32 {
+        self.density_dpi / 160.0
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Queries the default display from the OHOS DisplayManager service.
+///
+/// Returns `None` if the service is unavailable or the query fails
+/// (e.g., running on a non-OHOS host or before the display service starts).
+pub fn query_default_display() -> Option<DisplayProperties> {
+    unsafe {
+        let mut info = std::mem::MaybeUninit::<NativeDisplayManager_DisplayInfo>::uninit();
+        let rc = OH_NativeDisplayManager_GetDefaultDisplayInfo(info.as_mut_ptr());
+        if rc != DISPLAY_MANAGER_OK {
+            warn!("OH_NativeDisplayManager_GetDefaultDisplayInfo failed: {rc}");
+            return query_fallback();
+        }
+        let info = info.assume_init();
+        Some(DisplayProperties {
+            width: info.width.max(0) as u32,
+            height: info.height.max(0) as u32,
+            density_dpi: info.density_dpi,
+            rotation_degrees: match info.rotation {
+                1 => 90,
+                2 => 180,
+                3 => 270,
+                _ => 0,
+            },
+        })
+    }
+}
+
+fn query_fallback() -> Option<DisplayProperties> {
+    unsafe {
+        let mut width: i32 = 0;
+        let mut height: i32 = 0;
+        let mut density: f32 = 0.0;
+
+        let rw = OH_NativeDisplayManager_GetDefaultDisplayWidth(&mut width as *mut i32);
+        let rh = OH_NativeDisplayManager_GetDefaultDisplayHeight(&mut height as *mut i32);
+        let rd = OH_NativeDisplayManager_GetDefaultDisplayDensityInfo(&mut density as *mut f32);
+
+        if rw != DISPLAY_MANAGER_OK || rh != DISPLAY_MANAGER_OK || width <= 0 || height <= 0 {
+            return None;
+        }
+
+        if rd != DISPLAY_MANAGER_OK || density <= 0.0 {
+            density = 320.0;
+        }
+
+        Some(DisplayProperties {
+            width: width as u32,
+            height: height as u32,
+            density_dpi: density,
+            rotation_degrees: 0,
+        })
+    }
+}

--- a/crates/gpui_openharmony/src/events.rs
+++ b/crates/gpui_openharmony/src/events.rs
@@ -1,0 +1,168 @@
+use gpui::{
+    AppLifecyclePhase, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    PlatformInput, TouchEvent, TouchId, TouchPhase, point, px,
+};
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+/// A host-supplied event from the OpenHarmony side.
+///
+/// This is the contract between the OpenHarmony native runtime and the GPUI
+/// platform implementation. The host is responsible for converting raw
+/// XComponent, mouse, or key events into this portable form and calling
+/// [`OpenHarmonyPlatform::dispatch_event`](crate::OpenHarmonyPlatform::dispatch_event).
+#[derive(Clone, Debug)]
+pub enum OpenHarmonyHostEvent {
+    SurfaceCreated(SurfaceInfo),
+    SurfaceChanged(SurfaceInfo),
+    SurfaceDestroyed,
+    Touch(OpenHarmonyTouchEvent),
+    KeyDown(OpenHarmonyKeyEvent),
+    KeyUp(OpenHarmonyKeyEvent),
+    Lifecycle(AppLifecyclePhase),
+    MemoryWarning,
+}
+
+/// A pointer to an OpenHarmony native window (`OHNativeWindow`).
+///
+/// It is `Send` and `Sync` because it only carries an address, and the host
+/// is responsible for the validity and lifetime of the underlying pointer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NativeWindow(usize);
+
+unsafe impl Send for NativeWindow {}
+unsafe impl Sync for NativeWindow {}
+
+impl NativeWindow {
+    /// Creates a new `NativeWindow` from a raw pointer.
+    ///
+    /// # Safety
+    /// The pointer must be a valid `OHNativeWindow` that outlives this value.
+    pub unsafe fn new(ptr: *mut c_void) -> Self {
+        Self(ptr as usize)
+    }
+
+    /// Returns the raw pointer value.
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0 as *mut c_void
+    }
+
+    /// Returns the pointer as a `NonNull<c_void>` if it is non-null.
+    pub fn as_nonnull(&self) -> Option<NonNull<c_void>> {
+        NonNull::new(self.as_ptr())
+    }
+}
+
+/// Information about an OpenHarmony surface supplied by the host.
+#[derive(Clone, Debug)]
+pub struct SurfaceInfo {
+    /// The `OHNativeWindow` pointer for this surface.
+    pub native_window: NativeWindow,
+    /// Surface size in logical pixels.
+    pub size: gpui::Size<gpui::Pixels>,
+    /// Display scale factor for the surface.
+    pub scale_factor: f32,
+}
+
+/// A touch phase in the OpenHarmony host contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenHarmonyTouchPhase {
+    Down,
+    Up,
+    Move,
+    Cancel,
+}
+
+/// A touch event in the OpenHarmony host contract.
+#[derive(Clone, Debug)]
+pub struct OpenHarmonyTouchEvent {
+    pub id: u64,
+    pub phase: OpenHarmonyTouchPhase,
+    pub x: f32,
+    pub y: f32,
+    pub force: f32,
+}
+
+/// A key event in the OpenHarmony host contract.
+#[derive(Clone, Debug)]
+pub struct OpenHarmonyKeyEvent {
+    pub key: String,
+    pub modifiers: Modifiers,
+}
+
+impl OpenHarmonyHostEvent {
+    /// Convert a host touch event into the GPUI [`PlatformInput`] form.
+    pub fn to_platform_input(self) -> Option<PlatformInput> {
+        match self {
+            OpenHarmonyHostEvent::Touch(touch) => {
+                let phase = match touch.phase {
+                    OpenHarmonyTouchPhase::Down => TouchPhase::Started,
+                    OpenHarmonyTouchPhase::Up => TouchPhase::Ended,
+                    OpenHarmonyTouchPhase::Move => TouchPhase::Moved,
+                    OpenHarmonyTouchPhase::Cancel => TouchPhase::Cancelled,
+                };
+                let force = if touch.force > 0.0 {
+                    Some(touch.force.clamp(0.0, 1.0))
+                } else {
+                    None
+                };
+                Some(PlatformInput::Touch(TouchEvent {
+                    id: TouchId(touch.id),
+                    phase,
+                    position: point(px(touch.x), px(touch.y)),
+                    force,
+                }))
+            }
+            OpenHarmonyHostEvent::KeyDown(key) => {
+                let keystroke = gpui::Keystroke {
+                    modifiers: key.modifiers,
+                    key: key.key,
+                    key_char: None,
+                };
+                Some(PlatformInput::KeyDown(gpui::KeyDownEvent {
+                    keystroke,
+                    is_held: false,
+                    prefer_character_input: false,
+                }))
+            }
+            OpenHarmonyHostEvent::KeyUp(key) => {
+                let keystroke = gpui::Keystroke {
+                    modifiers: key.modifiers,
+                    key: key.key,
+                    key_char: None,
+                };
+                Some(PlatformInput::KeyUp(gpui::KeyUpEvent { keystroke }))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Converts a touch event into a mouse move or mouse down/up event for
+/// components that expect mouse input. GPUI handles raw touch on mobile,
+/// but some interactions still expect mouse-compatible events.
+pub(crate) fn touch_to_mouse(touch: &OpenHarmonyTouchEvent) -> Option<PlatformInput> {
+    let position = point(px(touch.x), px(touch.y));
+    let modifiers = Modifiers::default();
+    match touch.phase {
+        OpenHarmonyTouchPhase::Down => Some(PlatformInput::MouseDown(MouseDownEvent {
+            button: MouseButton::Left,
+            position,
+            modifiers,
+            click_count: 1,
+            first_mouse: true,
+        })),
+        OpenHarmonyTouchPhase::Up => Some(PlatformInput::MouseUp(MouseUpEvent {
+            button: MouseButton::Left,
+            position,
+            modifiers,
+            click_count: 1,
+        })),
+        OpenHarmonyTouchPhase::Move => Some(PlatformInput::MouseMove(MouseMoveEvent {
+            position,
+            pressed_button: Some(MouseButton::Left),
+            modifiers,
+        })),
+        OpenHarmonyTouchPhase::Cancel => None,
+    }
+}

--- a/crates/gpui_openharmony/src/gpui_openharmony.rs
+++ b/crates/gpui_openharmony/src/gpui_openharmony.rs
@@ -10,6 +10,10 @@ mod events;
 #[cfg(target_env = "ohos")]
 mod keyboard;
 #[cfg(target_env = "ohos")]
+mod clipboard;
+#[cfg(target_env = "ohos")]
+mod display_info;
+#[cfg(target_env = "ohos")]
 mod platform;
 #[cfg(target_env = "ohos")]
 mod text_system;

--- a/crates/gpui_openharmony/src/gpui_openharmony.rs
+++ b/crates/gpui_openharmony/src/gpui_openharmony.rs
@@ -1,0 +1,25 @@
+#![cfg_attr(target_env = "ohos", allow(dead_code))]
+#![allow(clippy::too_many_arguments)]
+
+#[cfg(target_env = "ohos")]
+mod dispatcher;
+#[cfg(target_env = "ohos")]
+mod display;
+#[cfg(target_env = "ohos")]
+mod events;
+#[cfg(target_env = "ohos")]
+mod keyboard;
+#[cfg(target_env = "ohos")]
+mod platform;
+#[cfg(target_env = "ohos")]
+mod text_system;
+#[cfg(target_env = "ohos")]
+mod window;
+
+#[cfg(target_env = "ohos")]
+pub use events::{
+    NativeWindow, OpenHarmonyHostEvent, OpenHarmonyKeyEvent, OpenHarmonyTouchEvent,
+    OpenHarmonyTouchPhase, SurfaceInfo,
+};
+#[cfg(target_env = "ohos")]
+pub use platform::{OpenHarmonyPlatform, current_platform};

--- a/crates/gpui_openharmony/src/keyboard.rs
+++ b/crates/gpui_openharmony/src/keyboard.rs
@@ -1,0 +1,29 @@
+use gpui::{KeybindingKeystroke, Keystroke, PlatformKeyboardLayout, PlatformKeyboardMapper};
+
+pub(crate) struct OpenHarmonyKeyboardLayout;
+
+impl PlatformKeyboardLayout for OpenHarmonyKeyboardLayout {
+    fn id(&self) -> &str {
+        "openharmony-us"
+    }
+
+    fn name(&self) -> &str {
+        "OpenHarmony US"
+    }
+}
+
+pub(crate) struct OpenHarmonyKeyboardMapper;
+
+impl PlatformKeyboardMapper for OpenHarmonyKeyboardMapper {
+    fn map_key_equivalent(
+        &self,
+        keystroke: Keystroke,
+        _use_key_equivalents: bool,
+    ) -> KeybindingKeystroke {
+        KeybindingKeystroke::from_keystroke(keystroke)
+    }
+
+    fn get_key_equivalents(&self) -> Option<&collections::HashMap<char, char>> {
+        None
+    }
+}

--- a/crates/gpui_openharmony/src/keyboard.rs
+++ b/crates/gpui_openharmony/src/keyboard.rs
@@ -1,4 +1,4 @@
-use gpui::{KeybindingKeystroke, Keystroke, PlatformKeyboardLayout, PlatformKeyboardMapper};
+use gpui::{KeybindingKeystroke, Keystroke, Modifiers, PlatformKeyboardLayout, PlatformKeyboardMapper};
 
 pub(crate) struct OpenHarmonyKeyboardLayout;
 
@@ -18,9 +18,25 @@ impl PlatformKeyboardMapper for OpenHarmonyKeyboardMapper {
     fn map_key_equivalent(
         &self,
         keystroke: Keystroke,
-        _use_key_equivalents: bool,
+        use_key_equivalents: bool,
     ) -> KeybindingKeystroke {
-        KeybindingKeystroke::from_keystroke(keystroke)
+        // On OpenHarmony there is no platform "Command" key.
+        // When `use_key_equivalents` is requested, remap Ctrl → platform
+        // modifier so that standard Ctrl+C/V/X/Z shortcuts activate the same
+        // keybindings that macOS binds to Cmd.
+        let mapped = if use_key_equivalents && keystroke.modifiers.control {
+            Keystroke {
+                modifiers: Modifiers {
+                    control: false,
+                    platform: true,
+                    ..keystroke.modifiers
+                },
+                ..keystroke
+            }
+        } else {
+            keystroke
+        };
+        KeybindingKeystroke::from_keystroke(mapped)
     }
 
     fn get_key_equivalents(&self) -> Option<&collections::HashMap<char, char>> {

--- a/crates/gpui_openharmony/src/platform.rs
+++ b/crates/gpui_openharmony/src/platform.rs
@@ -1,0 +1,537 @@
+use crate::{
+    display::OpenHarmonyDisplay,
+    dispatcher::OpenHarmonyDispatcher,
+    events::{OpenHarmonyHostEvent, OpenHarmonyKeyEvent, OpenHarmonyTouchEvent, SurfaceInfo},
+    keyboard::{OpenHarmonyKeyboardLayout, OpenHarmonyKeyboardMapper},
+    text_system::text_system,
+    window::{OpenHarmonyWindow, OpenHarmonyWindowHandle},
+};
+use anyhow::{Result, anyhow};
+use futures::channel::oneshot;
+use gpui::{
+    AnyWindowHandle, AppLifecyclePhase, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle,
+    DisplayId, ForegroundExecutor, Keymap, Menu, MenuItem, OwnedMenu, PathPromptOptions, Platform,
+    PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
+    PlatformWindow, ScreenCaptureSource, SystemNotification, SystemNotificationResponse,
+    Task, ThermalState, WindowAppearance, WindowButtonLayout, WindowParams, point, px,
+};
+use gpui_wgpu::GpuContext;
+use smallvec::SmallVec;
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+/// The GPUI platform implementation for OpenHarmony.
+///
+/// This is designed to be driven by an OpenHarmony host. The host is
+/// responsible for creating and managing the XComponent surface, converting
+/// native events into [`OpenHarmonyHostEvent`] values, and calling
+/// [`OpenHarmonyPlatform::process_events`] regularly (for example, on each
+/// VSync or XComponent callback).
+pub struct OpenHarmonyPlatform {
+    dispatcher: Arc<OpenHarmonyDispatcher>,
+    background_executor: BackgroundExecutor,
+    foreground_executor: ForegroundExecutor,
+    text_system: Arc<dyn PlatformTextSystem>,
+    display: RefCell<Option<Rc<OpenHarmonyDisplay>>>,
+    windows: RefCell<HashMap<AnyWindowHandle, Rc<OpenHarmonyWindow>>>,
+    active_window: RefCell<Option<AnyWindowHandle>>,
+    surface_info: RefCell<Option<SurfaceInfo>>,
+    on_finish_launching: RefCell<Option<Box<dyn FnOnce() + 'static>>>,
+    appearance: Cell<WindowAppearance>,
+    appearance_override: Cell<Option<WindowAppearance>>,
+    on_app_lifecycle: RefCell<Option<Box<dyn FnMut(AppLifecyclePhase)>>>,
+    on_memory_warning: RefCell<Option<Box<dyn FnMut()>>>,
+    on_quit: RefCell<Option<Box<dyn FnMut()>>>,
+    on_reopen: RefCell<Option<Box<dyn FnMut()>>>,
+    on_system_wake: RefCell<Option<Box<dyn FnMut()>>>,
+    on_thermal_state_change: RefCell<Option<Box<dyn FnMut()>>>,
+    on_keyboard_layout_change: RefCell<Option<Box<dyn FnMut()>>>,
+    needs_process: Arc<AtomicBool>,
+    gpu_context: GpuContext,
+}
+
+impl OpenHarmonyPlatform {
+    /// Creates a new OpenHarmony platform.
+    ///
+    /// The returned `Rc` can be passed to [`gpui::App::new_inaccessible`] or
+    /// used directly to receive surface and event callbacks from the host.
+    pub fn new() -> Rc<Self> {
+        let needs_process = Arc::new(AtomicBool::new(false));
+        let wake = {
+            let needs_process = needs_process.clone();
+            Arc::new(move || {
+                needs_process.store(true, Ordering::Release);
+            }) as Arc<dyn Fn() + Send + Sync>
+        };
+        let dispatcher = Arc::new(OpenHarmonyDispatcher::new(wake));
+        let background_executor = BackgroundExecutor::new(dispatcher.clone());
+        let foreground_executor = ForegroundExecutor::new(dispatcher.clone());
+
+        Rc::new(Self {
+            dispatcher,
+            background_executor,
+            foreground_executor,
+            text_system: text_system(),
+            display: RefCell::new(None),
+            windows: RefCell::new(HashMap::default()),
+            active_window: RefCell::new(None),
+            surface_info: RefCell::new(None),
+            on_finish_launching: RefCell::new(None),
+            appearance: Cell::new(WindowAppearance::Light),
+            appearance_override: Cell::new(None),
+            on_app_lifecycle: RefCell::new(None),
+            on_memory_warning: RefCell::new(None),
+            on_quit: RefCell::new(None),
+            on_reopen: RefCell::new(None),
+            on_system_wake: RefCell::new(None),
+            on_thermal_state_change: RefCell::new(None),
+            on_keyboard_layout_change: RefCell::new(None),
+            needs_process,
+            gpu_context: Rc::new(RefCell::new(None)),
+        })
+    }
+
+    /// Returns the platform's dispatcher.
+    pub(crate) fn dispatcher(&self) -> Arc<OpenHarmonyDispatcher> {
+        self.dispatcher.clone()
+    }
+
+    /// Notifies the platform that the host has created a surface.
+    ///
+    /// This should be called from the XComponent `OnSurfaceCreated` callback.
+    pub fn surface_created(&self, info: SurfaceInfo) {
+        let display = Rc::new(OpenHarmonyDisplay::new(
+            DisplayId::new(0),
+            info.size,
+            info.scale_factor,
+        ));
+        self.display.replace(Some(display));
+        self.surface_info.replace(Some(info));
+
+        if let Some(callback) = self.on_finish_launching.borrow_mut().take() {
+            self.foreground_executor
+                .spawn(async move {
+                    callback();
+                })
+                .detach();
+        }
+    }
+
+    /// Notifies the platform that the host surface size or scale changed.
+    pub fn surface_changed(&self, info: SurfaceInfo) {
+        if let Some(display) = self.display.borrow().as_ref() {
+            display.set_size(info.size);
+            display.set_scale_factor(info.scale_factor);
+        }
+
+        if let Some(window) = self.windows.borrow().values().next() {
+            window.set_size(info.size);
+            window.set_scale_factor(info.scale_factor);
+        }
+
+        if let Some(surface) = self.surface_info.borrow_mut().as_mut() {
+            surface.size = info.size;
+            surface.scale_factor = info.scale_factor;
+        }
+    }
+
+    /// Notifies the platform that the host surface is being destroyed.
+    pub fn surface_destroyed(&self) {
+        if let Some(window) = self.windows.borrow().values().next() {
+            window.on_surface_destroyed();
+        }
+        self.surface_info.replace(None);
+        self.display.replace(None);
+    }
+
+    /// Dispatches a host event into GPUI.
+    pub fn dispatch_event(&self, event: OpenHarmonyHostEvent) {
+        match event {
+            OpenHarmonyHostEvent::SurfaceCreated(info) => self.surface_created(info),
+            OpenHarmonyHostEvent::SurfaceChanged(info) => self.surface_changed(info),
+            OpenHarmonyHostEvent::SurfaceDestroyed => self.surface_destroyed(),
+            OpenHarmonyHostEvent::Touch(touch) => self.dispatch_touch(touch),
+            OpenHarmonyHostEvent::KeyDown(key) => self.dispatch_key_down(key),
+            OpenHarmonyHostEvent::KeyUp(key) => self.dispatch_key_up(key),
+            OpenHarmonyHostEvent::Lifecycle(phase) => {
+                if let Some(callback) = self.on_app_lifecycle.borrow_mut().as_mut() {
+                    callback(phase);
+                }
+            }
+            OpenHarmonyHostEvent::MemoryWarning => {
+                if let Some(callback) = self.on_memory_warning.borrow_mut().as_mut() {
+                    callback();
+                }
+            }
+        }
+    }
+
+    fn dispatch_touch(&self, touch: OpenHarmonyTouchEvent) {
+        if let Some(input) = OpenHarmonyHostEvent::Touch(touch.clone()).to_platform_input() {
+            if let Some(window) = self.active_window() {
+                window.dispatch_input(input);
+                if let Some(mouse_input) = crate::events::touch_to_mouse(&touch) {
+                    window.dispatch_input(mouse_input);
+                }
+            }
+        }
+    }
+
+    fn dispatch_key_down(&self, key: OpenHarmonyKeyEvent) {
+        if let Some(input) = OpenHarmonyHostEvent::KeyDown(key).to_platform_input() {
+            if let Some(window) = self.active_window() {
+                window.dispatch_input(input);
+            }
+        }
+    }
+
+    fn dispatch_key_up(&self, key: OpenHarmonyKeyEvent) {
+        if let Some(input) = OpenHarmonyHostEvent::KeyUp(key).to_platform_input() {
+            if let Some(window) = self.active_window() {
+                window.dispatch_input(input);
+            }
+        }
+    }
+
+    /// Processes any pending main-thread work and clears the wake flag.
+    ///
+    /// The host should call this whenever the platform is woken (via the
+    /// internal wake callback) or at the end of each frame.
+    pub fn process_events(&self) {
+        self.needs_process.store(false, Ordering::Release);
+        self.dispatcher.process_main_thread_queue();
+    }
+
+    /// Returns whether the platform has pending main-thread work.
+    pub fn needs_process(&self) -> bool {
+        self.needs_process.load(Ordering::Acquire)
+    }
+
+    fn active_window(&self) -> Option<Rc<OpenHarmonyWindow>> {
+        let active = *self.active_window.borrow();
+        active.and_then(|handle| self.windows.borrow().get(&handle).cloned())
+    }
+
+    fn set_appearance_for_all_windows(&self, appearance: WindowAppearance) {
+        for window in self.windows.borrow().values() {
+            window.set_appearance(appearance);
+        }
+    }
+}
+
+impl Platform for OpenHarmonyPlatform {
+    fn background_executor(&self) -> BackgroundExecutor {
+        self.background_executor.clone()
+    }
+
+    fn foreground_executor(&self) -> ForegroundExecutor {
+        self.foreground_executor.clone()
+    }
+
+    fn text_system(&self) -> Arc<dyn PlatformTextSystem> {
+        self.text_system.clone()
+    }
+
+    fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {
+        self.on_finish_launching.replace(Some(on_finish_launching));
+
+        if self.surface_info.borrow().is_some() {
+            if let Some(callback) = self.on_finish_launching.borrow_mut().take() {
+                self.foreground_executor
+                    .spawn(async move {
+                        callback();
+                    })
+                    .detach();
+            }
+        }
+    }
+
+    fn quit(&self) {
+        std::process::exit(0);
+    }
+
+    fn restart(&self, _binary_path: Option<PathBuf>) {}
+
+    fn activate(&self, _ignoring_other_apps: bool) {}
+
+    fn hide(&self) {}
+
+    fn hide_other_apps(&self) {}
+
+    fn unhide_other_apps(&self) {}
+
+    fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
+        if let Some(display) = self.display.borrow().as_ref() {
+            vec![display.clone() as Rc<dyn PlatformDisplay>]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        self.display
+            .borrow()
+            .as_ref()
+            .map(|display| display.clone() as Rc<dyn PlatformDisplay>)
+    }
+
+    fn active_window(&self) -> Option<AnyWindowHandle> {
+        *self.active_window.borrow()
+    }
+
+    fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
+        Some(self.windows.borrow().keys().copied().collect())
+    }
+
+    fn open_window(
+        &self,
+        handle: AnyWindowHandle,
+        params: WindowParams,
+    ) -> Result<Box<dyn PlatformWindow>> {
+        let surface_info = self
+            .surface_info
+            .borrow()
+            .as_ref()
+            .ok_or_else(|| anyhow!("surface not created; call surface_created first"))?
+            .clone();
+        let display = self
+            .display
+            .borrow()
+            .as_ref()
+            .ok_or_else(|| anyhow!("display not created"))?
+            .clone();
+
+        let mut params = params;
+        if f32::from(params.bounds.size.width) <= 0.0
+            || f32::from(params.bounds.size.height) <= 0.0
+        {
+            params.bounds = Bounds::new(point(px(0.), px(0.)), surface_info.size);
+        }
+
+        let window = Rc::new(OpenHarmonyWindow::new(
+            handle,
+            params,
+            &surface_info,
+            display,
+            self.gpu_context.clone(),
+        )?);
+        self.windows.borrow_mut().insert(handle, window.clone());
+        self.active_window.replace(Some(handle));
+
+        Ok(Box::new(OpenHarmonyWindowHandle(window)) as Box<dyn PlatformWindow>)
+    }
+
+    fn window_appearance(&self) -> WindowAppearance {
+        self.appearance_override
+            .get()
+            .unwrap_or_else(|| self.appearance.get())
+    }
+
+    fn set_window_appearance(&self, appearance: Option<WindowAppearance>) {
+        self.appearance_override.set(appearance);
+        let appearance = self.window_appearance();
+        self.set_appearance_for_all_windows(appearance);
+    }
+
+    fn button_layout(&self) -> Option<WindowButtonLayout> {
+        None
+    }
+
+    fn open_url(&self, _url: &str) {}
+
+    fn on_open_urls(&self, _callback: Box<dyn FnMut(Vec<String>)>) {}
+
+    fn register_url_scheme(&self, _url: &str) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
+
+    fn prompt_for_paths(
+        &self,
+        _options: PathPromptOptions,
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(None)).ok();
+        rx
+    }
+
+    fn prompt_for_new_path(
+        &self,
+        _directory: &Path,
+        _suggested_name: Option<&str>,
+    ) -> oneshot::Receiver<Result<Option<PathBuf>>> {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(None)).ok();
+        rx
+    }
+
+    fn can_select_mixed_files_and_dirs(&self) -> bool {
+        false
+    }
+
+    fn reveal_path(&self, _path: &Path) {}
+
+    fn open_with_system(&self, _path: &Path) {}
+
+    fn on_quit(&self, callback: Box<dyn FnMut()>) {
+        self.on_quit.replace(Some(callback));
+    }
+
+    fn on_reopen(&self, callback: Box<dyn FnMut()>) {
+        self.on_reopen.replace(Some(callback));
+    }
+
+    fn on_system_wake(&self, callback: Box<dyn FnMut()>) {
+        self.on_system_wake.replace(Some(callback));
+    }
+
+    fn on_app_lifecycle(&self, callback: Box<dyn FnMut(AppLifecyclePhase)>) {
+        self.on_app_lifecycle.replace(Some(callback));
+    }
+
+    fn on_memory_warning(&self, callback: Box<dyn FnMut()>) {
+        self.on_memory_warning.replace(Some(callback));
+    }
+
+    fn set_menus(&self, _menus: Vec<Menu>, _keymap: &Keymap) {}
+
+    fn get_menus(&self) -> Option<Vec<OwnedMenu>> {
+        None
+    }
+
+    fn set_dock_menu(&self, _menu: Vec<MenuItem>, _keymap: &Keymap) {}
+
+    fn perform_dock_menu_action(&self, _action: usize) {}
+
+    fn add_recent_document(&self, _path: &Path) {}
+
+    fn update_jump_list(
+        &self,
+        _menus: Vec<MenuItem>,
+        _entries: Vec<SmallVec<[PathBuf; 2]>>,
+    ) -> Task<Vec<SmallVec<[PathBuf; 2]>>> {
+        Task::ready(Vec::new())
+    }
+
+    fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn gpui::Action)>) {}
+
+    fn on_will_open_app_menu(&self, _callback: Box<dyn FnMut()>) {}
+
+    fn on_validate_app_menu_command(&self, _callback: Box<dyn FnMut(&dyn gpui::Action) -> bool>) {}
+
+    fn thermal_state(&self) -> ThermalState {
+        ThermalState::Nominal
+    }
+
+    fn on_thermal_state_change(&self, callback: Box<dyn FnMut()>) {
+        self.on_thermal_state_change.replace(Some(callback));
+    }
+
+    fn set_app_identity(&self, _identifier: &str, _name: &str) {}
+
+    fn show_system_notification(&self, _notification: SystemNotification) {}
+
+    fn dismiss_system_notification(&self, _tag: &str) {}
+
+    fn on_system_notification_response(
+        &self,
+        _callback: Box<dyn FnMut(SystemNotificationResponse)>,
+    ) {
+    }
+
+    fn compositor_name(&self) -> &'static str {
+        "wgpu"
+    }
+
+    fn app_path(&self) -> Result<PathBuf> {
+        Err(anyhow!("app_path not supported on OpenHarmony"))
+    }
+
+    fn path_for_auxiliary_executable(&self, _name: &str) -> Result<PathBuf> {
+        Err(anyhow!(
+            "path_for_auxiliary_executable not supported on OpenHarmony"
+        ))
+    }
+
+    fn set_cursor_style(&self, _style: CursorStyle) {}
+
+    fn hide_cursor_until_mouse_moves(&self) {}
+
+    fn is_cursor_visible(&self) -> bool {
+        true
+    }
+
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        true
+    }
+
+    fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        None
+    }
+
+    fn write_to_clipboard(&self, _item: ClipboardItem) {}
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn read_from_primary(&self) -> Option<ClipboardItem> {
+        None
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn write_to_primary(&self, _item: ClipboardItem) {}
+
+    fn write_credentials(
+        &self,
+        _url: &str,
+        _username: &str,
+        _password: &[u8],
+    ) -> Task<Result<()>> {
+        Task::ready(Err(anyhow!("write_credentials not supported on OpenHarmony")))
+    }
+
+    fn read_credentials(
+        &self,
+        _url: &str,
+    ) -> Task<Result<Option<(String, Vec<u8>)>>> {
+        Task::ready(Ok(None))
+    }
+
+    fn delete_credentials(&self, _url: &str) -> Task<Result<()>> {
+        Task::ready(Err(anyhow!("delete_credentials not supported on OpenHarmony")))
+    }
+
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(OpenHarmonyKeyboardLayout)
+    }
+
+    fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper> {
+        Rc::new(OpenHarmonyKeyboardMapper)
+    }
+
+    fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
+        self.on_keyboard_layout_change.replace(Some(callback));
+    }
+
+    fn is_screen_capture_supported(&self) -> bool {
+        false
+    }
+
+    fn screen_capture_sources(
+        &self,
+    ) -> oneshot::Receiver<Result<Vec<Rc<dyn ScreenCaptureSource>>>> {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(Vec::new())).ok();
+        rx
+    }
+}
+
+/// Returns the default OpenHarmony platform.
+pub fn current_platform() -> Rc<dyn Platform> {
+    OpenHarmonyPlatform::new()
+}

--- a/crates/gpui_openharmony/src/platform.rs
+++ b/crates/gpui_openharmony/src/platform.rs
@@ -108,13 +108,22 @@ impl OpenHarmonyPlatform {
     ///
     /// This should be called from the XComponent `OnSurfaceCreated` callback.
     pub fn surface_created(&self, info: SurfaceInfo) {
+        // Query real display properties from the OHOS DisplayManager service.
+        // Use the DisplayManager DPI for scale factor when available, falling
+        // back to the host-provided value.
+        let scale_factor = crate::display_info::query_default_display()
+            .map(|dp| dp.scale_factor())
+            .unwrap_or(info.scale_factor);
+
+        let surface_info = SurfaceInfo { scale_factor, ..info };
+
         let display = Rc::new(OpenHarmonyDisplay::new(
             DisplayId::new(0),
             info.size,
-            info.scale_factor,
+            scale_factor,
         ));
         self.display.replace(Some(display));
-        self.surface_info.replace(Some(info));
+        self.surface_info.replace(Some(surface_info));
 
         if let Some(callback) = self.on_finish_launching.borrow_mut().take() {
             self.foreground_executor
@@ -473,10 +482,12 @@ impl Platform for OpenHarmonyPlatform {
     }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
-        None
+        crate::clipboard::read_from_clipboard()
     }
 
-    fn write_to_clipboard(&self, _item: ClipboardItem) {}
+    fn write_to_clipboard(&self, item: ClipboardItem) {
+        crate::clipboard::write_to_clipboard(&item);
+    }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn read_from_primary(&self) -> Option<ClipboardItem> {

--- a/crates/gpui_openharmony/src/text_system.rs
+++ b/crates/gpui_openharmony/src/text_system.rs
@@ -1,0 +1,5 @@
+use std::sync::Arc;
+
+pub(crate) fn text_system() -> Arc<dyn gpui::PlatformTextSystem> {
+    Arc::new(gpui_wgpu::CosmicTextSystem::new("HarmonyOS Sans"))
+}

--- a/crates/gpui_openharmony/src/window.rs
+++ b/crates/gpui_openharmony/src/window.rs
@@ -1,0 +1,409 @@
+use crate::{display::OpenHarmonyDisplay, events::SurfaceInfo};
+use anyhow::{Context as _, anyhow};
+use futures::channel::oneshot;
+use gpui::{
+    AnyWindowHandle, Bounds, DispatchEventResult, Pixels, PlatformInput, PlatformInputHandler,
+    PlatformWindow, Point, PromptButton, PromptLevel, RequestFrameOptions, Scene, Size,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowInsets,
+    WindowParams, GpuSpecs, point, px,
+};
+use gpui_wgpu::{CompositorGpuHint, GpuContext, WgpuRenderer, WgpuSurfaceConfig, wgpu};
+use raw_window_handle::{
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, OhosDisplayHandle,
+    OhosNdkWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle,
+};
+use std::{
+    cell::{Cell, RefCell},
+    ffi::c_void,
+    marker::PhantomData,
+    ops::Deref,
+    ptr::NonNull,
+    rc::Rc,
+    sync::Arc,
+};
+
+pub(crate) struct OpenHarmonyWindow {
+    handle: AnyWindowHandle,
+    native_window: NonNull<c_void>,
+    display: Rc<OpenHarmonyDisplay>,
+    bounds: RefCell<Bounds<Pixels>>,
+    scale_factor: Cell<f32>,
+    is_active: Cell<bool>,
+    is_hovered: Cell<bool>,
+    mouse_position: Cell<Point<Pixels>>,
+    modifiers: Cell<gpui::Modifiers>,
+    capslock: Cell<gpui::Capslock>,
+    appearance: Cell<WindowAppearance>,
+    background_appearance: Cell<WindowBackgroundAppearance>,
+    renderer: RefCell<WgpuRenderer>,
+    callbacks: RefCell<WindowCallbacks>,
+    input_handler: RefCell<Option<PlatformInputHandler>>,
+}
+
+pub(crate) struct OpenHarmonyWindowHandle(pub(crate) Rc<OpenHarmonyWindow>);
+
+impl Deref for OpenHarmonyWindowHandle {
+    type Target = OpenHarmonyWindow;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl HasWindowHandle for OpenHarmonyWindowHandle {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        self.0.window_handle()
+    }
+}
+
+impl HasDisplayHandle for OpenHarmonyWindowHandle {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        self.0.display_handle()
+    }
+}
+
+#[derive(Default)]
+struct WindowCallbacks {
+    request_frame: Option<Box<dyn FnMut(RequestFrameOptions) + 'static>>,
+    input: Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult + 'static>>,
+    active: Option<Box<dyn FnMut(bool) + 'static>>,
+    hover: Option<Box<dyn FnMut(bool) + 'static>>,
+    resize: Option<Box<dyn FnMut(Size<Pixels>, f32) + 'static>>,
+    moved: Option<Box<dyn FnMut() + 'static>>,
+    should_close: Option<Box<dyn FnMut() -> bool + 'static>>,
+    close: Option<Box<dyn FnOnce() + 'static>>,
+    appearance_changed: Option<Box<dyn FnMut() + 'static>>,
+    hit_test: Option<Box<dyn FnMut() -> Option<WindowControlArea> + 'static>>,
+    insets_changed: Option<Box<dyn FnMut(WindowInsets) + 'static>>,
+}
+
+impl OpenHarmonyWindow {
+    pub fn new(
+        handle: AnyWindowHandle,
+        params: WindowParams,
+        surface_info: &SurfaceInfo,
+        display: Rc<OpenHarmonyDisplay>,
+        gpu_context: GpuContext,
+    ) -> anyhow::Result<Self> {
+        let scale_factor = surface_info.scale_factor;
+        let bounds = params.bounds.map(|v| v / scale_factor);
+        let device_size = bounds.size.to_device_pixels(scale_factor);
+
+        let native_window = surface_info
+            .native_window
+            .as_nonnull()
+            .ok_or_else(|| anyhow!("invalid native window"))?;
+
+        let raw_window = OpenHarmonyRawWindow {
+            native_window,
+            _marker: PhantomData,
+        };
+
+        let renderer = WgpuRenderer::new(
+            gpu_context,
+            &raw_window,
+            WgpuSurfaceConfig {
+                size: device_size,
+                transparent: false,
+                preferred_present_mode: Some(wgpu::PresentMode::Fifo),
+            },
+            None::<CompositorGpuHint>,
+        )
+        .context("failed to create wgpu renderer")?;
+
+        Ok(Self {
+            handle,
+            native_window,
+            display,
+            bounds: RefCell::new(bounds),
+            scale_factor: Cell::new(scale_factor),
+            is_active: Cell::new(false),
+            is_hovered: Cell::new(false),
+            mouse_position: Cell::new(point(px(0.), px(0.))),
+            modifiers: Cell::new(gpui::Modifiers::default()),
+            capslock: Cell::new(gpui::Capslock::default()),
+            appearance: Cell::new(WindowAppearance::Light),
+            background_appearance: Cell::new(WindowBackgroundAppearance::default()),
+            renderer: RefCell::new(renderer),
+            callbacks: RefCell::new(WindowCallbacks::default()),
+            input_handler: RefCell::new(None),
+        })
+    }
+
+    pub fn handle(&self) -> AnyWindowHandle {
+        self.handle
+    }
+
+    pub fn native_window(&self) -> NonNull<c_void> {
+        self.native_window
+    }
+
+    pub fn set_size(&self, size: Size<Pixels>) {
+        self.bounds.borrow_mut().size = size;
+        let device_size = size.to_device_pixels(self.scale_factor.get());
+        self.renderer.borrow_mut().update_drawable_size(device_size);
+        if let Some(callback) = self.callbacks.borrow_mut().resize.as_mut() {
+            callback(size, self.scale_factor.get());
+        }
+        if let Some(callback) = self.callbacks.borrow_mut().moved.as_mut() {
+            callback();
+        }
+    }
+
+    pub fn set_scale_factor(&self, scale_factor: f32) {
+        self.scale_factor.set(scale_factor);
+        self.set_size(self.bounds.borrow().size);
+    }
+
+    pub fn set_active(&self, active: bool) {
+        self.is_active.set(active);
+        if let Some(callback) = self.callbacks.borrow_mut().active.as_mut() {
+            callback(active);
+        }
+    }
+
+    pub fn set_hovered(&self, hovered: bool) {
+        self.is_hovered.set(hovered);
+        if let Some(callback) = self.callbacks.borrow_mut().hover.as_mut() {
+            callback(hovered);
+        }
+    }
+
+    pub fn set_mouse_position(&self, position: Point<Pixels>) {
+        self.mouse_position.set(position);
+    }
+
+    pub fn dispatch_input(&self, input: PlatformInput) -> DispatchEventResult {
+        if let Some(handler) = self.callbacks.borrow_mut().input.as_mut() {
+            handler(input)
+        } else {
+            DispatchEventResult::default()
+        }
+    }
+
+    pub fn request_frame(&self) {
+        if let Some(callback) = self.callbacks.borrow_mut().request_frame.as_mut() {
+            callback(RequestFrameOptions {
+                require_presentation: true,
+                force_render: false,
+            });
+        }
+    }
+
+    pub fn on_surface_destroyed(&self) {
+        self.renderer.borrow_mut().destroy();
+    }
+
+    pub fn set_appearance(&self, appearance: WindowAppearance) {
+        self.appearance.set(appearance);
+        if let Some(callback) = self.callbacks.borrow_mut().appearance_changed.as_mut() {
+            callback();
+        }
+    }
+}
+
+impl PlatformWindow for OpenHarmonyWindowHandle {
+    fn bounds(&self) -> Bounds<Pixels> {
+        *self.0.bounds.borrow()
+    }
+
+    fn is_maximized(&self) -> bool {
+        false
+    }
+
+    fn window_bounds(&self) -> WindowBounds {
+        WindowBounds::Windowed(self.bounds())
+    }
+
+    fn content_size(&self) -> Size<Pixels> {
+        self.bounds().size
+    }
+
+    fn resize(&mut self, size: Size<Pixels>) {
+        self.0.set_size(size);
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.0.scale_factor.get()
+    }
+
+    fn appearance(&self) -> WindowAppearance {
+        self.0.appearance.get()
+    }
+
+    fn display(&self) -> Option<Rc<dyn gpui::PlatformDisplay>> {
+        Some(self.0.display.clone())
+    }
+
+    fn mouse_position(&self) -> Point<Pixels> {
+        self.0.mouse_position.get()
+    }
+
+    fn modifiers(&self) -> gpui::Modifiers {
+        self.0.modifiers.get()
+    }
+
+    fn capslock(&self) -> gpui::Capslock {
+        self.0.capslock.get()
+    }
+
+    fn set_input_handler(&mut self, input_handler: PlatformInputHandler) {
+        self.0.input_handler.replace(Some(input_handler));
+    }
+
+    fn take_input_handler(&mut self) -> Option<PlatformInputHandler> {
+        self.0.input_handler.take()
+    }
+
+    fn prompt(
+        &self,
+        _level: PromptLevel,
+        _msg: &str,
+        _detail: Option<&str>,
+        _answers: &[PromptButton],
+    ) -> Option<oneshot::Receiver<usize>> {
+        None
+    }
+
+    fn activate(&self) {
+        self.0.set_active(true);
+    }
+
+    fn is_active(&self) -> bool {
+        self.0.is_active.get()
+    }
+
+    fn is_hovered(&self) -> bool {
+        self.0.is_hovered.get()
+    }
+
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.0.background_appearance.get()
+    }
+
+    fn set_title(&mut self, _title: &str) {}
+
+    fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance) {
+        self.0.background_appearance.set(background_appearance);
+    }
+
+    fn minimize(&self) {}
+
+    fn zoom(&self) {}
+
+    fn toggle_fullscreen(&self) {}
+
+    fn is_fullscreen(&self) -> bool {
+        false
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions) + 'static>) {
+        self.0.callbacks.borrow_mut().request_frame = Some(callback);
+    }
+
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult + 'static>) {
+        self.0.callbacks.borrow_mut().input = Some(callback);
+    }
+
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool) + 'static>) {
+        self.0.callbacks.borrow_mut().active = Some(callback);
+    }
+
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool) + 'static>) {
+        self.0.callbacks.borrow_mut().hover = Some(callback);
+    }
+
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32) + 'static>) {
+        self.0.callbacks.borrow_mut().resize = Some(callback);
+    }
+
+    fn on_moved(&self, callback: Box<dyn FnMut() + 'static>) {
+        self.0.callbacks.borrow_mut().moved = Some(callback);
+    }
+
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool + 'static>) {
+        self.0.callbacks.borrow_mut().should_close = Some(callback);
+    }
+
+    fn on_hit_test_window_control(
+        &self,
+        callback: Box<dyn FnMut() -> Option<WindowControlArea> + 'static>,
+    ) {
+        self.0.callbacks.borrow_mut().hit_test = Some(callback);
+    }
+
+    fn on_close(&self, callback: Box<dyn FnOnce() + 'static>) {
+        self.0.callbacks.borrow_mut().close = Some(callback);
+    }
+
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut() + 'static>) {
+        self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
+    }
+
+    fn on_insets_changed(&self, callback: Box<dyn FnMut(WindowInsets) + 'static>) {
+        self.0.callbacks.borrow_mut().insets_changed = Some(callback);
+    }
+
+    fn draw(&self, scene: &Scene) {
+        self.0.renderer.borrow_mut().draw(scene);
+    }
+
+    fn sprite_atlas(&self) -> Arc<dyn gpui::PlatformAtlas> {
+        self.0.renderer.borrow().sprite_atlas().clone()
+    }
+
+    fn is_subpixel_rendering_supported(&self) -> bool {
+        true
+    }
+
+    fn update_ime_position(&self, _bounds: Bounds<Pixels>) {}
+
+    fn insets(&self) -> WindowInsets {
+        WindowInsets::default()
+    }
+
+    fn gpu_specs(&self) -> Option<GpuSpecs> {
+        Some(self.0.renderer.borrow().gpu_specs())
+    }
+}
+
+impl HasWindowHandle for OpenHarmonyWindow {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        let handle = OhosNdkWindowHandle::new(self.native_window);
+        let raw = RawWindowHandle::OhosNdk(handle);
+        Ok(unsafe { WindowHandle::borrow_raw(raw) })
+    }
+}
+
+impl HasDisplayHandle for OpenHarmonyWindow {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        let handle = OhosDisplayHandle::new();
+        let raw = RawDisplayHandle::Ohos(handle);
+        Ok(unsafe { DisplayHandle::borrow_raw(raw) })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OpenHarmonyRawWindow {
+    native_window: NonNull<c_void>,
+    _marker: PhantomData<*mut c_void>,
+}
+
+unsafe impl Send for OpenHarmonyRawWindow {}
+unsafe impl Sync for OpenHarmonyRawWindow {}
+
+impl HasWindowHandle for OpenHarmonyRawWindow {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        let handle = OhosNdkWindowHandle::new(self.native_window);
+        let raw = RawWindowHandle::OhosNdk(handle);
+        Ok(unsafe { WindowHandle::borrow_raw(raw) })
+    }
+}
+
+impl HasDisplayHandle for OpenHarmonyRawWindow {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        let handle = OhosDisplayHandle::new();
+        let raw = RawDisplayHandle::Ohos(handle);
+        Ok(unsafe { DisplayHandle::borrow_raw(raw) })
+    }
+}

--- a/crates/gpui_platform/Cargo.toml
+++ b/crates/gpui_platform/Cargo.toml
@@ -36,3 +36,6 @@ gpui_linux.workspace = true
 [target.'cfg(target_family = "wasm")'.dependencies]
 gpui_web.workspace = true
 console_error_panic_hook.workspace = true
+
+[target.'cfg(target_env = "ohos")'.dependencies]
+gpui_openharmony.workspace = true

--- a/crates/gpui_platform/src/gpui_platform.rs
+++ b/crates/gpui_platform/src/gpui_platform.rs
@@ -57,7 +57,16 @@ pub fn current_platform(headless: bool) -> Rc<dyn Platform> {
         )
     }
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(target_env = "ohos")]
+    {
+        let _ = headless;
+        gpui_openharmony::current_platform()
+    }
+
+    #[cfg(all(
+        any(target_os = "linux", target_os = "freebsd"),
+        not(target_env = "ohos")
+    ))]
     {
         gpui_linux::current_platform(headless)
     }


### PR DESCRIPTION
## Summary

- Adds `gpui_openharmony` crate implementing the OpenHarmony `Platform`, `PlatformWindow`, dispatcher, display, keyboard, text system, and host surface/event contract.
- Wires `gpui_openharmony::current_platform` into `gpui_platform` for `target_env = "ohos"`.
- Adds a smoke-test example that builds for `x86_64-unknown-linux-ohos` and `aarch64-unknown-linux-ohos`.
- Verified `cargo check`/`cargo clippy` for both targets and ran the smoke test in the Oniro/OpenHarmony x86_64 emulator.

Release Notes:

- N/A