### PR TITLE
solo_diff_view: Hide multibuffer controls in solo diffs

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -951,7 +951,7 @@ impl BufferSearchBar {
     }
 
     fn deployed_toolbar_location(&self, cx: &App) -> ToolbarItemLocation {
-        if self.needs_expand_collapse_option(cx) && !self.uses_hidden_splittable_editor(cx) {
+        if self.needs_expand_collapse_option(cx) {
             ToolbarItemLocation::PrimaryLeft
         } else {
             ToolbarItemLocation::Secondary
@@ -976,10 +976,11 @@ impl BufferSearchBar {
     // We provide an expand/collapse button if we are in a multibuffer
     // and not doing a project search.
     fn needs_expand_collapse_option(&self, cx: &App) -> bool {
-        self.active_searchable_item.as_ref().is_some_and(|item| {
-            item.buffer_kind(cx) == ItemBufferKind::Multibuffer
-                && !item.supported_options(cx).find_in_results
-        })
+        !self.uses_hidden_splittable_editor(cx)
+            && self.active_searchable_item.as_ref().is_some_and(|item| {
+                item.buffer_kind(cx) == ItemBufferKind::Multibuffer
+                    && !item.supported_options(cx).find_in_results
+            })
     }
 
     fn toggle_fold_all(&mut self, _: &ToggleFoldAll, window: &mut Window, cx: &mut Context<Self>) {


### PR DESCRIPTION
# Objective

Remove the redundant expand/collapse-all-files control from solo diff views. A solo diff represents one file, so the multibuffer-wide control is not applicable and duplicates the per-file full-file/changes-only toggle.

## Solution

Treat searchable items that intentionally hide their underlying splittable editor as ineligible for the generic multibuffer expand/collapse control.

This keeps search bound to the focused side of a split diff while preserving the existing expand/collapse controls in Project Diff, Branch Diff, staged/unstaged diffs, Commit View, and other regular multibuffer views.

## Testing

- `cargo -q test -p search test_uses_primary_left_when_in_multi_buffer -- --nocapture`
- `cargo -q test -p search buffer_search -- --nocapture` (26 passed)
- `git diff --check`
- Manually verified the solo diff no longer shows the expand/collapse-all-files control and that the full-file/changes-only toggle remains available.

Reviewers can open a file from Project Diff, use Option+Enter to switch between Project Diff and Solo Diff, and verify search follows the focused side in split diff mode.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Solo diff views now retain the full-file/changes-only toggle without showing the unrelated expand/collapse-all-files control.

<details>
  <summary>Click to view showcase</summary>
<img width="1120" height="724" alt="Screenshot 2026-07-31 at 6 44 50 PM" src="https://github.com/user-attachments/assets/58519dda-d77a-410e-bbe2-0aebfac93fbd" />

</details>

---

Release Notes:

- Fixed a redundant expand/collapse-all-files control appearing in solo diff views.
