### PR TITLE
editor: Revert punctuation word movement changes

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -265,69 +265,24 @@ pub fn line_end(
 /// uppercase letter, lowercase letter, '_' character or language-specific word character (like '-' in CSS).
 pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
     let raw_point = point.to_point(map);
-    let buffer_snapshot = map.buffer_snapshot();
-    let classifier = buffer_snapshot.char_classifier_at(raw_point);
-    let cursor_offset = raw_point.to_offset(buffer_snapshot);
-    let cursor_char = buffer_snapshot.chars_at(cursor_offset).next();
+    let classifier = map.buffer_snapshot().char_classifier_at(raw_point);
 
     let mut is_first_iteration = true;
-    let word_start = find_preceding_boundary_display_point(
-        map,
-        point,
-        FindRange::MultiLine,
-        &mut |left, right| {
-            // Make alt-left skip punctuation to respect VSCode behaviour. For example: hello.| goes to |hello.
-            if is_first_iteration
-                && classifier.is_punctuation(right)
-                && !classifier.is_punctuation(left)
-                && left != '\n'
-                && (!classifier.is_whitespace(left)
-                    || cursor_char.is_some_and(|character| {
-                        !classifier.is_whitespace(character) && character != '\n'
-                    }))
-            {
-                is_first_iteration = false;
-                return false;
-            }
+    find_preceding_boundary_display_point(map, point, FindRange::MultiLine, &mut |left, right| {
+        // Make alt-left skip punctuation to respect VSCode behaviour. For example: hello.| goes to |hello.
+        if is_first_iteration
+            && classifier.is_punctuation(right)
+            && !classifier.is_punctuation(left)
+            && left != '\n'
+        {
             is_first_iteration = false;
+            return false;
+        }
+        is_first_iteration = false;
 
-            (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
-                || left == '\n'
-        },
-    );
-
-    let word_start_point = word_start.to_point(map);
-    let word_start_offset = word_start_point.to_offset(buffer_snapshot);
-    let mut chars_before_word = buffer_snapshot.reversed_chars_at(word_start_offset);
-    let Some(punctuation) = chars_before_word
-        .next()
-        .filter(|character| classifier.is_punctuation(*character))
-    else {
-        return word_start;
-    };
-
-    let punctuation_is_single = chars_before_word
-        .next()
-        .is_none_or(|character| !classifier.is_punctuation(character));
-    let punctuation_prefixes_word = buffer_snapshot
-        .chars_at(word_start_offset)
-        .next()
-        .is_some_and(|character| classifier.is_word(character));
-    let cursor_is_at_word_end = buffer_snapshot
-        .reversed_chars_at(cursor_offset)
-        .next()
-        .is_some_and(|character| classifier.is_word(character))
-        && cursor_char.is_none_or(|character| !classifier.is_word(character));
-
-    // Forward movement treats a single punctuation prefix as part of the following word.
-    // Include it when moving back from the word's end so `|@word` and `@word|` are symmetric.
-    if cursor_is_at_word_end && punctuation_is_single && punctuation_prefixes_word {
-        let mut punctuation_offset = word_start_offset;
-        punctuation_offset -= punctuation.len_utf8();
-        punctuation_offset.to_display_point(map)
-    } else {
-        word_start
-    }
+        (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
+            || left == '\n'
+    })
 }
 
 /// Returns a position of the previous word boundary, where a word character is defined as either
@@ -491,7 +446,7 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
         // Make alt-right skip punctuation to respect VSCode behaviour. For example: |.hello goes to .hello|
         if is_first_iteration
             && classifier.is_punctuation(left)
-            && classifier.is_word(right)
+            && !classifier.is_punctuation(right)
             && right != '\n'
         {
             is_first_iteration = false;
@@ -1118,13 +1073,6 @@ mod tests {
         assert("helloˇ.---..ˇtest", cx);
         assert("test  ˇ.--ˇtest", cx);
         assert("oneˇ,;:!?ˇtwo", cx);
-        assert("foo ˇ.ˇ bar", cx);
-        assert("ˇfoo @ˇbar", cx);
-        assert("foo ˇ@barˇ baz", cx);
-        assert("foo @ˇbˇar", cx);
-        assert("foo ..ˇbarˇ baz", cx);
-        assert("ˇ.helloˇ", cx);
-        assert("[2001:4860:4860::8888ˇ] ˇ", cx);
     }
 
     #[gpui::test]
@@ -1308,10 +1256,6 @@ mod tests {
         assert("helloˇ.---..ˇtest", cx);
         assert("testˇ.--ˇ test", cx);
         assert("oneˇ,;:!?ˇtwo", cx);
-        assert("foo ˇ.ˇ bar", cx);
-        assert("fooˇ.ˇ bar", cx);
-        assert("foo ˇ@barˇ baz", cx);
-        assert("[2001:4860:4860::8888ˇ]ˇ ", cx);
     }
 
     #[gpui::test]

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -306,9 +306,9 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
         return word_start;
     };
 
-    let char_before_punctuation = chars_before_word.next();
-    let punctuation_is_single =
-        char_before_punctuation.is_none_or(|character| !classifier.is_punctuation(character));
+    let punctuation_is_single = chars_before_word
+        .next()
+        .is_none_or(|character| !classifier.is_punctuation(character));
     let punctuation_prefixes_word = buffer_snapshot
         .chars_at(word_start_offset)
         .next()
@@ -321,15 +321,7 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
 
     // Forward movement treats a single punctuation prefix as part of the following word.
     // Include it when moving back from the word's end so `|@word` and `@word|` are symmetric.
-    // Only do this when the punctuation is a true prefix (not preceded by a word char),
-    // otherwise `a-b-c|` would jump to `a-b|-c` instead of `a-b-|c`.
-    let punctuation_is_prefix =
-        char_before_punctuation.is_none_or(|character| !classifier.is_word(character));
-    if cursor_is_at_word_end
-        && punctuation_is_single
-        && punctuation_prefixes_word
-        && punctuation_is_prefix
-    {
+    if cursor_is_at_word_end && punctuation_is_single && punctuation_prefixes_word {
         let mut punctuation_offset = word_start_offset;
         punctuation_offset -= punctuation.len_utf8();
         punctuation_offset.to_display_point(map)
@@ -1133,14 +1125,6 @@ mod tests {
         assert("foo ..ˇbarˇ baz", cx);
         assert("ˇ.helloˇ", cx);
         assert("[2001:4860:4860::8888ˇ] ˇ", cx);
-        // Punctuation between words is a separator, not a prefix.
-        // opt-left should stop to the right of the punctuation, not the left.
-        assert("a-b-ˇcˇ", cx);
-        assert("a.b.ˇcˇ", cx);
-        assert("foo.ˇbarˇ", cx);
-        assert("a@ˇbˇ", cx);
-        // Punctuation at start of buffer (or after whitespace) is a true prefix.
-        assert("ˇ@wordˇ", cx);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Reverted due to regressions in editor word navigation around punctuation:

- https://github.com/zed-industries/zed/pull/58882#issuecomment-5138947209
- https://github.com/zed-industries/zed/pull/58882#issuecomment-5153627453
- https://github.com/zed-industries/zed/pull/62065#issuecomment-5178850523

Release Notes:

- Reverted #61916 and #58882