### PR TITLE
editor: Fix `fold_at_level` folding function arguments and not function body

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2215,6 +2215,36 @@ fn test_fold_at_level_chain_fold(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_at_level_with_single_row_crease(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("aaaaaa\n@file.txt and more\ncccccc\n", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let range =
+            snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(1, 9));
+
+        editor.insert_creases(Some(Crease::simple(range, FoldPlaceholder::test())), cx);
+
+        editor.fold_at_level(&FoldAtLevel(1), window, cx);
+
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                aaaaaa
+                ⋯ and more
+                cccccc
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
 fn test_move_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2187,31 +2187,32 @@ fn test_fold_at_level_chain_fold(cx: &mut TestAppContext) {
         build_editor(buffer, window, cx)
     });
 
-    _ = editor.update(cx, |editor, window, cx| {
-        editor.fold_at_level(&FoldAtLevel(1), window, cx);
-        println!("{}", editor.display_text(cx));
-        assert_eq!(
-            editor.display_text(cx),
-            "
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.fold_at_level(&FoldAtLevel(1), window, cx);
+            assert_eq!(
+                editor.display_text(cx),
+                "
                 fn foo(⋯) {⋯}
             "
-            .unindent(),
-        );
+                .unindent(),
+            );
 
-        editor.unfold_all(&UnfoldAll, window, cx);
-        editor.fold_at_level(&FoldAtLevel(2), window, cx);
-        assert_eq!(
-            editor.display_text(cx),
-            "
+            editor.unfold_all(&UnfoldAll, window, cx);
+            editor.fold_at_level(&FoldAtLevel(2), window, cx);
+            assert_eq!(
+                editor.display_text(cx),
+                "
                 fn foo(
                     a: i32,
                 ) {
                     if true {⋯} else {⋯}
                 }
             "
-            .unindent(),
-        );
-    });
+                .unindent(),
+            );
+        })
+        .unwrap();
 }
 
 #[gpui::test]
@@ -2223,25 +2224,27 @@ fn test_fold_at_level_with_single_row_crease(cx: &mut TestAppContext) {
         build_editor(buffer, window, cx)
     });
 
