### PR TITLE
Group agent checkouts under their main project and show Delta thread rows

### DIFF
--- a/assets/icons/delta.svg
+++ b/assets/icons/delta.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 3L13.2 12.5H2.8L8 3Z" stroke="#DCE0E5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -528,6 +528,7 @@ impl RejoinedProject {
                     // todo(collab): Get these fields from database
                     root_repo_is_linked_worktree: false,
                     root_repo_shared_objects_main_path: None,
+                    root_repo_delta_thread_stamp_json: None,
                 })
                 .collect(),
             collaborators: self

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -525,8 +525,9 @@ impl RejoinedProject {
                     visible: worktree.visible,
                     abs_path: worktree.abs_path.clone(),
                     root_repo_common_dir: None,
-                    // todo(collab): Get this field from database
+                    // todo(collab): Get these fields from database
                     root_repo_is_linked_worktree: false,
+                    root_repo_shared_objects_main_path: None,
                 })
                 .collect(),
             collaborators: self

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1614,8 +1614,9 @@ fn notify_rejoined_projects(
                 abs_path: worktree.abs_path.clone(),
                 root_name: worktree.root_name,
                 root_repo_common_dir: worktree.root_repo_common_dir,
-                // todo(collab): Get this field from database
+                // todo(collab): Get these fields from database
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
                 updated_entries: worktree.updated_entries,
                 removed_entries: worktree.removed_entries,
                 scan_id: worktree.scan_id,
@@ -2024,8 +2025,9 @@ async fn join_project(
             visible: worktree.visible,
             abs_path: worktree.abs_path.clone(),
             root_repo_common_dir: None,
-            // todo(collab): Get this field from database
+            // todo(collab): Get these fields from database
             root_repo_is_linked_worktree: false,
+            root_repo_shared_objects_main_path: None,
         })
         .collect::<Vec<_>>();
 
