### PR TITLE
bug: Show notebook filenames in tabs when opened as single file worktrees

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -110,6 +110,23 @@ pub struct NotebookEditor {
 }
 
 impl NotebookEditor {
+    fn kernel_working_directory(
+        project: &Project,
+        worktree_id: project::WorktreeId,
+        cx: &App,
+    ) -> PathBuf {
+        project
+            .worktree_for_id(worktree_id, cx)
+            .and_then(|worktree| {
+                let worktree = worktree.read(cx);
+                worktree
+                    .root_dir()
+                    .map(|path| path.to_path_buf())
+                    .or_else(|| worktree.abs_path().parent().map(|path| path.to_path_buf()))
+            })
+            .unwrap_or_else(std::env::temp_dir)
+    }
+
     pub fn new(
         project: Entity<Project>,
         notebook_item: Entity<NotebookItem>,
@@ -375,12 +392,8 @@ impl NotebookEditor {
         cx: &mut Context<Self>,
     ) {
         let entity_id = cx.entity_id();
-        let working_directory = self
-            .project
-            .read(cx)
-            .worktree_for_id(self.worktree_id, cx)
-            .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
-            .unwrap_or_else(std::env::temp_dir);
+        let working_directory =
+            Self::kernel_working_directory(self.project.read(cx), self.worktree_id, cx);
         let fs = self.project.read(cx).fs().clone();
         let view = cx.entity();
 
@@ -2247,6 +2260,13 @@ mod tests {
             project_path.path.extension().is_none(),
             "single-file worktree relative path should have no extension"
         );
+
+        project.read_with(cx, |project, cx| {
+            assert_eq!(
+                NotebookEditor::kernel_working_directory(project, project_path.worktree_id, cx),
+                PathBuf::from(path!("/notebooks"))
+            );
+        });
 
         let notebook_item = cx
             .update(|cx| {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1721,21 +1721,37 @@ impl project::ProjectItem for NotebookItem {
 }
 
 impl NotebookItem {
+    fn file_name_for_path(path: &Path, path_style: PathStyle) -> Option<String> {
+        if path_style == PathStyle::local() {
+            return path
+                .file_name()
+                .map(|file_name| file_name.to_string_lossy().into_owned());
+        }
+
+        let path = path_style.normalize(&path.to_string_lossy());
+        let file_name = path_style.split(&path).1;
+        (!file_name.is_empty()).then(|| file_name.to_string())
+    }
+
     fn file_name(&self, project: &Project, cx: &App) -> String {
+        let worktree = project.worktree_for_id(self.project_path.worktree_id, cx);
+
         self.project_path
             .path
             .file_name()
             .map(|file_name| file_name.to_string())
             .or_else(|| {
-                self.path
-                    .file_name()
-                    .map(|file_name| file_name.to_string_lossy().into_owned())
+                worktree.as_ref().and_then(|worktree| {
+                    let worktree = worktree.read(cx);
+                    Self::file_name_for_path(&self.path, worktree.path_style())
+                })
             })
             .or_else(|| {
-                project
-                    .worktree_for_id(self.project_path.worktree_id, cx)
+                worktree
+                    .as_ref()
                     .map(|worktree| worktree.read(cx).root_name_str().to_owned())
             })
+            .or_else(|| Self::file_name_for_path(&self.path, PathStyle::local()))
             .unwrap_or_default()
     }
 
@@ -2102,13 +2118,21 @@ mod tests {
     }"#;
 
     #[test]
-    fn test_parent_directory_for_remote_windows_path() {
+    fn test_single_file_remote_windows_path() {
         assert_eq!(
             NotebookEditor::parent_directory(
                 Path::new(r"C:\notebooks\single.ipynb"),
                 PathStyle::Windows,
             ),
             Some(PathBuf::from(r"C:\notebooks\"))
+        );
+
+        assert_eq!(
+            NotebookItem::file_name_for_path(
+                Path::new(r"C:\notebooks\single.ipynb"),
+                PathStyle::Windows,
+            ),
+            Some("single.ipynb".to_string())
         );
     }
 

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1,6 +1,9 @@
 #![allow(unused, dead_code)]
 use std::future::Future;
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{Context as _, Result};
 use client::proto::ViewId;
@@ -19,6 +22,7 @@ use log;
 use project::{Project, ProjectEntryId, ProjectPath};
 use settings::Settings as _;
 use ui::{CommonAnimationExt, KeyBinding, Tooltip, prelude::*};
+use util::paths::PathStyle;
 use workspace::item::{ItemEvent, SaveOptions, TabContentParams};
 use workspace::searchable::SearchableItemHandle;
 use workspace::{Item, ItemHandle, Pane, ProjectItem, ToolbarItemLocation};
@@ -110,6 +114,15 @@ pub struct NotebookEditor {
 }
 
 impl NotebookEditor {
+    fn parent_directory(path: &Path, path_style: PathStyle) -> Option<PathBuf> {
+        if path_style == PathStyle::local() {
+            return path.parent().map(Path::to_path_buf);
+        }
+
+        let path = path_style.normalize(&path.to_string_lossy());
+        path_style.split(&path).0.map(PathBuf::from)
+    }
+
     fn kernel_working_directory(
         project: &Project,
         worktree_id: project::WorktreeId,
@@ -122,7 +135,7 @@ impl NotebookEditor {
                 worktree
                     .root_dir()
                     .map(|path| path.to_path_buf())
-                    .or_else(|| worktree.abs_path().parent().map(|path| path.to_path_buf()))
+                    .or_else(|| Self::parent_directory(&worktree.abs_path(), worktree.path_style()))
             })
             .unwrap_or_else(std::env::temp_dir)
     }
@@ -1714,6 +1727,11 @@ impl NotebookItem {
             .file_name()
             .map(|file_name| file_name.to_string())
             .or_else(|| {
+                self.path
+                    .file_name()
+                    .map(|file_name| file_name.to_string_lossy().into_owned())
+            })
+            .or_else(|| {
                 project
                     .worktree_for_id(self.project_path.worktree_id, cx)
                     .map(|worktree| worktree.read(cx).root_name_str().to_owned())
@@ -2082,6 +2100,17 @@ mod tests {
             }
         ]
     }"#;
+
+    #[test]
+    fn test_parent_directory_for_remote_windows_path() {
+        assert_eq!(
+            NotebookEditor::parent_directory(
+                Path::new(r"C:\notebooks\single.ipynb"),
+                PathStyle::Windows,
+            ),
+            Some(PathBuf::from(r"C:\notebooks\"))
+        );
+    }
 
     /// When the configured interpreter doesn't exist (e.g. Python isn't installed),
     /// running a cell must not leave it stuck in the executing state. It should

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1695,6 +1695,19 @@ impl project::ProjectItem for NotebookItem {
 }
 
 impl NotebookItem {
+    fn file_name(&self, project: &Project, cx: &App) -> String {
+        self.project_path
+            .path
+            .file_name()
+            .map(|file_name| file_name.to_string())
+            .or_else(|| {
+                project
+                    .worktree_for_id(self.project_path.worktree_id, cx)
+                    .map(|worktree| worktree.read(cx).root_name_str().to_owned())
+            })
+            .unwrap_or_default()
+    }
+
     pub fn language_name(&self) -> Option<String> {
         self.notebook
             .metadata
@@ -1808,11 +1821,7 @@ impl Item for NotebookEditor {
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
         self.notebook_item
             .read(cx)
-            .project_path
-            .path
-            .file_name()
-            .map(|s| s.to_string())
-            .unwrap_or_default()
+            .file_name(self.project.read(cx), cx)
             .into()
     }
 
@@ -2144,6 +2153,10 @@ mod tests {
             cx.new(|cx| NotebookEditor::new(project.clone(), notebook_item, window, cx))
         });
 
+        editor.read_with(cx, |editor, cx| {
+            assert_eq!(editor.tab_content_text(0, cx), "test.ipynb");
+        });
+
         // Creating the editor launches the kernel. Wait for the actual launch
         // task, which fails because the interpreter cannot be spawned.
         let pending_kernel = editor.read_with(cx, |editor, _| match &editor.kernel {
@@ -2243,8 +2256,9 @@ mod tests {
             .await
             .expect("notebook should parse");
 
-        notebook_item.read_with(cx, |item, _| {
+        notebook_item.read_with(cx, |item, cx| {
             assert_eq!(item.notebook.cells.len(), 1);
+            assert_eq!(item.file_name(project.read(cx), cx), "single.ipynb");
         });
     }
 }


### PR DESCRIPTION
## Summary

Notebook tabs could appear blank when notebooks were opened directly as single-file worktrees.

This change shows the notebook filename, including `.ipynb`, for both project notebooks and directly opened notebooks.

## Testing

- `cargo test -p repl notebook::notebook_ui::tests`
- `cargo fmt --check`
- `./script/clippy -p repl`

## Manual verification

- Opened a notebook from a project folder.
- Opened a notebook directly by path.
- Confirmed both tabs display their `.ipynb` filenames.

## Screenshots

Before: 
<img width="1624" height="1060" alt="Screenshot 2026-08-01 at 8 07 29 AM" src="https://github.com/user-attachments/assets/9f921f46-664b-4d9d-ae8c-2eeb21d413e1" />

After: 
<img width="1624" height="1060" alt="Screenshot 2026-08-01 at 8 07 26 AM" src="https://github.com/user-attachments/assets/25b932c1-4174-4af9-bfbd-b29906bcad95" />


Release Notes:

- Fixed notebook tabs displaying without a filename.