### PR TITLE
project_panel: Add file nesting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14321,6 +14321,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rayon",
+ "regex",
  "remote_connection",
  "schemars 1.0.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14299,6 +14299,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rayon",
+ "regex",
  "remote_connection",
  "schemars 1.0.4",
  "serde",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -917,6 +917,20 @@
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.
     "git_status_indicator": false,
+    // Settings related to file nesting in the project panel.
+    "file_nesting": {
+      // Whether to nest related files under an expandable parent file
+      // in the project panel, according to `patterns`.
+      "enabled": false,
+      // The map of file patterns used to nest files.
+      // The key is a parent file pattern that can contain one `*` wildcard.
+      // The value is a comma-separated list of child file patterns, where
+      // `${capture}` expands to the text matched by the parent's wildcard
+      // and `*` matches any text.
+      //
+      // Example: `{"*.ts": "${capture}.js, ${capture}.d.ts"}`
+      "patterns": {}
+    },
     // Whether to enable drag-and-drop operations in the project panel.
     "drag_and_drop": true,
     // Whether to hide the root entry when only one folder is open in the window;

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -906,6 +906,20 @@
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.
     "git_status_indicator": false,
+    // Settings related to file nesting in the project panel.
+    "file_nesting": {
+      // Whether to nest related files under an expandable parent file
+      // in the project panel, according to `patterns`.
+      "enabled": false,
+      // The map of file patterns used to nest files.
+      // The key is a parent file pattern that can contain one `*` wildcard.
+      // The value is a comma-separated list of child file patterns, where
+      // `${capture}` expands to the text matched by the parent's wildcard
+      // and `*` matches any text.
+      //
+      // Example: `{"*.ts": "${capture}.js, ${capture}.d.ts"}`
+      "patterns": {}
+    },
     // Whether to enable drag-and-drop operations in the project panel.
     "drag_and_drop": true,
     // Whether to hide the root entry when only one folder is open in the window;

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -37,6 +37,7 @@ smallvec.workspace = true
 theme.workspace = true
 theme_settings.workspace = true
 rayon.workspace = true
+regex.workspace = true
 ui.workspace = true
 util.workspace = true
 client.workspace = true

