### PR TITLE
project: Include related diagnostic information in code action requests

### DIFF
--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -12,7 +12,7 @@ use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use client::proto::{self, PeerId};
 use clock::Global;
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use futures::future;
 use gpui::{App, AsyncApp, Entity, SharedString, Task, TaskExt, prelude::FluentBuilder};
 use language::{
@@ -2949,12 +2949,45 @@ impl LspCommand for GetCodeActions {
         language_server: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::CodeActionParams> {
-        let mut relevant_diagnostics = Vec::new();
-        for entry in buffer
-            .snapshot()
+        let text_document = make_text_document_identifier(path)?;
+        let snapshot = buffer.snapshot();
+        let diagnostic_entries = snapshot
             .diagnostics_in_range::<_, language::PointUtf16>(self.range.clone(), false)
-        {
-            relevant_diagnostics.push(entry.to_lsp_diagnostic_stub()?);
+            .collect::<Vec<_>>();
+        let primary_group_ids = diagnostic_entries
+            .iter()
+            .filter(|entry| entry.diagnostic.is_primary)
+            .map(|entry| entry.diagnostic.group_id)
+            .collect::<HashSet<_>>();
+        let mut relevant_diagnostics = Vec::new();
+        for entry in diagnostic_entries {
+            // Related information is stored as separate entries for rendering. Reassemble it on
+            // primary diagnostics without also sending those entries as top-level diagnostics.
+            if !entry.diagnostic.is_primary
+                && primary_group_ids.contains(&entry.diagnostic.group_id)
+            {
+                continue;
+            }
+
+            let mut diagnostic = entry.to_lsp_diagnostic_stub()?;
+            if entry.diagnostic.is_primary {
+                let related_information = snapshot
+                    .diagnostic_group::<language::PointUtf16>(entry.diagnostic.group_id)
+                    .filter(|entry| !entry.diagnostic.is_primary)
+                    .map(|entry| {
+                        Ok(lsp::DiagnosticRelatedInformation {
+                            location: lsp::Location {
+                                uri: text_document.uri.clone(),
+                                range: range_to_lsp(entry.range)?,
+                            },
+                            message: entry.diagnostic.message.clone(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                diagnostic.related_information =
+                    (!related_information.is_empty()).then_some(related_information);
+            }
+            relevant_diagnostics.push(diagnostic);
         }
 
         let only = if let Some(requested) = &self.kinds {
@@ -2979,7 +3012,7 @@ impl LspCommand for GetCodeActions {
         };
 
         Ok(lsp::CodeActionParams {
-            text_document: make_text_document_identifier(path)?,
+            text_document,
             range: range_to_lsp(self.range.to_point_utf16(buffer))?,
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -9449,6 +9449,108 @@ async fn test_code_actions_only_kinds(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_code_actions_include_related_diagnostics(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "a.ts": "abcd",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(typescript_lang());
+    let mut fake_language_servers = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                code_action_provider: Some(lsp::CodeActionProviderCapability::Simple(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/a.ts"), cx)
+        })
+        .await
+        .unwrap();
+    let fake_server = fake_language_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    let uri = Uri::from_file_path(path!("/dir/a.ts")).unwrap();
+    let related_information = vec![
+        lsp::DiagnosticRelatedInformation {
+            location: lsp::Location {
+                uri: uri.clone(),
+                range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 1)),
+            },
+            message: "overlapping related diagnostic".to_string(),
+        },
+        lsp::DiagnosticRelatedInformation {
+            location: lsp::Location {
+                uri: uri.clone(),
+                range: lsp::Range::new(lsp::Position::new(0, 2), lsp::Position::new(0, 3)),
+            },
+            message: "non-overlapping related diagnostic".to_string(),
+        },
+    ];
+    fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
+        uri,
+        version: None,
+        diagnostics: vec![lsp::Diagnostic {
+            range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 1)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(lsp::NumberOrString::String("test-code".to_string())),
+            source: Some("test-language-server".to_string()),
+            message: "primary diagnostic".to_string(),
+            related_information: Some(related_information.clone()),
+            data: Some(json!({ "fix_id": "test-fix" })),
+            ..Default::default()
+        }],
+    });
+    cx.executor().run_until_parked();
+
+    let mut request_handled = fake_server
+        .set_request_handler::<lsp::request::CodeActionRequest, _, _>(move |params, _| {
+            let related_information = related_information.clone();
+            async move {
+                assert_eq!(
+                    params.context.diagnostics,
+                    vec![lsp::Diagnostic {
+                        range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 1)),
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        code: Some(lsp::NumberOrString::String("test-code".to_string())),
+                        source: Some("test-language-server".to_string()),
+                        message: "primary diagnostic".to_string(),
+                        related_information: Some(related_information),
+                        data: Some(json!({ "fix_id": "test-fix" })),
+                        ..Default::default()
+                    }]
+                );
+                Ok(Some(Vec::new()))
+            }
+        });
+
+    let code_actions_task = project.update(cx, |project, cx| {
+        project.code_actions(&buffer, 0..1, None, cx)
+    });
+
+    request_handled
+        .next()
+        .await
+        .expect("The code action request should have been triggered");
+    assert!(code_actions_task.await.unwrap().unwrap().is_empty());
+}
+
+#[gpui::test]
 async fn test_code_actions_without_requested_kinds_do_not_send_only_filter(
     cx: &mut gpui::TestAppContext,
 ) {


### PR DESCRIPTION
# Objective

Code action requests lost LSP `relatedInformation` because Zed stores related diagnostics as grouped buffer entries.

## Solution

Reassemble those entries on the primary diagnostic when building `CodeActionContext`, without sending overlapping related entries twice. The integration test also checks that diagnostic code and data survive the round trip.

## Testing

- `cargo test -p project test_code_actions`
- `cargo test -p project test_grouped_diagnostics`
- `cargo fmt --all -- --check`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed code actions that rely on related diagnostic information.
