### PR TITLE
gpui: Fix centered window bounds to display settings header

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -743,7 +743,10 @@ impl Bounds<Pixels> {
             .or_else(|| cx.primary_display());
 
         display
-            .map(|display| Bounds::centered_at(display.bounds().center(), size))
+            .map(|display| {
+                let visible_bounds = display.visible_bounds();
+                Bounds::centered_at(visible_bounds.center(), size.min(&visible_bounds.size))
+            })
             .unwrap_or_else(|| Bounds {
                 origin: point(px(0.), px(0.)),
                 size,


### PR DESCRIPTION
# Objective

- Fixes https://github.com/zed-industries/zed/issues/61914 
- The setting window gets cut off from the top of the screen when using a high DP on Windows (e.g. 250% 2560×1600). This is because `Bounds::centered` computes a wide rectangle with `origin = display.center() - size / 2` which can cause issues on higher DPI. 
## Solution

`Bounds::centered` now centers within the display's work area. 
```rust
let visible_bounds = display.visible_bounds();
Bounds::centered_at(visible_bounds.center(), size.min(&visible_bounds.size))
```
Added visible_bounds() and size.min(&visible_bounds.size). Size::min will clamp each axis, windows that already fit are unaffected

## Testing

- Reproduced the bug locally and on production that the settings header does not get clipped anymore; the video showcase shows this.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/5cafd03c-7835-488c-a70b-ba559e4cfff3

0:00 - 0:11. Current behaviour in production, settings header gets clipped at 225% 
0:11 - 0:20. My fix, header does not get clipped


Release Notes:

- Fixed the Settings window opening with its header off-screen at high DPI scaling on Windows
- [GPUI] N/A