### PR TITLE
editor: Add Fix with Agent to diagnostic popovers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,7 @@ dependencies = [
 name = "editor"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "aho-corasick",
  "anyhow",
  "assets",

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -24,8 +24,8 @@ use serde::{Deserialize, Serialize};
 use zed_actions::{
     DecreaseBufferFontSize, IncreaseBufferFontSize, ResetBufferFontSize,
     agent::{
-        AddSelectionToThread, ConflictContent, LogoutAgent, OpenSettings, ReauthenticateAgent,
-        ResetAgentZoom, ResetOnboarding, ResolveConflictedFilesWithAgent,
+        AddSelectionToThread, ConflictContent, FixDiagnosticWithAgent, LogoutAgent, OpenSettings,
+        ReauthenticateAgent, ResetAgentZoom, ResetOnboarding, ResolveConflictedFilesWithAgent,
         ResolveConflictsWithAgent, ReviewBranchDiff, SelectAgent,
     },
     assistant::{
@@ -582,6 +582,32 @@ pub fn init(cx: &mut App) {
                         );
                     });
                 })
+                .register_action(|workspace, action: &FixDiagnosticWithAgent, window, cx| {
+                    let Some(panel) = workspace.panel::<AgentPanel>(cx) else {
+                        return;
+                    };
+                    let content_blocks = vec![acp::ContentBlock::Text(acp::TextContent::new(
+                        diagnostic_fix_prompt(action),
+                    ))];
+
+                    workspace.focus_panel::<AgentPanel>(window, cx);
+                    panel.update(cx, |panel, cx| {
+                        panel.external_thread(
+                            None,
+                            None,
+                            None,
+                            None,
+                            Some(AgentInitialContent::ContentBlock {
+                                blocks: content_blocks,
+                                auto_submit: true,
+                            }),
+                            true,
+                            AgentThreadSource::AgentPanel,
+                            window,
+                            cx,
+                        );
+                    });
+                })
                 .register_action(
                     |workspace, action: &ResolveConflictsWithAgent, window, cx| {
                         let Some(panel) = workspace.panel::<AgentPanel>(cx) else {
@@ -889,6 +915,13 @@ fn build_conflict_resolution_prompt(conflicts: &[ConflictContent]) -> Vec<acp::C
     }
 
     blocks
+}
+
+fn diagnostic_fix_prompt(action: &FixDiagnosticWithAgent) -> String {
+    format!(
+        "Fix the following diagnostic in `{}` at line {}, column {}:\n\n{}",
+        action.path, action.line, action.column, action.message
+    )
 }
 
 fn build_conflicted_files_resolution_prompt(
@@ -6843,6 +6876,21 @@ mod tests {
         assert!(is_known_terminal_agent_command("codex"));
         assert!(!is_known_terminal_agent_command("cargo"));
         assert!(!is_known_terminal_agent_command("internal-agent"));
+    }
+
+    #[test]
+    fn test_diagnostic_fix_prompt() {
+        let action = FixDiagnosticWithAgent {
+            path: "/project/src/main.rs".into(),
+            line: 12,
+            column: 7,
+            message: "mismatched types".into(),
+        };
+
+        assert_eq!(
+            diagnostic_fix_prompt(&action),
+            "Fix the following diagnostic in `/project/src/main.rs` at line 12, column 7:\n\nmismatched types"
+        );
     }
 
     #[test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -919,8 +919,8 @@ fn build_conflict_resolution_prompt(conflicts: &[ConflictContent]) -> Vec<acp::C
 
 fn diagnostic_fix_prompt(action: &FixDiagnosticWithAgent) -> String {
     format!(
-        "Fix the following diagnostic in `{}` at line {}, column {}:\n\n{}",
-        action.path, action.line, action.column, action.message
+        "Fix the following diagnostic in `{}` at line {}:\n\n{}",
+        action.path, action.line, action.message
     )
 }
 
@@ -6883,13 +6883,12 @@ mod tests {
         let action = FixDiagnosticWithAgent {
             path: "/project/src/main.rs".into(),
             line: 12,
-            column: 7,
             message: "mismatched types".into(),
         };
 
         assert_eq!(
             diagnostic_fix_prompt(&action),
-            "Fix the following diagnostic in `/project/src/main.rs` at line 12, column 7:\n\nmismatched types"
+            "Fix the following diagnostic in `/project/src/main.rs` at line 12:\n\nmismatched types"
         );
     }
 

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -31,6 +31,7 @@ test-support = [
 ]
 
 [dependencies]
+agent_settings.workspace = true
 aho-corasick.workspace = true
 anyhow.workspace = true
 assets.workspace = true

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -435,7 +435,6 @@ fn show_hover(
                     Some(FixDiagnosticWithAgent {
                         path: path.clone().into(),
                         line: point.row + 1,
-                        column: point.column + 1,
                         message: local_diagnostic.diagnostic.message.clone().into(),
                     })
                 });

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -7,6 +7,7 @@ use crate::{
     movement::TextLayoutDetails,
     scroll::ScrollAmount,
 };
+use agent_settings::AgentSettings;
 use anyhow::Context as _;
 use gpui::{
     AnyElement, App, AsyncWindowContext, Bounds, Context, Entity, Focusable as _, FontWeight, Hsla,
@@ -19,7 +20,7 @@ use language::{DiagnosticEntry, Language, LanguageRegistry};
 use lsp::DiagnosticSeverity;
 use markdown::{CopyButtonVisibility, Markdown, MarkdownElement, MarkdownStyle};
 use multi_buffer::{MultiBufferOffset, ToOffset, ToPoint};
-use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart};
+use project::{DisableAiSettings, HoverBlock, HoverBlockKind, InlayHintLabelPart};
 use settings::Settings;
 use std::{
     borrow::Cow,
@@ -32,6 +33,7 @@ use ui::{CopyButton, Scrollbars, WithScrollbar, prelude::*, theme_is_transparent
 use url::Url;
 use util::TryFutureExt;
 use workspace::{OpenOptions, OpenVisible, Workspace};
+use zed_actions::agent::FixDiagnosticWithAgent;
 
 pub const MIN_POPOVER_CHARACTER_WIDTH: f32 = 20.;
 pub const MIN_POPOVER_LINE_HEIGHT: f32 = 4.;
@@ -281,11 +283,17 @@ fn show_hover(
 
     let snapshot = editor.snapshot(window, cx);
 
-    let (buffer_position, _) = editor
-        .buffer
-        .read(cx)
-        .snapshot(cx)
-        .anchor_to_buffer_anchor(anchor)?;
+    let (buffer_position, buffer_snapshot) =
+        snapshot.buffer_snapshot().anchor_to_buffer_anchor(anchor)?;
+    let diagnostic_path = if AgentSettings::get_global(cx).enabled(cx)
+        && !DisableAiSettings::is_ai_disabled_for_file(buffer_snapshot.file(), cx)
+    {
+        buffer_snapshot
+            .file()
+            .map(|file| file.full_path(cx).to_string_lossy().into_owned())
+    } else {
+        None
+    };
     let buffer = editor.buffer.read(cx).buffer(buffer_position.buffer_id)?;
 
     let language_registry = editor
@@ -416,6 +424,21 @@ fn show_hover(
                             .buffer_snapshot()
                             .anchor_after(local_diagnostic.range.end),
                 };
+                let fix_action = diagnostic_path.as_ref().and_then(|path| {
+                    if local_diagnostic.diagnostic.severity != DiagnosticSeverity::ERROR {
+                        return None;
+                    }
+                    let (diagnostic_start, buffer_snapshot) = snapshot
+                        .buffer_snapshot()
+                        .anchor_to_buffer_anchor(local_diagnostic.range.start)?;
+                    let point = text::ToPoint::to_point(&diagnostic_start, buffer_snapshot);
+                    Some(FixDiagnosticWithAgent {
+                        path: path.clone().into(),
+                        line: point.row + 1,
+                        column: point.column + 1,
+                        message: local_diagnostic.diagnostic.message.clone().into(),
+                    })
+                });
 
                 let scroll_handle = ScrollHandle::new();
 
@@ -425,6 +448,7 @@ fn show_hover(
                     border_color,
                     scroll_handle,
                     background_color,
+                    fix_action,
                     keyboard_grace: Rc::new(RefCell::new(ignore_timeout)),
                     anchor,
                     last_bounds: Rc::new(Cell::new(None)),
@@ -1150,6 +1174,7 @@ pub struct DiagnosticPopover {
     markdown: Entity<Markdown>,
     border_color: Hsla,
     background_color: Hsla,
+    fix_action: Option<FixDiagnosticWithAgent>,
     pub keyboard_grace: Rc<RefCell<bool>>,
     pub anchor: Anchor,
     pub last_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
@@ -1167,10 +1192,11 @@ impl DiagnosticPopover {
         let keyboard_grace = Rc::clone(&self.keyboard_grace);
         let this = cx.entity().downgrade();
         let bounds_cell = self.last_bounds.clone();
-        div()
+        let fix_action = self.fix_action.clone();
+        v_flex()
+            .items_start()
             .id("diagnostic")
             .occlude()
-            .elevation_2_borderless(cx)
             .child(
                 canvas(
                     {
@@ -1183,11 +1209,6 @@ impl DiagnosticPopover {
                 .absolute()
                 .size_full(),
             )
-            // Don't draw the background color if the theme
-            // allows transparent surfaces.
-            .when(theme_is_transparent(cx), |this| {
-                this.bg(gpui::transparent_black())
-            })
             // Prevent a mouse move on the popover from being propagated to the editor,
             // because that would dismiss the popover.
             .on_mouse_move({
@@ -1208,55 +1229,88 @@ impl DiagnosticPopover {
                 *keyboard_grace = false;
                 cx.stop_propagation();
             })
+            .when_some(fix_action, |this, action| {
+                this.child(
+                    h_flex().pb_1().child(
+                        Button::new("fix-diagnostic-with-agent", "Fix with Agent")
+                            .size(ButtonSize::Compact)
+                            .style(ButtonStyle::Filled)
+                            .label_size(LabelSize::Small)
+                            .start_icon(
+                                Icon::new(IconName::ZedAssistant)
+                                    .size(IconSize::Small)
+                                    .color(Color::Muted),
+                            )
+                            .on_click(move |_, window, cx| {
+                                cx.stop_propagation();
+                                window.dispatch_action(Box::new(action.clone()), cx);
+                            }),
+                    ),
+                )
+            })
             .child(
                 div()
-                    .relative()
-                    .py_1()
-                    .pl_2()
-                    .pr_8()
-                    .bg(self.background_color)
-                    .border_1()
-                    .border_color(self.border_color)
-                    .rounded_lg()
+                    .elevation_2_borderless(cx)
+                    // Don't draw the background color if the theme
+                    // allows transparent surfaces.
+                    .when(theme_is_transparent(cx), |this| {
+                        this.bg(gpui::transparent_black())
+                    })
                     .child(
                         div()
-                            .id("diagnostic-content-container")
-                            .max_w(max_size.width)
-                            .max_h(max_size.height)
-                            .overflow_y_scroll()
-                            .track_scroll(&self.scroll_handle)
+                            .relative()
+                            .py_1()
+                            .pl_2()
+                            .pr_8()
+                            .bg(self.background_color)
+                            .border_1()
+                            .border_color(self.border_color)
+                            .rounded_lg()
                             .child(
-                                MarkdownElement::new(
-                                    self.markdown.clone(),
-                                    diagnostics_markdown_style(window, cx),
-                                )
-                                .code_block_renderer(markdown::CodeBlockRenderer::Default {
-                                    copy_button_visibility: CopyButtonVisibility::Hidden,
-                                    wrap_button_visibility: markdown::WrapButtonVisibility::Hidden,
-                                    border: false,
-                                })
-                                .on_url_click(
-                                    move |link, window, cx| {
-                                        if let Some(renderer) = GlobalDiagnosticRenderer::global(cx)
-                                        {
-                                            this.update(cx, |this, cx| {
-                                                renderer.as_ref().open_link(this, link, window, cx);
-                                            })
-                                            .ok();
-                                        }
-                                    },
-                                ),
+                                div()
+                                    .id("diagnostic-content-container")
+                                    .max_w(max_size.width)
+                                    .max_h(max_size.height)
+                                    .overflow_y_scroll()
+                                    .track_scroll(&self.scroll_handle)
+                                    .child(
+                                        MarkdownElement::new(
+                                            self.markdown.clone(),
+                                            diagnostics_markdown_style(window, cx),
+                                        )
+                                        .code_block_renderer(markdown::CodeBlockRenderer::Default {
+                                            copy_button_visibility: CopyButtonVisibility::Hidden,
+                                            wrap_button_visibility:
+                                                markdown::WrapButtonVisibility::Hidden,
+                                            border: false,
+                                        })
+                                        .on_url_click(
+                                            move |link, window, cx| {
+                                                if let Some(renderer) =
+                                                    GlobalDiagnosticRenderer::global(cx)
+                                                {
+                                                    this.update(cx, |this, cx| {
+                                                        renderer
+                                                            .as_ref()
+                                                            .open_link(this, link, window, cx);
+                                                    })
+                                                    .ok();
+                                                }
+                                            },
+                                        ),
+                                    ),
+                            )
+                            .child(div().absolute().top_1().right_1().child({
+                                let message = self.local_diagnostic.diagnostic.message.clone();
+                                CopyButton::new("copy-diagnostic", message)
+                                    .tooltip_label("Copy Diagnostic")
+                            }))
+                            .custom_scrollbars(
+                                Scrollbars::for_settings::<EditorSettingsScrollbarProxy>()
+                                    .tracked_scroll_handle(&self.scroll_handle),
+                                window,
+                                cx,
                             ),
-                    )
-                    .child(div().absolute().top_1().right_1().child({
-                        let message = self.local_diagnostic.diagnostic.message.clone();
-                        CopyButton::new("copy-diagnostic", message).tooltip_label("Copy Diagnostic")
-                    }))
-                    .custom_scrollbars(
-                        Scrollbars::for_settings::<EditorSettingsScrollbarProxy>()
-                            .tracked_scroll_handle(&self.scroll_handle),
-                        window,
-                        cx,
                     ),
             )
             .into_any_element()

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -627,8 +627,6 @@ pub mod agent {
         pub path: SharedString,
         /// The one-based line containing the diagnostic.
         pub line: u32,
-        /// The one-based column containing the diagnostic.
-        pub column: u32,
         pub message: SharedString,
     }
 

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -619,6 +619,19 @@ pub mod agent {
         pub base_ref: SharedString,
     }
 
+    /// Opens a new agent thread to fix an editor diagnostic.
+    #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
+    #[action(namespace = agent)]
+    #[serde(deny_unknown_fields)]
+    pub struct FixDiagnosticWithAgent {
+        pub path: SharedString,
+        /// The one-based line containing the diagnostic.
+        pub line: u32,
+        /// The one-based column containing the diagnostic.
+        pub column: u32,
+        pub message: SharedString,
+    }
+
     /// A single merge conflict region extracted from a file.
     #[derive(Clone, Debug, PartialEq, Deserialize, JsonSchema)]
     pub struct ConflictContent {


### PR DESCRIPTION
# Objective

- Make editor diagnostics directly actionable without requiring users to manually copy diagnostic details into the Agent Panel.
- Provide a quick way to ask the Agent to fix errors from the diagnostic hover popover.

## Solution

Add a compact **Fix with Agent** button above error diagnostic messages.

## Show Case


https://github.com/user-attachments/assets/e41664ea-2ed8-47f5-8c26-f69e95740b30



Release Notes:

- Added a Fix with Agent action to editor error diagnostic popovers.
