### PR TITLE
acp_thread: Fix invisible worktree leak that crashes Zed

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3748,6 +3748,28 @@ impl AcpThread {
             id: turn_id,
             send_task: cx.spawn(async move |this, cx| {
                 cancel_task.await;
+                // shared_buffers only needs to live long enough to back
+                // reuse_shared_snapshot and read/write consistency *within* a
+                // turn (see the comment on ResolvedLocation - it's held
+                // strong "for saving on the thread", not for the thread's
+                // whole lifetime). Carrying entries forward across turns
+                // pins their buffers, and the invisible worktrees created to
+                // open out-of-workspace files, alive for the rest of the
+                // chat - across a long session that exhausts the OS's file
+                // descriptor/watch limits. Old tool-call locations stay
+                // resolvable regardless: resolve_locations always re-opens
+                // the buffer by path instead of depending on this cache.
+                //
+                // This runs after awaiting cancel_task, which narrows the
+                // window against the *previous* turn's own in-flight
+                // resolution work (cancel_task only waits on that turn's
+                // send_task, not on detached resolve_locations calls, so a
+                // straggler can still land after this clear - it's cleaned
+                // up at the next turn boundary instead). It always runs
+                // before invoking `f`, so it never clears anything *this*
+                // turn is about to populate.
+                this.update(cx, |this, _cx| this.shared_buffers.clear())
+                    .ok();
                 tx.send(f(this, cx).await).ok();
             }),
         });
@@ -6392,6 +6414,153 @@ mod tests {
                 .expect("resolved location should keep an open buffer");
             assert_eq!(buffer.read(cx).text(), "skill body");
         });
