### PR TITLE
solo_diff_view: Use expand and fold icons for solo diff

### DIFF
--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -630,9 +630,9 @@ impl Render for SoloDiffStyleToolbar {
             GitPanelSettings::get_global(cx).status_style != StatusStyle::LabelColor;
 
         let (expand_icon, expand_tooltip) = if showing_full_file {
-            (IconName::ChevronDownUp, "Show Changes Only")
+            (IconName::FoldVertical, "Show Changes Only")
         } else {
-            (IconName::ChevronUpDown, "Show Full File")
+            (IconName::ExpandVertical, "Show Full File")
         };
 
         h_flex()


### PR DESCRIPTION
## Objective

Use distinct expand and fold icons for the solo diff view's full-file and changes-only states.

## Solution

Updated `crates/git_ui/src/solo_diff_view.rs` to use:

- `IconName::ExpandVertical` for “Show Full File”
- `IconName::FoldVertical` for “Show Changes Only”

The existing labels and behavior are unchanged.

## Testing

- Not run; this is a small icon-only UI change.
- Reviewers can verify the result by opening a solo diff and toggling between “Show Full File” and “Show Changes Only”.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

This is a visual-only icon update in the solo diff toolbar. The toggle behavior and tooltips remain unchanged.

<details>
  <summary>Click to view showcase</summary>

Collapse Icon:
<img width="1344" height="948" alt="new_expand" src="https://github.com/user-attachments/assets/439abb33-04b1-4493-a5ab-d7f2fb90b5bf" />

Expand Icon:
<img width="1344" height="948" alt="new_collapse" src="https://github.com/user-attachments/assets/adceae19-895a-4526-9e4b-931dea14b4ef" />

</details>
---

Release Notes:

- Improved solo diff toolbar icons for expanding and folding the view.