### PR TITLE
Add per-server setting to opt out of LSP file watcher registration

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24285,6 +24285,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppCon
                     "some other init value": false
                 })),
                 enable_lsp_tasks: false,
+                enable_file_watchers: None,
                 fetch: None,
             },
         );
@@ -24306,6 +24307,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppCon
                     "anotherInitValue": false
                 })),
                 enable_lsp_tasks: false,
+                enable_file_watchers: None,
                 fetch: None,
             },
         );
@@ -24327,6 +24329,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppCon
                     "anotherInitValue": false
                 })),
                 enable_lsp_tasks: false,
+                enable_file_watchers: None,
                 fetch: None,
             },
         );
@@ -24346,6 +24349,7 @@ async fn test_language_server_restart_due_to_settings_change(cx: &mut TestAppCon
                 settings: None,
                 initialization_options: None,
                 enable_lsp_tasks: false,
+                enable_file_watchers: None,
                 fetch: None,
             },
         );

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -271,6 +271,7 @@ struct UnifiedLanguageServer {
 struct LanguageServerSeedSettings {
     binary: Option<BinarySettings>,
     initialization_options: Option<serde_json::Value>,
+    enable_file_watchers: Option<bool>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -378,6 +379,7 @@ impl LocalLspStore {
             settings: LanguageServerSeedSettings {
                 binary: disposition.settings.binary.clone(),
                 initialization_options: disposition.settings.initialization_options.clone(),
+                enable_file_watchers: disposition.settings.enable_file_watchers,
             },
             toolchain: disposition.toolchain.clone(),
         };
@@ -428,6 +430,7 @@ impl LocalLspStore {
         let worktree_abs_path = worktree.abs_path();
         let toolchain = key.toolchain.clone();
         let override_options = settings.initialization_options.clone();
+        let enable_file_watchers = settings.enable_file_watchers.unwrap_or(true);
 
         let stderr_capture = Arc::new(Mutex::new(Some(String::new())));
 
@@ -582,7 +585,15 @@ impl LocalLspStore {
                             cx,
                         );
                         params.initialization_options = initialization_options;
-                        adapter.adapter.prepare_initialize_params(params, cx)
+                        let mut params = adapter.adapter.prepare_initialize_params(params, cx)?;
+                        if !enable_file_watchers
+                            && let Some(workspace) = params.capabilities.workspace.as_mut()
+                            && let Some(did_change_watched_files) =
+                                workspace.did_change_watched_files.as_mut()
+                        {
+                            did_change_watched_files.dynamic_registration = Some(false);
+                        }
+                        anyhow::Ok(params)
                     })?;
 
                     Self::setup_lsp_messages(
@@ -5796,6 +5807,7 @@ impl LspStore {
                                         .settings
                                         .initialization_options
                                         .clone(),
+                                    enable_file_watchers: disposition.settings.enable_file_watchers,
                                 },
                                 toolchain: local.toolchain_store.read(cx).active_toolchain(
                                     path.worktree_id,

--- a/crates/project/tests/integration/dynamic_registration.rs
+++ b/crates/project/tests/integration/dynamic_registration.rs
@@ -1737,6 +1737,90 @@ async fn test_multiple_did_change_watched_files_registrations(cx: &mut gpui::Tes
     );
 }
 
+#[gpui::test]
+async fn test_advertised_file_watcher_registration_capability(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    assert_eq!(
+        advertised_file_watcher_dynamic_registration(None, cx).await,
+        Some(true),
+        "file watcher registration should be advertised by default"
+    );
+    assert_eq!(
+        advertised_file_watcher_dynamic_registration(Some(true), cx).await,
+        Some(true),
+    );
+    assert_eq!(
+        advertised_file_watcher_dynamic_registration(Some(false), cx).await,
+        Some(false),
+        "`enable_file_watchers: false` should tell the server that Zed will not watch files for it"
+    );
+}
+
+/// Starts a language server with the given `lsp.the-language-server.enable_file_watchers`
+/// setting and returns the `workspace.didChangeWatchedFiles.dynamicRegistration` client
+/// capability that Zed advertised to it.
+async fn advertised_file_watcher_dynamic_registration(
+    enable_file_watchers: Option<bool>,
+    cx: &mut gpui::TestAppContext,
+) -> Option<bool> {
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.lsp.0.insert(
+                    "the-language-server".into(),
+                    settings::LspSettings {
+                        enable_file_watchers,
+                        ..Default::default()
+                    },
+                );
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/the-root"), json!({ "a.rs": "" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/the-root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+
+    let (capabilities_tx, mut capabilities_rx) = futures::channel::mpsc::unbounded();
+    let _fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "the-language-server",
+            initializer: Some(Box::new(move |fake_server| {
+                let capabilities_tx = capabilities_tx.clone();
+                fake_server.set_request_handler::<lsp::request::Initialize, _, _>(
+                    move |params, _| {
+                        capabilities_tx.unbounded_send(params.capabilities).ok();
+                        async move { Ok(lsp::InitializeResult::default()) }
+                    },
+                );
+            })),
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let _buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/the-root/a.rs"), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    capabilities_rx
+        .next()
+        .await
+        .expect("language server should have been initialized")
+        .workspace
+        .and_then(|workspace| workspace.did_change_watched_files)
+        .and_then(|watched_files| watched_files.dynamic_registration)
+}
+
 async fn setup_dynamic_registration_test(
     cx: &mut gpui::TestAppContext,
     capabilities: lsp::ServerCapabilities,

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -186,6 +186,16 @@ pub struct LspSettings {
     /// Default: true
     #[serde(default = "default_true")]
     pub enable_lsp_tasks: bool,
+    /// Whether to let this language server ask Zed to watch files on its behalf
+    /// (`workspace/didChangeWatchedFiles`).
+    ///
+    /// Some language servers register a very large number of watchers in big
+    /// workspaces, which can make Zed slow. Setting this to `false` makes Zed
+    /// advertise `workspace.didChangeWatchedFiles.dynamicRegistration: false`, so
+    /// servers that support it fall back to watching files themselves.
+    ///
+    /// Default: true
+    pub enable_file_watchers: Option<bool>,
     pub fetch: Option<FetchSettings>,
 }
 
@@ -196,6 +206,7 @@ impl Default for LspSettings {
             initialization_options: None,
             settings: None,
             enable_lsp_tasks: true,
+            enable_file_watchers: None,
             fetch: None,
         }
     }

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -269,6 +269,29 @@ Language servers are automatically downloaded or launched if found in your path,
   }
 ```
 
+#### File watching
+
+Language servers can ask Zed to watch files on their behalf via
+[`workspace/didChangeWatchedFiles`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles).
+A few servers register a very large number of watchers in big workspaces — Roslyn, for
+example, registers several per project, which adds up to thousands in a solution with
+hundreds of projects — and that can make Zed slow to open and edit files.
+
+If you hit this, you can tell Zed not to offer file watching to a particular server:
+
+```json [settings]
+  "lsp": {
+    "roslyn": {
+      "enable_file_watchers": false
+    }
+  }
+```
+
+Zed then advertises `workspace.didChangeWatchedFiles.dynamicRegistration: false`, and
+servers that respect it fall back to watching files themselves. Servers that rely on Zed
+for file watching may stop noticing changes made outside the editor, so only reach for
+this when a server is causing you trouble.
+
 ### Enabling or Disabling Language Servers
 
 You can toggle language server support globally or per-language:

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1827,6 +1827,7 @@ The following settings can be overridden for specific language servers:
 
 - `initialization_options`
 - `settings`
+- `enable_file_watchers`
 
 To override configuration for a language server, add an entry for that language server's name to the `lsp` value.
 
@@ -1859,6 +1860,21 @@ While other options may be changed at a runtime and should be placed under `sett
           "keyOrdering": true // Enforces alphabetical ordering of keys in maps
         }
       }
