### PR TITLE
Make keybinding sequence timeout configurable

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -25,6 +25,9 @@
   // 8. "Cursor"
   // 9. "None"
   "base_keymap": "Zed",
+  // Time to wait in milliseconds before resolving a keybinding that is also
+  // the prefix of a longer keybinding.
+  "keybinding_sequence_timeout_ms": 1000,
   // The name of a font to use for rendering text in the editor
   // ".ZedMono" currently aliases to Lilex
   // but this may change in the future.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -74,6 +74,7 @@ mod visual_test_context;
 
 /// The duration for which futures returned from [Context::on_app_quit] can run before the application fully quits.
 pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(200);
+const DEFAULT_KEYBINDING_SEQUENCE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Temporary(?) wrapper around [`RefCell<App>`] to help us debug any double borrows.
 /// Strongly consider removing after stabilization.
@@ -705,6 +706,7 @@ pub struct App {
     pub(crate) window_handles: FxHashMap<WindowId, AnyWindowHandle>,
     pub(crate) focus_handles: Arc<FocusMap>,
     pub(crate) keymap: Rc<RefCell<Keymap>>,
+    pub(crate) keybinding_sequence_timeout: Duration,
     pub(crate) keyboard_layout: Box<dyn PlatformKeyboardLayout>,
     pub(crate) keyboard_mapper: Rc<dyn PlatformKeyboardMapper>,
     pub(crate) global_action_listeners:
@@ -826,6 +828,7 @@ impl App {
                 window_handles: FxHashMap::default(),
                 focus_handles: Arc::new(RwLock::new(SlotMap::with_key())),
                 keymap: Rc::new(RefCell::new(Keymap::default())),
+                keybinding_sequence_timeout: DEFAULT_KEYBINDING_SEQUENCE_TIMEOUT,
                 keyboard_layout,
                 keyboard_mapper,
                 global_action_listeners: Default::default(),
@@ -2171,6 +2174,16 @@ impl App {
     /// Get all key bindings in the app.
     pub fn key_bindings(&self) -> Rc<RefCell<Keymap>> {
         self.keymap.clone()
+    }
+
+    /// Returns how long ambiguous keybinding sequences wait for another keystroke.
+    pub fn keybinding_sequence_timeout(&self) -> Duration {
+        self.keybinding_sequence_timeout
+    }
+
+    /// Sets how long ambiguous keybinding sequences wait for another keystroke.
+    pub fn set_keybinding_sequence_timeout(&mut self, timeout: Duration) {
+        self.keybinding_sequence_timeout = timeout;
     }
 
     /// Register a global handler for actions invoked via the keyboard. These handlers are run at

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -630,6 +630,7 @@ mod tests {
         cell::{Cell, RefCell},
         ops::Range,
         rc::Rc,
+        time::Duration,
     };
 
     use crate::{
@@ -1251,6 +1252,21 @@ mod tests {
             assert_eq!(test.action_count.get(), 1);
             assert_eq!(test.text.borrow().as_str(), "");
         });
+
+        cx.update(|_, cx| {
+            assert_eq!(cx.keybinding_sequence_timeout(), Duration::from_secs(1));
+            cx.set_keybinding_sequence_timeout(Duration::from_millis(200));
+        });
+        cx.simulate_keystrokes("ctrl-b");
+        test.update(cx, |test, _| assert_eq!(test.action_count.get(), 1));
+
+        cx.executor().advance_clock(Duration::from_millis(199));
+        cx.run_until_parked();
+        test.update(cx, |test, _| assert_eq!(test.action_count.get(), 1));
+
+        cx.executor().advance_clock(Duration::from_millis(1));
+        cx.run_until_parked();
+        test.update(cx, |test, _| assert_eq!(test.action_count.get(), 2));
 
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5232,8 +5232,9 @@ impl Window {
                 match_result.pending_has_binding || text_input_requires_timeout;
 
             if currently_pending.needs_timeout {
+                let timeout = cx.keybinding_sequence_timeout();
                 currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(Duration::from_secs(1)).await;
+                    cx.background_executor.timer(timeout).await;
                     cx.update(move |window, cx| {
                         let Some(currently_pending) = window
                             .pending_input

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1294,6 +1294,7 @@ struct PendingInput {
     focus: Option<FocusId>,
     timer: Option<Task<()>>,
     needs_timeout: bool,
+    needs_keybinding_sequence_timeout: bool,
 }
 
 pub(crate) struct ElementStateBox {
@@ -5230,10 +5231,16 @@ impl Window {
 
             currently_pending.needs_timeout |=
                 match_result.pending_has_binding || text_input_requires_timeout;
+            currently_pending.needs_keybinding_sequence_timeout |= match_result.pending_has_binding;
 
             if currently_pending.needs_timeout {
+                let timeout = if currently_pending.needs_keybinding_sequence_timeout {
+                    cx.keybinding_sequence_timeout()
+                } else {
+                    Duration::from_secs(1)
+                };
                 currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(Duration::from_secs(1)).await;
+                    cx.background_executor.timer(timeout).await;
                     cx.update(move |window, cx| {
                         let Some(currently_pending) = window
                             .pending_input

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -177,6 +177,7 @@ impl VsCodeSettings {
             audio: None,
             auto_update: None,
             base_keymap: Some(BaseKeymapContent::VSCode),
+            keybinding_sequence_timeout_ms: None,
             calls: None,
             collaboration_panel: None,
             credentials_url: None,

--- a/crates/settings_content/src/merge_from.rs
+++ b/crates/settings_content/src/merge_from.rs
@@ -52,6 +52,7 @@ merge_from_overwrites!(
     char,
     std::num::NonZeroUsize,
     std::num::NonZeroU32,
+    std::num::NonZeroU64,
     String,
     std::sync::Arc<str>,
     std::path::PathBuf,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -188,6 +188,11 @@ pub struct SettingsContent {
     /// Default: VSCode
     pub base_keymap: Option<BaseKeymapContent>,
 
+    /// Time to wait in milliseconds before resolving an ambiguous keybinding sequence.
+    ///
+    /// Default: 1000
+    pub keybinding_sequence_timeout_ms: Option<u64>,
+
     /// Configuration for the collab panel visual settings.
     pub collaboration_panel: Option<PanelSettingsContent>,
 

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -69,6 +69,7 @@ macro_rules! settings_overrides {
 }
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 pub use util::serde::default_true;
 
@@ -187,6 +188,11 @@ pub struct SettingsContent {
     ///
     /// Default: VSCode
     pub base_keymap: Option<BaseKeymapContent>,
+
+    /// Time to wait in milliseconds before resolving an ambiguous keybinding sequence.
+    ///
+    /// Default: 1000
+    pub keybinding_sequence_timeout_ms: Option<NonZeroU64>,
 
     /// Configuration for the collab panel visual settings.
     pub collaboration_panel: Option<PanelSettingsContent>,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1533,7 +1533,7 @@ fn appearance_page() -> SettingsPage {
 }
 
 fn keymap_page() -> SettingsPage {
-    fn keybindings_section() -> [SettingsPageItem; 2] {
+    fn keybindings_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Keybindings"),
             SettingsPageItem::ActionLink(ActionLink {
@@ -1553,6 +1553,22 @@ fn keymap_page() -> SettingsPage {
                         .ok();
                     window.remove_window();
                 }),
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Keybinding Sequence Timeout",
+                description: "Time to wait in milliseconds before resolving an ambiguous keybinding sequence.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("keybinding_sequence_timeout_ms"),
+                    pick: |settings_content| {
+                        settings_content.keybinding_sequence_timeout_ms.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.keybinding_sequence_timeout_ms = value;
+                    },
+                }),
+                metadata: None,
                 files: USER,
             }),
         ]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1558,7 +1558,7 @@ fn keymap_page() -> SettingsPage {
         ]
     }
 
-    fn base_keymap_section() -> [SettingsPageItem; 2] {
+    fn base_keymap_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Base Keymap"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1576,6 +1576,22 @@ fn keymap_page() -> SettingsPage {
                     should_do_titlecase: Some(false),
                     ..Default::default()
                 })),
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Keybinding Sequence Timeout",
+                description: "Time to wait in milliseconds before resolving an ambiguous keybinding sequence.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("keybinding_sequence_timeout_ms"),
+                    pick: |settings_content| {
+                        settings_content.keybinding_sequence_timeout_ms.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.keybinding_sequence_timeout_ms = value;
+                    },
+                }),
+                metadata: None,
                 files: USER,
             }),
         ]

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -82,6 +82,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
     sync::atomic::{self, AtomicBool},
+    time::Duration,
 };
 use terminal_view::terminal_panel::{self, TerminalPanel};
 use theme::{ActiveTheme, SystemAppearance, ThemeRegistry, deserialize_icon_theme};
@@ -434,6 +435,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
     .detach();
 
     init_cursor_hide_mode(cx);
+    init_keybinding_sequence_timeout(cx);
     init_app_appearance(cx);
     init_reduce_motion(cx);
 
@@ -2060,6 +2062,25 @@ impl Settings for CursorHideModeSetting {
 
 fn init_cursor_hide_mode(cx: &mut App) {
     let apply = |cx: &mut App| cx.set_cursor_hide_mode(CursorHideModeSetting::get_global(cx).0);
+    apply(cx);
+    cx.observe_global::<SettingsStore>(apply).detach();
+}
+
+#[derive(Copy, Clone, Debug, settings::RegisterSetting)]
+struct KeybindingSequenceTimeoutSetting(Duration);
+
+impl Settings for KeybindingSequenceTimeoutSetting {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        Self(Duration::from_millis(
+            content.keybinding_sequence_timeout_ms.unwrap(),
+        ))
+    }
+}
+
+fn init_keybinding_sequence_timeout(cx: &mut App) {
+    let apply = |cx: &mut App| {
+        cx.set_keybinding_sequence_timeout(KeybindingSequenceTimeoutSetting::get_global(cx).0);
+    };
     apply(cx);
     cx.observe_global::<SettingsStore>(apply).detach();
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -82,6 +82,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
     sync::atomic::{self, AtomicBool},
+    time::Duration,
 };
 use terminal_view::terminal_panel::{self, TerminalPanel};
 use theme::{ActiveTheme, SystemAppearance, ThemeRegistry, deserialize_icon_theme};
@@ -434,6 +435,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
     .detach();
 
     init_cursor_hide_mode(cx);
+    init_keybinding_sequence_timeout(cx);
     init_app_appearance(cx);
     init_reduce_motion(cx);
 
@@ -2060,6 +2062,25 @@ impl Settings for CursorHideModeSetting {
 
 fn init_cursor_hide_mode(cx: &mut App) {
     let apply = |cx: &mut App| cx.set_cursor_hide_mode(CursorHideModeSetting::get_global(cx).0);
+    apply(cx);
+    cx.observe_global::<SettingsStore>(apply).detach();
+}
+
+#[derive(Copy, Clone, Debug, settings::RegisterSetting)]
+struct KeybindingSequenceTimeoutSetting(Duration);
+
+impl Settings for KeybindingSequenceTimeoutSetting {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        Self(Duration::from_millis(
+            content.keybinding_sequence_timeout_ms.unwrap().get(),
+        ))
+    }
+}
+
+fn init_keybinding_sequence_timeout(cx: &mut App) {
+    let apply = |cx: &mut App| {
+        cx.set_keybinding_sequence_timeout(KeybindingSequenceTimeoutSetting::get_global(cx).0);
+    };
     apply(cx);
     cx.observe_global::<SettingsStore>(apply).detach();
 }

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -173,7 +173,24 @@ When multiple keybindings have the same keystroke and are active at the same tim
 
 The other kind of conflict that arises is when you have two bindings, one of which is a prefix of the other. For example, if you have `"ctrl-w":"editor::DeleteToNextWordEnd"` and `"ctrl-w left":"editor::DeleteToEndOfLine"`.
 
-When this happens, and both bindings are active in the current context, Zed will wait for 1 second after you type `ctrl-w` to see if you're about to type `left`. If you don't type anything, or if you type a different key, then `DeleteToNextWordEnd` will be triggered. If you do, then `DeleteToEndOfLine` will be triggered.
+When this happens, and both bindings are active in the current context, Zed
+waits for the duration configured by `keybinding_sequence_timeout_ms` after you
+type `ctrl-w` to see if you're about to type `left`. The default is 1000
+milliseconds. If you don't type anything, or if you type a different key, then
+`DeleteToNextWordEnd` is triggered. If you type `left` within the timeout, then
+`DeleteToEndOfLine` is triggered.
+
+To change the timeout, open the Settings Editor ({#kb zed::OpenSettings}),
+search for "Keybinding Sequence Timeout", and enter a positive number of
+milliseconds.
+
+Alternatively, add the setting to your `settings.json` file:
+
+```json [settings]
+{
+  "keybinding_sequence_timeout_ms": 300
+}
+```
 
 ### Non-QWERTY keyboards
 

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -173,7 +173,20 @@ When multiple keybindings have the same keystroke and are active at the same tim
 
 The other kind of conflict that arises is when you have two bindings, one of which is a prefix of the other. For example, if you have `"ctrl-w":"editor::DeleteToNextWordEnd"` and `"ctrl-w left":"editor::DeleteToEndOfLine"`.
 
-When this happens, and both bindings are active in the current context, Zed will wait for 1 second after you type `ctrl-w` to see if you're about to type `left`. If you don't type anything, or if you type a different key, then `DeleteToNextWordEnd` will be triggered. If you do, then `DeleteToEndOfLine` will be triggered.
+When this happens, and both bindings are active in the current context, Zed
+waits for the duration configured by `keybinding_sequence_timeout_ms` after you
+type `ctrl-w` to see if you're about to type `left`. The default is 1000
+milliseconds. If you don't type anything, or if you type a different key, then
+`DeleteToNextWordEnd` is triggered. If you type `left` within the timeout, then
+`DeleteToEndOfLine` is triggered.
+
+You can change the timeout in your settings:
+
+```json [settings]
+{
+  "keybinding_sequence_timeout_ms": 300
+}
+```
 
 ### Non-QWERTY keyboards
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1711,6 +1711,16 @@ This setting enables integration with macOS’s native window tabbing feature. W
 
 `boolean` values
 
+## Keybinding Sequence Timeout
+
+- Description: Time to wait in milliseconds before resolving a keybinding that is also the prefix of a longer keybinding.
+- Setting: `keybinding_sequence_timeout_ms`
+- Default: `1000`
+
+**Options**
+
+Positive `integer` values
+
 ## Line Ending
 
 - Description: How line endings should be handled for new files and during format and save. This can be specified on a per-language basis.


### PR DESCRIPTION
# Objective

- Make the timeout for ambiguous keybinding sequences configurable instead of
  always waiting one second.
- This addresses the use case described in
  [Discussion #28576](https://github.com/zed-industries/zed/discussions/28576),
  including conflicts where a complete binding such as `Ctrl+W` is also the
  prefix of Vim pane commands.

## Solution

- Add a global `keybinding_sequence_timeout_ms` setting with a backward-compatible
  default of `1000` and require the value to be greater than zero.
- Store the configured duration in GPUI and use it only when scheduling ambiguous
  keybinding sequence resolution; text-input/IME pending replay keeps its existing
  one-second timeout.
- Apply setting changes without restarting Zed.
- Expose the setting in the Settings Editor and document it in both the keybinding
  guide and the complete settings reference.

## Testing

- `cargo test -p gpui test_input_handler_pending --lib`
- `cargo check -p settings_content`
- `cargo fmt --all -- --check`
- `cd docs && npx prettier --check src/key-bindings.md src/reference/all-settings.md`

The focused test verifies both the existing one-second default and a configured
200 ms keybinding sequence timeout.

`cargo check -p settings_ui -p zed` is blocked in this Linux environment while
building `webrtc-sys` C++ trampoline assembly, before reaching the changed crates.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added a setting to configure the timeout for ambiguous keybinding sequences.