--- a/crates/project_panel/src/file_nesting.rs
+++ b/crates/project_panel/src/file_nesting.rs
@@ -1,0 +1,221 @@
+use collections::HashMap;
+use regex::Regex;
+use util::ResultExt as _;
+
+pub struct FileNestingPatterns {
+    /// Sorted by parent pattern so that the nesting assignment does not depend
+    /// on the iteration order of the settings map.
+    patterns: Vec<FileNestingPattern>,
+}
+
+struct FileNestingPattern {
+    parent_regex: Regex,
+    /// Child templates in `regex::Captures::expand` syntax, so `${capture}`
+    /// from the settings appears here as `${1}`.
+    child_templates: Vec<String>,
+}
+
+impl FileNestingPatterns {
+    pub fn new(patterns: &HashMap<String, String>) -> Self {
+        let mut compiled = patterns
+            .iter()
+            .filter_map(|(parent_pattern, child_patterns)| {
+                let parent_regex = compile_wildcard_pattern(parent_pattern, true)?;
+                let child_templates = child_patterns
+                    .split(',')
+                    .map(|child| child.trim().replace("${capture}", "${1}"))
+                    .filter(|child| !child.is_empty())
+                    .collect::<Vec<_>>();
+                if child_templates.is_empty() {
+                    return None;
+                }
+                Some((
+                    parent_pattern.clone(),
+                    FileNestingPattern {
+                        parent_regex,
+                        child_templates,
+                    },
+                ))
+            })
+            .collect::<Vec<_>>();
+        compiled.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Self {
+            patterns: compiled.into_iter().map(|(_, pattern)| pattern).collect(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Given the file names of one directory's children, returns for each name
+    /// the index of the name it nests under, if any.
+    ///
+    /// Names are considered as parents in lexicographic order. A name that is
+    /// already nested cannot become a parent, and a name that already has
+    /// children cannot become nested, so chains cannot form.
+    pub fn nesting_parents(&self, names: &[&str]) -> Vec<Option<usize>> {
+        let mut parent_of = vec![None; names.len()];
+        if self.patterns.is_empty() {
+            return parent_of;
+        }
+
+        let name_to_index: HashMap<&str, usize> = names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (*name, index))
+            .collect();
+        let mut sorted_indices: Vec<usize> = (0..names.len()).collect();
+        sorted_indices.sort_by_key(|index| names[*index]);
+        let mut has_children = vec![false; names.len()];
+
+        for &parent_index in &sorted_indices {
+            if parent_of[parent_index].is_some() {
+                continue;
+            }
+            for pattern in &self.patterns {
+                let Some(captures) = pattern.parent_regex.captures(names[parent_index]) else {
+                    continue;
+                };
+                for child_template in &pattern.child_templates {
+                    let mut child_pattern = String::new();
+                    captures.expand(child_template, &mut child_pattern);
+
+                    let mut claim = |child_index: usize| {
+                        if child_index != parent_index
+                            && parent_of[child_index].is_none()
+                            && !has_children[child_index]
+                        {
+                            parent_of[child_index] = Some(parent_index);
+                            has_children[parent_index] = true;
+                        }
+                    };
+
+                    if child_pattern.contains('*') {
+                        let Some(child_regex) = compile_wildcard_pattern(&child_pattern, false)
+                        else {
+                            continue;
+                        };
+                        for &child_index in &sorted_indices {
+                            if child_regex.is_match(names[child_index]) {
+                                claim(child_index);
+                            }
+                        }
+                    } else if let Some(&child_index) = name_to_index.get(child_pattern.as_str()) {
+                        claim(child_index);
+                    }
+                }
+            }
+        }
+
+        parent_of
+    }
+}
+
+fn compile_wildcard_pattern(pattern: &str, capture: bool) -> Option<Regex> {
+    let wildcard = if capture { "(.*)" } else { ".*" };
+    let regex_pattern = pattern
+        .split('*')
+        .map(regex::escape)
+        .collect::<Vec<_>>()
+        .join(wildcard);
+    Regex::new(&format!("^{regex_pattern}$")).log_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patterns(entries: &[(&str, &str)]) -> FileNestingPatterns {
+        FileNestingPatterns::new(
+            &entries
+                .iter()
+                .map(|(parent, children)| (parent.to_string(), children.to_string()))
+                .collect(),
+        )
+    }
+
+    #[track_caller]
+    fn assert_nesting(patterns: &FileNestingPatterns, names: &[&str], expected: &[(&str, &str)]) {
+        let parents = patterns.nesting_parents(names);
+        let actual: Vec<(&str, &str)> = parents
+            .iter()
+            .enumerate()
+            .filter_map(|(child, parent)| parent.map(|parent| (names[child], names[parent])))
+            .collect();
+        assert_eq!(actual, expected, "for names {names:?}");
+    }
+
+    #[test]
+    fn test_exact_child_names() {
+        let patterns = patterns(&[("package.json", "package-lock.json, .npmrc")]);
+        assert_nesting(
+            &patterns,
+            &["package.json", "package-lock.json", ".npmrc", "index.js"],
+            &[
+                ("package-lock.json", "package.json"),
+                (".npmrc", "package.json"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_capture_expansion() {
+        let patterns = patterns(&[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+        assert_nesting(
+            &patterns,
+            &["foo.ts", "foo.js", "foo.d.ts", "bar.js"],
+            &[("foo.js", "foo.ts"), ("foo.d.ts", "foo.ts")],
+        );
+    }
+
+    #[test]
+    fn test_no_chains() {
+        // `foo.d.ts` nests `foo.d.js`, so it cannot also become a child of
+        // `foo.ts`: the result is two flat groups instead of a chain.
+        let patterns = patterns(&[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+        assert_nesting(
+            &patterns,
+            &["foo.ts", "foo.js", "foo.d.ts", "foo.d.js"],
+            &[("foo.js", "foo.ts"), ("foo.d.js", "foo.d.ts")],
+        );
+    }
+
+    #[test]
+    fn test_glob_child_pattern() {
+        let patterns = patterns(&[("*.go", "${capture}_test.go, ${capture}.*.go")]);
+        assert_nesting(
+            &patterns,
+            &["main.go", "main_test.go", "main.helper.go", "other.go"],
+            &[("main_test.go", "main.go"), ("main.helper.go", "main.go")],
+        );
+    }
+
+    #[test]
+    fn test_parent_with_children_cannot_be_claimed() {
+        // `a.go` would claim `a.b.go` via the glob, but `a.b.go` already has
+        // children of its own by the time `a.go` is considered.
+        let patterns = patterns(&[("*.go", "${capture}.*.go")]);
+        assert_nesting(
+            &patterns,
+            &["a.go", "a.b.go", "a.b.c.go"],
+            &[("a.b.c.go", "a.b.go")],
+        );
+    }
+
+    #[test]
+    fn test_file_does_not_nest_under_itself() {
+        let patterns = patterns(&[("*.js", "${capture}.js, *.js")]);
+        assert_nesting(&patterns, &["foo.js", "bar.js"], &[("foo.js", "bar.js")]);
+    }
+
+    #[test]
+    fn test_invalid_and_empty_patterns_are_ignored() {
+        let patterns = patterns(&[("*.rs", ""), ("*.ts", "${capture}.js")]);
+        assert_nesting(
+            &patterns,
+            &["foo.rs", "foo.ts", "foo.js"],
+            &[("foo.js", "foo.ts")],
+        );
+    }
+}

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1,7 +1,9 @@
+mod file_nesting;
 pub mod project_panel_settings;
 mod undo;
 mod utils;
 
+use crate::file_nesting::FileNestingPatterns;
 use anyhow::{Context as _, Result};
 use client::{ErrorCode, ErrorExt};
 use collections::{BTreeSet, HashMap, hash_map};
@@ -39,7 +41,7 @@ use project::{
     git_store::{GitStoreEvent, RepositoryEvent, git_traversal::ChildEntriesGitIter},
     project_settings::GoToDiagnosticSeverityFilter,
 };
-use project_panel_settings::ProjectPanelSettings;
+use project_panel_settings::{FileNestingSettings, ProjectPanelSettings};
 use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -79,7 +81,7 @@ use workspace::{
     focus_follows_mouse::FocusFollowsMouse as _,
     notifications::{DetachAndPromptErr, NotifyResultExt, NotifyTaskExt},
 };
-use worktree::CreatedEntry;
+use worktree::{CreatedEntry, Snapshot as WorktreeSnapshot};
 use zed_actions::{
     project_panel::{Toggle, ToggleFocus},
     workspace::OpenWithSystem,
@@ -93,10 +95,37 @@ use crate::{
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
 
+#[derive(Debug, Default)]
+struct FileNesting {
+    child_to_parent: HashMap<ProjectEntryId, ProjectEntryId>,
+    parents: HashSet<ProjectEntryId>,
+}
+
 struct VisibleEntriesForWorktree {
     worktree_id: WorktreeId,
     entries: Vec<GitEntry>,
     index: OnceCell<HashSet<Arc<RelPath>>>,
+    nesting: FileNesting,
+}
+
+impl VisibleEntriesForWorktree {
+    fn paths(&self) -> &HashSet<Arc<RelPath>> {
+        self.index.get_or_init(|| {
+            self.entries
+                .iter()
+                .map(|entry| entry.path.clone())
+                .collect()
+        })
+    }
+
+    fn depth_and_difference(&self, entry: &Entry) -> (usize, usize) {
+        let (mut depth, difference) =
+            ProjectPanel::calculate_depth_and_difference(entry, self.paths());
+        if self.nesting.child_to_parent.contains_key(&entry.id) {
+            depth += 1;
+        }
+        (depth, difference)
+    }
 }
 
 struct State {
@@ -153,6 +182,7 @@ pub struct ProjectPanel {
     clipboard: Option<ClipboardEntry>,
     _dragged_entry_destination: Option<Arc<Path>>,
     workspace: WeakEntity<Workspace>,
+    file_nesting_patterns: Option<Arc<FileNestingPatterns>>,
     diagnostics: HashMap<(WorktreeId, Arc<RelPath>), DiagnosticSeverity>,
     diagnostic_counts: HashMap<(WorktreeId, Arc<RelPath>), DiagnosticCount>,
     diagnostic_summary_update: Task<()>,
@@ -288,6 +318,7 @@ struct EntryDetails {
     is_private: bool,
     worktree_id: WorktreeId,
     canonical_path: Option<Arc<Path>>,
+    is_nested_parent: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -799,7 +830,15 @@ impl ProjectPanel {
             .detach();
 
             let mut project_panel_settings = *ProjectPanelSettings::get_global(cx);
+            let mut file_nesting_settings = FileNestingSettings::get_global(cx).clone();
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
+                let new_file_nesting_settings = FileNestingSettings::get_global(cx).clone();
+                if file_nesting_settings != new_file_nesting_settings {
+                    file_nesting_settings = new_file_nesting_settings;
+                    this.file_nesting_patterns = build_file_nesting_patterns(cx);
+                    this.update_visible_entries(None, false, false, window, cx);
+                    cx.notify();
+                }
                 let new_settings = *ProjectPanelSettings::get_global(cx);
                 if project_panel_settings != new_settings {
                     if project_panel_settings.hide_gitignore != new_settings.hide_gitignore {
@@ -844,6 +883,7 @@ impl ProjectPanel {
                 clipboard: None,
                 _dragged_entry_destination: None,
                 workspace: workspace.weak_handle(),
+                file_nesting_patterns: build_file_nesting_patterns(cx),
                 diagnostics: Default::default(),
                 diagnostic_counts: Default::default(),
                 diagnostic_summary_update: Task::ready(()),
@@ -1296,9 +1336,10 @@ impl ProjectPanel {
                 cx.notify();
                 return;
             }
-            if entry.is_dir() {
-                let worktree_id = worktree.id();
-                let entry_id = entry.id;
+            let worktree_id = worktree.id();
+            let entry_id = entry.id;
+            let is_dir = entry.is_dir();
+            if is_dir || self.is_nested_parent(worktree_id, entry_id) {
                 let expanded_dir_ids = if let Some(expanded_dir_ids) =
                     self.state.expanded_dir_ids.get_mut(&worktree_id)
                 {
@@ -1310,9 +1351,11 @@ impl ProjectPanel {
                 match expanded_dir_ids.binary_search(&entry_id) {
                     Ok(_) => self.select_next(&SelectNext, window, cx),
                     Err(ix) => {
-                        self.project.update(cx, |project, cx| {
-                            project.expand_entry(worktree_id, entry_id, cx);
-                        });
+                        if is_dir {
+                            self.project.update(cx, |project, cx| {
+                                project.expand_entry(worktree_id, entry_id, cx);
+                            });
+                        }
 
                         expanded_dir_ids.insert(ix, entry_id);
                         self.update_visible_entries(None, false, false, window, cx);
@@ -1351,12 +1394,28 @@ impl ProjectPanel {
             return;
         }
         let worktree_id = worktree.id();
+        let nesting_parent = self.nesting_parent_of(worktree_id, entry.id);
         let expanded_dir_ids =
             if let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id) {
                 expanded_dir_ids
             } else {
                 return;
             };
+
+        if let Some(nesting_parent) = nesting_parent
+            && let Ok(ix) = expanded_dir_ids.binary_search(&nesting_parent)
+        {
+            expanded_dir_ids.remove(ix);
+            self.update_visible_entries(
+                Some((worktree_id, nesting_parent)),
+                false,
+                false,
+                window,
+                cx,
+            );
+            cx.notify();
+            return;
+        }
 
         let mut entry = &entry;
         loop {
@@ -4259,6 +4318,7 @@ impl ProjectPanel {
             .collect();
         let hide_root = settings.hide_root && visible_worktrees.len() == 1;
         let hide_hidden = settings.hide_hidden;
+        let file_nesting_patterns = self.file_nesting_patterns.clone();
 
         let visible_entries_task = cx.spawn_in(window, async move |this, cx| {
             let new_state = cx
@@ -4284,6 +4344,8 @@ impl ProjectPanel {
                         let mut entry_iter =
                             GitTraversal::new(&repo_snapshots, worktree_snapshot.entries(true, 0));
                         let mut auto_folded_ancestors = vec![];
+                        let mut nesting = FileNesting::default();
+                        let mut nesting_computed_dirs = HashSet::<Arc<RelPath>>::new();
                         let worktree_abs_path = worktree_snapshot.abs_path();
                         while let Some(entry) = entry_iter.entry() {
                             if hide_root && Some(entry.entry) == worktree_snapshot.root_entry() {
@@ -4355,10 +4417,37 @@ impl ProjectPanel {
                                 }
                             }
                             auto_folded_ancestors.clear();
+                            if let Some(patterns) = &file_nesting_patterns
+                                && entry.is_file()
+                                && let Some(dir_path) = entry.path.parent()
+                                && !nesting_computed_dirs.contains(dir_path)
+                            {
+                                for (child_id, parent_id) in dir_nesting_pairs(
+                                    patterns,
+                                    &worktree_snapshot,
+                                    dir_path,
+                                    hide_gitignore,
+                                    hide_hidden,
+                                ) {
+                                    nesting.child_to_parent.insert(child_id, parent_id);
+                                    nesting.parents.insert(parent_id);
+                                }
+                                nesting_computed_dirs.insert(dir_path.into());
+                            }
                             if (!hide_gitignore || !entry.is_ignored)
                                 && (!hide_hidden || !entry.is_hidden)
                             {
-                                visible_worktree_entries.push(entry.to_owned());
+                                let hidden_nested_child =
+                                    nesting.child_to_parent.get(&entry.id).is_some_and(
+                                        |parent_id| {
+                                            new_state.expanded_dir_ids.get(&worktree_id).is_none_or(
+                                                |ids| ids.binary_search(parent_id).is_err(),
+                                            )
+                                        },
+                                    );
+                                if !hidden_nested_child {
+                                    visible_worktree_entries.push(entry.to_owned());
+                                }
                             }
                             let precedes_new_entry = if let Some(new_entry_id) = new_entry_parent_id
                             {
@@ -4401,7 +4490,10 @@ impl ProjectPanel {
                                 else {
                                     continue;
                                 };
-                                let depth = entry.path.ancestors().count() - 1;
+                                let mut depth = entry.path.ancestors().count() - 1;
+                                if nesting.child_to_parent.contains_key(&entry.id) {
+                                    depth += 1;
+                                }
                                 (depth, path_name.chars().count())
                             } else {
                                 let path = new_state
@@ -4478,10 +4570,17 @@ impl ProjectPanel {
                             sort_mode,
                             sort_order,
                         );
+                        if !nesting.child_to_parent.is_empty() {
+                            visible_worktree_entries = group_nested_children(
+                                visible_worktree_entries,
+                                &nesting.child_to_parent,
+                            );
+                        }
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
                             entries: visible_worktree_entries,
                             index: OnceCell::new(),
+                            nesting,
                         })
                     }
                     if let Some((project_entry_id, worktree_id, _)) = max_width_item {
@@ -4566,6 +4665,28 @@ impl ProjectPanel {
                 let worktree = worktree.read(cx);
 
                 if let Some(mut entry) = worktree.entry_for_id(entry_id) {
+                    if let Some(patterns) = &self.file_nesting_patterns
+                        && entry.is_file()
+                        && let Some(dir_path) = entry.path.parent()
+                    {
+                        let settings = ProjectPanelSettings::get_global(cx);
+                        let nesting_parent = dir_nesting_pairs(
+                            patterns,
+                            &worktree.snapshot(),
+                            dir_path,
+                            settings.hide_gitignore,
+                            settings.hide_hidden,
+                        )
+                        .into_iter()
+                        .find_map(|(child_id, parent_id)| {
+                            (child_id == entry_id).then_some(parent_id)
+                        });
+                        if let Some(parent_id) = nesting_parent
+                            && let Err(ix) = expanded_dir_ids.binary_search(&parent_id)
+                        {
+                            expanded_dir_ids.insert(ix, parent_id);
+                        }
+                    }
                     loop {
                         if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
                             expanded_dir_ids.insert(ix, entry.id);
@@ -5089,6 +5210,30 @@ impl ProjectPanel {
         None
     }
 
+    fn worktree_nesting(&self, worktree_id: WorktreeId) -> Option<&FileNesting> {
+        self.state
+            .visible_entries
+            .iter()
+            .find(|visible| visible.worktree_id == worktree_id)
+            .map(|visible| &visible.nesting)
+    }
+
+    fn is_nested_parent(&self, worktree_id: WorktreeId, entry_id: ProjectEntryId) -> bool {
+        self.worktree_nesting(worktree_id)
+            .is_some_and(|nesting| nesting.parents.contains(&entry_id))
+    }
+
+    fn nesting_parent_of(
+        &self,
+        worktree_id: WorktreeId,
+        entry_id: ProjectEntryId,
+    ) -> Option<ProjectEntryId> {
+        self.worktree_nesting(worktree_id)?
+            .child_to_parent
+            .get(&entry_id)
+            .copied()
+    }
+
     fn iter_visible_entries(
         &self,
         range: Range<usize>,
@@ -5097,7 +5242,7 @@ impl ProjectPanel {
         callback: &mut dyn FnMut(
             &Entry,
             usize,
-            &HashSet<Arc<RelPath>>,
+            &VisibleEntriesForWorktree,
             &mut Window,
             &mut Context<ProjectPanel>,
         ),
@@ -5115,13 +5260,10 @@ impl ProjectPanel {
 
             let end_ix = range.end.min(ix + visible.entries.len());
             let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
-            let entries = visible
-                .index
-                .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
             let base_index = ix + entry_range.start;
             for (i, entry) in visible.entries[entry_range].iter().enumerate() {
                 let global_index = base_index + i;
-                callback(entry, global_index, entries, window, cx);
+                callback(entry, global_index, visible, window, cx);
             }
             ix = end_ix;
         }
@@ -5164,9 +5306,6 @@ impl ProjectPanel {
                 let root_name = snapshot.root_name();
 
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
-                let entries = visible
-                    .index
-                    .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
                 for entry in visible.entries[entry_range].iter() {
                     let status = git_status_setting
                         .then_some(entry.git_summary)
@@ -5176,7 +5315,7 @@ impl ProjectPanel {
                         entry,
                         visible.worktree_id,
                         root_name,
-                        entries,
+                        visible,
                         status,
                         None,
                         window,
@@ -5633,6 +5772,8 @@ impl ProjectPanel {
         const GROUP_NAME: &str = "project_entry";
 
         let kind = details.kind;
+        let is_nested_parent = details.is_nested_parent;
+        let is_expanded = details.is_expanded;
         let is_sticky = details.sticky.is_some();
         let sticky_index = details.sticky.as_ref().map(|this| this.sticky_index);
         let settings = ProjectPanelSettings::get_global(cx);
@@ -6114,6 +6255,13 @@ impl ProjectPanel {
                         ProjectPanelEntrySpacing::Standard => ListItemSpacing::ExtraDense,
                     })
                     .selectable(false)
+                    .when(is_nested_parent, |this| {
+                        this.toggle(is_expanded).on_toggle(cx.listener(
+                            move |project_panel, _, window, cx| {
+                                project_panel.toggle_expanded(entry_id, window, cx);
+                            },
+                        ))
+                    })
                     .when(
                         canonical_path.is_some()
                             || diagnostic_count.is_some()
@@ -6517,7 +6665,7 @@ impl ProjectPanel {
         entry: &Entry,
         worktree_id: WorktreeId,
         root_name: &RelPath,
-        entries_paths: &HashSet<Arc<RelPath>>,
+        visible: &VisibleEntriesForWorktree,
         git_status: GitSummary,
         sticky: Option<StickyDetails>,
         _window: &mut Window,
@@ -6554,8 +6702,7 @@ impl ProjectPanel {
         };
 
         let path_style = self.project.read(cx).path_style(cx);
-        let (depth, difference) =
-            ProjectPanel::calculate_depth_and_difference(entry, entries_paths);
+        let (depth, difference) = visible.depth_and_difference(entry);
 
         let filename = if difference > 1 {
             entry
@@ -6618,6 +6765,7 @@ impl ProjectPanel {
             is_private: entry.is_private,
             worktree_id,
             canonical_path: entry.canonical_path.clone(),
+            is_nested_parent: visible.nesting.parents.contains(&entry.id),
         }
     }
 
@@ -6733,16 +6881,9 @@ impl ProjectPanel {
             let end = start + child_count;
 
             let visible_worktree = &self.state.visible_entries[worktree_ix];
-            let visible_worktree_entries = visible_worktree.index.get_or_init(|| {
-                visible_worktree
-                    .entries
-                    .iter()
-                    .map(|e| e.path.clone())
-                    .collect()
-            });
 
             // Calculate the actual depth of the entry, taking into account that directories can be auto-folded.
-            let (depth, _) = Self::calculate_depth_and_difference(entry, visible_worktree_entries);
+            let (depth, _) = visible_worktree.depth_and_difference(entry);
             (start..end, depth)
         };
 
@@ -6788,9 +6929,7 @@ impl ProjectPanel {
         };
         let worktree = worktree.read(cx).snapshot();
 
-        let paths = visible
-            .index
-            .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
+        let paths = visible.paths();
 
         let mut sticky_parents = Vec::new();
         let mut current_path = entry_ref.path.clone();
@@ -6848,7 +6987,7 @@ impl ProjectPanel {
                     entry,
                     worktree_id,
                     root_name,
-                    paths,
+                    visible,
                     git_status,
                     sticky_details,
                     window,
@@ -7136,11 +7275,9 @@ impl Render for ProjectPanel {
                                                 range,
                                                 window,
                                                 cx,
-                                                &mut |entry, _, entries, _, _| {
+                                                &mut |entry, _, visible, _, _| {
                                                     let (depth, _) =
-                                                        Self::calculate_depth_and_difference(
-                                                            entry, entries,
-                                                        );
+                                                        visible.depth_and_difference(entry);
                                                     items.push(depth);
                                                 },
                                             );
@@ -7250,11 +7387,9 @@ impl Render for ProjectPanel {
                                             range,
                                             window,
                                             cx,
-                                            &mut |entry, index, entries, _, _| {
+                                            &mut |entry, index, visible, _, _| {
                                                 let (depth, _) =
-                                                    Self::calculate_depth_and_difference(
-                                                        entry, entries,
-                                                    );
+                                                    visible.depth_and_difference(entry);
                                                 let candidate =
                                                     StickyProjectPanelCandidate { index, depth };
                                                 items.push(candidate);
@@ -7753,6 +7888,78 @@ pub fn par_sort_worktree_entries(
     order: settings::ProjectPanelSortOrder,
 ) {
     entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
+}
+
+fn build_file_nesting_patterns(cx: &App) -> Option<Arc<FileNestingPatterns>> {
+    let settings = FileNestingSettings::get_global(cx);
+    if !settings.enabled {
+        return None;
+    }
+    let patterns = FileNestingPatterns::new(&settings.patterns);
+    (!patterns.is_empty()).then(|| Arc::new(patterns))
+}
+
+/// Computes the file nesting assignment among the files of one directory,
+/// returning `(child, parent)` entry id pairs.
+fn dir_nesting_pairs(
+    patterns: &FileNestingPatterns,
+    snapshot: &WorktreeSnapshot,
+    dir_path: &RelPath,
+    hide_gitignore: bool,
+    hide_hidden: bool,
+) -> Vec<(ProjectEntryId, ProjectEntryId)> {
+    let files: Vec<(ProjectEntryId, &str)> = snapshot
+        .child_entries(dir_path)
+        .filter(|entry| {
+            entry.is_file()
+                && (!hide_gitignore || !entry.is_ignored)
+                && (!hide_hidden || !entry.is_hidden)
+        })
+        .filter_map(|entry| Some((entry.id, entry.path.file_name()?)))
+        .collect();
+    let names: Vec<&str> = files.iter().map(|(_, name)| *name).collect();
+    files
+        .iter()
+        .zip(patterns.nesting_parents(&names))
+        .filter_map(|((child_id, _), parent_index)| {
+            let (parent_id, _) = files.get(parent_index?)?;
+            Some((*child_id, *parent_id))
+        })
+        .collect()
+}
+
+fn group_nested_children(
+    entries: Vec<GitEntry>,
+    child_to_parent: &HashMap<ProjectEntryId, ProjectEntryId>,
+) -> Vec<GitEntry> {
+    let mut children_by_parent: HashMap<ProjectEntryId, Vec<GitEntry>> = HashMap::default();
+    let mut top_level = Vec::with_capacity(entries.len());
+    for entry in entries {
+        match child_to_parent.get(&entry.id) {
+            Some(parent_id) => children_by_parent
+                .entry(*parent_id)
+                .or_default()
+                .push(entry),
+            None => top_level.push(entry),
+        }
+    }
+    let mut result = Vec::with_capacity(top_level.len());
+    for entry in top_level {
+        let entry_id = entry.id;
+        result.push(entry);
+        if let Some(children) = children_by_parent.remove(&entry_id) {
+            result.extend(children);
+        }
+    }
+    // A nested file whose parent is not part of `entries` cannot occur,
+    // because the parent passes the same visibility filters as its children.
+    // Still, keep any such file at the end rather than losing it.
+    if !children_by_parent.is_empty() {
+        let mut orphans: Vec<GitEntry> = children_by_parent.into_values().flatten().collect();
+        orphans.sort_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
+        result.extend(orphans);
+    }
+    result
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1,7 +1,9 @@
+mod file_nesting;
 pub mod project_panel_settings;
 mod undo;
 mod utils;
 
+use crate::file_nesting::FileNestingPatterns;
 use anyhow::{Context as _, Result};
 use client::{ErrorCode, ErrorExt};
 use collections::{BTreeSet, HashMap, hash_map};
@@ -38,7 +40,7 @@ use project::{
     git_store::{GitStoreEvent, RepositoryEvent, git_traversal::ChildEntriesGitIter},
     project_settings::GoToDiagnosticSeverityFilter,
 };
-use project_panel_settings::ProjectPanelSettings;
+use project_panel_settings::{FileNestingSettings, ProjectPanelSettings};
 use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -78,7 +80,7 @@ use workspace::{
     focus_follows_mouse::FocusFollowsMouse as _,
     notifications::{DetachAndPromptErr, NotifyResultExt, NotifyTaskExt},
 };
-use worktree::CreatedEntry;
+use worktree::{CreatedEntry, Snapshot as WorktreeSnapshot};
 use zed_actions::{
     project_panel::{Toggle, ToggleFocus},
     workspace::OpenWithSystem,
@@ -92,10 +94,37 @@ use crate::{
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
 
+#[derive(Debug, Default)]
+struct FileNesting {
+    child_to_parent: HashMap<ProjectEntryId, ProjectEntryId>,
+    parents: HashSet<ProjectEntryId>,
+}
+
 struct VisibleEntriesForWorktree {
     worktree_id: WorktreeId,
     entries: Vec<GitEntry>,
     index: OnceCell<HashSet<Arc<RelPath>>>,
+    nesting: FileNesting,
+}
+
+impl VisibleEntriesForWorktree {
+    fn paths(&self) -> &HashSet<Arc<RelPath>> {
+        self.index.get_or_init(|| {
+            self.entries
+                .iter()
+                .map(|entry| entry.path.clone())
+                .collect()
+        })
+    }
+
+    fn depth_and_difference(&self, entry: &Entry) -> (usize, usize) {
+        let (mut depth, difference) =
+            ProjectPanel::calculate_depth_and_difference(entry, self.paths());
+        if self.nesting.child_to_parent.contains_key(&entry.id) {
+            depth += 1;
+        }
+        (depth, difference)
+    }
 }
 
 struct State {
@@ -152,6 +181,7 @@ pub struct ProjectPanel {
     clipboard: Option<ClipboardEntry>,
     _dragged_entry_destination: Option<Arc<Path>>,
     workspace: WeakEntity<Workspace>,
+    file_nesting_patterns: Option<Arc<FileNestingPatterns>>,
     diagnostics: HashMap<(WorktreeId, Arc<RelPath>), DiagnosticSeverity>,
     diagnostic_counts: HashMap<(WorktreeId, Arc<RelPath>), DiagnosticCount>,
     diagnostic_summary_update: Task<()>,
@@ -287,6 +317,7 @@ struct EntryDetails {
     is_private: bool,
     worktree_id: WorktreeId,
     canonical_path: Option<Arc<Path>>,
+    is_nested_parent: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -809,7 +840,15 @@ impl ProjectPanel {
             .detach();
 
             let mut project_panel_settings = *ProjectPanelSettings::get_global(cx);
+            let mut file_nesting_settings = FileNestingSettings::get_global(cx).clone();
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
+                let new_file_nesting_settings = FileNestingSettings::get_global(cx).clone();
+                if file_nesting_settings != new_file_nesting_settings {
+                    file_nesting_settings = new_file_nesting_settings;
+                    this.file_nesting_patterns = build_file_nesting_patterns(cx);
+                    this.update_visible_entries(None, false, false, window, cx);
+                    cx.notify();
+                }
                 let new_settings = *ProjectPanelSettings::get_global(cx);
                 if project_panel_settings != new_settings {
                     if project_panel_settings.hide_gitignore != new_settings.hide_gitignore {
@@ -854,6 +893,7 @@ impl ProjectPanel {
                 clipboard: None,
                 _dragged_entry_destination: None,
                 workspace: workspace.weak_handle(),
+                file_nesting_patterns: build_file_nesting_patterns(cx),
                 diagnostics: Default::default(),
                 diagnostic_counts: Default::default(),
                 diagnostic_summary_update: Task::ready(()),
@@ -1303,9 +1343,10 @@ impl ProjectPanel {
                 cx.notify();
                 return;
             }
-            if entry.is_dir() {
-                let worktree_id = worktree.id();
-                let entry_id = entry.id;
+            let worktree_id = worktree.id();
+            let entry_id = entry.id;
+            let is_dir = entry.is_dir();
+            if is_dir || self.is_nested_parent(worktree_id, entry_id) {
                 let expanded_dir_ids = if let Some(expanded_dir_ids) =
                     self.state.expanded_dir_ids.get_mut(&worktree_id)
                 {
@@ -1317,9 +1358,11 @@ impl ProjectPanel {
                 match expanded_dir_ids.binary_search(&entry_id) {
                     Ok(_) => self.select_next(&SelectNext, window, cx),
                     Err(ix) => {
-                        self.project.update(cx, |project, cx| {
-                            project.expand_entry(worktree_id, entry_id, cx);
-                        });
+                        if is_dir {
+                            self.project.update(cx, |project, cx| {
+                                project.expand_entry(worktree_id, entry_id, cx);
+                            });
+                        }
 
                         expanded_dir_ids.insert(ix, entry_id);
                         self.update_visible_entries(None, false, false, window, cx);
@@ -1358,12 +1401,28 @@ impl ProjectPanel {
             return;
         }
         let worktree_id = worktree.id();
+        let nesting_parent = self.nesting_parent_of(worktree_id, entry.id);
         let expanded_dir_ids =
             if let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id) {
                 expanded_dir_ids
             } else {
                 return;
             };
+
+        if let Some(nesting_parent) = nesting_parent
+            && let Ok(ix) = expanded_dir_ids.binary_search(&nesting_parent)
+        {
+            expanded_dir_ids.remove(ix);
+            self.update_visible_entries(
+                Some((worktree_id, nesting_parent)),
+                false,
+                false,
+                window,
+                cx,
+            );
+            cx.notify();
+            return;
+        }
 
         let mut entry = &entry;
         loop {
@@ -4288,6 +4347,7 @@ impl ProjectPanel {
             .collect();
         let hide_root = settings.hide_root && visible_worktrees.len() == 1;
         let hide_hidden = settings.hide_hidden;
+        let file_nesting_patterns = self.file_nesting_patterns.clone();
 
         let visible_entries_task = cx.spawn_in(window, async move |this, cx| {
             let new_state = cx
@@ -4313,6 +4373,8 @@ impl ProjectPanel {
                         let mut entry_iter =
                             GitTraversal::new(&repo_snapshots, worktree_snapshot.entries(true, 0));
                         let mut auto_folded_ancestors = vec![];
+                        let mut nesting = FileNesting::default();
+                        let mut nesting_computed_dirs = HashSet::<Arc<RelPath>>::new();
                         let worktree_abs_path = worktree_snapshot.abs_path();
                         while let Some(entry) = entry_iter.entry() {
                             if hide_root && Some(entry.entry) == worktree_snapshot.root_entry() {
@@ -4384,10 +4446,37 @@ impl ProjectPanel {
                                 }
                             }
                             auto_folded_ancestors.clear();
+                            if let Some(patterns) = &file_nesting_patterns
+                                && entry.is_file()
+                                && let Some(dir_path) = entry.path.parent()
+                                && !nesting_computed_dirs.contains(dir_path)
+                            {
+                                for (child_id, parent_id) in dir_nesting_pairs(
+                                    patterns,
+                                    &worktree_snapshot,
+                                    dir_path,
+                                    hide_gitignore,
+                                    hide_hidden,
+                                ) {
+                                    nesting.child_to_parent.insert(child_id, parent_id);
+                                    nesting.parents.insert(parent_id);
+                                }
+                                nesting_computed_dirs.insert(dir_path.into());
+                            }
                             if (!hide_gitignore || !entry.is_ignored)
                                 && (!hide_hidden || !entry.is_hidden)
                             {
-                                visible_worktree_entries.push(entry.to_owned());
+                                let hidden_nested_child =
+                                    nesting.child_to_parent.get(&entry.id).is_some_and(
+                                        |parent_id| {
+                                            new_state.expanded_dir_ids.get(&worktree_id).is_none_or(
+                                                |ids| ids.binary_search(parent_id).is_err(),
+                                            )
+                                        },
+                                    );
+                                if !hidden_nested_child {
+                                    visible_worktree_entries.push(entry.to_owned());
+                                }
                             }
                             let precedes_new_entry = if let Some(new_entry_id) = new_entry_parent_id
                             {
@@ -4430,7 +4519,10 @@ impl ProjectPanel {
                                 else {
                                     continue;
                                 };
-                                let depth = entry.path.ancestors().count() - 1;
+                                let mut depth = entry.path.ancestors().count() - 1;
+                                if nesting.child_to_parent.contains_key(&entry.id) {
+                                    depth += 1;
+                                }
                                 (depth, path_name.chars().count())
                             } else {
                                 let path = new_state
@@ -4507,10 +4599,17 @@ impl ProjectPanel {
                             sort_mode,
                             sort_order,
                         );
+                        if !nesting.child_to_parent.is_empty() {
+                            visible_worktree_entries = group_nested_children(
+                                visible_worktree_entries,
+                                &nesting.child_to_parent,
+                            );
+                        }
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
                             entries: visible_worktree_entries,
                             index: OnceCell::new(),
+                            nesting,
                         })
                     }
                     if let Some((project_entry_id, worktree_id, _)) = max_width_item {
@@ -4595,6 +4694,28 @@ impl ProjectPanel {
                 let worktree = worktree.read(cx);
 
                 if let Some(mut entry) = worktree.entry_for_id(entry_id) {
+                    if let Some(patterns) = &self.file_nesting_patterns
+                        && entry.is_file()
+                        && let Some(dir_path) = entry.path.parent()
+                    {
+                        let settings = ProjectPanelSettings::get_global(cx);
+                        let nesting_parent = dir_nesting_pairs(
+                            patterns,
+                            &worktree.snapshot(),
+                            dir_path,
+                            settings.hide_gitignore,
+                            settings.hide_hidden,
+                        )
+                        .into_iter()
+                        .find_map(|(child_id, parent_id)| {
+                            (child_id == entry_id).then_some(parent_id)
+                        });
+                        if let Some(parent_id) = nesting_parent
+                            && let Err(ix) = expanded_dir_ids.binary_search(&parent_id)
+                        {
+                            expanded_dir_ids.insert(ix, parent_id);
+                        }
+                    }
                     loop {
                         if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
                             expanded_dir_ids.insert(ix, entry.id);
@@ -5118,6 +5239,30 @@ impl ProjectPanel {
         None
     }
 
+    fn worktree_nesting(&self, worktree_id: WorktreeId) -> Option<&FileNesting> {
+        self.state
+            .visible_entries
+            .iter()
+            .find(|visible| visible.worktree_id == worktree_id)
+            .map(|visible| &visible.nesting)
+    }
+
+    fn is_nested_parent(&self, worktree_id: WorktreeId, entry_id: ProjectEntryId) -> bool {
+        self.worktree_nesting(worktree_id)
+            .is_some_and(|nesting| nesting.parents.contains(&entry_id))
+    }
+
+    fn nesting_parent_of(
+        &self,
+        worktree_id: WorktreeId,
+        entry_id: ProjectEntryId,
+    ) -> Option<ProjectEntryId> {
+        self.worktree_nesting(worktree_id)?
+            .child_to_parent
+            .get(&entry_id)
+            .copied()
+    }
+
     fn iter_visible_entries(
         &self,
         range: Range<usize>,
@@ -5126,7 +5271,7 @@ impl ProjectPanel {
         callback: &mut dyn FnMut(
             &Entry,
             usize,
-            &HashSet<Arc<RelPath>>,
+            &VisibleEntriesForWorktree,
             &mut Window,
             &mut Context<ProjectPanel>,
         ),
@@ -5144,13 +5289,10 @@ impl ProjectPanel {
 
             let end_ix = range.end.min(ix + visible.entries.len());
             let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
-            let entries = visible
-                .index
-                .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
             let base_index = ix + entry_range.start;
             for (i, entry) in visible.entries[entry_range].iter().enumerate() {
                 let global_index = base_index + i;
-                callback(entry, global_index, entries, window, cx);
+                callback(entry, global_index, visible, window, cx);
             }
             ix = end_ix;
         }
@@ -5193,9 +5335,6 @@ impl ProjectPanel {
                 let root_name = snapshot.root_name();
 
                 let entry_range = range.start.saturating_sub(ix)..end_ix - ix;
-                let entries = visible
-                    .index
-                    .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
                 for entry in visible.entries[entry_range].iter() {
                     let status = git_status_setting
                         .then_some(entry.git_summary)
@@ -5205,7 +5344,7 @@ impl ProjectPanel {
                         entry,
                         visible.worktree_id,
                         root_name,
-                        entries,
+                        visible,
                         status,
                         None,
                         window,
@@ -5662,6 +5801,8 @@ impl ProjectPanel {
         const GROUP_NAME: &str = "project_entry";
 
         let kind = details.kind;
+        let is_nested_parent = details.is_nested_parent;
+        let is_expanded = details.is_expanded;
         let is_sticky = details.sticky.is_some();
         let sticky_index = details.sticky.as_ref().map(|this| this.sticky_index);
         let settings = ProjectPanelSettings::get_global(cx);
@@ -6143,6 +6284,13 @@ impl ProjectPanel {
                         ProjectPanelEntrySpacing::Standard => ListItemSpacing::ExtraDense,
                     })
                     .selectable(false)
+                    .when(is_nested_parent, |this| {
+                        this.toggle(is_expanded).on_toggle(cx.listener(
+                            move |project_panel, _, window, cx| {
+                                project_panel.toggle_expanded(entry_id, window, cx);
+                            },
+                        ))
+                    })
                     .when(
                         canonical_path.is_some()
                             || diagnostic_count.is_some()
@@ -6546,7 +6694,7 @@ impl ProjectPanel {
         entry: &Entry,
         worktree_id: WorktreeId,
         root_name: &RelPath,
-        entries_paths: &HashSet<Arc<RelPath>>,
+        visible: &VisibleEntriesForWorktree,
         git_status: GitSummary,
         sticky: Option<StickyDetails>,
         _window: &mut Window,
@@ -6583,8 +6731,7 @@ impl ProjectPanel {
         };
 
         let path_style = self.project.read(cx).path_style(cx);
-        let (depth, difference) =
-            ProjectPanel::calculate_depth_and_difference(entry, entries_paths);
+        let (depth, difference) = visible.depth_and_difference(entry);
 
         let filename = if difference > 1 {
             entry
@@ -6647,6 +6794,7 @@ impl ProjectPanel {
             is_private: entry.is_private,
             worktree_id,
             canonical_path: entry.canonical_path.clone(),
+            is_nested_parent: visible.nesting.parents.contains(&entry.id),
         }
     }
 
@@ -6762,16 +6910,9 @@ impl ProjectPanel {
             let end = start + child_count;
 
             let visible_worktree = &self.state.visible_entries[worktree_ix];
-            let visible_worktree_entries = visible_worktree.index.get_or_init(|| {
-                visible_worktree
-                    .entries
-                    .iter()
-                    .map(|e| e.path.clone())
-                    .collect()
-            });
 
             // Calculate the actual depth of the entry, taking into account that directories can be auto-folded.
-            let (depth, _) = Self::calculate_depth_and_difference(entry, visible_worktree_entries);
+            let (depth, _) = visible_worktree.depth_and_difference(entry);
             (start..end, depth)
         };
 
@@ -6817,9 +6958,7 @@ impl ProjectPanel {
         };
         let worktree = worktree.read(cx).snapshot();
 
-        let paths = visible
-            .index
-            .get_or_init(|| visible.entries.iter().map(|e| e.path.clone()).collect());
+        let paths = visible.paths();
 
         let mut sticky_parents = Vec::new();
         let mut current_path = entry_ref.path.clone();
@@ -6877,7 +7016,7 @@ impl ProjectPanel {
                     entry,
                     worktree_id,
                     root_name,
-                    paths,
+                    visible,
                     git_status,
                     sticky_details,
                     window,
@@ -7164,11 +7303,9 @@ impl Render for ProjectPanel {
                                                 range,
                                                 window,
                                                 cx,
-                                                &mut |entry, _, entries, _, _| {
+                                                &mut |entry, _, visible, _, _| {
                                                     let (depth, _) =
-                                                        Self::calculate_depth_and_difference(
-                                                            entry, entries,
-                                                        );
+                                                        visible.depth_and_difference(entry);
                                                     items.push(depth);
                                                 },
                                             );
@@ -7278,11 +7415,9 @@ impl Render for ProjectPanel {
                                             range,
                                             window,
                                             cx,
-                                            &mut |entry, index, entries, _, _| {
+                                            &mut |entry, index, visible, _, _| {
                                                 let (depth, _) =
-                                                    Self::calculate_depth_and_difference(
-                                                        entry, entries,
-                                                    );
+                                                    visible.depth_and_difference(entry);
                                                 let candidate =
                                                     StickyProjectPanelCandidate { index, depth };
                                                 items.push(candidate);
@@ -7781,6 +7916,78 @@ pub fn par_sort_worktree_entries(
     order: settings::ProjectPanelSortOrder,
 ) {
     entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
+}
+
+fn build_file_nesting_patterns(cx: &App) -> Option<Arc<FileNestingPatterns>> {
+    let settings = FileNestingSettings::get_global(cx);
+    if !settings.enabled {
+        return None;
+    }
+    let patterns = FileNestingPatterns::new(&settings.patterns);
+    (!patterns.is_empty()).then(|| Arc::new(patterns))
+}
+
+/// Computes the file nesting assignment among the files of one directory,
+/// returning `(child, parent)` entry id pairs.
+fn dir_nesting_pairs(
+    patterns: &FileNestingPatterns,
+    snapshot: &WorktreeSnapshot,
+    dir_path: &RelPath,
+    hide_gitignore: bool,
+    hide_hidden: bool,
+) -> Vec<(ProjectEntryId, ProjectEntryId)> {
+    let files: Vec<(ProjectEntryId, &str)> = snapshot
+        .child_entries(dir_path)
+        .filter(|entry| {
+            entry.is_file()
+                && (!hide_gitignore || !entry.is_ignored)
+                && (!hide_hidden || !entry.is_hidden)
+        })
+        .filter_map(|entry| Some((entry.id, entry.path.file_name()?)))
+        .collect();
+    let names: Vec<&str> = files.iter().map(|(_, name)| *name).collect();
+    files
+        .iter()
+        .zip(patterns.nesting_parents(&names))
+        .filter_map(|((child_id, _), parent_index)| {
+            let (parent_id, _) = files.get(parent_index?)?;
+            Some((*child_id, *parent_id))
+        })
+        .collect()
+}
+
+fn group_nested_children(
+    entries: Vec<GitEntry>,
+    child_to_parent: &HashMap<ProjectEntryId, ProjectEntryId>,
+) -> Vec<GitEntry> {
+    let mut children_by_parent: HashMap<ProjectEntryId, Vec<GitEntry>> = HashMap::default();
+    let mut top_level = Vec::with_capacity(entries.len());
+    for entry in entries {
+        match child_to_parent.get(&entry.id) {
+            Some(parent_id) => children_by_parent
+                .entry(*parent_id)
+                .or_default()
+                .push(entry),
+            None => top_level.push(entry),
+        }
+    }
+    let mut result = Vec::with_capacity(top_level.len());
+    for entry in top_level {
+        let entry_id = entry.id;
+        result.push(entry);
+        if let Some(children) = children_by_parent.remove(&entry_id) {
+            result.extend(children);
+        }
+    }
+    // A nested file whose parent is not part of `entries` cannot occur,
+    // because the parent passes the same visibility filters as its children.
+    // Still, keep any such file at the end rather than losing it.
+    if !children_by_parent.is_empty() {
+        let mut orphans: Vec<GitEntry> = children_by_parent.into_values().flatten().collect();
+        orphans.sort_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
+        result.extend(orphans);
+    }
+    result
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -1,3 +1,4 @@
+use collections::HashMap;
 use editor::{EditorSettings, ui_scrollbar_settings_from_raw};
 use gpui::Pixels;
 use schemars::JsonSchema;
@@ -38,6 +39,25 @@ pub struct ProjectPanelSettings {
     pub sort_order: ProjectPanelSortOrder,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
+}
+
+/// File nesting is registered as its own setting, separate from
+/// `ProjectPanelSettings`, so that the latter can stay `Copy` despite the
+/// pattern map.
+#[derive(Clone, Debug, Deserialize, PartialEq, RegisterSetting)]
+pub struct FileNestingSettings {
+    pub enabled: bool,
+    pub patterns: HashMap<String, String>,
+}
+
+impl Settings for FileNestingSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let file_nesting = content.project_panel.clone().unwrap().file_nesting.unwrap();
+        Self {
+            enabled: file_nesting.enabled.unwrap(),
+            patterns: file_nesting.patterns.unwrap(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -11301,6 +11301,326 @@ async fn test_focus_follows_mouse_into_blank_area(cx: &mut gpui::TestAppContext)
     });
 }
 
+fn set_file_nesting_settings(cx: &mut TestAppContext, enabled: bool, patterns: &[(&str, &str)]) {
+    let patterns = patterns
+        .iter()
+        .map(|(parent, children)| (parent.to_string(), children.to_string()))
+        .collect();
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project_panel.get_or_insert_default().file_nesting =
+                    Some(settings::FileNestingSettingsContent {
+                        enabled: Some(enabled),
+                        patterns: Some(patterns),
+                    });
+            });
+        });
+    });
+}
+
+async fn setup_file_nesting_panel(
+    cx: &mut TestAppContext,
+    tree: serde_json::Value,
+) -> (Entity<ProjectPanel>, VisualTestContext) {
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", tree).await;
+    let project = Project::test(fs, ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(&mut cx, ProjectPanel::new);
+    cx.run_until_parked();
+    (panel, cx)
+}
+
+#[gpui::test]
+async fn test_file_nesting_flat_parent_and_children(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+            "foo.d.ts": "",
+            "bar.ts": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // Nested files start hidden behind their collapsed parent.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      bar.ts", "      foo.ts"]
+    );
+
+    // `foo.d.ts` matches `*.ts` too, but it must not form a chain: both
+    // `foo.js` and `foo.d.ts` nest directly under `foo.ts`.
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      bar.ts",
+            "      foo.ts  <== selected",
+            "          foo.js",
+            "          foo.d.ts",
+        ]
+    );
+
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      bar.ts", "      foo.ts  <== selected"]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_no_chains(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+            "foo.d.ts": "",
+            "foo.d.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // `foo.d.ts` nests `foo.d.js`, so it cannot also nest under `foo.ts`:
+    // two flat groups form instead of a chain.
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    toggle_expand_dir(&panel, "root/foo.d.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      foo.ts",
+            "          foo.js",
+            "      foo.d.ts  <== selected",
+            "          foo.d.js",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_with_mixed_sort_mode(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("package.json", "yarn.lock")]);
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project_panel.get_or_insert_default().sort_mode =
+                    Some(settings::ProjectPanelSortMode::Mixed);
+            });
+        });
+    });
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "package.json": "",
+            "src": {},
+            "yarn.lock": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // In mixed sort mode, `src` separates `package.json` from `yarn.lock`.
+    // The nested file must still follow its parent directly.
+    toggle_expand_dir(&panel, "root/package.json", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      package.json  <== selected",
+            "          yarn.lock",
+            "    > src",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_glob_targets(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.go", "${capture}_test.go, ${capture}.*.go")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "main.go": "",
+            "main.helper.go": "",
+            "main_test.go": "",
+            "other.go": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      main.go", "      other.go"]
+    );
+
+    toggle_expand_dir(&panel, "root/main.go", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      main.go  <== selected",
+            "          main.helper.go",
+            "          main_test.go",
+            "      other.go",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_keyboard_navigation(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // Expanding the selected nested parent shows its children.
+    select_path(&panel, "root/foo.ts", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_selected_entry(&ExpandSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts  <== selected", "          foo.js"]
+    );
+
+    // Expanding again moves the selection to the first child.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_selected_entry(&ExpandSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts", "          foo.js  <== selected"]
+    );
+
+    // Collapsing a nested file collapses its parent and selects it.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_selected_entry(&CollapseSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts  <== selected"]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_reveal_nested_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts"]
+    );
+
+    // Revealing a hidden nested file expands its parent.
+    panel.update_in(cx, |panel, window, cx| {
+        let project = panel.project.clone();
+        let entry_id = project
+            .read(cx)
+            .worktrees(cx)
+            .next()
+            .unwrap()
+            .read(cx)
+            .entry_for_path(rel_path("foo.js"))
+            .unwrap()
+            .id;
+        panel
+            .reveal_entry(project, entry_id, false, window, cx)
+            .unwrap();
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      foo.ts",
+            "          foo.js  <== selected  <== marked",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_setting_toggle(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, false, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let visual_cx = &mut cx;
+
+    // Patterns are ignored while nesting is disabled.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, visual_cx),
+        &["v root", "      foo.js", "      foo.ts"]
+    );
+
+    // Enabling the setting at runtime applies the nesting.
+    visual_cx.update(|_, cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project_panel
+                    .get_or_insert_default()
+                    .file_nesting
+                    .get_or_insert_default()
+                    .enabled = Some(true);
+            });
+        });
+    });
+    visual_cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, visual_cx),
+        &["v root", "      foo.ts"]
+    );
+}
+
 pub(crate) fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -11312,6 +11312,326 @@ async fn test_focus_follows_mouse_into_blank_area(cx: &mut gpui::TestAppContext)
     });
 }
 
+fn set_file_nesting_settings(cx: &mut TestAppContext, enabled: bool, patterns: &[(&str, &str)]) {
+    let patterns = patterns
+        .iter()
+        .map(|(parent, children)| (parent.to_string(), children.to_string()))
+        .collect();
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project_panel.get_or_insert_default().file_nesting =
+                    Some(settings::FileNestingSettingsContent {
+                        enabled: Some(enabled),
+                        patterns: Some(patterns),
+                    });
+            });
+        });
+    });
+}
+
+async fn setup_file_nesting_panel(
+    cx: &mut TestAppContext,
+    tree: serde_json::Value,
+) -> (Entity<ProjectPanel>, VisualTestContext) {
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", tree).await;
+    let project = Project::test(fs, ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(&mut cx, ProjectPanel::new);
+    cx.run_until_parked();
+    (panel, cx)
+}
+
+#[gpui::test]
+async fn test_file_nesting_flat_parent_and_children(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+            "foo.d.ts": "",
+            "bar.ts": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // Nested files start hidden behind their collapsed parent.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      bar.ts", "      foo.ts"]
+    );
+
+    // `foo.d.ts` matches `*.ts` too, but it must not form a chain: both
+    // `foo.js` and `foo.d.ts` nest directly under `foo.ts`.
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      bar.ts",
+            "      foo.ts  <== selected",
+            "          foo.js",
+            "          foo.d.ts",
+        ]
+    );
+
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      bar.ts", "      foo.ts  <== selected"]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_no_chains(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js, ${capture}.d.ts")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+            "foo.d.ts": "",
+            "foo.d.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // `foo.d.ts` nests `foo.d.js`, so it cannot also nest under `foo.ts`:
+    // two flat groups form instead of a chain.
+    toggle_expand_dir(&panel, "root/foo.ts", cx);
+    toggle_expand_dir(&panel, "root/foo.d.ts", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      foo.ts",
+            "          foo.js",
+            "      foo.d.ts  <== selected",
+            "          foo.d.js",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_with_mixed_sort_mode(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("package.json", "yarn.lock")]);
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project_panel.get_or_insert_default().sort_mode =
+                    Some(settings::ProjectPanelSortMode::Mixed);
+            });
+        });
+    });
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "package.json": "",
+            "src": {},
+            "yarn.lock": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // In mixed sort mode, `src` separates `package.json` from `yarn.lock`.
+    // The nested file must still follow its parent directly.
+    toggle_expand_dir(&panel, "root/package.json", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      package.json  <== selected",
+            "          yarn.lock",
+            "    > src",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_glob_targets(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.go", "${capture}_test.go, ${capture}.*.go")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "main.go": "",
+            "main.helper.go": "",
+            "main_test.go": "",
+            "other.go": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      main.go", "      other.go"]
+    );
+
+    toggle_expand_dir(&panel, "root/main.go", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      main.go  <== selected",
+            "          main.helper.go",
+            "          main_test.go",
+            "      other.go",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_keyboard_navigation(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    // Expanding the selected nested parent shows its children.
+    select_path(&panel, "root/foo.ts", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_selected_entry(&ExpandSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts  <== selected", "          foo.js"]
+    );
+
+    // Expanding again moves the selection to the first child.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_selected_entry(&ExpandSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts", "          foo.js  <== selected"]
+    );
+
+    // Collapsing a nested file collapses its parent and selects it.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_selected_entry(&CollapseSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts  <== selected"]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_reveal_nested_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, true, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let cx = &mut cx;
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v root", "      foo.ts"]
+    );
+
+    // Revealing a hidden nested file expands its parent.
+    panel.update_in(cx, |panel, window, cx| {
+        let project = panel.project.clone();
+        let entry_id = project
+            .read(cx)
+            .worktrees(cx)
+            .next()
+            .unwrap()
+            .read(cx)
+            .entry_for_path(rel_path("foo.js"))
+            .unwrap()
+            .id;
+        panel
+            .reveal_entry(project, entry_id, false, window, cx)
+            .unwrap();
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v root",
+            "      foo.ts",
+            "          foo.js  <== selected  <== marked",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_file_nesting_setting_toggle(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    set_file_nesting_settings(cx, false, &[("*.ts", "${capture}.js")]);
+
+    let (panel, mut cx) = setup_file_nesting_panel(
+        cx,
+        json!({
+            "foo.ts": "",
+            "foo.js": "",
+        }),
+    )
+    .await;
+    let visual_cx = &mut cx;
+
+    // Patterns are ignored while nesting is disabled.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, visual_cx),
+        &["v root", "      foo.js", "      foo.ts"]
+    );
+
+    // Enabling the setting at runtime applies the nesting.
+    visual_cx.update(|_, cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project_panel
+                    .get_or_insert_default()
+                    .file_nesting
+                    .get_or_insert_default()
+                    .enabled = Some(true);
+            });
+        });
+    });
+    visual_cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, visual_cx),
+        &["v root", "      foo.ts"]
+    );
+}
+
 pub(crate) fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -855,6 +855,17 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
+            file_nesting: {
+                let enabled = self.read_bool("explorer.fileNesting.enabled");
+                let patterns = self
+                    .read_value("explorer.fileNesting.patterns")
+                    .and_then(|value| serde_json::from_value(value.clone()).ok());
+                if enabled.is_some() || patterns.is_some() {
+                    Some(FileNestingSettingsContent { enabled, patterns })
+                } else {
+                    None
+                }
+            },
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -854,6 +854,17 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
+            file_nesting: {
+                let enabled = self.read_bool("explorer.fileNesting.enabled");
+                let patterns = self
+                    .read_value("explorer.fileNesting.patterns")
+                    .and_then(|value| serde_json::from_value(value.clone()).ok());
+                if enabled.is_some() || patterns.is_some() {
+                    Some(FileNestingSettingsContent { enabled, patterns })
+                } else {
+                    None
+                }
+            },
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -856,6 +856,28 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// Settings related to file nesting in the project panel.
+    pub file_nesting: Option<FileNestingSettingsContent>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
+pub struct FileNestingSettingsContent {
+    /// Whether to nest related files under an expandable parent file
+    /// in the project panel, according to `patterns`.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+    /// The map of file patterns used to nest files.
+    /// The key is a parent file pattern that can contain one `*` wildcard.
+    /// The value is a comma-separated list of child file patterns, where
+    /// `${capture}` expands to the text matched by the parent's wildcard
+    /// and `*` matches any text.
+    ///
+    /// Example: `{"*.ts": "${capture}.js, ${capture}.d.ts"}`
+    ///
+    /// Default: {}
+    pub patterns: Option<HashMap<String, String>>,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -828,6 +828,28 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// Settings related to file nesting in the project panel.
+    pub file_nesting: Option<FileNestingSettingsContent>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
+pub struct FileNestingSettingsContent {
+    /// Whether to nest related files under an expandable parent file
+    /// in the project panel, according to `patterns`.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+    /// The map of file patterns used to nest files.
+    /// The key is a parent file pattern that can contain one `*` wildcard.
+    /// The value is a comma-separated list of child file patterns, where
+    /// `${capture}` expands to the text matched by the parent's wildcard
+    /// and `*` matches any text.
+    ///
+    /// Example: `{"*.ts": "${capture}.js, ${capture}.d.ts"}`
+    ///
+    /// Default: {}
+    pub patterns: Option<HashMap<String, String>>,
 }
 
 #[derive(


### PR DESCRIPTION
This is a rework of #50133. It applies the review feedback from that PR.

File nesting groups related files under one parent file in the project panel. For example, package-lock.json nests under package.json. The feature is off by default.

It supports the exact same features and formats as [VSCode's file nesting](https://code.visualstudio.com/updates/v1_67#_explorer-file-nesting).

Changes from the last PR, from @smitbarmase [comment](https://github.com/zed-industries/zed/pull/50133#issuecomment-4192864527):

1. Flat data model. A file has at most one parent. A nested file cannot have children. That means chains such as foo.ts -> foo.js -> foo.d.ts cannot form.

2. Nesting works on all siblings of a directory. The panel computes nesting from the worktree snapshot, per directory. It does not depend on contiguous runs of sorted entries. That means it works with all sort modes. For example, package.json nests yarn.lock in mixed sort mode, with the src directory between them.

3. Parents expand and collapse like directories. A nested parent reuses the panel's expanded_dir_ids state. That means keyboard navigation, the chevron, collapse, collapse-all, and reveal work through the existing code paths.

Merging this PR closes #25156.