### PR TITLE
edit_prediction: Stop FIM completions at the Qwen repo-level tokens

### DIFF
--- a/crates/edit_prediction/src/fim.rs
+++ b/crates/edit_prediction/src/fim.rs
@@ -199,6 +199,8 @@ fn get_fim_stop_tokens() -> Vec<String> {
     vec![
         "<|endoftext|>".to_string(),
         "<|file_separator|>".to_string(),
+        "<|file_sep|>".to_string(),
+        "<|repo_name|>".to_string(),
         "<|fim_pad|>".to_string(),
         "<|fim_prefix|>".to_string(),
         "<|fim_middle|>".to_string(),
@@ -220,6 +222,8 @@ fn clean_fim_completion(response: &str) -> String {
     let end_tokens = [
         "<|endoftext|>",
         "<|file_separator|>",
+        "<|file_sep|>",
+        "<|repo_name|>",
         "<|fim_pad|>",
         "<|fim_prefix|>",
         "<|fim_middle|>",


### PR DESCRIPTION
# Objective

The FIM stop list does not hold the tokens that Qwen coder models write at the end of a file.

Qwen2.5-Coder is trained on repo-level fill-in-the-middle. It writes `<|file_sep|>` to end one file and start the next. It writes `<|repo_name|>` to open a repository. The stop list holds the CodeGemma token `<|file_separator|>`, but neither Qwen spelling.

The model therefore does not stop at the end of a file. It runs to the output token limit and starts to write a new file. `clean_fim_completion` reads a second copy of the same list, so it does not truncate the token either. Zed inserts the marker and the invented file into the buffer.

There is no existing issue for this.

## Solution

Add `<|file_sep|>` and `<|repo_name|>` to both lists in `crates/edit_prediction/src/fim.rs`:

- `get_fim_stop_tokens`, which Zed sends to the server as stop strings.
- `end_tokens` in `clean_fim_completion`, which truncates the reply.

No other model family writes these two strings, so the change does not alter behavior for other families.

## Testing

I measured this against `qwen2.5-coder-1.5b` (4-bit MLX) served by LM Studio, on macOS (arm64), with `prompt_format: "qwen"` and `max_output_tokens: 256`.

Before the change, on 18 completions in the Qwen arrangement:

- 2 completions held `<|file_sep|>`.
- Those 2 took 950 ms at the median. The other 16 took 428 ms.
- One completion gave a correct docstring line. It then added `<|file_sep|>/parquet/format/schema.py` and the first lines of that invented file.

To reproduce:

1. Serve a Qwen2.5-Coder model at an OpenAI-compatible completions endpoint.
2. In `settings.json`, set the edit prediction provider to `open_ai_compatible_api` and `prompt_format` to `"qwen"`.
3. Type in a buffer until the model decides the file is complete. A docstring or the end of a module reaches this state most often.
4. Read the suggestion. Before the change it can hold `<|file_sep|>` and a path. After the change it stops at that token.

Parts that need more testing:

- `crates/edit_prediction/src/fim.rs` has no test coverage today, and this change adds none. A test for `clean_fim_completion` is possible without a server, because the function is pure. Tell me if you want that test in this PR.
- I tested one Qwen model on one platform. I did not test CodeGemma, StarCoder, CodeLlama, or DeepSeek. The change adds two strings that those families do not emit, so I expect no effect on them.

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed edit predictions inserting `<|file_sep|>` and text from an invented file when the model is a Qwen coder model.
