### PR TITLE
Fix typo in tasks.md documentation

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -16,7 +16,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated [terminal](
     // Env overrides for the command, will be appended to the terminal's environment from the settings.
     "env": { "foo": "bar" },
     // Current working directory to spawn the command into, defaults to current project root.
-    //"cwd": "/path/to/working/directory",
+    "cwd": "/path/to/working/directory",
     // Whether to use a new terminal tab or reuse the existing one to spawn the process, defaults to `false`.
     "use_new_terminal": false,
     // Whether to allow multiple instances of the same task to be run, or rather wait for the existing ones to finish, defaults to `false`.


### PR DESCRIPTION
"cwd" is an actual setting, uncommenting it.

# Objective

Fixes a minor typo in the documentation.

## Solution

- Describe the solution used to achieve the objective above.

## Testing

I checked that setting "cwd" is supported.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [NA] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [NA] Tests cover the new/changed behavior
- [NA] Performance impact has been considered and is acceptable