### PR TITLE
acp: Poll the client connection future on a dedicated thread

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -669,9 +669,12 @@ const MINIMUM_SUPPORTED_VERSION: ProtocolVersion = ProtocolVersion::V1;
 /// dispatch queue via `dispatch_tx`, where they are handled by the
 /// `handle_*` functions on a GPUI context. The returned future drives the
 /// connection and completes when the transport closes; callers are expected
-/// to spawn it on a background executor and hold the task for the lifetime
-/// of the connection. The `connection_tx` oneshot receives the
-/// `ConnectionTo<Agent>` handle as soon as the builder runs its `main_fn`.
+/// to poll it in the background and hold the task for the lifetime of the
+/// connection. In unoptimized builds each inbound dispatch needs ~0.5 MiB
+/// of stack, so poll it on a thread with room to spare (macOS GCD workers'
+/// 512 KiB is not enough — see `AcpConnection::stdio`). The `connection_tx`
+/// oneshot receives the `ConnectionTo<Agent>` handle as soon as the builder
+/// runs its `main_fn`.
 fn connect_client_future(
     name: &'static str,
     transport: impl agent_client_protocol::ConnectTo<Client> + 'static,
@@ -925,17 +928,25 @@ impl AcpConnection {
         });
 
         // `connect_client_future` installs the production handler set and
-        // hands us back both the connection-future (to run on a background
-        // executor) and a oneshot receiver that produces the
-        // `ConnectionTo<Agent>` once the transport handshake is ready.
+        // hands us back both the connection-future and a oneshot receiver
+        // that produces the `ConnectionTo<Agent>` once the transport
+        // handshake is ready. The future must be polled on a dedicated
+        // thread rather than via `background_spawn`: in unoptimized builds
+        // its dispatch chain needs ~0.5 MiB of stack per inbound message,
+        // which overflows the fixed 512 KiB stacks of the GCD workers that
+        // poll background tasks on macOS, crashing dev builds as soon as an
+        // agent sends its first message. See `spawn_dedicated` for the
+        // stack guarantee that makes the dedicated thread sufficient.
         let (connection_tx, connection_rx) = futures::channel::oneshot::channel();
         let connection_future =
             connect_client_future("zed", transport, dispatch_tx.clone(), connection_tx);