-    _ = editor.update(cx, |editor, window, cx| {
-        let snapshot = editor.buffer().read(cx).snapshot(cx);
-        let range =
-            snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(1, 9));
+    editor
+        .update(cx, |editor, window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let range =
+                snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(1, 9));
 
-        editor.insert_creases(Some(Crease::simple(range, FoldPlaceholder::test())), cx);
+            editor.insert_creases(Some(Crease::simple(range, FoldPlaceholder::test())), cx);
 
-        editor.fold_at_level(&FoldAtLevel(1), window, cx);
+            editor.fold_at_level(&FoldAtLevel(1), window, cx);
 
-        assert_eq!(
-            editor.display_text(cx),
-            "
+            assert_eq!(
+                editor.display_text(cx),
+                "
                 aaaaaa
                 ⋯ and more
                 cccccc
             "
-            .unindent(),
-        );
-    });
+                .unindent(),
+            );
+        })
+        .unwrap();
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2165,6 +2165,56 @@ fn test_fold_at_level(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_at_level_chain_fold(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let text = "
+            fn foo(
+                a: i32,
+            ) {
+                if true {
+                    let b = a;
+                } else {
+                    let b = a;
+                }
+            }
+        "
+        .unindent();
+        let buffer = cx.new(|cx| Buffer::local(&text, cx).with_language(rust_lang(), cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_at_level(&FoldAtLevel(1), window, cx);
+        println!("{}", editor.display_text(cx));
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                fn foo(⋯) {⋯}
+            "
+            .unindent(),
+        );
+
+        editor.unfold_all(&UnfoldAll, window, cx);
+        editor.fold_at_level(&FoldAtLevel(2), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                fn foo(
+                    a: i32,
+                ) {
+                    if true {⋯} else {⋯}
+                }
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
 fn test_move_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2248,6 +2248,41 @@ fn test_fold_at_level_with_single_row_crease(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_fold_at_level_with_crease_on_boundary_row(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("aaa\nbbb\nccc\nddd eee\nfff\n", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    editor
+        .update(cx, |editor, window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let outer =
+                snapshot.anchor_before(Point::new(1, 0))..snapshot.anchor_after(Point::new(3, 7));
+            let inner =
+                snapshot.anchor_before(Point::new(3, 0))..snapshot.anchor_after(Point::new(3, 3));
+
+            editor.insert_creases(
+                [
+                    Crease::simple(outer, FoldPlaceholder::test()),
+                    Crease::simple(inner, FoldPlaceholder::test()),
+                ],
+                cx,
+            );
+
+            editor.fold_at_level(&FoldAtLevel(1), window, cx);
+            assert_eq!(editor.display_text(cx), "aaa\n⋯\nfff\n");
+
+            editor.unfold_all(&UnfoldAll, window, cx);
+            editor.fold_at_level(&FoldAtLevel(2), window, cx);
+            assert_eq!(editor.display_text(cx), "aaa\nbbb\nccc\nddd eee\nfff\n");
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 fn test_move_cursor(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/fold.rs
+++ b/crates/editor/src/fold.rs
@@ -769,7 +769,7 @@ impl Editor {
                         if current_level < fold_at_level {
                             stack.push((nested_start_row, nested_end_row, current_level + 1));
                         } else if current_level == fold_at_level {
-                            // Fold iff there is no selection completely contained within the fold region
+                            // Fold if there is no selection completely contained within the fold region
                             if !row_ranges_to_keep.iter().any(|selection| {
                                 selection.end >= nested_start_row
                                     && selection.start <= nested_end_row
@@ -778,7 +778,7 @@ impl Editor {
                             }
                         }
 
-                        start_row = nested_end_row + 1;
+                        start_row = nested_end_row;
                     }
                     None => start_row += 1,
                 }

--- a/crates/editor/src/fold.rs
+++ b/crates/editor/src/fold.rs
@@ -769,7 +769,7 @@ impl Editor {
                         if current_level < fold_at_level {
                             stack.push((nested_start_row, nested_end_row, current_level + 1));
                         } else if current_level == fold_at_level {
-                            // Fold if there is no selection completely contained within the fold region
+                            // Fold if and only if there is no selection completely contained within the fold region
                             if !row_ranges_to_keep.iter().any(|selection| {
                                 selection.end >= nested_start_row
                                     && selection.start <= nested_end_row

--- a/crates/editor/src/fold.rs
+++ b/crates/editor/src/fold.rs
@@ -778,7 +778,7 @@ impl Editor {
                             }
                         }
 
-                        start_row = nested_end_row;
+                        start_row = (start_row + 1).max(nested_end_row);
                     }
                     None => start_row += 1,
                 }


### PR DESCRIPTION
# Objective

Fixes #58104.

When using the `fold_at_level` action (default keybind: Ctrl-K Ctrl-(1-9) on Windows) on a function with its arguments split across multiple lines (see the example in #58104), only the arguments would be folded, while the function body remained expanded and only blocks at the next level inside the function were folded.

To reproduce:

1. Open a `.rs` file (or any language with similar folding behavior).
2. Add a function with multiline arguments:

```rust
fn test(
    a: i32,
) {
    let b = a;
}
```

3. Run `fold_at_level` with level `1`.
4. Observe that the argument list is folded, but the function body remains expanded.

## Solution

When iterating through foldable ranges, `fold_at_level` advanced the search position to the line after the folded crease. This caused it to skip any crease starting on the same line as the end of the previous one. The fix keeps the search position on the last line of the folded crease instead, allowing consecutive creases to be processed.

## Testing

Automated: Added 1 test covering chained foldable blocks, including functions with multiline arguments and if/else blocks.

Manual: Verified that invoking `fold_at_level(1)` on a function with multiline arguments folds both the argument list and the function body.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

**Before:**

<img width="211" height="107" alt="image" src="https://github.com/user-attachments/assets/dbfbbdfa-faee-42f3-ac25-0581a796e124" />

**After:**

<img width="221" height="41" alt="image" src="https://github.com/user-attachments/assets/6746b341-0587-48a4-908a-e743c974cae9" />

## Release Notes:

- Fixed: `fold_at_level` not folding function bodies when arguments span multiple lines