### PR TITLE
agent: Improve error messages when missing parameters

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -8736,3 +8736,79 @@ async fn test_mid_turn_model_and_settings_refresh(cx: &mut TestAppContext) {
     // Thinking should now be enabled.
     assert!(model_b_completions[0].thinking_allowed);
 }
+
+#[gpui::test]
+async fn test_recv_returns_serde_error_not_generic_message(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct ToolWithRequiredFields {
+        _command: String,
+        _cd: String,
+    }
+
+    let (mut sender, input): (ToolInputSender, ToolInput<ToolWithRequiredFields>) =
+        ToolInput::test();
+
+    sender.send_full(json!({"_command": "ls"}));
+
+    let error = input.recv().await.expect_err("should fail with missing field");
+    let error_message = error.to_string();
+
+    assert!(
+        error_message.contains("missing field"),
+        "Expected serde error about missing field, got: {error_message}"
+    );
+    assert!(
+        !error_message.contains("tool input was not fully received"),
+        "Should not contain generic error message, got: {error_message}"
+    );
+}
+
+#[gpui::test]
+async fn test_next_returns_serde_error_for_streaming_tools(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct StreamingToolInput {
+        _text: String,
+        _count: u32,
+    }
+
+    let (mut sender, mut input): (ToolInputSender, ToolInput<StreamingToolInput>) =
+        ToolInput::test();
+
+    sender.send_partial(json!({"_text": "hello"}));
+    sender.send_full(json!({"_text": "hello"}));
+
+    let partial = input.next().await.expect("partial should succeed");
+    assert!(matches!(partial, ToolInputPayload::Partial(_)));
+
+    let error_message = input
+        .next()
+        .await
+        .err()
+        .expect("full with missing field should fail")
+        .to_string();
+
+    assert!(
+        error_message.contains("missing field"),
+        "Expected serde error about missing field, got: {error_message}"
+    );
+}
+
+#[gpui::test]
+async fn test_recv_still_reports_channel_closed_when_no_data(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct AnyInput {
+        _value: String,
+    }
+
+    let (sender, input): (ToolInputSender, ToolInput<AnyInput>) = ToolInput::test();
+
+    drop(sender);
+
+    let error = input.recv().await.expect_err("should fail when channel closes");
+    let error_message = error.to_string();
+
+    assert!(
+        error_message.contains("tool input was not fully received"),
+        "Expected channel-closed error, got: {error_message}"
+    );
+}

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -8719,3 +8719,79 @@ async fn test_mid_turn_model_and_settings_refresh(cx: &mut TestAppContext) {
     // Thinking should now be enabled.
     assert!(model_b_completions[0].thinking_allowed);
 }
