### PR TITLE
sidebar: Fix window controls position with no open projects

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -7518,46 +7518,52 @@ impl Sidebar {
             })
             .when(!right_window_controls, |this| this.pr_1p5())
             .gap_1()
-            .when(!no_open_projects, |this| {
-                this.border_b_1()
-                    .border_color(cx.theme().colors().border)
-                    .when(traffic_lights, |this| {
-                        this.child(Divider::vertical().color(ui::DividerColor::Border))
-                    })
-                    .child(
-                        div().ml_1().child(
-                            Icon::new(IconName::MagnifyingGlass)
-                                .size(IconSize::Small)
-                                .color(Color::Muted),
-                        ),
-                    )
-                    .child(self.render_filter_input(cx))
-                    .child(
-                        h_flex()
-                            .gap_1()
-                            .when(
-                                self.selection.is_some()
-                                    && !self.filter_editor.focus_handle(cx).is_focused(window),
-                                |this| this.child(KeyBinding::for_action(&FocusSidebarFilter, cx)),
-                            )
-                            .when(has_query, |this| {
-                                this.child(
-                                    IconButton::new("clear_filter", IconName::Close)
-                                        .icon_size(IconSize::Small)
-                                        .tooltip(Tooltip::text("Clear Search"))
-                                        .on_click(cx.listener(|this, _, window, cx| {
-                                            this.reset_filter_editor_text(window, cx);
-                                            this.update_entries(cx);
-                                        })),
+            .when_else(
+                no_open_projects,
+                // Nothing else is rendered in the header, so nothing pushes the window
+                // controls to the far edge. Add an explicit spacer to keep them flush
+                // with the sidebar's edge, matching the layout used when projects are
+                // open. A spacer rather than `justify_end` so that left-side window
+                // controls stay flush with the opposite edge.
+                |this| this.child(div().flex_1()),
+                |this| {
+                    this.border_b_1()
+                        .border_color(cx.theme().colors().border)
+                        .when(traffic_lights, |this| {
+                            this.child(Divider::vertical().color(ui::DividerColor::Border))
+                        })
+                        .child(
+                            div().ml_1().child(
+                                Icon::new(IconName::MagnifyingGlass)
+                                    .size(IconSize::Small)
+                                    .color(Color::Muted),
+                            ),
+                        )
+                        .child(self.render_filter_input(cx))
+                        .child(
+                            h_flex()
+                                .gap_1()
+                                .when(
+                                    self.selection.is_some()
+                                        && !self.filter_editor.focus_handle(cx).is_focused(window),
+                                    |this| {
+                                        this.child(KeyBinding::for_action(&FocusSidebarFilter, cx))
+                                    },
                                 )
-                            }),
-                    )
-            })
-            // When there are no open projects, the flex-growing filter input above is not
-            // rendered, so nothing pushes the window controls to the far edge of the
-            // header. Add an explicit spacer to keep them flush with the sidebar's edge,
-            // matching the layout used when projects are open.
-            .when(no_open_projects, |this| this.child(div().flex_1()))
+                                .when(has_query, |this| {
+                                    this.child(
+                                        IconButton::new("clear_filter", IconName::Close)
+                                            .icon_size(IconSize::Small)
+                                            .tooltip(Tooltip::text("Clear Search"))
+                                            .on_click(cx.listener(|this, _, window, cx| {
+                                                this.reset_filter_editor_text(window, cx);
+                                                this.update_entries(cx);
+                                            })),
+                                    )
+                                }),
+                        )
+                },
+            )
             .when(right_window_controls, |this| {
                 this.children(Self::render_right_window_controls(window, cx))
             })

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -7553,6 +7553,11 @@ impl Sidebar {
                             }),
                     )
             })
+            // When there are no open projects, the flex-growing filter input above is not
+            // rendered, so nothing pushes the window controls to the far edge of the
+            // header. Add an explicit spacer to keep them flush with the sidebar's edge,
+            // matching the layout used when projects are open.
+            .when(no_open_projects, |this| this.child(div().flex_1()))
             .when(right_window_controls, |this| {
                 this.children(Self::render_right_window_controls(window, cx))
             })


### PR DESCRIPTION
## Problem

<img width="442" height="1028" alt="side-bar-bug" src="https://github.com/user-attachments/assets/c4271778-b350-434a-a630-60a6158a8ab5" />

When the threads sidebar is docked on the right (`agent.sidebar_side: "right"`) and no project is open, the window control buttons (close/minimize/maximize) end up misaligned in the sidebar header, instead of sitting flush at the edge of the window like they do once a project is open.

## Root cause

In `render_sidebar_header`, the window control buttons are pushed to the correct edge by the flex-growing filter input (`render_filter_input`, which has `.flex_1()`). That input is only rendered when there are open projects. When there are no open projects (empty state), nothing takes up the flexible space, so the buttons collapse toward the opposite side of the header.

## Fix

Add an explicit `flex_1` spacer for the empty-project case, mirroring the same
mechanism already used when projects are open. Following review feedback, that
spacer and the existing filter-input branch are now a single `when_else` call,
since the two conditions were complementary.

<img width="396" height="1031" alt="fixed-side-bar" src="https://github.com/user-attachments/assets/536a998c-78f3-4652-8410-1cdbeaafd9c5" />


## Testing

Verified manually on Windows 11 with a local debug build, with
`agent.sidebar_side: "right"` and no folders open. The window controls now sit
flush with the right edge of the sidebar header, in the same position they
occupy when a project is open, and the position does not shift when a project
is then opened.

Not tested on Linux, which is the only platform where `left_window_controls`
actually renders inside this header (on macOS the flag is `cfg`-disabled, and on
Windows `render_left_window_controls` returns `None`).
