### PR TITLE
language: Fix block comment continuation for large comments

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5444,6 +5444,21 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         * text
         ˇ
     "});
+
+        // Ensure block comment continuation works for very long comments
+        // (larger than MAX_BYTES_TO_QUERY). Previously, the containing byte
+        // range filter in override_id excluded large comment nodes, causing
+        // the "comment" scope to not be detected.
+        let mut long_comment = String::from("/**\n");
+        for i in 0..600 {
+            long_comment.push_str(&format!(" * Line {i} padding padding padding\n"));
+        }
+        long_comment.push_str(" * Last lineˇ\n");
+        long_comment.push_str(" */");
+        cx.set_state(&long_comment);
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        let expected = long_comment.replace(" * Last lineˇ\n", " * Last line\n * ˇ\n");
+        cx.assert_editor_state(&expected);
     }
     // Ensure that comment continuations can be disabled.
     update_test_language_settings(cx, &|settings| {

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1858,10 +1858,6 @@ impl<'a> SyntaxLayer<'a> {
 
         let mut query_cursor = QueryCursorHandle::new();
         query_cursor.set_byte_range(offset.saturating_sub(1)..offset.saturating_add(1));
-        query_cursor.set_containing_byte_range(
-            offset.saturating_sub(MAX_BYTES_TO_QUERY / 2)
-                ..offset.saturating_add(MAX_BYTES_TO_QUERY / 2),
-        );
 
         let mut smallest_match: Option<(u32, Range<usize>)> = None;
         let mut matches = query_cursor.matches(&config.query, self.node(), text);


### PR DESCRIPTION
Closes #61903

Release Notes:

- Fixed block comment auto-continuation stopping for very long comments

https://github.com/user-attachments/assets/12795c4d-9fc7-4e74-8d84-626b430366fb