### PR TITLE
Show dangling symlinks in the project panel

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5400,43 +5400,51 @@ impl BackgroundScanner {
             if job.is_external {
                 child_entry.is_external = true;
             } else if child_metadata.is_symlink {
-                let canonical_path = match self.fs.canonicalize(&child_abs_path).await {
-                    Ok(path) => path,
-                    Err(err) => {
-                        log::error!("error reading target of symlink {child_abs_path:?}: {err:#}",);
-                        continue;
-                    }
-                };
+                match self.fs.canonicalize(&child_abs_path).await {
+                    Ok(canonical_path) => {
+                        // lazily canonicalize the root path in order to determine if
+                        // symlinks point outside of the worktree.
+                        let root_canonical_path = match &root_canonical_path {
+                            Some(path) => path,
+                            None => match self.fs.canonicalize(&root_abs_path).await {
+                                Ok(path) => root_canonical_path.insert(path),
+                                Err(err) => {
+                                    log::error!(
+                                        "error canonicalizing root {:?}: {:?}",
+                                        root_abs_path,
+                                        err
+                                    );
+                                    continue;
+                                }
+                            },
+                        };
 
-                // lazily canonicalize the root path in order to determine if
-                // symlinks point outside of the worktree.
-                let root_canonical_path = match &root_canonical_path {
-                    Some(path) => path,
-                    None => match self.fs.canonicalize(&root_abs_path).await {
-                        Ok(path) => root_canonical_path.insert(path),
-                        Err(err) => {
-                            log::error!("error canonicalizing root {:?}: {:?}", root_abs_path, err);
-                            continue;
+                        if !canonical_path.starts_with(root_canonical_path) {
+                            child_entry.is_external = true;
                         }
-                    },
-                };
 
-                if !canonical_path.starts_with(root_canonical_path) {
-                    child_entry.is_external = true;
-                }
+                        if child_metadata.is_dir {
+                            let mut state = self.state.lock().await;
+                            let paths = state
+                                .symlink_paths_by_target
+                                .entry(Arc::from(canonical_path.clone()))
+                                .or_default();
+                            if !paths.iter().any(|path| path == &child_path) {
+                                paths.push(child_path.clone());
+                            }
+                        }
 
-                if child_metadata.is_dir {
-                    let mut state = self.state.lock().await;
-                    let paths = state
-                        .symlink_paths_by_target
-                        .entry(Arc::from(canonical_path.clone()))
-                        .or_default();
-                    if !paths.iter().any(|path| path == &child_path) {
-                        paths.push(child_path.clone());
+                        child_entry.canonical_path = Some(canonical_path.into());
+                    }
+                    Err(err) => {
+                        // Keep dangling symlinks in the snapshot. Otherwise they are
+                        // invisible in the project panel and can cause hidden filename
+                        // collisions when their target is later created.
+                        log::debug!(
+                            "unable to resolve target of symlink {child_abs_path:?}: {err:#}"
+                        );
                     }
                 }
-
-                child_entry.canonical_path = Some(canonical_path.into());
             }
 
             if child_entry.is_dir() {
@@ -5579,7 +5587,16 @@ impl BackgroundScanner {
                 .map(|abs_path| async move {
                     let metadata = self.fs.metadata(abs_path).await?;
                     if let Some(metadata) = metadata {
-                        let canonical_path = self.fs.canonicalize(abs_path).await?;
+                        let canonical_path = match self.fs.canonicalize(abs_path).await {
+                            Ok(path) => Some(SanitizedPath::new_arc(&path)),
+                            Err(err) if metadata.is_symlink => {
+                                log::debug!(
+                                    "unable to resolve target of symlink {abs_path:?}: {err:#}"
+                                );
+                                None
+                            }
+                            Err(err) => return Err(err),
+                        };
 
                         // If we're on a case-insensitive filesystem (default on macOS), we want
                         // to only ignore metadata for non-symlink files if their absolute-path matches
@@ -5588,14 +5605,15 @@ impl BackgroundScanner {
                         // and we want to ignore the metadata for the old path (`test.txt`) so it's
                         // treated as removed.
                         if !self.fs_case_sensitive && !metadata.is_symlink {
-                            let canonical_file_name = canonical_path.file_name();
+                            let canonical_file_name =
+                                canonical_path.as_ref().and_then(|path| path.file_name());
                             let file_name = abs_path.file_name();
                             if canonical_file_name != file_name {
                                 return Ok(None);
                             }
                         }
 
-                        anyhow::Ok(Some((metadata, SanitizedPath::new_arc(&canonical_path))))
+                        anyhow::Ok(Some((metadata, canonical_path)))
                     } else {
                         Ok(None)
                     }
@@ -5636,7 +5654,9 @@ impl BackgroundScanner {
                         .snapshot
                         .ignore_stack_for_abs_path(&abs_path, metadata.is_dir, self.fs.as_ref())
                         .await;
-                    let is_external = !canonical_path.starts_with(&root_canonical_path);
+                    let is_external = canonical_path
+                        .as_ref()
+                        .is_some_and(|path| !path.starts_with(&root_canonical_path));
                     let entry_id = state.entry_id_for(self.next_entry_id.as_ref(), path, &metadata);
                     let mut fs_entry = Entry::new(
                         path.clone(),
@@ -5644,7 +5664,9 @@ impl BackgroundScanner {
                         entry_id,
                         state.snapshot.root_char_bag,
                         if metadata.is_symlink {
-                            Some(canonical_path.as_path().to_path_buf().into())
+                            canonical_path
+                                .as_ref()
+                                .map(|path| path.as_path().to_path_buf().into())
                         } else {
                             None
                         },

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1198,6 +1198,55 @@ async fn test_real_fs_scan_symlinks_expanded(cx: &mut TestAppContext) {
     });
 }
 
+#[cfg(unix)]
+#[gpui::test]
+async fn test_real_fs_shows_dangling_symlinks(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    init_test(cx);
+
+    let temp_root = TempTree::new(json!({ "project": {} }));
+    let project_root = temp_root.path().join("project");
+    std::os::unix::fs::symlink("Agents.md", project_root.join("AGENTS.md")).unwrap();
+
+    let tree = Worktree::local(
+        project_root.as_path(),
+        true,
+        Arc::new(RealFs::new(None, cx.executor())),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    tree.read_with(cx, |tree, _| {
+        let entry = tree.entry_for_path(rel_path("AGENTS.md")).unwrap();
+        assert!(entry.is_file());
+        assert_eq!(entry.canonical_path, None);
+    });
+
+    std::os::unix::fs::symlink("Missing.md", project_root.join("README.link")).unwrap();
+    tree.flush_fs_events(cx).await;
+
+    tree.read_with(cx, |tree, _| {
+        let entry = tree.entry_for_path(rel_path("README.link")).unwrap();
+        assert!(entry.is_file());
+        assert_eq!(entry.canonical_path, None);
+    });
+
+    std::fs::write(project_root.join("Agents.md"), "").unwrap();
+    tree.flush_fs_events(cx).await;
+
+    tree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("AGENTS.md")).is_some());
+        assert!(tree.entry_for_path(rel_path("Agents.md")).is_some());
+    });
+}
+
 #[gpui::test]
 async fn test_internal_symlink_updates_preserve_entry_ids(cx: &mut TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
# Objective

Keep dangling symlinks visible in the Project Panel instead of silently dropping them from the worktree snapshot.

Related to #25181. The earlier full fix attempt #33623 was closed as stale. PR #45458 later fixed `RealFs::metadata` for broken and recursive symlinks, while explicitly noting that the worktree scanner still dropped entries whose targets could not be canonicalized. This PR completes that remaining worktree layer.

This was reproduced while investigating the Project Panel refresh report in #29242 and follow-up PR #62200, but it has a separate root cause.

A real case had these entries in the same directory:

```text
AGENTS.md -> Agents.md
Agents.md
```

The symlink was initially dangling, so Zed omitted it. After the target was created, the panel only showed `Agents.md`; renaming it to `AGENTS.md` then failed with an apparently inexplicable `File exists (os error 17)` because the hidden symlink still occupied that name. Reloading did not make the collision understandable.

## Solution

When symlink canonicalization fails:

- retain the symlink as a file entry in the initial worktree scan;
- retain newly created dangling symlinks during filesystem-event refreshes;
- leave `canonical_path` unset until the target can be resolved, avoiding treating an unresolved path as canonical.

Resolvable symlinks keep their existing canonical-path, external-path, and directory-scanning behavior.

## Testing

- Added a real-filesystem regression test covering:
  - a dangling symlink present during initial scan;
  - a dangling symlink created after the scan;
  - creation of the original symlink target, ensuring both differently-cased directory entries remain visible.
- `cargo test -p worktree --features test-support --test integration` (66 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed dangling symlinks being hidden in the Project Panel and causing invisible filename collisions.
