### PR TITLE
Fix parameter colors for gruvbox themes

### DIFF
--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -398,7 +398,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#83a598ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -820,7 +820,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#83a598ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1242,7 +1242,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#83a598ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1664,7 +1664,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#076678ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2086,7 +2086,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#076678ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2508,7 +2508,7 @@
             "font_weight": null
           },
           "variable.parameter": {
-            "color": "#076678ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Left before, right after:
<img width="1728" height="370" alt="image" src="https://github.com/user-attachments/assets/3229ba26-18e6-415e-8df3-25fa5fea43aa" />

Closes https://github.com/zed-industries/zed/issues/61976

https://github.com/zed-industries/zed/pull/61134 picked a wrong color for `variable.parameter` that exactly matched `variable.special` and caused visual conflicts.
Instead, use `variable` for such colors.


Release Notes:

- Fixed Gruvbox parameter colors