@@ -2078,8 +2080,9 @@ async fn join_project(
             abs_path: worktree.abs_path.clone(),
             root_name: worktree.root_name,
             root_repo_common_dir: worktree.root_repo_common_dir,
-            // todo(collab): Get this field from database
+            // todo(collab): Get these fields from database
             root_repo_is_linked_worktree: false,
+            root_repo_shared_objects_main_path: None,
             updated_entries: worktree.entries,
             removed_entries: Default::default(),
             scan_id: worktree.scan_id,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1617,6 +1617,7 @@ fn notify_rejoined_projects(
                 // todo(collab): Get these fields from database
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
                 updated_entries: worktree.updated_entries,
                 removed_entries: worktree.removed_entries,
                 scan_id: worktree.scan_id,
@@ -2028,6 +2029,7 @@ async fn join_project(
             // todo(collab): Get these fields from database
             root_repo_is_linked_worktree: false,
             root_repo_shared_objects_main_path: None,
+            root_repo_delta_thread_stamp_json: None,
         })
         .collect::<Vec<_>>();
 
@@ -2083,6 +2085,7 @@ async fn join_project(
             // todo(collab): Get these fields from database
             root_repo_is_linked_worktree: false,
             root_repo_shared_objects_main_path: None,
+            root_repo_delta_thread_stamp_json: None,
             updated_entries: worktree.entries,
             removed_entries: Default::default(),
             scan_id: worktree.scan_id,

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -100,6 +100,7 @@ pub enum IconName {
     DebugStepInto,
     DebugStepOut,
     DebugStepOver,
+    Delta,
     Diff,
     DiffSplit,
     DiffSplitAuto,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -147,8 +147,8 @@ use util::{
 use worktree::{CreatedEntry, Snapshot, Traversal};
 pub use worktree::{
     Entry, EntryKind, FS_WATCH_LATENCY, File, LocalWorktree, PathChange, ProjectEntryId,
-    UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree, WorktreeId, WorktreeSettings,
-    discover_root_repo_common_dir,
+    RootRepoMetadata, UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree, WorktreeId,
+    WorktreeSettings, discover_root_repo_metadata,
 };
 use worktree_store::{WorktreeStore, WorktreeStoreEvent};
 
@@ -2163,6 +2163,7 @@ impl Project {
                 abs_path: abs_path.to_string(),
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             },
             client,
             PathStyle::Unix,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2164,6 +2164,7 @@ impl Project {
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             },
             client,
             PathStyle::Unix,

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -903,6 +903,8 @@ impl WorktreeStore {
                         abs_path: response.canonicalized_path,
                         root_repo_common_dir: response.root_repo_common_dir,
                         root_repo_is_linked_worktree: response.root_repo_is_linked_worktree,
+                        root_repo_shared_objects_main_path: response
+                            .root_repo_shared_objects_main_path,
                     },
                     client,
                     path_style,
@@ -1041,7 +1043,9 @@ impl WorktreeStore {
     ) -> Option<Entity<Worktree>> {
         self.visible_worktrees(cx).find(|worktree| {
             let worktree = worktree.read(cx);
-            if let Some(common_dir) = worktree.root_repo_common_dir() {
+            if let Some(main_path) = worktree.root_repo_shared_objects_main_path() {
+                main_path.as_ref() == path
+            } else if let Some(common_dir) = worktree.root_repo_common_dir() {
                 common_dir.parent() == Some(path)
             } else {
                 worktree.abs_path().as_ref() == path
@@ -1232,6 +1236,9 @@ impl WorktreeStore {
                         .root_repo_common_dir()
                         .map(|p| p.to_string_lossy().into_owned()),
                     root_repo_is_linked_worktree: worktree.root_repo_is_linked_worktree(),
+                    root_repo_shared_objects_main_path: worktree
+                        .root_repo_shared_objects_main_path()
+                        .map(|p| p.to_string_lossy().into_owned()),
                 }
             })
             .collect()
@@ -1482,15 +1489,20 @@ impl WorktreeStore {
                 let snapshot = worktree.read(cx).snapshot();
                 let folder_path = snapshot.abs_path().to_path_buf();
                 let main_path = snapshot
-                    .root_repo_common_dir()
-                    .filter(|dir| !crate::git_store::is_submodule_git_dir(dir))
-                    .map(|dir| crate::git_store::repo_identity_path(dir))
-                    .filter(|repo_path| {
-                        snapshot.root_repo_is_linked_worktree()
-                            || *repo_path == folder_path.as_path()
-                            || !folder_path.starts_with(*repo_path)
+                    .root_repo_shared_objects_main_path()
+                    .map(|main_path| main_path.to_path_buf())
+                    .or_else(|| {
+                        snapshot
+                            .root_repo_common_dir()
+                            .filter(|dir| !crate::git_store::is_submodule_git_dir(dir))
+                            .map(|dir| crate::git_store::repo_identity_path(dir))
+                            .filter(|repo_path| {
+                                snapshot.root_repo_is_linked_worktree()
+                                    || *repo_path == folder_path.as_path()
+                                    || !folder_path.starts_with(*repo_path)
+                            })
+                            .map(Path::to_path_buf)
                     })
-                    .map(Path::to_path_buf)
                     .unwrap_or_else(|| folder_path.clone());
                 (main_path, folder_path)
             })

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -905,6 +905,8 @@ impl WorktreeStore {
                         root_repo_is_linked_worktree: response.root_repo_is_linked_worktree,
                         root_repo_shared_objects_main_path: response
                             .root_repo_shared_objects_main_path,
+                        root_repo_delta_thread_stamp_json: response
+                            .root_repo_delta_thread_stamp_json,
                     },
                     client,
                     path_style,
@@ -1239,6 +1241,9 @@ impl WorktreeStore {
                     root_repo_shared_objects_main_path: worktree
                         .root_repo_shared_objects_main_path()
                         .map(|p| p.to_string_lossy().into_owned()),
+                    root_repo_delta_thread_stamp_json: worktree
+                        .root_repo_delta_thread_stamp()
+                        .and_then(|stamp| serde_json::to_string(stamp.as_ref()).ok()),
                 }
             })
             .collect()

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -13316,6 +13316,70 @@ async fn test_project_group_keys_remain_distinct_for_sibling_repo_subdirectories
     );
 }
 
+#[gpui::test]
+async fn test_project_group_keys_match_for_repos_sharing_an_object_store(
+    executor: gpui::BackgroundExecutor,
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/main_repo"),
+        json!({
+            ".git": { "objects": {} },
+            "file.txt": "content",
+        }),
+    )
+    .await;
+    // A standalone repository borrowing the main repository's object store via
+    // `objects/info/alternates` (e.g. `git clone --shared`, or an agent tool's
+    // checkout of the user's repository). It has its own refs and `HEAD`, but
+    // for project grouping it belongs to the main repository.
+    fs.insert_tree(
+        path!("/checkouts/agent/main_repo"),
+        json!({
+            ".git": {
+                "objects": {
+                    "info": {
+                        "alternates": format!("{}\n", path!("/main_repo/.git/objects")),
+                    }
+                }
+            },
+            "file.txt": "content",
+        }),
+    )
+    .await;
+
+    let main_project = Project::test(fs.clone(), [path!("/main_repo").as_ref()], cx).await;
+    let agent_project = Project::test(fs, [path!("/checkouts/agent/main_repo").as_ref()], cx).await;
+
+    main_project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    agent_project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        project_group_key_paths(&agent_project, cx),
+        vec![PathBuf::from(path!("/main_repo"))],
+        "a repository sharing the main repository's object store should group under it"
+    );
+    assert_eq!(
+        project_group_key_paths(&main_project, cx),
+        project_group_key_paths(&agent_project, cx),
+    );
+
+    let (folder_paths, main_paths) = project_worktree_paths(&agent_project, cx);
+    assert_eq!(
+        folder_paths,
+        vec![PathBuf::from(path!("/checkouts/agent/main_repo"))]
+    );
+    assert_eq!(main_paths, vec![PathBuf::from(path!("/main_repo"))]);
+}
+
 fn project_group_key_paths(project: &Entity<Project>, cx: &TestAppContext) -> Vec<PathBuf> {
     project.read_with(cx, |project, cx| {
         ProjectGroupKey::from_project(project, cx)

--- a/crates/proto/proto/call.proto
+++ b/crates/proto/proto/call.proto
@@ -233,6 +233,7 @@ message UpdateWorktree {
   optional string root_repo_common_dir = 11;
   bool root_repo_is_linked_worktree = 12;
   optional string root_repo_shared_objects_main_path = 13;
+  optional string root_repo_delta_thread_stamp_json = 14;
 }
 
 // deprecated

--- a/crates/proto/proto/call.proto
+++ b/crates/proto/proto/call.proto
@@ -232,6 +232,7 @@ message UpdateWorktree {
   string abs_path = 10;
   optional string root_repo_common_dir = 11;
   bool root_repo_is_linked_worktree = 12;
+  optional string root_repo_shared_objects_main_path = 13;
 }
 
 // deprecated

--- a/crates/proto/proto/worktree.proto
+++ b/crates/proto/proto/worktree.proto
@@ -42,6 +42,7 @@ message AddWorktreeResponse {
   string canonicalized_path = 2;
   optional string root_repo_common_dir = 3;
   bool root_repo_is_linked_worktree = 4;
+  optional string root_repo_shared_objects_main_path = 5;
 }
 
 message RemoveWorktree {
@@ -66,6 +67,7 @@ message WorktreeMetadata {
   string abs_path = 4;
   optional string root_repo_common_dir = 5;
   bool root_repo_is_linked_worktree = 6;
+  optional string root_repo_shared_objects_main_path = 7;
 }
 
 message ProjectPath {

--- a/crates/proto/proto/worktree.proto
+++ b/crates/proto/proto/worktree.proto
@@ -43,6 +43,7 @@ message AddWorktreeResponse {
   optional string root_repo_common_dir = 3;
   bool root_repo_is_linked_worktree = 4;
   optional string root_repo_shared_objects_main_path = 5;
+  optional string root_repo_delta_thread_stamp_json = 6;
 }
 
 message RemoveWorktree {
@@ -68,6 +69,7 @@ message WorktreeMetadata {
   optional string root_repo_common_dir = 5;
   bool root_repo_is_linked_worktree = 6;
   optional string root_repo_shared_objects_main_path = 7;
+  optional string root_repo_delta_thread_stamp_json = 8;
 }
 
 message ProjectPath {

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -980,6 +980,7 @@ pub fn split_worktree_update(mut message: UpdateWorktree) -> impl Iterator<Item 
             root_repo_common_dir: message.root_repo_common_dir.clone(),
             root_repo_is_linked_worktree: message.root_repo_is_linked_worktree,
             root_repo_shared_objects_main_path: message.root_repo_shared_objects_main_path.clone(),
+            root_repo_delta_thread_stamp_json: message.root_repo_delta_thread_stamp_json.clone(),
             updated_entries,
             removed_entries,
             scan_id: message.scan_id,

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -979,6 +979,7 @@ pub fn split_worktree_update(mut message: UpdateWorktree) -> impl Iterator<Item 
             abs_path: message.abs_path.clone(),
             root_repo_common_dir: message.root_repo_common_dir.clone(),
             root_repo_is_linked_worktree: message.root_repo_is_linked_worktree,
+            root_repo_shared_objects_main_path: message.root_repo_shared_objects_main_path.clone(),
             updated_entries,
             removed_entries,
             scan_id: message.scan_id,

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -538,6 +538,9 @@ impl HeadlessProject {
                     .root_repo_common_dir()
                     .map(|p| p.to_string_lossy().into_owned()),
                 root_repo_is_linked_worktree: worktree.root_repo_is_linked_worktree(),
+                root_repo_shared_objects_main_path: worktree
+                    .root_repo_shared_objects_main_path()
+                    .map(|p| p.to_string_lossy().into_owned()),
             }
         });
 

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -541,6 +541,9 @@ impl HeadlessProject {
                 root_repo_shared_objects_main_path: worktree
                     .root_repo_shared_objects_main_path()
                     .map(|p| p.to_string_lossy().into_owned()),
+                root_repo_delta_thread_stamp_json: worktree
+                    .root_repo_delta_thread_stamp()
+                    .and_then(|stamp| serde_json::to_string(stamp.as_ref()).ok()),
             }
         });
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -603,9 +603,9 @@ fn workspace_menu_worktree_labels(
     workspace: &Entity<Workspace>,
     cx: &App,
 ) -> Vec<WorkspaceMenuWorktreeLabel> {
-    let root_paths = workspace.read(cx).root_paths(cx);
-    let show_folder_name = root_paths.len() > 1;
     let project = workspace.read(cx).project().clone();
+    let worktrees: Vec<_> = project.read(cx).visible_worktrees(cx).collect();
+    let show_folder_name = worktrees.len() > 1;
     let repository_snapshots: Vec<_> = project
         .read(cx)
         .repositories(cx)
@@ -613,10 +613,12 @@ fn workspace_menu_worktree_labels(
         .map(|repo| repo.read(cx).snapshot())
         .collect();
 
-    root_paths
+    worktrees
         .into_iter()
-        .map(|root_path| {
-            let root_path = root_path.as_ref();
+        .map(|worktree| {
+            let worktree = worktree.read(cx);
+            let root_path_arc = worktree.abs_path();
+            let root_path: &std::path::Path = root_path_arc.as_ref();
             let folder_name = root_path
                 .file_name()
                 .map(|name| SharedString::from(name.to_string_lossy().to_string()))
@@ -632,6 +634,11 @@ fn workspace_menu_worktree_labels(
                         .and_then(|main_worktree_path| {
                             project::linked_worktree_short_name(main_worktree_path, root_path)
                         })
+                        .unwrap_or_else(|| folder_name.clone())
+                } else if let Some(main_worktree_path) =
+                    worktree.root_repo_shared_objects_main_path()
+                {
+                    project::linked_worktree_short_name(main_worktree_path, root_path)
                         .unwrap_or_else(|| folder_name.clone())
                 } else {
                     "main".into()

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -402,6 +402,25 @@ enum ListEntry {
     },
     Thread(Arc<ThreadEntry>),
     Terminal(TerminalEntry),
+    DeltaThread(DeltaThreadEntry),
+}
+
+/// An ephemeral row for a Delta thread whose checkout is open as a workspace
+/// in this window, synthesized from the provenance stamp Delta writes into
+/// its checkouts' git dirs ([`worktree::DeltaThreadStamp`]). Derived from
+/// open workspace state rather than the thread store, so it never persists:
+/// it disappears when the workspace closes and can't leak into the archive,
+/// drafts, or the MRU switcher. It is the "you are here" anchor for windows
+/// opened from Delta.
+#[derive(Clone)]
+struct DeltaThreadEntry {
+    /// Delta's thread id, used for row identity and the
+    /// `delta://thread/<id>` backlink.
+    thread_id: SharedString,
+    title: SharedString,
+    workspace: Entity<Workspace>,
+    worktrees: Vec<ThreadItemWorktreeInfo>,
+    highlight_positions: Vec<usize>,
 }
 
 #[derive(Clone)]
@@ -412,6 +431,9 @@ enum ActivatableEntry {
     Terminal {
         metadata: TerminalThreadMetadata,
         workspace: ThreadEntryWorkspace,
+    },
+    DeltaThread {
+        workspace: Entity<Workspace>,
     },
 }
 
@@ -425,6 +447,9 @@ impl ActivatableEntry {
                 metadata: terminal.metadata.clone(),
                 workspace: terminal.workspace.clone(),
             }),
+            ListEntry::DeltaThread(entry) => Some(Self::DeltaThread {
+                workspace: entry.workspace.clone(),
+            }),
             ListEntry::ProjectHeader { .. } => None,
         }
     }
@@ -435,7 +460,9 @@ impl ListEntry {
     fn session_id(&self) -> Option<&acp::SessionId> {
         match self {
             ListEntry::Thread(thread_entry) => thread_entry.metadata.session_id.as_ref(),
-            ListEntry::Terminal(_) | ListEntry::ProjectHeader { .. } => None,
+            ListEntry::Terminal(_)
+            | ListEntry::ProjectHeader { .. }
+            | ListEntry::DeltaThread(_) => None,
         }
     }
 
@@ -456,6 +483,7 @@ impl ListEntry {
             ListEntry::ProjectHeader { key, .. } => {
                 multi_workspace.workspaces_for_project_group(key, cx)
             }
+            ListEntry::DeltaThread(entry) => vec![entry.workspace.clone()],
         }
     }
 }
@@ -496,6 +524,7 @@ enum EntryShape {
     },
     Thread(ThreadId),
     Terminal(TerminalId),
+    DeltaThread(SharedString, gpui::EntityId),
 }
 
 impl SidebarContents {
@@ -1541,6 +1570,44 @@ impl Sidebar {
                     .has_notification
                     .then_some(terminal.metadata.terminal_id)
             }));
+
+            // Ephemeral rows for Delta threads whose checkouts are open in
+            // this group's workspaces, derived from the provenance stamps in
+            // the checkouts' git dirs. One row per (thread, workspace): a
+            // thread with several worktrees open in one workspace still
+            // reads as one location.
+            let mut delta_threads: Vec<DeltaThreadEntry> = Vec::new();
+            for workspace in group_workspaces {
+                let project = workspace.read(cx).project().read(cx);
+                let worktree_paths = project.worktree_paths(cx);
+                for worktree in project.visible_worktrees(cx) {
+                    let snapshot = worktree.read(cx).snapshot();
+                    let Some(stamp) = snapshot.root_repo_delta_thread_stamp() else {
+                        continue;
+                    };
+                    if delta_threads.iter().any(|entry| {
+                        entry.thread_id.as_ref() == stamp.thread_id && entry.workspace == *workspace
+                    }) {
+                        continue;
+                    }
+                    let title = stamp
+                        .thread_title
+                        .clone()
+                        .map(SharedString::from)
+                        .unwrap_or_else(|| SharedString::from("Delta thread"));
+                    delta_threads.push(DeltaThreadEntry {
+                        thread_id: SharedString::from(stamp.thread_id.clone()),
+                        title,
+                        workspace: workspace.clone(),
+                        worktrees: worktree_info_from_thread_paths(
+                            &worktree_paths,
+                            &branch_by_path,
+                        ),
+                        highlight_positions: Vec::new(),
+                    });
+                }
+            }
+
             if group_key.path_list().paths().is_empty() {
                 continue;
             }
@@ -1801,7 +1868,8 @@ impl Sidebar {
                 }
             }
 
-            let has_visible_rows = !threads.is_empty() || !terminals.is_empty();
+            let has_visible_rows =
+                !threads.is_empty() || !terminals.is_empty() || !delta_threads.is_empty();
             let has_stored_thread_rows = !should_load_threads && !has_visible_rows && {
                 let store = ThreadMetadataStore::global(cx).read(cx);
                 store
@@ -1875,7 +1943,34 @@ impl Sidebar {
                     }
                 }
 
-                if matched_threads.is_empty() && matched_terminals.is_empty() && !workspace_matched
+                let mut matched_delta_threads: Vec<DeltaThreadEntry> = Vec::new();
+                for mut delta_thread in delta_threads {
+                    let mut delta_thread_matched = false;
+                    if let Some(positions) =
+                        fuzzy_match_positions(&query, delta_thread.title.as_ref())
+                    {
+                        delta_thread.highlight_positions = positions;
+                        delta_thread_matched = true;
+                    }
+                    let mut worktree_matched = false;
+                    for worktree in &mut delta_thread.worktrees {
+                        let Some(name) = worktree.worktree_name.as_ref() else {
+                            continue;
+                        };
+                        if let Some(positions) = fuzzy_match_positions(&query, name) {
+                            worktree.highlight_positions = positions;
+                            worktree_matched = true;
+                        }
+                    }
+                    if workspace_matched || delta_thread_matched || worktree_matched {
+                        matched_delta_threads.push(delta_thread);
+                    }
+                }
+
+                if matched_threads.is_empty()
+                    && matched_terminals.is_empty()
+                    && matched_delta_threads.is_empty()
+                    && !workspace_matched
                 {
                     continue;
                 }
@@ -1900,6 +1995,11 @@ impl Sidebar {
                     has_threads,
                 });
 
+                entries.extend(
+                    matched_delta_threads
+                        .into_iter()
+                        .map(ListEntry::DeltaThread),
+                );
                 Self::push_entries_by_display_time(
                     &mut entries,
                     matched_terminals,
@@ -1950,6 +2050,7 @@ impl Sidebar {
                     continue;
                 }
 
+                entries.extend(delta_threads.into_iter().map(ListEntry::DeltaThread));
                 Self::push_entries_by_display_time(
                     &mut entries,
                     terminals,
@@ -2074,6 +2175,9 @@ impl Sidebar {
             },
             ListEntry::Thread(thread) => EntryShape::Thread(thread.metadata.thread_id),
             ListEntry::Terminal(terminal) => EntryShape::Terminal(terminal.metadata.terminal_id),
+            ListEntry::DeltaThread(entry) => {
+                EntryShape::DeltaThread(entry.thread_id.clone(), entry.workspace.entity_id())
+            }
         })
     }
 
@@ -2158,7 +2262,12 @@ impl Sidebar {
             .contents
             .entries
             .iter()
-            .position(|entry| matches!(entry, ListEntry::Thread(_) | ListEntry::Terminal(_)))
+            .position(|entry| {
+                matches!(
+                    entry,
+                    ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::DeltaThread(_)
+                )
+            })
             .or_else(|| {
                 if self.contents.entries.is_empty() {
                     None
@@ -2184,10 +2293,22 @@ impl Sidebar {
         let is_group_header_after_first =
             ix > 0 && matches!(entry, ListEntry::ProjectHeader { .. });
 
-        let is_active = self
-            .active_entry
-            .as_ref()
-            .is_some_and(|active| active.matches_entry(entry));
+        let is_active = match entry {
+            // Delta thread rows aren't tracked by `active_entry` (they're
+            // derived, not activatable panel state); they're "active" when
+            // theirs is the window's active workspace.
+            ListEntry::DeltaThread(entry) => {
+                self.multi_workspace
+                    .upgrade()
+                    .is_some_and(|multi_workspace| {
+                        multi_workspace.read(cx).workspace() == &entry.workspace
+                    })
+            }
+            _ => self
+                .active_entry
+                .as_ref()
+                .is_some_and(|active| active.matches_entry(entry)),
+        };
 
         let rendered = match entry {
             ListEntry::ProjectHeader {
@@ -2224,6 +2345,9 @@ impl Sidebar {
             ListEntry::Thread(thread) => self.render_thread(ix, thread, is_active, is_selected, cx),
             ListEntry::Terminal(terminal) => {
                 self.render_terminal(ix, terminal, is_active, is_selected, cx)
+            }
+            ListEntry::DeltaThread(entry) => {
+                self.render_delta_thread(ix, &entry.clone(), is_active, is_selected, cx)
             }
         };
 
@@ -3563,7 +3687,28 @@ impl Sidebar {
                 let workspace = terminal.workspace.clone();
                 self.activate_terminal_entry(metadata, workspace, false, window, cx);
             }
+            ListEntry::DeltaThread(entry) => {
+                let workspace = entry.workspace.clone();
+                self.activate_delta_thread_entry(workspace, window, cx);
+            }
         }
+    }
+
+    /// Activates the workspace a Delta thread's checkout is open in. The
+    /// thread itself lives in Delta, so there is nothing to load — the row
+    /// is a location, not a conversation.
+    fn activate_delta_thread_entry(
+        &mut self,
+        workspace: Entity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(multi_workspace) = self.multi_workspace.upgrade() {
+            multi_workspace.update(cx, |multi_workspace, cx| {
+                multi_workspace.activate(workspace, None, window, cx);
+            });
+        }
+        cx.notify();
     }
 
     fn find_workspace_across_windows(
@@ -4292,7 +4437,7 @@ impl Sidebar {
                     self.update_entries(cx);
                 }
             }
-            Some(ListEntry::Thread(_) | ListEntry::Terminal(_)) => {
+            Some(ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::DeltaThread(_)) => {
                 for i in (0..ix).rev() {
                     if let Some(ListEntry::ProjectHeader { key, .. }) = self.contents.entries.get(i)
                     {
@@ -4319,12 +4464,14 @@ impl Sidebar {
         // Find the group header for the current selection.
         let header_ix = match self.contents.entries.get(ix) {
             Some(ListEntry::ProjectHeader { .. }) => Some(ix),
-            Some(ListEntry::Thread(_) | ListEntry::Terminal(_)) => (0..ix).rev().find(|&i| {
-                matches!(
-                    self.contents.entries.get(i),
-                    Some(ListEntry::ProjectHeader { .. })
-                )
-            }),
+            Some(ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::DeltaThread(_)) => {
+                (0..ix).rev().find(|&i| {
+                    matches!(
+                        self.contents.entries.get(i),
+                        Some(ListEntry::ProjectHeader { .. })
+                    )
+                })
+            }
             None => None,
         };
 
@@ -4463,6 +4610,10 @@ impl Sidebar {
                     window,
                     cx,
                 );
+                true
+            }
+            ActivatableEntry::DeltaThread { workspace } => {
+                self.activate_delta_thread_entry(workspace.clone(), window, cx);
                 true
             }
         }
@@ -5723,7 +5874,8 @@ impl Sidebar {
                 }
                 ListEntry::Thread(thread) => Sidebar::thread_display_time(&thread.metadata),
                 ListEntry::Terminal(terminal) => terminal.metadata.created_at,
-                ListEntry::ProjectHeader { .. } => unreachable!(),
+                // Delta thread rows are pushed ahead of this time-sorted run.
+                ListEntry::DeltaThread(_) | ListEntry::ProjectHeader { .. } => unreachable!(),
             }
         }
 
@@ -5781,6 +5933,9 @@ impl Sidebar {
                     current_header_key = Some(key.clone());
                     None
                 }
+                // The switcher cycles conversations; a Delta thread row is a
+                // location, not a conversation.
+                ListEntry::DeltaThread(_) => None,
                 ListEntry::Thread(thread) => {
                     if thread.draft == Some(DraftKind::Empty) {
                         return None;
@@ -6555,6 +6710,52 @@ impl Sidebar {
             .into_any_element()
     }
 
+    fn render_delta_thread(
+        &self,
+        ix: usize,
+        entry: &DeltaThreadEntry,
+        is_active: bool,
+        is_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let id = ElementId::from(format!("delta-thread-{}-{}", entry.thread_id, ix));
+        let is_hovered = self.hovered_thread_index == Some(ix);
+        let color = cx.theme().colors();
+        let sidebar_bg = color
+            .title_bar_background
+            .blend(color.panel_background.opacity(0.25));
+        let worktrees = apply_worktree_label_mode(
+            entry.worktrees.clone(),
+            cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
+        );
+        let is_remote = !entry.workspace.read(cx).project().read(cx).is_local();
+
+        ThreadItem::new(id, entry.title.clone())
+            .base_bg(sidebar_bg)
+            .icon(IconName::Delta)
+            .is_remote(is_remote)
+            .worktrees(worktrees)
+            .highlight_positions(entry.highlight_positions.clone())
+            .selected(is_active)
+            .focused(is_focused)
+            .hovered(is_hovered)
+            .on_hover(cx.listener(move |this, is_hovered: &bool, _window, cx| {
+                if *is_hovered {
+                    this.hovered_thread_index = Some(ix);
+                } else if this.hovered_thread_index == Some(ix) {
+                    this.hovered_thread_index = None;
+                }
+                cx.notify();
+            }))
+            .on_click(cx.listener({
+                let workspace = entry.workspace.clone();
+                move |this, _, window, cx| {
+                    this.activate_delta_thread_entry(workspace.clone(), window, cx);
+                }
+            }))
+            .into_any_element()
+    }
+
     fn render_filter_input(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .min_w_0()
@@ -7135,6 +7336,10 @@ impl Sidebar {
                 let metadata = terminal.metadata.clone();
                 let workspace = terminal.workspace.clone();
                 self.activate_terminal_entry(metadata, workspace, true, window, cx);
+            }
+            ListEntry::DeltaThread(entry) => {
+                let workspace = entry.workspace.clone();
+                self.activate_delta_thread_entry(workspace, window, cx);
             }
             ListEntry::ProjectHeader { .. } => {}
         }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -187,6 +187,12 @@ fn assert_remote_project_integration_sidebar_state(
                     terminal.metadata.title
                 );
             }
+            ListEntry::DeltaThread(entry) => {
+                panic!(
+                    "unexpected sidebar delta thread while simulating remote project integration flicker: title=`{}`",
+                    entry.title
+                );
+            }
         }
     }
 
@@ -601,6 +607,10 @@ fn visible_entries_as_strings(
                         let title = terminal.metadata.display_title();
                         let worktree = format_linked_worktree_chips(&terminal.worktrees);
                         format!("  {title}{worktree}{selected}")
+                    }
+                    ListEntry::DeltaThread(delta_thread) => {
+                        let worktree = format_linked_worktree_chips(&delta_thread.worktrees);
+                        format!("  {}{} (delta){}", delta_thread.title, worktree, selected)
                     }
                 }
             })
@@ -5078,7 +5088,9 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
                     thread.metadata.thread_id,
                     thread.metadata.display_title(),
                 )),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::DeltaThread(_) => None,
             })
             .expect("sidebar should have a thread entry")
     });
