### PR TITLE
feature_flags: Enable project panel undo/redo on all release channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6567,7 +6567,6 @@ dependencies = [
  "fs",
  "gpui",
  "inventory",
- "release_channel",
  "schemars 1.0.4",
  "serde_json",
  "settings",

--- a/crates/feature_flags/Cargo.toml
+++ b/crates/feature_flags/Cargo.toml
@@ -17,7 +17,6 @@ feature_flags_macros.workspace = true
 fs.workspace = true
 gpui.workspace = true
 inventory.workspace = true
-release_channel.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -89,10 +89,7 @@ impl FeatureFlag for ProjectPanelUndoRedoFeatureFlag {
     }
 
     fn enabled_for_all() -> bool {
-        !matches!(
-            *release_channel::RELEASE_CHANNEL,
-            release_channel::ReleaseChannel::Stable
-        )
+        true
     }
 }
 register_feature_flag!(ProjectPanelUndoRedoFeatureFlag);


### PR DESCRIPTION
# Objective

Ensure that the Project Panel's Undo/Redo system is enabled in Stable before this week's release, as it's enabled on all release channels except stable.

Since, as far as I'm aware, there hasn't been any issue reported regarding last week's Preview release, I'm going to go ahead and enable this in stable.

## Solution

Update `feature_flags::flags::ProjectPanelUndoRedoFeatureFlag::enabled_for_all` to `true`, we no longer need to match on the release channel.

## Testing

N/A

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
