### PR TITLE
google_ai: Add Gemini 3.6 Flash

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -531,6 +531,8 @@ pub enum Model {
     Gemini3Flash,
     #[serde(rename = "gemini-3.5-flash")]
     Gemini35Flash,
+    #[serde(rename = "gemini-3.6-flash")]
+    Gemini36Flash,
     #[serde(rename = "gemini-3.1-pro-preview", alias = "gemini-3-pro-preview")]
     Gemini31Pro,
     #[serde(rename = "custom")]
@@ -557,6 +559,7 @@ impl Model {
             Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
             Self::Gemini35Flash => "gemini-3.5-flash",
+            Self::Gemini36Flash => "gemini-3.6-flash",
             Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
@@ -569,6 +572,7 @@ impl Model {
             Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
             Self::Gemini35Flash => "gemini-3.5-flash",
+            Self::Gemini36Flash => "gemini-3.6-flash",
             Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
@@ -582,6 +586,7 @@ impl Model {
             Self::Gemini31FlashLite => "Gemini 3.1 Flash-Lite",
             Self::Gemini3Flash => "Gemini 3 Flash",
             Self::Gemini35Flash => "Gemini 3.5 Flash",
+            Self::Gemini36Flash => "Gemini 3.6 Flash",
             Self::Gemini31Pro => "Gemini 3.1 Pro",
             Self::Custom {
                 name, display_name, ..
@@ -597,6 +602,7 @@ impl Model {
             | Self::Gemini31FlashLite
             | Self::Gemini3Flash
             | Self::Gemini35Flash
+            | Self::Gemini36Flash
             | Self::Gemini31Pro => 1_048_576,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -610,6 +616,7 @@ impl Model {
             | Model::Gemini31FlashLite
             | Model::Gemini3Flash
             | Model::Gemini35Flash
+            | Model::Gemini36Flash
             | Model::Gemini31Pro => Some(65_536),
             Model::Custom { .. } => None,
         }
@@ -632,6 +639,7 @@ impl Model {
                 | Self::Gemini31FlashLite
                 | Self::Gemini3Flash
                 | Self::Gemini35Flash
+                | Self::Gemini36Flash
                 | Self::Gemini31Pro
                 | Self::Custom {
                     mode: GoogleModelMode::Thinking { .. },
@@ -642,7 +650,10 @@ impl Model {
 
     pub fn supported_thinking_levels(&self) -> &'static [ThinkingLevel] {
         match self {
-            Self::Gemini31FlashLite | Self::Gemini3Flash | Self::Gemini35Flash => &[
+            Self::Gemini31FlashLite
+            | Self::Gemini3Flash
+            | Self::Gemini35Flash
+            | Self::Gemini36Flash => &[
                 ThinkingLevel::Minimal,
                 ThinkingLevel::Low,
                 ThinkingLevel::Medium,
@@ -662,6 +673,7 @@ impl Model {
             Self::Gemini31FlashLite => Some(ThinkingLevel::Minimal),
             Self::Gemini3Flash => Some(ThinkingLevel::High),
             Self::Gemini35Flash => Some(ThinkingLevel::Medium),
+            Self::Gemini36Flash => Some(ThinkingLevel::Medium),
             Self::Gemini31Pro => Some(ThinkingLevel::High),
             _ => None,
         }
@@ -679,6 +691,7 @@ impl Model {
             Self::Gemini31FlashLite
             | Self::Gemini3Flash
             | Self::Gemini35Flash
+            | Self::Gemini36Flash
             | Self::Gemini31Pro => GoogleModelMode::Thinking {
                 budget_tokens: None,
             },
@@ -697,6 +710,19 @@ impl std::fmt::Display for Model {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_gemini_3_6_flash_model_metadata() {
+        let model = Model::Gemini36Flash;
+        assert_eq!(model.id(), "gemini-3.6-flash");
+        assert_eq!(model.request_id(), "gemini-3.6-flash");
+        assert_eq!(model.display_name(), "Gemini 3.6 Flash");
+
+        let serialized = serde_json::to_value(&model).unwrap();
+        assert_eq!(serialized, json!("gemini-3.6-flash"));
+        let deserialized: Model = serde_json::from_value(json!("gemini-3.6-flash")).unwrap();
+        assert_eq!(deserialized, Model::Gemini36Flash);
+    }
 
     #[test]
     fn test_function_call_part_with_signature_serializes_correctly() {


### PR DESCRIPTION
Closes #62007

Adds Gemini 3.6 Flash to the Google AI provider so it can be selected in the agent, alongside the existing Gemini 3.5 Flash.

Google released Gemini 3.6 Flash on July 21, 2026. It keeps the 1 million token context window, has a 64k output limit, and supports thinking. The model is added with the same capabilities and thinking levels as 3.5 Flash (Minimal, Low, Medium, High, defaulting to Medium).

The provider builds its model list from `google_ai::Model::iter()`, so adding the enum variant is enough for it to show up in the model dropdown. The thinking behavior in `completion.rs` keys off the `gemini-3` id prefix, so it already applies to this model.

Release Notes:

- Added Gemini 3.6 Flash to the Google AI models