-        let io_task = cx.background_spawn(async move {
-            if let Err(err) = connection_future.await {
-                log::error!("ACP connection error: {err}");
-            }
-        });
+        let io_task = cx
+            .background_executor()
+            .spawn_dedicated(move |_executor| async move {
+                if let Err(err) = connection_future.await {
+                    log::error!("ACP connection error: {err}");
+                }
+            });
 
         let connection_rx = async move {
             connection_rx

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -84,6 +84,27 @@ impl BackgroundExecutor {
         self.inner.clone()
     }
 
+    /// Spawn a closure on a fresh session pinned to its own [`SchedulerLocalExecutor`].
+    /// The closure runs on a new OS thread under the platform scheduler, or on
+    /// the test scheduler's loop in tests.
+    ///
+    /// Prefer this over [`Self::spawn`] for futures whose polls need more stack
+    /// than shared background threads guarantee. Dedicated threads get the
+    /// standard library's default 2 MiB, while `spawn` polls futures on
+    /// whatever threads the platform dispatcher provides — on macOS those are
+    /// GCD workers whose stacks are fixed at 512 KiB by the kernel (see `PTH_DEFAULT_STACKSIZE` in
+    /// <https://github.com/apple-oss-distributions/libpthread/blob/42d026df5b07825070f60134b980a1ec2552dfee/kern/kern_internal.h#L154>),
+    /// the tightest background-stack budget of any platform.
+    #[track_caller]
+    pub fn spawn_dedicated<F, Fut>(&self, f: F) -> Task<Fut::Output>
+    where
+        F: FnOnce(SchedulerLocalExecutor) -> Fut + Send + 'static,
+        Fut: Future + 'static,
+        Fut::Output: Send + Sync + 'static,
+    {
+        self.inner.spawn_dedicated(f)
+    }
+
     /// Enqueues the given future to be run to completion on a background thread.
     #[track_caller]
     pub fn spawn<R>(&self, future: impl Future<Output = R> + Send + 'static) -> Task<R>


### PR DESCRIPTION
Some context behind this change: I’ve been meaning to look into this because I kept running into this crash when working on [other](https://github.com/zed-industries/zed/issues/61040) fixes. Everything worked fine in dev builds, right up until you tried to create a new Agent Thread using an ACP adapter. The crash reports in this instance were throwing me off: I was seeing different things each time.

So, I had Fable look into this. It did so by binary-searching the minimum thread stack on which a probe replicating Zed’s exact handler chain can dispatch one message. Full methodology, probe source, and raw numbers can be found in [this gist](https://gist.github.com/yeskunall/2ac2b00f51389d9388d607974f6f8a04). The results of the probe are as follows:

| SDK | Minimum stack (dev profile) | vs. 512 KiB GCD budget |
|---|---|---|
| 1.3.0 | 409,600–413,696 B | fit, ~100 KiB headroom |
| 2.0.0 | 507,904–512,000 B | entire budget before runtime overhead |

The oversized frames are monomorphized into `agent_servers`, not the SDK crate -- a `[profile.dev.package]` opt-level override on `agent-client-protocol` does **not** fix this (see gist), and optimized builds collapse the frames entirely, which is why only dev builds crashed. It found that the real signature is `fault_address == stack_pointer` on a `com.apple.root.default-qos` thread inside the ACP dispatch specialization, which I then had it verify across six local `.ips` reports. It seems in #61570, we pushed the dispatch chain past the GCD budget, explained further below:

`AcpConnection::stdio` polled the ACP client connection future via `background_spawn`, which on macOS executes runnables on [GCD’s](https://developer.apple.com/documentation/DISPATCH) global-queue workers. Those threads have kernel-fixed, unconfigurable [512 KiB stacks](https://github.com/apple-oss-distributions/libpthread/blob/42d026df5b07825070f60134b980a1ec2552dfee/kern/kern_internal.h#L154). In unoptimized builds, the SDK’s chained-handler dispatch needs **~0.5 MiB of stack per inbound message** (again, see linked gist), so the first message overflows the guard page and takes the process down.

Therefore, this 512 KiB constraint is **macOS-only**. Linux doesn’t use GCD -- GPUI [spawns its own `std::thread` workers](https://github.com/zed-industries/zed/blob/82878540b5410b288a2c92cb9ee5675533e4d807/crates/gpui_linux/src/linux/dispatcher.rs#L39) ([2 MiB Rust default](https://github.com/rust-lang/rust/blob/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/sys/thread/unix.rs#L26)). Windows uses [the OS thread pool](https://github.com/zed-industries/zed/blob/82878540b5410b288a2c92cb9ee5675533e4d807/crates/gpui_windows/src/dispatcher.rs#L68), which [inherits the executable’s stack reserve](https://github.com/MicrosoftDocs/sdk-api/blob/4502fff176b3b56beddb6a63c9f980377b11ba9b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolstackinformation.md?plain=1#L58) -- [1 MB linker default](https://github.com/MicrosoftDocs/win32/blob/2eb6588c6703d31599285bbb06563c3d41b57590/desktop-src/ProcThread/thread-stack-size.md?plain=1#L17), but Zed already bumps it to 8 MiB in [crates/zed/build.rs:88](https://github.com/zed-industries/zed/blob/82878540b5410b288a2c92cb9ee5675533e4d807/crates/zed/build.rs#L88) (see [TODO comment](https://github.com/zed-industries/zed/blob/82878540b5410b288a2c92cb9ee5675533e4d807/crates/zed/build.rs#L87)).

---

Release Notes:

- N/A