### PR TITLE
sidebar: Avoid repeated workspace scans while rendering

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -392,6 +392,7 @@ impl ThreadEntry {
 enum ListEntry {
     ProjectHeader {
         key: ProjectGroupKey,
+        workspaces: Arc<[Entity<Workspace>]>,
         label: SharedString,
         highlight_positions: Vec<usize>,
         has_running_threads: bool,
@@ -439,10 +440,10 @@ impl ListEntry {
         }
     }
 
-    fn reachable_workspaces<'a>(
-        &'a self,
-        multi_workspace: &'a workspace::MultiWorkspace,
-        cx: &'a App,
+    fn reachable_workspaces(
+        &self,
+        _multi_workspace: &workspace::MultiWorkspace,
+        _cx: &App,
     ) -> Vec<Entity<Workspace>> {
         match self {
             ListEntry::Thread(thread) => match &thread.workspace {
@@ -453,9 +454,7 @@ impl ListEntry {
                 ThreadEntryWorkspace::Open(workspace) => vec![workspace.clone()],
                 ThreadEntryWorkspace::Closed { .. } => Vec::new(),
             },
-            ListEntry::ProjectHeader { key, .. } => {
-                multi_workspace.workspaces_for_project_group(key, cx)
-            }
+            ListEntry::ProjectHeader { workspaces, .. } => workspaces.to_vec(),
         }
     }
 }
@@ -1884,6 +1883,7 @@ impl Sidebar {
                 project_header_indices.push(entries.len());
                 entries.push(ListEntry::ProjectHeader {
                     key: group_key.clone(),
+                    workspaces: Arc::from(group_workspaces.as_slice()),
                     label,
                     highlight_positions: workspace_highlight_positions,
                     has_running_threads,
@@ -1930,6 +1930,7 @@ impl Sidebar {
                 project_header_indices.push(entries.len());
                 entries.push(ListEntry::ProjectHeader {
                     key: group_key.clone(),
+                    workspaces: Arc::from(group_workspaces.as_slice()),
                     label,
                     highlight_positions: Vec::new(),
                     has_running_threads,
@@ -2185,6 +2186,7 @@ impl Sidebar {
         let rendered = match entry {
             ListEntry::ProjectHeader {
                 key,
+                workspaces,
                 label,
                 highlight_positions,
                 has_running_threads,
@@ -2202,6 +2204,7 @@ impl Sidebar {
                     ix,
                     false,
                     key,
+                    workspaces.clone(),
                     label,
                     highlight_positions,
                     *has_running_threads,
@@ -2261,6 +2264,7 @@ impl Sidebar {
         ix: usize,
         is_sticky: bool,
         key: &ProjectGroupKey,
+        workspaces: Arc<[Entity<Workspace>]>,
         label: &SharedString,
         highlight_positions: &[usize],
         has_running_threads: bool,
@@ -2416,7 +2420,14 @@ impl Sidebar {
                     .gap_px()
                     .pr_1p5()
                     .children(opaque_window.then(|| gradient_overlay()))
-                    .child(self.render_new_thread_button(ix, id_prefix, key, &group_name, cx))
+                    .child(self.render_new_thread_button(
+                        ix,
+                        id_prefix,
+                        key,
+                        workspaces,
+                        &group_name,
+                        cx,
+                    ))
                     .child(self.render_project_header_ellipsis_menu(
                         ix,
                         id_prefix,
@@ -2482,6 +2493,7 @@ impl Sidebar {
         ix: usize,
         id_prefix: &str,
         key: &ProjectGroupKey,
+        open_workspaces: Arc<[Entity<Workspace>]>,
         group_name: &SharedString,
         cx: &mut Context<Self>,
     ) -> AnyElement {
@@ -2501,12 +2513,6 @@ impl Sidebar {
         .selected_style(ButtonStyle::Tinted(TintColor::Accent))
         .icon_size(IconSize::Small)
         .when(!is_menu_open, |this| this.visible_on_hover(group_name));
-
-        let open_workspaces = self
-            .multi_workspace
-            .upgrade()
-            .map(|mw| mw.read(cx).workspaces_for_project_group(key, cx))
-            .unwrap_or_default();
 
         if open_workspaces.is_empty() {
             let key = key.clone();
@@ -3160,6 +3166,7 @@ impl Sidebar {
 
         let ListEntry::ProjectHeader {
             key,
+            workspaces,
             label,
             highlight_positions,
             has_running_threads,
@@ -3179,6 +3186,7 @@ impl Sidebar {
             header_idx,
             true,
             key,
+            workspaces.clone(),
             &label,
             &highlight_positions,
             *has_running_threads,

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1158,6 +1158,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
             // Expanded project header
             ListEntry::ProjectHeader {
                 key: ProjectGroupKey::new(None, expanded_path.clone()),
+                workspaces: Arc::from([workspace.clone()]),
                 label: "expanded-project".into(),
                 highlight_positions: Vec::new(),
                 has_running_threads: false,
@@ -1305,6 +1306,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
             // Collapsed project header
             ListEntry::ProjectHeader {
                 key: ProjectGroupKey::new(None, collapsed_path.clone()),
+                workspaces: Arc::from([]),
                 label: "collapsed-project".into(),
                 highlight_positions: Vec::new(),
                 has_running_threads: false,
@@ -6669,6 +6671,11 @@ async fn test_threadless_workspace_shows_new_thread_with_worktree_chip(cx: &mut 
     multi_workspace.update_in(cx, |mw, window, cx| {
         mw.test_add_workspace(project_b.clone(), window, cx);
     });
+    let workspace_ids = multi_workspace.read_with(cx, |mw, _| {
+        mw.workspaces()
+            .map(|workspace| workspace.entity_id())
+            .collect::<HashSet<_>>()
+    });
     let sidebar = setup_sidebar(&multi_workspace, cx);
 
     // Only save a thread for workspace A.
@@ -6676,6 +6683,27 @@ async fn test_threadless_workspace_shows_new_thread_with_worktree_chip(cx: &mut 
 
     multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
     cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _| {
+        let headers = sidebar
+            .contents
+            .entries
+            .iter()
+            .filter_map(|entry| match entry {
+                ListEntry::ProjectHeader { workspaces, .. } => Some(workspaces),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(headers.len(), 1, "expected one project header");
+        assert_eq!(
+            headers[0]
+                .iter()
+                .map(|workspace| workspace.entity_id())
+                .collect::<HashSet<_>>(),
+            workspace_ids,
+            "project header should cache both open workspaces"
+        );
+    });
 
     // Workspace A's thread appears normally. Workspace B (threadless)
     // appears as a "New Thread" button with its worktree chip.
@@ -8312,9 +8340,11 @@ async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppCon
     let sidebar = setup_sidebar(&multi_workspace, cx);
     let main_workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
-    let _worktree_workspace = multi_workspace.update_in(cx, |mw, window, cx| {
-        mw.test_add_workspace(worktree_project.clone(), window, cx)
-    });
+    let worktree_workspace_id = multi_workspace
+        .update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(worktree_project.clone(), window, cx)
+        })
+        .entity_id();
 
     // Save a thread for the main project.
     save_thread_metadata(
@@ -8400,6 +8430,17 @@ async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppCon
         1,
         "linked worktree workspace should be removed after archiving its last thread"
     );
+    sidebar.read_with(cx, |sidebar, _| {
+        assert!(
+            sidebar.contents.entries.iter().all(|entry| match entry {
+                ListEntry::ProjectHeader { workspaces, .. } => workspaces
+                    .iter()
+                    .all(|workspace| workspace.entity_id() != worktree_workspace_id),
+                _ => true,
+            }),
+            "project headers should not cache a removed workspace"
+        );
+    });
 
     multi_workspace.read_with(cx, |mw, _| {
         assert_eq!(


### PR DESCRIPTION
# Objective

Each project-header render called `MultiWorkspace::workspaces_for_project_group`, repeatedly scanning retained workspaces and reconstructing worktree-based project-group keys. Workspaces with many agent worktrees amplify that render-time work into sustained CPU usage.

## Solution

Store the workspace slice already produced while rebuilding each `ListEntry::ProjectHeader`. Ordinary and sticky project-header rendering, including the new-thread menu, now reuse that cached slice instead of rescanning the multi-workspace collection.

The shared `workspaces_for_project_group` lookup remains unchanged for non-render callers.

## Testing

macOS with runtime shaders:

- `cargo fmt --all -- --check`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_threadless_workspace_shows_new_thread_with_worktree_chip -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_linked_worktree_workspace_reachable_after_adding_unrelated_project -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_archive_last_worktree_thread_removes_workspace -- --nocapture`
- `./script/clippy -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders`
- `git diff --check`
- `sample <pid> 10 1` against the locally built debug Zed while the sidebar was actively rendering: 19 `render_project_header` samples and no `workspaces_for_project_group` samples. The remaining project-group derivation occurred during `rebuild_contents`, where the cache is populated.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed high CPU usage when the project sidebar contains many agent worktrees.
