### PR TITLE
gpui: Add async task benchmark support

### DIFF
--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -257,6 +257,52 @@ impl Drop for FrameTraceScope {
     }
 }
 
+struct MeasuredTaskInput<Input> {
+    input: Input,
+    frame_trace_scope: Option<FrameTraceScope>,
+}
+
+struct MeasuredTaskOutput<Output> {
+    frame_trace_scope: Option<FrameTraceScope>,
+    report: BenchReport,
+    _output: Output,
+}
+
+impl<Output> Drop for MeasuredTaskOutput<Output> {
+    fn drop(&mut self) {
+        let frame_trace_scope = self
+            .frame_trace_scope
+            .take()
+            .expect("measured task output should retain its frame trace scope");
+        self.report
+            .record_frame_timings(frame_trace_scope.finish().iter());
+    }
+}
+
+fn run_task_to_completion<Output>(
+    foreground_executor: &ForegroundExecutor,
+    task: Task<Output>,
+) -> Output
+where
+    Output: 'static,
+{
+    let output = Rc::new(RefCell::new(None));
+    foreground_executor
+        .spawn({
+            let output = output.clone();
+            async move {
+                *output.borrow_mut() = Some(task.await);
+            }
+        })
+        .detach();
+
+    foreground_executor
+        .dispatcher()
+        .as_threaded()
+        .expect("BenchAppContext requires a ThreadedDispatcher")
+        .run_until(|| output.borrow_mut().take())
+}
+
 /// A GPUI app context for Criterion benchmarks.
 ///
 /// `BenchAppContext` is intentionally separate from `TestAppContext`: it owns a
@@ -382,6 +428,74 @@ impl<'a, 'measurement> BenchAppContext<'a, 'measurement> {
         let mut benchmark = || benchmark(self);
         bencher.iter(&mut benchmark);
         self.report.record_frame_timings(collector.finish().iter());
+        self.replace_bencher(bencher);
+    }
+
+    /// Measures a GPUI task to completion using Criterion's iteration loop.
+    ///
+    /// The closure is invoked once per Criterion iteration. The returned task
+    /// may depend on foreground work, background work, timers, or external
+    /// workers that wake GPUI tasks. Its output is dropped after the timed
+    /// interval.
+    ///
+    /// Any window draws triggered by the task are recorded into the benchmark's
+    /// frame report through the GPUI frame profiler.
+    pub fn bench_task<Output>(&mut self, mut benchmark: impl FnMut(&mut Self) -> Task<Output>)
+    where
+        Output: 'static,
+    {
+        self.bench_batched_task_internal("bench_task", |_| (), |_, cx| benchmark(cx));
+    }
+
+    /// Measures a GPUI task with per-iteration setup outside the timed interval.
+    ///
+    /// `setup` runs before timing starts. The returned input is passed by mutable
+    /// reference to `benchmark`, which returns the task whose completion is
+    /// measured. Both the setup input and task output are dropped after timing
+    /// stops.
+    ///
+    /// Each iteration is kept in its own Criterion batch so frame tracing and
+    /// destruction cannot overlap adjacent measurements.
+    pub fn bench_batched_task<Input, Output>(
+        &mut self,
+        setup: impl FnMut(&mut Self) -> Input,
+        benchmark: impl FnMut(&mut Input, &mut Self) -> Task<Output>,
+    ) where
+        Output: 'static,
+    {
+        self.bench_batched_task_internal("bench_batched_task", setup, benchmark);
+    }
+
+    fn bench_batched_task_internal<Input, Output>(
+        &mut self,
+        benchmark_kind: &str,
+        mut setup: impl FnMut(&mut Self) -> Input,
+        mut benchmark: impl FnMut(&mut Input, &mut Self) -> Task<Output>,
+    ) where
+        Output: 'static,
+    {
+        let bencher = self.take_bencher(benchmark_kind);
+        let mut setup_context = self.clone();
+        let mut benchmark_context = self.clone();
+        let foreground_executor = self.foreground_executor.clone();
+        let report = self.report.clone();
+
+        bencher.iter_batched_ref(
+            || MeasuredTaskInput {
+                input: setup(&mut setup_context),
+                frame_trace_scope: Some(FrameTraceScope::start()),
+            },
+            |measured_input| {
+                let task = benchmark(&mut measured_input.input, &mut benchmark_context);
+                let output = run_task_to_completion(&foreground_executor, task);
+                MeasuredTaskOutput {
+                    frame_trace_scope: measured_input.frame_trace_scope.take(),
+                    report: report.clone(),
+                    _output: output,
+                }
+            },
+            criterion::BatchSize::PerIteration,
+        );
         self.replace_bencher(bencher);
     }
 
