### PR TITLE
copilot_chat: Remove settings dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,7 +3896,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "settings",
  "util",
  "zed_credentials_provider",
 ]

--- a/crates/copilot_chat/Cargo.toml
+++ b/crates/copilot_chat/Cargo.toml
@@ -14,10 +14,7 @@ doctest = false
 
 [features]
 default = []
-test-support = [
-    "gpui/test-support",
-    "settings/test-support",
-]
+test-support = ["gpui/test-support"]
 
 [dependencies]
 anthropic.workspace = true
@@ -31,7 +28,6 @@ language_model.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-settings.workspace = true
 util.workspace = true
 zed_credentials_provider.workspace = true
 

--- a/crates/copilot_chat/src/responses.rs
+++ b/crates/copilot_chat/src/responses.rs
@@ -4,9 +4,9 @@ use super::{ChatLocation, copilot_request_headers};
 use anyhow::{Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
 use http_client::{AsyncBody, HttpClient, HttpRequestExt, Method, Request as HttpRequest};
+pub use language_model::ReasoningEffort;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-pub use settings::OpenAiReasoningEffort as ReasoningEffort;
 
 #[derive(Serialize, Debug)]
 pub struct Request {


### PR DESCRIPTION
Removes an unnecessary dependency on settings as `settings::OpenAiReasoningEffort` just points to `language_model::ReasoningEffort`

Release Notes:

- N/A