+    }
+  }
+}
+```
+
+`enable_file_watchers` controls whether a language server may ask Zed to watch files
+on its behalf (`workspace/didChangeWatchedFiles`). Some servers register a very large
+number of watchers in big workspaces, which can make Zed slow; setting this to `false`
+makes servers that support it watch files themselves instead:
+
+```json [settings]
+{
+  "lsp": {
+    "roslyn": {
+      "enable_file_watchers": false
     }
   }
 }


### PR DESCRIPTION
# Objective

Zed always advertises `workspace.didChangeWatchedFiles.dynamicRegistration: true` (`crates/lsp/src/lsp.rs`), so there is currently no way to tell a language server that it should watch files itself. That is a problem for servers that register one watcher per `client/registerCapability` request instead of batching them.

I measured this by driving `Microsoft.CodeAnalysis.LanguageServer` 5.11.0 directly over stdio and counting `client/registerCapability` calls carrying a `workspace/didChangeWatchedFiles` registration:

| Workspace | `registerCapability` calls |
| --- | --- |
| `dotnet new console` | 10 |
| 20 trivial projects | 124 (~6.2/project) |
| A real solution with 184 `.csproj` | **2,245** |

Each call carries exactly one watcher, and many are redundant — 184 identical registrations for the same `analysislevel_10_default.globalconfig`, 322 for individual reference DLLs under two `microsoft.netcore.app.ref` folders, two near-duplicate `**/*{.cs,.razor,.cshtml}` patterns per project (Roslyn's and Razor cohost's, differing only in brace order), plus repeated recursive `**/*.dll` scans over `/usr/local/share/dotnet/packs`.

