### PR TITLE
terminal: Respect word boundaries after tree branches

### DIFF
--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -17,7 +17,7 @@ use alacritty_terminal::{
     },
     sync::FairMutex,
     term::{
-        Config, Osc52, RenderableCursor, Term, TermMode,
+        Config, Osc52, RenderableCursor, SEMANTIC_ESCAPE_CHARS, Term, TermMode,
         cell::{Cell as AlacCell, Flags, Hyperlink as AlacHyperlink},
         search::{Match, RegexIter, RegexSearch},
     },
@@ -123,6 +123,7 @@ pub(super) fn display_only_term_config(
     Config {
         scrolling_history,
         default_cursor_style: alacritty_cursor_style(cursor_shape),
+        semantic_escape_chars: format!("{SEMANTIC_ESCAPE_CHARS}─"),
         osc52: Osc52::Disabled,
         ..Config::default()
     }
@@ -135,6 +136,7 @@ pub(super) fn pty_term_config(
     Config {
         scrolling_history,
         default_cursor_style: alacritty_cursor_style(cursor_shape),
+        semantic_escape_chars: format!("{SEMANTIC_ESCAPE_CHARS}─"),
         ..Config::default()
     }
 }
@@ -1100,5 +1102,24 @@ mod tests {
                 is_block: true,
             }
         );
+    }
+
+    #[test]
+    fn semantic_selection_stops_at_tree_branch() {
+        let config = pty_term_config(1000, SettingsCursorShape::default());
+        let (events_tx, _events_rx) = futures::channel::mpsc::unbounded();
+        let mut term = Term::new(config, &TerminalBounds::default(), ZedListener(events_tx));
+        for character in "└─zms-demo.target".chars() {
+            term.input(character);
+        }
+
+        let selection = Selection::new(
+            SelectionType::Semantic,
+            Point::new(0, 2),
+            SelectionSide::Left,
+        );
+        set_selection(&mut term, Some(&selection));
+
+        assert_eq!(selection_text(&term).as_deref(), Some("zms-demo.target"));
     }
 }


### PR DESCRIPTION
# Objective

Fixes #61767.

Double-clicking a service name after a `systemctl` tree branch also selects the `└─` prefix.

## Solution

Add `─` to Alacritty's semantic escape characters for both PTY and display-only terminals. The regression test checks that selecting `└─zms-demo.target` returns only `zms-demo.target`.

## Testing

  - `cargo fmt --all -- --check`
  - `git diff --check`
  - Added `semantic_selection_stops_at_tree_branch`

The regression test could not run locally because this Windows environment does not have MSVC's `link.exe`. It can be run with:

  `cargo test -p terminal semantic_selection_stops_at_tree_branch`

## Self-Review Checklist:

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [x] Unsafe blocks (if any) have justifying comments
  - [x] The content adheres to Zed's UI standards
  - [x] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

---
  Release Notes:

  - Fixed terminal word selection around tree branch glyphs.