### PR TITLE
git_ui: Enforce byte limit in commit diff compression

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3236,6 +3236,14 @@ impl GitPanel {
 
         compressed = Self::truncate_iteratively(&compressed, max_bytes);
 
+        // truncate_iteratively cannot reduce single-hunk files (e.g. newly
+        // added files with one giant hunk), so the limit must be enforced
+        // unconditionally here.
+        if compressed.len() > max_bytes {
+            compressed.truncate(compressed.floor_char_boundary(max_bytes));
+            compressed.push_str("\n...[diff truncated to size limit]...\n");
+        }
+
         compressed
     }
 
@@ -12021,8 +12029,80 @@ mod tests {
              more context
         ", long_line};
         let result = GitPanel::compress_commit_diff(&diff, 100);
-        assert!(result.contains("...[truncated]"));
+        // With max_bytes=100 the size cap fires before the line-level
+        // "...[truncated]" marker becomes reachable, so only verify the
+        // bound and that some truncation indicator is present.
+        let marker = "\n...[diff truncated to size limit]...\n";
+        assert!(
+            result.len() <= 100 + marker.len(),
+            "result length {} exceeds size cap",
+            result.len()
+        );
         assert!(result.len() < diff.len());
+        assert!(
+            result.contains("truncated"),
+            "result must contain a truncation indicator"
+        );
+    }
+
+    #[test]
+    fn test_compress_diff_line_truncation_without_size_cap() {
+        // The raw diff must exceed max_bytes so the function proceeds past
+        // the early-return guard. After line-level truncation (256 chars)
+        // the result falls under max_bytes, so the size cap does not fire
+        // and the "...[truncated]" marker is preserved.
+        let long_line = "x".repeat(1000);
+        let diff = indoc::formatdoc! {"
+            --- a/file.txt
+            +++ b/file.txt
+            @@ -1,2 +1,3 @@
+             context
+            +{}
+             more context
+        ", long_line};
+        assert!(diff.len() > 1000, "raw diff must exceed max_bytes");
+
+        let result = GitPanel::compress_commit_diff(&diff, 1000);
+        assert!(
+            result.contains("...[truncated]"),
+            "line-level truncation marker must be present when the size cap does not fire"
+        );
+        assert!(result.len() < diff.len());
+    }
+
+    #[test]
+    fn test_compress_diff_single_hunk_size_cap() {
+        // Simulate a newly added file with a single large hunk.
+        // truncate_iteratively cannot drop hunks when only 1 remains,
+        // so the size cap must enforce the byte limit.
+        let large_content = "+line of content\n".repeat(500);
+        let diff = format!(
+            "--- /dev/null\n+++ b/big_file.txt\n@@ -0,0 +1,500 @@\n{}",
+            large_content
+        );
+        assert!(
+            diff.len() > 2000,
+            "test precondition: diff must exceed limit"
+        );
+
+        let max_bytes = 2000;
+        let result = GitPanel::compress_commit_diff(&diff, max_bytes);
+
+        let marker = "\n...[diff truncated to size limit]...\n";
+        assert!(
+            result.len() <= max_bytes + marker.len(),
+            "result length {} exceeds size cap {} + marker",
+            result.len(),
+            max_bytes
+        );
+        assert!(
+            result.contains("[diff truncated to size limit]"),
+            "result must contain the truncation marker"
+        );
+        assert!(
+            result.contains("+++ b/big_file.txt"),
+            "file header must be preserved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

"Generate Commit Message" compresses the diff to `MAX_DIFF_BYTES` (20 KB) via `compress_commit_diff` before sending it to the LLM. The hunk-level stage (`truncate_iteratively`) drops whole hunks from the files with the most hunks, but exits once every file is down to a single hunk — and nothing after it enforces the limit.

Newly added files appear in a diff as one giant hunk (e.g. `@@ -0,0 +1,7878 @@`), so a large new file escapes truncation entirely, and staging a few large new files sends a multi-megabyte prompt to the LLM. Depending on the provider this causes:

- Providers with a request body size limit reject the request, and the raw error response is displayed in the commit message editor instead of a commit message.
- Providers that accept the request may still fail with a context-window overflow error.
- Even when the request succeeds, megabytes of diff are wasted tokens and cost for a one-line commit message.

## Fix

Enforce `max_bytes` unconditionally after all reduction stages: truncate at a UTF-8 character boundary and append a truncation marker. Diffs that already fit are returned unchanged by the existing early return, so behavior only changes where the limit was already being exceeded.

## Tests

- `test_compress_diff_single_hunk_size_cap` — regression test for the single-hunk escape path
- `test_compress_diff_line_truncation_without_size_cap` — line-level truncation marker preserved when the cap does not fire
- `test_compress_diff_truncate_long_lines` — adapted for the size cap

Release Notes:

- Fixed commit message generation sending oversized requests (and displaying raw API error responses) when the diff contains large newly-added files
