### PR TITLE
workspace: Remember a flexible dock's width for an empty center separately

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -359,6 +359,12 @@ pub struct PanelSizeState {
     pub size: Option<Pixels>,
     #[serde(default)]
     pub flex: Option<f32>,
+    /// Width used while the center has no open items, kept separate so that
+    /// resizing a dock to read a file doesn't overwrite the width the dock had
+    /// when nothing was open. Falls back to `flex` until the user resizes the
+    /// dock with an empty center.
+    #[serde(default)]
+    pub flex_when_center_empty: Option<f32>,
 }
 
 struct PanelEntry {
@@ -388,13 +394,18 @@ fn resize_panel_entry(
     entry: &mut PanelEntry,
     size: Option<Pixels>,
     flex: Option<f32>,
+    center_is_empty: bool,
     window: &mut Window,
     cx: &mut App,
 ) -> (&'static str, PanelSizeState) {
     let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
     let uses_flexible_width = panel_uses_flexible_width(position, entry.panel.as_ref(), window, cx);
     if uses_flexible_width {
-        entry.size_state.flex = flex;
+        if center_is_empty {
+            entry.size_state.flex_when_center_empty = flex;
+        } else {
+            entry.size_state.flex = flex;
+        }
     } else {
         entry.size_state.size = size;
     }
@@ -1003,14 +1014,22 @@ impl Dock {
         &mut self,
         size: Option<Pixels>,
         flex: Option<f32>,
+        center_is_empty: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(index) = self.active_panel_index
             && let Some(entry) = self.panel_entries.get_mut(index)
         {
-            let (panel_key, size_state) =
-                resize_panel_entry(self.position, entry, size, flex, window, cx);
+            let (panel_key, size_state) = resize_panel_entry(
+                self.position,
+                entry,
+                size,
+                flex,
+                center_is_empty,
+                window,
+                cx,
+            );
 
             let workspace = self.workspace.clone();
             cx.defer(move |cx| {
@@ -1028,6 +1047,7 @@ impl Dock {
         &mut self,
         size: Option<Pixels>,
         flex: Option<f32>,
+        center_is_empty: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1051,6 +1071,7 @@ impl Dock {
                     entry,
                     size,
                     flex,
+                    center_is_empty,
                     window,
                     cx,
                 ));
@@ -1151,7 +1172,14 @@ impl Render for Dock {
                         MouseButton::Left,
                         cx.listener(|dock, e: &MouseUpEvent, window, cx| {
                             if e.click_count == 2 {
-                                dock.resize_active_panel(None, None, window, cx);
+                                // Double-clicking the handle resets whichever width
+                                // is in play, so an empty center's width can be
+                                // forgotten without disturbing the other one.
+                                let center_is_empty = dock
+                                    .workspace
+                                    .read_with(cx, |workspace, cx| workspace.center_is_empty(cx))
+                                    .unwrap_or(false);
+                                dock.resize_active_panel(None, None, center_is_empty, window, cx);
                                 dock.workspace
                                     .update(cx, |workspace, cx| {
                                         workspace.serialize_workspace(window, cx);
@@ -1566,6 +1594,7 @@ pub mod test {
             PanelSizeState {
                 size: None,
                 flex: None,
+                flex_when_center_empty: None,
             }
         }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2451,7 +2451,9 @@ impl Workspace {
 
         if position.axis() == Axis::Horizontal
             && use_flex
-            && let Some(flex) = size_state.flex.or_else(|| self.default_dock_flex(position))
+            && let Some(flex) = self
+                .effective_dock_flex(&size_state, cx)
+                .or_else(|| self.default_dock_flex(position))
         {
             let workspace_width = self.bounds.size.width;
             if workspace_width <= Pixels::ZERO {
@@ -2529,6 +2531,7 @@ impl Workspace {
         let mut size_state = opposite_dock
             .stored_panel_size_state(panel.as_ref())
             .unwrap_or_default();
+        size_state.flex = self.effective_dock_flex(&size_state, cx);
         if size_state.flex.is_none() && panel.has_flexible_size(window, cx) {
             size_state.flex = self.default_dock_flex(opposite_position);
         }
@@ -2537,6 +2540,23 @@ impl Workspace {
 
     fn center_full_height_column_count(&self) -> f32 {
         self.center.full_height_column_count().max(1) as f32
+    }
+
+    /// Whether the center holds no items at all, in which case flexible docks
+    /// use the width they were last given while the center was empty.
+    pub fn center_is_empty(&self, cx: &App) -> bool {
+        self.center
+            .panes()
+            .iter()
+            .all(|pane| pane.read(cx).items_len() == 0)
+    }
+
+    fn effective_dock_flex(&self, size_state: &PanelSizeState, cx: &App) -> Option<f32> {
+        if self.center_is_empty(cx) {
+            size_state.flex_when_center_empty.or(size_state.flex)
+        } else {
+            size_state.flex
+        }
     }
 
     pub fn default_dock_flex(&self, position: DockPosition) -> Option<f32> {
@@ -2570,7 +2590,7 @@ impl Workspace {
                     load_legacy_panel_size(T::panel_key(), dock_position, self, cx).map(|size| {
                         let state = dock::PanelSizeState {
                             size: Some(size),
-                            flex: None,
+                            ..Default::default()
                         };
                         self.persist_panel_size_state(T::panel_key(), state, cx);
                         state
@@ -8135,7 +8155,7 @@ impl Workspace {
                 let use_flexible = panel.has_flexible_size(window, cx);
                 let flex_grow = if use_flexible {
                     size_state
-                        .and_then(|state| state.flex)
+                        .and_then(|state| self.effective_dock_flex(&state, cx))
                         .or_else(|| self.default_dock_flex(position))
                 } else {
                     None
@@ -8432,14 +8452,15 @@ impl Workspace {
         });
 
         let flex_grow = self.dock_flex_for_size(DockPosition::Left, size, window, cx);
+        let center_is_empty = self.center_is_empty(cx);
         self.left_dock.update(cx, |left_dock, cx| {
             if WorkspaceSettings::get_global(cx)
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Left)
             {
-                left_dock.resize_all_panels(Some(size), flex_grow, window, cx);
+                left_dock.resize_all_panels(Some(size), flex_grow, center_is_empty, window, cx);
             } else {
-                left_dock.resize_active_panel(Some(size), flex_grow, window, cx);
+                left_dock.resize_active_panel(Some(size), flex_grow, center_is_empty, window, cx);
             }
         });
     }
@@ -8456,14 +8477,15 @@ impl Workspace {
             }
         });
         let flex_grow = self.dock_flex_for_size(DockPosition::Right, size, window, cx);
+        let center_is_empty = self.center_is_empty(cx);
         self.right_dock.update(cx, |right_dock, cx| {
             if WorkspaceSettings::get_global(cx)
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Right)
             {
-                right_dock.resize_all_panels(Some(size), flex_grow, window, cx);
+                right_dock.resize_all_panels(Some(size), flex_grow, center_is_empty, window, cx);
             } else {
-                right_dock.resize_active_panel(Some(size), flex_grow, window, cx);
+                right_dock.resize_active_panel(Some(size), flex_grow, center_is_empty, window, cx);
             }
         });
     }
@@ -8475,9 +8497,9 @@ impl Workspace {
                 .resize_all_panels_in_dock
                 .contains(&DockPosition::Bottom)
             {
-                bottom_dock.resize_all_panels(Some(size), None, window, cx);
+                bottom_dock.resize_all_panels(Some(size), None, false, window, cx);
             } else {
-                bottom_dock.resize_active_panel(Some(size), None, window, cx);
+                bottom_dock.resize_active_panel(Some(size), None, false, window, cx);
             }
         });
     }
@@ -14352,6 +14374,7 @@ mod tests {
                     dock::PanelSizeState {
                         size: None,
                         flex: Some(1.0),
+                        flex_when_center_empty: None,
                     },
                     cx,
                 );
@@ -14794,6 +14817,120 @@ mod tests {
                 "flexible right panel should share workspace width via flex ratios"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_flexible_dock_width_is_remembered_per_center_emptiness(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.bounds.size.width = px(900.);
+        });
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new_flexible(DockPosition::Left, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.toggle_dock(DockPosition::Left, window, cx);
+            panel
+        });
+
+        let stored_state = |cx: &mut VisualTestContext| {
+            workspace.read_with(cx, |workspace, cx| {
+                workspace
+                    .left_dock()
+                    .read(cx)
+                    .stored_panel_size_state(&panel)
+                    .unwrap_or_default()
+            })
+        };
+        // Widths round-trip through a flex ratio, so they come back within a rounding
+        // error of the requested size rather than exactly equal to it.
+        let assert_left_width = |cx: &mut VisualTestContext, expected: f32, message: &str| {
+            let width = workspace.update_in(cx, |workspace, window, cx| {
+                workspace.bounds.size.width = px(900.);
+                let left_dock = workspace.left_dock().read(cx);
+                workspace
+                    .dock_size(&left_dock, window, cx)
+                    .expect("left dock should have an active panel")
+            });
+            assert!(
+                (width - px(expected)).abs() < px(1.),
+                "{message}: expected about {expected}px, got {width:?}"
+            );
+        };
+
+        // Widening the dock while nothing is open in the center records a width that
+        // only applies while the center stays empty.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.bounds.size.width = px(900.);
+            workspace.resize_left_dock(px(800.), window, cx);
+        });
+        let state = stored_state(cx);
+        assert_eq!(
+            state.flex, None,
+            "resizing with an empty center should leave the ordinary width untouched"
+        );
+        assert!(
+            state.flex_when_center_empty.is_some(),
+            "resizing with an empty center should record an empty-center width"
+        );
+        assert_left_width(
+            cx,
+            800.,
+            "an empty center should use the empty-center width",
+        );
+
+        // Opening an item falls back to the ordinary width, which here is still the
+        // default even split.
+        let item = workspace.update_in(cx, |workspace, window, cx| {
+            let item = cx.new(|cx| {
+                TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "one.txt", cx)])
+            });
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+            item
+        });
+        assert_left_width(
+            cx,
+            450.,
+            "an open item should restore the ordinary dock width",
+        );
+
+        // Narrowing the dock to read that item must not disturb the empty-center width.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.bounds.size.width = px(900.);
+            workspace.resize_left_dock(px(300.), window, cx);
+        });
+        let state_after = stored_state(cx);
+        assert_eq!(
+            state_after.flex_when_center_empty,
+            state.flex_when_center_empty
+        );
+        assert!(state_after.flex.is_some());
+        assert_left_width(
+            cx,
+            300.,
+            "resizing with an open item should apply immediately",
+        );
+
+        // Closing the item returns to the width the dock had when the center was last empty.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.active_pane().update(cx, |pane, cx| {
+                pane.remove_item(item.item_id(), false, false, window, cx);
+            });
+        });
+        assert_left_width(
+            cx,
+            800.,
+            "emptying the center should restore the empty-center width",
+        );
     }
 
     struct TestModal(FocusHandle);


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/68a9cb67-7e78-4124-8045-4f7497d77449


## The problem

A flexible dock shares the row with the center pane, so it has to give space back whenever a file is opened. That is correct — but the dock only stores **one** width, and both situations write to it.

Working agent-first, where the panel is the thing you look at and files are opened briefly to check what the agent changed, the loop is:

1. Widen the dock to fill the window while nothing is open.
2. Open a file. It appears in whatever sliver is left, so you drag the divider left to read it — which overwrites the width from step 1.
3. Close the file. The dock stays narrow, and the now-empty center keeps space nothing is using.
4. Drag the divider right again.

Step 4 is needed on every cycle, and the same single stored width is why opening a file from a full-width dock puts it in a sliver in the first place.

## The change

Store a second width that applies while the center holds no items, and pick between the two at render time. `PanelSizeState` gains `flex_when_center_empty`, resolved through one helper (`Workspace::effective_dock_flex`) that every consumer goes through, so the read paths cannot disagree.

Nothing changes by default. The new width stays `None` until the divider is dragged with an empty center, and falls back to the existing `flex` until then — so a dock that is never resized in that state behaves exactly as before. There is no new setting: the behavior only exists for docks already opted into `flexible` sizing, and the divider is what selects it.

Because the stored ratio is a flex value rather than a pixel width, the dock keeps tracking window resizes in both states, and repeated open/close cycles return to the same layout instead of drifting.

The center is not collapsed or hidden — `resize_left_dock` already clamps to `workspace_width - RESIZE_HANDLE_SIZE`, so the divider survives at the extreme and remains draggable. Empty-center drop targets and the welcome page keep whatever space the user leaves them.

## Tests

`test_flexible_dock_width_is_remembered_per_center_emptiness` walks the loop above and asserts both directions: resizing with an empty center leaves `flex` untouched, resizing with an open item leaves `flex_when_center_empty` untouched, and closing the item restores the empty-center width. It fails without the change.

237 workspace tests pass, including the existing `test_flexible_dock_sizing` and `test_flexible_panel_left_dock_sizing`.

## Suggested .rules additions

`crates/workspace` — `Workspace::bounds` is recomputed on every draw, so a test that sets `bounds.size.width` and then spans several `update_in` calls silently gets the test window's width back from the second step onward. Pin the width inside each closure that measures or resizes, or keep the whole assertion inside one update.

Release Notes:

- Improved flexible docks to remember their width separately for when the center has no open items, so a dock widened over an empty center returns to that width after a file is closed.