### PR TITLE
picker: Fix a phantom scrollbar at non-default UI font sizes

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -1452,7 +1452,11 @@ impl<D: PickerDelegate> Picker<D> {
             }))
     }
 
-    fn render_element_container(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_element_container(
+        &self,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         // When the picker shrinks to fit its content, the list infers its size
         // from its items. When it fills its full height (preview visible), the
         // list fills the available space.
@@ -1474,7 +1478,8 @@ impl<D: PickerDelegate> Picker<D> {
             )
             .with_sizing_behavior(sizing_behavior)
             .flex_grow_1()
-            .py_1()
+            // Rounded, as fractional padding makes a list that fits its rows scrollable by 1px.
+            .py((window.rem_size() * 0.25).round())
             .track_scroll(&scroll_handle)
             .into_any_element(),
             ElementContainer::List(state) => list(

--- a/crates/picker/src/render.rs
+++ b/crates/picker/src/render.rs
@@ -234,7 +234,7 @@ impl<D: PickerDelegate> Picker<D> {
                         )
                         .overflow_hidden()
                         .children(self.delegate.render_header(window, cx))
-                        .child(self.render_element_container(cx))
+                        .child(self.render_element_container(window, cx))
                         .when(self.show_scrollbar, |this| {
                             let base_scrollbar_config = Scrollbars::new(ScrollAxes::Vertical);
 

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -856,7 +856,8 @@ impl<T: ScrollableHandle> ScrollbarState<T> {
             .flat_map(move |axis| {
                 let max_offset = max_offset.along(axis);
                 let viewport_size = viewport_size.along(axis);
-                if max_offset.is_zero() || viewport_size.is_zero() {
+                // A scroll range under 2px is layout rounding noise, not scrollable content.
+                if max_offset < px(2.) || viewport_size.is_zero() {
                     return None;
                 }
                 let content_size = viewport_size + max_offset;


### PR DESCRIPTION
At any UI font size where 0.25rem is fractional, the picker results list's padding loses a pixel to layout snapping, which makes a list that fits its rows scrollable by that pixel: the mouse wheel nudges it, and with `show_scrollbar` enabled a full-height thumb appears. Measured on a dropdown with 3 rows: content 123px, container 133px, padding 5.5px per side, max scroll offset exactly 1px.

Two changes: the list padding rounds to whole pixels, and the shared scrollbar skips drawing a thumb for a sub-2px scroll range, so other fractional-padding scroll containers don't hit the same artifact.

Extracted from #62138 (the continuation of #62051), which builds on these two commits.

Release Notes:

- Fixed a phantom scrollbar and a one-pixel wheel scroll in picker dropdowns at non-default UI font sizes.