@@ -777,5 +891,40 @@ impl VisualContext for BenchWindowContext<'_, '_> {
         self.window.update(&mut self.cx, |_, window, cx| {
             entity.read(cx).focus_handle(cx).focus(window, cx)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{rc::Rc, sync::Arc};
+
+    use super::*;
+
+    #[test]
+    fn task_completion_supports_non_send_foreground_output() {
+        let dispatcher = Arc::new(ThreadedDispatcher::new());
+        let background_executor = BackgroundExecutor::new(dispatcher.clone());
+        let foreground_executor = ForegroundExecutor::new(dispatcher);
+        let (sender, receiver) = futures::channel::oneshot::channel();
+
+        background_executor
+            .spawn(async move {
+                sender
+                    .send(())
+                    .expect("foreground receiver should remain alive");
+            })
+            .detach();
+        let expected_output = Rc::new(42);
+        let task_output = expected_output.clone();
+        let task = foreground_executor.spawn(async move {
+            receiver.await.expect("background task should send a value");
+            task_output
+        });
+
+        let output = run_task_to_completion(&foreground_executor, task);
+        assert!(
+            Rc::ptr_eq(&output, &expected_output),
+            "task runner should preserve non-Send foreground output"
+        );
     }
 }

--- a/crates/gpui/src/platform/threaded_dispatcher.rs
+++ b/crates/gpui/src/platform/threaded_dispatcher.rs
@@ -257,6 +257,31 @@ impl ThreadedDispatcher {
         }
     }
 
+    /// Drives main-thread work until `ready` returns a value.
+    ///
+    /// Unlike [`Self::run_until_idle`], this waits across temporary quiescence.
+    /// This is required when completion can arrive from an external worker that
+    /// is not represented in the dispatcher's in-flight count.
+    #[cfg(any(test, feature = "bench"))]
+    pub(crate) fn run_until<R>(&self, mut ready: impl FnMut() -> Option<R>) -> R {
+        assert!(
+            self.is_main_thread(),
+            "run_until must be called on the threaded dispatcher's main thread"
+        );
+        loop {
+            self.drain_main_queue();
+            if let Some(result) = ready() {
+                return result;
+            }
+
+            let mut inflight = self.idle.inflight.lock();
+            if self.main_queue_has_work() {
+                continue;
+            }
+            self.idle.condvar.wait(&mut inflight);
+        }
+    }
+
     /// Runs all main-thread tasks that are queued right now, without waiting for
     /// background work or timers to finish.
     pub fn run_ready_main_tasks(&self) -> bool {
@@ -446,6 +471,36 @@ mod tests {
             .detach();
 
         dispatcher.run_until_idle();
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn run_until_waits_for_untracked_external_wakes() {
+        let dispatcher = Arc::new(ThreadedDispatcher::new());
+        let foreground = ForegroundExecutor::new(dispatcher.clone());
+        let (sender, receiver) = futures::channel::oneshot::channel();
+        let sender_thread = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            sender
+                .send(())
+                .expect("foreground receiver should remain alive");
+        });
+
+        let completed = Arc::new(AtomicBool::new(false));
+        foreground
+            .spawn({
+                let completed = completed.clone();
+                async move {
+                    receiver
+                        .await
+                        .expect("external sender should deliver its wake");
+                    completed.store(true, Ordering::SeqCst);
+                }
+            })
+            .detach();
+
+        dispatcher.run_until(|| completed.load(Ordering::SeqCst).then_some(()));
+        sender_thread.join().expect("sender thread should finish");
         assert!(completed.load(Ordering::SeqCst));
     }
 


### PR DESCRIPTION
### Summary

This PR improves GPUI's Criterion benchmark integration by adding task-based measurement APIs to `BenchAppContext`. Benchmarks can now await asynchronous GPUI operations whose completion depends on foreground work, background work, timers, or external wakes, while keeping setup and destruction outside the measured interval.

#### Added `BenchAppContext` APIs

- Add `bench_task` to measure a GPUI `Task` through completion in Criterion's iteration loop.
- Add `bench_batched_task` to perform per-iteration setup outside the timed interval before measuring a task.
- Preserve support for non-`Send` foreground task outputs and destroy outputs after timing stops.
- Collect frame timings produced during asynchronous benchmark iterations without including collection in the measurement.
- Drive task completion across temporary dispatcher quiescence and externally delivered wakes.

Release Notes:

- N/A
