### PR TITLE
http_client: Bound GitHub release requests

### DIFF
--- a/crates/http_client/src/github.rs
+++ b/crates/http_client/src/github.rs
@@ -1,12 +1,13 @@
-use crate::{HttpClient, HttpRequestExt};
+use crate::{AsyncBody, HttpClient, HttpRequestExt};
 use anyhow::{Context as _, Result, anyhow, bail};
 use futures::AsyncReadExt;
 use http::Request;
 use serde::Deserialize;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use url::Url;
 
 const GITHUB_API_URL: &str = "https://api.github.com";
+const GITHUB_RELEASE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct GitHubLspBinaryVersion {
     pub name: String,
@@ -39,12 +40,7 @@ pub async fn latest_github_release(
 ) -> anyhow::Result<GithubRelease> {
     let url = format!("{GITHUB_API_URL}/repos/{repo_name_with_owner}/releases");
 
-    let request = Request::get(&url)
-        .follow_redirects(crate::RedirectPolicy::FollowAll)
-        .when_some(std::env::var("GITHUB_TOKEN").ok(), |builder, token| {
-            builder.header("Authorization", format!("Bearer {}", token))
-        })
-        .body(Default::default())?;
+    let request = github_api_request(&url)?;
 
     let mut response = http
         .send(request)
@@ -101,12 +97,7 @@ pub async fn get_release_by_tag_name(
 ) -> anyhow::Result<GithubRelease> {
     let url = format!("{GITHUB_API_URL}/repos/{repo_name_with_owner}/releases/tags/{tag}");
 
-    let request = Request::get(&url)
-        .follow_redirects(crate::RedirectPolicy::FollowAll)
-        .when_some(std::env::var("GITHUB_TOKEN").ok(), |builder, token| {
-            builder.header("Authorization", format!("Bearer {}", token))
-        })
-        .body(Default::default())?;
+    let request = github_api_request(&url)?;
 
     let mut response = http
         .send(request)
@@ -141,6 +132,17 @@ pub async fn get_release_by_tag_name(
     Ok(release)
 }
 
+fn github_api_request(url: &str) -> Result<Request<AsyncBody>> {
+    Request::get(url)
+        .follow_redirects(crate::RedirectPolicy::FollowAll)
+        .timeout(GITHUB_RELEASE_REQUEST_TIMEOUT)
+        .when_some(std::env::var("GITHUB_TOKEN").ok(), |builder, token| {
+            builder.header("Authorization", format!("Bearer {}", token))
+        })
+        .body(Default::default())
+        .map_err(Into::into)
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AssetKind {
     TarGz,
@@ -172,7 +174,21 @@ pub fn build_asset_url(repo_name_with_owner: &str, tag: &str, kind: AssetKind) -
 
 #[cfg(test)]
 mod tests {
-    use crate::github::{AssetKind, build_asset_url};
+    use crate::{
+        RequestTimeout,
+        github::{AssetKind, GITHUB_RELEASE_REQUEST_TIMEOUT, build_asset_url, github_api_request},
+    };
+
+    #[test]
+    fn github_api_requests_have_a_total_deadline() {
+        let request =
+            github_api_request("https://api.github.com/repos/zed-industries/zed/releases").unwrap();
+
+        assert_eq!(
+            request.extensions().get::<RequestTimeout>(),
+            Some(&RequestTimeout(GITHUB_RELEASE_REQUEST_TIMEOUT))
+        );
+    }
 
     #[test]
     fn test_build_asset_url() {

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -13,9 +13,9 @@ use http::{HeaderName, HeaderValue};
 use futures::future::BoxFuture;
 use parking_lot::Mutex;
 use serde::Serialize;
-use std::sync::Arc;
 #[cfg(feature = "test-support")]
 use std::{any::type_name, fmt};
+use std::{sync::Arc, time::Duration};
 pub use url::{Host, Url};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
@@ -26,6 +26,9 @@ pub enum RedirectPolicy {
     FollowAll,
 }
 pub struct FollowRedirects(pub bool);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestTimeout(pub Duration);
 
 pub trait HttpRequestExt {
     /// Conditionally modify self with the given closure.
@@ -49,11 +52,19 @@ pub trait HttpRequestExt {
 
     /// Whether or not to follow redirects
     fn follow_redirects(self, follow: RedirectPolicy) -> Self;
+
+    /// Sets a deadline for the complete HTTP request, including its response body.
+    fn timeout(self, timeout: Duration) -> Self;
 }
 
 impl HttpRequestExt for http::request::Builder {
     fn follow_redirects(self, follow: RedirectPolicy) -> Self {
         self.extension(follow)
+    }
+
+    fn timeout(self, timeout: Duration) -> Self {
+        debug_assert!(!timeout.is_zero(), "timeout must be positive");
+        self.extension(RequestTimeout(timeout))
     }
 }
 

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -7,7 +7,7 @@ use gpui_util::defer;
 use anyhow::anyhow;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{AsyncRead, FutureExt as _, TryStreamExt as _};
-use http_client::{RedirectPolicy, Url, http};
+use http_client::{RedirectPolicy, RequestTimeout, Url, http};
 use regex::Regex;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
@@ -274,16 +274,19 @@ impl http_client::HttpClient for ReqwestClient {
     > {
         let (parts, body) = req.into_parts();
 
-        let mut request = self.client.request(parts.method, parts.uri.to_string());
-        request = request.headers(parts.headers);
+        let mut request_builder = self.client.request(parts.method, parts.uri.to_string());
+        request_builder = request_builder.headers(parts.headers);
         if let Some(redirect_policy) = parts.extensions.get::<RedirectPolicy>() {
-            request = request.redirect_policy(match redirect_policy {
+            request_builder = request_builder.redirect_policy(match redirect_policy {
                 RedirectPolicy::NoFollow => redirect::Policy::none(),
                 RedirectPolicy::FollowLimit(limit) => redirect::Policy::limited(*limit as usize),
                 RedirectPolicy::FollowAll => redirect::Policy::limited(100),
             });
         }
-        let request = request.body(match body.0 {
+        if let Some(timeout) = parts.extensions.get::<RequestTimeout>() {
+            request_builder = request_builder.timeout(timeout.0);
+        }
+        let request = request_builder.body(match body.0 {
             http_client::Inner::Empty => reqwest::Body::default(),
             http_client::Inner::Bytes(cursor) => cursor.into_inner().into(),
             http_client::Inner::AsyncReader(stream) => {
@@ -319,10 +322,14 @@ impl http_client::HttpClient for ReqwestClient {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read as _, Write as _};
+    use std::io::{BufRead as _, BufReader, Read as _, Write as _};
     use std::net::TcpListener;
+    use std::time::{Duration, Instant};
 
-    use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest, Url};
+    use futures::AsyncReadExt as _;
+    use http_client::{
+        AsyncBody, HttpClient, HttpRequestExt as _, Method, Request as HttpRequest, Url,
+    };
 
     use crate::ReqwestClient;
 
@@ -400,6 +407,58 @@ mod tests {
             .unwrap();
         let response = futures::executor::block_on(client.send(request)).unwrap();
         assert!(response.status().is_success());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn test_request_timeout_applies_while_reading_response_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(&mut stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                assert_ne!(reader.read_line(&mut line).unwrap(), 0);
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            drop(reader);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 1\r\n\r\n")
+                .unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            let mut buffer = [0; 1];
+            match stream.read(&mut buffer) {
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                    ) => {}
+                Err(error) => panic!("failed while waiting for the client to close: {error}"),
+            }
+        });
+
+        let client = ReqwestClient::new();
+        let request = HttpRequest::get(format!("http://{address}/"))
+            .timeout(Duration::from_millis(100))
+            .body(AsyncBody::default())
+            .unwrap();
+        let started_at = Instant::now();
+        let mut response = futures::executor::block_on(client.send(request)).unwrap();
+        let mut body = Vec::new();
+        let result = futures::executor::block_on(response.body_mut().read_to_end(&mut body));
+        assert!(result.is_err(), "the response body should time out");
+        assert!(
+            started_at.elapsed() < Duration::from_millis(500),
+            "the request timeout should not wait for the server to close the connection"
+        );
+        drop(response);
         server.join().unwrap();
     }
 


### PR DESCRIPTION
# Objective

- Stop language-server update checks from waiting forever.
**Note:** I tried to find any existing issue but no luck.

## Solution

- Set one time limit for the full response body. If the GitHub, for example, release request stops responding, return an error. Do not let it block language-server update checks without limit.

## Testing

- Did you test these changes? If so, how?

   1. This is a flaky issue, reproducing it is not that trivial.
   2. The easiest way I found is just restarting Zed until you get the notification in the status bar `Checking for updates <language_server_naem>`

- Are there any parts that need more testing?

   No

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

   See above.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

   - macOS
   - Linux

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="2624" height="2260" alt="CleanShot 2026-08-03 at 20 29 11@2x" src="https://github.com/user-attachments/assets/83e2781c-15bc-4924-be33-88c26f20387d" />

---

Release Notes:

- Improved language server update checks for extension-provided language servers to get stuck less frequently on flaky internet connections.
