### PR TITLE
agent_ui: Show the agent panel's full screen button as toggled

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6051,21 +6051,15 @@ impl AgentPanel {
         };
 
         let is_full_screen = self.is_zoomed(window, cx);
-        let (icon_id, icon_name, tooltip_text) = if is_full_screen {
-            (
-                "disable-full-screen",
-                IconName::Minimize,
-                "Disable Full Screen",
-            )
+        let tooltip_text = if is_full_screen {
+            "Disable Full Screen"
         } else {
-            (
-                "enable-full-screen",
-                IconName::Maximize,
-                "Enable Full Screen",
-            )
+            "Enable Full Screen"
         };
-        let full_screen_button = IconButton::new(icon_id, icon_name)
+        let full_screen_button = IconButton::new("toggle-full-screen", IconName::Maximize)
             .icon_size(IconSize::Small)
+            .toggle_state(is_full_screen)
+            .selected_icon(IconName::Minimize)
             .tooltip(move |_, cx| Tooltip::for_action(tooltip_text, &ToggleZoom, cx))
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.toggle_zoom(&ToggleZoom, window, cx);

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6051,15 +6051,14 @@ impl AgentPanel {
         };
 
         let is_full_screen = self.is_zoomed(window, cx);
-        let tooltip_text = if is_full_screen {
-            "Disable Full Screen"
+        let (icon_name, tooltip_text) = if is_full_screen {
+            (IconName::Minimize, "Disable Full Screen")
         } else {
-            "Enable Full Screen"
+            (IconName::Maximize, "Enable Full Screen")
         };
-        let full_screen_button = IconButton::new("toggle-full-screen", IconName::Maximize)
+        let full_screen_button = IconButton::new("toggle-full-screen", icon_name)
             .icon_size(IconSize::Small)
             .toggle_state(is_full_screen)
-            .selected_icon(IconName::Minimize)
             .tooltip(move |_, cx| Tooltip::for_action(tooltip_text, &ToggleZoom, cx))
             .on_click(cx.listener(move |this, _, window, cx| {
                 this.toggle_zoom(&ToggleZoom, window, cx);


### PR DESCRIPTION
The agent panel's full screen button and a pane's zoom button drive the same mechanism — both emit `PanelEvent::ZoomIn`/`ZoomOut`, and `Workspace::zoomed` holds a single entry, so at most one of them is active at a time.

The pane's button reflects that state: it is rendered with `toggle_state(zoomed)`, so it is visibly active while zoomed (`crates/workspace/src/pane.rs`). The agent panel's button only swapped its icon, so while the panel was zoomed the button still looked like an inactive control.

This makes the agent panel's button use the same `toggle_state` + `selected_icon` pattern as the pane's. Behavior is unchanged; the button now looks active while full screen is on. The element id is now stable across both states instead of changing with the icon.

Unrelated to this change, but worth mentioning since it is the same button: the two controls also disagree on wording. The pane calls it "Zoom In"/"Zoom Out", the agent panel "Enable/Disable Full Screen". Because `Workspace::zoomed` is a single slot, activating any other panel's zoom drops the agent panel back out of full screen — which reads as surprising under the "full screen" name and unsurprising under "zoom". Happy to align the wording in a follow-up if you'd like, but I left it alone here since it is a naming call rather than a fix.

Release Notes:

- Fixed the agent panel's full screen button not appearing active while full screen was enabled.