### PR TITLE
gpui: return HandleError::NotSupported from TestWindow raw handles

### DIFF
--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -49,7 +49,7 @@ impl HasWindowHandle for TestWindow {
     fn window_handle(
         &self,
     ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
-        unimplemented!("Test Windows are not backed by a real platform window")
+        Err(raw_window_handle::HandleError::NotSupported)
     }
 }
 
@@ -57,7 +57,7 @@ impl HasDisplayHandle for TestWindow {
     fn display_handle(
         &self,
     ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
-        unimplemented!("Test Windows are not backed by a real platform window")
+        Err(raw_window_handle::HandleError::NotSupported)
     }
 }
 


### PR DESCRIPTION
# Objective

`TestWindow` implemented `HasWindowHandle`/`HasDisplayHandle` with `unimplemented!()`, so any downstream code probing for a native handle (common in UI libraries installing platform hooks) panicked in every test that opened a window, with no way to catch it via the `Result` the trait already provides.

## Solution

Test windows are not backed by a real platform window. Return the error `raw-window-handle` defines for exactly this case, so callers that probe for a native handle (e.g. UI libraries installing AppKit/Win32 hooks) can gracefully skip test windows instead of panicking every test that renders them.

## Testing

This patch is being used in several new tests in https://github.com/eidola-ai/eidola and prevents hacks within our fork of `gpui-component` to run tests.

As the change is truly trivial, I didn't add any test cases here.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] ~Tests cover the new/changed behavior~ **Not necessary IMO.**
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- return HandleError::NotSupported from TestWindow raw handles instead of panicking
