### PR TITLE
file_finder: add Recently Opened Files palette

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -2,9 +2,11 @@
 mod file_finder_tests;
 #[cfg(test)]
 mod multi_select_tests;
+mod recent_files;
 
 use futures::future::join_all;
 pub use open_path_prompt::OpenPathDelegate;
+pub use recent_files::{RecentFiles, RecentFilesDelegate, Toggle as ToggleRecentFiles};
 
 use channel::ChannelStore;
 use client::ChannelId;
@@ -76,6 +78,7 @@ pub fn init(cx: &mut App) {
     cx.observe_new(FileFinder::register).detach();
     cx.observe_new(OpenPathPrompt::register).detach();
     cx.observe_new(OpenPathPrompt::register_new_path).detach();
+    recent_files::init(cx);
 }
 
 impl FileFinder {

--- a/crates/file_finder/src/recent_files.rs
+++ b/crates/file_finder/src/recent_files.rs
@@ -1,0 +1,400 @@
+#[cfg(test)]
+mod recent_files_tests;
+
+use std::sync::Arc;
+
+use futures::future::join_all;
+use gpui::{
+    Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Modifiers,
+    ModifiersChangedEvent, ParentElement, Render, SharedString, Styled, Task, TaskExt, WeakEntity,
+    Window, actions, rems,
+};
+use picker::{Picker, PickerDelegate};
+use project::ProjectPath;
+use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
+use util::ResultExt;
+use workspace::{ModalView, Workspace};
+
+use crate::FoundPath;
+
+const PANEL_WIDTH_REMS: f32 = 34.;
+const MAX_MATCHES: usize = 100;
+
+actions!(
+    recent_files,
+    [
+        /// Toggles the recently opened files palette.
+        Toggle
+    ]
+);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(RecentFiles::register).detach();
+}
+
+pub struct RecentFiles {
+    picker: Entity<Picker<RecentFilesDelegate>>,
+    init_modifiers: Option<Modifiers>,
+}
+
+impl ModalView for RecentFiles {}
+
+impl RecentFiles {
+    fn register(
+        workspace: &mut Workspace,
+        _window: Option<&mut Window>,
+        _: &mut Context<Workspace>,
+    ) {
+        workspace.register_action(|workspace, _: &Toggle, window, cx| {
+            let Some(recent_files) = workspace.active_modal::<Self>(cx) else {
+                Self::open(workspace, window, cx).detach();
+                return;
+            };
+
+            recent_files.update(cx, |recent_files, cx| {
+                recent_files.init_modifiers = Some(window.modifiers());
+                recent_files.picker.update(cx, |picker, cx| {
+                    picker.cycle_selection(window, cx);
+                });
+            });
+        });
+    }
+
+    fn open(
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Task<()> {
+        let project = workspace.project().read(cx);
+        let fs = project.fs().clone();
+
+        let currently_opened_project_path = workspace
+            .active_item(cx)
+            .and_then(|item| item.project_path(cx));
+
+        // Same resolution as `FileFinder::open`'s history_items: prefer the fast
+        // in-worktree check, and fall back to an async filesystem existence check
+        // for history entries whose worktree isn't currently loaded.
+        let history_items = workspace
+            .recent_navigation_history(None, cx)
+            .into_iter()
+            .filter_map(|(project_path, abs_path)| {
+                if project.entry_for_path(&project_path, cx).is_some() {
+                    return Some(Task::ready(Some(FoundPath::new(project_path, abs_path?))));
+                }
+                let abs_path = abs_path?;
+                if project.is_local() {
+                    let fs = fs.clone();
+                    Some(cx.background_spawn(async move {
+                        if fs.is_file(&abs_path).await {
+                            Some(FoundPath::new(project_path, abs_path))
+                        } else {
+                            None
+                        }
+                    }))
+                } else {
+                    Some(Task::ready(Some(FoundPath::new(project_path, abs_path))))
+                }
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn_in(window, async move |workspace, cx| {
+            let history_items: Vec<FoundPath> = join_all(history_items)
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
+
+            workspace
+                .update_in(cx, |workspace, window, cx| {
+                    let weak_workspace = cx.entity().downgrade();
+                    workspace.toggle_modal(window, cx, |window, cx| {
+                        let delegate = RecentFilesDelegate::new(
+                            cx.entity().downgrade(),
+                            weak_workspace,
+                            currently_opened_project_path,
+                            history_items,
+                        );
+                        RecentFiles::new(delegate, window, cx)
+                    });
+                })
+                .ok();
+        })
+    }
+
+    fn new(delegate: RecentFilesDelegate, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let init_modifiers = window.modifiers().modified().then_some(window.modifiers());
+        Self {
+            picker: cx
+                .new(|cx| Picker::list(delegate, window, cx).initial_width(rems(PANEL_WIDTH_REMS))),
+            init_modifiers,
+        }
+    }
+
+    fn handle_modifiers_changed(
+        &mut self,
+        event: &ModifiersChangedEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(init_modifiers) = self.init_modifiers else {
+            return;
+        };
+        if !event.modified() || !init_modifiers.is_subset_of(event) {
+            self.init_modifiers = None;
+            if self.picker.read(cx).delegate.matches.is_empty() {
+                cx.emit(DismissEvent)
+            } else {
+                window.dispatch_action(menu::Confirm.boxed_clone(), cx);
+            }
+        }
+    }
+}
+
+impl EventEmitter<DismissEvent> for RecentFiles {}
+
+impl Focusable for RecentFiles {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl Render for RecentFiles {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("RecentFiles")
+            .w(rems(PANEL_WIDTH_REMS))
+            .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
+            .child(self.picker.clone())
+    }
+}
+
+/// A single candidate in the recent-files list: a resolved path plus the
+/// pre-split display strings so matching only needs to run against the file
+/// name, not the whole absolute path.
+#[derive(Clone)]
+struct RecentFileEntry {
+    path: FoundPath,
+    file_name: SharedString,
+    parent_path: SharedString,
+}
+
+impl RecentFileEntry {
+    fn new(path: FoundPath) -> Self {
+        let file_name = path
+            .absolute
+            .file_name()
+            .map_or_else(String::new, |name| name.to_string_lossy().into_owned());
+        let parent_path = path
+            .absolute
+            .parent()
+            .map_or_else(String::new, |parent| parent.to_string_lossy().into_owned());
+        Self {
+            path,
+            file_name: file_name.into(),
+            parent_path: parent_path.into(),
+        }
+    }
+}
+
+struct RecentFileMatch {
+    entry_index: usize,
+    positions: Vec<usize>,
+}
+
+pub struct RecentFilesDelegate {
+    recent_files: WeakEntity<RecentFiles>,
+    workspace: WeakEntity<Workspace>,
+    currently_opened_project_path: Option<ProjectPath>,
+    selected_index: usize,
+    entries: Vec<RecentFileEntry>,
+    matches: Vec<RecentFileMatch>,
+}
+
+impl RecentFilesDelegate {
+    fn new(
+        recent_files: WeakEntity<RecentFiles>,
+        workspace: WeakEntity<Workspace>,
+        currently_opened_project_path: Option<ProjectPath>,
+        history_items: Vec<FoundPath>,
+    ) -> Self {
+        // Most-recent-first order comes from `recent_navigation_history`; the
+        // currently open file (if present in history) stays in the list so the
+        // palette reads the same as the editor's tab order.
+        let entries = history_items
+            .into_iter()
+            .map(RecentFileEntry::new)
+            .collect();
+
+        Self {
+            recent_files,
+            workspace,
+            currently_opened_project_path,
+            selected_index: 0,
+            entries,
+            matches: Vec::new(),
+        }
+    }
+
+    fn unfiltered_matches(entry_count: usize) -> Vec<RecentFileMatch> {
+        (0..entry_count)
+            .map(|entry_index| RecentFileMatch {
+                entry_index,
+                positions: Vec::new(),
+            })
+            .collect()
+    }
+
+    /// Index of the first entry that isn't the currently open file, so that
+    /// pressing Enter with no query immediately switches to a different file
+    /// rather than reopening the one already on screen.
+    fn default_selected_index(&self) -> usize {
+        if self.matches.len() > 1
+            && let Some(currently_opened_project_path) = &self.currently_opened_project_path
+            && self
+                .entries
+                .first()
+                .is_some_and(|entry| &entry.path.project == currently_opened_project_path)
+        {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+impl PickerDelegate for RecentFilesDelegate {
+    type ListItem = ListItem;
+
+    fn name() -> &'static str {
+        "recent files"
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Search recently opened files…".into()
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("No recently opened files".into())
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+        cx.notify();
+    }
+
+    fn separators_after_indices(&self) -> Vec<usize> {
+        Vec::new()
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        if query.is_empty() {
+            self.matches = Self::unfiltered_matches(self.entries.len());
+            self.selected_index = self.default_selected_index();
+        } else {
+            let candidates: Vec<_> = self
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(id, entry)| {
+                    fuzzy_nucleo::StringMatchCandidate::from_shared(id, entry.file_name.clone())
+                })
+                .collect();
+            self.matches = fuzzy_nucleo::match_strings(
+                &candidates,
+                &query,
+                fuzzy_nucleo::Case::Smart,
+                fuzzy_nucleo::LengthPenalty::On,
+                MAX_MATCHES,
+            )
+            .into_iter()
+            .map(|string_match| RecentFileMatch {
+                entry_index: string_match.candidate_id,
+                positions: string_match.positions,
+            })
+            .collect();
+            self.selected_index = 0;
+        }
+        Task::ready(())
+    }
+
+    fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let Some(entry_match) = self.matches.get(self.selected_index) else {
+            return;
+        };
+        let Some(entry) = self.entries.get(entry_match.entry_index) else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+
+        let project_path = entry.path.project.clone();
+        workspace.update(cx, |workspace, cx| {
+            workspace
+                .open_path(project_path, None, true, window, cx)
+                .detach_and_log_err(cx);
+        });
+
+        self.recent_files
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.recent_files
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let entry_match = self.matches.get(ix)?;
+        let entry = self.entries.get(entry_match.entry_index)?;
+
+        Some(
+            ListItem::new(ix)
+                .spacing(ListItemSpacing::Sparse)
+                .inset(true)
+                .toggle_state(selected)
+                .child(
+                    v_flex()
+                        .w_full()
+                        .min_w_0()
+                        .overflow_hidden()
+                        .child(HighlightedLabel::new(
+                            entry.file_name.clone(),
+                            entry_match.positions.clone(),
+                        ))
+                        .child(
+                            Label::new(entry.parent_path.clone())
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        ),
+                ),
+        )
+    }
+}

--- a/crates/file_finder/src/recent_files/recent_files_tests.rs
+++ b/crates/file_finder/src/recent_files/recent_files_tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use crate::file_finder_tests::init_test;
+use editor::Editor;
+use gpui::{Entity, VisualTestContext};
+use menu::Confirm;
+use project::{Project, ProjectPath};
+use serde_json::json;
+use util::{path, rel_path::rel_path};
+use workspace::{CloseActiveItem, MultiWorkspace, Workspace};
+
+/// Opens `file_name` in the active pane and waits for the workspace to settle.
+async fn open_file(file_name: &str, workspace: &Entity<Workspace>, cx: &mut VisualTestContext) {
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            let worktree_id = workspace.worktrees(cx).next().unwrap().read(cx).id();
+            workspace.open_path(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path(file_name).into(),
+                },
+                None,
+                true,
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+}
+
+/// Closes the active item. Zed's navigation history only records an item once
+/// the pane moves away from it, so tests close each file before opening the
+/// next one to get a predictable history order (matches the pattern used by
+/// `file_finder_tests::open_close_queried_buffer`).
+fn close_active_item(cx: &mut VisualTestContext) {
+    cx.dispatch_action(CloseActiveItem {
+        save_intent: None,
+        close_pinned: false,
+    });
+    cx.run_until_parked();
+}
+
+fn open_recent_files(cx: &mut VisualTestContext) {
+    cx.dispatch_action(Toggle);
+    cx.run_until_parked();
+}
+
+fn active_recent_files_picker(
+    workspace: &Entity<Workspace>,
+    cx: &mut VisualTestContext,
+) -> Entity<Picker<RecentFilesDelegate>> {
+    workspace.update(cx, |workspace, cx| {
+        workspace
+            .active_modal::<RecentFiles>(cx)
+            .expect("recent files palette is not open")
+            .read(cx)
+            .picker
+            .clone()
+    })
+}
+
+fn matched_file_names(
+    picker: &Entity<Picker<RecentFilesDelegate>>,
+    cx: &mut VisualTestContext,
+) -> Vec<String> {
+    picker.read_with(cx, |picker, _| {
+        picker
+            .delegate
+            .matches
+            .iter()
+            .filter_map(|m| picker.delegate.entries.get(m.entry_index))
+            .map(|entry| entry.file_name.to_string())
+            .collect()
+    })
+}
+
+#[gpui::test]
+async fn test_recent_files_shows_history_in_recency_order(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+                "third.rs": "// Third Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+    close_active_item(cx);
+    // third.rs stays open, mimicking "I'm in this file, show me my other recents".
+    open_file("third.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    let picker = active_recent_files_picker(&workspace, cx);
+    assert_eq!(
+        matched_file_names(&picker, cx),
+        vec![
+            "third.rs".to_string(),
+            "second.rs".to_string(),
+            "first.rs".to_string()
+        ],
+        "Recent files should list navigation history newest-first, including the \
+         currently open file"
+    );
+    picker.read_with(cx, |picker, _| {
+        assert_eq!(
+            picker.delegate.selected_index, 1,
+            "Selection should skip the currently open file (index 0) so pressing \
+             Enter immediately switches away from it"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_recent_files_filters_by_substring(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+                "third.rs": "// Third Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("third.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    let picker = active_recent_files_picker(&workspace, cx);
+    cx.simulate_input("sec");
+    cx.run_until_parked();
+
+    assert_eq!(
+        matched_file_names(&picker, cx),
+        vec!["second.rs".to_string()],
+        "Typing a substring should filter the recent files list to matching file names"
+    );
+}
+
+#[gpui::test]
+async fn test_recent_files_confirm_opens_file(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    // second.rs is the currently open file, so selection should skip it and
+    // land on first.rs; confirming should switch to first.rs.
+    cx.dispatch_action(Confirm);
+    cx.run_until_parked();
+
+    workspace.read_with(cx, |workspace, cx| {
+        let active_editor = workspace.active_item_as::<Editor>(cx).unwrap();
+        assert_eq!(active_editor.read(cx).title(cx), "first.rs");
+    });
+}


### PR DESCRIPTION
## Summary

Part of #4663.

Adds a dedicated, searchable **Recently Opened Files** palette (`recent_files::Toggle`, unbound by default).

Today `cmd-p`/`ctrl-p` shows history entries mixed in with fuzzy path search, and there's no way to search *only* recent files by name the way JetBrains' "Recent Files" (`ctrl-e`) does. This PR adds a separate modal for that, reusing `workspace::recent_navigation_history` (no new state) and following the same `Picker`/`PickerDelegate` pattern as `tab_switcher`.

Behavior:
- Lists files from navigation history, newest first, including the currently open file (mirrors tab switcher's "show everything, but don't pre-select what's already active" behavior).
- Selection defaults to the first entry that isn't the current file, so pressing Enter with no query switches you elsewhere immediately.
- Typing filters by file name substring/fuzzy match (`fuzzy_nucleo`), consistent with `tab_switcher`.

This is intentionally scoped small - it's PR 1 of 2 toward #4663. A follow-up PR will persist recent files across restarts (currently, like all navigation history, it's in-memory only for the life of the workspace).

## Open questions for maintainers

- **Keybinding**: I didn't add a default keymap entry. JetBrains' `cmd-e`/`ctrl-e` and other "e"-based combos are already claimed several times over in `default-macos.json`/`default-linux.json` (buffer_search, project_panel, settings_editor, etc.), so I'd rather defer the binding choice to you than squat on something. Happy to add one if you have a preference.
- **Separate modal vs. file finder mode**: I built this as its own modal (new `RecentFiles`/`RecentFilesDelegate`, same crate) rather than a mode of `FileFinder`, since the existing history-in-file-finder behavior seems intentional and I didn't want to disturb it. Open to folding this in differently if you'd prefer.

## Test plan

- [x] `cargo test -p file_finder --lib` - all 82 tests pass (79 existing + 3 new), no regressions
- [x] `cargo clippy -p file_finder --no-deps` - clean
- [x] `cargo fmt -p file_finder --check` - clean
- [ ] Manual verification in a running `cargo run` build (I built and tested this in a disk-constrained CI-like environment and haven't yet driven it in the full GUI - will do before marking ready for review)

