### PR TITLE
keymaps: Keep `⌃P` bound to the File Finder

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -11,7 +11,6 @@
       "ctrl-n": "menu::SelectNext",
       "tab": "menu::SelectNext",
       "down": "menu::SelectNext",
-      "ctrl-p": "menu::SelectPrevious",
       "shift-tab": "menu::SelectPrevious",
       "up": "menu::SelectPrevious",
       "enter": "menu::Confirm",
@@ -870,7 +869,6 @@
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
-      "ctrl-p": "editor::ContextMenuPrevious",
       "up": "editor::ContextMenuPrevious",
       "ctrl-n": "editor::ContextMenuNext",
       "down": "editor::ContextMenuNext",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -12,7 +12,6 @@
       "ctrl-n": "menu::SelectNext",
       "tab": "menu::SelectNext",
       "down": "menu::SelectNext",
-      "ctrl-p": "menu::SelectPrevious",
       "shift-tab": "menu::SelectPrevious",
       "up": "menu::SelectPrevious",
       "enter": "menu::Confirm",
@@ -866,7 +865,6 @@
     "context": "Editor && (showing_code_actions || showing_completions)",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-p": "editor::ContextMenuPrevious",
       "up": "editor::ContextMenuPrevious",
       "ctrl-n": "editor::ContextMenuNext",
       "down": "editor::ContextMenuNext",


### PR DESCRIPTION
I think this fixes the issue while maintaining parity with macOS. But I’m not sure if that’s what’s intended here. I’ll test out the new behavior on my other machines to see test-drive how these changes feel and then move it from draft status.

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed `⌃P` not opening the File Finder from some Panels and menus on Windows and Linux
