### PR TITLE
wgpu: Only store embedded fonts once in memory

### DIFF
--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -212,14 +212,7 @@ impl CosmicTextSystemState {
     fn add_fonts(&mut self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
         let db = self.font_system.db_mut();
         for bytes in fonts {
-            match bytes {
-                Cow::Borrowed(embedded_font) => {
-                    db.load_font_data(embedded_font.to_vec());
-                }
-                Cow::Owned(bytes) => {
-                    db.load_font_data(bytes);
-                }
-            }
+            db.load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(bytes)));
         }
         Ok(())
     }
@@ -929,12 +922,10 @@ fn pick_covering_slot(
     if covers(current_id, ch) {
         return current;
     }
-    for (ix, (fb_id, _)) in fallback_chain.iter().enumerate() {
-        if covers(*fb_id, ch) {
-            return Some(ix);
-        }
-    }
-    None
+
+    fallback_chain
+        .iter()
+        .position(|(fb_id, _)| covers(*fb_id, ch))
 }
 
 fn charmap_covers(loaded_fonts: &[LoadedFont], id: FontId, ch: char) -> bool {


### PR DESCRIPTION
# Objective

Zed's `wgpu` backend currently allocates memory for fonts, even if they are statically available in memory. Zed embeds 8 fonts, which accounts for about 1.6 megabytes of memory. This change should reduce memory usage by that amount on the `wgpu` backend. (Linux and Web)

For more context, this is the function signature for `load_font_data`:

```rust
/// Loads a font data into the `Database`.
///
/// Will load all font faces in case of a font collection.
pub fn load_font_data(&mut self, data: Vec<u8>) {
    self.load_font_source(Source::Binary(alloc::sync::Arc::new(data)));
}
```

## Solution

Instead of calling `fontdb::Database::load_font_data`, which needs an owned `Vec`, use `load_font_source`, which allows us to create an `Arc` ourselves, which doesn't require ownership of the underlying data.

## Testing

All tests pass

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Slightly improved memory usage on Linux
