### PR TITLE
docs: Document the `--existing` CLI option

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -85,7 +85,15 @@ Reuse an existing window, replacing its current workspace with the new paths:
 zed -r ~/projects/different-project
 ```
 
-By default (without `-n`, `-a`, or `-r`), directories open in the current window's sidebar. You can change this default with the `cli_default_open_behavior` setting. See [Windows & Projects](../windows-and-projects.md) for more details.
+### `-e`, `--existing`
+
+Open paths in an existing Zed window instead of creating a new one:
+
+```sh
+zed -e myfile.txt
+```
+
+By default (without `-n`, `-a`, `-r`, or `-e`), directories open in the current window's sidebar. You can change this default with the `cli_default_open_behavior` setting. See [Windows & Projects](../windows-and-projects.md) for more details.
 
 ### `--diff <OLD_PATH> <NEW_PATH>`
 


### PR DESCRIPTION
# Objective

Fixes #61730.

Document the `-e`, `--existing` CLI option, which was missing from the CLI reference.

## Solution

- Added documentation for the `-e`, `--existing` CLI option.
- Added a usage example.
- Updated the default behavior note to include `-e`.

## Testing

- Built the documentation locally using `mdbook`.
- Verified that the new section renders correctly in the CLI Reference page.
- Confirmed the example and updated default behavior note appear as expected.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards (Not applicable)
- [ ] Tests cover the new/changed behavior (Documentation change only)
- [x] Performance impact has been considered and is acceptable

## Showcase

The CLI Reference now includes documentation for the `-e`, `--existing` option.

<details>
<summary>Documentation Preview</summary>

<img width="935" height="539" alt="Screenshot 2026-07-31 151714" src="https://github.com/user-attachments/assets/c2e4ad05-a961-4fe1-8c22-5e3a474e96ca" />


</details>

---

Release Notes:

- Improved CLI documentation by adding the missing `--existing` option.