### PR TITLE
sidebar: Drag and drop project groups

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2344,6 +2344,7 @@ impl Sidebar {
 
         let key_for_toggle = key.clone();
         let key_for_focus = key.clone();
+        let key_for_drag_over = key.clone();
         let key_for_drop = key.clone();
 
         // The fade gradient renders as a visible patch on transparent windows,
@@ -2519,7 +2520,7 @@ impl Sidebar {
             )
             .drag_over::<DraggedProjectGroup>({
                 move |style, dragged_project_group: &DraggedProjectGroup, _window, cx| {
-                    if dragged_project_group.key == key_for_drop {
+                    if dragged_project_group.key == key_for_drag_over {
                         return style;
                     }
                     let style = style
@@ -2533,6 +2534,15 @@ impl Sidebar {
                     }
                 }
             })
+            .on_drop::<DraggedProjectGroup>(cx.listener(
+                move |this, dragged_project_group: &DraggedProjectGroup, _window, cx| {
+                    this.multi_workspace
+                        .update(cx, |mw, cx| {
+                            mw.move_project_group(&dragged_project_group.key, &key_for_drop, cx);
+                        })
+                        .ok();
+                },
+            ))
             .block_mouse_except_scroll();
 
         if !is_collapsed && !has_threads {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -42,6 +42,7 @@ use notifications::status_toast::StatusToast;
 use project::{AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId};
 use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
+use theme_settings::ThemeSettings;
 use ui::utils::platform_title_bar_height;
 
 use serde::{Deserialize, Serialize};
@@ -759,6 +760,25 @@ fn create_worktree_in_workspace(
             cx,
         );
     });
+}
+
+#[derive(Clone)]
+struct DraggedProjectGroup {
+    label: SharedString,
+    width: Pixels,
+}
+
+impl Render for DraggedProjectGroup {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ui_font = ThemeSettings::get_global(cx).ui_font.family.clone();
+        h_flex()
+            .font_family(ui_font)
+            .bg(cx.theme().colors().background)
+            .w(self.width)
+            .p_1()
+            .gap_1()
+            .child(Label::new(self.label.clone()))
+    }
 }
 
 /// The sidebar re-derives its entire entry list from scratch on every
@@ -2328,6 +2348,10 @@ impl Sidebar {
         let opaque_window =
             cx.theme().window_background_appearance() == WindowBackgroundAppearance::Opaque;
 
+        let dragged_project_group = DraggedProjectGroup {
+            label: label.clone(),
+            width: self.width,
+        };
         let label = if highlight_positions.is_empty() {
             Label::new(label.clone())
                 .when(!is_active, |this| this.color(Color::Muted))
@@ -2483,6 +2507,10 @@ impl Sidebar {
                         this.toggle_collapse(&key_for_toggle, window, cx);
                     }
                 }),