+
+#[gpui::test]
+async fn test_recv_returns_serde_error_not_generic_message(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct ToolWithRequiredFields {
+        _command: String,
+        _cd: String,
+    }
+
+    let (mut sender, input): (ToolInputSender, ToolInput<ToolWithRequiredFields>) =
+        ToolInput::test();
+
+    sender.send_full(json!({"_command": "ls"}));
+
+    let error = input.recv().await.expect_err("should fail with missing field");
+    let error_message = error.to_string();
+
+    assert!(
+        error_message.contains("missing field"),
+        "Expected serde error about missing field, got: {error_message}"
+    );
+    assert!(
+        !error_message.contains("tool input was not fully received"),
+        "Should not contain generic error message, got: {error_message}"
+    );
+}
+
+#[gpui::test]
+async fn test_next_returns_serde_error_for_streaming_tools(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct StreamingToolInput {
+        _text: String,
+        _count: u32,
+    }
+
+    let (mut sender, mut input): (ToolInputSender, ToolInput<StreamingToolInput>) =
+        ToolInput::test();
+
+    sender.send_partial(json!({"_text": "hello"}));
+    sender.send_full(json!({"_text": "hello"}));
+
+    let partial = input.next().await.expect("partial should succeed");
+    assert!(matches!(partial, ToolInputPayload::Partial(_)));
+
+    let error_message = input
+        .next()
+        .await
+        .err()
+        .expect("full with missing field should fail")
+        .to_string();
+
+    assert!(
+        error_message.contains("missing field"),
+        "Expected serde error about missing field, got: {error_message}"
+    );
+}
+
+#[gpui::test]
+async fn test_recv_still_reports_channel_closed_when_no_data(_cx: &mut TestAppContext) {
+    #[derive(Debug, Deserialize)]
+    struct AnyInput {
+        _value: String,
+    }
+
+    let (sender, input): (ToolInputSender, ToolInput<AnyInput>) = ToolInput::test();
+
+    drop(sender);
+
+    let error = input.recv().await.expect_err("should fail when channel closes");
+    let error_message = error.to_string();
+
+    assert!(
+        error_message.contains("tool input was not fully received"),
+        "Expected channel-closed error, got: {error_message}"
+    );
+}

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4950,16 +4950,16 @@ impl<T: DeserializeOwned> ToolInput<T> {
     /// Wait for the final deserialized input, ignoring all partial updates.
     /// Non-streaming tools can use this to wait until the whole input is available.
     pub async fn recv(mut self) -> Result<T> {
-        while let Ok(value) = self.next().await {
-            match value {
-                ToolInputPayload::Full(value) => return Ok(value),
-                ToolInputPayload::Partial(_) => {}
-                ToolInputPayload::InvalidJson { error_message } => {
+        loop {
+            match self.next().await {
+                Ok(ToolInputPayload::Full(value)) => return Ok(value),
+                Ok(ToolInputPayload::Partial(_)) => {}
+                Ok(ToolInputPayload::InvalidJson { error_message }) => {
                     return Err(anyhow!(error_message));
                 }
+                Err(e) => return Err(e),
             }
         }
-        Err(anyhow!("tool input was not fully received"))
     }
 
     pub async fn next(&mut self) -> Result<ToolInputPayload<T>> {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4978,16 +4978,16 @@ impl<T: DeserializeOwned> ToolInput<T> {
     /// Wait for the final deserialized input, ignoring all partial updates.
     /// Non-streaming tools can use this to wait until the whole input is available.
     pub async fn recv(mut self) -> Result<T> {
-        while let Ok(value) = self.next().await {
-            match value {
-                ToolInputPayload::Full(value) => return Ok(value),
-                ToolInputPayload::Partial(_) => {}
-                ToolInputPayload::InvalidJson { error_message } => {
+        loop {
+            match self.next().await {
+                Ok(ToolInputPayload::Full(value)) => return Ok(value),
+                Ok(ToolInputPayload::Partial(_)) => {}
+                Ok(ToolInputPayload::InvalidJson { error_message }) => {
                     return Err(anyhow!(error_message));
                 }
+                Err(e) => return Err(e),
             }
         }
-        Err(anyhow!("tool input was not fully received"))
     }
 
     pub async fn next(&mut self) -> Result<ToolInputPayload<T>> {


### PR DESCRIPTION
# Objective

When a tool call is missing a parameter (most notably, when `terminal` is missing its `cd` parameter), then the feedback given to the model is very minimal, just a "tool input was not fully received" message.

However, Serde already knows what the real error is, so we just need to propagate it to the model in the tool call response.

## Solution

Instead of throwing out the error message from Serde and replacing it with a static one, use the Serde message as part of the tool call response.

I'm not familiar with Rust, but I have reviewed the code and it looks good to me. Claude Opus 4.6 wrote the entirety of this code. I have included my prompt as a transcript in the commit message for posterity.

## Testing

I ran a GitHub Actions workflow to build a Zed Dev build on macOS aarch64. Then I also built an aarch64 Linux remote server build and copied it to a remote server. I tested this with a simple prompt: "Try calling the terminal tool to `pwd` without and then with the `cd` parameter"

The result follows:

<details>
<summary>Markdown logs of the thread</summary>

    ## User
    
    Try calling the terminal tool to `pwd` without and then with the `cd` parameter
    
    ## Assistant
    
    <thinking>
    The user wants me to try calling the terminal tool with `pwd` - once without the `cd` parameter and once with it. Let me do both.
    </thinking>
    
    Let me try both. First, without `cd`:
    
    **Tool Call: **
    Status: Failed
    
    missing field `cd`
    
    ## Assistant
    
    <thinking>
    As expected, the tool requires the `cd` parameter. Let me now try with `cd` set to one of the project root directories.
    </thinking>
    
    As expected — the `cd` parameter is required. Now with it:
    
    **Tool Call: pwd**
    Status: Completed
    
    ```
    /home/tanner.guest/whyhc
    ```
    
    ## Assistant
    
    <thinking>
    Both calls confirm: the `cd` parameter is mandatory (the first call fails without it), and when provided, the command runs in the specified working directory.
    </thinking>
    
    That confirms it: the `cd` parameter is **mandatory** — without it, the call fails with `missing field 'cd'`. When provided with `/home/tanner.guest/whyhc`, `pwd` correctly reports that as the working directory.
    
    ## User (checkpoint)
    
    Test out a few other tools with and without the required parameters. Especially try testing tools that have multiple required parameters and leaving multiple of them out.
    
    ## Assistant
    
    <thinking>
    The user wants me to systematically test various tools by calling them with missing required parameters to see how the error messages behave. Let me test a variety of tools with different parameter patterns.
    
    Let me test:
    1. `read_file` - has one required parameter (`path`)
    2. `write_file` - has two required parameters (`path`, `content`)
    3. `edit_file` - has two required parameters (`path`, `edits`)
    4. `grep` - has one required parameter (`regex`)
    5. `find_path` - has one required parameter (`glob`)
    6. `move_path` - has two required parameters (`source_path`, `destination_path`)
    7. `copy_path` - has two required parameters (`source_path`, `destination_path`)
    8. `delete_path` - has one required parameter (`path`)
    9. `create_directory` - has one required parameter (`path`)
    10. `fetch` - has one required parameter (`url`)
    11. `diagnostics` - has no required parameters
    12. `skill` - has one required parameter (`name`)
    13. `spawn_agent` - has two required parameters (`label`, `message`)
    
    I should test:
    - No parameters at all
    - Some parameters but missing one required
    - Multiple required parameters missing
    
    Let me call several in parallel.
    </thinking>
    
    Let me test a variety of tools with missing required parameters. I'll try several in parallel:
    
    **Tool Call: Read file**
    Status: Failed
    
    ```json
    {
      "Text": "missing field `path`"
    }
    ```
    
    **Tool Call: Writing file**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Search with regex**
    Status: Failed
    
    missing field `regex`
    
    **Tool Call: Editing file**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Spawning agent**
    Status: Failed
    
    ```json
    {
      "error": "missing field `label`",
      "session_info": null
    }
    ```
    
    **Tool Call: Skill**
    Status: Failed
    
    ```json
    {
      "error": "missing field `name`"
    }
    ```
    
    ## Assistant
    
    <thinking>
    Interesting - all of them give "missing field" errors. Now let me test tools with multiple required parameters to see if they report all missing fields or just the first one. Let me also test `move_path`, `copy_path`, `delete_path`, `create_directory`, `fetch`, `find_path`, and `diagnostics`.
    </thinking>
    
    All report `missing field` for the first missing parameter. Now let me test tools with multiple required params by omitting **both**:
    
    **Tool Call: Writing file**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Editing file**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Move path**
    Status: Failed
    
    missing field `source_path`
    
    **Tool Call: Copy path**
    Status: Failed
    
    missing field `source_path`
    
    **Tool Call: test**
    Status: Failed
    
    ```json
    {
      "error": "missing field `message`",
      "session_info": null
    }
    ```
    
    ## Assistant
    
    <thinking>
    Key findings so far:
    1. When no required params are given, the error lists only the first missing field (e.g., `path` for write_file even though both `path` and `content` are required).
    2. When some required params are given but others are missing, it reports the next missing one.
    3. Error format varies: most tools return a plain string `"missing field 'X'"`, while `spawn_agent` returns a JSON object with an `error` field and `session_id: null`.
    4. `write_file` and `edit_file` append "No edits were made." to their error messages.
    
    Let me test a few more: `diagnostics` (no required params), `delete_path`, `create_directory`, `fetch`, and `find_path`.
    </thinking>
    
    Interesting patterns. Now let me test tools with no required params vs. single-required-param tools:
    
    **Tool Call: Check project diagnostics**
    Status: Completed
    
    Diagnostics successfully refreshed.
    
    No errors or warnings found in the project.
    
    **Tool Call: Delete path**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Create directory**
    Status: Failed
    
    missing field `path`
    
    **Tool Call: Fetch URL**
    Status: Failed
    
    missing field `url`
    
    **Tool Call: Find paths**
    Status: Failed
    
    ```json
    {
      "error": "missing field `glob`"
    }
    ```
    
    **Tool Call: List directory**
    Status: Failed
    
    missing field `path`
    
    ## Assistant
    
    <thinking>
    Now let me test one more edge case: `copy_path` and `move_path` with only the first param, and `edit_file`/`write_file` with only `path`.
    </thinking>
    
    Now let me test giving only `path` to tools that need more:
    
    **Tool Call: /tmp/test.txt**
    Status: Failed
    
    Can't create file: parent directory doesn't exist
    
    ## Assistant
    
    <thinking>
    Interesting! When `path` is provided but `content` is missing, it actually tries to validate the path and checks if the parent directory exists. So it's not just a simple "missing field" check - it validates the provided fields first. Let me try with a valid path within the project.
    
    Actually, I think what's happening is: it validates the path parameter first, but since `/tmp/test.txt` is outside the project roots, it rejects with a different error. Let me try a path inside the project.
    </thinking>
    
    That gave a different error! Let me try with a valid project path:
    
    **Tool Call: test.txt**
    Status: Failed
    
    missing field `content`
    
    ## Assistant
    
    <thinking>
    There we go. So the validation is: first validate that the path exists within the project root, then check that `content` is provided. Here's a summary of findings:
    
    1. **Single required param tools** (`read_file`, `grep`, `find_path`, `delete_path`, `create_directory`, `fetch`, `skill`, `list_directory`): Return `"missing field '<param>'"` when called with no parameters.
    
    2. **Multi required param tools** (`write_file`, `edit_file`, `move_path`, `copy_path`, `spawn_agent`): 
       - Report only the **first** missing required field in schema order
       - `write_file` and `edit_file` append "No edits were made."
       - `spawn_agent` returns JSON `{"session_id": null, "error": "missing field '<param>'"}`
       - `copy_path`/`move_path` report the first missing field (`source_path`)
    
    3. **Path validation runs before content validation**: When `path` is provided but `content` is missing for `write_file`, the path is validated first — if outside project roots, you get a path error; if valid, you get `missing field 'content'`.
    
    4. **No required params tools** (`diagnostics`): Works fine with no params — returns diagnostics for the whole project.
    
    That's a thorough exploration! Let me summarize.
    </thinking>
    
    Now that's interesting — path validation happens before `content` is checked. Here's a summary of findings:
    
    ## Tool Parameter Validation Behavior
    
    ### Single required-param tools
    Tools like `read_file`, `grep`, `find_path`, `delete_path`, `create_directory`, `fetch`, `skill`, `list_directory` all return a simple string: `missing field '<param>'` when called empty.
    
    ### Multi required-param tools
    - **`write_file` / `edit_file`**: Reports only the **first** missing field in schema order, appending `"No edits were made."`. But if `path` is provided (and valid), it validates that before checking `content`.
    - **`move_path` / `copy_path`**: Reports the first missing field (`source_path`).
    - **`spawn_agent`**: Returns **JSON** format: `{"session_id": null, "error": "missing field '<param>'"}` — distinct from the plain-string format of all other tools.
    
    ### Path validation is staged
    When I gave `write_file` a `path` but no `content`, it first checked whether the path was valid (outside-project paths get rejected with `"parent directory doesn't exist"`), only then did it report `missing field 'content'`. Validation order is: path existence → other required fields.
    
    ### No-required-params tools
    `diagnostics` works fine with zero parameters — runs project-wide.
    
    ### Key takeaway
    You only ever get told about **one** missing field at a time — the first one the validator encounters. No bulk "you're missing X, Y, and Z" feedback. And `spawn_agent` is the odd one out with its JSON error format.

</details>

There's at least one drawback to this solution: it only reports the first missing field, not multiple (as evidenced in the above thread transcript).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved tool call response error messages when an invalid or incomplete response is given by the model.
