### PR TITLE
language_model_core: Distinguish 413 payload rejections from token overflow

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4566,7 +4566,8 @@ impl Thread {
             | PermissionError { .. }
             | NoApiKey { .. }
             | ApiEndpointNotFound { .. }
-            | PromptTooLarge { .. } => None,
+            | PromptTooLarge { .. }
+            | RequestPayloadTooLarge { .. } => None,
             // These errors might be transient, so retry them
             SerializeRequest { .. } | BuildRequestBody { .. } | StreamEndedUnexpectedly { .. } => {
                 Some(RetryStrategy::Fixed {

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -106,6 +106,13 @@ impl LanguageModelCompletionEvent {
 pub enum LanguageModelCompletionError {
     #[error("prompt too large for context window")]
     PromptTooLarge { tokens: Option<u64> },
+    /// The request body exceeded a provider or gateway size limit (HTTP 413).
+    /// Distinct from [`Self::PromptTooLarge`]: the request was rejected on
+    /// bytes, not tokens, so neither trimming the context to fewer tokens of
+    /// text nor switching to a larger context window helps — the payload
+    /// itself (typically images or other attachments) has to shrink.
+    #[error("request payload too large for {provider}'s API")]
+    RequestPayloadTooLarge { provider: LanguageModelProviderName },
     /// The model requires the user to consent to the upstream provider
     /// retaining inference logs (see `LanguageModel::requires_data_retention`)
     /// and that consent has not been given.
@@ -268,8 +275,14 @@ impl LanguageModelCompletionError {
             StatusCode::UNAUTHORIZED => Self::AuthenticationError { provider, message },
             StatusCode::FORBIDDEN => Self::PermissionError { provider, message },
             StatusCode::NOT_FOUND => Self::ApiEndpointNotFound { provider },
-            StatusCode::PAYLOAD_TOO_LARGE => Self::PromptTooLarge {
-                tokens: parse_prompt_too_long(&message),
+            StatusCode::PAYLOAD_TOO_LARGE => match parse_prompt_too_long(&message) {
+                // Providers occasionally phrase a token overflow as a 413; a
+                // stated token count identifies those as context problems
+                // rather than body-size rejections.
+                Some(tokens) => Self::PromptTooLarge {
+                    tokens: Some(tokens),
+                },
+                None => Self::RequestPayloadTooLarge { provider },
             },
             StatusCode::TOO_MANY_REQUESTS => Self::RateLimitExceeded {
                 provider,
@@ -694,6 +707,37 @@ mod tests {
         assert!(matches!(
             error,
             LanguageModelCompletionError::BadRequestFormat { .. }
+        ));
+    }
+
+    #[test]
+    fn test_from_http_status_maps_413_to_request_payload_too_large() {
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("Zed").into(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "413 Request Entity Too Large".to_string(),
+            None,
+        );
+
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::RequestPayloadTooLarge { .. }
+        ));
+
+        // A 413 whose body states a token count is a context-window overflow
+        // wearing a payload status; keep reporting it as one.
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("Anthropic").into(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "prompt is too long: 207131 tokens > 204798 maximum".to_string(),
+            None,
+        );
+
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::PromptTooLarge {
+                tokens: Some(207_131)
+            }
         ));
     }
 

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -111,8 +111,12 @@ pub enum LanguageModelCompletionError {
     /// bytes, not tokens, so neither trimming the context to fewer tokens of
     /// text nor switching to a larger context window helps — the payload
     /// itself (typically images or other attachments) has to shrink.
-    #[error("request payload too large for {provider}'s API")]
-    RequestPayloadTooLarge { provider: LanguageModelProviderName },
+    ///
+    /// `message` is the provider's response body; providers that state the
+    /// rejected size or their limit do so there. Callers know the request
+    /// they sent, so its size is theirs to report.
+    #[error("request body exceeded the provider's size limit: {message}")]
+    RequestPayloadTooLarge { message: String },
     /// The model requires the user to consent to the upstream provider
     /// retaining inference logs (see `LanguageModel::requires_data_retention`)
     /// and that consent has not been given.
@@ -282,7 +286,7 @@ impl LanguageModelCompletionError {
                 Some(tokens) => Self::PromptTooLarge {
                     tokens: Some(tokens),
                 },
-                None => Self::RequestPayloadTooLarge { provider },
+                None => Self::RequestPayloadTooLarge { message },
             },
             StatusCode::TOO_MANY_REQUESTS => Self::RateLimitExceeded {
                 provider,


### PR DESCRIPTION
`LanguageModelCompletionError` maps both HTTP 413 (request body too large) and genuine context-window overflows to `PromptTooLarge`, so consumers can't tell them apart. The distinction matters because the remedies differ: a token overflow can be addressed by compacting the conversation or moving to a larger context window, while a body-size rejection — typically a request carrying many images, which are enormous in bytes but cheap in tokens — can only be fixed by shrinking the payload itself.

This adds a `RequestPayloadTooLarge { provider }` variant and maps `PAYLOAD_TOO_LARGE` to it, with one carve-out: a 413 whose body states a token count ("prompt is too long: N tokens > M maximum") is a context problem wearing a payload status and stays `PromptTooLarge`, now carrying the parsed count. The agent's retry policy treats the new variant as non-retryable, same as `PromptTooLarge`; the agent UI's error mapping falls through to its generic arm, which renders the variant's own message ("request payload too large for {provider}'s API") — strictly more accurate than the previous "prompt too large" framing.

Testing:

- New unit test covering both sides of the 413 split; existing context-length mapping tests unchanged and passing.
- `cargo nextest run -p language_model_core`, agent retry tests, `./script/clippy`.

Release Notes:

- Improved agent error reporting to distinguish oversized request payloads from context window exhaustion.
