### PR TITLE
deps: Bump pathfinder_simd & fix upcoming rustc warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6115,7 +6115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7336,7 +7336,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11314,7 +11314,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11751,7 +11751,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15959,7 +15959,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17427,7 +17427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -18568,7 +18568,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -21590,7 +21590,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,9 +4592,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -5306,7 +5306,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6115,7 +6115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7336,7 +7336,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10278,9 +10278,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.17.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linkify"
@@ -10293,9 +10293,9 @@ dependencies = [
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -11314,7 +11314,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11751,7 +11751,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15959,7 +15959,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17427,7 +17427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18568,7 +18568,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21590,7 +21590,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12889,9 +12889,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -589,7 +589,7 @@ core-video = { version = "0.5.2", features = ["metal"] }
 cpal = "0.17"
 crash-handler = "0.7"
 criterion = { version = "0.5", features = ["html_reports"] }
-ctor = "1.0.6"
+ctor = "1.0.12"
 dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "1b461b310481d01e02b2603c16d7144b926339f8" }
 dashmap = "6.0"
 derive_more = { version = "2.1.1", features = [

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -918,7 +918,7 @@ impl ConfigureContextServerModal {
                         )
                         .key_binding(
                             KeyBinding::for_action_in(&menu::Cancel, &focus_handle, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(
                             cx.listener(|this, _event, _window, cx| this.cancel(&menu::Cancel, cx)),
@@ -929,7 +929,7 @@ impl ConfigureContextServerModal {
                             .disabled(is_busy)
                             .key_binding(
                                 KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(|this, _event, _window, cx| {
                                 this.confirm(&menu::Confirm, cx)

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -926,7 +926,7 @@ impl ManageProfilesModal {
                                                     &self.focus_handle,
                                                     cx,
                                                 )
-                                                .size(rems_from_px(12.)),
+                                                .size(rems_from_px(12_f32)),
                                             ),
                                         )
                                         .on_click({
@@ -974,7 +974,7 @@ impl Render for ManageProfilesModal {
                     .end_slot(
                         div().child(
                             KeyBinding::for_action_in(&menu::Cancel, &self.focus_handle, cx)
-                                .size(rems_from_px(12.)),
+                                .size(rems_from_px(12_f32)),
                         ),
                     )
                     .on_click({

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -833,7 +833,7 @@ fn render_diff_hunk_controls(
                 .disabled(is_created_file)
                 .key_binding(
                     KeyBinding::for_action_in(&Reject, &editor.read(cx).focus_handle(cx), cx)
-                        .map(|kb| kb.size(rems_from_px(12.))),
+                        .map(|kb| kb.size(rems_from_px(12_f32))),
                 )
                 .on_click({
                     let editor = editor.clone();
@@ -856,7 +856,7 @@ fn render_diff_hunk_controls(
             Button::new(("keep", row as u64), "Keep")
                 .key_binding(
                     KeyBinding::for_action_in(&Keep, &editor.read(cx).focus_handle(cx), cx)
-                        .map(|kb| kb.size(rems_from_px(12.))),
+                        .map(|kb| kb.size(rems_from_px(12_f32))),
                 )
                 .on_click({
                     let editor = editor.clone();
@@ -1161,7 +1161,7 @@ impl Render for AgentDiffToolbar {
                                             &editor_focus_handle,
                                             cx,
                                         )
-                                        .map(|kb| kb.size(rems_from_px(12.)))
+                                        .map(|kb| kb.size(rems_from_px(12_f32)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&RejectAll, window, cx)
@@ -1175,7 +1175,7 @@ impl Render for AgentDiffToolbar {
                                             &editor_focus_handle,
                                             cx,
                                         )
-                                        .map(|kb| kb.size(rems_from_px(12.)))
+                                        .map(|kb| kb.size(rems_from_px(12_f32)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&KeepAll, window, cx)
@@ -1253,7 +1253,7 @@ impl Render for AgentDiffToolbar {
                                 Button::new("reject-all", "Reject All")
                                     .key_binding({
                                         KeyBinding::for_action_in(&RejectAll, &focus_handle, cx)
-                                            .map(|kb| kb.size(rems_from_px(12.)))
+                                            .map(|kb| kb.size(rems_from_px(12_f32)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&RejectAll, window, cx)
@@ -1263,7 +1263,7 @@ impl Render for AgentDiffToolbar {
                                 Button::new("keep-all", "Keep All")
                                     .key_binding({
                                         KeyBinding::for_action_in(&KeepAll, &focus_handle, cx)
-                                            .map(|kb| kb.size(rems_from_px(12.)))
+                                            .map(|kb| kb.size(rems_from_px(12_f32)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&KeepAll, window, cx)

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -62,7 +62,7 @@ impl RenderOnce for AgentRegistryCard {
                 .p_3()
                 .mt_4()
                 .w_full()
-                .min_h(rems_from_px(86.))
+                .min_h(rems_from_px(86_f32))
                 .gap_2()
                 .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
                 .border_1()
@@ -241,7 +241,7 @@ impl AgentRegistryPage {
         h_flex()
             .key_context(key_context)
             .h_8()
-            .min_w(rems_from_px(384.))
+            .min_w(rems_from_px(384_f32))
             .flex_1()
             .pl_1p5()
             .pr_2()
@@ -635,7 +635,7 @@ impl Render for AgentRegistryPage {
                                         ],
                                     )
                                     .style(ToggleButtonGroupStyle::Outlined)
-                                    .size(ToggleButtonGroupSize::Custom(rems_from_px(30.)))
+                                    .size(ToggleButtonGroupSize::Custom(rems_from_px(30_f32)))
                                     .label_size(LabelSize::Default)
                                     .auto_width()
                                     .selected_index(match self.filter {

--- a/crates/agent_ui/src/conversation_view/elicitation.rs
+++ b/crates/agent_ui/src/conversation_view/elicitation.rs
@@ -1457,7 +1457,7 @@ impl<'a> ElicitationCard<'a> {
             .colors()
             .element_background
             .blend(cx.theme().colors().editor_foreground.opacity(0.025));
-        let tool_name_font_size = rems_from_px(13.);
+        let tool_name_font_size = rems_from_px(13_f32);
         let is_pending = matches!(&self.elicitation.status, ElicitationStatus::Pending { .. });
         let is_accepted_url = matches!(
             (&self.elicitation.status, &self.elicitation.request.mode),
@@ -1715,7 +1715,7 @@ impl<'a> ElicitationCard<'a> {
                                     self.entry_ix, option.value
                                 )))
                                 .w_full()
-                                .min_h(rems_from_px(28.))
+                                .min_h(rems_from_px(28_f32))
                                 .items_start()
                                 .gap_1p5()
                                 .rounded_sm()
@@ -1782,7 +1782,7 @@ impl<'a> ElicitationCard<'a> {
                 h_flex()
                     .id(option_id)
                     .w_full()
-                    .min_h(rems_from_px(28.))
+                    .min_h(rems_from_px(28_f32))
                     .items_start()
                     .gap_1p5()
                     .rounded_sm()
@@ -1925,7 +1925,7 @@ impl<'a> ElicitationCard<'a> {
             .min_w_0()
             .items_start()
             .child(
-                div().h(rems_from_px(16.)).flex().items_center().child(
+                div().h(rems_from_px(16_f32)).flex().items_center().child(
                     Icon::new(IconName::Link)
                         .size(IconSize::XSmall)
                         .color(Color::Muted),

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6481,9 +6481,9 @@ impl ThreadView {
 
         let primary = if is_indented {
             let line_top = if is_first_indented {
-                rems_from_px(-12.0)
+                rems_from_px(-12.0_f32)
             } else {
-                rems_from_px(0.0)
+                rems_from_px(0.0_f32)
             };
 
             div()
@@ -6494,7 +6494,7 @@ impl ThreadView {
                 .child(
                     div()
                         .absolute()
-                        .left(rems_from_px(18.0))
+                        .left(rems_from_px(18.0_f32))
                         .top(line_top)
                         .bottom_0()
                         .w_px()

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3671,7 +3671,7 @@ impl ThreadView {
                     .label_size(LabelSize::Small)
                     .key_binding(
                         KeyBinding::for_action(&ClearMessageQueue, cx)
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                     )
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.clear_queue(cx);
@@ -4180,7 +4180,7 @@ impl ThreadView {
                             })
                             .key_binding(
                                 KeyBinding::for_action_in(&RejectAll, &focus_handle.clone(), cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.reject_all(&RejectAll, window, cx);
@@ -4195,7 +4195,7 @@ impl ThreadView {
                             })
                             .key_binding(
                                 KeyBinding::for_action_in(&KeepAll, &focus_handle, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.keep_all(&KeepAll, window, cx);
@@ -4460,7 +4460,7 @@ impl ThreadView {
             .when(is_next, |this| {
                 this.key_binding(
                     KeyBinding::for_action_in(&ToggleSteerFirstQueuedMessage, &focus_handle, cx)
-                        .map(|kb| kb.size(rems_from_px(12.))),
+                        .map(|kb| kb.size(rems_from_px(12_f32))),
                 )
             })
             .tooltip(move |_window, cx| {
@@ -4504,10 +4504,10 @@ impl ThreadView {
                 };
 
                 let editor_focused = editor.focus_handle(cx).is_focused(_window);
-                let keybinding_size = rems_from_px(12.);
+                let keybinding_size = rems_from_px(12_f32);
                 let steer_on = entry.steer;
 
-                let min_width = rems_from_px(160.);
+                let min_width = rems_from_px(160_f32);
 
                 h_flex()
                     .group("queue_entry")
@@ -7329,7 +7329,7 @@ impl ThreadView {
         h_flex()
             .id("generating-spinner")
             .py_2()
-            .px(rems_from_px(22.))
+            .px(rems_from_px(22_f32))
             .gap_2()
             .map(|this| {
                 if confirmation {
@@ -7756,8 +7756,8 @@ impl ThreadView {
 
         let mut style =
             MarkdownStyle::themed(MarkdownFont::Agent, window, cx).with_agent_buffer_font(cx);
-        style.container_style.text.font_size = Some(rems_from_px(12.).into());
-        style.container_style.text.line_height = Some(rems_from_px(17.).into());
+        style.container_style.text.font_size = Some(rems_from_px(12_f32).into());
+        style.container_style.text.line_height = Some(rems_from_px(17_f32).into());
         style.height_is_multiple_of_line_height = true;
         // Soft-wrap the command instead of horizontally scrolling it: the card is
         // narrow, and in scroll mode a long command wraps anyway but its wrapped
@@ -8458,7 +8458,7 @@ impl ThreadView {
                             .justify_between()
                             .when(use_card_layout, |this| {
                                 this.p_0p5()
-                                    .rounded_t(rems_from_px(5.))
+                                    .rounded_t(rems_from_px(5_f32))
                                     .bg(self.tool_card_header_bg(cx))
                             })
                             .child(self.render_tool_call_label(
@@ -8599,7 +8599,7 @@ impl ThreadView {
                                                 .label_size(LabelSize::Small)
                                                 .key_binding(
                                                     KeyBinding::for_action_in(&OpenExcerpts, &tool_call_output_focus_handle, cx)
-                                                        .map(|s| s.size(rems_from_px(12.))),
+                                                        .map(|s| s.size(rems_from_px(12_f32))),
                                                 )
                                                 .on_click(|_, window, cx| {
                                                     window.dispatch_action(
@@ -9474,7 +9474,7 @@ impl ThreadView {
                                         focus_handle,
                                         cx,
                                     )
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                                 )
                             })
                             .on_click(cx.listener({
@@ -9506,7 +9506,7 @@ impl ThreadView {
                                         focus_handle,
                                         cx,
                                     )
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                                 )
                             })
                             .on_click(cx.listener({
@@ -9560,7 +9560,7 @@ impl ThreadView {
                                 &self.focus_handle(cx),
                                 cx,
                             )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                     }),
             )
@@ -9650,7 +9650,7 @@ impl ThreadView {
                                 &self.focus_handle(cx),
                                 cx,
                             )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                     }),
             )
@@ -9880,7 +9880,7 @@ impl ThreadView {
 
                         this.key_binding(
                             KeyBinding::for_action_in(action, focus_handle, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                     })
                     .label_size(LabelSize::Small)
@@ -10047,7 +10047,7 @@ impl ThreadView {
             .when(has_location || use_card_layout, |this| this.px_1())
             .when(has_location, |this| {
                 this.cursor(CursorStyle::PointingHand)
-                    .rounded(rems_from_px(3.)) // Concentric border radius
+                    .rounded(rems_from_px(3_f32)) // Concentric border radius
                     .hover(|s| s.bg(cx.theme().colors().element_hover.opacity(0.5)))
             })
             .overflow_hidden()
@@ -10991,7 +10991,7 @@ impl ThreadView {
     }
 
     fn tool_name_font_size(&self) -> Rems {
-        rems_from_px(13.)
+        rems_from_px(13_f32)
     }
 
     fn provider_by_name(name: &SharedString, cx: &App) -> Option<Arc<dyn LanguageModelProvider>> {

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -237,7 +237,7 @@ impl<T: 'static> Render for PromptEditor<T> {
                             div()
                                 .size_full()
                                 .min_w_0()
-                                .pt(rems_from_px(3.))
+                                .pt(rems_from_px(3_f32))
                                 .pl_0p5()
                                 .flex_1()
                                 .border_t_1()

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -117,8 +117,8 @@ impl<T: 'static> Render for PromptEditor<T> {
         };
 
         let bottom_padding = match &self.mode {
-            PromptEditorMode::Buffer { .. } => rems_from_px(2.0),
-            PromptEditorMode::Terminal { .. } => rems_from_px(4.0),
+            PromptEditorMode::Buffer { .. } => rems_from_px(2.0_f32),
+            PromptEditorMode::Terminal { .. } => rems_from_px(4.0_f32),
         };
 
         buttons.extend(self.render_buttons(window, cx));

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -799,7 +799,7 @@ impl PickerDelegate for ProfilePickerDelegate {
                                         &focus_handle,
                                         cx,
                                     )
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                                 )
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -582,7 +582,7 @@ impl Render for ThreadImportModal {
                         Section::new().child(
                             v_flex()
                                 .id("thread-import-agent-list")
-                                .max_h(rems_from_px(320.))
+                                .max_h(rems_from_px(320_f32))
                                 .pb_1()
                                 .overflow_y_scroll()
                                 .when(has_agents, |this| this.children(agent_rows))
@@ -627,7 +627,7 @@ impl Render for ThreadImportModal {
                                     .disabled(disabled_import_thread)
                                     .key_binding(
                                         KeyBinding::for_action(&menu::SecondaryConfirm, cx)
-                                            .map(|kb| kb.size(rems_from_px(12.))),
+                                            .map(|kb| kb.size(rems_from_px(12_f32))),
                                     )
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.import_threads(&menu::SecondaryConfirm, window, cx);

--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -243,7 +243,7 @@ impl RenderOnce for ModelSelectorFooter {
                     .style(ButtonStyle::Outlined)
                     .key_binding(
                         KeyBinding::for_action_in(action.as_ref(), &focus_handle, cx)
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                     )
                     .on_click(move |_, window, cx| {
                         window.dispatch_action(action.boxed_clone(), cx);

--- a/crates/agent_ui/src/ui/sandbox_status_tooltip.rs
+++ b/crates/agent_ui/src/ui/sandbox_status_tooltip.rs
@@ -191,7 +191,7 @@ impl RenderOnce for SandboxStatusTooltip {
         };
 
         v_flex()
-            .w(rems_from_px(280.))
+            .w(rems_from_px(280_f32))
             .gap_1()
             .child(Label::new("Sandboxing"))
             .child(content)

--- a/crates/ai_onboarding/src/ai_onboarding.rs
+++ b/crates/ai_onboarding/src/ai_onboarding.rs
@@ -86,8 +86,8 @@ impl ZedAiOnboarding {
         div().absolute().bottom_1().right_1().child(
             Vector::new(
                 VectorName::ProUserStamp,
-                rems_from_px(156.),
-                rems_from_px(60.),
+                rems_from_px(156_f32),
+                rems_from_px(60_f32),
             )
             .color(Color::Custom(cx.theme().colors().text_accent.alpha(0.8))),
         )
@@ -97,8 +97,8 @@ impl ZedAiOnboarding {
         div().absolute().bottom_1().right_1().child(
             Vector::new(
                 VectorName::ProTrialStamp,
-                rems_from_px(156.),
-                rems_from_px(60.),
+                rems_from_px(156_f32),
+                rems_from_px(60_f32),
             )
             .color(Color::Custom(cx.theme().colors().text.alpha(0.8))),
         )
@@ -108,8 +108,8 @@ impl ZedAiOnboarding {
         div().absolute().bottom_1().right_1().child(
             Vector::new(
                 VectorName::BusinessStamp,
-                rems_from_px(156.),
-                rems_from_px(60.),
+                rems_from_px(156_f32),
+                rems_from_px(60_f32),
             )
             .color(Color::Custom(cx.theme().colors().text_accent.alpha(0.8))),
         )
@@ -117,8 +117,12 @@ impl ZedAiOnboarding {
 
     fn vip_stamp(cx: &App) -> impl IntoElement {
         div().absolute().bottom_1().right_1().child(
-            Vector::new(VectorName::VipStamp, rems_from_px(156.), rems_from_px(60.))
-                .color(Color::Custom(cx.theme().colors().text.alpha(0.8))),
+            Vector::new(
+                VectorName::VipStamp,
+                rems_from_px(156_f32),
+                rems_from_px(60_f32),
+            )
+            .color(Color::Custom(cx.theme().colors().text.alpha(0.8))),
         )
     }
 
@@ -126,8 +130,8 @@ impl ZedAiOnboarding {
         div().absolute().bottom_1().right_1().child(
             Vector::new(
                 VectorName::StudentStamp,
-                rems_from_px(156.),
-                rems_from_px(60.),
+                rems_from_px(156_f32),
+                rems_from_px(60_f32),
             )
             .color(Color::Custom(cx.theme().colors().text.alpha(0.8))),
         )

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -56,7 +56,7 @@ const COLLABORATION_PANEL_KEY: &str = "CollaborationPanel";
 const TOAST_DURATION: Duration = Duration::from_secs(5);
 
 fn panel_row_height() -> Rems {
-    rems_from_px(26.)
+    rems_from_px(26_f32)
 }
 
 actions!(

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -162,7 +162,7 @@ impl Render for ChannelModal {
                     .child(
                         h_flex()
                             .w_full()
-                            .h(rems_from_px(22.))
+                            .h(rems_from_px(22_f32))
                             .justify_between()
                             .line_height(rems(1.25))
                             .child(

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -669,7 +669,7 @@ impl PickerDelegate for CommandPaletteDelegate {
             Button::new("change", "Change Keybinding…")
                 .key_binding(
                     KeyBinding::for_action_in(&menu::SecondaryConfirm, focus_handle, cx)
-                        .map(|kb| kb.size(rems_from_px(12.))),
+                        .map(|kb| kb.size(rems_from_px(12_f32))),
                 )
                 .on_click(move |_, window, cx| {
                     window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx);
@@ -678,7 +678,7 @@ impl PickerDelegate for CommandPaletteDelegate {
             Button::new("add", "Add Keybinding…")
                 .key_binding(
                     KeyBinding::for_action_in(&menu::SecondaryConfirm, focus_handle, cx)
-                        .map(|kb| kb.size(rems_from_px(12.))),
+                        .map(|kb| kb.size(rems_from_px(12_f32))),
                 )
                 .on_click(move |_, window, cx| {
                     window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx);
@@ -698,7 +698,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                     Button::new("run-action", "Run")
                         .key_binding(
                             KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1305,7 +1305,7 @@ impl DebugPanel {
         thread_status: ThreadStatus,
         running_state: &Entity<RunningState>,
     ) -> impl IntoElement {
-        let chevron_button_size = rems_from_px(20.);
+        let chevron_button_size = rems_from_px(20_f32);
         PopoverMenu::new("debug-back-in-history-menu")
             .trigger(
                 ButtonLike::new_rounded_right("debug-back-in-history-menu-trigger")

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -907,7 +907,7 @@ impl LineBreakpoint {
                 )))
                 .w_full()
                 .gap_1()
-                .min_h(rems_from_px(26.))
+                .min_h(rems_from_px(26_f32))
                 .justify_between()
                 .on_click({
                     let weak = weak.clone();
@@ -1037,7 +1037,7 @@ impl DataBreakpoint {
             h_flex()
                 .w_full()
                 .gap_1()
-                .min_h(rems_from_px(26.))
+                .min_h(rems_from_px(26_f32))
                 .justify_between()
                 .child(
                     v_flex()
@@ -1140,7 +1140,7 @@ impl ExceptionBreakpoint {
             h_flex()
                 .w_full()
                 .gap_1()
-                .min_h(rems_from_px(26.))
+                .min_h(rems_from_px(26_f32))
                 .justify_between()
                 .child(
                     v_flex()

--- a/crates/dev_container/src/lib.rs
+++ b/crates/dev_container/src/lib.rs
@@ -432,7 +432,7 @@ impl PickerDelegate for TemplatePickerDelegate {
                     Button::new("run-action", "Continue")
                         .key_binding(
                             KeyBinding::for_action(&menu::Confirm, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)
@@ -629,7 +629,7 @@ impl PickerDelegate for FeaturePickerDelegate {
                     Button::new("run-action", "Select Feature")
                         .key_binding(
                             KeyBinding::for_action(&menu::Confirm, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)
@@ -639,7 +639,7 @@ impl PickerDelegate for FeaturePickerDelegate {
                     Button::new("run-action-secondary", "Confirm Selections")
                         .key_binding(
                             KeyBinding::for_action(&menu::SecondaryConfirm, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx)

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -1125,7 +1125,7 @@ impl EditPredictionButton {
 
                         v_flex()
                             .max_w_64()
-                            .h(rems_from_px(148.))
+                            .h(rems_from_px(148_f32))
                             .child(render_zeta_tab_animation(cx))
                             .child(Label::new("Edit Prediction"))
                             .child(

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1562,8 +1562,8 @@ fn render_completion_kind_letter(
         .flex_none()
         .w(IconSize::XSmall.rems())
         .text_center()
-        .text_size(rems_from_px(11.))
-        .line_height(rems_from_px(14.));
+        .text_size(rems_from_px(11_f32))
+        .line_height(rems_from_px(14_f32));
 
     let Some(kind) = kind else {
         return badge.into_any_element();

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -2516,7 +2516,7 @@ impl Render for MissingEditPredictionKeybindingTooltip {
             container
                 .flex_shrink_0()
                 .max_w_80()
-                .min_h(rems_from_px(124.))
+                .min_h(rems_from_px(124_f32))
                 .justify_between()
                 .child(
                     v_flex()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6899,7 +6899,7 @@ pub fn render_breadcrumb_text(
             )
             .into_any_element(),
         None => element
-            .h(rems_from_px(22.)) // Match the height and padding of the `ButtonLike` in the other arm.
+            .h(rems_from_px(22_f32)) // Match the height and padding of the `ButtonLike` in the other arm.
             .pl_1()
             .child(breadcrumbs)
             .into_any_element(),

--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -737,7 +737,7 @@ pub(crate) fn render_buffer_header(
                     let buffer_id = for_excerpt.buffer_id();
                     let toggle_chevron_icon =
                         FileIcons::get_chevron_icon(!is_folded, cx).map(Icon::from_path);
-                    let button_size = rems_from_px(28.);
+                    let button_size = rems_from_px(28_f32);
 
                     header.child(
                         div()

--- a/crates/extensions_ui/src/components/extension_card.rs
+++ b/crates/extensions_ui/src/components/extension_card.rs
@@ -626,7 +626,7 @@ impl RenderOnce for ExtensionCard {
             v_flex()
                 .mt_4()
                 .w_full()
-                .h(rems_from_px(110.))
+                .h(rems_from_px(110_f32))
                 .p_3()
                 .gap_2()
                 .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -785,7 +785,7 @@ impl ExtensionsPage {
         h_flex()
             .key_context(key_context)
             .h_8()
-            .min_w(rems_from_px(384.))
+            .min_w(rems_from_px(384_f32))
             .flex_1()
             .pl_1p5()
             .pr_2()
@@ -1445,7 +1445,7 @@ impl Render for ExtensionsPage {
                                         ],
                                     )
                                     .style(ToggleButtonGroupStyle::Outlined)
-                                    .size(ToggleButtonGroupSize::Custom(rems_from_px(30.))) // Perfectly matches the input
+                                    .size(ToggleButtonGroupSize::Custom(rems_from_px(30_f32))) // Perfectly matches the input
                                     .label_size(LabelSize::Default)
                                     .auto_width()
                                     .selected_index(match self.filter {

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -2009,7 +2009,7 @@ impl PickerDelegate for BranchListDelegate {
                                     &focus_handle,
                                     cx,
                                 )
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.delegate.confirm(true, window, cx);
@@ -2031,7 +2031,7 @@ impl PickerDelegate for BranchListDelegate {
                                             &focus_handle,
                                             cx,
                                         )
-                                        .map(|kb| kb.size(rems_from_px(12.))),
+                                        .map(|kb| kb.size(rems_from_px(12_f32))),
                                     )
                                     .on_click(|_, window, cx| {
                                         window.dispatch_action(
@@ -2046,7 +2046,7 @@ impl PickerDelegate for BranchListDelegate {
                         Button::new("switch_branch", "Switch")
                             .key_binding(
                                 KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.delegate.confirm(false, window, cx);
@@ -2065,7 +2065,7 @@ impl PickerDelegate for BranchListDelegate {
                                             &focus_handle,
                                             cx,
                                         )
-                                        .map(|kb| kb.size(rems_from_px(12.))),
+                                        .map(|kb| kb.size(rems_from_px(12_f32))),
                                     )
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.delegate.confirm(false, window, cx);
@@ -2088,7 +2088,7 @@ impl PickerDelegate for BranchListDelegate {
                                     &focus_handle,
                                     cx,
                                 )
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.delegate.confirm(true, window, cx);
@@ -2106,7 +2106,7 @@ impl PickerDelegate for BranchListDelegate {
                             Button::new("create-new-branch", "Create")
                                 .key_binding(
                                     KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                        .map(|kb| kb.size(rems_from_px(12.))),
+                                        .map(|kb| kb.size(rems_from_px(12_f32))),
                                 )
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.delegate.confirm(false, window, cx);
@@ -2122,7 +2122,7 @@ impl PickerDelegate for BranchListDelegate {
                         Button::new("confirm-create-remote", "Confirm")
                             .key_binding(
                                 KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.delegate.confirm(false, window, cx);

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -567,7 +567,7 @@ impl CommitView {
             time_format::TimestampFormat::MediumAbsolute,
         );
 
-        let avatar_size = rems_from_px(40.);
+        let avatar_size = rems_from_px(40_f32);
         let avatar_size_px = avatar_size.to_pixels(window.rem_size());
         let gutter_width = self.editor.update(cx, |editor, cx| {
             let editor = editor.rhs_editor().clone();
@@ -581,7 +581,7 @@ impl CommitView {
                     .full_width()
             })
         });
-        let avatar_min_side_padding = rems_from_px(6.).to_pixels(window.rem_size());
+        let avatar_min_side_padding = rems_from_px(6_f32).to_pixels(window.rem_size());
         let avatar_container_min = avatar_size_px + avatar_min_side_padding;
         let avatar_container_width = gutter_width.max(avatar_container_min);
 

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -636,7 +636,7 @@ impl Render for MergeConflictIndicator {
         let border_color = cx.theme().colors().text_accent.opacity(0.2);
 
         h_flex()
-            .h(rems_from_px(22.))
+            .h(rems_from_px(22_f32))
             .rounded_sm()
             .border_1()
             .border_color(border_color)

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -1151,7 +1151,7 @@ pub(crate) fn render_split_button_chevron_trigger(
     id: impl Into<ElementId>,
     menu_open: bool,
 ) -> ButtonLike {
-    let chevron_button_size = rems_from_px(20.);
+    let chevron_button_size = rems_from_px(20_f32);
     let chevron_icon = if menu_open {
         IconName::ChevronUp
     } else {

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -874,7 +874,7 @@ impl Render for SoloDiffGitToolbar {
             .child(Divider::vertical())
             .child(h_group_sm().child(if button_states.stage_file {
                 Button::new("stage-file", "Stage All")
-                    .width(rems_from_px(80.))
+                    .width(rems_from_px(80_f32))
                     .disabled(!button_states.stage_file)
                     .tooltip(Tooltip::for_action_title_in(
                         "Stage All",
@@ -884,7 +884,7 @@ impl Render for SoloDiffGitToolbar {
                     .on_click(cx.listener(|this, _, window, cx| this.stage_file(window, cx)))
             } else {
                 Button::new("unstage-file", "Unstage All")
-                    .width(rems_from_px(80.))
+                    .width(rems_from_px(80_f32))
                     .disabled(!button_states.unstage_file)
                     .tooltip(Tooltip::for_action_title_in(
                         "Unstage All",

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -712,7 +712,7 @@ impl Render for StagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("unstage-all", "Unstage All")
-                    .width(rems_from_px(80.))
+                    .width(rems_from_px(80_f32))
                     .disabled(!button_states.unstage_all)
                     .tooltip(Tooltip::for_action_title_in(
                         "Unstage All Changes",

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -650,7 +650,7 @@ impl PickerDelegate for StashListDelegate {
                                 &focus_handle,
                                 cx,
                             )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(stash_picker::DropStashItem.boxed_clone(), cx)
@@ -664,7 +664,7 @@ impl PickerDelegate for StashListDelegate {
                                 &focus_handle,
                                 cx,
                             )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(cx.listener(move |picker, _, window, cx| {
                             cx.stop_propagation();
@@ -676,7 +676,7 @@ impl PickerDelegate for StashListDelegate {
                     Button::new("pop-stash", "Pop")
                         .key_binding(
                             KeyBinding::for_action_in(&menu::SecondaryConfirm, &focus_handle, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx)
@@ -686,7 +686,7 @@ impl PickerDelegate for StashListDelegate {
                     Button::new("apply-stash", "Apply")
                         .key_binding(
                             KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -826,7 +826,7 @@ impl Render for UnstagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("stage-all", "Stage All")
-                    .width(rems_from_px(80.))
+                    .width(rems_from_px(80_f32))
                     .disabled(!button_states.stage_all)
                     .tooltip(Tooltip::for_action_title_in(
                         "Stage All Changes",
@@ -838,7 +838,7 @@ impl Render for UnstagedDiffToolbar {
             .child(Divider::vertical())
             .child(
                 Button::new("restore-all", "Restore All")
-                    .width(rems_from_px(80.))
+                    .width(rems_from_px(80_f32))
                     .disabled(!button_states.restore_all)
                     .tooltip(Tooltip::text("Restore All Changes"))
                     .on_click(cx.listener(|this, _, window, cx| this.restore_all(window, cx))),

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -1425,7 +1425,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                 Button::new("configure-worktree-tasks", "Automate Setup")
                     .key_binding(
                         KeyBinding::for_action_in(&OpenWorktreeSetupTasks, &focus_handle, cx)
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            .map(|kb| kb.size(rems_from_px(12_f32))),
                     )
                     .on_click(|_, window, cx| {
                         window.dispatch_action(OpenWorktreeSetupTasks.boxed_clone(), cx)
@@ -1439,7 +1439,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                         Button::new("create-worktree", "Create")
                             .key_binding(
                                 KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(|_, window, cx| {
                                 window.dispatch_action(menu::Confirm.boxed_clone(), cx)
@@ -1470,7 +1470,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                                                 &focus_handle,
                                                 cx,
                                             )
-                                            .map(|kb| kb.size(rems_from_px(12.))),
+                                            .map(|kb| kb.size(rems_from_px(12_f32))),
                                         )
                                         .on_click(|_, window, cx| {
                                             window.dispatch_action(DeleteWorktree.boxed_clone(), cx)
@@ -1487,7 +1487,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                                                 &focus_handle,
                                                 cx,
                                             )
-                                            .map(|kb| kb.size(rems_from_px(12.))),
+                                            .map(|kb| kb.size(rems_from_px(12_f32))),
                                         )
                                         .on_click(|_, window, cx| {
                                             window.dispatch_action(
@@ -1506,7 +1506,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                                                 &focus_handle,
                                                 cx,
                                             )
-                                            .map(|kb| kb.size(rems_from_px(12.))),
+                                            .map(|kb| kb.size(rems_from_px(12_f32))),
                                         )
                                         .on_click(|_, window, cx| {
                                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -2076,7 +2076,7 @@ impl Render for KeymapEditor {
                                         Button::new("edit-in-json", "Edit in JSON")
                                             .key_binding(
                                                 ui::KeyBinding::for_action_in(&zed_actions::OpenKeymapFile, &focus_handle, cx)
-                                                    .map(|kb| kb.size(rems_from_px(10.))),
+                                                    .map(|kb| kb.size(rems_from_px(10_f32))),
                                             )
                                             .on_click(|_, window, cx| {
                                                 window.dispatch_action(
@@ -2090,7 +2090,7 @@ impl Render for KeymapEditor {
                                             .style(ButtonStyle::Outlined)
                                             .key_binding(
                                                 ui::KeyBinding::for_action_in(&OpenCreateKeybindingModal, &focus_handle, cx)
-                                                    .map(|kb| kb.size(rems_from_px(10.))),
+                                                    .map(|kb| kb.size(rems_from_px(10_f32))),
                                             )
                                             .on_click(|_, window, cx| {
                                                 window.dispatch_action(

--- a/crates/keymap_editor/src/ui_components/keystroke_input.rs
+++ b/crates/keymap_editor/src/ui_components/keystroke_input.rs
@@ -468,7 +468,7 @@ impl Render for KeystrokeInput {
         let is_focused = self.outer_focus_handle.contains_focused(window, cx);
         let is_recording = self.is_recording(window);
 
-        let width = rems_from_px(64.);
+        let width = rems_from_px(64_f32);
 
         let recording_bg_color = colors
             .editor_background

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -611,7 +611,7 @@ impl LanguageServerState {
                                     .id("metadata-container")
                                     .gap_1()
                                     .when_some(server_message.as_ref(), |this, _| {
-                                        this.w(rems_from_px(240.))
+                                        this.w(rems_from_px(240_f32))
                                     })
                                     .child(
                                         h_flex()

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -89,7 +89,7 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
                 .tab_index(tab_index)
                 .selected_index(theme_mode as usize)
                 .style(ui::ToggleButtonGroupStyle::Outlined)
-                .width(rems_from_px(3. * 64.)),
+                .width(rems_from_px(3. * 64._f32)),
             ),
         )
         .child(

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -89,7 +89,7 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
                 .tab_index(tab_index)
                 .selected_index(theme_mode as usize)
                 .style(ui::ToggleButtonGroupStyle::Outlined)
-                .width(rems_from_px(3. * 64._f32)),
+                .width(rems_from_px(3.0_f32 * 64.0_f32)),
             ),
         )
         .child(

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -334,7 +334,7 @@ impl Render for Onboarding {
                     .child(
                         v_flex()
                             .min_w_0()
-                            .max_w(rems_from_px(780.))
+                            .max_w(rems_from_px(780_f32))
                             .w_full()
                             .mx_auto()
                             .p_12()
@@ -366,7 +366,7 @@ impl Render for Onboarding {
                                         Button::new("finish_setup", "Finish Setup")
                                             .style(ButtonStyle::Filled)
                                             .size(ButtonSize::Medium)
-                                            .width(rems_from_px(200.))
+                                            .width(rems_from_px(200_f32))
                                             .key_binding(KeyBinding::for_action_in(
                                                 &Finish,
                                                 &self.focus_handle,

--- a/crates/picker/src/footer.rs
+++ b/crates/picker/src/footer.rs
@@ -145,7 +145,7 @@ impl<D: PickerDelegate> Picker<D> {
                     .when(preview_visible, |this| this.color(Color::Accent))
                     .key_binding(
                         KeyBinding::for_action_in(&TogglePreview, &focus_handle, cx)
-                            .size(rems_from_px(12.)),
+                            .size(rems_from_px(12_f32)),
                     )
                     .on_click(
                         cx.listener(|this, _, window, cx| this.toggle_preview_visible(window, cx)),
@@ -201,7 +201,7 @@ impl<D: PickerDelegate> Picker<D> {
                 Button::new("picker-actions-trigger", "Actions…")
                     .key_binding(
                         KeyBinding::for_action_in(&ToggleActionsMenu, &focus_handle, cx)
-                            .size(rems_from_px(12.)),
+                            .size(rems_from_px(12_f32)),
                     )
                     .selected_style(ui::ButtonStyle::Tinted(ui::TintColor::Accent)),
             )

--- a/crates/picker/src/render.rs
+++ b/crates/picker/src/render.rs
@@ -149,7 +149,7 @@ impl<D: PickerDelegate> Picker<D> {
         let ui_font_size = ThemeSettings::get_global(cx).ui_font_size(cx);
         let window_size = window.viewport_size();
         let rem_size = window.rem_size();
-        let is_wide_window = window_size.width / rem_size > rems_from_px(800.).0;
+        let is_wide_window = window_size.width / rem_size > rems_from_px(800_f32).0;
 
         let aside = self.delegate.documentation_aside(window, cx);
 

--- a/crates/picker/src/shape.rs
+++ b/crates/picker/src/shape.rs
@@ -242,12 +242,12 @@ impl Default for SizeBounds {
             // over the lower bar so clear another 5 rems there.
             max_height: (RelativeHeight::FULL - Rems(10.0)) * 0.95,
             min_results: Size {
-                width: rems_from_px(280.),
-                height: rems_from_px(320.),
+                width: rems_from_px(280_f32),
+                height: rems_from_px(320_f32),
             },
             min_preview: Size {
-                width: rems_from_px(128.),
-                height: rems_from_px(96.),
+                width: rems_from_px(128_f32),
+                height: rems_from_px(96_f32),
             },
         }
     }

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -330,7 +330,7 @@ impl PickerDelegate for DevContainerPickerDelegate {
                     Button::new("run-action", "Start Dev Container")
                         .key_binding(
                             KeyBinding::for_action(&menu::Confirm, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::Confirm.boxed_clone(), cx)
@@ -340,7 +340,7 @@ impl PickerDelegate for DevContainerPickerDelegate {
                     Button::new("run-action-secondary", "Open devcontainer.json")
                         .key_binding(
                             KeyBinding::for_action(&menu::SecondaryConfirm, cx)
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx)

--- a/crates/remote_connection/src/remote_connection.rs
+++ b/crates/remote_connection/src/remote_connection.rs
@@ -394,7 +394,7 @@ impl Render for RemoteConnectionModal {
                         .child(Label::new("Cancel"))
                         .end_slot(
                             KeyBinding::for_action_in(&menu::Cancel, &self.focus_handle(cx), cx)
-                                .size(rems_from_px(12.)),
+                                .size(rems_from_px(12_f32)),
                         )
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.dismiss(&menu::Cancel, window, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -331,7 +331,7 @@ impl Render for BufferSearchBar {
                         query_focus.clone(),
                     ))
                     .when(!narrow_mode, |this| {
-                        this.child(div().ml_2().min_w(rems_from_px(40.)).child(
+                        this.child(div().ml_2().min_w(rems_from_px(40_f32)).child(
                             Label::new(match_text).size(LabelSize::Small).color(
                                 if self.active_match_index.is_some() {
                                     Color::Default

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2435,7 +2435,7 @@ impl Render for ProjectSearchBar {
                 div()
                     .id("matches")
                     .ml_2()
-                    .min_w(rems_from_px(40.))
+                    .min_w(rems_from_px(40_f32))
                     .child(
                         h_flex()
                             .gap_1p5()

--- a/crates/settings_ui/src/components/font_picker.rs
+++ b/crates/settings_ui/src/components/font_picker.rs
@@ -180,7 +180,7 @@ pub fn font_picker(
 
     Picker::uniform_list(delegate, window, cx)
         .show_scrollbar(true)
-        .initial_width(rems_from_px(210.))
+        .initial_width(rems_from_px(210_f32))
         .max_height(rems(18.))
         .popover()
 }

--- a/crates/settings_ui/src/components/icon_theme_picker.rs
+++ b/crates/settings_ui/src/components/icon_theme_picker.rs
@@ -193,7 +193,7 @@ pub fn icon_theme_picker(
 
     Picker::uniform_list(delegate, window, cx)
         .show_scrollbar(true)
-        .initial_width(rems_from_px(210.))
+        .initial_width(rems_from_px(210_f32))
         .max_height(rems(18.))
         .popover()
 }

--- a/crates/settings_ui/src/components/ollama_model_picker.rs
+++ b/crates/settings_ui/src/components/ollama_model_picker.rs
@@ -211,7 +211,7 @@ pub fn render_ollama_model_picker(
 
                 Picker::uniform_list(delegate, window, cx)
                     .show_scrollbar(true)
-                    .initial_width(rems_from_px(210.))
+                    .initial_width(rems_from_px(210_f32))
                     .max_height(rems(18.))
                     .popover()
             }))

--- a/crates/settings_ui/src/components/theme_picker.rs
+++ b/crates/settings_ui/src/components/theme_picker.rs
@@ -178,7 +178,7 @@ pub fn theme_picker(
 
     Picker::uniform_list(delegate, window, cx)
         .show_scrollbar(true)
-        .initial_width(rems_from_px(210.))
+        .initial_width(rems_from_px(210_f32))
         .max_height(rems(18.))
         .popover()
 }

--- a/crates/settings_ui/src/pages/skills_setup.rs
+++ b/crates/settings_ui/src/pages/skills_setup.rs
@@ -136,7 +136,7 @@ fn render_skill_row(
     let group = format!("group-{}", skill.name);
 
     let title = h_flex()
-        .ml(rems_from_px(-22.))
+        .ml(rems_from_px(-22._f32))
         .gap_1()
         .child({
             let share_skill_file_path = skill.skill_file_path.clone();

--- a/crates/settings_ui/src/pages/skills_setup.rs
+++ b/crates/settings_ui/src/pages/skills_setup.rs
@@ -136,7 +136,7 @@ fn render_skill_row(
     let group = format!("group-{}", skill.name);
 
     let title = h_flex()
-        .ml(rems_from_px(-22._f32))
+        .ml(rems_from_px(-22.0_f32))
         .gap_1()
         .child({
             let share_skill_file_path = skill.skill_file_path.clone();

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1534,10 +1534,10 @@ fn render_settings_item_link(
         .map(|this| {
             if sub_field {
                 this.visible_on_hover("setting-sub-item")
-                    .left(rems_from_px(-8.5))
+                    .left(rems_from_px(-8.5_f32))
             } else {
                 this.visible_on_hover("setting-item")
-                    .left(rems_from_px(-22.))
+                    .left(rems_from_px(-22._f32))
             }
         })
         .child(

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1530,7 +1530,7 @@ fn render_settings_item_link(
 
     div()
         .absolute()
-        .top(rems_from_px(18.))
+        .top(rems_from_px(18_f32))
         .map(|this| {
             if sub_field {
                 this.visible_on_hover("setting-sub-item")

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1537,7 +1537,7 @@ fn render_settings_item_link(
                     .left(rems_from_px(-8.5_f32))
             } else {
                 this.visible_on_hover("setting-item")
-                    .left(rems_from_px(-22._f32))
+                    .left(rems_from_px(-22.0_f32))
             }
         })
         .child(

--- a/crates/sidebar/src/thread_switcher.rs
+++ b/crates/sidebar/src/thread_switcher.rs
@@ -361,7 +361,7 @@ impl Render for ThreadSwitcher {
             .key_context("ThreadSwitcher")
             .track_focus(&self.focus_handle)
             .p_1p5()
-            .w(rems_from_px(440.))
+            .w(rems_from_px(440_f32))
             .elevation_3(cx)
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .on_action(cx.listener(Self::confirm))

--- a/crates/ui/src/components/ai/skills_illustration.rs
+++ b/crates/ui/src/components/ai/skills_illustration.rs
@@ -74,7 +74,7 @@ impl RenderOnce for SkillsIllustration {
 
         v_flex()
             .relative()
-            .h(rems_from_px(150.))
+            .h(rems_from_px(150_f32))
             .justify_end()
             .items_center()
             .rounded_t_md()

--- a/crates/ui/src/components/avatar.rs
+++ b/crates/ui/src/components/avatar.rs
@@ -150,8 +150,8 @@ impl RenderOnce for AvatarAudioStatusIndicator {
 
         div()
             .absolute()
-            .bottom(rems_from_px(-3._f32))
-            .right(rems_from_px(-6._f32))
+            .bottom(rems_from_px(-3.0_f32))
+            .right(rems_from_px(-6.0_f32))
             .w(width_in_px + padding_x)
             .h(icon_size.rems())
             .child(

--- a/crates/ui/src/components/avatar.rs
+++ b/crates/ui/src/components/avatar.rs
@@ -150,8 +150,8 @@ impl RenderOnce for AvatarAudioStatusIndicator {
 
         div()
             .absolute()
-            .bottom(rems_from_px(-3.))
-            .right(rems_from_px(-6.))
+            .bottom(rems_from_px(-3._f32))
+            .right(rems_from_px(-6._f32))
             .w(width_in_px + padding_x)
             .h(icon_size.rems())
             .child(

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -464,11 +464,11 @@ pub enum ButtonSize {
 impl ButtonSize {
     pub fn rems(self) -> Rems {
         match self {
-            ButtonSize::Large => rems_from_px(32.),
-            ButtonSize::Medium => rems_from_px(28.),
-            ButtonSize::Default => rems_from_px(22.),
-            ButtonSize::Compact => rems_from_px(18.),
-            ButtonSize::None => rems_from_px(16.),
+            ButtonSize::Large => rems_from_px(32_f32),
+            ButtonSize::Medium => rems_from_px(28_f32),
+            ButtonSize::Default => rems_from_px(22_f32),
+            ButtonSize::Compact => rems_from_px(18_f32),
+            ButtonSize::None => rems_from_px(16_f32),
         }
     }
 }

--- a/crates/ui/src/components/button/toggle_button.rs
+++ b/crates/ui/src/components/button/toggle_button.rs
@@ -617,7 +617,7 @@ impl<T: ButtonBuilder, const COLS: usize, const ROWS: usize> Component
                             ],
                         )
                         .selected_index(3)
-                        .width(rems_from_px(100.))
+                        .width(rems_from_px(100_f32))
                         .style(ToggleButtonGroupStyle::Filled)
                         .into_any_element(),
                     ),
@@ -637,7 +637,7 @@ impl<T: ButtonBuilder, const COLS: usize, const ROWS: usize> Component
                             ],
                         )
                         .selected_index(3)
-                        .width(rems_from_px(100.))
+                        .width(rems_from_px(100_f32))
                         .style(ToggleButtonGroupStyle::Filled)
                         .into_any_element(),
                     ),

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -2196,7 +2196,7 @@ impl Render for ContextMenu {
         let ui_font_family = theme_settings.ui_font(cx).family.clone();
         let window_size = window.viewport_size();
         let rem_size = window.rem_size();
-        let is_wide_window = window_size.width / rem_size > rems_from_px(800.).0;
+        let is_wide_window = window_size.width / rem_size > rems_from_px(800_f32).0;
 
         let mut focus_submenu: Option<FocusHandle> = None;
 

--- a/crates/ui/src/components/count_badge.rs
+++ b/crates/ui/src/components/count_badge.rs
@@ -46,7 +46,7 @@ impl RenderOnce for CountBadge {
             .shadow_sm()
             .child(
                 Label::new(label)
-                    .size(LabelSize::Custom(rems_from_px(9.)))
+                    .size(LabelSize::Custom(rems_from_px(9_f32)))
                     .weight(FontWeight::MEDIUM),
             )
     }

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -69,11 +69,11 @@ pub enum IconSize {
 impl IconSize {
     pub fn rems(self) -> Rems {
         match self {
-            IconSize::Indicator => rems_from_px(10.),
-            IconSize::XSmall => rems_from_px(12.),
-            IconSize::Small => rems_from_px(14.),
-            IconSize::Medium => rems_from_px(16.),
-            IconSize::XLarge => rems_from_px(48.),
+            IconSize::Indicator => rems_from_px(10_f32),
+            IconSize::XSmall => rems_from_px(12_f32),
+            IconSize::Small => rems_from_px(14_f32),
+            IconSize::Medium => rems_from_px(16_f32),
+            IconSize::XLarge => rems_from_px(48_f32),
             IconSize::Custom(size) => size,
         }
     }

--- a/crates/ui/src/components/image.rs
+++ b/crates/ui/src/components/image.rs
@@ -112,7 +112,7 @@ impl Component for Vector {
     }
 
     fn preview(_window: &mut Window, _cx: &mut App) -> AnyElement {
-        let size = rems_from_px(60.);
+        let size = rems_from_px(60_f32);
 
         v_flex()
             .gap_6()
@@ -127,12 +127,12 @@ impl Component for Vector {
                         single_example(
                             "Custom Size",
                             h_flex()
-                                .h(rems_from_px(120.))
+                                .h(rems_from_px(120_f32))
                                 .justify_center()
                                 .child(Vector::new(
                                     VectorName::ZedLogo,
-                                    rems_from_px(120.),
-                                    rems_from_px(200.),
+                                    rems_from_px(120_f32),
+                                    rems_from_px(200_f32),
                                 ))
                                 .into_any_element(),
                         ),
@@ -159,7 +159,7 @@ impl Component for Vector {
                     "Different Vectors",
                     vec![single_example(
                         "Zed X Copilot",
-                        Vector::square(VectorName::ZedXCopilot, rems_from_px(100.))
+                        Vector::square(VectorName::ZedXCopilot, rems_from_px(100_f32))
                             .into_any_element(),
                     )],
                 ),

--- a/crates/ui/src/components/indicator.rs
+++ b/crates/ui/src/components/indicator.rs
@@ -69,7 +69,7 @@ impl RenderOnce for Indicator {
 
         match self.kind {
             IndicatorKind::Icon(icon) => container
-                .child(icon.map(|icon| icon.custom_size(rems_from_px(8.)).color(self.color))),
+                .child(icon.map(|icon| icon.custom_size(rems_from_px(8_f32)).color(self.color))),
             IndicatorKind::Dot => container
                 .w_1p5()
                 .h_1p5()

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -259,7 +259,7 @@ impl<M: ManagedView> PopoverMenu<M> {
     fn resolved_offset(&self, window: &mut Window) -> Point<Pixels> {
         self.offset.unwrap_or_else(|| {
             // Default offset = 4px padding + 1px border
-            let offset = rems_from_px(5.) * window.rem_size();
+            let offset = rems_from_px(5_f32) * window.rem_size();
             match self.anchor {
                 Anchor::TopRight | Anchor::BottomRight | Anchor::RightCenter => {
                     point(offset, px(0.))

--- a/crates/ui/src/components/tree_view_item.rs
+++ b/crates/ui/src/components/tree_view_item.rs
@@ -138,7 +138,7 @@ impl RenderOnce for TreeViewItem {
         let selected_border = cx.theme().colors().border.opacity(0.4);
         let focused_border = cx.theme().colors().border_focused;
 
-        let item_size = rems_from_px(28.);
+        let item_size = rems_from_px(28_f32);
         let indentation_line = h_flex()
             .h(item_size)
             .w(px(22.))

--- a/crates/ui/src/styles/typography.rs
+++ b/crates/ui/src/styles/typography.rs
@@ -135,10 +135,10 @@ impl TextSize {
         let settings = theme::theme_settings(cx);
 
         match self {
-            Self::Large => rems_from_px(16.),
-            Self::Default => rems_from_px(14.),
-            Self::Small => rems_from_px(12.),
-            Self::XSmall => rems_from_px(10.),
+            Self::Large => rems_from_px(16_f32),
+            Self::Default => rems_from_px(14_f32),
+            Self::Small => rems_from_px(12_f32),
+            Self::XSmall => rems_from_px(10_f32),
             Self::Ui => rems_from_px(settings.ui_font_size(cx)),
             Self::Editor => rems_from_px(settings.buffer_font_size(cx)),
         }

--- a/crates/ui/src/styles/units.rs
+++ b/crates/ui/src/styles/units.rs
@@ -8,7 +8,7 @@ pub const BASE_REM_SIZE_IN_PX: f32 = 16.;
 /// This can be used to compute rem values relative to pixel sizes, without
 /// needing to hard-code the rem value.
 ///
-/// For instance, instead of writing `rems(0.875)` you can write `rems_from_px(14.)`
+/// For instance, instead of writing `rems(0.875)` you can write `rems_from_px(14_f32)`
 #[inline(always)]
 pub fn rems_from_px(px: impl Into<f32>) -> Rems {
     rems(px.into() / BASE_REM_SIZE_IN_PX)

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -279,7 +279,7 @@ impl Render for SecurityModal {
                                     &ToggleWorktreeSecurity,
                                     cx,
                                 )
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                                .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(move |security_modal, _, _, cx| {
                                 security_modal.trusted = Some(false);
@@ -293,7 +293,7 @@ impl Render for SecurityModal {
                             .layer(ui::ElevationIndex::ModalSurface)
                             .key_binding(
                                 KeyBinding::for_action(&menu::Confirm, cx)
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    .map(|kb| kb.size(rems_from_px(12_f32))),
                             )
                             .on_click(cx.listener(move |security_modal, _, _, cx| {
                                 security_modal.trust_and_dismiss(cx);

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -118,7 +118,7 @@ impl RenderOnce for SectionButton {
                     )
                     .child(
                         KeyBinding::for_action_in(action_ref, &self.focus_handle, cx)
-                            .size(rems_from_px(12.)),
+                            .size(rems_from_px(12_f32)),
                     ),
             )
             .on_click(move |_, window, cx| {
@@ -366,7 +366,7 @@ impl WelcomePage {
                     .style(ButtonStyle::Outlined)
                     .key_binding(
                         KeyBinding::for_action_in(&ToggleFocus, &self.focus_handle, cx)
-                            .size(rems_from_px(12.)),
+                            .size(rems_from_px(12_f32)),
                     )
                     .on_click(move |_, window, cx| {
                         focus.dispatch_action(&ToggleWorkspaceSidebar, window, cx);
@@ -477,7 +477,7 @@ impl Render for WelcomePage {
                             .justify_center()
                             .mb_4()
                             .gap_4()
-                            .child(Vector::square(VectorName::ZedLogo, rems_from_px(45.)))
+                            .child(Vector::square(VectorName::ZedLogo, rems_from_px(45_f32)))
                             .child(
                                 v_flex().child(Headline::new(welcome_label)).child(
                                     Label::new("The editor for what's next")


### PR DESCRIPTION
While building Zed with nightly rustc I've noticed it doesn't compile because of good old pathfinder_simd. It also emits a bunch of warnings about use of f64 literals where f32 is expected, so I've fixed them - it should make future upgrades more straightforward.