### PR TITLE
collab_ui: Fix inconsistent channel icons in collab panel

### DIFF
--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -457,8 +457,8 @@ impl Item for ChannelView {
     fn tab_icon(&self, _: &Window, cx: &App) -> Option<Icon> {
         let channel = self.channel(cx)?;
         let icon = match channel.visibility {
-            ChannelVisibility::Public => IconName::Public,
-            ChannelVisibility::Members => IconName::Hash,
+            ChannelVisibility::Public => IconName::Hash,
+            ChannelVisibility::Members => IconName::Lock,
         };
 
         Some(Icon::new(icon))


### PR DESCRIPTION
# Objective

In PR #61397, the channel icons for public and private channels were updated, but the tab icon for channel notes was not covered, causing the tab icon to mismatch the channel icons shown in the collab panel, as shown below:
<img width="850" height="185" alt="before" src="https://github.com/user-attachments/assets/232a798c-122e-4ce1-9735-900fde851736" />

## Solution

Update the tab icon for channel notes to match the already-updated channel icons in the collab panel (public channels use `#`, private channels use a lock).

## Testing

Built and tested locally, with before/after comparison attached below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

| Before | After |
|:--:|:--:|
|<img width="850" height="185" alt="before" src="https://github.com/user-attachments/assets/f915f61d-4fac-451d-b930-b751e6a1035e" />|<img width="905" height="195" alt="after" src="https://github.com/user-attachments/assets/11ffe280-4416-4050-8b2d-ea5bc989c39a" />|

---

Release Notes:

- Fixed channel tab icons for public and private channels not matching the icons shown in the collab panel.