+    }
+
+    #[gpui::test]
+    async fn test_shared_buffers_do_not_leak_invisible_worktrees_across_turns(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        const TURN_COUNT: usize = 6;
+        let fs = FakeFs::new(cx.executor());
+        let history_root = std::path::PathBuf::from(path!("/tmp/acp-history"));
+        let mut history_paths = Vec::new();
+        for i in 0..TURN_COUNT {
+            let dir = history_root.join(format!("case-{i}"));
+            fs.insert_tree(&dir, json!({ "file.txt": "content" })).await;
+            history_paths.push(dir.join("file.txt"));
+        }
+
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new().on_user_message(
+            |_request, _thread, _cx| {
+                async move { Ok(acp::PromptResponse::new(acp::StopReason::EndTurn)) }.boxed_local()
+            },
+        ));
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        for path in &history_paths {
+            // Each iteration is a fresh prompt/response cycle (a new turn), and
+            // the tool call's location simulates the agent touching a file
+            // outside the visible workspace - e.g. a Read/Edit on an unrelated
+            // project - exactly what accumulated across turns in production.
+            cx.update(|cx| thread.update(cx, |thread, cx| thread.send(vec!["go".into()], cx)))
+                .await
+                .unwrap();
+
+            thread
+                .update(cx, |thread, cx| {
+                    thread.handle_session_update(
+                        acp::SessionUpdate::ToolCall(
+                            acp::ToolCall::new("read_file", "Read file")
+                                .kind(acp::ToolKind::Read)
+                                .status(acp::ToolCallStatus::Completed)
+                                .locations(vec![acp::ToolCallLocation::new(path.clone())]),
+                        ),
+                        cx,
+                    )
+                })
+                .unwrap();
+            cx.run_until_parked();
+        }
+
+        let diagnostics = project.read_with(cx, |project, cx| {
+            project.worktree_store().read(cx).diagnostics(cx)
+        });
+        let invisible_live = diagnostics.live_worktrees - diagnostics.visible_worktrees;
+        assert!(
+            invisible_live <= 2,
+            "expected old tool-call locations' invisible worktrees to be released once later \
+             turns start, but {invisible_live} are still live after {TURN_COUNT} turns \
+             (diagnostics: {diagnostics:?})",
+        );
+    }
+
+    #[gpui::test]
+    async fn test_read_text_file_reuses_shared_snapshot_within_a_turn(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/tmp"), json!({"foo": "one\n"})).await;
+        let project = Project::test(fs, [], cx).await;
+        // read_text_file (unlike resolve_locations) has no fallback for paths
+        // outside a registered worktree, so make one cover it first.
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/tmp/foo"), true, cx)
+            })
+            .await
+            .unwrap();
+        let connection = Rc::new(FakeAgentConnection::new().on_user_message({
+            let project = project.clone();
+            move |_request, thread, mut cx| {
+                let project = project.clone();
+                async move {
+                    let first = thread
+                        .update(&mut cx, |thread, cx| {
+                            thread.read_text_file(path!("/tmp/foo").into(), None, None, true, cx)
+                        })
+                        .unwrap()
+                        .await
+                        .unwrap();
+                    assert_eq!(first, "one\n");
+
+                    // Edit the already-open buffer directly (not just the
+                    // backing FakeFs) after the agent's read, in the same
+                    // turn, before it reads again - this is what
+                    // reuse_shared_snapshot is actually meant to shield
+                    // against, e.g. a concurrent edit from the user.
+                    let project_path = project
+                        .update(&mut cx, |project, cx| {
+                            project.project_path_for_absolute_path(Path::new(path!("/tmp/foo")), cx)
+                        })
+                        .expect("path is covered by the worktree created above");
+                    let buffer = project
+                        .update(&mut cx, |project, cx| project.open_buffer(project_path, cx))
+                        .await
+                        .unwrap();
+                    buffer
+                        .update(&mut cx, |buffer, cx| buffer.set_text("two\n", cx))
+                        .unwrap();
+
+                    let second = thread
+                        .update(&mut cx, |thread, cx| {
+                            thread.read_text_file(path!("/tmp/foo").into(), None, None, true, cx)
+                        })
+                        .unwrap()
+                        .await
+                        .unwrap();
+                    assert_eq!(
+                        second, "one\n",
+                        "reuse_shared_snapshot should return the snapshot captured earlier in \
+                         the same turn, not the buffer's current content"
+                    );
+
+                    Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+                }
+                .boxed_local()
+            }
+        }));
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        cx.update(|cx| thread.update(cx, |thread, cx| thread.send(vec!["go".into()], cx)))
+            .await
+            .unwrap();
     }
 
     #[gpui::test]

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -970,15 +970,20 @@ impl GlobalWatcher {
 
     fn start_native_watch_limit_cooldown(&self, path: &Path) {
         let mut state = self.state.lock();
-        let now = Instant::now();
-        let should_log = !state.is_native_watch_limit_cooldown_active();
-        state.cooldown_until = Some(now + *NATIVE_WATCH_LIMIT_COOLDOWN);
-        if should_log {
-            log::warn!(
-                "OS file watch limit reached while watching {path:?}; skipping new native file watcher registrations for {} seconds",
-                NATIVE_WATCH_LIMIT_COOLDOWN.as_secs()
-            );
+        // A cooldown already in flight must not be pushed further out: both the
+        // add path (repeatedly failing to register new paths) and the remove
+        // path (repeatedly failing to unwatch, since notify's FSEvents backend
+        // recreates the stream on removal too) can call this in a tight loop
+        // while the OS limit is hit, and neither should be able to keep
+        // resetting the deadline indefinitely.
+        if state.is_native_watch_limit_cooldown_active() {
+            return;
         }
+        state.cooldown_until = Some(Instant::now() + *NATIVE_WATCH_LIMIT_COOLDOWN);
+        log::warn!(
+            "OS file watch limit reached while watching {path:?}; skipping new native file watcher registrations for {} seconds",
+            NATIVE_WATCH_LIMIT_COOLDOWN.as_secs()
+        );
     }
 
     pub fn remove(&self, id: WatcherRegistrationId) {
@@ -987,7 +992,18 @@ impl GlobalWatcher {
             return;
         };
         drop(state);
-        self.unwatch(path.as_path(), mode).log_err();
+        let result = self.unwatch(path.as_path(), mode);
+        // notify's FSEvents backend has to recreate the whole stream to drop a
+        // path too, so unwatching can hit the same OS limit as watching. Route
+        // it through the same cooldown instead of logging an error every time.
+        if let Err(error) = &result
+            && mode == WatcherMode::Native
+            && is_max_files_watch_error(error)
+        {
+            self.start_native_watch_limit_cooldown(path.as_path());
+            return;
+        }
+        result.log_err();
     }
 
     fn watch(&self, path: &Path, mode: WatcherMode) -> anyhow::Result<()> {
@@ -1081,10 +1097,18 @@ impl GlobalWatcher {
     }
 }
 
+/// macOS's FSEvents backend reports an `FSEventStreamStart` failure — which in
+/// practice means the process is out of file descriptors (EMFILE) — as this
+/// generic message rather than a structured `ErrorKind::MaxFilesWatch`
+/// (see `notify::fsevent`, `Error::generic(FSEVENT_STREAM_START_FAILURE)`
+/// upstream). Shared with the test module so the two never drift apart.
+const FSEVENT_STREAM_START_FAILURE: &str = "unable to start FSEvent stream";
+
 fn is_max_files_watch_error(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<notify::Error>()
-        .is_some_and(|error| matches!(&error.kind, notify::ErrorKind::MaxFilesWatch))
+    error.downcast_ref::<notify::Error>().is_some_and(|error| {
+        matches!(&error.kind, notify::ErrorKind::MaxFilesWatch)
+            || matches!(&error.kind, notify::ErrorKind::Generic(message) if message == FSEVENT_STREAM_START_FAILURE)
+    })
 }
 
 static POLL_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
@@ -1162,6 +1186,7 @@ mod tests {
         watch_calls: Vec<PathBuf>,
         unwatch_calls: Vec<PathBuf>,
         fail_with_watch_limit: bool,
+        fail_with_fsevent_stream_error: bool,
     }
 
     struct SharedFakeWatchBackend(Arc<Mutex<FakeWatchBackend>>);
@@ -1174,6 +1199,9 @@ mod tests {
             if backend.fail_with_watch_limit {
                 return Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch));
             }
+            if backend.fail_with_fsevent_stream_error {
+                return Err(notify::Error::generic(FSEVENT_STREAM_START_FAILURE));
+            }
             backend.watched_paths.insert(path);
             Ok(())
         }
