### PR TITLE
file_finder: Persist recently opened files across restarts

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -2,9 +2,11 @@
 mod file_finder_tests;
 #[cfg(test)]
 mod multi_select_tests;
+mod recent_files;
 
 use futures::future::join_all;
 pub use open_path_prompt::OpenPathDelegate;
+pub use recent_files::{RecentFiles, RecentFilesDelegate, Toggle as ToggleRecentFiles};
 
 use channel::ChannelStore;
 use client::ChannelId;
@@ -76,6 +78,7 @@ pub fn init(cx: &mut App) {
     cx.observe_new(FileFinder::register).detach();
     cx.observe_new(OpenPathPrompt::register).detach();
     cx.observe_new(OpenPathPrompt::register_new_path).detach();
+    recent_files::init(cx);
 }
 
 impl FileFinder {

--- a/crates/file_finder/src/recent_files.rs
+++ b/crates/file_finder/src/recent_files.rs
@@ -1,0 +1,400 @@
+#[cfg(test)]
+mod recent_files_tests;
+
+use std::sync::Arc;
+
+use futures::future::join_all;
+use gpui::{
+    Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Modifiers,
+    ModifiersChangedEvent, ParentElement, Render, SharedString, Styled, Task, TaskExt, WeakEntity,
+    Window, actions, rems,
+};
+use picker::{Picker, PickerDelegate};
+use project::ProjectPath;
+use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
+use util::ResultExt;
+use workspace::{ModalView, Workspace};
+
+use crate::FoundPath;
+
+const PANEL_WIDTH_REMS: f32 = 34.;
+const MAX_MATCHES: usize = 100;
+
+actions!(
+    recent_files,
+    [
+        /// Toggles the recently opened files palette.
+        Toggle
+    ]
+);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(RecentFiles::register).detach();
+}
+
+pub struct RecentFiles {
+    picker: Entity<Picker<RecentFilesDelegate>>,
+    init_modifiers: Option<Modifiers>,
+}
+
+impl ModalView for RecentFiles {}
+
+impl RecentFiles {
+    fn register(
+        workspace: &mut Workspace,
+        _window: Option<&mut Window>,
+        _: &mut Context<Workspace>,
+    ) {
+        workspace.register_action(|workspace, _: &Toggle, window, cx| {
+            let Some(recent_files) = workspace.active_modal::<Self>(cx) else {
+                Self::open(workspace, window, cx).detach();
+                return;
+            };
+
+            recent_files.update(cx, |recent_files, cx| {
+                recent_files.init_modifiers = Some(window.modifiers());
+                recent_files.picker.update(cx, |picker, cx| {
+                    picker.cycle_selection(window, cx);
+                });
+            });
+        });
+    }
+
+    fn open(
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Task<()> {
+        let project = workspace.project().read(cx);
+        let fs = project.fs().clone();
+
+        let currently_opened_project_path = workspace
+            .active_item(cx)
+            .and_then(|item| item.project_path(cx));
+
+        // Same resolution as `FileFinder::open`'s history_items: prefer the fast
+        // in-worktree check, and fall back to an async filesystem existence check
+        // for history entries whose worktree isn't currently loaded.
+        let history_items = workspace
+            .recent_navigation_history(None, cx)
+            .into_iter()
+            .filter_map(|(project_path, abs_path)| {
+                if project.entry_for_path(&project_path, cx).is_some() {
+                    return Some(Task::ready(Some(FoundPath::new(project_path, abs_path?))));
+                }
+                let abs_path = abs_path?;
+                if project.is_local() {
+                    let fs = fs.clone();
+                    Some(cx.background_spawn(async move {
+                        if fs.is_file(&abs_path).await {
+                            Some(FoundPath::new(project_path, abs_path))
+                        } else {
+                            None
+                        }
+                    }))
+                } else {
+                    Some(Task::ready(Some(FoundPath::new(project_path, abs_path))))
+                }
+            })
+            .collect::<Vec<_>>();
+
+        cx.spawn_in(window, async move |workspace, cx| {
+            let history_items: Vec<FoundPath> = join_all(history_items)
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
+
+            workspace
+                .update_in(cx, |workspace, window, cx| {
+                    let weak_workspace = cx.entity().downgrade();
+                    workspace.toggle_modal(window, cx, |window, cx| {
+                        let delegate = RecentFilesDelegate::new(
+                            cx.entity().downgrade(),
+                            weak_workspace,
+                            currently_opened_project_path,
+                            history_items,
+                        );
+                        RecentFiles::new(delegate, window, cx)
+                    });
+                })
+                .ok();
+        })
+    }
+
+    fn new(delegate: RecentFilesDelegate, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let init_modifiers = window.modifiers().modified().then_some(window.modifiers());
+        Self {
+            picker: cx
+                .new(|cx| Picker::list(delegate, window, cx).initial_width(rems(PANEL_WIDTH_REMS))),
+            init_modifiers,
+        }
+    }
+
+    fn handle_modifiers_changed(
+        &mut self,
+        event: &ModifiersChangedEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(init_modifiers) = self.init_modifiers else {
+            return;
+        };
+        if !event.modified() || !init_modifiers.is_subset_of(event) {
+            self.init_modifiers = None;
+            if self.picker.read(cx).delegate.matches.is_empty() {
+                cx.emit(DismissEvent)
+            } else {
+                window.dispatch_action(menu::Confirm.boxed_clone(), cx);
+            }
+        }
+    }
+}
+
+impl EventEmitter<DismissEvent> for RecentFiles {}
+
+impl Focusable for RecentFiles {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl Render for RecentFiles {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("RecentFiles")
+            .w(rems(PANEL_WIDTH_REMS))
+            .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
+            .child(self.picker.clone())
+    }
+}
+
+/// A single candidate in the recent-files list: a resolved path plus the
+/// pre-split display strings so matching only needs to run against the file
+/// name, not the whole absolute path.
+#[derive(Clone)]
+struct RecentFileEntry {
+    path: FoundPath,
+    file_name: SharedString,
+    parent_path: SharedString,
+}
+
+impl RecentFileEntry {
+    fn new(path: FoundPath) -> Self {
+        let file_name = path
+            .absolute
+            .file_name()
+            .map_or_else(String::new, |name| name.to_string_lossy().into_owned());
+        let parent_path = path
+            .absolute
+            .parent()
+            .map_or_else(String::new, |parent| parent.to_string_lossy().into_owned());
+        Self {
+            path,
+            file_name: file_name.into(),
+            parent_path: parent_path.into(),
+        }
+    }
+}
+
+struct RecentFileMatch {
+    entry_index: usize,
+    positions: Vec<usize>,
+}
+
+pub struct RecentFilesDelegate {
+    recent_files: WeakEntity<RecentFiles>,
+    workspace: WeakEntity<Workspace>,
+    currently_opened_project_path: Option<ProjectPath>,
+    selected_index: usize,
+    entries: Vec<RecentFileEntry>,
+    matches: Vec<RecentFileMatch>,
+}
+
+impl RecentFilesDelegate {
+    fn new(
+        recent_files: WeakEntity<RecentFiles>,
+        workspace: WeakEntity<Workspace>,
+        currently_opened_project_path: Option<ProjectPath>,
+        history_items: Vec<FoundPath>,
+    ) -> Self {
+        // Most-recent-first order comes from `recent_navigation_history`; the
+        // currently open file (if present in history) stays in the list so the
+        // palette reads the same as the editor's tab order.
+        let entries = history_items
+            .into_iter()
+            .map(RecentFileEntry::new)
+            .collect();
+
+        Self {
+            recent_files,
+            workspace,
+            currently_opened_project_path,
+            selected_index: 0,
+            entries,
+            matches: Vec::new(),
+        }
+    }
+
+    fn unfiltered_matches(entry_count: usize) -> Vec<RecentFileMatch> {
+        (0..entry_count)
+            .map(|entry_index| RecentFileMatch {
+                entry_index,
+                positions: Vec::new(),
+            })
+            .collect()
+    }
+
+    /// Index of the first entry that isn't the currently open file, so that
+    /// pressing Enter with no query immediately switches to a different file
+    /// rather than reopening the one already on screen.
+    fn default_selected_index(&self) -> usize {
+        if self.matches.len() > 1
+            && let Some(currently_opened_project_path) = &self.currently_opened_project_path
+            && self
+                .entries
+                .first()
+                .is_some_and(|entry| &entry.path.project == currently_opened_project_path)
+        {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+impl PickerDelegate for RecentFilesDelegate {
+    type ListItem = ListItem;
+
+    fn name() -> &'static str {
+        "recent files"
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Search recently opened files…".into()
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("No recently opened files".into())
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+        cx.notify();
+    }
+
+    fn separators_after_indices(&self) -> Vec<usize> {
+        Vec::new()
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        if query.is_empty() {
+            self.matches = Self::unfiltered_matches(self.entries.len());
+            self.selected_index = self.default_selected_index();
+        } else {
+            let candidates: Vec<_> = self
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(id, entry)| {
+                    fuzzy_nucleo::StringMatchCandidate::from_shared(id, entry.file_name.clone())
+                })
+                .collect();
+            self.matches = fuzzy_nucleo::match_strings(
+                &candidates,
+                &query,
+                fuzzy_nucleo::Case::Smart,
+                fuzzy_nucleo::LengthPenalty::On,
+                MAX_MATCHES,
+            )
+            .into_iter()
+            .map(|string_match| RecentFileMatch {
+                entry_index: string_match.candidate_id,
+                positions: string_match.positions,
+            })
+            .collect();
+            self.selected_index = 0;
+        }
+        Task::ready(())
+    }
+
+    fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let Some(entry_match) = self.matches.get(self.selected_index) else {
+            return;
+        };
+        let Some(entry) = self.entries.get(entry_match.entry_index) else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+
+        let project_path = entry.path.project.clone();
+        workspace.update(cx, |workspace, cx| {
+            workspace
+                .open_path(project_path, None, true, window, cx)
+                .detach_and_log_err(cx);
+        });
+
+        self.recent_files
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.recent_files
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let entry_match = self.matches.get(ix)?;
+        let entry = self.entries.get(entry_match.entry_index)?;
+
+        Some(
+            ListItem::new(ix)
+                .spacing(ListItemSpacing::Sparse)
+                .inset(true)
+                .toggle_state(selected)
+                .child(
+                    v_flex()
+                        .w_full()
+                        .min_w_0()
+                        .overflow_hidden()
+                        .child(HighlightedLabel::new(
+                            entry.file_name.clone(),
+                            entry_match.positions.clone(),
+                        ))
+                        .child(
+                            Label::new(entry.parent_path.clone())
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        ),
+                ),
+        )
+    }
+}

--- a/crates/file_finder/src/recent_files.rs
+++ b/crates/file_finder/src/recent_files.rs
@@ -1,8 +1,10 @@
 #[cfg(test)]
 mod recent_files_tests;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use collections::HashSet;
 use futures::future::join_all;
 use gpui::{
     Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Modifiers,
@@ -13,7 +15,7 @@ use picker::{Picker, PickerDelegate};
 use project::ProjectPath;
 use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
-use workspace::{ModalView, Workspace};
+use workspace::{ModalView, OpenOptions, Workspace, WorkspaceDb};
 
 use crate::FoundPath;
 
@@ -30,6 +32,49 @@ actions!(
 
 pub fn init(cx: &mut App) {
     cx.observe_new(RecentFiles::register).detach();
+    cx.observe_new(watch_active_item).detach();
+}
+
+/// Persists the active file to the `recently_opened_files` table on every
+/// active-item change, for the lifetime of the workspace, so the palette's
+/// history survives a restart. This runs independently of whether the
+/// palette itself is ever opened.
+fn watch_active_item(
+    _workspace: &mut Workspace,
+    _window: Option<&mut Window>,
+    cx: &mut Context<Workspace>,
+) {
+    cx.subscribe_self::<workspace::Event>(|workspace, event, cx| {
+        if !matches!(event, workspace::Event::ActiveItemChanged) {
+            return;
+        }
+        let Some(workspace_id) = workspace.database_id() else {
+            return;
+        };
+        let Some(project_path) = workspace
+            .active_item(cx)
+            .and_then(|item| item.project_path(cx))
+        else {
+            return;
+        };
+        let Some(abs_path) = workspace
+            .project()
+            .read(cx)
+            .worktree_for_id(project_path.worktree_id, cx)
+            .map(|worktree| worktree.read(cx).absolutize(&project_path.path))
+        else {
+            return;
+        };
+
+        let db = WorkspaceDb::global(cx);
+        cx.background_spawn(async move {
+            db.record_recently_opened_file(workspace_id, abs_path)
+                .await
+                .log_err();
+        })
+        .detach();
+    })
+    .detach();
 }
 
 pub struct RecentFiles {
@@ -98,12 +143,34 @@ impl RecentFiles {
             })
             .collect::<Vec<_>>();
 
+        // Files opened in a previous session, kept around so the palette
+        // survives a restart. Filtered through the same existence check as
+        // live history above, since these can be arbitrarily stale.
+        let persisted_paths = workspace.database_id().map(|workspace_id| {
+            let db = WorkspaceDb::global(cx);
+            let fs = fs.clone();
+            cx.background_spawn(async move {
+                let paths = db.recently_opened_files(workspace_id).log_err()?;
+                let mut existing = Vec::with_capacity(paths.len());
+                for path in paths {
+                    if fs.is_file(&path).await {
+                        existing.push(path);
+                    }
+                }
+                Some(existing)
+            })
+        });
+
         cx.spawn_in(window, async move |workspace, cx| {
             let history_items: Vec<FoundPath> = join_all(history_items)
                 .await
                 .into_iter()
                 .flatten()
                 .collect();
+            let persisted_paths = match persisted_paths {
+                Some(task) => task.await.unwrap_or_default(),
+                None => Vec::new(),
+            };
 
             workspace
                 .update_in(cx, |workspace, window, cx| {
@@ -114,6 +181,7 @@ impl RecentFiles {
                             weak_workspace,
                             currently_opened_project_path,
                             history_items,
+                            persisted_paths,
                         );
                         RecentFiles::new(delegate, window, cx)
                     });
@@ -172,28 +240,38 @@ impl Render for RecentFiles {
 /// A single candidate in the recent-files list: a resolved path plus the
 /// pre-split display strings so matching only needs to run against the file
 /// name, not the whole absolute path.
+///
+/// `project_path` is `Some` for files opened this session (from live
+/// navigation history) and `None` for files only known from a previous
+/// session's persisted history; opening always goes through `absolute_path`
+/// (see `confirm`), so a missing `project_path` doesn't block opening the
+/// file, it's only used to detect "this entry is the currently open file".
 #[derive(Clone)]
 struct RecentFileEntry {
-    path: FoundPath,
+    absolute_path: PathBuf,
+    project_path: Option<ProjectPath>,
     file_name: SharedString,
     parent_path: SharedString,
 }
 
 impl RecentFileEntry {
-    fn new(path: FoundPath) -> Self {
-        let file_name = path
-            .absolute
+    fn new(absolute_path: PathBuf, project_path: Option<ProjectPath>) -> Self {
+        let file_name = absolute_path
             .file_name()
             .map_or_else(String::new, |name| name.to_string_lossy().into_owned());
-        let parent_path = path
-            .absolute
+        let parent_path = absolute_path
             .parent()
             .map_or_else(String::new, |parent| parent.to_string_lossy().into_owned());
         Self {
-            path,
+            absolute_path,
+            project_path,
             file_name: file_name.into(),
             parent_path: parent_path.into(),
         }
+    }
+
+    fn from_found_path(found_path: FoundPath) -> Self {
+        Self::new(found_path.absolute, Some(found_path.project))
     }
 }
 
@@ -217,14 +295,27 @@ impl RecentFilesDelegate {
         workspace: WeakEntity<Workspace>,
         currently_opened_project_path: Option<ProjectPath>,
         history_items: Vec<FoundPath>,
+        persisted_paths: Vec<PathBuf>,
     ) -> Self {
         // Most-recent-first order comes from `recent_navigation_history`; the
         // currently open file (if present in history) stays in the list so the
-        // palette reads the same as the editor's tab order.
-        let entries = history_items
+        // palette reads the same as the editor's tab order. Persisted paths
+        // from previous sessions are appended after, deduplicated against the
+        // live entries, so files touched this session still take priority.
+        let mut entries: Vec<RecentFileEntry> = history_items
             .into_iter()
-            .map(RecentFileEntry::new)
+            .map(RecentFileEntry::from_found_path)
             .collect();
+        let seen_paths: HashSet<PathBuf> = entries
+            .iter()
+            .map(|entry| entry.absolute_path.clone())
+            .collect();
+        entries.extend(
+            persisted_paths
+                .into_iter()
+                .filter(|path| !seen_paths.contains(path))
+                .map(|path| RecentFileEntry::new(path, None)),
+        );
 
         Self {
             recent_files,
@@ -251,10 +342,9 @@ impl RecentFilesDelegate {
     fn default_selected_index(&self) -> usize {
         if self.matches.len() > 1
             && let Some(currently_opened_project_path) = &self.currently_opened_project_path
-            && self
-                .entries
-                .first()
-                .is_some_and(|entry| &entry.path.project == currently_opened_project_path)
+            && self.entries.first().is_some_and(|entry| {
+                entry.project_path.as_ref() == Some(currently_opened_project_path)
+            })
         {
             1
         } else {
@@ -347,10 +437,18 @@ impl PickerDelegate for RecentFilesDelegate {
             return;
         };
 
-        let project_path = entry.path.project.clone();
+        let absolute_path = entry.absolute_path.clone();
         workspace.update(cx, |workspace, cx| {
             workspace
-                .open_path(project_path, None, true, window, cx)
+                .open_abs_path(
+                    absolute_path,
+                    OpenOptions {
+                        focus: Some(true),
+                        ..Default::default()
+                    },
+                    window,
+                    cx,
+                )
                 .detach_and_log_err(cx);
         });
 

--- a/crates/file_finder/src/recent_files/recent_files_tests.rs
+++ b/crates/file_finder/src/recent_files/recent_files_tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use crate::file_finder_tests::init_test;
+use editor::Editor;
+use gpui::{Entity, VisualTestContext};
+use menu::Confirm;
+use project::{Project, ProjectPath};
+use serde_json::json;
+use util::{path, rel_path::rel_path};
+use workspace::{CloseActiveItem, MultiWorkspace, Workspace};
+
+/// Opens `file_name` in the active pane and waits for the workspace to settle.
+async fn open_file(file_name: &str, workspace: &Entity<Workspace>, cx: &mut VisualTestContext) {
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            let worktree_id = workspace.worktrees(cx).next().unwrap().read(cx).id();
+            workspace.open_path(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path(file_name).into(),
+                },
+                None,
+                true,
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+}
+
+/// Closes the active item. Zed's navigation history only records an item once
+/// the pane moves away from it, so tests close each file before opening the
+/// next one to get a predictable history order (matches the pattern used by
+/// `file_finder_tests::open_close_queried_buffer`).
+fn close_active_item(cx: &mut VisualTestContext) {
+    cx.dispatch_action(CloseActiveItem {
+        save_intent: None,
+        close_pinned: false,
+    });
+    cx.run_until_parked();
+}
+
+fn open_recent_files(cx: &mut VisualTestContext) {
+    cx.dispatch_action(Toggle);
+    cx.run_until_parked();
+}
+
+fn active_recent_files_picker(
+    workspace: &Entity<Workspace>,
+    cx: &mut VisualTestContext,
+) -> Entity<Picker<RecentFilesDelegate>> {
+    workspace.update(cx, |workspace, cx| {
+        workspace
+            .active_modal::<RecentFiles>(cx)
+            .expect("recent files palette is not open")
+            .read(cx)
+            .picker
+            .clone()
+    })
+}
+
+fn matched_file_names(
+    picker: &Entity<Picker<RecentFilesDelegate>>,
+    cx: &mut VisualTestContext,
+) -> Vec<String> {
+    picker.read_with(cx, |picker, _| {
+        picker
+            .delegate
+            .matches
+            .iter()
+            .filter_map(|m| picker.delegate.entries.get(m.entry_index))
+            .map(|entry| entry.file_name.to_string())
+            .collect()
+    })
+}
+
+#[gpui::test]
+async fn test_recent_files_shows_history_in_recency_order(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+                "third.rs": "// Third Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+    close_active_item(cx);
+    // third.rs stays open, mimicking "I'm in this file, show me my other recents".
+    open_file("third.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    let picker = active_recent_files_picker(&workspace, cx);
+    assert_eq!(
+        matched_file_names(&picker, cx),
+        vec![
+            "third.rs".to_string(),
+            "second.rs".to_string(),
+            "first.rs".to_string()
+        ],
+        "Recent files should list navigation history newest-first, including the \
+         currently open file"
+    );
+    picker.read_with(cx, |picker, _| {
+        assert_eq!(
+            picker.delegate.selected_index, 1,
+            "Selection should skip the currently open file (index 0) so pressing \
+             Enter immediately switches away from it"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_recent_files_filters_by_substring(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+                "third.rs": "// Third Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("third.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    let picker = active_recent_files_picker(&workspace, cx);
+    cx.simulate_input("sec");
+    cx.run_until_parked();
+
+    assert_eq!(
+        matched_file_names(&picker, cx),
+        vec!["second.rs".to_string()],
+        "Typing a substring should filter the recent files list to matching file names"
+    );
+}
+
+#[gpui::test]
+async fn test_recent_files_confirm_opens_file(cx: &mut gpui::TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "first.rs": "// First Rust file",
+                "second.rs": "// Second Rust file",
+            }),
+        )
+        .await;
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    workspace.update_in(cx, |_workspace, window, cx| window.focused(cx));
+
+    open_file("first.rs", &workspace, cx).await;
+    close_active_item(cx);
+    open_file("second.rs", &workspace, cx).await;
+
+    open_recent_files(cx);
+    // second.rs is the currently open file, so selection should skip it and
+    // land on first.rs; confirming should switch to first.rs.
+    cx.dispatch_action(Confirm);
+    cx.run_until_parked();
+
+    workspace.read_with(cx, |workspace, cx| {
+        let active_editor = workspace.active_item_as::<Editor>(cx).unwrap();
+        assert_eq!(active_editor.read(cx).title(cx), "first.rs");
+    });
+}

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1051,6 +1051,17 @@ impl Domain for WorkspaceDb {
         sql!(
             ALTER TABLE bookmarks ADD COLUMN label TEXT NOT NULL DEFAULT "";
         ),
+        sql!(
+            CREATE TABLE recently_opened_files (
+                workspace_id INTEGER NOT NULL,
+                abs_path TEXT NOT NULL,
+                opened_at INTEGER NOT NULL,
+                PRIMARY KEY(workspace_id, abs_path),
+                FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+                ON DELETE CASCADE
+                ON UPDATE CASCADE
+            );
+        ),
     ];
 
     // Allow recovering from bad migration that was initially shipped to nightly
@@ -2655,7 +2666,78 @@ VALUES {placeholders};"#
             DELETE FROM trusted_worktrees
         }
     }
+
+    /// Records `abs_path` as opened just now in `workspace_id`, and prunes the
+    /// workspace's history down to the most recent [`MAX_RECENTLY_OPENED_FILES`]
+    /// entries. Upserts on (workspace_id, abs_path), so reopening a file just
+    /// bumps its timestamp rather than creating a duplicate row.
+    ///
+    /// Timestamps are computed here (millisecond-precision, via `chrono`)
+    /// rather than with SQLite's `CURRENT_TIMESTAMP`, which only has
+    /// second-resolution and would tie-break arbitrarily under rapid
+    /// successive opens (e.g. tabbing through several files quickly).
+    pub async fn record_recently_opened_file(
+        &self,
+        workspace_id: WorkspaceId,
+        abs_path: PathBuf,
+    ) -> Result<()> {
+        let opened_at = Utc::now().timestamp_millis();
+        self.upsert_recently_opened_file(workspace_id, abs_path, opened_at)
+            .await?;
+        self.prune_recently_opened_files(workspace_id).await
+    }
+
+    /// Returns up to [`MAX_RECENTLY_OPENED_FILES`] absolute paths previously
+    /// recorded for `workspace_id`, most recently opened first.
+    pub fn recently_opened_files(&self, workspace_id: WorkspaceId) -> Result<Vec<PathBuf>> {
+        let mut paths = self.recently_opened_files_query(workspace_id)?;
+        paths.truncate(MAX_RECENTLY_OPENED_FILES);
+        Ok(paths)
+    }
+
+    // `INSERT OR REPLACE` (rather than `ON CONFLICT DO UPDATE`) deletes and
+    // re-inserts the conflicting row, which gives it a fresh (larger) rowid.
+    // Combined with `ORDER BY opened_at DESC, rowid DESC` below, this keeps
+    // ordering fully deterministic even when several files are opened within
+    // the same millisecond (millisecond precision alone isn't enough under
+    // rapid successive opens).
+    query! {
+        async fn upsert_recently_opened_file(workspace_id: WorkspaceId, abs_path: PathBuf, opened_at: i64) -> Result<()> {
+            INSERT OR REPLACE INTO recently_opened_files (workspace_id, abs_path, opened_at)
+            VALUES (?1, ?2, ?3)
+        }
+    }
+
+    query! {
+        fn recently_opened_files_query(workspace_id: WorkspaceId) -> Result<Vec<PathBuf>> {
+            SELECT abs_path
+            FROM recently_opened_files
+            WHERE workspace_id = ?1
+            ORDER BY opened_at DESC, rowid DESC
+            LIMIT 100
+        }
+    }
+
+    // Keeps only the MAX_RECENTLY_OPENED_FILES most recent rows for this workspace.
+    // The LIMIT here must stay in sync with `recently_opened_files_query` above.
+    query! {
+        async fn prune_recently_opened_files(workspace_id: WorkspaceId) -> Result<()> {
+            DELETE FROM recently_opened_files
+            WHERE workspace_id = ?1
+            AND abs_path NOT IN (
+                SELECT abs_path FROM recently_opened_files
+                WHERE workspace_id = ?1
+                ORDER BY opened_at DESC, rowid DESC
+                LIMIT 100
+            )
+        }
+    }
 }
+
+/// Keep in sync with the `LIMIT 100` literals in `recently_opened_files_query`
+/// and `prune_recently_opened_files` above (`query!`-generated SQL can't
+/// reference a Rust const directly).
+const MAX_RECENTLY_OPENED_FILES: usize = 100;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RecentWorkspace {
@@ -3046,6 +3128,91 @@ mod tests {
         );
         assert_eq!(loaded_breakpoints[4].state, hit_condition_breakpoint.state);
         assert_eq!(loaded_breakpoints[4].path, Arc::from(path));
+    }
+
+    #[gpui::test]
+    async fn test_recently_opened_files_orders_by_recency() {
+        zlog::init_test();
+
+        let db = WorkspaceDb::open_test_db("test_recently_opened_files_orders_by_recency").await;
+        let id = db.next_id().await.unwrap();
+
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/first.rs"))
+            .await
+            .unwrap();
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/second.rs"))
+            .await
+            .unwrap();
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/third.rs"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.recently_opened_files(id).unwrap(),
+            vec![
+                PathBuf::from("/tmp/third.rs"),
+                PathBuf::from("/tmp/second.rs"),
+                PathBuf::from("/tmp/first.rs"),
+            ]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_recently_opened_files_upsert_deduplicates() {
+        zlog::init_test();
+
+        let db = WorkspaceDb::open_test_db("test_recently_opened_files_upsert_deduplicates").await;
+        let id = db.next_id().await.unwrap();
+
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/first.rs"))
+            .await
+            .unwrap();
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/second.rs"))
+            .await
+            .unwrap();
+        // Reopening first.rs should move it to the front, not duplicate it.
+        db.record_recently_opened_file(id, PathBuf::from("/tmp/first.rs"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.recently_opened_files(id).unwrap(),
+            vec![
+                PathBuf::from("/tmp/first.rs"),
+                PathBuf::from("/tmp/second.rs")
+            ],
+        );
+    }
+
+    #[gpui::test]
+    async fn test_recently_opened_files_prune_keeps_most_recent() {
+        zlog::init_test();
+
+        let db =
+            WorkspaceDb::open_test_db("test_recently_opened_files_prune_keeps_most_recent").await;
+        let id = db.next_id().await.unwrap();
+
+        // Bypass `record_recently_opened_file`'s wall-clock timestamp so ordering
+        // is deterministic regardless of how fast this loop runs.
+        for i in 0..(MAX_RECENTLY_OPENED_FILES + 5) {
+            db.upsert_recently_opened_file(
+                id,
+                PathBuf::from(format!("/tmp/file-{i}.rs")),
+                i as i64,
+            )
+            .await
+            .unwrap();
+        }
+        db.prune_recently_opened_files(id).await.unwrap();
+
+        let remaining = db.recently_opened_files(id).unwrap();
+        assert_eq!(remaining.len(), MAX_RECENTLY_OPENED_FILES);
+        // Highest timestamps (most recently inserted) should survive; oldest 5 pruned.
+        assert_eq!(
+            remaining[0],
+            PathBuf::from(format!("/tmp/file-{}.rs", MAX_RECENTLY_OPENED_FILES + 4))
+        );
+        assert!(!remaining.contains(&PathBuf::from("/tmp/file-0.rs")));
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

Closes #4663.

Depends on #62188 (the palette itself) - please review/merge that first; this PR's diff is only the incremental persistence layer on top of it.

Adds a `recently_opened_files` table to the workspace database and a `watch_active_item` subscription, registered for the lifetime of every workspace, that records the active file whenever it changes. `RecentFiles::open` (from #62188) now merges these previous-session paths in after the current session's live navigation history - deduplicated, and filtered through the same filesystem-existence check already used for live entries - so stale/deleted files don't linger in the list across restarts.

## Design notes

- **Ordering**: `opened_at` is a millisecond-precision timestamp computed in Rust, not SQLite's `CURRENT_TIMESTAMP` (second resolution - ties under rapid successive opens, e.g. tabbing through several files quickly, would otherwise sort arbitrarily). Writes use `INSERT OR REPLACE` (not `ON CONFLICT DO UPDATE`) so a re-opened file gets a fresh `rowid`, used as a secondary sort key (`ORDER BY opened_at DESC, rowid DESC`) to keep ordering fully deterministic even within the same millisecond.
- **Pruning**: capped at 100 rows per workspace, pruned after every write.
- **Opening**: `confirm()` now goes through `Workspace::open_abs_path` uniformly (previously `open_path` with a `ProjectPath`) - persisted entries from a prior session don't necessarily have a resolvable `ProjectPath` in the current one, but always have a valid absolute path.
- **Recording is independent of the palette**: the subscription is set up once per workspace regardless of whether the palette is ever opened, same lifecycle as other per-workspace persistence hooks.

## Test plan

- [x] `cargo test -p workspace --lib recently_opened_files` - 3 new tests (recency ordering, upsert dedup, prune-to-100), all passing
- [x] `cargo test -p file_finder --lib`- all 82 tests pass (unchanged from #62188 + this PR's additions), no regressions
- [x] `cargo clippy -p workspace --no-deps` / `cargo clippy -p file_finder --no-deps` - clean
- [x] `cargo fmt --check` on both crates - clean
- [ ] Manual end-to-end verification (open files, restart Zed, confirm they appear in the palette) - the DB layer and the palette's merge/dedup logic are each tested at their own level, but I can't drive the full record→restart→reopen flow from an automated test: `Workspace::set_database_id` is `pub(crate)` to the `workspace` crate, so a `file_finder`-crate test can't get a live test workspace to report a real `database_id()`. Will verify manually in a running build before marking ready for review; flagging this gap in case a maintainer wants an integration test added in `workspace`'s own test suite instead.
