### PR TITLE
project_panel: Add opt-in per-extension click routing to system viewer

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -798,9 +798,9 @@ impl ProjectPanel {
             })
             .detach();
 
-            let mut project_panel_settings = *ProjectPanelSettings::get_global(cx);
+            let mut project_panel_settings = ProjectPanelSettings::get_global(cx).clone();
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
-                let new_settings = *ProjectPanelSettings::get_global(cx);
+                let new_settings = ProjectPanelSettings::get_global(cx).clone();
                 if project_panel_settings != new_settings {
                     if project_panel_settings.hide_gitignore != new_settings.hide_gitignore {
                         this.update_visible_entries(None, false, false, window, cx);
@@ -6086,6 +6086,22 @@ impl ProjectPanel {
                             project_panel.toggle_expanded(entry_id, window, cx);
                         }
                     } else {
+                        let settings = ProjectPanelSettings::get_global(cx);
+                        let open_with_system = settings
+                            .open_with_system_extensions
+                            .iter()
+                            .any(|ext| path.extension().is_some_and(|file_ext| file_ext == ext.as_str()));
+
+                        if open_with_system {
+                            if let Some(worktree) =
+                                project_panel.project.read(cx).worktree_for_id(worktree_id, cx)
+                            {
+                                let abs_path = worktree.read(cx).absolutize(&path);
+                                cx.open_with_system(&abs_path);
+                            }
+                            return;
+                        }
+
                         let preview_tabs_enabled =
                             PreviewTabsSettings::get_global(cx).enable_preview_from_project_panel;
                         let click_count = event.click_count();

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -11,7 +11,7 @@ use ui::{
     scrollbars::{ScrollbarVisibility, ShowScrollbar},
 };
 
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, RegisterSetting)]
+#[derive(Deserialize, Debug, Clone, PartialEq, RegisterSetting)]
 pub struct ProjectPanelSettings {
     pub button: bool,
     pub hide_gitignore: bool,
@@ -38,6 +38,7 @@ pub struct ProjectPanelSettings {
     pub sort_order: ProjectPanelSortOrder,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
+    pub open_with_system_extensions: Vec<String>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -145,6 +146,9 @@ impl Settings for ProjectPanelSettings {
             sort_order: project_panel.sort_order.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
+            open_with_system_extensions: project_panel
+                .open_with_system_extensions
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -590,7 +590,7 @@ async fn test_auto_collapse_dir_paths(cx: &mut gpui::TestAppContext) {
         .unwrap();
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -677,7 +677,7 @@ async fn test_auto_collapse_dir_paths(cx: &mut gpui::TestAppContext) {
             .unwrap();
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     auto_fold_dirs: true,
@@ -3843,7 +3843,7 @@ async fn test_select_first_last(cx: &mut gpui::TestAppContext) {
     );
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_root: true,
@@ -4351,7 +4351,7 @@ async fn test_rename_with_hide_root(cx: &mut gpui::TestAppContext) {
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: true,
@@ -4393,7 +4393,7 @@ async fn test_rename_with_hide_root(cx: &mut gpui::TestAppContext) {
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: true,
@@ -5051,7 +5051,7 @@ async fn test_dragged_selection_resolve_entry(cx: &mut gpui::TestAppContext) {
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -5218,7 +5218,7 @@ async fn test_drag_marked_entries_in_folded_directories(cx: &mut gpui::TestAppCo
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -7021,7 +7021,7 @@ async fn test_deletion_gitignored(cx: &mut gpui::TestAppContext) {
 
     // Test 1: Auto selection with one gitignored file next to the deleted file
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_gitignore: true,
@@ -7122,7 +7122,7 @@ async fn test_nested_deletion_gitignore(cx: &mut gpui::TestAppContext) {
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_gitignore: true,
@@ -7820,7 +7820,7 @@ async fn test_expand_all_for_entry(cx: &mut gpui::TestAppContext) {
 
     // Test 1: When auto-fold is enabled
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -7883,7 +7883,7 @@ async fn test_expand_all_for_entry(cx: &mut gpui::TestAppContext) {
 
     // Test 2: When auto-fold is disabled
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: false,
@@ -8052,7 +8052,7 @@ async fn test_collapse_all_for_entry(cx: &mut gpui::TestAppContext) {
     // Test 2: With auto-fold enabled
     {
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     auto_fold_dirs: true,
@@ -8108,7 +8108,7 @@ async fn test_collapse_all_for_entry(cx: &mut gpui::TestAppContext) {
     // Test 3: With auto-fold disabled
     {
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     auto_fold_dirs: false,
@@ -8719,7 +8719,7 @@ async fn test_expand_all_entries_via_window_dispatch(cx: &mut gpui::TestAppConte
         .unwrap();
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_reveal_entries: false,
@@ -8860,7 +8860,7 @@ async fn test_expand_all_entries_with_auto_fold(cx: &mut gpui::TestAppContext) {
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -8989,7 +8989,7 @@ async fn test_create_entries_without_selection_hide_root(cx: &mut gpui::TestAppC
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_root: true,
@@ -9136,7 +9136,7 @@ async fn test_context_menu_new_file_in_empty_hidden_root(cx: &mut gpui::TestAppC
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_root: true,
@@ -9792,7 +9792,7 @@ async fn test_hide_root(cx: &mut gpui::TestAppContext) {
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: false,
@@ -9830,7 +9830,7 @@ async fn test_hide_root(cx: &mut gpui::TestAppContext) {
 
         // Set hide_root to true
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: true,
@@ -9876,7 +9876,7 @@ async fn test_hide_root(cx: &mut gpui::TestAppContext) {
 
         // Set hide_root to true
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: true,
@@ -9915,7 +9915,7 @@ async fn test_hide_root(cx: &mut gpui::TestAppContext) {
         let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
         cx.update(|_, cx| {
-            let settings = *ProjectPanelSettings::get_global(cx);
+            let settings = ProjectPanelSettings::get_global(cx).clone();
             ProjectPanelSettings::override_global(
                 ProjectPanelSettings {
                     hide_root: false,
@@ -10224,7 +10224,7 @@ async fn test_hide_hidden_entries(cx: &mut gpui::TestAppContext) {
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_hidden: false,
@@ -10274,7 +10274,7 @@ async fn test_hide_hidden_entries(cx: &mut gpui::TestAppContext) {
     );
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_hidden: true,
@@ -10303,7 +10303,7 @@ async fn test_hide_hidden_entries(cx: &mut gpui::TestAppContext) {
     );
 
     panel.update_in(cx, |panel, window, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 hide_hidden: false,
@@ -10584,7 +10584,7 @@ async fn test_sort_mode_default_fallback(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
     // Verify that when sort_mode is not specified, it defaults to DirectoriesFirst
-    let default_settings = cx.read(|cx| *ProjectPanelSettings::get_global(cx));
+    let default_settings = cx.read(|cx| ProjectPanelSettings::get_global(cx).clone());
     assert_eq!(
         default_settings.sort_mode,
         settings::ProjectPanelSortMode::DirectoriesFirst,
@@ -10953,7 +10953,7 @@ async fn test_preserve_temporary_unfolded_active_index_on_blur_from_context_menu
     });
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -11137,7 +11137,7 @@ async fn run_create_file_in_folded_path_case(
     });
 
     cx.update(|_, cx| {
-        let settings = *ProjectPanelSettings::get_global(cx);
+        let settings = ProjectPanelSettings::get_global(cx).clone();
         ProjectPanelSettings::override_global(
             ProjectPanelSettings {
                 auto_fold_dirs: true,
@@ -11596,4 +11596,66 @@ async fn test_restore_file_prompt_escapes_markdown_in_file_name(cx: &mut gpui::T
         .expect("restore should show a confirmation prompt");
 
     assert_eq!(message, "Discard changes to `__init__.py`?");
+}
+
+#[gpui::test]
+async fn test_open_with_system_extensions_setting(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    // Verify the setting defaults to empty
+    cx.update(|cx| {
+        let settings = ProjectPanelSettings::get_global(cx);
+        assert!(
+            settings.open_with_system_extensions.is_empty(),
+            "open_with_system_extensions should default to empty"
+        );
+    });
+
+    // Configure the setting
+    cx.update_global::<SettingsStore, _>(|store, cx| {
+        store.update_user_settings(cx, |settings| {
+            settings
+                .project_panel
+                .get_or_insert_default()
+                .open_with_system_extensions = Some(vec!["pdf".to_string(), "html".to_string()]);
+        });
+    });
+
+    // Verify the setting is loaded
+    cx.update(|cx| {
+        let settings = ProjectPanelSettings::get_global(cx);
+        assert_eq!(
+            settings.open_with_system_extensions,
+            vec!["pdf".to_string(), "html".to_string()]
+        );
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/src"),
+        json!({
+            "test": {
+                "code.rs": "// Rust file",
+                "document.pdf": "%PDF-1.4 fake",
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/src").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    toggle_expand_dir(&panel, "src/test", cx);
+
+    // Opening a .rs file should still work normally (not routed to system)
+    select_path(&panel, "src/test/code.rs", cx);
+    panel.update_in(cx, |panel, window, cx| panel.open(&Open, window, cx));
+    cx.executor().run_until_parked();
+    ensure_single_file_is_opened(&workspace, "test/code.rs", cx);
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -854,6 +854,7 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
+            open_with_system_extensions: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -828,6 +828,11 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// File extensions that should be opened in the system default application
+    /// when clicked in the project panel, instead of being opened as text in the editor.
+    ///
+    /// Default: []
+    pub open_with_system_extensions: Option<Vec<String>>,
 }
 
 #[derive(


### PR DESCRIPTION
## Summary

When a user clicks a file in the project panel whose extension matches the configurable `open_with_system_extensions` setting, Zed opens it in the system default application instead of opening it as text in the editor. This leverages the existing `OpenWithSystem` action (`cx.open_with_system()`), which was previously only accessible via `ctrl-shift-enter` or the right-click context menu.

The setting defaults to empty — **zero behavior change unless explicitly configured**.

## Motivation

When the native PDF renderer PRs (#51040, #51870) were closed, the stated stance was:

> *"Make it easy to open these files in the system viewer from Zed instead of doing it in Zed"*

Zed already has the `OpenWithSystem` infrastructure, but it's not discoverable — there's no single-click path. The project panel's click handler unconditionally calls `open_entry()`, opening every file as text regardless of type. This PR implements the "make it easy to open in the system viewer" direction by adding a settings-driven extension check before `open_entry()`.

This is not a replacement for the webview work in #21208 — it's the interim solution the maintainers already pointed toward.

## Settings

```jsonc
{
  "project_panel": {
    "open_with_system_extensions": ["pdf", "html", "xlsx"]
  }
}
```

Default: `[]` (no files routed to system viewer)

## Changes

- **`settings_content/src/workspace.rs`**: Add `open_with_system_extensions: Option<Vec<String>>` to `ProjectPanelSettingsContent`
- **`project_panel/src/project_panel_settings.rs`**: Remove `Copy` from `ProjectPanelSettings` derive (precedented by `ExtensionSettings`, `JournalSettings`, `VimSettings`), add `open_with_system_extensions: Vec<String>` field with `unwrap_or_default()`
- **`project_panel/src/project_panel.rs`**: Extension check in click handler before `open_entry` — routes to `cx.open_with_system()` if matched
- **`settings/src/vscode_import.rs`**: Add `open_with_system_extensions: None` default
- **`project_panel/src/project_panel_tests.rs`**: Fix `*ProjectPanelSettings::get_global(cx)` → `.clone()` (27 sites), add test
- **`file_finder/src/file_finder_tests.rs`**: Fix `*ProjectPanelSettings::get_global(cx)` → `.clone()` (14 sites)

Total: 6 files, +132/-44 lines. Core logic is 15 lines.

## Test plan

- [x] `cargo check -p project_panel` — passes
- [x] `cargo test -p project_panel test_open_with_system_extensions_setting` — passes (verifies setting defaults, loading, and that non-matching files still open normally)
- [x] `cargo test -p file_finder` — all 69 tests pass
- [ ] Manual: click a `.pdf` in the project panel with `["pdf"]` configured → opens in Preview
- [ ] Manual: click a `.html` in the project panel with `["html"]` configured → opens in browser
- [ ] Manual: click a `.rs` file with the setting configured → opens in editor as normal
- [ ] Manual: with setting unconfigured (default) → all files open in editor as normal

Release Notes:
- Added `project_panel.open_with_system_extensions` setting to route clicks on specific file extensions to the system default application instead of the editor.

Related: #21208, #51040, #51870, #23524