@@ -1182,6 +1210,12 @@ mod tests {
             let path = path.to_path_buf();
             let mut backend = self.0.lock();
             backend.unwatch_calls.push(path.clone());
+            if backend.fail_with_watch_limit {
+                return Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch));
+            }
+            if backend.fail_with_fsevent_stream_error {
+                return Err(notify::Error::generic(FSEVENT_STREAM_START_FAILURE));
+            }
             if backend.watched_paths.remove(&path) {
                 Ok(())
             } else {
@@ -1329,6 +1363,84 @@ mod tests {
 
         let native_backend = native_backend.lock();
         assert_eq!(native_backend.watch_calls, &[first_path.to_path_buf()]);
+    }
+
+    #[test]
+    fn macos_fsevent_stream_start_failure_triggers_native_watch_limit_cooldown() {
+        let native_backend = Arc::new(Mutex::new(FakeWatchBackend {
+            fail_with_fsevent_stream_error: true,
+            ..Default::default()
+        }));
+        let poll_backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let watcher = test_watcher_with_backends(Some(native_backend.clone()), Some(poll_backend));
+        let first_path = Arc::<Path>::from(Path::new("/repo/first"));
+        let second_path = Arc::<Path>::from(Path::new("/repo/second"));
+
+        let first_registration = watcher
+            .add(first_path.clone(), WatcherMode::Native, false, |_| {})
+            .expect("fsevent stream-start failure is handled");
+        let second_registration = watcher
+            .add(second_path, WatcherMode::Native, false, |_| {})
+            .expect("fsevent stream-start failure backoff is handled");
+
+        assert!(first_registration.is_none());
+        assert!(second_registration.is_none());
+
+        // The second attempt is skipped by the cooldown rather than retrying
+        // FSEventStreamStart, so only the first path ever reaches the backend.
+        let native_backend = native_backend.lock();
+        assert_eq!(native_backend.watch_calls, &[first_path.to_path_buf()]);
+    }
+
+    #[test]
+    fn unwatch_failure_from_native_watch_limit_starts_cooldown_instead_of_erroring() {
+        let native_backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let poll_backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let watcher = test_watcher_with_backends(Some(native_backend.clone()), Some(poll_backend));
+
+        let registration = watcher
+            .add(
+                Arc::<Path>::from(Path::new("/repo/first")),
+                WatcherMode::Native,
+                false,
+                |_| {},
+            )
+            .expect("native watch succeeds")
+            .expect("native watch registered");
+
+        native_backend.lock().fail_with_fsevent_stream_error = true;
+        watcher.remove(registration);
+
+        assert!(watcher.state.lock().is_native_watch_limit_cooldown_active());
+    }
+
+    #[test]
+    fn repeated_failures_do_not_extend_an_already_active_cooldown() {
+        let native_backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let poll_backend = Arc::new(Mutex::new(FakeWatchBackend::default()));
+        let watcher = test_watcher_with_backends(Some(native_backend), Some(poll_backend));
+        let path = Path::new("/repo/first");
+
+        watcher.start_native_watch_limit_cooldown(path);
+        let first_deadline = watcher
+            .state
+            .lock()
+            .cooldown_until
+            .expect("cooldown started");
+
+        // A second failure while the cooldown from the first is still active
+        // (e.g. GlobalWatcher::remove hitting the same OS limit trying to
+        // unwatch a different path) must not push the deadline further out -
+        // otherwise a steady stream of failures under sustained fd pressure
+        // would never let the cooldown actually expire.
+        watcher.start_native_watch_limit_cooldown(path);
+        let second_deadline = watcher
+            .state
+            .lock()
+            .cooldown_until
+            .expect("cooldown still active");
+
+        assert_eq!(first_deadline, second_deadline);
     }
 
     fn modify_event(path: &str) -> notify::Event {


### PR DESCRIPTION
This crash was found and fixed with AI assistance (Claude Code), working from two real macOS crash reports and the accompanying Zed log, under my supervision and review. I'm disclosing this per your AI policy rather than leaving it out. Full root-cause writeup with log excerpts is below and I'm happy to answer questions or make changes.

## What was crashing

Zed 1.13.1 crashed with SIGABRT (panic converted to `abort()` by Zed's own crash handler) inside `BackgroundScanner::scan_dir`, during long-running ACP agent sessions (many tool calls across many files, over hours). Two crash reports had an identical faulting-thread stack:

```
DirStream::drop
-> Arc<InnerReadDir>::drop_slow
-> ... BackgroundScanner::scan_dir::{closure}::{closure}
-> BackgroundScanner::scan_dir
-> BackgroundScanner::scan_dirs
-> gpui_macos::dispatcher::trampoline
```

The accompanying `Zed.log.old` shows the mechanism directly:

- `AcpThread::shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>` never released an entry for the life of a chat session. Every tool-call location that got resolved (essentially every Read/Edit/Bash-with-file-reference call) inserted into it, and nothing ever removed anything.
- Non-visible ("invisible", ad-hoc) worktrees created for out-of-workspace files are stored as `WeakEntity<Worktree>` in `WorktreeStore` - they only stay alive as long as something else holds them strong. `shared_buffers` was that something, permanently.
- Zed's own internal `worktree diagnostics` log line caught this directly in the wild:
  ```
  17:22:14 worktree diagnostics: stores 22, slots 200, live 199, visible 26, strong 26, ...
  17:32:14 worktree diagnostics: stores 22, slots 204, live 203, visible 26, strong 26, ...
  17:34:44 worktree diagnostics: stores 22, slots 207, live 206, visible 26, strong 26, ...
  ```
  `visible`/`strong` (real open projects) stayed flat at 26 the whole time; `live` climbed steadily - that's ~175-180 invisible worktrees accumulating with no release.
- Once enough piled up, the process hit its file descriptor limit (`Too many open files (os error 24)`, confirmed in the log at the same timestamps). macOS's FSEvents backend then started failing to (re)create its stream, logged 5291 times as `unable to start FSEvent stream` - both when registering new watches and when unwatching old ones (`notify`'s FSEvents backend has to recreate the whole stream for either). Zed's existing native-watch-limit cooldown (built for Linux's `MaxFilesWatch`) never caught this, because the vendored `notify` fork reports it as a generic error, not `ErrorKind::MaxFilesWatch`. So Zed retried every ~2 seconds, forever, for every pending path - confirmed in the log by consecutive `WARN ... retrying` lines exactly 2 seconds apart, for the same paths, for as long as the pressure lasted.
- Eventually a `BackgroundScanner::scan_dir` directory scan's own `closedir()` failed under the same fd pressure, which panics inside std's `Drop for Dir`, which Zed's panic hook turns into `abort()`.

## The fix

1. **`crates/acp_thread/src/acp_thread.rs`** - clear `shared_buffers` at the start of each new turn (`AcpThread::run_turn`) instead of letting it grow for the whole chat. This is safe: `AgentLocation.buffer` is already a `WeakEntity<Buffer>` (see the existing comment on `ResolvedLocation`, "held strong for saving on the thread" - not the thread's whole lifetime), and `resolve_locations`/`resolve_location` always re-open the buffer by path from the tool call's raw location - old tool-call locations stay resolvable regardless of this cache's state. `reuse_shared_snapshot` and `write_text_file` consistency both still work within a turn, since the clear runs before that turn's own tool calls (inside the turn's own spawned task, after awaiting the previous turn's `cancel_task`, before invoking the turn's callback).
2. **`crates/fs/src/fs_watcher.rs`** - recognize the macOS FSEvents generic error as the same class as `MaxFilesWatch`, so it shares the existing native-watch-limit cooldown in both the watch path (`GlobalWatcher::add`) and the unwatch path (`GlobalWatcher::remove`, which previously just logged an unthrottled `ERROR` on every failure with no cooldown at all). Also guarded the cooldown against being pushed further out by repeated failures while one is already active.

## Testing

- New regression test `test_shared_buffers_do_not_leak_invisible_worktrees_across_turns`: drives 6 turns through a real `AcpThread`, each reporting a tool-call location outside the visible workspace. Confirmed failing on the pre-fix code (`6 are still live after 6 turns`), passing after the fix.
- New test `test_read_text_file_reuses_shared_snapshot_within_a_turn` covers the within-turn `reuse_shared_snapshot` consistency guarantee.
- 6 new/updated tests in `fs_watcher.rs` covering macOS error recognition, the cooldown guard against repeated-failure ratcheting, and the pre-existing Linux `MaxFilesWatch` path (unchanged, still passing).
- `cargo test -p acp_thread --lib`: 125 passed, 0 failed.
- `cargo test -p fs --lib`: 18 passed, 0 failed.
- `cargo clippy -p fs -p acp_thread --all-targets -- -D warnings`: clean.
- `cargo fmt -p acp_thread -p fs -- --check`: clean.
- Not done: a real multi-hour soak test against actual fd exhaustion (impractical to automate in a unit test; happy to do this before merge if it would help).

One related, deliberately out-of-scope observation: `crates/agent/src/tools/edit_session.rs` also holds a real project buffer strong indefinitely via `Diff` in the permanent transcript (`entries`), for every Edit tool call. That's architecturally different (diffs are meant to stay renderable in history by design) and doesn't create new invisible worktrees or leak file descriptors the way this crash did, so I left it alone - happy to open a separate issue for it if useful.

Release Notes:

- Fixed a crash (`SIGABRT` in `BackgroundScanner::scan_dir`) caused by invisible worktrees and their file watchers accumulating without bound during long ACP agent sessions.