+            )
+            .on_drag(
+                dragged_project_group.clone(),
+                move |dragged_project_group, _, _, cx| cx.new(|_| dragged_project_group.clone()),
             )
             .block_mouse_except_scroll();
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -764,7 +764,9 @@ fn create_worktree_in_workspace(
 
 #[derive(Clone)]
 struct DraggedProjectGroup {
+    key: ProjectGroupKey,
     label: SharedString,
+    index: usize,
     width: Pixels,
 }
 
@@ -2342,6 +2344,7 @@ impl Sidebar {
 
         let key_for_toggle = key.clone();
         let key_for_focus = key.clone();
+        let key_for_drop = key.clone();
 
         // The fade gradient renders as a visible patch on transparent windows,
         // so truncate the label instead.
@@ -2349,7 +2352,9 @@ impl Sidebar {
             cx.theme().window_background_appearance() == WindowBackgroundAppearance::Opaque;
 
         let dragged_project_group = DraggedProjectGroup {
+            key: key.clone(),
             label: label.clone(),
+            index: ix,
             width: self.width,
         };
         let label = if highlight_positions.is_empty() {
@@ -2512,6 +2517,22 @@ impl Sidebar {
                 dragged_project_group.clone(),
                 move |dragged_project_group, _, _, cx| cx.new(|_| dragged_project_group.clone()),
             )
+            .drag_over::<DraggedProjectGroup>({
+                move |style, dragged_project_group: &DraggedProjectGroup, _window, cx| {
+                    if dragged_project_group.key == key_for_drop {
+                        return style;
+                    }
+                    let style = style
+                        .bg(cx.theme().colors().drop_target_background)
+                        .border_color(cx.theme().colors().drop_target_border)
+                        .border_0();
+                    if ix < dragged_project_group.index {
+                        style.border_t_2()
+                    } else {
+                        style.border_b_2()
+                    }
+                }
+            })
             .block_mouse_except_scroll();
 
         if !is_collapsed && !has_threads {

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -903,6 +903,42 @@ impl MultiWorkspace {
         true
     }
 
+    pub fn move_project_group(
+        &mut self,
+        source: &ProjectGroupKey,
+        destination: &ProjectGroupKey,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if source == destination {
+            return false;
+        }
+
+        let Some(source_index) = self
+            .project_groups
+            .iter()
+            .position(|group| group.key == *source)
+        else {
+            return false;
+        };
+        let Some(destination_index) = self
+            .project_groups
+            .iter()
+            .position(|group| group.key == *destination)
+        else {
+            return false;
+        };
+
+        let project_group_to_move = self.project_groups.remove(source_index);
+        self.project_groups
+            .insert(destination_index, project_group_to_move);
+
+        cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
+        self.serialize(cx);
+        cx.notify();
+
+        true
+    }
+
     pub fn workspaces_for_project_group(
         &self,
         key: &ProjectGroupKey,

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -1546,3 +1546,189 @@ async fn test_nearest_retained_workspace_skips_disconnected_workspace(cx: &mut T
         );
     });
 }
+
+#[gpui::test]
+async fn test_move_project_group_moving_down_lands_source_after_destination(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+
+    fs.insert_tree("/root_a", json!({ "file_a.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    fs.insert_tree("/root_b", json!({ "file_b.txt": "" })).await;
+    let project_b = Project::test(fs.clone(), ["/root_b".as_ref()], cx).await;
+    fs.insert_tree("/root_c", json!({ "file_c.txt": "" })).await;
+    let project_c = Project::test(fs, ["/root_c".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_c.clone(), window, cx));
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_b.clone(), window, cx);
+    });
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_a.clone(), window, cx);
+    });
+
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    multi_workspace.update(cx, |mw, cx| {
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone(), key_c.clone()],
+        );
+        assert!(mw.move_project_group(&key_a, &key_c, cx));
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_b.clone(), key_c.clone(), key_a.clone()],
+        );
+    });
+
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_move_project_group_moving_up_lands_source_before_destination(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+
+    fs.insert_tree("/root_a", json!({ "file_a.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    fs.insert_tree("/root_b", json!({ "file_b.txt": "" })).await;
+    let project_b = Project::test(fs.clone(), ["/root_b".as_ref()], cx).await;
+    fs.insert_tree("/root_c", json!({ "file_c.txt": "" })).await;
+    let project_c = Project::test(fs, ["/root_c".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_c.clone(), window, cx));
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_b.clone(), window, cx);
+    });
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_a.clone(), window, cx);
+    });
+
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    multi_workspace.update(cx, |mw, cx| {
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone(), key_c.clone()],
+        );
+        assert!(mw.move_project_group(&key_c, &key_a, cx));
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_c.clone(), key_a.clone(), key_b.clone()],
+        );
+    });
+
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_move_project_group_source_equals_destination_leaves_order_unchanged(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+
+    fs.insert_tree("/root_a", json!({ "file_a.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    fs.insert_tree("/root_b", json!({ "file_b.txt": "" })).await;
+    let project_b = Project::test(fs.clone(), ["/root_b".as_ref()], cx).await;
+    fs.insert_tree("/root_c", json!({ "file_c.txt": "" })).await;
+    let project_c = Project::test(fs, ["/root_c".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_c.clone(), window, cx));
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_b.clone(), window, cx);
+    });
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_a.clone(), window, cx);
+    });
+
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    multi_workspace.update(cx, |mw, cx| {
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone(), key_c.clone()],
+        );
+        assert!(!mw.move_project_group(&key_a, &key_a, cx));
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone(), key_c.clone()],
+        );
+    });
+
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_move_project_group_source_or_destination_unknown_leaves_order_unchanged(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+
+    fs.insert_tree("/root_a", json!({ "file_a.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    fs.insert_tree("/root_b", json!({ "file_b.txt": "" })).await;
+    let project_b = Project::test(fs.clone(), ["/root_b".as_ref()], cx).await;
+    fs.insert_tree("/root_c", json!({ "file_c.txt": "" })).await;
+    let project_c = Project::test(fs, ["/root_c".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_b.clone(), window, cx));
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_a.clone(), window, cx);
+    });
+
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    multi_workspace.update(cx, |mw, cx| {
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone()],
+        );
+        assert!(!mw.move_project_group(&key_a, &key_c, cx));
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone()],
+        );
+        assert!(!mw.move_project_group(&key_c, &key_a, cx));
+        assert_eq!(
+            mw.project_group_keys(),
+            [key_a.clone(), key_b.clone()],
+        );
+    });
+
+    cx.run_until_parked();
+}


### PR DESCRIPTION
# Objective

Reorder project groups on sidebar by dragging and dropping. Indicate drop target while dragging. 

## Solution

Generalize #57448 

## Testing

- Covered the underlying logic of moving project groups with unit tests
- Launched the application and dragged project groups around

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/aa63ae77-9e9b-4cb4-a53d-b03b4fd53ac7

## AI Diligence

My purpose of this PR is to learn both Rust and understand Zed better. I asked Claude Fable 5 to guide me through implementing this feature with this in mind. I implemented everything based on my back-and-forth conversation with Claude.

---

Release Notes:

- sidebar: Added reordering project groups by dragging and dropping.
