### PR TITLE
project: Fix branch diff with older servers

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8798,8 +8798,10 @@ impl Repository {
                 RepositoryState::Remote(RemoteRepositoryState { client, project_id }) => {
                     let (is_merge, includes_worktree, base, head) = match diff_type {
                         DiffTreeType::MergeBase { base, head } => (true, false, base, head),
+                        // Older servers ignore `includes_worktree` and use the existing fields,
+                        // so HEAD keeps this request valid as a committed-only fallback.
                         DiffTreeType::MergeBaseWithWorktree { base } => {
-                            (true, true, base, SharedString::default())
+                            (true, true, base, "HEAD".into())
                         }
                         DiffTreeType::Since { base, head } => (false, false, base, head),
                     };


### PR DESCRIPTION
# Objective

Prevent branch diffs from failing when a server does not recognize worktree diff requests.

## Solution

Send `HEAD` as a valid committed-only fallback for servers that ignore `includes_worktree`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
