### PR TITLE
agent_ui: Add CLI support for sending agent prompts

### DIFF
--- a/crates/agent_ui/src/agent_cli.rs
+++ b/crates/agent_ui/src/agent_cli.rs
@@ -1,0 +1,1094 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use acp_thread::{AcpThread, ThreadStatus};
+use agent_client_protocol::schema::v1 as acp;
+use agent_settings::{AgentProfileId, AgentSettings};
+use anyhow::{Context as _, Result, anyhow};
+use chrono::{DateTime, Utc};
+use collections::HashSet;
+use gpui::{App, AsyncApp, Entity, Task, WindowHandle};
+use language_model::LanguageModelRegistry;
+use remote::RemoteConnectionOptions;
+use settings::Settings as _;
+use workspace::{AppState, MultiWorkspace, PathList, SerializedWorkspaceLocation, Workspace};
+
+use crate::{
+    Agent, AgentInitialContent, AgentPanel, AgentThreadSource, ExternalSourcePrompt, ThreadId,
+    agent_panel::CreateThreadOptions,
+    conversation_view::ThreadView,
+    thread_metadata_store::{ThreadMetadata, ThreadMetadataStore},
+};
+
+/// How the caller identified the thread to target.
+pub enum ThreadSelector {
+    /// Exact `ThreadId`.
+    Id(ThreadId),
+    /// Case-insensitive prefix of a `ThreadId`, compared with hyphens ignored
+    /// so that `550e8400-e29b` and `550e8400e29b` behave identically.
+    Prefix(String),
+    /// An ACP session id.
+    Session(String),
+    /// Most recently updated non-archived thread for the project.
+    MostRecent,
+    /// Always create a fresh thread.
+    New,
+}
+
+impl ThreadSelector {
+    /// Interprets a user-supplied thread argument.
+    ///
+    /// A value that parses as a complete UUID is an exact id; anything else is
+    /// treated as a prefix. `uuid` accepts several complete forms (hyphenated,
+    /// simple, URN, braced), so this deliberately does not assume hyphens.
+    pub fn from_thread_argument(value: &str) -> Self {
+        match value.parse::<ThreadId>() {
+            Ok(thread_id) => Self::Id(thread_id),
+            Err(_) => Self::Prefix(value.to_string()),
+        }
+    }
+}
+
+/// Lower-cases and strips hyphens so that thread id prefixes can be given with
+/// or without the hyphens of the canonical form.
+fn normalize_thread_id_fragment(fragment: &str) -> String {
+    fragment
+        .chars()
+        .filter(|character| *character != '-')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+pub struct CliPromptRequest {
+    pub selector: ThreadSelector,
+    pub prompt: String,
+    /// Absolute path scoping lookup/creation. `None` means "any".
+    pub project: Option<PathBuf>,
+    /// Agent profile for a thread being created, which decides the available
+    /// tools. Only honored alongside [`ThreadSelector::New`].
+    pub profile: Option<String>,
+    /// Model for a thread being created, as `provider/model-id`. Only honored
+    /// alongside [`ThreadSelector::New`].
+    pub model: Option<String>,
+    pub wait: bool,
+}
+
+/// Profile and model applied to a thread being created, validated up front.
+struct TurnSettings {
+    profile: Option<AgentProfileId>,
+    model: Option<String>,
+}
+
+/// One row of `--agent-list` output.
+pub struct ThreadListEntry {
+    pub thread_id: ThreadId,
+    pub title: String,
+    pub updated_at: DateTime<Utc>,
+    /// When a person last engaged with the thread from the panel, as opposed
+    /// to `updated_at`, which also moves when the agent makes progress.
+    /// Prompts delivered by this module deliberately leave it alone.
+    pub interacted_at: Option<DateTime<Utc>>,
+    pub is_open: bool,
+    /// The worktree folders the thread belongs to. For a thread created in a
+    /// linked git worktree these are that worktree's paths, not the main
+    /// checkout's.
+    pub paths: Vec<PathBuf>,
+}
+
+/// What happened to a prompt that was dispatched successfully.
+pub enum DispatchOutcome {
+    /// Prompt was sent, either into an idle thread or auto-submitted on a
+    /// freshly created one.
+    Sent { thread_id: ThreadId },
+    /// Thread was generating; prompt was appended to the message queue.
+    Queued { thread_id: ThreadId },
+}
+
+/// Lists threads, most-recently-updated first. When `project` is `Some`,
+/// only threads whose worktree paths match are returned.
+pub fn list_threads(project: Option<&Path>, cx: &App) -> Vec<ThreadListEntry> {
+    let store = ThreadMetadataStore::global(cx);
+    let store = store.read(cx);
+
+    let open_thread_ids = scan_open_thread_ids(cx);
+
+    let mut entries: Vec<ThreadListEntry> = store
+        .entries()
+        .filter(|metadata| !metadata.archived)
+        .filter(|metadata| {
+            if let Some(project_path) = project {
+                thread_matches_path(metadata, project_path)
+            } else {
+                true
+            }
+        })
+        .map(|metadata| ThreadListEntry {
+            thread_id: metadata.thread_id,
+            title: metadata.display_title().to_string(),
+            updated_at: metadata.updated_at,
+            interacted_at: metadata.interacted_at,
+            is_open: open_thread_ids.contains(&metadata.thread_id),
+            paths: metadata
+                .folder_paths()
+                .paths()
+                .iter()
+                .map(|p| p.as_path().to_path_buf())
+                .collect(),
+        })
+        .collect();
+
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.updated_at));
+    entries
+}
+
+/// Resolves the selector and dispatches the prompt. When `wait` is true, the
+/// returned task additionally waits for the turn to complete.
+pub fn dispatch_cli_prompt(
+    request: CliPromptRequest,
+    app_state: Arc<AppState>,
+    cx: &mut AsyncApp,
+) -> Task<Result<DispatchOutcome>> {
+    cx.spawn(async move |mut cx| {
+        let CliPromptRequest {
+            selector,
+            prompt,
+            project: project_filter,
+            profile,
+            model,
+            wait,
+        } = request;
+
+        // Prompts are frequently piped in from webhooks, so strip bidi and
+        // control characters that could misrepresent what is being sent.
+        let prompt = ExternalSourcePrompt::new(&prompt)
+            .context("prompt contained no usable text")?
+            .into_string();
+        let blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(prompt))];
+
+        // Validated before anything is dispatched, so a typo can't leave a
+        // thread running under the wrong tool set.
+        let turn = cx.update(|cx| {
+            let profile = profile
+                .as_deref()
+                .map(|profile| validate_profile(profile, cx))
+                .transpose()?;
+            if let Some(model) = model.as_deref() {
+                validate_model(model, cx)?;
+            }
+            anyhow::Ok(TurnSettings { profile, model })
+        })?;
+
+        match selector {
+            ThreadSelector::New => {
+                dispatch_into_new_thread(blocks, wait, app_state, project_filter, turn, &mut cx)
+                    .await
+            }
+            _ => {
+                // Both settings persist on the thread, and switching the
+                // profile also selects that profile's preferred model and
+                // applies to running subagents, so they configure a thread
+                // being created rather than reconfigure an existing one.
+                anyhow::ensure!(
+                    turn.profile.is_none() && turn.model.is_none(),
+                    "a profile or model can only be set when creating a thread"
+                );
+
+                let resolved_id = resolve_thread_id(&selector, project_filter.as_deref(), &cx)?;
+
+                // Dispatching into a thread that is already open avoids both a
+                // reload from disk and any disturbance to the user's focus.
+                let open_result = find_open_thread_window(resolved_id, &mut cx);
+                if let Some(window_handle) = open_result {
+                    return dispatch_into_open_window(
+                        window_handle,
+                        resolved_id,
+                        blocks,
+                        wait,
+                        &mut cx,
+                    )
+                    .await;
+                }
+
+                dispatch_into_stored_thread(resolved_id, blocks, wait, app_state, &mut cx).await
+            }
+        }
+    })
+}
+
+/// Waits for `window` to register an [`AgentPanel`] in any of its workspaces.
+///
+/// A workspace registers its docks asynchronously after it opens, so a request
+/// that arrives during startup would otherwise find no panel at all. Polling
+/// rather than awaiting `Workspace::take_panels_task` is deliberate: that task
+/// can only be taken once, so whichever caller got there first would leave
+/// everyone else believing initialization had finished.
+async fn wait_for_agent_panel(window: &WindowHandle<MultiWorkspace>, cx: &mut AsyncApp) {
+    const PANEL_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+    let deadline = std::time::Instant::now() + PANEL_LOAD_TIMEOUT;
+    loop {
+        let registered = window
+            .update(cx, |multi, _window, cx| {
+                multi
+                    .workspaces()
+                    .any(|workspace| workspace.read(cx).panel::<AgentPanel>(cx).is_some())
+            })
+            .unwrap_or(true);
+        if registered || std::time::Instant::now() >= deadline {
+            return;
+        }
+        cx.background_executor().timer(POLL_INTERVAL).await;
+    }
+}
+
+/// Collects all `ThreadId`s currently open in any workspace's `AgentPanel`.
+fn scan_open_thread_ids(cx: &App) -> HashSet<ThreadId> {
+    let mut open_ids = HashSet::default();
+    for window in cx.windows() {
+        let Some(multi_workspace) = window.downcast::<MultiWorkspace>() else {
+            continue;
+        };
+        let Ok(multi) = multi_workspace.read(cx) else {
+            continue;
+        };
+        for workspace in multi.workspaces() {
+            let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+                continue;
+            };
+            let panel = panel.read(cx);
+            for thread_id in panel.retained_threads().keys() {
+                open_ids.insert(*thread_id);
+            }
+            if let Some(active_id) = panel.active_thread_id(cx) {
+                open_ids.insert(active_id);
+            }
+            if let Some(draft_id) = panel.ephemeral_draft_thread_id(cx) {
+                open_ids.insert(draft_id);
+            }
+        }
+    }
+    open_ids
+}
+
+/// Find the `WindowHandle<MultiWorkspace>` that contains an already-open
+/// thread. Returns `None` if the thread isn't currently open.
+fn find_open_thread_window(
+    thread_id: ThreadId,
+    cx: &mut AsyncApp,
+) -> Option<WindowHandle<MultiWorkspace>> {
+    let windows = cx.update(|cx| cx.windows());
+    for window in windows {
+        let Some(multi_workspace) = window.downcast::<MultiWorkspace>() else {
+            continue;
+        };
+        let check_result = multi_workspace.update(cx, |multi, _window, cx| {
+            for workspace in multi.workspaces() {
+                let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+                    continue;
+                };
+                let panel = panel.read(cx);
+                if panel.conversation_view_for_id(&thread_id, cx).is_some() {
+                    return true;
+                }
+            }
+            false
+        });
+        if check_result.is_ok_and(|found| found) {
+            return Some(multi_workspace);
+        }
+    }
+    None
+}
+
+/// Dispatch the prompt into a thread that is open in some window.
+async fn dispatch_into_open_window(
+    window_handle: WindowHandle<MultiWorkspace>,
+    thread_id: ThreadId,
+    blocks: Vec<acp::ContentBlock>,
+    wait: bool,
+    cx: &mut AsyncApp,
+) -> Result<DispatchOutcome> {
+    // Perform the send or queue operation inside `window_handle.update`
+    // because both `send_content` and `add_to_queue` require `&mut Window`.
+    let outcome = window_handle.update(cx, |multi, window, cx| {
+        let Some((thread_view, acp_thread)) = find_thread_view_in_workspaces(multi, thread_id, cx)
+        else {
+            return Err(anyhow!("thread not found in window after initial lookup"));
+        };
+
+        let is_generating = acp_thread.read(cx).status() != ThreadStatus::Idle;
+
+        if is_generating {
+            thread_view.update(cx, |view, cx| {
+                view.add_to_queue(blocks, Vec::new(), window, cx);
+            });
+            Ok(DispatchOutcome::Queued { thread_id })
+        } else {
+            // A queue left in the paused state by a manual stop would never
+            // drain on its own, because no further `Stop` event is coming.
+            thread_view.update(cx, |view, cx| {
+                view.resume_message_queue();
+                view.send_content(
+                    Task::ready(Ok(Some((blocks, Vec::new())))),
+                    false,
+                    window,
+                    cx,
+                );
+            });
+            Ok(DispatchOutcome::Sent { thread_id })
+        }
+    })??;
+
+    if wait {
+        wait_for_idle_and_empty_queue_in_window(&window_handle, thread_id, cx).await;
+    }
+
+    Ok(outcome)
+}
+
+/// Checks a profile name against the configured profiles.
+///
+/// Automation depends on the tool set a profile implies, so an unknown name is
+/// an error rather than a silent fallback to the default.
+fn validate_profile(profile: &str, cx: &App) -> Result<AgentProfileId> {
+    let profile_id = AgentProfileId(profile.into());
+    let settings = AgentSettings::get_global(cx);
+    if settings.profiles.contains_key(&profile_id) {
+        return Ok(profile_id);
+    }
+    let mut available = settings
+        .profiles
+        .keys()
+        .map(|id| id.as_str())
+        .collect::<Vec<_>>();
+    available.sort_unstable();
+    Err(anyhow!(
+        "unknown agent profile \"{profile}\"; available profiles: {}",
+        available.join(", ")
+    ))
+}
+
+/// Checks a `provider/model-id` string against the registered models.
+fn validate_model(model: &str, cx: &mut App) -> Result<()> {
+    let selected = crate::agent_panel::parse_provider_slash_model(model).with_context(|| {
+        format!("could not parse model \"{model}\"; expected `provider/model-id`")
+    })?;
+    LanguageModelRegistry::global(cx)
+        .update(cx, |registry, cx| registry.select_model(&selected, cx))
+        .with_context(|| format!("no configured model matches \"{model}\""))?;
+    Ok(())
+}
+
+/// The agent panel for `preferred`, falling back to any panel in the window.
+///
+/// The window can come from the "any active workspace" fallback, in which case
+/// no workspace in it matches the thread but its panel is still the right place
+/// to put the conversation.
+fn agent_panel_for_window(
+    multi_workspace: &MultiWorkspace,
+    preferred: Option<&Entity<Workspace>>,
+    cx: &App,
+) -> Result<Entity<AgentPanel>> {
+    preferred
+        .and_then(|workspace| workspace.read(cx).panel::<AgentPanel>(cx))
+        .or_else(|| {
+            multi_workspace
+                .workspaces()
+                .find_map(|workspace| workspace.read(cx).panel::<AgentPanel>(cx))
+        })
+        .ok_or_else(|| anyhow!("no agent panel available (is `disable_ai` set?)"))
+}
+
+/// Whether `workspace` is the one a thread with these worktree paths belongs to.
+fn workspace_hosts_thread(
+    workspace: &Entity<Workspace>,
+    host: Option<&RemoteConnectionOptions>,
+    folder_paths: &PathList,
+    cx: &App,
+) -> bool {
+    let workspace = workspace.read(cx);
+    if workspace.project_group_key(cx).host().as_ref() != host {
+        return false;
+    }
+    let root_paths = PathList::new(&workspace.root_paths(cx));
+    folder_paths.paths().iter().any(|folder_path| {
+        root_paths
+            .paths()
+            .iter()
+            .any(|root_path| folder_path.as_path().starts_with(root_path.as_path()))
+    })
+}
+
+/// Finds a `ThreadView` and its `AcpThread` among a window's workspaces.
+///
+/// This takes `&MultiWorkspace` rather than looking the window up by handle
+/// because callers run inside `WindowHandle::update`, which temporarily removes
+/// the window from the app; reading it by handle from there always fails.
+fn find_thread_view_in_workspaces(
+    multi_workspace: &MultiWorkspace,
+    thread_id: ThreadId,
+    cx: &App,
+) -> Option<(Entity<ThreadView>, Entity<AcpThread>)> {
+    for workspace in multi_workspace.workspaces() {
+        let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+            continue;
+        };
+        let Some(conversation_view) = panel
+            .read(cx)
+            .conversation_view_for_id(&thread_id, cx)
+            .cloned()
+        else {
+            continue;
+        };
+        let Some(thread_view) = conversation_view.read(cx).root_thread_view() else {
+            continue;
+        };
+        let acp_thread = thread_view.read(cx).thread.clone();
+        return Some((thread_view, acp_thread));
+    }
+    None
+}
+
+/// Wait for the AcpThread to become Idle AND for its message queue to drain.
+/// There is deliberately no timeout.
+async fn wait_for_idle_and_empty_queue_in_window(
+    window_handle: &WindowHandle<MultiWorkspace>,
+    thread_id: ThreadId,
+    cx: &mut AsyncApp,
+) {
+    loop {
+        // A closed window or a vanished thread leaves nothing to wait for.
+        let done = window_handle
+            .update(cx, |multi, _window, cx| {
+                let Some((thread_view, acp_thread)) =
+                    find_thread_view_in_workspaces(multi, thread_id, cx)
+                else {
+                    return true;
+                };
+                let is_idle = acp_thread.read(cx).status() == ThreadStatus::Idle;
+                is_idle && thread_view.read(cx).is_message_queue_empty()
+            })
+            .unwrap_or(true);
+
+        if done {
+            return;
+        }
+
+        cx.background_executor()
+            .timer(Duration::from_millis(200))
+            .await;
+    }
+}
+
+/// Load a thread from the metadata store and dispatch into it.
+async fn dispatch_into_stored_thread(
+    thread_id: ThreadId,
+    blocks: Vec<acp::ContentBlock>,
+    wait: bool,
+    app_state: Arc<AppState>,
+    cx: &mut AsyncApp,
+) -> Result<DispatchOutcome> {
+    // The thread's own stored worktree paths decide where it reopens, so any
+    // caller-supplied project filter has already done its job during lookup.
+    let metadata = cx.update(|cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+        store
+            .entry(thread_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("thread \"{thread_id}\" not found in metadata store"))
+    })?;
+
+    let location = metadata
+        .remote_connection
+        .as_ref()
+        .map(|conn| SerializedWorkspaceLocation::Remote(conn.clone()))
+        .unwrap_or(SerializedWorkspaceLocation::Local);
+
+    let folder_paths = metadata.folder_paths().clone();
+    let host = metadata.remote_connection.as_ref();
+    let agent: Agent = metadata.agent_id.clone().into();
+    let work_dirs = Some(folder_paths.clone());
+    let title = metadata.title();
+
+    let candidate_windows =
+        cx.update(|cx| workspace::workspace_windows_for_location(&location, cx));
+
+    let mut found_window: Option<WindowHandle<MultiWorkspace>> = None;
+    for multi_window in &candidate_windows {
+        let matches = multi_window
+            .update(cx, |multi, _window, cx| {
+                multi
+                    .workspaces()
+                    .any(|workspace| workspace_hosts_thread(workspace, host, &folder_paths, cx))
+            })
+            .unwrap_or(false);
+        if matches {
+            found_window = Some(*multi_window);
+            break;
+        }
+    }
+
+    let window_handle = match found_window {
+        Some(window) => window,
+        None => workspace::get_any_active_multi_workspace(app_state.clone(), cx.clone())
+            .await
+            .context("no workspace available to load thread into")?,
+    };
+
+    wait_for_agent_panel(&window_handle, cx).await;
+
+    window_handle.update(cx, |multi, window, cx| {
+        let preferred = multi
+            .workspaces()
+            .find(|workspace| workspace_hosts_thread(workspace, host, &folder_paths, cx))
+            .cloned();
+        let panel = agent_panel_for_window(multi, preferred.as_ref(), cx)?;
+
+        panel.update(cx, |panel, cx| {
+            panel.load_agent_thread(
+                agent.clone(),
+                thread_id,
+                work_dirs.clone(),
+                title.clone(),
+                false,
+                AgentThreadSource::AgentPanel,
+                window,
+                cx,
+            );
+        });
+        anyhow::Ok(())
+    })??;
+
+    wait_for_thread_view_and_dispatch(window_handle, thread_id, blocks, wait, cx).await
+}
+
+/// After `load_agent_thread`, poll until the ThreadView is ready
+/// (the agent server connection is asynchronous) and then dispatch.
+async fn wait_for_thread_view_and_dispatch(
+    window_handle: WindowHandle<MultiWorkspace>,
+    thread_id: ThreadId,
+    blocks: Vec<acp::ContentBlock>,
+    wait: bool,
+    cx: &mut AsyncApp,
+) -> Result<DispatchOutcome> {
+    const THREAD_LOAD_TIMEOUT: Duration = Duration::from_secs(60);
+    const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    let deadline = std::time::Instant::now() + THREAD_LOAD_TIMEOUT;
+    loop {
+        // A failed update means the window was closed while we were waiting;
+        // propagate rather than polling a handle that can never become ready.
+        let ready = window_handle
+            .update(cx, |multi, _window, cx| {
+                find_thread_view_in_workspaces(multi, thread_id, cx).is_some()
+            })
+            .with_context(|| {
+                format!("window closed while waiting for thread {thread_id} to load")
+            })?;
+
+        if ready {
+            return dispatch_into_open_window(window_handle, thread_id, blocks, wait, cx).await;
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for thread {thread_id} to finish loading"
+        );
+
+        cx.background_executor().timer(POLL_INTERVAL).await;
+    }
+}
+
+/// Create a new thread and dispatch into it.
+async fn dispatch_into_new_thread(
+    blocks: Vec<acp::ContentBlock>,
+    wait: bool,
+    app_state: Arc<AppState>,
+    project_filter: Option<PathBuf>,
+    turn: TurnSettings,
+    cx: &mut AsyncApp,
+) -> Result<DispatchOutcome> {
+    let initial_content = AgentInitialContent::ContentBlock {
+        blocks,
+        auto_submit: true,
+    };
+
+    // Remembering which workspace matched keeps the thread in the requested
+    // project; a window can host several workspaces, each with its own panel.
+    let mut matched_workspace = None;
+    let window_handle = if let Some(ref project_path) = project_filter {
+        let path_list = PathList::new(std::slice::from_ref(project_path));
+        let location = SerializedWorkspaceLocation::Local;
+
+        let candidate_windows =
+            cx.update(|cx| workspace::workspace_windows_for_location(&location, cx));
+
+        let mut found_window = None;
+        for multi_window in &candidate_windows {
+            let workspace = multi_window
+                .update(cx, |multi, _window, cx| {
+                    multi.workspace_for_paths(&path_list, None, cx)
+                })
+                .ok()
+                .flatten();
+            if let Some(workspace) = workspace {
+                matched_workspace = Some(workspace);
+                found_window = Some(*multi_window);
+                break;
+            }
+        }
+
+        // Falling back to whichever window happens to be active would put the
+        // thread in the wrong project while still reporting success.
+        found_window.with_context(|| {
+            format!(
+                "{} is not open in Zed; open it first, or omit --agent-project \
+                 to use the active window",
+                project_path.display()
+            )
+        })?
+    } else {
+        workspace::get_any_active_multi_workspace(app_state.clone(), cx.clone())
+            .await
+            .context("no workspace available to create thread in")?
+    };
+
+    wait_for_agent_panel(&window_handle, cx).await;
+
+    let thread_id = window_handle.update(cx, |multi, window, cx| {
+        let panel = agent_panel_for_window(multi, matched_workspace.as_ref(), cx)?;
+
+        let result = panel.update(cx, |panel, cx| {
+            panel.create_thread_with_options(
+                CreateThreadOptions {
+                    initial_content: Some(initial_content),
+                    model: turn.model.clone(),
+                    profile: turn.profile.clone(),
+                    work_dirs: project_filter
+                        .as_ref()
+                        .map(|project_path| PathList::new(std::slice::from_ref(project_path))),
+                    ..Default::default()
+                },
+                AgentThreadSource::AgentPanel,
+                window,
+                cx,
+            )
+        });
+        anyhow::Ok(result)
+    })??;
+
+    if wait {
+        // The thread was created with `auto_submit`, so waiting for it to go
+        // idle also covers the automatic first turn.
+        wait_for_idle_and_empty_queue_in_window(&window_handle, thread_id, cx).await;
+    }
+
+    Ok(DispatchOutcome::Sent { thread_id })
+}
+
+/// Resolve a `ThreadSelector` to a `ThreadId` by consulting the metadata store.
+fn resolve_thread_id(
+    selector: &ThreadSelector,
+    project_filter: Option<&Path>,
+    cx: &AsyncApp,
+) -> Result<ThreadId> {
+    cx.update(|cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+
+        match selector {
+            ThreadSelector::New => Err(anyhow!(
+                "ThreadSelector::New should be handled before resolve_thread_id"
+            )),
+            ThreadSelector::Id(thread_id) => {
+                if store.entry(*thread_id).is_none() {
+                    return Err(anyhow!("thread \"{thread_id}\" not found"));
+                }
+                Ok(*thread_id)
+            }
+            ThreadSelector::Prefix(prefix) => {
+                let candidates = selectable_threads(&store, project_filter);
+                select_by_prefix(&candidates, prefix)
+            }
+            ThreadSelector::Session(session_id) => {
+                let session_id = acp::SessionId::new(session_id.clone());
+                if let Some(metadata) = store.entry_by_session(&session_id) {
+                    Ok(metadata.thread_id)
+                } else {
+                    Err(anyhow!("no thread found for session \"{}\"", session_id))
+                }
+            }
+            ThreadSelector::MostRecent => {
+                let candidates = selectable_threads(&store, project_filter);
+                select_most_recent(&candidates, &scan_open_thread_ids(cx))
+            }
+        }
+    })
+}
+
+/// Non-archived threads belonging to `project_filter`, if one was given.
+fn selectable_threads<'a>(
+    store: &'a ThreadMetadataStore,
+    project_filter: Option<&Path>,
+) -> Vec<&'a ThreadMetadata> {
+    store
+        .entries()
+        .filter(|metadata| !metadata.archived)
+        .filter(|metadata| {
+            project_filter.is_none_or(|project_path| thread_matches_path(metadata, project_path))
+        })
+        .collect()
+}
+
+fn select_by_prefix(candidates: &[&ThreadMetadata], prefix: &str) -> Result<ThreadId> {
+    let normalized_prefix = normalize_thread_id_fragment(prefix);
+    // An empty prefix matches every thread, so it would silently resolve
+    // whenever exactly one thread exists.
+    if normalized_prefix.is_empty() {
+        return Err(anyhow!("thread id prefix must not be empty"));
+    }
+
+    let mut matches: Vec<&ThreadMetadata> = candidates
+        .iter()
+        .copied()
+        .filter(|metadata| {
+            normalize_thread_id_fragment(&metadata.thread_id.to_string())
+                .starts_with(&normalized_prefix)
+        })
+        .collect();
+    matches.sort_by_key(|metadata| std::cmp::Reverse(metadata.updated_at));
+
+    match matches.as_slice() {
+        [] => Err(anyhow!("no thread found matching prefix \"{prefix}\"")),
+        [only] => Ok(only.thread_id),
+        ambiguous => {
+            let listed = ambiguous
+                .iter()
+                .map(|metadata| {
+                    format!("  {} \"{}\"", metadata.thread_id, metadata.display_title())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(anyhow!(
+                "ambiguous prefix \"{prefix}\" matches {} threads:\n{listed}",
+                ambiguous.len()
+            ))
+        }
+    }
+}
+
+fn select_most_recent(
+    candidates: &[&ThreadMetadata],
+    open_thread_ids: &HashSet<ThreadId>,
+) -> Result<ThreadId> {
+    candidates
+        .iter()
+        .max_by_key(|metadata| {
+            // Prefer an already-open thread when timestamps tie.
+            (
+                metadata.updated_at,
+                open_thread_ids.contains(&metadata.thread_id),
+            )
+        })
+        .map(|metadata| metadata.thread_id)
+        .ok_or_else(|| anyhow!("no threads found"))
+}
+
+/// Returns `true` when the thread's worktree paths intersect with the
+/// given project path.
+///
+/// The comparison is containment in either direction because `project_path`
+/// usually defaults to the caller's working directory, which is commonly a
+/// subdirectory of the worktree root the thread was created against.
+fn thread_matches_path(metadata: &ThreadMetadata, project_path: &Path) -> bool {
+    metadata
+        .folder_paths()
+        .paths()
+        .iter()
+        .chain(metadata.main_worktree_paths().paths().iter())
+        .any(|thread_path| {
+            let thread_path = thread_path.as_path();
+            thread_path.starts_with(project_path) || project_path.starts_with(thread_path)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use project::WorktreePaths;
+
+    fn metadata_for_paths(paths: &[&str]) -> ThreadMetadata {
+        let path_list = PathList::new(&paths.iter().map(PathBuf::from).collect::<Vec<_>>());
+        ThreadMetadata {
+            thread_id: ThreadId::new(),
+            session_id: None,
+            agent_id: agent::ZED_AGENT_ID.clone(),
+            title: None,
+            title_override: None,
+            updated_at: Utc::now(),
+            created_at: None,
+            interacted_at: None,
+            worktree_paths: WorktreePaths::from_folder_paths(&path_list),
+            remote_connection: None,
+            archived: false,
+        }
+    }
+
+    fn metadata_with_id(thread_id: ThreadId, updated_at: DateTime<Utc>) -> ThreadMetadata {
+        ThreadMetadata {
+            thread_id,
+            updated_at,
+            ..metadata_for_paths(&["/home/user/project"])
+        }
+    }
+
+    #[test]
+    fn test_prompts_are_stripped_of_invisible_characters() {
+        // Webhook payloads are attacker-influenced; a bidi override could
+        // otherwise make the rendered prompt disagree with what is sent.
+        let sanitized = ExternalSourcePrompt::new("delete\u{202E}everything")
+            .expect("prompt should survive sanitization")
+            .into_string();
+        assert_eq!(sanitized, "deleteeverything");
+    }
+
+    #[test]
+    fn test_prompts_of_only_invisible_characters_are_rejected() {
+        assert!(ExternalSourcePrompt::new("\u{202E}\u{0000}").is_none());
+    }
+
+    #[test]
+    fn test_prefixes_select_a_single_matching_thread() {
+        let wanted = ThreadId::new();
+        let other = ThreadId::new();
+        let entries = [
+            metadata_with_id(wanted, Utc::now()),
+            metadata_with_id(other, Utc::now()),
+        ];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        let fragment = &wanted.to_string()[..8];
+        assert_eq!(
+            select_by_prefix(&candidates, fragment).expect("prefix should resolve"),
+            wanted
+        );
+    }
+
+    #[test]
+    fn test_prefixes_match_regardless_of_hyphens_and_case() {
+        let wanted = ThreadId::new();
+        let entries = [metadata_with_id(wanted, Utc::now())];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        // The first two hyphen-delimited groups, with and without the hyphen.
+        let rendered = wanted.to_string();
+        let hyphenated = &rendered[..13];
+        let hyphenless = hyphenated.replace('-', "");
+
+        for fragment in [
+            hyphenated.to_string(),
+            hyphenless,
+            hyphenated.to_uppercase(),
+        ] {
+            assert_eq!(
+                select_by_prefix(&candidates, &fragment)
+                    .unwrap_or_else(|_| panic!("{fragment} should resolve")),
+                wanted
+            );
+        }
+    }
+
+    #[test]
+    fn test_ambiguous_prefixes_report_every_candidate() {
+        // Both ids share a leading `0`, so a one-character prefix is ambiguous.
+        let first: ThreadId = "0aaaaaaa-0000-4000-8000-000000000000"
+            .parse()
+            .expect("valid uuid");
+        let second: ThreadId = "0bbbbbbb-0000-4000-8000-000000000000"
+            .parse()
+            .expect("valid uuid");
+        let entries = [
+            metadata_with_id(first, Utc::now()),
+            metadata_with_id(second, Utc::now()),
+        ];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        let error = select_by_prefix(&candidates, "0")
+            .expect_err("an ambiguous prefix should not resolve")
+            .to_string();
+        assert!(error.contains(&first.to_string()), "{error}");
+        assert!(error.contains(&second.to_string()), "{error}");
+    }
+
+    #[test]
+    fn test_unmatched_prefixes_are_rejected() {
+        let entries = [metadata_with_id(ThreadId::new(), Utc::now())];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        assert!(select_by_prefix(&candidates, "ffffffff").is_err());
+    }
+
+    #[test]
+    fn test_hyphen_only_prefixes_are_rejected() {
+        // Normalization strips hyphens, so `-` must not become a match-all.
+        let entries = [metadata_with_id(ThreadId::new(), Utc::now())];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        assert!(select_by_prefix(&candidates, "-").is_err());
+        assert!(select_by_prefix(&candidates, "").is_err());
+    }
+
+    #[test]
+    fn test_most_recent_selects_the_newest_thread() {
+        let older = ThreadId::new();
+        let newer = ThreadId::new();
+        let now = Utc::now();
+        let entries = [
+            metadata_with_id(older, now - chrono::Duration::hours(2)),
+            metadata_with_id(newer, now),
+        ];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        assert_eq!(
+            select_most_recent(&candidates, &HashSet::default()).expect("should resolve"),
+            newer
+        );
+    }
+
+    #[test]
+    fn test_most_recent_prefers_an_open_thread_when_timestamps_tie() {
+        let closed = ThreadId::new();
+        let open = ThreadId::new();
+        let now = Utc::now();
+        let entries = [metadata_with_id(closed, now), metadata_with_id(open, now)];
+        let candidates: Vec<&ThreadMetadata> = entries.iter().collect();
+
+        let mut open_thread_ids = HashSet::default();
+        open_thread_ids.insert(open);
+
+        assert_eq!(
+            select_most_recent(&candidates, &open_thread_ids).expect("should resolve"),
+            open
+        );
+    }
+
+    #[test]
+    fn test_most_recent_reports_when_no_threads_exist() {
+        assert!(select_most_recent(&[], &HashSet::default()).is_err());
+    }
+
+    #[test]
+    fn test_thread_id_round_trips_through_string() {
+        let thread_id = ThreadId::new();
+        let parsed: ThreadId = thread_id
+            .to_string()
+            .parse()
+            .expect("a rendered thread id should parse back");
+        assert_eq!(thread_id, parsed);
+    }
+
+    #[test]
+    fn test_thread_id_parses_hyphenless_form() {
+        let thread_id = ThreadId::new();
+        let hyphenless = thread_id.to_string().replace('-', "");
+        let parsed: ThreadId = hyphenless
+            .parse()
+            .expect("the hyphenless form should also parse");
+        assert_eq!(thread_id, parsed);
+    }
+
+    #[test]
+    fn test_complete_thread_ids_select_by_exact_id() {
+        let thread_id = ThreadId::new();
+
+        for form in [
+            thread_id.to_string(),
+            thread_id.to_string().replace('-', ""),
+            thread_id.to_string().to_uppercase(),
+        ] {
+            match ThreadSelector::from_thread_argument(&form) {
+                ThreadSelector::Id(parsed) => assert_eq!(parsed, thread_id),
+                _ => panic!("{form} should select by exact id"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_partial_thread_ids_select_by_prefix() {
+        let thread_id = ThreadId::new().to_string();
+        let fragment = &thread_id[..8];
+
+        match ThreadSelector::from_thread_argument(fragment) {
+            ThreadSelector::Prefix(prefix) => assert_eq!(prefix, fragment),
+            _ => panic!("a partial id should select by prefix"),
+        }
+    }
+
+    #[test]
+    fn test_thread_id_fragments_normalize_case_and_hyphens() {
+        assert_eq!(
+            normalize_thread_id_fragment("550E8400-E29B"),
+            normalize_thread_id_fragment("550e8400e29b")
+        );
+    }
+
+    #[test]
+    fn test_empty_thread_id_fragments_normalize_to_empty() {
+        // Guards the check that stops a bare `-` from matching every thread.
+        assert!(normalize_thread_id_fragment("-").is_empty());
+        assert!(normalize_thread_id_fragment("").is_empty());
+    }
+
+    #[test]
+    fn test_threads_match_their_own_worktree_root() {
+        let metadata = metadata_for_paths(&["/home/user/project"]);
+        assert!(thread_matches_path(
+            &metadata,
+            Path::new("/home/user/project")
+        ));
+    }
+
+    #[test]
+    fn test_threads_match_when_invoked_from_a_subdirectory() {
+        // `--agent-project` defaults to the shell's working directory, which is
+        // usually below the worktree root the thread was created against.
+        let metadata = metadata_for_paths(&["/home/user/project"]);
+        assert!(thread_matches_path(
+            &metadata,
+            Path::new("/home/user/project/crates/agent_ui")
+        ));
+    }
+
+    #[test]
+    fn test_threads_match_when_scoped_to_a_parent_directory() {
+        let metadata = metadata_for_paths(&["/home/user/project/crates"]);
+        assert!(thread_matches_path(
+            &metadata,
+            Path::new("/home/user/project")
+        ));
+    }
+
+    #[test]
+    fn test_threads_do_not_match_sibling_projects() {
+        let metadata = metadata_for_paths(&["/home/user/project"]);
+        assert!(!thread_matches_path(
+            &metadata,
+            Path::new("/home/user/other")
+        ));
+    }
+
+    #[test]
+    fn test_threads_do_not_match_partial_path_components() {
+        // `starts_with` compares whole components, so `project-two` must not
+        // match a thread rooted at `project`.
+        let metadata = metadata_for_paths(&["/home/user/project"]);
+        assert!(!thread_matches_path(
+            &metadata,
+            Path::new("/home/user/project-two")
+        ));
+    }
+}

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -57,7 +57,7 @@ use crate::{
     },
     ui::{AgentNotification, AgentNotificationEvent, EndTrialUpsell},
 };
-use agent_settings::AgentSettings;
+use agent_settings::{AgentProfileId, AgentSettings};
 use ai_onboarding::AgentPanelOnboarding;
 use anyhow::{Context as _, Result, anyhow};
 #[cfg(feature = "audio")]
@@ -979,6 +979,9 @@ pub struct CreateThreadOptions {
     /// Model override, as `provider/model-id`. Only applied when the thread
     /// uses the native Zed agent.
     pub model: Option<String>,
+    /// Profile to run the thread under, deciding which tools are available.
+    /// Only applied when the thread uses the native Zed agent.
+    pub profile: Option<AgentProfileId>,
     /// Working directories to attach to the new thread (e.g., the path of a
     /// freshly-created sibling worktree). When `None`, the thread inherits
     /// the project's default path list.
@@ -1898,6 +1901,7 @@ impl AgentPanel {
             Some(metadata.folder_paths().clone()),
             metadata.title.clone(),
             initial_content,
+            None,
             None,
             AgentThreadSource::AgentPanel,
             window,
@@ -3020,6 +3024,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             source,
             window,
             cx,
@@ -3218,6 +3223,7 @@ impl AgentPanel {
             options.title.clone(),
             options.initial_content,
             options.model,
+            options.profile,
             source,
             window,
             cx,
@@ -3483,6 +3489,7 @@ impl AgentPanel {
             work_dirs,
             title,
             initial_content,
+            None,
             None,
             source,
             window,
@@ -4457,6 +4464,7 @@ impl AgentPanel {
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
         model_override: Option<String>,
+        profile_override: Option<AgentProfileId>,
         source: AgentThreadSource,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -4474,6 +4482,7 @@ impl AgentPanel {
             title,
             initial_content,
             model_override,
+            profile_override,
             source,
             window,
             cx,
@@ -4509,6 +4518,7 @@ impl AgentPanel {
             title,
             initial_content,
             None,
+            None,
             source,
             window,
             cx,
@@ -4525,6 +4535,7 @@ impl AgentPanel {
         title: Option<SharedString>,
         initial_content: Option<AgentInitialContent>,
         model_override: Option<String>,
+        profile_override: Option<AgentProfileId>,
         source: AgentThreadSource,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -4587,10 +4598,10 @@ impl AgentPanel {
         // already established by the time the observe fires.
         self.ensure_sibling_host_installed(&conversation_view, window, cx);
 
-        if let Some(model) = model_override {
+        if model_override.is_some() || profile_override.is_some() {
             // The native thread is constructed asynchronously after the
             // connection establishes. Wait for the first `RootThreadUpdated`
-            // event that yields a native thread, then apply the override once.
+            // event that yields a native thread, then apply the overrides once.
             let applied = Cell::new(false);
             cx.subscribe(
                 &conversation_view,
@@ -4601,7 +4612,16 @@ impl AgentPanel {
                     let Some(native_thread) = view.read(cx).as_native_thread(cx) else {
                         return;
                     };
-                    apply_native_model_override(&native_thread, &model, cx);
+                    if let Some(profile_id) = profile_override.clone() {
+                        native_thread.update(cx, |thread, cx| {
+                            thread.set_profile(profile_id, cx);
+                        });
+                    }
+                    // Applied after the profile because switching profiles can
+                    // itself select that profile's preferred model.
+                    if let Some(model) = model_override.as_deref() {
+                        apply_native_model_override(&native_thread, model, cx);
+                    }
                     applied.set(true);
                 },
             )
@@ -4683,7 +4703,7 @@ pub(crate) fn apply_native_model_override(
     });
 }
 
-fn parse_provider_slash_model(input: &str) -> Option<language_model::SelectedModel> {
+pub(crate) fn parse_provider_slash_model(input: &str) -> Option<language_model::SelectedModel> {
     let (provider, model) = input.split_once('/')?;
     if provider.is_empty() || model.is_empty() {
         return None;
@@ -4759,6 +4779,7 @@ impl agent::SiblingThreadHost for AgentPanelSiblingHost {
                 initial_content: Some(initial_content),
                 agent: agent_choice.clone(),
                 model: request.model.clone(),
+                profile: None,
                 work_dirs: None,
             };
 
@@ -5276,6 +5297,7 @@ impl AgentPanel {
                 None,
                 None,
                 Some(initial_content),
+                None,
                 None,
                 AgentThreadSource::AgentPanel,
                 window,
@@ -6582,6 +6604,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             AgentThreadSource::AgentPanel,
             window,
             cx,
@@ -6622,6 +6645,7 @@ impl AgentPanel {
             None,
             None,
             None,
+            None,
             AgentThreadSource::AgentPanel,
             window,
             cx,
@@ -6651,6 +6675,7 @@ impl AgentPanel {
         let thread = self.create_agent_thread_with_server(
             ext_agent,
             Some(server),
+            None,
             None,
             None,
             None,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -1,3 +1,4 @@
+mod agent_cli;
 mod agent_configuration;
 pub mod agent_connection_store;
 mod agent_diff;
@@ -68,6 +69,10 @@ use std::any::TypeId;
 use std::path::{Path, PathBuf};
 use workspace::{OpenOptions, Workspace};
 
+pub use crate::agent_cli::{
+    CliPromptRequest, DispatchOutcome, ThreadListEntry, ThreadSelector, dispatch_cli_prompt,
+    list_threads,
+};
 use crate::agent_configuration::ManageProfilesModal;
 pub use crate::agent_connection_store::{ActiveAcpConnection, AgentConnectionStore};
 pub use crate::agent_panel::{

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -3905,6 +3905,44 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_send_content_preserves_an_unsent_draft(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        let thread_view = active_thread(&conversation_view, cx);
+
+        // Whatever the user has typed but not sent must survive a prompt that
+        // arrives from outside the panel, such as one sent by `zed --agent`.
+        thread_view.update_in(cx, |view, window, cx| {
+            view.message_editor.update(cx, |editor, cx| {
+                editor.set_text("half-written thought", window, cx);
+            });
+        });
+
+        thread_view.update_in(cx, |view, window, cx| {
+            let blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(
+                "prompt from the CLI".to_string(),
+            ))];
+            view.send_content(
+                Task::ready(Ok(Some((blocks, Vec::new())))),
+                false,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        thread_view.read_with(cx, |view, cx| {
+            assert_eq!(
+                view.message_editor.read(cx).text(cx),
+                "half-written thought",
+                "the user's unsent draft should be untouched"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_external_source_prompt_requires_manual_send(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2154,6 +2154,20 @@ impl ThreadView {
         cx.notify();
     }
 
+    /// Resume the message queue after a manual stop. The queue auto-drains on
+    /// [`AcpThreadEvent::Stopped`], but if the user previously hit Stop and put
+    /// the queue into [`ProcessingState::Paused`], no `Stopped` event will fire
+    /// until a new turn starts. Callers that initiate a new turn (such as the
+    /// CLI agent dispatch) must resume the queue first, matching what
+    /// [`send_impl`] does.
+    pub(crate) fn resume_message_queue(&mut self) {
+        self.message_queue.resume();
+    }
+
+    pub(crate) fn is_message_queue_empty(&self) -> bool {
+        self.message_queue.is_empty()
+    }
+
     fn handle_queue_editor_event(
         &mut self,
         id: QueueEntryId,

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -40,7 +40,25 @@ impl ThreadId {
 
     /// Stable, hyphenated string form suitable for use as a key.
     pub fn to_key_string(&self) -> String {
-        self.0.hyphenated().to_string()
+        self.to_string()
+    }
+}
+
+/// Renders the hyphenated form, which is what [`ThreadId::to_key_string`]
+/// persists and what users see in `zed --agent-list`.
+impl std::fmt::Display for ThreadId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0.hyphenated())
+    }
+}
+
+/// Accepts every form `uuid` understands, not just the hyphenated one written
+/// by [`Display`], so a thread id copied from anywhere still parses.
+impl std::str::FromStr for ThreadId {
+    type Err = uuid::Error;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Ok(Self(uuid::Uuid::parse_str(source)?))
     }
 }
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -53,6 +53,38 @@ pub enum CliBehaviorSetting {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub enum AgentAction {
+    /// Send a prompt into a thread, creating one if needed.
+    Prompt {
+        prompt: String,
+        /// A complete `ThreadId`, or a unique leading fragment of one with
+        /// hyphens optional.
+        thread: Option<String>,
+        /// An ACP session id.
+        session: Option<String>,
+        /// Absolute path scoping thread lookup/creation.
+        project: Option<PathBuf>,
+        /// Agent profile for a new thread, which decides the available tools.
+        /// Only honored when `new_thread` is set.
+        profile: Option<String>,
+        /// Model for a new thread, as `provider/model-id`. Only honored when
+        /// `new_thread` is set.
+        model: Option<String>,
+        /// Force creation of a brand-new thread.
+        new_thread: bool,
+        /// Block until the agent turn completes.
+        wait: bool,
+    },
+    /// List known threads.
+    List {
+        project: Option<PathBuf>,
+        /// Emit machine-readable JSON instead of one thread per line.
+        #[serde(default)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub enum CliRequest {
     Open {
         paths: Vec<String>,
@@ -71,6 +103,12 @@ pub enum CliRequest {
     },
     SetOpenBehavior {
         behavior: CliBehaviorSetting,
+    },
+    Agent {
+        action: AgentAction,
+        /// Directory the CLI was invoked from, used to scope thread lookup
+        /// when no explicit project was given.
+        cwd: Option<PathBuf>,
     },
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,7 +13,7 @@ use crate::completions::Shell;
 
 use anyhow::{Context as _, Result};
 use clap::{CommandFactory, Parser};
-use cli::{CliRequest, CliResponse, IpcHandshake, ipc::IpcOneShotServer};
+use cli::{AgentAction, CliRequest, CliResponse, IpcHandshake, ipc::IpcOneShotServer};
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -138,6 +138,40 @@ struct Args {
     /// When directories are provided, recurses into them and shows all changed files in a single multi-diff view.
     #[arg(long, action = clap::ArgAction::Append, num_args = 2, value_names = ["OLD_PATH", "NEW_PATH"], value_hint = clap::ValueHint::AnyPath)]
     diff: Vec<String>,
+    /// Send a prompt to the Zed agent in a running instance
+    #[arg(long)]
+    agent: bool,
+    /// List agent threads instead of sending a prompt
+    #[arg(long)]
+    agent_list: bool,
+    /// Target an existing thread by id, given either in full or as a unique
+    /// leading fragment of one. Hyphens are optional, so `550e8400-e29b` and
+    /// `550e8400e29b` select the same thread. Use `--agent-list` to see ids.
+    #[arg(long, value_name = "ID")]
+    agent_thread: Option<String>,
+    /// Target an existing thread by ACP session id
+    #[arg(long, value_name = "SESSION_ID")]
+    agent_session: Option<String>,
+    /// Scope the thread lookup to a project directory, defaulting to the working directory
+    #[arg(long, value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    agent_project: Option<PathBuf>,
+    /// Always start a new agent thread and print its id
+    #[arg(long)]
+    agent_new: bool,
+    /// Wait for the agent turn to finish before exiting
+    #[arg(long)]
+    agent_wait: bool,
+    /// Agent profile for a new thread, which decides the available tools.
+    /// Requires `--agent-new`
+    #[arg(long, value_name = "PROFILE")]
+    agent_profile: Option<String>,
+    /// Model for a new thread, given as `provider/model-id`. Requires
+    /// `--agent-new`
+    #[arg(long, value_name = "PROVIDER/MODEL")]
+    agent_model: Option<String>,
+    /// Output format for `--agent-list`
+    #[arg(long, value_name = "FORMAT", default_value_t = AgentListFormat::Text)]
+    agent_list_format: AgentListFormat,
     /// Generate shell completions for Zed
     #[arg(long, value_names = ["SHELL"])]
     completions: Option<Shell>,
@@ -153,6 +187,27 @@ struct Args {
     /// by having Zed act like netcat communicating over a Unix socket.
     #[arg(long, hide = true)]
     askpass: Option<String>,
+}
+
+/// Output format for `--agent-list`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[non_exhaustive]
+#[value(rename_all = "lower")]
+enum AgentListFormat {
+    /// One thread per line, for reading in a terminal.
+    Text,
+    /// A JSON array, for scripts that would otherwise parse columns.
+    Json,
+}
+
+impl std::fmt::Display for AgentListFormat {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Text => "text",
+            Self::Json => "json",
+        };
+        formatter.write_str(name)
+    }
 }
 
 /// Parses a path containing a position (e.g. `path:line:column`)
@@ -427,6 +482,366 @@ mod tests {
         .unwrap();
         assert_eq!(result, expected);
     }
+
+    fn make_args() -> Args {
+        Args {
+            wait: false,
+            add: false,
+            new: false,
+            reuse: false,
+            existing: false,
+            classic: false,
+            user_data_dir: None,
+            paths_with_position: vec![],
+            version: false,
+            foreground: false,
+            zed: None,
+            dev_server_token: None,
+            #[cfg(target_os = "windows")]
+            wsl: None,
+            system_specs: false,
+            dev_container: false,
+            diff: vec![],
+            agent: false,
+            agent_list: false,
+            agent_thread: None,
+            agent_session: None,
+            agent_project: None,
+            agent_new: false,
+            agent_wait: false,
+            agent_list_format: AgentListFormat::Text,
+            agent_profile: None,
+            agent_model: None,
+            completions: None,
+            #[cfg(all(
+                any(target_os = "linux", target_os = "macos"),
+                not(feature = "no-bundled-uninstall")
+            ))]
+            uninstall: false,
+            askpass: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_agent_no_flags_is_ok() {
+        let args = make_args();
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_thread_without_agent_is_error() {
+        let args = Args {
+            agent_thread: Some("abc123".to_string()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_session_without_agent_is_error() {
+        let args = Args {
+            agent_session: Some("session-1".to_string()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_new_without_agent_is_error() {
+        let args = Args {
+            agent_new: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_wait_without_agent_is_error() {
+        let args = Args {
+            agent_wait: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_prompt_is_error() {
+        let args = Args {
+            agent_list: true,
+            paths_with_position: vec!["some prompt".to_string()],
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_new_is_error() {
+        let args = Args {
+            agent_list: true,
+            agent_new: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_wait_is_error() {
+        let args = Args {
+            agent_list: true,
+            agent_wait: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_thread_is_error() {
+        let args = Args {
+            agent_list: true,
+            agent_thread: Some("abc".into()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_session_is_error() {
+        let args = Args {
+            agent_list: true,
+            agent_session: Some("sess1".into()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_thread_and_session_together_is_error() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["hello".into()],
+            agent_thread: Some("abc".into()),
+            agent_session: Some("sess1".into()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_new_with_thread_is_error() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["hello".into()],
+            agent_new: true,
+            agent_thread: Some("abc".into()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_new_with_session_is_error() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["hello".into()],
+            agent_new: true,
+            agent_session: Some("sess1".into()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_format_without_agent_list_is_error() {
+        let without_agent_flags = Args {
+            agent_list_format: AgentListFormat::Json,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&without_agent_flags).is_err());
+
+        let with_prompt = Args {
+            agent: true,
+            paths_with_position: vec!["hello".to_string()],
+            agent_list_format: AgentListFormat::Json,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&with_prompt).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_json_format_is_ok() {
+        let args = Args {
+            agent_list: true,
+            agent_list_format: AgentListFormat::Json,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_profile_and_model_without_agent_or_list_are_errors() {
+        for mutate in [
+            (|args: &mut Args| args.agent_profile = Some("write".to_string())) as fn(&mut Args),
+            |args: &mut Args| args.agent_model = Some("anthropic/claude".to_string()),
+        ] {
+            let mut args = make_args();
+            mutate(&mut args);
+            assert!(validate_agent_args(&args).is_err());
+
+            let mut listing = Args {
+                agent_list: true,
+                ..make_args()
+            };
+            mutate(&mut listing);
+            assert!(validate_agent_args(&listing).is_err());
+        }
+    }
+
+    #[test]
+    fn test_validate_agent_with_profile_and_model_requires_new_thread() {
+        let existing_thread = Args {
+            agent: true,
+            paths_with_position: vec!["hello".to_string()],
+            agent_profile: Some("write".to_string()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&existing_thread).is_err());
+
+        let new_thread = Args {
+            agent: true,
+            agent_new: true,
+            paths_with_position: vec!["hello".to_string()],
+            agent_profile: Some("write".to_string()),
+            agent_model: Some("anthropic/claude-sonnet-4".to_string()),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&new_thread).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_project_without_agent_is_error() {
+        let args = Args {
+            agent_project: Some(PathBuf::from("/tmp")),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_with_open_behavior_flags_is_error() {
+        for mutate in [
+            (|args: &mut Args| args.wait = true) as fn(&mut Args),
+            |args: &mut Args| args.add = true,
+            |args: &mut Args| args.new = true,
+            |args: &mut Args| args.reuse = true,
+            |args: &mut Args| args.existing = true,
+            |args: &mut Args| args.classic = true,
+            |args: &mut Args| args.dev_container = true,
+            |args: &mut Args| args.diff = vec!["a".to_string(), "b".to_string()],
+        ] {
+            let mut args = Args {
+                agent: true,
+                paths_with_position: vec!["hello".to_string()],
+                ..make_args()
+            };
+            mutate(&mut args);
+            assert!(validate_agent_args(&args).is_err());
+        }
+    }
+
+    #[test]
+    fn test_validate_agent_allows_foreground() {
+        // `--foreground` is how a development build is driven.
+        let args = Args {
+            agent: true,
+            foreground: true,
+            paths_with_position: vec!["hello".to_string()],
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_and_agent_list_together_is_error() {
+        let args = Args {
+            agent: true,
+            agent_list: true,
+            paths_with_position: vec!["hello".to_string()],
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_whitespace_prompt_is_error() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["   ".to_string()],
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_no_prompt_is_error() {
+        let args = Args {
+            agent: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_validate_agent_with_prompt_is_ok() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["hello".into()],
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_list_alone_is_ok() {
+        let args = Args {
+            agent_list: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_list_with_project_is_ok() {
+        let args = Args {
+            agent_list: true,
+            agent_project: Some(PathBuf::from("/tmp")),
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_with_thread_and_project_is_ok() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["fix this".into()],
+            agent_thread: Some("abc123".into()),
+            agent_project: Some(PathBuf::from("/tmp")),
+            agent_wait: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_new_alone_is_ok() {
+        let args = Args {
+            agent: true,
+            paths_with_position: vec!["fix this".into()],
+            agent_new: true,
+            ..make_args()
+        };
+        assert!(validate_agent_args(&args).is_ok());
+    }
 }
 
 fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
@@ -481,6 +896,148 @@ fn main() {
     }
 }
 
+fn validate_agent_args(args: &Args) -> Result<()> {
+    let is_agent_list = args.agent_list;
+    let is_prompt = args.agent;
+
+    if !is_prompt && !is_agent_list {
+        // The modifier flags are meaningless on their own, and silently
+        // ignoring them would mask a forgotten `--agent`.
+        anyhow::ensure!(
+            args.agent_thread.is_none(),
+            "--agent-thread requires --agent"
+        );
+        anyhow::ensure!(
+            args.agent_session.is_none(),
+            "--agent-session requires --agent"
+        );
+        anyhow::ensure!(!args.agent_new, "--agent-new requires --agent");
+        anyhow::ensure!(!args.agent_wait, "--agent-wait requires --agent");
+        anyhow::ensure!(
+            args.agent_project.is_none(),
+            "--agent-project requires --agent or --agent-list"
+        );
+        anyhow::ensure!(
+            args.agent_list_format == AgentListFormat::Text,
+            "--agent-list-format requires --agent-list"
+        );
+        anyhow::ensure!(
+            args.agent_profile.is_none(),
+            "--agent-profile requires --agent"
+        );
+        anyhow::ensure!(args.agent_model.is_none(), "--agent-model requires --agent");
+        return Ok(());
+    }
+
+    anyhow::ensure!(
+        !(is_prompt && args.agent_list_format != AgentListFormat::Text),
+        "--agent-list-format requires --agent-list"
+    );
+
+    anyhow::ensure!(
+        !(is_prompt && is_agent_list),
+        "--agent and --agent-list cannot be used together"
+    );
+
+    // Flags that steer file opening have no meaning for an agent request, and
+    // silently dropping them would hide a mistyped command. `--foreground` is
+    // deliberately still allowed: it is how a development build is driven.
+    for (is_set, flag) in [
+        (args.wait, "--wait"),
+        (args.add, "--add"),
+        (args.new, "--new"),
+        (args.reuse, "--reuse"),
+        (args.existing, "--existing"),
+        (args.classic, "--classic"),
+        (args.dev_container, "--dev-container"),
+        (!args.diff.is_empty(), "--diff"),
+        (args.askpass.is_some(), "--askpass"),
+    ] {
+        anyhow::ensure!(
+            !is_set,
+            "{flag} cannot be combined with --agent or --agent-list"
+        );
+    }
+
+    anyhow::ensure!(
+        !(is_agent_list && !args.paths_with_position.is_empty()),
+        "--agent-list does not take a prompt"
+    );
+
+    // --agent-list with any prompt-only flags is invalid.
+    if is_agent_list {
+        anyhow::ensure!(
+            !args.agent_new,
+            "--agent-list cannot be combined with --agent-new"
+        );
+        anyhow::ensure!(
+            !args.agent_wait,
+            "--agent-list cannot be combined with --agent-wait"
+        );
+        anyhow::ensure!(
+            args.agent_thread.is_none(),
+            "--agent-list cannot be combined with --agent-thread"
+        );
+        anyhow::ensure!(
+            args.agent_session.is_none(),
+            "--agent-list cannot be combined with --agent-session"
+        );
+        anyhow::ensure!(
+            args.agent_profile.is_none(),
+            "--agent-list cannot be combined with --agent-profile"
+        );
+        anyhow::ensure!(
+            args.agent_model.is_none(),
+            "--agent-list cannot be combined with --agent-model"
+        );
+    }
+
+    // --agent-thread together with --agent-session is invalid.
+    anyhow::ensure!(
+        !(args.agent_thread.is_some() && args.agent_session.is_some()),
+        "--agent-thread and --agent-session cannot be used together"
+    );
+
+    // Profile and model are persisted on the thread and also cascade into the
+    // model selection and any running subagents, so they are only accepted when
+    // creating a thread rather than reconfiguring one the user already owns.
+    if !args.agent_new {
+        anyhow::ensure!(
+            args.agent_profile.is_none(),
+            "--agent-profile requires --agent-new"
+        );
+        anyhow::ensure!(
+            args.agent_model.is_none(),
+            "--agent-model requires --agent-new"
+        );
+    }
+
+    // --agent-new together with --agent-thread or --agent-session is invalid.
+    if args.agent_new {
+        anyhow::ensure!(
+            args.agent_thread.is_none(),
+            "--agent-new cannot be combined with --agent-thread"
+        );
+        anyhow::ensure!(
+            args.agent_session.is_none(),
+            "--agent-new cannot be combined with --agent-session"
+        );
+    }
+
+    // --agent requires a prompt (or stdin). A prompt made only of whitespace
+    // would otherwise reach the agent as an empty message it cannot act on.
+    if is_prompt && !is_agent_list {
+        anyhow::ensure!(
+            args.paths_with_position
+                .iter()
+                .any(|argument| !argument.trim().is_empty()),
+            "no prompt provided: pass a prompt as positional arguments, or pipe one via stdin using '-'"
+        );
+    }
+
+    Ok(())
+}
+
 fn run() -> Result<()> {
     #[cfg(unix)]
     util::prevent_root_execution();
@@ -511,6 +1068,10 @@ fn run() -> Result<()> {
     }
 
     let args = Args::parse();
+
+    // Validate agent arg combinations before doing any IPC work.
+    validate_agent_args(&args)?;
+    let is_agent_mode = args.agent || args.agent_list;
 
     // `zed --askpass` Makes zed operate in nc/netcat mode for use with askpass
     if let Some(socket) = &args.askpass {
@@ -632,69 +1193,138 @@ fn run() -> Result<()> {
     };
 
     let exit_status = Arc::new(Mutex::new(None));
+
+    let mut agent_prompt: Option<String> = None;
+    let mut agent_project: Option<PathBuf> = None;
+
+    if is_agent_mode {
+        if !args.paths_with_position.is_empty() {
+            let prompt_text = args.paths_with_position.join(" ");
+            if prompt_text == "-" {
+                // Read prompt from stdin. Do this synchronously before the
+                // sender thread so we know the full prompt before we handshake.
+                let mut stdin = std::io::stdin().lock();
+                if !io::IsTerminal::is_terminal(&stdin) {
+                    let mut buffer = String::new();
+                    std::io::Read::read_to_string(&mut stdin, &mut buffer)?;
+                    agent_prompt = Some(buffer);
+                } else {
+                    anyhow::bail!(
+                        "stdin is a terminal, but '-' was given as the prompt; pipe input or pass a literal prompt"
+                    );
+                }
+            } else {
+                agent_prompt = Some(prompt_text);
+            }
+        }
+
+        if args.agent {
+            // An all-whitespace prompt would otherwise be dispatched as an
+            // empty content block, which the agent cannot act on.
+            let prompt = agent_prompt
+                .as_deref()
+                .map(str::trim)
+                .filter(|prompt| !prompt.is_empty())
+                .context("no prompt provided: pipe one via stdin, or pass it as arguments")?;
+            agent_prompt = Some(prompt.to_string());
+        }
+
+        if let Some(project_path) = args.agent_project.as_deref() {
+            // Without this the app silently falls back to whichever project
+            // happens to be open, which looks like success but targets the
+            // wrong thread.
+            anyhow::ensure!(
+                project_path.is_dir(),
+                "--agent-project directory does not exist: \"{}\"",
+                project_path.display()
+            );
+        }
+        agent_project = args
+            .agent_project
+            .clone()
+            .or_else(|| env::current_dir().ok());
+        if let Some(ref project_path) = agent_project {
+            if project_path.exists() {
+                agent_project = Some(fs::canonicalize(project_path)?);
+            }
+        }
+    }
+
     let mut paths = vec![];
     let mut urls = vec![];
     let mut diff_paths = vec![];
+    let mut diff_all_mode = false;
     let mut stdin_tmp_file: Option<fs::File> = None;
     let mut anonymous_fd_tmp_files = vec![];
-
-    // Check if any diff paths are directories to determine diff_all mode
-    let diff_all_mode = args
-        .diff
-        .chunks(2)
-        .any(|pair| Path::new(&pair[0]).is_dir() || Path::new(&pair[1]).is_dir());
-
-    for path in args.diff.chunks(2) {
-        let left = parse_path_with_position(&path[0])?;
-        let right = parse_path_with_position(&path[1])?;
-        for diff_path in [&left, &right] {
-            anyhow::ensure!(
-                diff_path_exists(diff_path),
-                "--diff path does not exist: {diff_path}"
-            );
+    let wsl_for_ipc: Option<String> = {
+        #[cfg(target_os = "windows")]
+        {
+            if !is_agent_mode {
+                args.wsl.clone()
+            } else {
+                None
+            }
         }
-        diff_paths.push([left, right]);
-    }
-
-    let (expanded_diff_paths, temp_dirs) = expand_directory_diff_pairs(diff_paths)?;
-    diff_paths = expanded_diff_paths;
-    // Prevent automatic cleanup of temp directories containing empty stub files
-    // for directory diffs. The CLI process may exit before Zed has read these
-    // files (e.g., when RPC-ing into an already-running instance). The files
-    // live in the OS temp directory and will be cleaned up on reboot.
-    for temp_dir in temp_dirs {
-        let _ = temp_dir.keep();
-    }
-
-    #[cfg(target_os = "windows")]
-    let wsl = args.wsl.as_ref();
-    #[cfg(not(target_os = "windows"))]
-    let wsl = None;
-
-    for path in args.paths_with_position.iter() {
-        if URL_PREFIX.iter().any(|&prefix| path.starts_with(prefix)) {
-            urls.push(path.to_string());
-        } else if path == "-" && args.paths_with_position.len() == 1 {
-            let file = NamedTempFile::new()?;
-            paths.push(file.path().to_string_lossy().into_owned());
-            let (file, _) = file.keep()?;
-            stdin_tmp_file = Some(file);
-        } else if let Some(file) = anonymous_fd(path) {
-            let tmp_file = NamedTempFile::new()?;
-            paths.push(tmp_file.path().to_string_lossy().into_owned());
-            let (tmp_file, _) = tmp_file.keep()?;
-            anonymous_fd_tmp_files.push((file, tmp_file));
-        } else if let Some(wsl) = wsl {
-            urls.push(format!("file://{}", parse_path_in_wsl(path, wsl)?));
-        } else {
-            paths.push(parse_path_with_position(path)?);
+        #[cfg(not(target_os = "windows"))]
+        {
+            None
         }
-    }
+    };
 
-    anyhow::ensure!(
-        args.dev_server_token.is_none(),
-        "Dev servers were removed in v0.157.x please upgrade to SSH remoting: https://zed.dev/docs/remote-development"
-    );
+    if !is_agent_mode {
+        diff_all_mode = args
+            .diff
+            .chunks(2)
+            .any(|pair| Path::new(&pair[0]).is_dir() || Path::new(&pair[1]).is_dir());
+
+        for path in args.diff.chunks(2) {
+            let left = parse_path_with_position(&path[0])?;
+            let right = parse_path_with_position(&path[1])?;
+            for diff_path in [&left, &right] {
+                anyhow::ensure!(
+                    diff_path_exists(diff_path),
+                    "--diff path does not exist: {diff_path}"
+                );
+            }
+            diff_paths.push([left, right]);
+        }
+
+        let (expanded_diff_paths, temp_dirs) = expand_directory_diff_pairs(diff_paths)?;
+        diff_paths = expanded_diff_paths;
+        for temp_dir in temp_dirs {
+            let _ = temp_dir.keep();
+        }
+
+        #[cfg(target_os = "windows")]
+        let wsl = args.wsl.as_ref();
+        #[cfg(not(target_os = "windows"))]
+        let wsl: Option<&String> = None;
+
+        for path in args.paths_with_position.iter() {
+            if URL_PREFIX.iter().any(|&prefix| path.starts_with(prefix)) {
+                urls.push(path.to_string());
+            } else if path == "-" && args.paths_with_position.len() == 1 {
+                let file = NamedTempFile::new()?;
+                paths.push(file.path().to_string_lossy().into_owned());
+                let (file, _) = file.keep()?;
+                stdin_tmp_file = Some(file);
+            } else if let Some(file) = anonymous_fd(path) {
+                let tmp_file = NamedTempFile::new()?;
+                paths.push(tmp_file.path().to_string_lossy().into_owned());
+                let (tmp_file, _) = tmp_file.keep()?;
+                anonymous_fd_tmp_files.push((file, tmp_file));
+            } else if let Some(wsl) = wsl {
+                urls.push(format!("file://{}", parse_path_in_wsl(path, wsl)?));
+            } else {
+                paths.push(parse_path_with_position(path)?);
+            }
+        }
+
+        anyhow::ensure!(
+            args.dev_server_token.is_none(),
+            "Dev servers were removed in v0.157.x please upgrade to SSH remoting: https://zed.dev/docs/remote-development"
+        );
+    }
 
     rayon::ThreadPoolBuilder::new()
         .num_threads(4)
@@ -703,35 +1333,53 @@ fn run() -> Result<()> {
         .build_global()
         .unwrap();
 
+    let ipc_request = if is_agent_mode {
+        let action = if args.agent_list {
+            AgentAction::List {
+                project: agent_project,
+                json: args.agent_list_format == AgentListFormat::Json,
+            }
+        } else {
+            AgentAction::Prompt {
+                prompt: agent_prompt.unwrap_or_default(),
+                thread: args.agent_thread.clone(),
+                session: args.agent_session.clone(),
+                project: agent_project,
+                profile: args.agent_profile.clone(),
+                model: args.agent_model.clone(),
+                new_thread: args.agent_new,
+                wait: args.agent_wait,
+            }
+        };
+        CliRequest::Agent {
+            action,
+            cwd: env::current_dir().ok(),
+        }
+    } else {
+        CliRequest::Open {
+            paths,
+            urls,
+            diff_paths,
+            diff_all: diff_all_mode,
+            wsl: wsl_for_ipc,
+            wait: args.wait,
+            open_behavior,
+            env,
+            user_data_dir: user_data_dir.clone(),
+            dev_container: args.dev_container,
+            cwd: env::current_dir().ok(),
+        }
+    };
+
     let sender: JoinHandle<anyhow::Result<()>> = thread::Builder::new()
         .name("CliReceiver".to_string())
         .spawn({
             let exit_status = exit_status.clone();
-            let user_data_dir_for_thread = user_data_dir.clone();
             move || {
                 let (_, handshake) = server.accept().context("Handshake after Zed spawn")?;
                 let (tx, rx) = (handshake.requests, handshake.responses);
 
-                #[cfg(target_os = "windows")]
-                let wsl = args.wsl;
-                #[cfg(not(target_os = "windows"))]
-                let wsl = None;
-
-                let open_request = CliRequest::Open {
-                    paths,
-                    urls,
-                    diff_paths,
-                    diff_all: diff_all_mode,
-                    wsl,
-                    wait: args.wait,
-                    open_behavior,
-                    env,
-                    user_data_dir: user_data_dir_for_thread,
-                    dev_container: args.dev_container,
-                    cwd: env::current_dir().ok(),
-                };
-
-                tx.send(open_request)?;
+                tx.send(ipc_request)?;
 
                 while let Ok(response) = rx.recv() {
                     match response {
@@ -743,11 +1391,26 @@ fn run() -> Result<()> {
                             return Ok(());
                         }
                         CliResponse::PromptOpenBehavior => {
-                            let behavior = prompt_open_behavior()
-                                .unwrap_or(cli::CliBehaviorSetting::ExistingWindow);
-                            tx.send(CliRequest::SetOpenBehavior { behavior })?;
+                            // Should not occur in agent mode, but handle gracefully.
+                            if is_agent_mode {
+                                eprintln!(
+                                    "protocol error: received PromptOpenBehavior in agent mode"
+                                );
+                            } else {
+                                let behavior = prompt_open_behavior()
+                                    .unwrap_or(cli::CliBehaviorSetting::ExistingWindow);
+                                tx.send(CliRequest::SetOpenBehavior { behavior })?;
+                            }
                         }
                     }
+                }
+
+                // The channel closed without an `Exit`, which means Zed went
+                // away mid-request. Reporting success here would let a webhook
+                // treat a dropped request as a delivered one.
+                if is_agent_mode && exit_status.lock().is_none() {
+                    eprintln!("error: Zed closed the connection without responding");
+                    exit_status.lock().replace(1);
                 }
 
                 Ok(())

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -2,6 +2,7 @@ use crate::handle_open_request;
 use crate::restore_or_create_workspace;
 use agent_ui::ExternalSourcePrompt;
 use anyhow::{Context as _, Result, anyhow};
+use chrono::{DateTime, Utc};
 use cli::{CliRequest, CliResponse, CliResponseSink};
 use cli::{IpcHandshake, ipc};
 use client::{ZedLink, parse_zed_link};
@@ -676,6 +677,133 @@ pub async fn handle_cli_connection(
                 // resolve_open_behavior
                 debug_panic!("unexpected SetOpenBehavior message");
             }
+            CliRequest::Agent { action, cwd } => {
+                match action {
+                    cli::AgentAction::List { project, json } => {
+                        // Scope to the invoking shell's directory when no
+                        // project was given, so `zed --agent-list` inside a
+                        // project lists that project's threads.
+                        let project = project.or(cwd);
+                        let entries =
+                            cx.update(|cx| agent_ui::list_threads(project.as_deref(), cx));
+
+                        let mut status = 0;
+                        if json {
+                            // Always emit an array, so callers can pipe straight
+                            // into `jq` without special-casing "no threads".
+                            match serde_json::to_string_pretty(&thread_list_json(&entries)) {
+                                Ok(message) => {
+                                    responses.send(CliResponse::Stdout { message }).log_err();
+                                }
+                                Err(error) => {
+                                    responses
+                                        .send(CliResponse::Stderr {
+                                            message: format!(
+                                                "could not serialize threads: {error}"
+                                            ),
+                                        })
+                                        .log_err();
+                                    status = 1;
+                                }
+                            }
+                        } else if entries.is_empty() {
+                            responses
+                                .send(CliResponse::Stdout {
+                                    message: "no agent threads found".into(),
+                                })
+                                .log_err();
+                        } else {
+                            let now = Utc::now();
+                            let lines = entries
+                                .iter()
+                                .map(|entry| {
+                                    let age = format_compact_relative_age(now, entry.updated_at);
+                                    let marker = if entry.is_open { "  (open)" } else { "" };
+                                    let title = truncate_title(&entry.title, 60);
+                                    format!("{}  {}  {}{}", entry.thread_id, age, title, marker)
+                                })
+                                .collect::<Vec<_>>();
+                            responses
+                                .send(CliResponse::Stdout {
+                                    message: lines.join("\n"),
+                                })
+                                .log_err();
+                        }
+                        responses.send(CliResponse::Exit { status }).log_err();
+                    }
+                    cli::AgentAction::Prompt {
+                        prompt,
+                        thread,
+                        session,
+                        project,
+                        profile,
+                        model,
+                        new_thread,
+                        wait,
+                    } => {
+                        let selector = if new_thread {
+                            agent_ui::ThreadSelector::New
+                        } else if let Some(session) = session {
+                            agent_ui::ThreadSelector::Session(session)
+                        } else if let Some(thread) = thread {
+                            agent_ui::ThreadSelector::from_thread_argument(&thread)
+                        } else {
+                            agent_ui::ThreadSelector::MostRecent
+                        };
+
+                        // Deliberately do NOT call cx.activate(true) —
+                        // a webhook/automation-triggered agent turn should not
+                        // steal window focus from the user.
+
+                        let request = agent_ui::CliPromptRequest {
+                            selector,
+                            prompt,
+                            project: project.or(cwd),
+                            profile,
+                            model,
+                            wait,
+                        };
+
+                        match agent_ui::dispatch_cli_prompt(request, app_state.clone(), cx).await {
+                            Ok(outcome) => {
+                                match outcome {
+                                    agent_ui::DispatchOutcome::Sent { thread_id } => {
+                                        responses
+                                            .send(CliResponse::Stdout {
+                                                message: thread_id.to_string(),
+                                            })
+                                            .log_err();
+                                    }
+                                    agent_ui::DispatchOutcome::Queued { thread_id } => {
+                                        // Keep stdout to the bare id so callers
+                                        // can capture it either way.
+                                        responses
+                                            .send(CliResponse::Stderr {
+                                                message: "agent is busy; message queued"
+                                                    .to_string(),
+                                            })
+                                            .log_err();
+                                        responses
+                                            .send(CliResponse::Stdout {
+                                                message: thread_id.to_string(),
+                                            })
+                                            .log_err();
+                                    }
+                                }
+                                responses.send(CliResponse::Exit { status: 0 }).log_err();
+                            }
+                            Err(error) => {
+                                responses
+                                    .send(CliResponse::Stderr {
+                                        message: format!("{error:#}"),
+                                    })
+                                    .log_err();
+                                responses.send(CliResponse::Exit { status: 1 }).log_err();
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -1121,6 +1249,105 @@ pub async fn derive_paths_with_position(
         result.push(parsed);
     }
     result
+}
+
+/// Formats a relative age in compact style: "just now", "2m ago", "3h ago", "1d ago", etc.
+///
+/// `time_format` spells these out ("2 minutes ago"), which would push the title
+/// column of `--agent-list` around as ages change; the listing is meant to stay
+/// readable in a terminal and greppable in a script.
+fn format_compact_relative_age(now: DateTime<Utc>, timestamp: DateTime<Utc>) -> String {
+    let delta = now - timestamp;
+    let minutes = delta.num_minutes();
+    if minutes < 1 {
+        "just now".into()
+    } else if minutes == 1 {
+        "1m ago".into()
+    } else if minutes < 60 {
+        format!("{}m ago", minutes)
+    } else {
+        let hours = delta.num_hours();
+        if hours == 1 {
+            "1h ago".into()
+        } else if hours < 24 {
+            format!("{}h ago", hours)
+        } else {
+            let days = delta.num_days();
+            if days == 1 {
+                "1d ago".into()
+            } else if days < 7 {
+                format!("{}d ago", days)
+            } else {
+                let weeks = delta.num_weeks();
+                if weeks == 1 {
+                    "1w ago".into()
+                } else if weeks < 5 {
+                    format!("{}w ago", weeks)
+                } else {
+                    let months = days / 30;
+                    if months == 1 {
+                        "1mo ago".into()
+                    } else if months < 12 {
+                        format!("{}mo ago", months)
+                    } else {
+                        let years = days / 365;
+                        if years == 1 {
+                            "1y ago".into()
+                        } else {
+                            format!("{}y ago", years)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Shapes threads for `--agent-list --agent-list-format json`.
+///
+/// Timestamps are RFC 3339 and paths are absolute, so a caller can match a
+/// thread to a git worktree without re-deriving either.
+fn thread_list_json(entries: &[agent_ui::ThreadListEntry]) -> serde_json::Value {
+    serde_json::Value::Array(
+        entries
+            .iter()
+            .map(|entry| {
+                serde_json::json!({
+                    "id": entry.thread_id.to_string(),
+                    "title": entry.title,
+                    "updated_at": entry.updated_at.to_rfc3339(),
+                    "interacted_at": entry.interacted_at.map(|at| at.to_rfc3339()),
+                    "is_open": entry.is_open,
+                    "paths": entry.paths,
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Collapse a title onto a single line and truncate it to `max_len`
+/// characters, appending "…" if truncated.
+///
+/// Titles are agent-generated and may contain newlines, which would otherwise
+/// split one thread across several lines of the line-oriented listing.
+fn truncate_title(title: &str, max_len: usize) -> String {
+    let title: String = title
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    let title = title.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if title.chars().count() <= max_len {
+        return title;
+    }
+    let truncated: String = title.chars().take(max_len.saturating_sub(1)).collect();
+    format!("{truncated}…")
 }
 
 #[cfg(test)]
@@ -3018,5 +3245,65 @@ mod tests {
         );
         // File opened in existing window
         assert_eq!(cx.windows().len(), 1);
+    }
+
+    #[test]
+    fn test_agent_list_json_exposes_worktree_paths_and_timestamps() {
+        let updated_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+        let entries = vec![agent_ui::ThreadListEntry {
+            thread_id: "0f53a524-44b8-4121-a653-c62ef9584c17"
+                .parse()
+                .expect("valid thread id"),
+            title: "Worktree thread".to_string(),
+            updated_at,
+            interacted_at: None,
+            is_open: true,
+            paths: vec![PathBuf::from(path!("/repo-featx"))],
+        }];
+
+        let json = thread_list_json(&entries);
+        let entry = &json.as_array().expect("an array")[0];
+
+        assert_eq!(entry["id"], "0f53a524-44b8-4121-a653-c62ef9584c17");
+        assert_eq!(entry["title"], "Worktree thread");
+        assert_eq!(entry["updated_at"], "2026-01-02T03:04:05+00:00");
+        assert_eq!(entry["interacted_at"], serde_json::Value::Null);
+        assert_eq!(entry["is_open"], true);
+        assert_eq!(entry["paths"][0], path!("/repo-featx"));
+    }
+
+    #[test]
+    fn test_agent_list_json_is_an_array_when_no_threads_match() {
+        // Scripts pipe this straight into `jq`, so the shape must not change
+        // when there is nothing to report.
+        assert_eq!(thread_list_json(&[]), serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_agent_list_titles_stay_on_one_line() {
+        // `--agent-list` output is parsed line by line, so a title containing
+        // newlines must not split one thread across several lines.
+        let title = truncate_title("first line\nsecond line\r\nthird", 60);
+        assert_eq!(title, "first line second line third");
+        assert!(!title.contains('\n'));
+    }
+
+    #[test]
+    fn test_agent_list_titles_are_truncated_with_an_ellipsis() {
+        let title = truncate_title("abcdefghij", 5);
+        assert_eq!(title, "abcd…");
+    }
+
+    #[test]
+    fn test_agent_list_titles_shorter_than_the_limit_are_unchanged() {
+        assert_eq!(truncate_title("short title", 60), "short title");
+    }
+
+    #[test]
+    fn test_agent_list_titles_handle_multibyte_characters() {
+        // Truncation counts characters, so slicing must not land mid-codepoint.
+        assert_eq!(truncate_title("日本語の依頼です", 4), "日本語…");
     }
 }

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -206,6 +206,163 @@ Specify a custom path to the Zed application or binary:
 zed --zed /path/to/Zed.app myfile.txt
 ```
 
+## Sending Prompts to the Agent
+
+The CLI can start an agent turn in a running Zed instance, which is useful for driving the agent from scripts, git hooks, or webhooks.
+
+Send a prompt to the most recently updated thread for the current project:
+
+```sh
+zed --agent "Summarize the changes on this branch"
+```
+
+The Agent Panel does not need to be focused, and the prompt is never written into an editor you are typing in. If the agent is already generating, the prompt is added to that thread's message queue and sent when the current turn finishes, exactly as if you had typed it while the agent was working.
+
+### `--agent`
+
+Send a prompt. The prompt is taken from the remaining arguments, or from stdin when the prompt is `-`:
+
+```sh
+zed --agent "Fix the failing test in parser.rs"
+curl -s https://example.com/task | zed --agent -
+```
+
+On success the target thread's id is printed to stdout, so scripts can capture it and keep talking to the same thread:
+
+```sh
+thread=$(zed --agent --agent-new "Start reviewing this PR")
+zed --agent --agent-thread "$thread" "Now check the tests"
+```
+
+### `--agent-list`
+
+List known threads, most recently updated first. Threads currently open in a window are marked `(open)`:
+
+```sh
+zed --agent-list
+```
+
+```text
+567079b5-f231-4837-8283-23581f508113  just now  Fix failing parser test  (open)
+8bb41db0-b3cd-4f45-b2eb-4dc49cc57602  2h ago  Add CLI reference docs
+```
+
+### `--agent-list-format <FORMAT>`
+
+Either `text` (the default, shown above) or `json`. JSON emits an array — including when nothing matches — so scripts can pipe it straight into `jq` without parsing columns:
+
+```sh
+zed --agent-list --agent-list-format json
+```
+
+```json
+[
+  {
+    "id": "567079b5-f231-4837-8283-23581f508113",
+    "title": "Fix failing parser test",
+    "updated_at": "2026-01-02T03:04:05+00:00",
+    "interacted_at": "2026-01-02T03:03:11+00:00",
+    "is_open": true,
+    "paths": ["/Users/me/projects/myproject"]
+  }
+]
+```
+
+`updated_at` moves whenever the thread changes, including while the agent is working. `interacted_at` moves when you send, queue, retry, or regenerate a message in the Agent Panel, so it tells you when a person last engaged with the thread; prompts delivered by the CLI deliberately leave it alone. `paths` are the thread's worktree folders, which is what lets you match a thread to a specific git worktree:
+
+```sh
+# The most recently updated thread for the worktree checked out at $worktree
+zed --agent-list --agent-list-format json --agent-project "$worktree" \
+  | jq -r '.[0].id'
+```
+
+### `--agent-thread <ID>`
+
+Target a specific thread. The id may be given in full or as a unique leading fragment, and hyphens are optional, so `567079b5-f231` and `567079b5f231` select the same thread:
+
+```sh
+zed --agent --agent-thread 567079b5 "Add a test for that"
+```
+
+If the fragment matches more than one thread, Zed reports the candidates instead of guessing.
+
+### `--agent-new`
+
+Always start a new thread rather than continuing an existing one:
+
+```sh
+zed --agent --agent-new "Investigate the flaky CI job"
+```
+
+### `--agent-project <DIR>`
+
+Scope thread lookup and creation to a project. Defaults to the working directory, so running the CLI anywhere inside a project targets that project's threads:
+
+```sh
+zed --agent --agent-project ~/projects/myproject "What changed today?"
+```
+
+### `--agent-profile <PROFILE>`
+
+Create the thread under a specific [agent profile](../ai/agent-profiles.md), which decides the tools the agent may use. This matters for unattended runs, where a narrower profile limits what a prompt can do:
+
+```sh
+zed --agent --agent-new --agent-profile ask "Summarize what changed on this branch"
+```
+
+An unknown profile is an error listing the configured ones, rather than a silent fallback to the default.
+
+### `--agent-model <PROVIDER/MODEL>`
+
+Create the thread with a specific model:
+
+```sh
+zed --agent --agent-new --agent-model anthropic/claude-sonnet-4-5 "Review this diff"
+```
+
+An unconfigured model is an error.
+
+Both flags require `--agent-new`. A thread stores its profile and model, and changing the profile also switches the model and applies to any subagents it is running. They configure a thread you are creating rather than silently reconfiguring one you already have open. To run a prompt under a different profile, start a new thread for it.
+
+### `--agent-wait`
+
+Block until the agent finishes its turn:
+
+```sh
+zed --agent --agent-wait "Run the test suite and fix what breaks"
+```
+
+There is deliberately no timeout. If the agent asks for permission to run a tool, it waits for you to answer in the Agent Panel, the same as a prompt you typed yourself. See [Agent Settings](../ai/agent-settings.md) for how to configure tool permissions.
+
+### `--agent-session <SESSION_ID>`
+
+Target a thread by its Agent Client Protocol session id. This is mainly useful for tooling that already tracks ACP sessions:
+
+```sh
+zed --agent --agent-session 8bb41db0-b3cd-4f45-b2eb-4dc49cc57602 "Continue this review"
+```
+
+### Targeting a Git Worktree
+
+Because threads remember the worktree folders they belong to, a hook that knows a branch can find the right thread by resolving the branch to its worktree first:
+
+```sh
+worktree=$(git -C "$repo" worktree list --porcelain \
+  | awk -v branch="refs/heads/$branch" '/^worktree /{path=$2} $0=="branch "branch{print path}')
+
+zed --agent --agent-project "$worktree" "CI failed on $branch: $details"
+```
+
+Pass `--agent-project` explicitly rather than relying on the working directory. A thread created in a linked worktree also records the main checkout, so a lookup made from the main checkout can match threads belonging to any of its linked worktrees, while a lookup made from the linked worktree matches only its own.
+
+The worktree must already be open in Zed. If it isn't, the CLI reports that rather than falling back to another project, so a hook can open it first:
+
+```sh
+git -C "$repo" worktree add "$worktree" "$branch"
+zed "$worktree"
+zed --agent --agent-project "$worktree" --agent-new "Investigate the CI failure on $branch"
+```
+
 ## Reading from Standard Input
 
 Read content from stdin by passing `-` as the path:


### PR DESCRIPTION
# Objective

Zed's agent is driven from inside the app. Making it reachable from the command
line opens up a category of "kick off the agent when X happens" workflows —
scripts, git hooks, CI, webhooks.

There's an existing `zed://agent?prompt=…` URL, but it's built for a different
purpose: `zed://` is an OS-registered scheme (`osx_url_schemes = ["zed"]`,
`x-scheme-handler/zed`), so any web page can navigate to it. It pre-fills the
message editor and shows a "Review Before Sending" callout, deliberately leaving
the final keystroke to a human. That's the right behavior for an untrusted
caller.

Requested in #58262, which asks for exactly these two capabilities — enumerating
threads and sending a user message to an existing one — for automation and
orchestration workflows. Adjacent asks: #54221 (scheduled prompts, which needs a
way to deliver a prompt later) and #49313 (controlling agent runs remotely).
Distinct from #59146, which proposes running the agent as a standalone headless
binary; this drives the agent already running in your editor.

## Solution

Add a `--agent` flag group to the `zed` CLI. It travels over the existing
`zed-cli://` IPC channel, which is not OS-registered and is only reachable from a
local process, so it can submit directly. The `zed://agent` path is not touched
by this change.

```sh
zed --agent "Summarize the changes on this branch"
zed --agent --agent-new "Investigate the flaky CI job"   # prints the new thread id
zed --agent --agent-thread 567079b5 "Now check the tests"
zed --agent --agent-wait "Run the tests and fix what breaks"
zed --agent-list
curl -s https://example.com/task | zed --agent -
```

**Highlights**

- New `agent_ui::agent_cli` module resolves a thread and dispatches a prompt into
  it. Threads are addressed by `ThreadId` (in full or as a unique fragment, with
  hyphens optional), by ACP session id, or implicitly as the most recently
  updated thread for the working directory.
- Prompts take the same route as pressing Enter in the panel:
  `ThreadView::send_content` when the thread is idle, `ThreadView::add_to_queue`
  when it's generating. A queued message shows up as a real queue entry that you
  can steer or delete, and it drains on `AcpThreadEvent::Stopped`.
- Resolution checks in-memory threads first. `AgentPanel` is per-`Workspace`
  rather than per-window, so this iterates `MultiWorkspace::workspaces()` instead
  of `MultiWorkspace::panel()`, which only sees the active workspace. A thread
  that's open in a background project is reachable without stealing focus or
  reloading it from disk.
- `--agent-list` prints `id  age  title  (open)`, and
  `--agent-list-format json` emits an array with `id`, `title`, `updated_at`,
  `interacted_at`, `is_open`, and the thread's worktree `paths`. The array shape
  holds even when nothing matches, so it pipes straight into `jq`. The prompt
  paths keep stdout to the bare thread id so `id=$(zed --agent …)` works.
- New `CliRequest::Agent` variant, appended after `SetOpenBehavior` so the
  existing `Open` and `SetOpenBehavior` variants keep their wire representation.
- `ThreadId` gains `Display`/`FromStr`. Prompts run through the existing
  `ExternalSourcePrompt` sanitizer, which strips bidi and control characters —
  worth keeping for a path that's often fed webhook payloads.
- `--agent-profile` and `--agent-model` configure a thread at creation and
  require `--agent-new`. A thread persists both, and changing the profile also
  swaps the model and cascades into any running subagents, so applying them to an
  existing thread would silently reconfigure something the user already owns.
  Both are validated before anything is dispatched — an unknown profile lists the
  configured ones, an unconfigured model is an error — so a typo can't leave a
  thread running under the wrong tool set.
- Tool permissions are untouched: a CLI-triggered turn still asks before running
  tools, and `--agent-wait` blocks until you answer, matching what happens when
  you send the same prompt by hand.
- `docs/src/reference/cli.md` documents the new flags alongside the existing
  ones.

## Testing

Verified manually against a debug bundle (`script/bundle-mac -d -i`), driving a
running instance over the real IPC path:

- `--agent-new` creates a thread and prints its id; `--agent-list` then shows it
  marked `(open)`.
- `--agent-thread` resolves a full id, an 8-character prefix, and a hyphenless
  fragment to the same thread.
- Sending while the agent was generating printed `agent is busy; message queued`
  on stderr with the bare id on stdout, and the message appeared in the panel as
  a queue entry.
- With two projects open in one window, each directory's `--agent-list` showed
  only its own threads. `--agent-project` reached across to the other project,
  and a mismatched scope failed with exit code 1.
- Running from a subdirectory of a project still resolves that project's threads.
- In a repo with a linked git worktree, `--agent-list --agent-list-format json`
  reported the linked worktree's path, and resolving a branch to its worktree
  then piping the id into `--agent-thread` delivered a message to the right
  thread. `--agent-list-format` is rejected outside `--agent-list`, and an
  unmatched project still yields `[]`.
- `echo … | zed --agent -` reads the prompt from stdin.
- `--agent-wait` blocked for the duration of the turn, then exited 0.
- `--agent-profile` and `--agent-model` are rejected without `--agent-new`, and
  with it a bad profile reports `unknown agent profile "nope"; available
  profiles: ask, coding-agent, ..., write` while `--agent-model bogus/model` and
  `--agent-model notaslash` each fail with their own message. A valid profile
  creates the thread, and sending to an existing thread still works.
- Argument validation rejects `--agent-project` without `--agent`, `--agent`
  together with `--agent-list`, and file-opening flags (`--diff`, `--wait`,
  `--new`, …) in agent mode.

A user's unsent draft is left alone: the CLI calls `send_content`, which unlike
`send_impl` never touches the message editor. There's a test pinning this, and I
confirmed it fails if the editor is cleared.

Automated coverage: 21 unit tests in `agent_cli` (id parsing and normalization,
prefix ambiguity, most-recent tie-breaking, path matching, prompt sanitization),
28 in `cli` (argument validation), and 4 in `open_listener` (list formatting).
The dispatch functions themselves are covered by the manual runs above rather
than by tests. `./script/clippy` and `cargo fmt --check` are clean.

Reviewers can try this on macOS with `script/bundle-mac -d -i`, then use the CLI
inside the bundle at `/Applications/Zed Dev.app/Contents/MacOS/cli` so requests
attach to the running instance.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added `zed --agent` for starting an agent turn from the command line




