### PR TITLE
Prevent inactive windows from updating the IME position on linux/Wayland

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1891,6 +1891,9 @@ impl PlatformWindow for WaylandWindow {
 
     fn update_ime_position(&self, bounds: Bounds<Pixels>) {
         let state = self.borrow();
+        if !state.active {
+            return;
+        }
         state.client.update_ime_position(bounds);
     }
 


### PR DESCRIPTION
# Objective
Fixes #62084

Fix the Wayland IME candidate window flickering between two positions when an inactive Zed window has a terminal producing continuous output.

Terminal wakeup events in the inactive window can trigger IME position updates, causing its cursor bounds to alternate with those from the active window.

https://github.com/zed-industries/zed/blob/90d024b88abc91264d9a0ad260eb4f365fa695c3/crates/terminal_view/src/terminal_view.rs#L1130-L1136

https://github.com/zed-industries/zed/blob/90d024b88abc91264d9a0ad260eb4f365fa695c3/crates/gpui/src/window.rs#L5617-L5627

## Solution

Ignore IME position updates from inactive Wayland windows.

This ensures that only the active window can update the cursor rectangle of the shared Wayland text-input object.

## Testing

To test manually on Linux with Wayland and Fcitx5:

1. Open two Zed windows.
2. Start continuous terminal output in the first window.
3. Use the Chinese IME in an editor in the second window.
4. Verify that the IME candidate window remains at a stable position.


## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uxui-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

after fix:


[2026-08-02 22-43-35.webm](https://github.com/user-attachments/assets/ff2e3bc7-7772-481e-82f8-92e6e3fa7275)



---

Release Notes:

- Fixed the IME candidate window flickering when another Zed window has continuous terminal output