@@ -5164,7 +5176,9 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
             .iter()
             .find_map(|entry| match entry {
                 ListEntry::Thread(thread) => Some(thread),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::DeltaThread(_) => None,
             })
             .expect("renamed thread should match the search");
         let title = thread.metadata.display_title();
@@ -5203,7 +5217,9 @@ async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut Tes
             .enumerate()
             .find_map(|(ix, entry)| match entry {
                 ListEntry::Thread(thread) => Some((ix, thread.metadata.thread_id)),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::DeltaThread(_) => None,
             })
             .expect("sidebar should have a thread entry")
     });
@@ -7251,6 +7267,12 @@ async fn test_clicking_worktree_thread_does_not_briefly_render_as_separate_proje
                     panic!(
                         "unexpected sidebar terminal while opening linked worktree thread: title=`{}`",
                         terminal.metadata.title
+                    );
+                }
+                ListEntry::DeltaThread(entry) => {
+                    panic!(
+                        "unexpected sidebar delta thread while opening linked worktree thread: title=`{}`",
+                        entry.title
                     );
                 }
             }
@@ -11322,6 +11344,76 @@ async fn test_linked_worktree_workspace_shows_main_worktree_threads(cx: &mut Tes
     assert!(
         entries.iter().any(|e| e.contains("Worktree Thread")),
         "expected worktree thread to be visible, got: {entries:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_delta_thread_row_for_stamped_agent_checkout(cx: &mut TestAppContext) {
+    let (fs, project_main) = init_multi_project_test(&["/main_repo"], cx).await;
+    fs.insert_tree("/main_repo/.git", serde_json::json!({ "objects": {} }))
+        .await;
+    // An agent checkout of /main_repo: it borrows the main repository's
+    // object store (grouping it under /main_repo's project group) and
+    // carries a Delta thread stamp in its git dir.
+    fs.insert_tree(
+        "/main_repo/.delta/worktrees/thread-ns/main_repo",
+        serde_json::json!({
+            ".git": {
+                "objects": { "info": { "alternates": "/main_repo/.git/objects\n" } },
+                "delta-thread.json": serde_json::json!({
+                    "version": 1,
+                    "thread_id": "thread-42",
+                    "thread_title": "Fix the panic",
+                    "source_repository_path": "/main_repo",
+                })
+                .to_string(),
+            },
+            "src": {},
+        }),
+    )
+    .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_main.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+    let checkout_workspace = add_test_project(
+        "/main_repo/.delta/worktrees/thread-ns/main_repo",
+        &fs,
+        &multi_workspace,
+        cx,
+    )
+    .await;
+    cx.run_until_parked();
+
+    let entries = visible_entries_as_strings(&sidebar, cx);
+    assert_eq!(
+        entries.iter().filter(|e| e.contains("[main_repo]")).count(),
+        1,
+        "the agent checkout must join the main repository's project group \
+         instead of forming its own; entries: {entries:#?}",
+    );
+    let delta_row = entries
+        .iter()
+        .find(|entry| entry.contains("(delta)"))
+        .unwrap_or_else(|| panic!("expected a delta thread row; entries: {entries:#?}"));
+    assert!(
+        delta_row.contains("Fix the panic"),
+        "the row should carry the stamped thread title: {delta_row}",
+    );
+
+    // The row is derived from the open workspace, so closing the workspace
+    // removes it.
+    multi_workspace
+        .update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.remove([checkout_workspace], RemovalIntent::KeepProject, window, cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+    let entries = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        !entries.iter().any(|entry| entry.contains("(delta)")),
+        "the delta thread row must disappear with its workspace; entries: {entries:#?}",
     );
 }
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -257,6 +257,21 @@ impl Render for TitleBar {
                         repo.is_linked_worktree()
                             .then_some(project_name.clone())
                             .flatten()
+                    })
+                    .or_else(|| {
+                        // A repository that borrows another repository's
+                        // object store (e.g. an agent checkout) labels like a
+                        // linked worktree of that repository, though git-wise
+                        // it is independent.
+                        worktree
+                            .read(cx)
+                            .root_repo_shared_objects_main_path()
+                            .and_then(|main_worktree_path| {
+                                linked_worktree_short_name(
+                                    main_worktree_path,
+                                    worktree_abs_path.as_ref(),
+                                )
+                            })
                     });
 
                 let identity = repo_identity_path(&repo.common_dir_abs_path);

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -1138,6 +1138,7 @@ async fn test_remote_project_root_dir_changes_update_groups(cx: &mut TestAppCont
                 removed_repositories: vec![],
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             });
     });
     cx.run_until_parked();

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -1139,6 +1139,7 @@ async fn test_remote_project_root_dir_changes_update_groups(cx: &mut TestAppCont
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             });
     });
     cx.run_until_parked();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9751,15 +9751,23 @@ pub async fn apply_restored_multiworkspace_state(
             }
             let mut resolved_paths = Vec::new();
             for path in key.path_list().paths() {
-                if key.host().is_none()
-                    && let Some(common_dir) =
-                        project::discover_root_repo_common_dir(path, fs.as_ref()).await
-                    && !project::is_submodule_git_dir(&common_dir)
-                {
-                    let main_path = project::repo_identity_path(&common_dir);
-                    resolved_paths.push(main_path.to_path_buf());
+                let metadata = if key.host().is_none() {
+                    project::discover_root_repo_metadata(path, fs.as_ref()).await
                 } else {
-                    resolved_paths.push(path.to_path_buf());
+                    None
+                };
+                match metadata {
+                    Some(metadata) => {
+                        if let Some(main_path) = metadata.shared_objects_main_path {
+                            resolved_paths.push(main_path.to_path_buf());
+                        } else if !project::is_submodule_git_dir(&metadata.common_dir) {
+                            let main_path = project::repo_identity_path(&metadata.common_dir);
+                            resolved_paths.push(main_path.to_path_buf());
+                        } else {
+                            resolved_paths.push(path.to_path_buf());
+                        }
+                    }
+                    None => resolved_paths.push(path.to_path_buf()),
                 }
             }
             let resolved = ProjectGroupKey::new(key.host(), PathList::new(&resolved_paths));

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -188,6 +188,8 @@ pub struct Snapshot {
     /// grouping and labels alongside `root_repo_common_dir`, never in git
     /// operations.
     root_repo_shared_objects_main_path: Option<Arc<SanitizedPath>>,
+    /// See [`DeltaThreadStamp`]. Display-only, like the shared-objects path.
+    root_repo_delta_thread_stamp: Option<Arc<DeltaThreadStamp>>,
     always_included_entries: Vec<Arc<RelPath>>,
 
     /// A number that increases every time the worktree begins scanning
@@ -370,6 +372,8 @@ struct LocalRepositoryEntry {
     repository_dir_abs_path: Arc<Path>,
     /// See [`discover_shared_objects_main_path`].
     shared_objects_main_path: Option<Arc<Path>>,
+    /// See [`DeltaThreadStamp`].
+    delta_thread_stamp: Option<Arc<DeltaThreadStamp>>,
 }
 
 impl sum_tree::Item for LocalRepositoryEntry {
@@ -510,6 +514,7 @@ impl Worktree {
                 snapshot.root_repo_shared_objects_main_path = metadata
                     .shared_objects_main_path
                     .map(SanitizedPath::from_arc);
+                snapshot.root_repo_delta_thread_stamp = metadata.delta_thread_stamp;
             }
 
             let worktree_id = snapshot.id();
@@ -604,6 +609,10 @@ impl Worktree {
             snapshot.root_repo_shared_objects_main_path = worktree
                 .root_repo_shared_objects_main_path
                 .map(|p| SanitizedPath::new_arc(Path::new(&p)));
+            snapshot.root_repo_delta_thread_stamp = worktree
+                .root_repo_delta_thread_stamp_json
+                .as_deref()
+                .and_then(parse_delta_thread_stamp_json);
 
             let background_snapshot = Arc::new(Mutex::new((
                 snapshot.clone(),
@@ -670,6 +679,8 @@ impl Worktree {
                             this.snapshot.root_repo_is_linked_worktree;
                         let old_root_repo_shared_objects_main_path =
                             this.snapshot.root_repo_shared_objects_main_path.clone();
+                        let old_root_repo_delta_thread_stamp =
+                            this.snapshot.root_repo_delta_thread_stamp.clone();
                         let mut changed_entries: Vec<(Arc<RelPath>, ProjectEntryId, PathChange)> =
                             Vec::new();
                         {
@@ -718,6 +729,8 @@ impl Worktree {
                                 != old_root_repo_is_linked_worktree
                             || this.snapshot.root_repo_shared_objects_main_path
                                 != old_root_repo_shared_objects_main_path
+                            || this.snapshot.root_repo_delta_thread_stamp
+                                != old_root_repo_delta_thread_stamp
                             || (is_first_update && this.snapshot.root_repo_common_dir.is_none())
                         {
                             cx.emit(Event::UpdatedRootRepoCommonDir {
@@ -817,6 +830,10 @@ impl Worktree {
             root_repo_shared_objects_main_path: self
                 .root_repo_shared_objects_main_path()
                 .map(|p| p.to_string_lossy().into_owned()),
+            root_repo_delta_thread_stamp_json: self
+                .root_repo_delta_thread_stamp
+                .as_deref()
+                .and_then(delta_thread_stamp_to_json),
         }
     }
 
@@ -1424,13 +1441,16 @@ impl LocalWorktree {
                 .shared_objects_main_path
                 .clone()
                 .map(SanitizedPath::from_arc);
+            let delta_thread_stamp = repo.delta_thread_stamp.clone();
             new_snapshot.root_repo_common_dir = Some(common_dir);
             new_snapshot.root_repo_is_linked_worktree = is_linked_worktree;
             new_snapshot.root_repo_shared_objects_main_path = shared_objects_main_path;
+            new_snapshot.root_repo_delta_thread_stamp = delta_thread_stamp;
         } else {
             new_snapshot.root_repo_common_dir = None;
             new_snapshot.root_repo_is_linked_worktree = false;
             new_snapshot.root_repo_shared_objects_main_path = None;
+            new_snapshot.root_repo_delta_thread_stamp = None;
         }
 
         let root_repo_metadata_changed = self.snapshot.root_repo_common_dir
@@ -1438,7 +1458,9 @@ impl LocalWorktree {
             || self.snapshot.root_repo_is_linked_worktree
                 != new_snapshot.root_repo_is_linked_worktree
             || self.snapshot.root_repo_shared_objects_main_path
-                != new_snapshot.root_repo_shared_objects_main_path;
+                != new_snapshot.root_repo_shared_objects_main_path
+            || self.snapshot.root_repo_delta_thread_stamp
+                != new_snapshot.root_repo_delta_thread_stamp;
         let old_root_repo_common_dir =
             root_repo_metadata_changed.then(|| self.snapshot.root_repo_common_dir.clone());
         self.snapshot = new_snapshot;
@@ -2555,6 +2577,7 @@ impl Snapshot {
             root_repo_common_dir: None,
             root_repo_is_linked_worktree: false,
             root_repo_shared_objects_main_path: None,
+            root_repo_delta_thread_stamp: None,
             scan_id: 1,
             completed_scan_id: 0,
         }
@@ -2597,6 +2620,11 @@ impl Snapshot {
             .map(SanitizedPath::cast_arc_ref)
     }
 
+    /// See [`DeltaThreadStamp`].
+    pub fn root_repo_delta_thread_stamp(&self) -> Option<&Arc<DeltaThreadStamp>> {
+        self.root_repo_delta_thread_stamp.as_ref()
+    }
+
     fn build_initial_update(&self, project_id: u64, worktree_id: u64) -> proto::UpdateWorktree {
         let mut updated_entries = self
             .entries_by_path
@@ -2617,6 +2645,10 @@ impl Snapshot {
             root_repo_shared_objects_main_path: self
                 .root_repo_shared_objects_main_path()
                 .map(|p| p.to_string_lossy().into_owned()),
+            root_repo_delta_thread_stamp_json: self
+                .root_repo_delta_thread_stamp
+                .as_deref()
+                .and_then(delta_thread_stamp_to_json),
             updated_entries,
             removed_entries: Vec::new(),
             scan_id: self.scan_id as u64,
@@ -2774,11 +2806,16 @@ impl Snapshot {
                 self.root_repo_shared_objects_main_path = update
                     .root_repo_shared_objects_main_path
                     .map(|p| SanitizedPath::new_arc(Path::new(&p)));
+                self.root_repo_delta_thread_stamp = update
+                    .root_repo_delta_thread_stamp_json
+                    .as_deref()
+                    .and_then(parse_delta_thread_stamp_json);
             }
             None if update.is_last_update => {
                 self.root_repo_common_dir = None;
                 self.root_repo_is_linked_worktree = false;
                 self.root_repo_shared_objects_main_path = None;
+                self.root_repo_delta_thread_stamp = None;
             }
             None => {}
         }
@@ -3028,6 +3065,10 @@ impl LocalSnapshot {
             root_repo_shared_objects_main_path: self
                 .root_repo_shared_objects_main_path()
                 .map(|p| p.to_string_lossy().into_owned()),
+            root_repo_delta_thread_stamp_json: self
+                .root_repo_delta_thread_stamp
+                .as_deref()
+                .and_then(delta_thread_stamp_to_json),
             updated_entries,
             removed_entries,
             scan_id: self.scan_id as u64,
@@ -3604,11 +3645,15 @@ impl BackgroundScannerState {
 
         let (repository_dir_abs_path, common_dir_abs_path) =
             discover_git_paths(&dot_git_abs_path, fs).await;
-        let shared_objects_main_path = if repository_dir_abs_path == common_dir_abs_path {
-            discover_shared_objects_main_path(&repository_dir_abs_path, fs).await
-        } else {
-            None
-        };
+        let (shared_objects_main_path, delta_thread_stamp) =
+            if repository_dir_abs_path == common_dir_abs_path {
+                (
+                    discover_shared_objects_main_path(&repository_dir_abs_path, fs).await,
+                    discover_delta_thread_stamp(&repository_dir_abs_path, fs).await,
+                )
+            } else {
+                (None, None)
+            };
         watcher
             .add(&common_dir_abs_path)
             .context("failed to add common directory to watcher")
@@ -3651,6 +3696,7 @@ impl BackgroundScannerState {
             common_dir_abs_path,
             repository_dir_abs_path,
             shared_objects_main_path,
+            delta_thread_stamp,
         };
 
         self.snapshot
@@ -7080,6 +7126,8 @@ pub struct RootRepoMetadata {
     pub is_linked_worktree: bool,
     /// See [`discover_shared_objects_main_path`].
     pub shared_objects_main_path: Option<Arc<Path>>,
+    /// See [`DeltaThreadStamp`].
+    pub delta_thread_stamp: Option<Arc<DeltaThreadStamp>>,
 }
 
 pub async fn discover_root_repo_metadata(
@@ -7093,16 +7141,70 @@ pub async fn discover_root_repo_metadata(
     let dot_git_path: Arc<Path> = root_dot_git.into();
     let (repository_dir, common_dir) = discover_git_paths(&dot_git_path, fs).await;
     let is_linked_worktree = repository_dir != common_dir;
-    let shared_objects_main_path = if is_linked_worktree {
-        None
+    let (shared_objects_main_path, delta_thread_stamp) = if is_linked_worktree {
+        (None, None)
     } else {
-        discover_shared_objects_main_path(&repository_dir, fs).await
+        (
+            discover_shared_objects_main_path(&repository_dir, fs).await,
+            discover_delta_thread_stamp(&repository_dir, fs).await,
+        )
     };
     Some(RootRepoMetadata {
         common_dir,
         is_linked_worktree,
         shared_objects_main_path,
+        delta_thread_stamp,
     })
+}
+
+/// Name of the provenance stamp file Delta writes into the git dir of the
+/// checkouts it manages (its "worktree mounts"), relating the checkout to the
+/// Delta thread that owns it. Part of Delta's contract with Zed; see
+/// `PROVENANCE_STAMP_FILE_NAME` in Delta's `worktree_mount` crate.
+const DELTA_THREAD_STAMP_FILE_NAME: &str = "delta-thread.json";
+
+/// Provenance stamp parsed from [`DELTA_THREAD_STAMP_FILE_NAME`] in a
+/// repository's git dir: which Delta thread owns the checkout. Delta rewrites
+/// the stamp on every mount, so the title is as fresh as the thread's last
+/// mount, and deletes it with the checkout's git state.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DeltaThreadStamp {
+    #[serde(default)]
+    pub version: u64,
+    /// Thread id, usable in a `delta://thread/<id>` link.
+    pub thread_id: String,
+    #[serde(default)]
+    pub thread_title: Option<String>,
+    #[serde(default)]
+    pub source_repository_path: Option<PathBuf>,
+}
+
+fn parse_delta_thread_stamp_json(json: &str) -> Option<Arc<DeltaThreadStamp>> {
+    serde_json::from_str(json).log_err().map(Arc::new)
+}
+
+fn delta_thread_stamp_to_json(stamp: &DeltaThreadStamp) -> Option<String> {
+    serde_json::to_string(stamp).log_err()
+}
+
+async fn discover_delta_thread_stamp(
+    repository_dir_abs_path: &Path,
+    fs: &dyn Fs,
+) -> Option<Arc<DeltaThreadStamp>> {
+    let contents = fs
+        .load(&repository_dir_abs_path.join(DELTA_THREAD_STAMP_FILE_NAME))
+        .await
+        .ok()?;
+    match serde_json::from_str::<DeltaThreadStamp>(&contents) {
+        Ok(stamp) => Some(Arc::new(stamp)),
+        Err(error) => {
+            log::warn!(
+                "failed to parse {DELTA_THREAD_STAMP_FILE_NAME} in {}: {error}",
+                repository_dir_abs_path.display()
+            );
+            None
+        }
+    }
 }
 
 /// The working directory of the repository whose object store this repository

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -184,6 +184,10 @@ pub struct Snapshot {
     entries_by_id: SumTree<PathEntry>,
     root_repo_common_dir: Option<Arc<SanitizedPath>>,
     root_repo_is_linked_worktree: bool,
+    /// See [`discover_shared_objects_main_path`]. Participates in project
+    /// grouping and labels alongside `root_repo_common_dir`, never in git
+    /// operations.
+    root_repo_shared_objects_main_path: Option<Arc<SanitizedPath>>,
     always_included_entries: Vec<Arc<RelPath>>,
 
     /// A number that increases every time the worktree begins scanning
@@ -364,6 +368,8 @@ struct LocalRepositoryEntry {
     /// `common_dir_abs_path`. For a submodule or worktree, this is some subdirectory of the
     /// commondir like `/project/.git/modules/foo`.
     repository_dir_abs_path: Arc<Path>,
+    /// See [`discover_shared_objects_main_path`].
+    shared_objects_main_path: Option<Arc<Path>>,
 }
 
 impl sum_tree::Item for LocalRepositoryEntry {
@@ -473,18 +479,10 @@ impl Worktree {
             None
         };
 
-        let (root_repo_common_dir, root_repo_is_linked_worktree) = if visible {
-            discover_root_repo_metadata(&abs_path, fs.as_ref())
-                .await
-                .map(|(common_dir, is_linked_worktree)| {
-                    (
-                        Some(SanitizedPath::from_arc(common_dir)),
-                        is_linked_worktree,
-                    )
-                })
-                .unwrap_or((None, false))
+        let root_repo_metadata = if visible {
+            discover_root_repo_metadata(&abs_path, fs.as_ref()).await
         } else {
-            (None, false)
+            None
         };
         Ok(cx.new(move |cx: &mut Context<Worktree>| {
             let mut snapshot = LocalSnapshot {
@@ -506,8 +504,13 @@ impl Worktree {
                 ),
                 root_file_handle,
             };
-            snapshot.root_repo_common_dir = root_repo_common_dir;
-            snapshot.root_repo_is_linked_worktree = root_repo_is_linked_worktree;
+            if let Some(metadata) = root_repo_metadata {
+                snapshot.root_repo_common_dir = Some(SanitizedPath::from_arc(metadata.common_dir));
+                snapshot.root_repo_is_linked_worktree = metadata.is_linked_worktree;
+                snapshot.root_repo_shared_objects_main_path = metadata
+                    .shared_objects_main_path
+                    .map(SanitizedPath::from_arc);
+            }
 
             let worktree_id = snapshot.id();
             let settings_location = Some(SettingsLocation {
@@ -598,6 +601,9 @@ impl Worktree {
                 .root_repo_common_dir
                 .map(|p| SanitizedPath::new_arc(Path::new(&p)));
             snapshot.root_repo_is_linked_worktree = worktree.root_repo_is_linked_worktree;
+            snapshot.root_repo_shared_objects_main_path = worktree
+                .root_repo_shared_objects_main_path
+                .map(|p| SanitizedPath::new_arc(Path::new(&p)));
 
             let background_snapshot = Arc::new(Mutex::new((
                 snapshot.clone(),
@@ -662,6 +668,8 @@ impl Worktree {
                         let old_root_repo_common_dir = this.snapshot.root_repo_common_dir.clone();
                         let old_root_repo_is_linked_worktree =
                             this.snapshot.root_repo_is_linked_worktree;
+                        let old_root_repo_shared_objects_main_path =
+                            this.snapshot.root_repo_shared_objects_main_path.clone();
                         let mut changed_entries: Vec<(Arc<RelPath>, ProjectEntryId, PathChange)> =
                             Vec::new();
                         {
@@ -708,6 +716,8 @@ impl Worktree {
                         if this.snapshot.root_repo_common_dir != old_root_repo_common_dir
                             || this.snapshot.root_repo_is_linked_worktree
                                 != old_root_repo_is_linked_worktree
+                            || this.snapshot.root_repo_shared_objects_main_path
+                                != old_root_repo_shared_objects_main_path
                             || (is_first_update && this.snapshot.root_repo_common_dir.is_none())
                         {
                             cx.emit(Event::UpdatedRootRepoCommonDir {
@@ -804,6 +814,9 @@ impl Worktree {
                 .root_repo_common_dir()
                 .map(|p| p.to_string_lossy().into_owned()),
             root_repo_is_linked_worktree: self.root_repo_is_linked_worktree(),
+            root_repo_shared_objects_main_path: self
+                .root_repo_shared_objects_main_path()
+                .map(|p| p.to_string_lossy().into_owned()),
         }
     }
 
@@ -1404,26 +1417,28 @@ impl LocalWorktree {
     ) {
         let repo_changes = self.changed_repos(&self.snapshot, &mut new_snapshot);
 
-        if let Some((common_dir, is_linked_worktree)) = new_snapshot
-            .local_repo_for_work_directory_path(RelPath::empty())
-            .map(|repo| {
-                (
-                    SanitizedPath::from_arc(repo.common_dir_abs_path.clone()),
-                    repo.repository_dir_abs_path != repo.common_dir_abs_path,
-                )
-            })
-        {
+        if let Some(repo) = new_snapshot.local_repo_for_work_directory_path(RelPath::empty()) {
+            let common_dir = SanitizedPath::from_arc(repo.common_dir_abs_path.clone());
+            let is_linked_worktree = repo.repository_dir_abs_path != repo.common_dir_abs_path;
+            let shared_objects_main_path = repo
+                .shared_objects_main_path
+                .clone()
+                .map(SanitizedPath::from_arc);
             new_snapshot.root_repo_common_dir = Some(common_dir);
             new_snapshot.root_repo_is_linked_worktree = is_linked_worktree;
+            new_snapshot.root_repo_shared_objects_main_path = shared_objects_main_path;
         } else {
             new_snapshot.root_repo_common_dir = None;
             new_snapshot.root_repo_is_linked_worktree = false;
+            new_snapshot.root_repo_shared_objects_main_path = None;
         }
 
         let root_repo_metadata_changed = self.snapshot.root_repo_common_dir
             != new_snapshot.root_repo_common_dir
             || self.snapshot.root_repo_is_linked_worktree
-                != new_snapshot.root_repo_is_linked_worktree;
+                != new_snapshot.root_repo_is_linked_worktree
+            || self.snapshot.root_repo_shared_objects_main_path
+                != new_snapshot.root_repo_shared_objects_main_path;
         let old_root_repo_common_dir =
             root_repo_metadata_changed.then(|| self.snapshot.root_repo_common_dir.clone());
         self.snapshot = new_snapshot;
@@ -2539,6 +2554,7 @@ impl Snapshot {
             entries_by_id: Default::default(),
             root_repo_common_dir: None,
             root_repo_is_linked_worktree: false,
+            root_repo_shared_objects_main_path: None,
             scan_id: 1,
             completed_scan_id: 0,
         }
@@ -2574,6 +2590,13 @@ impl Snapshot {
         self.root_repo_is_linked_worktree
     }
 
+    /// See [`discover_shared_objects_main_path`].
+    pub fn root_repo_shared_objects_main_path(&self) -> Option<&Arc<Path>> {
+        self.root_repo_shared_objects_main_path
+            .as_ref()
+            .map(SanitizedPath::cast_arc_ref)
+    }
+
     fn build_initial_update(&self, project_id: u64, worktree_id: u64) -> proto::UpdateWorktree {
         let mut updated_entries = self
             .entries_by_path
@@ -2591,6 +2614,9 @@ impl Snapshot {
                 .root_repo_common_dir()
                 .map(|p| p.to_string_lossy().into_owned()),
             root_repo_is_linked_worktree: self.root_repo_is_linked_worktree,
+            root_repo_shared_objects_main_path: self
+                .root_repo_shared_objects_main_path()
+                .map(|p| p.to_string_lossy().into_owned()),
             updated_entries,
             removed_entries: Vec::new(),
             scan_id: self.scan_id as u64,
@@ -2745,10 +2771,14 @@ impl Snapshot {
             Some(dir) => {
                 self.root_repo_common_dir = Some(dir);
                 self.root_repo_is_linked_worktree = update.root_repo_is_linked_worktree;
+                self.root_repo_shared_objects_main_path = update
+                    .root_repo_shared_objects_main_path
+                    .map(|p| SanitizedPath::new_arc(Path::new(&p)));
             }
             None if update.is_last_update => {
                 self.root_repo_common_dir = None;
                 self.root_repo_is_linked_worktree = false;
+                self.root_repo_shared_objects_main_path = None;
             }
             None => {}
         }
@@ -2995,6 +3025,9 @@ impl LocalSnapshot {
                 .root_repo_common_dir()
                 .map(|p| p.to_string_lossy().into_owned()),
             root_repo_is_linked_worktree: self.root_repo_is_linked_worktree,
+            root_repo_shared_objects_main_path: self
+                .root_repo_shared_objects_main_path()
+                .map(|p| p.to_string_lossy().into_owned()),
             updated_entries,
             removed_entries,
             scan_id: self.scan_id as u64,
@@ -3571,6 +3604,11 @@ impl BackgroundScannerState {
 
         let (repository_dir_abs_path, common_dir_abs_path) =
             discover_git_paths(&dot_git_abs_path, fs).await;
+        let shared_objects_main_path = if repository_dir_abs_path == common_dir_abs_path {
+            discover_shared_objects_main_path(&repository_dir_abs_path, fs).await
+        } else {
+            None
+        };
         watcher
             .add(&common_dir_abs_path)
             .context("failed to add common directory to watcher")
@@ -3612,6 +3650,7 @@ impl BackgroundScannerState {
             dot_git_abs_path,
             common_dir_abs_path,
             repository_dir_abs_path,
+            shared_objects_main_path,
         };
 
         self.snapshot
@@ -7028,16 +7067,25 @@ fn resolve_commondir_path(repository_dir_abs_path: &Path, commondir_path: &str) 
     }
 }
 
-pub async fn discover_root_repo_common_dir(root_abs_path: &Path, fs: &dyn Fs) -> Option<Arc<Path>> {
-    discover_root_repo_metadata(root_abs_path, fs)
-        .await
-        .map(|(common_dir, _)| common_dir)
+/// Git metadata discovered for the repository at a worktree's root, relating
+/// the repository to the "main" repository it was derived from, if any.
+#[derive(Debug, Clone)]
+pub struct RootRepoMetadata {
+    /// Absolute path to the repository's common git directory: the main
+    /// checkout's `.git` for a linked worktree, the repository's own git
+    /// directory otherwise.
+    pub common_dir: Arc<Path>,
+    /// Whether the repository is a linked worktree (created with
+    /// `git worktree add`) rather than the main checkout.
+    pub is_linked_worktree: bool,
+    /// See [`discover_shared_objects_main_path`].
+    pub shared_objects_main_path: Option<Arc<Path>>,
 }
 
-async fn discover_root_repo_metadata(
+pub async fn discover_root_repo_metadata(
     root_abs_path: &Path,
     fs: &dyn Fs,
-) -> Option<(Arc<Path>, bool)> {
+) -> Option<RootRepoMetadata> {
     let root_dot_git = root_abs_path.join(DOT_GIT);
     if !fs.metadata(&root_dot_git).await.is_ok_and(|m| m.is_some()) {
         return None;
@@ -7045,7 +7093,62 @@ async fn discover_root_repo_metadata(
     let dot_git_path: Arc<Path> = root_dot_git.into();
     let (repository_dir, common_dir) = discover_git_paths(&dot_git_path, fs).await;
     let is_linked_worktree = repository_dir != common_dir;
-    Some((common_dir, is_linked_worktree))
+    let shared_objects_main_path = if is_linked_worktree {
+        None
+    } else {
+        discover_shared_objects_main_path(&repository_dir, fs).await
+    };
+    Some(RootRepoMetadata {
+        common_dir,
+        is_linked_worktree,
+        shared_objects_main_path,
+    })
+}
+
+/// The working directory of the repository whose object store this repository
+/// borrows via `objects/info/alternates` — e.g. a repository created with
+/// `git clone --shared`, or an agent tool's checkout that shares the user's
+/// repository objects. Returns `None` when the repository owns its objects,
+/// or when no alternate resolves to another working directory's `.git/objects`
+/// (bare repositories have no working directory to relate to).
+///
+/// Sharing an object store is treated as evidence that the two checkouts
+/// belong to the same project, so this path participates in project grouping
+/// and window labeling the same way a linked worktree's main checkout does.
+/// It deliberately has no effect on git semantics: unlike a linked worktree,
+/// such a repository has its own refs, index, and `HEAD`.
+async fn discover_shared_objects_main_path(
+    repository_dir_abs_path: &Path,
+    fs: &dyn Fs,
+) -> Option<Arc<Path>> {
+    let alternates = fs
+        .load(&repository_dir_abs_path.join("objects/info/alternates"))
+        .await
+        .ok()?;
+    for line in alternates.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Relative entries are resolved against the repository's own objects
+        // directory, per gitrepository-layout(5).
+        let objects_dir = if Path::new(line).is_absolute() {
+            PathBuf::from(line)
+        } else {
+            repository_dir_abs_path.join("objects").join(line)
+        };
+        let Some(objects_dir) = fs.canonicalize(&objects_dir).await.log_err() else {
+            continue;
+        };
+        if objects_dir.file_name() == Some(OsStr::new("objects"))
+            && let Some(git_dir) = objects_dir.parent()
+            && git_dir.file_name() == Some(OsStr::new(DOT_GIT))
+            && let Some(main_path) = git_dir.parent()
+        {
+            return Some(main_path.into());
+        }
+    }
+    None
 }
 
 async fn discover_git_paths(dot_git_abs_path: &Arc<Path>, fs: &dyn Fs) -> (Arc<Path>, Arc<Path>) {

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4406,6 +4406,13 @@ async fn test_root_repo_shared_objects_main_path(
             "checkout.git": {
                 "HEAD": "ref: refs/heads/main",
                 "config": "[core]\n\tbare = false\n",
+                "delta-thread.json": serde_json::json!({
+                    "version": 1,
+                    "thread_id": "thread-123",
+                    "thread_title": "Fix the bug",
+                    "source_repository_path": path!("/main_repo"),
+                })
+                .to_string(),
                 "objects": {
                     "info": {
                         "alternates": format!("{}\n", path!("/main_repo/.git/objects")),
@@ -4461,6 +4468,11 @@ async fn test_root_repo_shared_objects_main_path(
                 .map(|p| p.as_ref()),
             Some(Path::new(path!("/main_repo"))),
         );
+        assert_eq!(
+            snapshot.root_repo_delta_thread_stamp(),
+            None,
+            "a repository without a stamp file must not report a delta thread"
+        );
         assert!(
             !snapshot.root_repo_is_linked_worktree(),
             "sharing an object store must not make the repository a linked worktree"
@@ -4497,6 +4509,15 @@ async fn test_root_repo_shared_objects_main_path(
             Some(Path::new(path!("/main_repo"))),
         );
         assert!(!snapshot.root_repo_is_linked_worktree());
+        let stamp = snapshot
+            .root_repo_delta_thread_stamp()
+            .expect("the delta-thread.json stamp should be discovered");
+        assert_eq!(stamp.thread_id, "thread-123");
+        assert_eq!(stamp.thread_title.as_deref(), Some("Fix the bug"));
+        assert_eq!(
+            stamp.source_repository_path.as_deref(),
+            Some(Path::new(path!("/main_repo")))
+        );
     });
 
     let bare_backed_tree = Worktree::local(
@@ -5870,6 +5891,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             },
             client,
             PathStyle::Unix,
@@ -5929,6 +5951,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             });
     });
 
@@ -5969,6 +5992,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             },
             client,
             PathStyle::Unix,
@@ -6025,6 +6049,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
                 root_repo_common_dir: Some("/home/user/project/.git".to_string()),
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             });
     });
 
@@ -6070,6 +6095,7 @@ async fn test_remote_worktree_root_repo_metadata_cleared_only_by_completed_scan(
                 root_repo_common_dir: Some("/home/user/monty/.bare".to_string()),
                 root_repo_is_linked_worktree: true,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             },
             client,
             PathStyle::Unix,
@@ -6101,6 +6127,7 @@ async fn test_remote_worktree_root_repo_metadata_cleared_only_by_completed_scan(
         root_repo_common_dir: None,
         root_repo_is_linked_worktree: false,
         root_repo_shared_objects_main_path: None,
+        root_repo_delta_thread_stamp_json: None,
     };
 
     // A mid-scan update without repo info must not clobber the seeded
@@ -6188,6 +6215,7 @@ async fn test_remote_worktree_update_entries_carry_changed_paths(cx: &mut TestAp
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
                 root_repo_shared_objects_main_path: None,
+                root_repo_delta_thread_stamp_json: None,
             },
             AnyProtoClient::new(NoopProtoClient::new()),
             PathStyle::local(),

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4366,6 +4366,161 @@ async fn test_root_repo_common_dir(executor: BackgroundExecutor, cx: &mut TestAp
 }
 
 #[gpui::test]
+async fn test_root_repo_shared_objects_main_path(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/main_repo"),
+        json!({
+            ".git": { "objects": {} },
+            "file.txt": "content",
+        }),
+    )
+    .await;
+    // A standalone repository that borrows the main repository's object store
+    // via `objects/info/alternates`, like one created by `git clone --shared`.
+    fs.insert_tree(
+        path!("/agent_checkout"),
+        json!({
+            ".git": {
+                "objects": {
+                    "info": {
+                        "alternates": format!("{}\n", path!("/main_repo/.git/objects")),
+                    }
+                }
+            },
+            "file.txt": "content",
+        }),
+    )
+    .await;
+    // The same relationship expressed through a separate git dir: the
+    // checkout holds only a `.git` file pointing at a git dir elsewhere,
+    // whose alternates borrow the main repository's objects.
+    fs.insert_tree(
+        path!("/clones"),
+        json!({
+            "checkout.git": {
+                "HEAD": "ref: refs/heads/main",
+                "config": "[core]\n\tbare = false\n",
+                "objects": {
+                    "info": {
+                        "alternates": format!("{}\n", path!("/main_repo/.git/objects")),
+                    }
+                },
+            },
+            "checkout": {
+                ".git": format!("gitdir: {}", path!("/clones/checkout.git")),
+                "file.txt": "content",
+            },
+        }),
+    )
+    .await;
+    // An alternate that doesn't point into another working directory's `.git`
+    // (e.g. a bare object store) names no main path.
+    fs.insert_tree(
+        path!("/bare_backed"),
+        json!({
+            ".git": {
+                "objects": {
+                    "info": {
+                        "alternates": format!("{}\n", path!("/object_store/objects")),
+                    }
+                }
+            },
+            "file.txt": "content",
+        }),
+    )
+    .await;
+    fs.insert_tree(path!("/object_store"), json!({ "objects": {} }))
+        .await;
+
+    let tree = Worktree::local(
+        path!("/agent_checkout").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    tree.update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        let snapshot = tree.snapshot();
+        assert_eq!(
+            snapshot
+                .root_repo_shared_objects_main_path()
+                .map(|p| p.as_ref()),
+            Some(Path::new(path!("/main_repo"))),
+        );
+        assert!(
+            !snapshot.root_repo_is_linked_worktree(),
+            "sharing an object store must not make the repository a linked worktree"
+        );
+        assert_eq!(
+            snapshot.root_repo_common_dir().map(|p| p.as_ref()),
+            Some(Path::new(path!("/agent_checkout/.git"))),
+            "the repository keeps its own git directory"
+        );
+    });
+
+    let separate_git_dir_tree = Worktree::local(
+        path!("/clones/checkout").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(1),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    separate_git_dir_tree
+        .update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    separate_git_dir_tree.read_with(cx, |tree, _| {
+        let snapshot = tree.snapshot();
+        assert_eq!(
+            snapshot
+                .root_repo_shared_objects_main_path()
+                .map(|p| p.as_ref()),
+            Some(Path::new(path!("/main_repo"))),
+        );
+        assert!(!snapshot.root_repo_is_linked_worktree());
+    });
+
+    let bare_backed_tree = Worktree::local(
+        path!("/bare_backed").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(2),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    bare_backed_tree
+        .update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    bare_backed_tree.read_with(cx, |tree, _| {
+        assert_eq!(tree.snapshot().root_repo_shared_objects_main_path(), None);
+    });
+}
+
+#[gpui::test]
 async fn test_invisible_worktree_does_not_track_ancestor_git_repository(
     executor: BackgroundExecutor,
     cx: &mut TestAppContext,
@@ -5714,6 +5869,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
                 abs_path: "/home/user/project".to_string(),
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             },
             client,
             PathStyle::Unix,
@@ -5772,6 +5928,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
                 removed_repositories: vec![],
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             });
     });
 
@@ -5811,6 +5968,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
                 abs_path: "/home/user/project".to_string(),
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             },
             client,
             PathStyle::Unix,
@@ -5866,6 +6024,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
                 removed_repositories: vec![],
                 root_repo_common_dir: Some("/home/user/project/.git".to_string()),
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             });
     });
 
@@ -5910,6 +6069,7 @@ async fn test_remote_worktree_root_repo_metadata_cleared_only_by_completed_scan(
                 abs_path: "/home/user/monty/feature-a".to_string(),
                 root_repo_common_dir: Some("/home/user/monty/.bare".to_string()),
                 root_repo_is_linked_worktree: true,
+                root_repo_shared_objects_main_path: None,
             },
             client,
             PathStyle::Unix,
@@ -5940,6 +6100,7 @@ async fn test_remote_worktree_root_repo_metadata_cleared_only_by_completed_scan(
         removed_repositories: vec![],
         root_repo_common_dir: None,
         root_repo_is_linked_worktree: false,
+        root_repo_shared_objects_main_path: None,
     };
 
     // A mid-scan update without repo info must not clobber the seeded
@@ -6026,6 +6187,7 @@ async fn test_remote_worktree_update_entries_carry_changed_paths(cx: &mut TestAp
                 abs_path: path!("/root").to_string(),
                 root_repo_common_dir: None,
                 root_repo_is_linked_worktree: false,
+                root_repo_shared_objects_main_path: None,
             },
             AnyProtoClient::new(NoopProtoClient::new()),
             PathStyle::local(),


### PR DESCRIPTION
This PR makes Zed a good citizen for repositories checked out by agent tools like Delta — concretely, Delta's worktree mounts — in two layered steps: grouping such checkouts under the project they belong to, and giving the owning Delta thread a visible, clickable presence in the threads sidebar. It implements sections 2.2 and 2.3 (sidebar half) of Delta's Zed integration plan; the Delta-side counterpart is zed-industries/delta#2484.

**Grouping via shared object stores.** A window opened on a repository that borrows another repository's object store via `objects/info/alternates` — a `git clone --shared`/`--reference` clone, or an agent tool's checkout of the user's repository — previously formed its own project group in the sidebar, named after its directory (e.g. `3h7nba2vje1k/delta`), even though it is a satellite of a repository the user already has open. Worktree scanning now resolves the alternates file: when a repository is not a linked git worktree and one of its alternates resolves to another working directory's `.git/objects`, that working directory is recorded as the repository's "shared objects main path". Project grouping (`ProjectGroupKey` via `WorktreeStore::paths`), session-restore group-key normalization, the sidebar's workspace labels, and the title bar's worktree chip all prefer this path, so such a window groups under the object-store owner's project and is labeled like a linked worktree of it. Git semantics are deliberately unchanged: the new field is carried alongside `root_repo_common_dir` but consumed only by grouping and labeling — an alternates-backed repository keeps its own refs, index, and `HEAD`, and stays out of `git worktree list`-driven features. Alternates parsing handles relative entries, multiple entries, and comments; alternates that don't name another working directory (bare stores) are ignored.

**Ephemeral Delta thread rows.** Delta stamps its mounts with a `delta-thread.json` provenance file in the checkout's git dir (thread id, title, source repository — zed-industries/delta#2484). Worktree scanning reads the stamp in the same discovery pass, and the sidebar synthesizes a row per stamped open workspace under its owning project group: titled with the Delta thread's title, marked with a new delta icon, showing the usual worktree chips, activating its workspace on click. The rows are derived from open workspace state rather than the thread metadata store, so they are ephemeral by construction — never persisted, unable to leak into the archive, drafts, or the MRU switcher, and gone when the workspace closes (or the checkout is deleted). They don't participate in thread cycling: they are locations, not conversations.

Deferred follow-up (per the plan): an agent-panel empty state with a "Go back to Delta" button opening `delta://thread/<id>`, plus its dismissal semantics.

Testing:

- Worktree tests covering alternates discovery in a plain `.git` layout, the separate-git-dir layout Delta actually produces (gitfile → external git dir → alternates), a bare-store alternate that must not match, and stamp parsing including the no-stamp case.
- Project test asserting a main repository and an alternates-backed checkout produce the same `ProjectGroupKey`.
- Sidebar test covering the full flow: a stamped agent checkout joins the main repository's project group, renders a titled delta row, and the row disappears when the workspace is removed.
- Full worktree (211), sidebar (144), project + workspace (547), and remote_server (44) suites pass; clippy clean.

Release Notes:

- Improved project grouping: windows opened on repositories that share another repository's object store (e.g. `git clone --shared`, or agent tools' checkouts) now group under that repository's project in the sidebar instead of appearing as separate projects.
- Added sidebar entries for Delta threads whose checkouts are open in the window: the row shows the thread's title under the repository's project group and jumps to that workspace.
