### PR TITLE
project: Compare WorktreePaths by pairing, not by path sets

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -150,28 +150,6 @@ impl WorktreePaths {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_worktree_paths_equality_compares_pairings() {
-        let main_paths = PathList::new(&[PathBuf::from("/main-a"), PathBuf::from("/main-b")]);
-        let first = WorktreePaths::from_path_lists(
-            main_paths.clone(),
-            PathList::new(&[PathBuf::from("/wt-x"), PathBuf::from("/wt-y")]),
-        )
-        .unwrap();
-        let second = WorktreePaths::from_path_lists(
-            main_paths,
-            PathList::new(&[PathBuf::from("/wt-y"), PathBuf::from("/wt-x")]),
-        )
-        .unwrap();
-
-        assert_ne!(first, second);
-    }
-}
-
 enum WorktreeStoreState {
     Local {
         fs: Arc<dyn Fs>,

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -50,7 +50,7 @@ pub struct WorktreePaths {
 
 impl PartialEq for WorktreePaths {
     fn eq(&self, other: &Self) -> bool {
-        self.paths == other.paths && self.main_paths == other.main_paths
+        self.ordered_pairs().eq(other.ordered_pairs())
     }
 }
 
@@ -147,6 +147,28 @@ impl WorktreePaths {
             .unzip();
         self.main_paths = PathList::new(&mains);
         self.paths = PathList::new(&folders);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_worktree_paths_equality_compares_pairings() {
+        let main_paths = PathList::new(&[PathBuf::from("/main-a"), PathBuf::from("/main-b")]);
+        let first = WorktreePaths::from_path_lists(
+            main_paths.clone(),
+            PathList::new(&[PathBuf::from("/wt-x"), PathBuf::from("/wt-y")]),
+        )
+        .unwrap();
+        let second = WorktreePaths::from_path_lists(
+            main_paths,
+            PathList::new(&[PathBuf::from("/wt-y"), PathBuf::from("/wt-x")]),
+        )
+        .unwrap();
+
+        assert_ne!(first, second);
     }
 }
 


### PR DESCRIPTION
# Objective

- Prevent changed main/folder associations from being skipped during thread metadata updates.

## Solution

- Compare WorktreePaths as ordered main/folder pairs.
- Keep PathList equality order-insensitive.

## Testing

- cargo test -p project test_worktree_paths_equality_compares_pairings

## Self-Review Checklist:

- [x] I have reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
