### PR TITLE
Fix Git toolbar button sizing

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -799,8 +799,6 @@ impl Render for ProjectDiffToolbar {
         let (additions, deletions) = project_diff.read(cx).calculate_changed_lines(cx);
         let is_multibuffer_empty = project_diff.read(cx).multibuffer(cx).read(cx).is_empty();
 
-        let stage_all_button_width = rems(5.);
-
         h_flex()
             .my_neg_1()
             .py_1()
@@ -896,7 +894,6 @@ impl Render for ProjectDiffToolbar {
                 |this| {
                     this.child(
                         Button::new("unstage-all", "Unstage All")
-                            .width(stage_all_button_width)
                             .tooltip(Tooltip::for_action_title_in(
                                 "Unstage All Changes",
                                 &UnstageAll,
@@ -913,7 +910,6 @@ impl Render for ProjectDiffToolbar {
                 |this| {
                     this.child(
                         Button::new("stage-all", "Stage All")
-                            .width(stage_all_button_width)
                             .disabled(!button_states.stage_all)
                             .tooltip(Tooltip::for_action_title_in(
                                 "Stage All Changes",

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -874,7 +874,6 @@ impl Render for SoloDiffGitToolbar {
             .child(Divider::vertical())
             .child(h_group_sm().child(if button_states.stage_file {
                 Button::new("stage-file", "Stage All")
-                    .width(rems_from_px(80.))
                     .disabled(!button_states.stage_file)
                     .tooltip(Tooltip::for_action_title_in(
                         "Stage All",
@@ -884,7 +883,6 @@ impl Render for SoloDiffGitToolbar {
                     .on_click(cx.listener(|this, _, window, cx| this.stage_file(window, cx)))
             } else {
                 Button::new("unstage-file", "Unstage All")
-                    .width(rems_from_px(80.))
                     .disabled(!button_states.unstage_file)
                     .tooltip(Tooltip::for_action_title_in(
                         "Unstage All",

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -712,7 +712,6 @@ impl Render for StagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("unstage-all", "Unstage All")
-                    .width(rems_from_px(80.))
                     .disabled(!button_states.unstage_all)
                     .tooltip(Tooltip::for_action_title_in(
                         "Unstage All Changes",

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -826,7 +826,6 @@ impl Render for UnstagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("stage-all", "Stage All")
-                    .width(rems_from_px(80.))
                     .disabled(!button_states.stage_all)
                     .tooltip(Tooltip::for_action_title_in(
                         "Stage All Changes",
@@ -838,7 +837,6 @@ impl Render for UnstagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("restore-all", "Restore All")
-                    .width(rems_from_px(80.))
                     .disabled(!button_states.restore_all)
                     .tooltip(Tooltip::text("Restore All Changes"))
                     .on_click(cx.listener(|this, _, window, cx| this.restore_all(window, cx))),


### PR DESCRIPTION
Objective

Fix Git diff toolbar buttons with longer labels, such as **Unstage All**, overflowing their fixed-width bounds

## Solution

Removed the fixed 80 px / 5 rem widths from the relevant Git toolbar buttons and allowed the existing button component to size itself based on its label.

This applies to the following actions across project, staged, unstaged, and single-file diff toolbars:

- Stage All
- Unstage All
- Restore All

## Testing

- Reviewed the diff for all affected Git toolbar implementations.
- Ran `git diff --check` successfully.
- Started `cargo check -p git_ui`; it progressed without errors but did not complete within the two-minute command timeout.
- Started the workspace formatting check; it did not complete within the two-minute command timeout.

Reviewers can test this by opening the project, staged, unstaged, and single-file diff views, then staging or unstaging all changes. Verify that the toolbar buttons fit their complete labels at different UI font sizes and display scaling settings.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

<details>
  <summary>Click to view showcase</summary>


Before:

https://github.com/user-attachments/assets/a45e5448-24a9-47fe-8cdc-baee9259ef47

After:

https://github.com/user-attachments/assets/8bca2a8f-9d43-476b-9fd3-ed0eebdc4986



</details>

---

Release Notes:

- Fixed Git diff toolbar action labels overflowing their buttons at some font sizes and display scaling settings.