Roslyn picks its watcher implementation purely from this client capability. With `dynamicRegistration: false` it sends **zero** watcher registrations and falls back to its internal `SimpleFileChangeWatcher`; projects still load normally. It has no CLI flag for this, and the Zed C# extension has no way to influence client capabilities, so the knob has to live in Zed.

This is related to but distinct from the work in #57346 and #61072, which make Zed's own watcher handling cheaper. Those are the real fix; this gives users an escape hatch that removes the registrations entirely, and it is useful for any server with the same shape (see the pyright reports in #55746).

## Solution

Add `lsp.<server>.enable_file_watchers`, default `true`:

```json
{
  "lsp": {
    "roslyn": {
      "enable_file_watchers": false
    }
  }
}
```

When `false`, Zed advertises `workspace.didChangeWatchedFiles.dynamicRegistration: false` to that server.

Notes on the implementation:

- The override is applied after `LspAdapter::prepare_initialize_params`, so the user setting wins over anything an adapter sets.
- The setting is part of `LanguageServerSeedSettings`, so toggling it restarts the affected servers the same way `initialization_options` does.
- It only changes what Zed advertises. A server that ignores the capability and registers watchers anyway is unaffected, which is why the docs frame this as a workaround rather than a guarantee.

## Testing

Added `test_advertised_file_watcher_registration_capability`, which starts a fake server, intercepts `initialize`, and asserts the advertised `dynamicRegistration` value for each of `None` / `Some(true)` / `Some(false)`. I confirmed it fails without the `lsp_store` change. `cargo test -p project` passes (307 tests), as does `cargo test -p settings`.

Tested on macOS (arm64). I could not compile the GUI crates locally (no full Xcode, so `gpui_macos` can't build its Metal shaders), so the four struct-literal updates in `crates/editor/src/editor_tests.rs` are unverified by a compiler — they are mechanical additions of `enable_file_watchers: None` to already-exhaustive `LspSettings` literals. CI will cover them.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added an `lsp.<server>.enable_file_watchers` setting, which stops a language server from registering file watchers with Zed. This can work around large slowdowns with servers that register very many watchers, such as Roslyn in solutions with many projects.