### PR TITLE
agent: Cap tool output sent to the model

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -9,6 +9,7 @@ mod templates;
 mod tests;
 mod thread;
 mod thread_store;
+mod tool_output;
 mod tool_permissions;
 mod tools;
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -16,6 +16,7 @@ use crate::sandboxing::{
     sandbox_worktree_writable_paths, sandboxing_available_for_project,
     sandboxing_enabled_for_project,
 };
+use crate::tool_output::truncate_tool_result;
 use agent_client_protocol::schema::v1 as acp;
 use agent_settings::{
     AgentProfileId, AgentProfileSettings, AgentSettings, AutoCompactThreshold, COMPACTION_PROMPT,
@@ -3613,7 +3614,7 @@ impl Thread {
         let supports_images = self.model().is_some_and(|model| model.supports_images());
         let tool_result = tool.run(tool_input, tool_event_stream, cx);
         cx.foreground_executor().spawn(async move {
-            let (is_error, output) = match tool_result.await {
+            let (is_error, mut output) = match tool_result.await {
                 Ok(mut output) => {
                     let contains_image = output
                         .llm_output
@@ -3655,6 +3656,7 @@ impl Thread {
                 }
                 Err(output) => (true, output),
             };
+            truncate_tool_result(&mut output.llm_output);
 
             (
                 owning_message_ix,

--- a/crates/agent/src/tool_output.rs
+++ b/crates/agent/src/tool_output.rs
@@ -1,0 +1,202 @@
+use language_model::LanguageModelToolResultContent;
+use std::fmt::Write as _;
+use util::size::format_file_size;
+
+/// Maximum number of lines a single tool result may occupy in the model's context.
+pub const MAX_TOOL_OUTPUT_LINES: usize = 2000;
+
+/// Maximum number of bytes a single tool result may occupy in the model's context.
+pub const MAX_TOOL_OUTPUT_BYTES: usize = 50 * 1024;
+
+/// Caps the text parts of a tool result to a shared line and byte budget so a
+/// single tool call can't flood the model's context. Oversized parts are
+/// middle-truncated: the head and tail are preserved and an inline notice
+/// replaces the elided middle. Images pass through untouched.
+///
+/// Only the content sent to the model is affected; the raw output persisted
+/// for the UI stays complete.
+pub fn truncate_tool_result(content: &mut [LanguageModelToolResultContent]) {
+    let mut remaining_lines = MAX_TOOL_OUTPUT_LINES;
+    let mut remaining_bytes = MAX_TOOL_OUTPUT_BYTES;
+    for part in content {
+        let LanguageModelToolResultContent::Text(text) = part else {
+            continue;
+        };
+        let line_count = text.lines().count();
+        if line_count <= remaining_lines && text.len() <= remaining_bytes {
+            remaining_lines -= line_count;
+            remaining_bytes -= text.len();
+        } else {
+            let truncated = truncate_middle(text, remaining_lines, remaining_bytes);
+            *part = truncated.into();
+            remaining_lines = 0;
+            remaining_bytes = 0;
+        }
+    }
+}
+
+/// Caps a display line to `max_chars` characters, returning the possibly
+/// shortened line and whether it was truncated.
+pub fn truncate_line(line: &str, max_chars: usize) -> (&str, bool) {
+    match line.char_indices().nth(max_chars) {
+        Some((ix, _)) => (&line[..ix], true),
+        None => (line, false),
+    }
+}
+
+fn truncate_middle(text: &str, max_lines: usize, max_bytes: usize) -> String {
+    let head_end = head_boundary(text, max_lines / 2, max_bytes / 2);
+    let tail_start =
+        tail_boundary(text, max_lines.div_ceil(2), max_bytes.div_ceil(2)).max(head_end);
+
+    let total_lines = text.lines().count();
+    let omitted_lines = text[head_end..tail_start].lines().count();
+    let omitted_bytes = (tail_start - head_end) as u64;
+
+    let mut result = String::with_capacity(head_end + (text.len() - tail_start) + 256);
+    result.push_str(&text[..head_end]);
+    if !result.is_empty() && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    let _ = writeln!(
+        result,
+        "[... omitted {omitted_lines} of {total_lines} lines ({}) from tool output. \
+         Re-run the tool with narrower parameters (e.g. offset/limit, start_line/end_line, \
+         or head_lines/tail_lines) to see more ...]",
+        format_file_size(omitted_bytes, true),
+    );
+    result.push_str(&text[tail_start..]);
+    result
+}
+
+/// Byte offset after the last whole line that fits in the budgets, or a
+/// mid-line cut when the first line alone exceeds `max_bytes`.
+fn head_boundary(text: &str, max_lines: usize, max_bytes: usize) -> usize {
+    let mut end = 0;
+    for line in text.split_inclusive('\n').take(max_lines) {
+        if end + line.len() > max_bytes {
+            break;
+        }
+        end += line.len();
+    }
+    if end == 0 && max_lines > 0 {
+        floor_char_boundary(text, max_bytes)
+    } else {
+        end
+    }
+}
+
+/// Byte offset where the tail begins: at most `max_lines` of the final
+/// `max_bytes` of `text`. May start mid-line when a single line exceeds the
+/// byte budget.
+fn tail_boundary(text: &str, max_lines: usize, max_bytes: usize) -> usize {
+    if max_lines == 0 || max_bytes == 0 {
+        return text.len();
+    }
+    let window_start = ceil_char_boundary(text, text.len().saturating_sub(max_bytes));
+    let mut line_starts = Vec::new();
+    let mut offset = window_start;
+    for line in text[window_start..].split_inclusive('\n') {
+        line_starts.push(offset);
+        offset += line.len();
+    }
+    let keep = line_starts.len().min(max_lines);
+    line_starts
+        .get(line_starts.len() - keep)
+        .copied()
+        .unwrap_or(text.len())
+}
+
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    while !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
+    while !text.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_part(text: &str) -> LanguageModelToolResultContent {
+        LanguageModelToolResultContent::Text(text.into())
+    }
+
+    fn text(part: &LanguageModelToolResultContent) -> &str {
+        match part {
+            LanguageModelToolResultContent::Text(text) => text,
+            LanguageModelToolResultContent::Image(_) => panic!("expected text part"),
+        }
+    }
+
+    #[test]
+    fn test_output_within_limits_is_unchanged() {
+        let mut content = vec![text_part("hello\nworld")];
+        truncate_tool_result(&mut content);
+        assert_eq!(text(&content[0]), "hello\nworld");
+    }
+
+    #[test]
+    fn test_line_limit_preserves_head_and_tail() {
+        let input = (0..MAX_TOOL_OUTPUT_LINES * 2)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut content = vec![text_part(&input)];
+        truncate_tool_result(&mut content);
+        let result = text(&content[0]);
+        assert!(result.starts_with("line 0\n"));
+        assert!(result.ends_with(&format!("line {}", MAX_TOOL_OUTPUT_LINES * 2 - 1)));
+        assert!(result.contains("omitted"));
+        assert!(result.lines().count() <= MAX_TOOL_OUTPUT_LINES + 1);
+    }
+
+    #[test]
+    fn test_byte_limit_preserves_head_and_tail() {
+        let line = "x".repeat(1024);
+        let input = vec![line.clone(); 100].join("\n");
+        let mut content = vec![text_part(&input)];
+        truncate_tool_result(&mut content);
+        let result = text(&content[0]);
+        assert!(result.starts_with(&line));
+        assert!(result.ends_with(&line));
+        assert!(result.contains("omitted"));
+        assert!(result.len() <= MAX_TOOL_OUTPUT_BYTES + 256);
+    }
+
+    #[test]
+    fn test_single_line_exceeding_byte_limit() {
+        let input = "y".repeat(MAX_TOOL_OUTPUT_BYTES * 4);
+        let mut content = vec![text_part(&input)];
+        truncate_tool_result(&mut content);
+        let result = text(&content[0]);
+        assert!(result.starts_with("yyy"));
+        assert!(result.ends_with("yyy"));
+        assert!(result.contains("omitted"));
+        assert!(result.len() <= MAX_TOOL_OUTPUT_BYTES + 256);
+    }
+
+    #[test]
+    fn test_budget_is_shared_across_parts() {
+        let big = "line\n".repeat(MAX_TOOL_OUTPUT_LINES);
+        let mut content = vec![text_part(&big), text_part("hello\nworld")];
+        truncate_tool_result(&mut content);
+        assert_eq!(text(&content[0]), big);
+        assert!(text(&content[1]).contains("omitted 2 of 2 lines"));
+    }
+
+    #[test]
+    fn test_truncate_line() {
+        assert_eq!(truncate_line("hello", 10), ("hello", false));
+        assert_eq!(truncate_line("hello", 5), ("hello", false));
+        assert_eq!(truncate_line("hello", 4), ("hell", true));
+        assert_eq!(truncate_line("èèèèè", 4), ("èèèè", true));
+    }
+}

--- a/crates/agent/src/tools/fetch_tool.rs
+++ b/crates/agent/src/tools/fetch_tool.rs
@@ -12,6 +12,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use ui::SharedString;
 use util::markdown::{MarkdownEscaped, MarkdownInlineCode};
+use util::size::format_file_size;
 
 use crate::sandboxing::{NetworkRequest, SandboxRequest};
 use crate::{AgentTool, ToolCallEventStream, ToolInput};
@@ -26,6 +27,10 @@ enum ContentType {
 /// The maximum number of HTTP redirects the fetch tool will follow. Each hop is
 /// re-authorized against the shared network grants before being followed.
 const MAX_REDIRECTS: usize = 20;
+
+/// Responses larger than this are rejected outright rather than truncated,
+/// since partially converted content is rarely useful to the model.
+const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
 /// The outcome of a single (non-redirect-following) HTTP request.
 enum FetchStep {
@@ -106,9 +111,15 @@ impl FetchTool {
         let mut body = Vec::new();
         response
             .body_mut()
+            .take(MAX_RESPONSE_BYTES as u64 + 1)
             .read_to_end(&mut body)
             .await
             .context("error reading response body")?;
+        anyhow::ensure!(
+            body.len() <= MAX_RESPONSE_BYTES,
+            "response body exceeds the {} limit; fetch a more specific URL instead",
+            format_file_size(MAX_RESPONSE_BYTES as u64, true)
+        );
 
         if status.is_client_error() {
             let text = String::from_utf8_lossy(body.as_slice());

--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -1,3 +1,4 @@
+use crate::tool_output::truncate_line;
 use crate::{AgentTool, ToolCallEventStream, ToolInput};
 use acp_thread::MentionUri;
 use agent_client_protocol::schema::v1 as acp;
@@ -121,6 +122,7 @@ impl AgentTool for GrepTool {
     ) -> Task<Result<Self::Output, Self::Output>> {
         const CONTEXT_LINES: u32 = 2;
         const MAX_ANCESTOR_LINES: u32 = 10;
+        const MAX_MATCH_LINE_LEN: usize = 500;
 
         let project = self.project.clone();
         cx.spawn(async move |cx|  {
@@ -184,6 +186,7 @@ impl AgentTool for GrepTool {
             let mut skips_remaining = input.offset;
             let mut matches_found = 0;
             let mut has_more_matches = false;
+            let mut lines_truncated = false;
 
             'outer: loop {
                 let search_result = futures::select! {
@@ -324,8 +327,16 @@ impl AgentTool for GrepTool {
 
                     let snippet: String = snapshot.text_for_range(range.clone()).collect();
                     output.push_str("```\n");
-                    output.push_str(&snippet);
-                    output.push_str("\n```\n");
+                    for line in snippet.lines() {
+                        let (line, truncated) = truncate_line(line, MAX_MATCH_LINE_LEN);
+                        output.push_str(line);
+                        if truncated {
+                            output.push('…');
+                            lines_truncated = true;
+                        }
+                        output.push('\n');
+                    }
+                    output.push_str("```\n");
 
                     if let Some(abs_path) = &abs_path {
                         let uri = MentionUri::Selection {
@@ -364,6 +375,10 @@ impl AgentTool for GrepTool {
 
                     matches_found += 1;
                 }
+            }
+
+            if lines_truncated {
+                writeln!(output, "\nSome matched lines were truncated to {MAX_MATCH_LINE_LEN} characters. Use read_file to see full lines.").ok();
             }
 
             if !content.is_empty() {
@@ -999,6 +1014,38 @@ mod tests {
             "#
         .unindent();
         assert_eq!(result, expected);
+    }
+
+    #[gpui::test]
+    async fn test_grep_truncates_long_lines(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.executor().allow_parking();
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                "long_line.txt": format!("needle {}", "x".repeat(2000))
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+        let input = GrepToolInput {
+            regex: "needle".to_string(),
+            include_pattern: None,
+            offset: 0,
+            case_sensitive: false,
+        };
+
+        let result = run_grep_tool(input, project, cx).await;
+        let matched_line = result
+            .lines()
+            .find(|line| line.starts_with("needle"))
+            .unwrap();
+        assert_eq!(matched_line.chars().count(), 501); // 500 chars + '…'
+        assert!(matched_line.ends_with('…'));
+        assert!(result.contains("Some matched lines were truncated to 500 characters"));
     }
 
     async fn run_grep_tool(

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 use std::sync::Arc;
 use util::markdown::MarkdownCodeBlock;
 
+use crate::tool_output::{MAX_TOOL_OUTPUT_BYTES, MAX_TOOL_OUTPUT_LINES};
+
 fn tool_content_err(e: impl std::fmt::Display) -> LanguageModelToolResultContent {
     LanguageModelToolResultContent::from(e.to_string())
 }
@@ -92,6 +94,36 @@ fn write_lines_numbered<'a>(
     }
 }
 
+/// Applies the ranged-read byte budget to numbered output, appending
+/// continuation guidance when the read stops short of the requested range.
+fn cap_ranged_output(
+    output: String,
+    start: u32,
+    capped_end: u32,
+    requested_end: u32,
+    total_lines: u32,
+) -> String {
+    use std::fmt::Write as _;
+
+    let byte_capped = util::truncate_lines_to_byte_limit(&output, MAX_TOOL_OUTPUT_BYTES);
+    if byte_capped.len() == output.len() && capped_end >= requested_end {
+        return output;
+    }
+
+    let last_line = if byte_capped.len() < output.len() {
+        start.saturating_add((byte_capped.matches('\n').count() as u32).saturating_sub(1))
+    } else {
+        capped_end
+    };
+    let mut result = byte_capped.to_string();
+    let _ = write!(
+        result,
+        "\nShowing lines {start}-{last_line} of {total_lines}. Continue with start_line: {}.",
+        last_line.saturating_add(1)
+    );
+    result
+}
+
 /// Read a file under the global skills directory directly via the filesystem,
 /// bypassing project/worktree resolution. Used for skill resources that live
 /// outside any worktree.
@@ -114,20 +146,26 @@ async fn read_global_skill_file(
             .line(start_line.map(|line| line.saturating_sub(1))),
     ]));
 
-    let (raw_text, first_line_number) = if start_line.is_some() || end_line.is_some() {
+    let result_text = if start_line.is_some() || end_line.is_some() {
         // `split_inclusive` keeps each line's terminator attached, so CRLF stays
         // CRLF and the trailing newline of the last returned line is preserved —
         // matching `Buffer::text_for_range` in the buffer-backed path.
         let (start, end) = resolve_line_range(start_line, end_line);
         let lines: Vec<&str> = content.split_inclusive('\n').collect();
         let start_idx = (start as usize).saturating_sub(1).min(lines.len());
-        let end_idx = (end as usize).min(lines.len()).max(start_idx);
-        (lines[start_idx..end_idx].concat(), start)
+        let requested_end_idx = (end as usize).min(lines.len()).max(start_idx);
+        let end_idx = requested_end_idx.min(start_idx.saturating_add(MAX_TOOL_OUTPUT_LINES));
+        let numbered = format_with_line_numbers(&lines[start_idx..end_idx].concat(), start);
+        cap_ranged_output(
+            numbered,
+            start,
+            end_idx as u32,
+            requested_end_idx as u32,
+            lines.len() as u32,
+        )
     } else {
-        (content, 1)
+        format_with_line_numbers(&content, 1)
     };
-
-    let result_text = format_with_line_numbers(&raw_text, first_line_number);
 
     let markdown = MarkdownCodeBlock {
         tag: requested_path,
@@ -425,13 +463,17 @@ impl AgentTool for ReadFileTool {
                         anchor = Some(buffer.anchor_before(Point::new(start_row, column)));
                     }
 
-                    // `end` is 1-indexed inclusive; `Point` rows are 0-indexed.
-                    // Using `end` directly as the (exclusive) end row is the
+                    let total_lines = buffer.max_point().row + 1;
+                    let requested_end = end.min(total_lines);
+                    let capped_end = requested_end
+                        .min(start.saturating_add(MAX_TOOL_OUTPUT_LINES as u32 - 1));
+                    // `capped_end` is 1-indexed inclusive; `Point` rows are 0-indexed.
+                    // Using it directly as the (exclusive) end row is the
                     // standard inclusive→exclusive translation, and since
                     // `resolve_line_range` guarantees `end >= start`, we always
                     // read at least one line.
                     let start_anchor = buffer.anchor_before(Point::new(start_row, 0));
-                    let end_anchor = buffer.anchor_before(Point::new(end, 0));
+                    let end_anchor = buffer.anchor_before(Point::new(capped_end, 0));
                     // Stream the numbered output directly from the buffer's
                     // chunk iterator so the unnumbered range is never
                     // materialized as its own `String`.
@@ -441,7 +483,7 @@ impl AgentTool for ReadFileTool {
                         buffer.text_for_range(start_anchor..end_anchor),
                         start,
                     );
-                    output
+                    cap_ranged_output(output, start, capped_end, requested_end, total_lines)
                 });
 
                 action_log.update(cx, |log, cx| {
@@ -991,6 +1033,52 @@ mod test {
             })
             .await;
         assert_eq!(result.unwrap(), "     3\tLine 3\n".into());
+    }
+
+    #[gpui::test]
+    async fn test_read_file_line_range_is_capped(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let total_lines = MAX_TOOL_OUTPUT_LINES + 500;
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                "big.txt": (1..=total_lines).map(|i| format!("Line {i}")).collect::<Vec<_>>().join("\n")
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let tool = Arc::new(ReadFileTool::new(project, action_log, true));
+
+        let result = cx
+            .update(|cx| {
+                let input = ReadFileToolInput {
+                    path: "root/big.txt".to_string(),
+                    start_line: Some(1),
+                    end_line: None,
+                };
+                tool.run(
+                    ToolInput::resolved(input),
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        let content = result.to_str().unwrap();
+
+        assert!(content.contains(&format!(
+            "{:>6}\tLine {}\n",
+            MAX_TOOL_OUTPUT_LINES, MAX_TOOL_OUTPUT_LINES
+        )));
+        assert!(content.ends_with(&format!(
+            "Showing lines 1-{} of {}. Continue with start_line: {}.",
+            MAX_TOOL_OUTPUT_LINES,
+            total_lines,
+            MAX_TOOL_OUTPUT_LINES + 1
+        )));
     }
 
     fn error_text(content: LanguageModelToolResultContent) -> String {

--- a/crates/agent/src/tools/symbol_locator.rs
+++ b/crates/agent/src/tools/symbol_locator.rs
@@ -3,6 +3,8 @@ use std::fmt;
 
 use gpui::{App, AsyncApp, Entity};
 use language::{Buffer, Location};
+
+use crate::tool_output::truncate_line;
 use project::{CodeAction, Project};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -64,14 +66,14 @@ impl LocationDisplay {
         let end_line = range.end.row + 1;
 
         let line_len = snapshot.line_len(range.start.row);
-        let truncated = line_len as usize > MAX_LINE_DISPLAY_LEN;
         let snippet: String = snapshot
             .text_for_range(Point::new(range.start.row, 0)..Point::new(range.start.row, line_len))
             .flat_map(|chunk| chunk.chars())
             .skip_while(|c| c.is_whitespace())
-            .take(MAX_LINE_DISPLAY_LEN)
+            .take(MAX_LINE_DISPLAY_LEN + 1)
             .collect::<String>();
-        let snippet = snippet.trim_end().to_string();
+        let (snippet, truncated) = truncate_line(snippet.trim_end(), MAX_LINE_DISPLAY_LEN);
+        let snippet = snippet.to_string();
 
         Self {
             path,
@@ -177,7 +179,6 @@ impl SymbolLocator {
             }
 
             let line_len = snapshot.line_len(row);
-            let truncated = line_len as usize > MAX_LINE_DISPLAY_LEN;
             let line_start = Point::new(row, 0);
             let line_end = Point::new(row, line_len);
             let line_chars = || {
@@ -185,25 +186,25 @@ impl SymbolLocator {
                     .text_for_range(line_start..line_end)
                     .flat_map(|chunk| chunk.chars())
             };
+            let display_line = || {
+                let text: String = line_chars()
+                    .skip_while(|c| c.is_whitespace())
+                    .take(MAX_LINE_DISPLAY_LEN + 1)
+                    .collect();
+                let (capped, truncated) = truncate_line(text.trim_end(), MAX_LINE_DISPLAY_LEN);
+                (capped.to_string(), truncated)
+            };
 
             let byte_offset = find_in_char_iter(line_chars(), symbol_name).ok_or_else(|| {
-                let preview: String = line_chars()
-                    .skip_while(|c| c.is_whitespace())
-                    .take(MAX_LINE_DISPLAY_LEN)
-                    .collect();
+                let (preview, _) = display_line();
                 format!(
                     "Symbol '{symbol_name}' not found on line {line} of '{file_path}'. \
-                     Line content: '{}'",
-                    preview.trim_end()
+                     Line content: '{preview}'"
                 )
             })?;
 
             let position = snapshot.anchor_before(Point::new(row, byte_offset as u32));
-            let display_text: String = line_chars()
-                .skip_while(|c| c.is_whitespace())
-                .take(MAX_LINE_DISPLAY_LEN)
-                .collect::<String>();
-            let display_text = display_text.trim_end().to_string();
+            let (display_text, truncated) = display_line();
 
             Ok((position, display_text, truncated))
         })?;


### PR DESCRIPTION
There's no real cap on how big an output can be for read_file, diagnostics, grep, fetch... The only real cap is the terminal tool's 16KB limit. This causes the Zed agent to bloat the context quickly and occasionally bypass the context limit, and the conversation has to reset to the last user message. My current workaround is to disable most tools and keep only the terminal tool, as current agents, even small ones, are really good at using the terminal. Most of this PR was written by Fable 5.

# Objective

The root cause is that tool results sent to the model were unbounded. The only real cap in the agent was the terminal tool's 16KB limit, and even that gets disabled when `head_lines`/`tail_lines` is set. Every other tool (`grep`, `read_file` with line ranges, `diagnostics`, `fetch`, `list_directory`, MCP tools, ...) could emit output of any size. A single grep match on a minified file can produce 100k+ chars, and one tool call can produce megabytes (see #59401).

Closes #62164

## Solution

Other agent harnesses (OpenCode, Pi, Codex) all cap tool output before it reaches the model, usually with a line + byte budget that keeps the head and tail. This PR does the same thing:

**Central safety net**, a new `tool_output` module in the `agent` crate:

- Every tool result is capped to a shared budget of **2000 lines / 50KB** in `Thread::run_tool`, the single choke point that all tools (native and MCP) flow through.
- Oversized results are middle-truncated: the head and tail are preserved (errors tend to be at the end, headers at the start) and an inline notice says how much was omitted and how to re-run with narrower parameters.
- Only the content sent to the model is affected. The raw output persisted for the UI and thread history stays complete, so you still see everything in the panel.
- This also closes the terminal tool's `head_lines`/`tail_lines` bypass, since the cap now applies after selection.

**Per-tool improvements** on top of the net:

- `grep`: matched lines are capped at 500 chars (with a `…` suffix and a one-time "use read_file to see full lines" notice), so one long line can't fill the whole budget with noise. The line-capping helper is shared with `symbol_locator`, which previously open-coded the same logic.
- `read_file`: ranged reads (which bypass the existing `AUTO_OUTLINE_SIZE` gate) are now capped, head-first since reads are sequential, with precise continuation guidance: `Showing lines 1-2000 of 2500. Continue with start_line: 2001.`
- `fetch`: responses over 5MB are rejected with an error instead of being buffered into memory unbounded.

## Testing

- New unit tests in `tool_output`: within-limit passthrough, line-limit and byte-limit middle truncation, single giant line, shared budget across multi-part (MCP-style) results, and per-line capping.
- New regression tests: `test_grep_truncates_long_lines` (grep on a 2000-char line asserts the 500-char cap and notice) and `test_read_file_line_range_is_capped` (ranged read of a 2500-line file asserts the cap and the continuation notice).
- Full `agent` crate suite passes: 727 tests, 0 failures. `cargo clippy` and `cargo fmt` clean.
- Tested on macOS (aarch64); the change is platform-independent.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (no unsafe code)
- [x] The content adheres to Zed's UI standards (no UI changes; the panel still shows full output)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable (the fast path is a single line count/length check per text part; truncation only does extra work on oversized outputs)

---

Release Notes:

- Improved the agent by capping tool output sent to the model.