### PR TITLE
editor: Fix movement mismatch between minimap thumb and cursor

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1517,6 +1517,7 @@ impl EditorElement {
             minimap_line_height,
             minimap_scroll_top,
             max_scroll_top: total_editor_lines,
+            visible_editor_lines,
         })
     }
 
@@ -6399,17 +6400,13 @@ impl EditorElement {
             }
 
             let minimap_axis = ScrollbarAxis::Vertical;
-            let pixels_per_line = Pixels::from(
-                ScrollPixelOffset::from(minimap_hitbox.size.height) / layout.max_scroll_top,
-            )
-            .min(layout.minimap_line_height);
-
-            let mut mouse_position = window.mouse_position();
 
             window.on_mouse_event({
                 let editor = self.editor.clone();
 
                 let minimap_hitbox = minimap_hitbox.clone();
+
+                let mut mouse_position = window.mouse_position();
 
                 move |event: &MouseMoveEvent, phase, window, cx| {
                     if phase == DispatchPhase::Capture {
@@ -6420,6 +6417,25 @@ impl EditorElement {
                         if event.pressed_button == Some(MouseButton::Left)
                             && editor.scroll_manager.is_dragging_minimap()
                         {
+                            let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds else {
+                                return;
+                            };
+
+                            let thumb_scrollable_range =
+                                minimap_hitbox.size.height - thumb_bounds.size.height;
+                            // `max_scroll_top` equals the total lines of the editor (document).
+                            let scrollable_editor_lines =
+                                (layout.max_scroll_top - layout.visible_editor_lines).max(0.);
+
+                            let editor_thumb_scrolling_ratio = if layout.minimap_scroll_top == 0. {
+                                layout.minimap_line_height
+                            } else {
+                                Pixels::from(
+                                    ScrollPixelOffset::from(thumb_scrollable_range)
+                                        / scrollable_editor_lines,
+                                )
+                            };
+
                             let old_position = mouse_position.along(minimap_axis);
                             let new_position = event.position.along(minimap_axis);
                             if (minimap_hitbox.origin.along(minimap_axis)
@@ -6429,7 +6445,8 @@ impl EditorElement {
                                 let position =
                                     editor.scroll_position(cx).apply_along(minimap_axis, |p| {
                                         (p + ScrollPixelOffset::from(
-                                            (new_position - old_position) / pixels_per_line,
+                                            (new_position - old_position)
+                                                / editor_thumb_scrolling_ratio,
                                         ))
                                         .max(0.)
                                     });
@@ -10113,6 +10130,7 @@ struct MinimapLayout {
     pub minimap_line_height: Pixels,
     pub thumb_border_style: MinimapThumbBorder,
     pub max_scroll_top: ScrollOffset,
+    pub visible_editor_lines: f64,
 }
 
 impl MinimapLayout {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1505,6 +1505,7 @@ impl EditorElement {
             minimap_line_height,
             minimap_scroll_top,
             max_scroll_top: total_editor_lines,
+            visible_editor_lines,
         })
     }
 
@@ -6378,17 +6379,13 @@ impl EditorElement {
             }
 
             let minimap_axis = ScrollbarAxis::Vertical;
-            let pixels_per_line = Pixels::from(
-                ScrollPixelOffset::from(minimap_hitbox.size.height) / layout.max_scroll_top,
-            )
-            .min(layout.minimap_line_height);
-
-            let mut mouse_position = window.mouse_position();
 
             window.on_mouse_event({
                 let editor = self.editor.clone();
 
                 let minimap_hitbox = minimap_hitbox.clone();
+
+                let mut mouse_position = window.mouse_position();
 
                 move |event: &MouseMoveEvent, phase, window, cx| {
                     if phase == DispatchPhase::Capture {
@@ -6399,6 +6396,25 @@ impl EditorElement {
                         if event.pressed_button == Some(MouseButton::Left)
                             && editor.scroll_manager.is_dragging_minimap()
                         {
+                            let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds else {
+                                return;
+                            };
+
+                            let max_thumb_moving_distance =
+                                minimap_hitbox.size.height - thumb_bounds.size.height;
+                            // `max_scroll_top` equals the total lines of the editor (document).
+                            let non_visible_editor_lines =
+                                (layout.max_scroll_top - layout.visible_editor_lines).max(0.);
+
+                            let pixels_per_line = if layout.minimap_scroll_top == 0. {
+                                layout.minimap_line_height
+                            } else {
+                                Pixels::from(
+                                    ScrollPixelOffset::from(max_thumb_moving_distance)
+                                        / non_visible_editor_lines,
+                                )
+                            };
+
                             let old_position = mouse_position.along(minimap_axis);
                             let new_position = event.position.along(minimap_axis);
                             if (minimap_hitbox.origin.along(minimap_axis)
@@ -10067,6 +10083,7 @@ struct MinimapLayout {
     pub minimap_line_height: Pixels,
     pub thumb_border_style: MinimapThumbBorder,
     pub max_scroll_top: ScrollOffset,
+    pub visible_editor_lines: f64,
 }
 
 impl MinimapLayout {


### PR DESCRIPTION
# Objective

Fixes #44824

This bug results from an incorrect mathematical derivation of the `pixels_per_line` calculation formula. The complete derivation is too lengthy to include here, so it is provided in a separate comment below.

This PR does the same thing as #60080, but it is a refined version of it.

## Solution

Replace the previous incorrect calculation formula with the correct one.

## Testing

These changes are manually tested on my computer and all worked as expected.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

This recording shows the behavior in short document environment:

https://github.com/user-attachments/assets/2e5e7aec-ccf2-47c3-a046-e7f668bdb6c0

While this one shows the behavior in long document environment:

https://github.com/user-attachments/assets/e5809c81-4cfb-45f9-8ec7-051a487bd6f7

It's apparent that the minimap thumb moves closely with the cursor in both environments.

---

Release Notes:

- Fixed movement mismatch between minimap thumb and cursor.