### PR TITLE
Feat file metadata filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14314,6 +14314,7 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
+ "smol",
  "telemetry",
  "tempfile",
  "theme",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -955,6 +955,12 @@
     },
   },
   {
+    "context": "ProjectPanelFilter",
+    "bindings": {
+      "escape": "project_panel::CancelFilter",
+    },
+  },
+  {
     "context": "ProjectPanel",
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1009,6 +1009,13 @@
     },
   },
   {
+    "context": "ProjectPanelFilter",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "project_panel::CancelFilter",
+    },
+  },
+  {
     "context": "ProjectPanel",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -956,6 +956,13 @@
     },
   },
   {
+    "context": "ProjectPanelFilter",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "project_panel::CancelFilter",
+    },
+  },
+  {
     "context": "ProjectPanel",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -639,6 +639,26 @@ impl Search {
                     {
                         return false;
                     }
+                    // Metadata predicates describe the file on disk, so in
+                    // opened-only mode they are matched against the worktree
+                    // entry rather than the (possibly unsaved) buffer. A buffer
+                    // with no entry has no metadata to test, so it cannot
+                    // satisfy the filter.
+                    if search_query.filters_metadata() {
+                        let Some(entry) = b
+                            .entry_id(cx)
+                            .and_then(|entry_id| worktree_store.entry_for_id(entry_id, cx))
+                        else {
+                            return false;
+                        };
+                        if !search_query.metadata_filters().matches(
+                            entry.path.file_name().unwrap_or_default(),
+                            entry.size,
+                            entry.mtime,
+                        ) {
+                            return false;
+                        }
+                    }
                 }
                 true
             })
@@ -823,6 +843,19 @@ impl RequestHandler<'_> {
             } = req;
 
             if entry.is_fifo || !entry.is_file() {
+                return Ok(());
+            }
+
+            // Metadata predicates are checked before the path globs because they
+            // read fields the worktree scan already populated, so they prune
+            // candidates without touching the filesystem.
+            if self.query.filters_metadata()
+                && !self.query.metadata_filters().matches(
+                    entry.path.file_name().unwrap_or_default(),
+                    entry.size,
+                    entry.mtime,
+                )
+            {
                 return Ok(());
             }
 

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -1,7 +1,9 @@
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
-use anyhow::{Ok, Result};
+use anyhow::{Context as _, Ok, Result, bail};
 use client::proto;
 use fancy_regex::{Captures, Regex, RegexBuilder};
+use fs::MTime;
+use globset::{GlobBuilder, GlobMatcher};
 use gpui::Entity;
 use itertools::Itertools as _;
 use language::{Buffer, BufferSnapshot, CharKind};
@@ -12,6 +14,7 @@ use std::{
     io::{BufRead, BufReader, Read},
     ops::Range,
     sync::{Arc, LazyLock},
+    time::{Duration, SystemTime},
 };
 use text::Anchor;
 use util::{
@@ -42,8 +45,226 @@ pub struct SearchInputs {
     query: Arc<str>,
     files_to_include: PathMatcher,
     files_to_exclude: PathMatcher,
+    metadata_filters: MetadataFilters,
     match_full_paths: bool,
     buffers: Option<Vec<Entity<Buffer>>>,
+}
+
+/// A `find(1)`-style numeric comparison: `+N` matches values greater than `N`
+/// and `-N` values less than `N`. What a bare `N` means is left to each
+/// predicate: `-mtime`/`-mmin` read it as "equal to", `-size` as "greater than".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FindComparison {
+    GreaterThan(u64),
+    LessThan(u64),
+    Equal(u64),
+}
+
+impl FindComparison {
+    fn matches(self, value: u64) -> bool {
+        match self {
+            Self::GreaterThan(threshold) => value > threshold,
+            Self::LessThan(threshold) => value < threshold,
+            Self::Equal(threshold) => value == threshold,
+        }
+    }
+
+    /// Splits the leading `+`/`-` off an operand. The constructor is `None` when
+    /// the operand carries no sign, so each predicate can supply its own default.
+    fn split(operand: &str) -> (Option<fn(u64) -> Self>, &str) {
+        if let Some(rest) = operand.strip_prefix('+') {
+            (Some(Self::GreaterThan), rest)
+        } else if let Some(rest) = operand.strip_prefix('-') {
+            (Some(Self::LessThan), rest)
+        } else {
+            (None, operand)
+        }
+    }
+}
+
+const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
+const SECONDS_PER_MINUTE: u64 = 60;
+
+/// File metadata filters modelled on the `find(1)` predicates of the same name.
+///
+/// These are matched against the worktree's own entry metadata, so they cost no
+/// extra syscalls and prune candidates before any file is read.
+///
+/// The syntax is `find`-inspired rather than `find`-compatible. `+N`/`-N` are
+/// plain greater-than/less-than comparisons and round down rather than up, and
+/// `-size` in particular defaults to KiB and to "greater than" -- see
+/// [`MetadataFilters::parse_size`]. Predicates are whitespace-separated, so a
+/// `-name` glob cannot contain spaces.
+#[derive(Clone, Debug)]
+pub struct MetadataFilters {
+    /// Verbatim user input, retained so the filters can round-trip over the
+    /// wire without having to re-render the parsed form.
+    source: String,
+    /// Glob on the base name, as `find -name` (or `-iname`, case-insensitive).
+    name: Option<GlobMatcher>,
+    /// File size, in bytes.
+    size: Option<FindComparison>,
+    /// Age in whole days, as `find -mtime`.
+    mtime: Option<FindComparison>,
+    /// Age in whole minutes, as `find -mmin`.
+    mmin: Option<FindComparison>,
+    /// Captured once when the query is built, so every entry in a single search
+    /// is aged against the same clock.
+    reference_time: SystemTime,
+}
+
+impl Default for MetadataFilters {
+    fn default() -> Self {
+        Self {
+            source: String::new(),
+            name: None,
+            size: None,
+            mtime: None,
+            mmin: None,
+            reference_time: SystemTime::UNIX_EPOCH,
+        }
+    }
+}
+
+impl MetadataFilters {
+    pub fn new(source: &str) -> Result<Self> {
+        Self::new_at(source, SystemTime::now())
+    }
+
+    fn new_at(source: &str, reference_time: SystemTime) -> Result<Self> {
+        let mut this = Self {
+            source: source.to_owned(),
+            reference_time,
+            ..Default::default()
+        };
+
+        let mut tokens = source.split_whitespace();
+        while let Some(predicate) = tokens.next() {
+            let operand = tokens
+                .next()
+                .with_context(|| format!("`{predicate}` is missing a value"))?;
+            match predicate {
+                // `-name` and `-iname` populate the same slot and differ only in
+                // case folding, so the last one written wins -- the same way a
+                // repeated `-size` does.
+                "-name" => this.name = Some(Self::parse_name(predicate, operand, false)?),
+                "-iname" => this.name = Some(Self::parse_name(predicate, operand, true)?),
+                "-size" => this.size = Some(Self::parse_size(operand)?),
+                "-mtime" => this.mtime = Some(Self::parse_count(predicate, operand)?),
+                "-mmin" => this.mmin = Some(Self::parse_count(predicate, operand)?),
+                _ => bail!(
+                    "unknown filter `{predicate}`, expected -name, -iname, -size, -mtime or -mmin"
+                ),
+            }
+        }
+
+        std::result::Result::Ok(this)
+    }
+
+    /// Parses a `-name`/`-iname` operand: a glob matched against the base name
+    /// only, as in `find`. `literal_separator` is left off because the value
+    /// never contains a separator to begin with.
+    fn parse_name(predicate: &str, operand: &str, case_insensitive: bool) -> Result<GlobMatcher> {
+        let glob = GlobBuilder::new(operand)
+            .case_insensitive(case_insensitive)
+            .build()
+            .with_context(|| format!("`{predicate} {operand}` is not a valid glob"))?;
+        std::result::Result::Ok(glob.compile_matcher())
+    }
+
+    /// Parses a `-size` operand.
+    ///
+    /// Two deliberate departures from `find`, both aimed at the common case of
+    /// "show me the big files":
+    /// - the default unit is KiB, not 512-byte blocks (`-size 9` is 9 KiB);
+    /// - an unsigned value means "greater than", not "equal to" (`-size 9` is
+    ///   `+9k`, and `-size +1` is "over 1024 bytes").
+    ///
+    /// An explicit unit suffix still wins: `c` bytes, `b` 512-byte blocks, `k`,
+    /// `M`, `G`.
+    fn parse_size(operand: &str) -> Result<FindComparison> {
+        let (comparison, digits) = FindComparison::split(operand);
+        const KIB: u64 = 1 << 10;
+        let (digits, unit) = match digits.as_bytes().last() {
+            Some(b'c') => (&digits[..digits.len() - 1], 1),
+            Some(b'b') => (&digits[..digits.len() - 1], 512),
+            Some(b'k') => (&digits[..digits.len() - 1], KIB),
+            Some(b'M') => (&digits[..digits.len() - 1], 1 << 20),
+            Some(b'G') => (&digits[..digits.len() - 1], 1 << 30),
+            _ => (digits, KIB),
+        };
+        let count: u64 = digits.parse().with_context(|| {
+            format!("`-size {operand}` is not a number with an optional c/b/k/M/G suffix")
+        })?;
+        let bytes = count
+            .checked_mul(unit)
+            .with_context(|| format!("`-size {operand}` overflows"))?;
+        std::result::Result::Ok(comparison.unwrap_or(FindComparison::GreaterThan)(bytes))
+    }
+
+    /// Parses a `-mtime`/`-mmin` operand. Unlike `-size`, an unsigned value here
+    /// keeps `find`'s "equal to" meaning.
+    fn parse_count(predicate: &str, operand: &str) -> Result<FindComparison> {
+        let (comparison, digits) = FindComparison::split(operand);
+        let count: u64 = digits
+            .parse()
+            .with_context(|| format!("`{predicate} {operand}` is not a number"))?;
+        std::result::Result::Ok(comparison.unwrap_or(FindComparison::Equal)(count))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.size.is_none() && self.mtime.is_none() && self.mmin.is_none()
+    }
+
+    /// The text these filters were parsed from, for round-tripping over RPC.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Tests a worktree entry against every configured predicate. `file_name` is
+    /// the entry's base name, matched by `-name`.
+    ///
+    /// `mtime` is `None` for entries whose modification time the worktree scan
+    /// could not read. Such an entry cannot be shown to satisfy an age filter,
+    /// so it is rejected rather than silently passed through. An mtime in the
+    /// future (clock skew, or a file written mid-scan) is treated as age zero.
+    pub fn matches(&self, file_name: &str, size: u64, mtime: Option<MTime>) -> bool {
+        if let Some(name) = &self.name
+            && !name.is_match(file_name)
+        {
+            return false;
+        }
+
+        if let Some(size_filter) = self.size
+            && !size_filter.matches(size)
+        {
+            return false;
+        }
+
+        if self.mtime.is_none() && self.mmin.is_none() {
+            return true;
+        }
+        let Some(mtime) = mtime else {
+            return false;
+        };
+        let age = self
+            .reference_time
+            .duration_since(mtime.timestamp_for_user())
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        if let Some(mtime_filter) = self.mtime
+            && !mtime_filter.matches(age / SECONDS_PER_DAY)
+        {
+            return false;
+        }
+        if let Some(mmin_filter) = self.mmin
+            && !mmin_filter.matches(age / SECONDS_PER_MINUTE)
+        {
+            return false;
+        }
+        true
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -67,6 +288,9 @@ impl SearchInputs {
     }
     pub fn files_to_exclude(&self) -> &PathMatcher {
         &self.files_to_exclude
+    }
+    pub fn metadata_filters(&self) -> &MetadataFilters {
+        &self.metadata_filters
     }
     pub fn buffers(&self) -> &Option<Vec<Entity<Buffer>>> {
         &self.buffers
@@ -139,6 +363,7 @@ impl SearchQuery {
             query: query.into(),
             files_to_exclude,
             files_to_include,
+            metadata_filters: MetadataFilters::default(),
             match_full_paths,
             buffers,
         };
@@ -173,6 +398,7 @@ impl SearchQuery {
             query: Arc::from(query.as_str()),
             files_to_include,
             files_to_exclude,
+            metadata_filters: MetadataFilters::default(),
             match_full_paths,
             buffers,
         };
@@ -208,6 +434,7 @@ impl SearchQuery {
             query: Arc::from(query.as_str()),
             files_to_include,
             files_to_exclude,
+            metadata_filters: MetadataFilters::default(),
             match_full_paths,
             buffers,
         };
@@ -335,7 +562,11 @@ impl SearchQuery {
             message.files_to_exclude
         };
 
-        if message.regex {
+        // Re-parsed here rather than sent pre-parsed, so `-mtime`/`-mmin` are
+        // aged against the host's clock -- the same clock the mtimes come from.
+        let metadata_filters = MetadataFilters::new(&message.metadata_filters)?;
+
+        let query = if message.regex {
             Self::regex(
                 message.query,
                 message.whole_word,
@@ -346,7 +577,7 @@ impl SearchQuery {
                 PathMatcher::new(files_to_exclude, path_style)?,
                 message.match_full_paths,
                 None, // search opened only don't need search remote
-            )
+            )?
         } else {
             Self::text(
                 message.query,
@@ -357,8 +588,9 @@ impl SearchQuery {
                 PathMatcher::new(files_to_exclude, path_style)?,
                 message.match_full_paths,
                 None, // search opened only don't need search remote
-            )
-        }
+            )?
+        };
+        Ok(query.with_metadata_filters(metadata_filters))
     }
 
     pub fn with_replacement(mut self, new_replacement: String) -> Self {
@@ -389,6 +621,7 @@ impl SearchQuery {
             files_to_include: files_to_include.clone().map(ToOwned::to_owned).collect(),
             files_to_exclude: files_to_exclude.clone().map(ToOwned::to_owned).collect(),
             match_full_paths: self.match_full_paths(),
+            metadata_filters: self.metadata_filters().source().to_string(),
             // Populate legacy fields for backwards compatibility
             files_to_include_legacy: files_to_include.join(","),
             files_to_exclude_legacy: files_to_exclude.join(","),
@@ -623,6 +856,28 @@ impl SearchQuery {
         self.as_inner().files_to_exclude()
     }
 
+    pub fn metadata_filters(&self) -> &MetadataFilters {
+        self.as_inner().metadata_filters()
+    }
+
+    /// Attaches `find(1)`-style size/age filters. Kept as a builder rather than
+    /// a constructor parameter so the many existing `text`/`regex` call sites
+    /// stay untouched.
+    pub fn with_metadata_filters(mut self, filters: MetadataFilters) -> Self {
+        match &mut self {
+            Self::Text { inner, .. } | Self::Regex { inner, .. } => {
+                inner.metadata_filters = filters
+            }
+        }
+        self
+    }
+
+    /// Whether any file metadata predicate is configured. Deliberately separate
+    /// from [`Self::filters_path`], which gates the path glob check.
+    pub fn filters_metadata(&self) -> bool {
+        !self.metadata_filters().is_empty()
+    }
+
     pub fn buffers(&self) -> Option<&Vec<Entity<Buffer>>> {
         self.as_inner().buffers.as_ref()
     }
@@ -694,5 +949,204 @@ impl SearchQuery {
             }
         }
         matches
+    }
+}
+
+#[cfg(test)]
+mod metadata_filter_tests {
+    use super::*;
+
+    /// A fixed clock, so `-mtime`/`-mmin` assertions don't depend on wall time.
+    fn now() -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000)
+    }
+
+    fn filters(source: &str) -> MetadataFilters {
+        MetadataFilters::new_at(source, now()).unwrap()
+    }
+
+    fn aged(seconds: u64) -> Option<MTime> {
+        let since_epoch = now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        Some(MTime::from_seconds_and_nanos(since_epoch - seconds, 0))
+    }
+
+    /// Assertions that are only about size or age use a fixed base name.
+    const ANY_NAME: &str = "file.txt";
+
+    #[test]
+    fn parses_all_predicates() {
+        let parsed = filters("-iname *.rs -size +1k -mtime -7 -mmin +30");
+        assert!(parsed.name.is_some());
+        assert_eq!(parsed.size, Some(FindComparison::GreaterThan(1024)));
+        assert_eq!(parsed.mtime, Some(FindComparison::LessThan(7)));
+        assert_eq!(parsed.mmin, Some(FindComparison::GreaterThan(30)));
+        assert!(!parsed.is_empty());
+    }
+
+    #[test]
+    fn iname_folds_case_and_name_does_not() {
+        let any_case = filters("-iname *.rs");
+        assert!(any_case.matches("main.rs", 0, None));
+        assert!(any_case.matches("MAIN.RS", 0, None));
+        assert!(!any_case.matches("main.ts", 0, None));
+
+        let exact_case = filters("-name *.rs");
+        assert!(exact_case.matches("main.rs", 0, None));
+        assert!(!exact_case.matches("MAIN.RS", 0, None));
+
+        // Both write the same slot, so the last one wins.
+        assert!(!filters("-iname *.rs -name *.rs").matches("MAIN.RS", 0, None));
+        assert!(filters("-name *.rs -iname *.rs").matches("MAIN.RS", 0, None));
+
+        // The glob applies to the whole base name, not a substring of it.
+        let readme = filters("-iname README*");
+        assert!(readme.matches("readme.md", 0, None));
+        assert!(!readme.matches("a-readme.md", 0, None));
+
+        assert!(MetadataFilters::new_at("-name [", now()).is_err());
+        assert!(MetadataFilters::new_at("-iname [", now()).is_err());
+    }
+
+    #[test]
+    fn empty_source_filters_nothing() {
+        let parsed = filters("   ");
+        assert!(parsed.is_empty());
+        assert!(parsed.matches(ANY_NAME, 0, None));
+    }
+
+    #[test]
+    fn size_defaults_to_kib_and_greater_than() {
+        // An unsigned `-size` means "greater than", and its unit is KiB.
+        assert_eq!(
+            filters("-size 9").size,
+            Some(FindComparison::GreaterThan(9 * 1024))
+        );
+        assert_eq!(
+            filters("-size +1").size,
+            Some(FindComparison::GreaterThan(1024))
+        );
+        assert_eq!(
+            filters("-size -4").size,
+            Some(FindComparison::LessThan(4 * 1024))
+        );
+    }
+
+    #[test]
+    fn parses_size_suffixes() {
+        // An explicit suffix overrides the KiB default; the unsigned-means-
+        // greater-than rule still applies.
+        assert_eq!(
+            filters("-size 100c").size,
+            Some(FindComparison::GreaterThan(100))
+        );
+        assert_eq!(
+            filters("-size 2b").size,
+            Some(FindComparison::GreaterThan(2 * 512))
+        );
+        assert_eq!(
+            filters("-size -4k").size,
+            Some(FindComparison::LessThan(4 * 1024))
+        );
+        assert_eq!(
+            filters("-size +3M").size,
+            Some(FindComparison::GreaterThan(3 * 1024 * 1024))
+        );
+        assert_eq!(
+            filters("-size +1G").size,
+            Some(FindComparison::GreaterThan(1024 * 1024 * 1024))
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_input() {
+        for source in [
+            "-size",
+            "-size abc",
+            "-mtime",
+            "-mtime 1.5",
+            "-mmin +",
+            "-atime 3",
+            "-name",
+            "-iname",
+            "size +1k",
+        ] {
+            assert!(
+                MetadataFilters::new_at(source, now()).is_err(),
+                "expected `{source}` to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_size() {
+        let larger_than_1k = filters("-size +1k");
+        assert!(larger_than_1k.matches(ANY_NAME, 2048, None));
+        assert!(!larger_than_1k.matches(ANY_NAME, 1024, None));
+        assert!(!larger_than_1k.matches(ANY_NAME, 0, None));
+
+        let smaller_than_1k = filters("-size -1k");
+        assert!(smaller_than_1k.matches(ANY_NAME, 1023, None));
+        assert!(!smaller_than_1k.matches(ANY_NAME, 1024, None));
+    }
+
+    #[test]
+    fn matches_age_in_days_and_minutes() {
+        let day = SECONDS_PER_DAY;
+
+        let modified_within_a_week = filters("-mtime -7");
+        assert!(modified_within_a_week.matches(ANY_NAME, 0, aged(3 * day)));
+        assert!(!modified_within_a_week.matches(ANY_NAME, 0, aged(8 * day)));
+
+        let older_than_a_week = filters("-mtime +7");
+        assert!(older_than_a_week.matches(ANY_NAME, 0, aged(8 * day)));
+        assert!(!older_than_a_week.matches(ANY_NAME, 0, aged(3 * day)));
+
+        // Truncating division, as `find` does: 7 days and change is still "7".
+        let exactly_seven_days = filters("-mtime 7");
+        assert!(exactly_seven_days.matches(ANY_NAME, 0, aged(7 * day + 60)));
+        assert!(!exactly_seven_days.matches(ANY_NAME, 0, aged(8 * day)));
+
+        let modified_in_last_half_hour = filters("-mmin -30");
+        assert!(modified_in_last_half_hour.matches(ANY_NAME, 0, aged(60)));
+        assert!(!modified_in_last_half_hour.matches(ANY_NAME, 0, aged(60 * 60)));
+    }
+
+    #[test]
+    fn predicates_are_conjunctive() {
+        let both = filters("-size +1k -mmin -30");
+        assert!(both.matches(ANY_NAME, 2048, aged(60)));
+        assert!(!both.matches(ANY_NAME, 512, aged(60)));
+        assert!(!both.matches(ANY_NAME, 2048, aged(60 * 60)));
+    }
+
+    #[test]
+    fn unreadable_mtime_cannot_satisfy_an_age_filter() {
+        assert!(!filters("-mtime -7").matches(ANY_NAME, 0, None));
+        assert!(!filters("-mmin +1").matches(ANY_NAME, 0, None));
+        // ...but a size-only filter doesn't care about mtime at all.
+        assert!(filters("-size +1k").matches(ANY_NAME, 2048, None));
+    }
+
+    #[test]
+    fn mtime_in_the_future_is_treated_as_age_zero() {
+        let future = now() + Duration::from_secs(SECONDS_PER_DAY);
+        let since_epoch = future
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mtime = Some(MTime::from_seconds_and_nanos(since_epoch, 0));
+
+        assert!(filters("-mmin -30").matches(ANY_NAME, 0, mtime));
+        assert!(!filters("-mmin +30").matches(ANY_NAME, 0, mtime));
+    }
+
+    #[test]
+    fn source_round_trips_verbatim() {
+        let source = "-size +1k -mtime -7";
+        assert_eq!(filters(source).source(), source);
+        assert_eq!(MetadataFilters::default().source(), "");
     }
 }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8417,6 +8417,26 @@ async fn test_search_with_metadata_filters(cx: &mut gpui::TestAppContext) {
         "`-size -1k` should only match the files smaller than 1 KiB"
     );
 
+    // Project search and the project panel share one parser, so the unsigned
+    // defaults have to hold here too: no sign means "greater than", and the
+    // unit is KiB. `-size 1` is therefore the same query as `-size +1k`.
+    assert_eq!(
+        search(&project, query("-size 1"), cx).await.unwrap(),
+        HashMap::from_iter([(path!("dir/large.rs").to_string(), vec![0..6])]),
+        "an unsigned `-size` should mean `+`, counted in KiB"
+    );
+    assert_eq!(
+        search(&project, query("-size 1"), cx).await.unwrap(),
+        search(&project, query("-size +1k"), cx).await.unwrap(),
+        "`-size 1` and `-size +1k` should be the same query"
+    );
+
+    assert_eq!(
+        search(&project, query("-mmin -1"), cx).await.unwrap(),
+        HashMap::from_iter([(path!("dir/fresh.rs").to_string(), vec![0..6])]),
+        "`-mmin -1` should only match the file written just now"
+    );
+
     assert_eq!(
         search(&project, query("-mtime -1"), cx).await.unwrap(),
         HashMap::from_iter([(path!("dir/fresh.rs").to_string(), vec![0..6])]),

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -61,7 +61,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use project::{
     Event, TaskContexts,
     git_store::{GitStoreEvent, Repository, RepositoryEvent, StatusEntry, pending_op},
-    search::{SearchQuery, SearchResult},
+    search::{MetadataFilters, SearchQuery, SearchResult},
     task_store::{TaskSettingsLocation, TaskStore},
     *,
 };
@@ -83,7 +83,7 @@ use std::{
     str::FromStr,
     sync::{Arc, OnceLock, atomic},
     task::Poll,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 use sum_tree::SumTree;
 use task::{ResolvedTask, ShellKind, TaskContext};
@@ -8353,6 +8353,91 @@ async fn test_search_with_inclusions(cx: &mut gpui::TestAppContext) {
             (path!("dir/two.rs").to_string(), vec![8..12]),
         ]),
         "Rust and typescript search should give both Rust and TypeScript files, even if other inclusions don't match anything"
+    );
+}
+
+#[gpui::test]
+async fn test_search_with_metadata_filters(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    // FakeFs hands out mtimes starting at the epoch, so these two count as very
+    // old regardless of when the test runs.
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "small.rs": "needle",
+            "large.rs": format!("needle{}", "x".repeat(2000)),
+        }),
+    )
+    .await;
+    fs.set_next_mtime(SystemTime::now());
+    fs.insert_file(path!("/dir/fresh.rs"), "needle".into())
+        .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+
+    let query = |metadata_filters: &str| {
+        SearchQuery::text(
+            "needle",
+            false,
+            true,
+            false,
+            Default::default(),
+            Default::default(),
+            false,
+            None,
+        )
+        .unwrap()
+        .with_metadata_filters(MetadataFilters::new(metadata_filters).unwrap())
+    };
+
+    assert_eq!(
+        search(&project, query(""), cx).await.unwrap(),
+        HashMap::from_iter([
+            (path!("dir/fresh.rs").to_string(), vec![0..6]),
+            (path!("dir/large.rs").to_string(), vec![0..6]),
+            (path!("dir/small.rs").to_string(), vec![0..6]),
+        ]),
+        "An empty filter should not exclude anything"
+    );
+
+    assert_eq!(
+        search(&project, query("-size +1k"), cx).await.unwrap(),
+        HashMap::from_iter([(path!("dir/large.rs").to_string(), vec![0..6])]),
+        "`-size +1k` should only match the file larger than 1 KiB"
+    );
+
+    assert_eq!(
+        search(&project, query("-size -1k"), cx).await.unwrap(),
+        HashMap::from_iter([
+            (path!("dir/fresh.rs").to_string(), vec![0..6]),
+            (path!("dir/small.rs").to_string(), vec![0..6]),
+        ]),
+        "`-size -1k` should only match the files smaller than 1 KiB"
+    );
+
+    assert_eq!(
+        search(&project, query("-mtime -1"), cx).await.unwrap(),
+        HashMap::from_iter([(path!("dir/fresh.rs").to_string(), vec![0..6])]),
+        "`-mtime -1` should only match the file written just now"
+    );
+
+    assert_eq!(
+        search(&project, query("-mmin +60"), cx).await.unwrap(),
+        HashMap::from_iter([
+            (path!("dir/large.rs").to_string(), vec![0..6]),
+            (path!("dir/small.rs").to_string(), vec![0..6]),
+        ]),
+        "`-mmin +60` should only match the files left at their epoch mtimes"
+    );
+
+    assert_eq!(
+        search(&project, query("-size -1k -mtime -1"), cx)
+            .await
+            .unwrap(),
+        HashMap::from_iter([(path!("dir/fresh.rs").to_string(), vec![0..6])]),
+        "Predicates should combine with AND"
     );
 }
 

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -34,6 +34,7 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smallvec.workspace = true
+smol.workspace = true
 theme.workspace = true
 theme_settings.workspace = true
 rayon.workspace = true

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -91,7 +91,7 @@ use crate::{
 };
 
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
-const FILTER_PLACEHOLDER: &str = "Filter: e.g. -iname *.rs -size 9 -mtime -7";
+const FILTER_PLACEHOLDER: &str = "Filter: e.g. -iname *.rs -size 9 -mtime -7 -mmin +30";
 /// How long the filter input stays quiet before the tree is rebuilt. Long enough
 /// to swallow a burst of typing, short enough not to read as lag.
 const FILTER_DEBOUNCE: Duration = Duration::from_millis(150);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -92,6 +92,13 @@ use crate::{
 
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 const FILTER_PLACEHOLDER: &str = "Filter: e.g. -iname *.rs -size 9 -mtime -7";
+/// How long the filter input stays quiet before the tree is rebuilt. Long enough
+/// to swallow a burst of typing, short enough not to read as lag.
+const FILTER_DEBOUNCE: Duration = Duration::from_millis(150);
+/// Entries traversed between yields while filtering. The filtered walk visits the
+/// whole worktree, so it must hand control back periodically for a dropped task
+/// to actually stop rather than run to completion.
+const FILTER_ENTRIES_PER_YIELD: usize = 2048;
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
 
 struct VisibleEntriesForWorktree {
@@ -158,6 +165,13 @@ pub struct ProjectPanel {
     /// the same as `filter_enabled`: an empty or unparseable input leaves the
     /// box open but the tree unfiltered, and the chevrons must follow the tree.
     filter_is_applied: bool,
+    /// Directories the user collapsed *while a filter was applied*. Kept apart
+    /// from `expanded_dir_ids` so a filtered session never rewrites the real
+    /// expansion state; dropped as soon as the filter stops applying.
+    filter_collapsed_dir_ids: HashSet<ProjectEntryId>,
+    /// Debounces the whole-tree walk that filtering requires, so a burst of
+    /// keystrokes costs one traversal rather than one per character.
+    filter_update_task: Option<Task<()>>,
     /// Parse error for the current filter text, shown under the input.
     filter_error: Option<String>,
     clipboard: Option<ClipboardEntry>,
@@ -390,6 +404,8 @@ actions!(
         ToggleHideHidden,
         /// Toggles the `find(1)`-style file filter input.
         ToggleFilter,
+        /// Clears the file filter input, then hides it if already empty.
+        CancelFilter,
         /// Starts a new search in the selected directory.
         NewSearchInDirectory,
         /// Unfolds the selected directory.
@@ -491,7 +507,12 @@ pub fn init(cx: &mut App) {
             let Some(panel) = workspace.panel::<ProjectPanel>(cx) else {
                 return;
             };
-            workspace.open_panel::<ProjectPanel>(window, cx);
+            // Only reveal the panel when the filter is being turned *on*.
+            // Opening it unconditionally would mean the same keystroke that
+            // hides the filter also forces the panel open.
+            if !panel.read(cx).filter_enabled {
+                workspace.open_panel::<ProjectPanel>(window, cx);
+            }
             panel.update(cx, |panel, cx| {
                 panel.toggle_filter(&ToggleFilter, window, cx);
             });
@@ -791,10 +812,7 @@ impl ProjectPanel {
                 window,
                 |project_panel, _, editor_event, window, cx| {
                     if matches!(editor_event, EditorEvent::BufferEdited) {
-                        // Assigning `update_visible_entries_task` drops the
-                        // previous task, so an in-flight traversal for older
-                        // filter text is cancelled rather than racing this one.
-                        project_panel.update_visible_entries(None, false, false, window, cx);
+                        project_panel.schedule_filter_update(window, cx);
                     }
                 },
             )
@@ -890,6 +908,8 @@ impl ProjectPanel {
                 // is visible, and an empty input filters nothing.
                 filter_enabled: true,
                 filter_is_applied: false,
+                filter_collapsed_dir_ids: HashSet::default(),
+                filter_update_task: None,
                 filter_error: None,
                 clipboard: None,
                 _dragged_entry_destination: None,
@@ -1346,6 +1366,14 @@ impl ProjectPanel {
             if entry.is_dir() {
                 let worktree_id = worktree.id();
                 let entry_id = entry.id;
+                if self.filter_owns_expansion(entry_id, cx).is_some() {
+                    if self.filter_collapsed_dir_ids.contains(&entry_id) {
+                        self.set_filter_collapsed(worktree_id, entry_id, false, window, cx);
+                    } else {
+                        self.select_next(&SelectNext, window, cx);
+                    }
+                    return;
+                }
                 let expanded_dir_ids = if let Some(expanded_dir_ids) =
                     self.state.expanded_dir_ids.get_mut(&worktree_id)
                 {
@@ -1398,6 +1426,26 @@ impl ProjectPanel {
             return;
         }
         let worktree_id = worktree.id();
+        if self.filter_is_applied {
+            // Mirror of the unfiltered loop below: collapse this directory, or
+            // walk up to the nearest ancestor that is still expanded.
+            let mut candidate = &entry;
+            loop {
+                if candidate.is_dir() && !self.filter_collapsed_dir_ids.contains(&candidate.id) {
+                    let entry_id = candidate.id;
+                    self.set_filter_collapsed(worktree_id, entry_id, true, window, cx);
+                    return;
+                }
+                let Some(parent) = candidate
+                    .path
+                    .parent()
+                    .and_then(|parent| worktree.entry_for_path(parent))
+                else {
+                    return;
+                };
+                candidate = parent;
+            }
+        }
         let expanded_dir_ids =
             if let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id) {
                 expanded_dir_ids
@@ -1513,6 +1561,22 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Wiping `expanded_dir_ids` here would destroy expansion state the user
+        // cannot even see while filtering. Collapse the filtered tree instead.
+        if self.filter_is_applied {
+            let visible_dirs: Vec<ProjectEntryId> = self
+                .state
+                .visible_entries
+                .iter()
+                .flat_map(|worktree| worktree.entries.iter())
+                .filter(|entry| entry.is_dir() && !entry.path.as_unix_str().is_empty())
+                .map(|entry| entry.id)
+                .collect();
+            self.filter_collapsed_dir_ids.extend(visible_dirs);
+            self.update_visible_entries(None, false, false, window, cx);
+            cx.notify();
+            return;
+        }
         let roots = self.all_worktree_roots(cx);
         self.collapse_worktree_roots(roots, window, cx);
     }
@@ -1613,6 +1677,18 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // While a filter is applied every listed directory renders expanded
+        // without being in `expanded_dir_ids`. Toggling the real set here would
+        // invert the click -- "collapse" would take the `Err` arm and expand --
+        // and would rewrite the expansion state the filter promises to leave
+        // alone. Collapsing is recorded in a filter-local set instead.
+        if let Some(worktree_id) = self.filter_owns_expansion(entry_id, cx) {
+            let collapsed = !self.filter_collapsed_dir_ids.contains(&entry_id);
+            self.set_filter_collapsed(worktree_id, entry_id, collapsed, window, cx);
+            window.focus(&self.focus_handle, cx);
+            return;
+        }
+
         if let Some(worktree_id) = self.project.read(cx).worktree_id_for_entry(entry_id, cx)
             && let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id)
         {
@@ -1639,6 +1715,16 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Expand/collapse-all has no filtered meaning: the filter already
+        // decides what is shown beneath a directory. Fall back to toggling just
+        // this one, against the filter-local state.
+        if let Some(worktree_id) = self.filter_owns_expansion(entry_id, cx) {
+            let collapsed = !self.filter_collapsed_dir_ids.contains(&entry_id);
+            self.set_filter_collapsed(worktree_id, entry_id, collapsed, window, cx);
+            window.focus(&self.focus_handle, cx);
+            return;
+        }
+
         if let Some(worktree_id) = self.project.read(cx).worktree_id_for_entry(entry_id, cx)
             && let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id)
         {
@@ -4286,11 +4372,16 @@ impl ProjectPanel {
             )
     }
 
-    /// Keeps matching files plus every directory on the path to one.
+    /// Keeps matching files plus every directory on the path to one, minus
+    /// anything the user collapsed while the filter was applied.
     ///
     /// Expects `entries` in traversal order; the ancestor set is built from the
     /// kept files, so ordering only affects the early-exit optimisation below.
-    fn retain_filtered_entries(entries: &mut Vec<GitEntry>, filter: &MetadataFilters) {
+    fn retain_filtered_entries(
+        entries: &mut Vec<GitEntry>,
+        filter: &MetadataFilters,
+        collapsed_dir_ids: &HashSet<ProjectEntryId>,
+    ) {
         // The placeholder for an in-progress create/rename has no real name or
         // metadata, so any filter would drop it and the inline input would
         // vanish mid-typing. It and its ancestors are always kept.
@@ -4312,9 +4403,33 @@ impl ProjectPanel {
             }
         }
 
+        // A directory collapsed during filtering stays on screen -- it still
+        // leads to a match -- but its descendants are hidden. The traversal
+        // cannot skip them, because whether the directory itself survives is
+        // only known once its descendants have been tested.
+        let collapsed_paths: HashSet<String> = if collapsed_dir_ids.is_empty() {
+            HashSet::default()
+        } else {
+            entries
+                .iter()
+                .filter(|entry| !entry.is_file() && collapsed_dir_ids.contains(&entry.id))
+                .map(|entry| entry.path.as_unix_str().to_owned())
+                .collect()
+        };
+        let is_under_collapsed = |entry: &GitEntry| {
+            !collapsed_paths.is_empty()
+                && entry
+                    .path
+                    .ancestors()
+                    .skip(1)
+                    .any(|ancestor| collapsed_paths.contains(ancestor.as_unix_str()))
+        };
+
         entries.retain(|entry| {
             if is_pending_edit(entry) {
                 true
+            } else if is_under_collapsed(entry) {
+                false
             } else if entry.is_file() {
                 Self::entry_matches_filter(entry, filter)
             } else {
@@ -4333,6 +4448,11 @@ impl ProjectPanel {
         let colors = cx.theme().colors();
         Some(
             v_flex()
+                // The bar sits outside the element carrying the panel's own key
+                // context, so it declares one of its own -- otherwise nothing
+                // dispatched from the focused input would reach a handler here.
+                .key_context("ProjectPanelFilter")
+                .on_action(cx.listener(Self::cancel_filter))
                 .w_full()
                 .flex_none()
                 .p_1p5()
@@ -4366,15 +4486,86 @@ impl ProjectPanel {
         if self.filter_enabled {
             window.focus(&self.filter_editor.focus_handle(cx), cx);
         } else {
-            // Clear rather than merely hide: a filter that keeps pruning the
-            // tree while its input is invisible is indistinguishable from a bug.
-            self.filter_editor
-                .update(cx, |editor, cx| editor.set_text("", window, cx));
-            self.filter_error = None;
+            self.clear_filter(window, cx);
             window.focus(&self.focus_handle, cx);
         }
         self.update_visible_entries(None, false, false, window, cx);
         cx.notify();
+    }
+
+    /// Empties the filter input and everything derived from it. Clearing rather
+    /// than merely hiding: a filter that keeps pruning the tree while its input
+    /// is invisible is indistinguishable from a bug.
+    ///
+    /// Focus is left alone -- moving it belongs to the callers that actually
+    /// hide the bar.
+    fn clear_filter(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.filter_editor
+            .update(cx, |editor, cx| editor.set_text("", window, cx));
+        self.filter_error = None;
+        self.filter_collapsed_dir_ids.clear();
+    }
+
+    /// Escape, in two stages: the first press empties a non-empty input, the
+    /// second hides the bar. Matching the input first means a mistyped filter
+    /// costs one keystroke to undo rather than reopening the bar afterwards.
+    fn cancel_filter(&mut self, _: &CancelFilter, window: &mut Window, cx: &mut Context<Self>) {
+        // The first press must leave the cursor in the input: focus moving to
+        // the tree would take the `ProjectPanelFilter` key context with it, and
+        // the second press could never reach this handler.
+        let hide = self.filter_editor.read(cx).text(cx).is_empty();
+        self.clear_filter(window, cx);
+        if hide {
+            self.filter_enabled = false;
+            window.focus(&self.focus_handle, cx);
+        }
+        self.update_visible_entries(None, false, false, window, cx);
+        cx.notify();
+    }
+
+    /// While a filter is applied, expansion belongs to `filter_collapsed_dir_ids`
+    /// rather than `expanded_dir_ids` -- see [`Self::toggle_expanded`]. Every
+    /// expand/collapse gesture asks this first, so the keyboard, the chevron and
+    /// the context menu all agree on which state they are editing.
+    fn filter_owns_expansion(&self, entry_id: ProjectEntryId, cx: &App) -> Option<WorktreeId> {
+        if !self.filter_is_applied {
+            return None;
+        }
+        self.project.read(cx).worktree_id_for_entry(entry_id, cx)
+    }
+
+    /// Records an expand/collapse against the filtered tree and rebuilds it.
+    fn set_filter_collapsed(
+        &mut self,
+        worktree_id: WorktreeId,
+        entry_id: ProjectEntryId,
+        collapsed: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if collapsed {
+            self.filter_collapsed_dir_ids.insert(entry_id);
+        } else {
+            self.filter_collapsed_dir_ids.remove(&entry_id);
+        }
+        self.update_visible_entries(Some((worktree_id, entry_id)), false, false, window, cx);
+        cx.notify();
+    }
+
+    /// Coalesces filter keystrokes. With a filter active `update_visible_entries`
+    /// walks and materialises every entry in the worktree, including collapsed
+    /// directories, so running it per character is what makes a large project
+    /// feel slow. Assigning the task drops the previous one, so only the last
+    /// keystroke of a burst survives the wait.
+    fn schedule_filter_update(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.filter_update_task = Some(cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor().timer(FILTER_DEBOUNCE).await;
+            this.update_in(cx, |this, window, cx| {
+                this.filter_update_task = None;
+                this.update_visible_entries(None, false, false, window, cx);
+            })
+            .ok();
+        }));
     }
 
     /// Parses the filter input, recording any error for display. Returns `None`
@@ -4413,6 +4604,12 @@ impl ProjectPanel {
         let now = Instant::now();
         let filter = self.active_filter(cx);
         let filter_is_applied = filter.is_some();
+        if !filter_is_applied {
+            // Collapses only mean anything relative to a filtered tree; keeping
+            // them would silently prune the next filter the user types.
+            self.filter_collapsed_dir_ids.clear();
+        }
+        let filter_collapsed_dir_ids = self.filter_collapsed_dir_ids.clone();
         let settings = ProjectPanelSettings::get_global(cx);
         let auto_collapse_dirs = settings.auto_fold_dirs;
         let hide_gitignore = settings.hide_gitignore;
@@ -4467,7 +4664,21 @@ impl ProjectPanel {
                             GitTraversal::new(&repo_snapshots, worktree_snapshot.entries(true, 0));
                         let mut auto_folded_ancestors = vec![];
                         let worktree_abs_path = worktree_snapshot.abs_path();
+                        let mut entries_since_yield = 0usize;
                         while let Some(entry) = entry_iter.entry() {
+                            // Only the filtered walk needs this: it visits the
+                            // whole worktree, so without an await point a task
+                            // dropped for newer filter text would still run to
+                            // completion. The unfiltered walk stays allocation-
+                            // and yield-free.
+                            if filter.is_some() {
+                                entries_since_yield += 1;
+                                if entries_since_yield >= FILTER_ENTRIES_PER_YIELD {
+                                    entries_since_yield = 0;
+                                    smol::future::yield_now().await;
+                                }
+                            }
+
                             if hide_root && Some(entry.entry) == worktree_snapshot.root_entry() {
                                 if new_entry_parent_id == Some(entry.id) {
                                     visible_worktree_entries.push(Self::create_new_git_entry(
@@ -4675,7 +4886,11 @@ impl ProjectPanel {
                         }
 
                         if let Some(filter) = &filter {
-                            Self::retain_filtered_entries(&mut visible_worktree_entries, filter);
+                            Self::retain_filtered_entries(
+                                &mut visible_worktree_entries,
+                                filter,
+                                &filter_collapsed_dir_ids,
+                            );
 
                             for entry in &visible_worktree_entries {
                                 let Some(width_estimate) = entry_widths.get(&entry.id).copied()
@@ -6766,9 +6981,15 @@ impl ProjectPanel {
         // A filter traverses into collapsed directories without recording them
         // as expanded, so every directory it lists is showing its (filtered)
         // children. Rendering a collapsed chevron above visible children would
-        // contradict what the user sees.
-        let is_expanded =
-            self.filter_is_applied || expanded_entry_ids.binary_search(&entry.id).is_ok();
+        // contradict what the user sees. While filtering, the only directories
+        // drawn collapsed are the ones collapsed *during* the filter, which is
+        // also the set `toggle_expanded` writes -- so the chevron and the click
+        // agree on which state they are toggling.
+        let is_expanded = if self.filter_is_applied {
+            !self.filter_collapsed_dir_ids.contains(&entry.id)
+        } else {
+            expanded_entry_ids.binary_search(&entry.id).is_ok()
+        };
 
         let icon = match entry.kind {
             EntryKind::File => {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -37,6 +37,7 @@ use project::{
     ProjectPath, Worktree, WorktreeId,
     git_store::{GitStoreEvent, RepositoryEvent, git_traversal::ChildEntriesGitIter},
     project_settings::GoToDiagnosticSeverityFilter,
+    search::MetadataFilters,
 };
 use project_panel_settings::ProjectPanelSettings;
 use rayon::slice::ParallelSliceMut;
@@ -90,6 +91,7 @@ use crate::{
 };
 
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
+const FILTER_PLACEHOLDER: &str = "Filter: e.g. -iname *.rs -size 9 -mtime -7";
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
 
 struct VisibleEntriesForWorktree {
@@ -149,6 +151,15 @@ pub struct ProjectPanel {
     selection: Option<SelectedEntry>,
     context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, Subscription)>,
     filename_editor: Entity<Editor>,
+    /// `find(1)`-style predicates narrowing which files the tree shows.
+    filter_editor: Entity<Editor>,
+    filter_enabled: bool,
+    /// Whether the entries currently on screen were produced by a filter. Not
+    /// the same as `filter_enabled`: an empty or unparseable input leaves the
+    /// box open but the tree unfiltered, and the chevrons must follow the tree.
+    filter_is_applied: bool,
+    /// Parse error for the current filter text, shown under the input.
+    filter_error: Option<String>,
     clipboard: Option<ClipboardEntry>,
     _dragged_entry_destination: Option<Arc<Path>>,
     workspace: WeakEntity<Workspace>,
@@ -377,6 +388,8 @@ actions!(
         ToggleHideGitIgnore,
         /// Toggles visibility of hidden files.
         ToggleHideHidden,
+        /// Toggles the `find(1)`-style file filter input.
+        ToggleFilter,
         /// Starts a new search in the selected directory.
         NewSearchInDirectory,
         /// Unfolds the selected directory.
@@ -469,6 +482,19 @@ pub fn init(cx: &mut App) {
             if !workspace.toggle_panel_focus::<ProjectPanel>(window, cx) {
                 workspace.close_panel::<ProjectPanel>(window, cx);
             }
+        });
+
+        // Registered on the workspace, not just on the panel's own element:
+        // an element-level handler is only reachable while the panel has focus,
+        // which also hides the command from the command palette everywhere else.
+        workspace.register_action(|workspace, _: &ToggleFilter, window, cx| {
+            let Some(panel) = workspace.panel::<ProjectPanel>(cx) else {
+                return;
+            };
+            workspace.open_panel::<ProjectPanel>(window, cx);
+            panel.update(cx, |panel, cx| {
+                panel.toggle_filter(&ToggleFilter, window, cx);
+            });
         });
 
         workspace.register_action(|workspace, _: &ToggleHideGitIgnore, _, cx| {
@@ -755,6 +781,25 @@ impl ProjectPanel {
 
             let filename_editor = cx.new(|cx| Editor::single_line(window, cx));
 
+            let filter_editor = cx.new(|cx| {
+                let mut editor = Editor::single_line(window, cx);
+                editor.set_placeholder_text(FILTER_PLACEHOLDER, window, cx);
+                editor
+            });
+            cx.subscribe_in(
+                &filter_editor,
+                window,
+                |project_panel, _, editor_event, window, cx| {
+                    if matches!(editor_event, EditorEvent::BufferEdited) {
+                        // Assigning `update_visible_entries_task` drops the
+                        // previous task, so an in-flight traversal for older
+                        // filter text is cancelled rather than racing this one.
+                        project_panel.update_visible_entries(None, false, false, window, cx);
+                    }
+                },
+            )
+            .detach();
+
             cx.subscribe_in(
                 &filename_editor,
                 window,
@@ -840,6 +885,12 @@ impl ProjectPanel {
                 selection: None,
                 context_menu: None,
                 filename_editor,
+                filter_editor,
+                // Shown by default: the filter is discoverable only if the input
+                // is visible, and an empty input filters nothing.
+                filter_enabled: true,
+                filter_is_applied: false,
+                filter_error: None,
                 clipboard: None,
                 _dragged_entry_destination: None,
                 workspace: workspace.weak_handle(),
@@ -4222,6 +4273,135 @@ impl ProjectPanel {
         }
     }
 
+    /// Tests one entry against the filter. Predicates apply to *files* only:
+    /// `-size`/`-mtime`/`-mmin` are meaningless for a directory, and a directory
+    /// matching `-iname` would still have no matching contents to show. So
+    /// directories earn their place solely by being an ancestor of a match.
+    fn entry_matches_filter(entry: &GitEntry, filter: &MetadataFilters) -> bool {
+        entry.is_file()
+            && filter.matches(
+                entry.path.file_name().unwrap_or_default(),
+                entry.size,
+                entry.mtime,
+            )
+    }
+
+    /// Keeps matching files plus every directory on the path to one.
+    ///
+    /// Expects `entries` in traversal order; the ancestor set is built from the
+    /// kept files, so ordering only affects the early-exit optimisation below.
+    fn retain_filtered_entries(entries: &mut Vec<GitEntry>, filter: &MetadataFilters) {
+        // The placeholder for an in-progress create/rename has no real name or
+        // metadata, so any filter would drop it and the inline input would
+        // vanish mid-typing. It and its ancestors are always kept.
+        let is_pending_edit = |entry: &GitEntry| entry.id == NEW_ENTRY_ID;
+
+        let mut kept_dirs: HashSet<String> = HashSet::default();
+        for entry in entries.iter() {
+            if !is_pending_edit(entry) && !Self::entry_matches_filter(entry, filter) {
+                continue;
+            }
+            // `ancestors()` yields the path itself first, then each parent down
+            // to the empty root -- which is the worktree root entry's own path,
+            // so the root survives too. Once an ancestor is already present all
+            // of its own ancestors are as well, so we can stop.
+            for ancestor in entry.path.ancestors().skip(1) {
+                if !kept_dirs.insert(ancestor.as_unix_str().to_owned()) {
+                    break;
+                }
+            }
+        }
+
+        entries.retain(|entry| {
+            if is_pending_edit(entry) {
+                true
+            } else if entry.is_file() {
+                Self::entry_matches_filter(entry, filter)
+            } else {
+                // The worktree root has the empty path. Keep it even when
+                // nothing matches, so a filter with no hits shows an empty
+                // project rather than an empty panel, which reads as a bug.
+                entry.path.as_unix_str().is_empty() || kept_dirs.contains(entry.path.as_unix_str())
+            }
+        });
+    }
+
+    fn render_filter_bar(&self, cx: &mut Context<Self>) -> Option<impl IntoElement + use<>> {
+        if !self.filter_enabled {
+            return None;
+        }
+        let colors = cx.theme().colors();
+        Some(
+            v_flex()
+                .w_full()
+                .flex_none()
+                .p_1p5()
+                .gap_1()
+                .border_b_1()
+                .border_color(colors.border)
+                .child(
+                    h_flex()
+                        .h_6()
+                        .w_full()
+                        .px_1p5()
+                        .rounded_sm()
+                        .border_1()
+                        .border_color(if self.filter_error.is_some() {
+                            Color::Error.color(cx)
+                        } else {
+                            colors.border
+                        })
+                        .child(self.filter_editor.clone()),
+                )
+                .children(self.filter_error.as_ref().map(|error| {
+                    Label::new(error.clone())
+                        .size(LabelSize::Small)
+                        .color(Color::Error)
+                })),
+        )
+    }
+
+    fn toggle_filter(&mut self, _: &ToggleFilter, window: &mut Window, cx: &mut Context<Self>) {
+        self.filter_enabled = !self.filter_enabled;
+        if self.filter_enabled {
+            window.focus(&self.filter_editor.focus_handle(cx), cx);
+        } else {
+            // Clear rather than merely hide: a filter that keeps pruning the
+            // tree while its input is invisible is indistinguishable from a bug.
+            self.filter_editor
+                .update(cx, |editor, cx| editor.set_text("", window, cx));
+            self.filter_error = None;
+            window.focus(&self.focus_handle, cx);
+        }
+        self.update_visible_entries(None, false, false, window, cx);
+        cx.notify();
+    }
+
+    /// Parses the filter input, recording any error for display. Returns `None`
+    /// when no filter is active, which lets callers skip the whole-tree walk.
+    fn active_filter(&mut self, cx: &App) -> Option<MetadataFilters> {
+        if !self.filter_enabled {
+            return None;
+        }
+        let text = self.filter_editor.read(cx).text(cx);
+        if text.trim().is_empty() {
+            self.filter_error = None;
+            return None;
+        }
+        match MetadataFilters::new(&text) {
+            Ok(filters) => {
+                self.filter_error = None;
+                Some(filters).filter(|filters| !filters.is_empty())
+            }
+            Err(e) => {
+                // Keep the tree unfiltered while the user is mid-word rather
+                // than blanking it on every transiently invalid keystroke.
+                self.filter_error = Some(e.to_string());
+                None
+            }
+        }
+    }
+
     fn update_visible_entries(
         &mut self,
         new_selected_entry: Option<(WorktreeId, ProjectEntryId)>,
@@ -4231,6 +4411,8 @@ impl ProjectPanel {
         cx: &mut Context<Self>,
     ) {
         let now = Instant::now();
+        let filter = self.active_filter(cx);
+        let filter_is_applied = filter.is_some();
         let settings = ProjectPanelSettings::get_global(cx);
         let auto_collapse_dirs = settings.auto_fold_dirs;
         let hide_gitignore = settings.hide_gitignore;
@@ -4259,6 +4441,10 @@ impl ProjectPanel {
         let visible_entries_task = cx.spawn_in(window, async move |this, cx| {
             let new_state = cx
                 .background_spawn(async move {
+                    // Width estimates for entries traversed while a filter is
+                    // active, resolved to a maximum only over those that survive
+                    // the retain. Cleared per worktree.
+                    let mut entry_widths: HashMap<ProjectEntryId, usize> = HashMap::default();
                     for worktree_snapshot in visible_worktrees {
                         let worktree_id = worktree_snapshot.id();
 
@@ -4433,17 +4619,27 @@ impl ProjectPanel {
                             let width_estimate =
                                 item_width_estimate(depth, chars, entry.canonical_path.is_some());
 
-                            match max_width_item.as_mut() {
-                                Some((id, worktree_id, width)) => {
-                                    if *width < width_estimate {
-                                        *id = entry.id;
-                                        *worktree_id = worktree_snapshot.id();
-                                        *width = width_estimate;
+                            // While filtering we cannot tell yet whether this
+                            // entry survives -- directory retention depends on
+                            // descendants that have not been traversed. Stash
+                            // the estimate and pick the maximum over the
+                            // retained entries once the retain has run, so the
+                            // panel does not size itself for hidden content.
+                            if filter.is_some() {
+                                entry_widths.insert(entry.id, width_estimate);
+                            } else {
+                                match max_width_item.as_mut() {
+                                    Some((id, worktree_id, width)) => {
+                                        if *width < width_estimate {
+                                            *id = entry.id;
+                                            *worktree_id = worktree_snapshot.id();
+                                            *width = width_estimate;
+                                        }
                                     }
-                                }
-                                None => {
-                                    max_width_item =
-                                        Some((entry.id, worktree_snapshot.id(), width_estimate))
+                                    None => {
+                                        max_width_item =
+                                            Some((entry.id, worktree_snapshot.id(), width_estimate))
+                                    }
                                 }
                             }
 
@@ -4461,12 +4657,46 @@ impl ProjectPanel {
                                     }
                                 };
 
-                            if expanded_dir_ids.binary_search(&entry.id).is_err()
+                            // With a filter active, descend into collapsed
+                            // directories too -- otherwise matches would only
+                            // ever surface under folders the user had already
+                            // expanded, which reads as the filter being broken.
+                            // Note this does not touch `expanded_dir_ids`, which
+                            // is persisted across updates: auto-expanding there
+                            // would leave the tree blown open once the filter is
+                            // cleared.
+                            if filter.is_none()
+                                && expanded_dir_ids.binary_search(&entry.id).is_err()
                                 && entry_iter.advance_to_sibling()
                             {
                                 continue;
                             }
                             entry_iter.advance();
+                        }
+
+                        if let Some(filter) = &filter {
+                            Self::retain_filtered_entries(&mut visible_worktree_entries, filter);
+
+                            for entry in &visible_worktree_entries {
+                                let Some(width_estimate) = entry_widths.get(&entry.id).copied()
+                                else {
+                                    continue;
+                                };
+                                match max_width_item.as_mut() {
+                                    Some((id, item_worktree_id, width)) => {
+                                        if *width < width_estimate {
+                                            *id = entry.id;
+                                            *item_worktree_id = worktree_id;
+                                            *width = width_estimate;
+                                        }
+                                    }
+                                    None => {
+                                        max_width_item =
+                                            Some((entry.id, worktree_id, width_estimate))
+                                    }
+                                }
+                            }
+                            entry_widths.clear();
                         }
 
                         par_sort_worktree_entries(
@@ -4505,6 +4735,9 @@ impl ProjectPanel {
                 .await;
             this.update_in(cx, |this, window, cx| {
                 this.state = new_state;
+                // Flipped together with the entries it describes, so the
+                // chevrons never disagree with what is on screen.
+                this.filter_is_applied = filter_is_applied;
                 if let Some((worktree_id, entry_id)) = new_selected_entry {
                     this.selection = Some(SelectedEntry {
                         worktree_id,
@@ -6530,7 +6763,12 @@ impl ProjectPanel {
             .get(&worktree_id)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        let is_expanded = expanded_entry_ids.binary_search(&entry.id).is_ok();
+        // A filter traverses into collapsed directories without recording them
+        // as expanded, so every directory it lists is showing its (filtered)
+        // children. Rendering a collapsed chevron above visible children would
+        // contradict what the user sees.
+        let is_expanded =
+            self.filter_is_applied || expanded_entry_ids.binary_search(&entry.id).is_ok();
 
         let icon = match entry.kind {
             EntryKind::File => {
@@ -6929,7 +7167,7 @@ impl Render for ProjectPanel {
         let is_collab = project.is_via_collab();
         let is_local = project.is_local();
 
-        if has_worktree {
+        let body = if has_worktree {
             let item_count = self
                 .state
                 .visible_entries
@@ -7023,6 +7261,7 @@ impl Render for ProjectPanel {
                     },
                 ))
                 .key_context(self.dispatch_context(window, cx))
+                .on_action(cx.listener(Self::toggle_filter))
                 .on_action(cx.listener(Self::scroll_up))
                 .on_action(cx.listener(Self::scroll_down))
                 .on_action(cx.listener(Self::scroll_cursor_center))
@@ -7566,7 +7805,12 @@ impl Render for ProjectPanel {
                         ))
                     })
                 })
-        }
+        };
+
+        v_flex()
+            .size_full()
+            .children(self.render_filter_bar(cx))
+            .child(body)
     }
 }
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10462,6 +10462,280 @@ async fn test_filter_entries(cx: &mut gpui::TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_filter_collapse_does_not_touch_real_expansion_state(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "top.rs": "x",
+            "nested": {
+                "deep": {
+                    "inner.rs": "x",
+                },
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    let nested = find_project_entry(&panel, "root/nested", cx).unwrap();
+
+    set_filter(&panel, "-iname *.rs", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v nested",
+            "        v deep",
+            "              inner.rs",
+            "      top.rs",
+        ],
+        "the filter reaches into directories the user never expanded"
+    );
+
+    // Collapsing while filtering must fold the directory, not unfold it. Before
+    // the filter-local set existed this took the `Err` arm of `toggle_expanded`
+    // and expanded `nested` instead, invisibly, because the chevron was forced
+    // open regardless.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_expanded(nested, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "    > nested  <== selected", "      top.rs"],
+        "collapsing a directory during a filter hides its matches but keeps the directory"
+    );
+
+    panel.update(cx, |panel, cx| {
+        let worktree_id = panel
+            .project
+            .read(cx)
+            .worktrees(cx)
+            .next()
+            .unwrap()
+            .read(cx)
+            .id();
+        assert!(
+            !panel.state.expanded_dir_ids[&worktree_id].contains(&nested),
+            "collapsing during a filter must not write the persistent expansion state"
+        );
+    });
+
+    // ...and clicking it again re-expands, within the filtered tree.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_expanded(nested, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v nested  <== selected",
+            "        v deep",
+            "              inner.rs",
+            "      top.rs",
+        ]
+    );
+
+    // Collapse again, then drop the filter: the collapse was filter-local, so
+    // the tree returns to the user's own state rather than remembering it.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_expanded(nested, window, cx);
+    });
+    cx.run_until_parked();
+    set_filter(&panel, "", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "    > nested  <== selected", "      top.rs",],
+        "clearing the filter restores the original collapsed tree"
+    );
+    panel.update(cx, |panel, _| {
+        assert!(
+            panel.filter_collapsed_dir_ids.is_empty(),
+            "filter-local collapses are dropped once the filter stops applying"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_cancel_filter_clears_then_hides(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", json!({ "a.rs": "x", "b.md": "x" }))
+        .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    set_filter(&panel, "-iname *.rs", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "      a.rs"]
+    );
+    // Note: the focus half of this behaviour is not asserted here. The panel is
+    // never drawn in these tests, so its focus handles are not in the dispatch
+    // tree and `window.focus` does not stick -- even via `toggle_filter`, which
+    // is what the app itself uses. What matters and is *not* covered: the first
+    // press must leave the cursor in the input, or the `ProjectPanelFilter` key
+    // context goes with it and the second press could never reach this handler.
+    // That is why `clear_filter` no longer touches focus and `cancel_filter`
+    // moves it only when the bar is actually hiding.
+
+    // First Escape empties the input but leaves the bar open.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.cancel_filter(&CancelFilter, window, cx);
+    });
+    cx.run_until_parked();
+    panel.update(cx, |panel, cx| {
+        assert!(
+            panel.filter_enabled,
+            "the bar stays open on the first press"
+        );
+        assert!(panel.filter_editor.read(cx).text(cx).is_empty());
+    });
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "      a.rs", "      b.md"],
+        "clearing the input unfilters the tree"
+    );
+
+    // Second Escape, with the input already empty, dismisses the bar.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.cancel_filter(&CancelFilter, window, cx);
+    });
+    cx.run_until_parked();
+    panel.update(cx, |panel, _| {
+        assert!(
+            !panel.filter_enabled,
+            "a second press on an empty input hides the bar"
+        );
+    });
+}
+
+/// The keyboard path must edit the same state the chevron does. `left`/`right`
+/// and expand-all go through their own functions, so fixing only the chevron
+/// would leave them writing `expanded_dir_ids` behind a filtered tree.
+#[gpui::test]
+async fn test_filter_collapse_via_keyboard(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "top.rs": "x",
+            "nested": { "deep": { "inner.rs": "x" } },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    let nested = find_project_entry(&panel, "root/nested", cx).unwrap();
+    let worktree_id = panel.update(cx, |panel, cx| {
+        panel
+            .project
+            .read(cx)
+            .worktrees(cx)
+            .next()
+            .unwrap()
+            .read(cx)
+            .id()
+    });
+
+    set_filter(&panel, "-iname *.rs", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.selection = Some(SelectedEntry {
+            worktree_id,
+            entry_id: nested,
+        });
+        panel.collapse_selected_entry(&CollapseSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "    > nested  <== selected", "      top.rs"],
+        "`left` collapses within the filtered tree"
+    );
+    panel.update(cx, |panel, _| {
+        assert!(
+            !panel.state.expanded_dir_ids[&worktree_id].contains(&nested),
+            "`left` must not write the persistent expansion state while filtering"
+        );
+    });
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.selection = Some(SelectedEntry {
+            worktree_id,
+            entry_id: nested,
+        });
+        panel.expand_selected_entry(&ExpandSelectedEntry, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v nested  <== selected",
+            "        v deep",
+            "              inner.rs",
+            "      top.rs",
+        ],
+        "`right` re-expands within the filtered tree"
+    );
+    panel.update(cx, |panel, _| {
+        assert!(
+            !panel.state.expanded_dir_ids[&worktree_id].contains(&nested),
+            "`right` must not write the persistent expansion state while filtering"
+        );
+    });
+
+    // Collapse-all folds the filtered tree instead of wiping expansion state
+    // the user cannot see.
+    let before = panel.update(cx, |panel, _| panel.state.expanded_dir_ids.clone());
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "    > nested  <== selected", "      top.rs"],
+        "collapse-all folds the filtered tree"
+    );
+    panel.update(cx, |panel, _| {
+        assert_eq!(
+            panel.state.expanded_dir_ids, before,
+            "collapse-all must leave the persistent expansion state untouched while filtering"
+        );
+    });
+}
+
 fn set_filter(panel: &Entity<ProjectPanel>, text: &str, cx: &mut VisualTestContext) {
     panel.update_in(cx, |panel, window, cx| {
         panel.filter_enabled = true;
@@ -10469,6 +10743,9 @@ fn set_filter(panel: &Entity<ProjectPanel>, text: &str, cx: &mut VisualTestConte
             .filter_editor
             .update(cx, |editor, cx| editor.set_text(text, window, cx));
     });
+    // Typing is debounced, so the tree is only rebuilt once the timer fires.
+    cx.executor()
+        .advance_clock(FILTER_DEBOUNCE + Duration::from_millis(10));
     cx.run_until_parked();
 }
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -10322,6 +10322,156 @@ async fn test_hide_hidden_entries(cx: &mut gpui::TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_filter_entries(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "big.rs": "x".repeat(2000),
+            "small.rs": "x",
+            "notes.md": "x",
+            "nested": {
+                "deep": {
+                    "inner.rs": "x",
+                },
+            },
+            "other": {
+                "thing.md": "x",
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    // Everything below the root starts collapsed; this is what makes the
+    // assertions below meaningful, since a filter has to reach into directories
+    // the user never expanded.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > nested",
+            "    > other",
+            "      big.rs",
+            "      notes.md",
+            "      small.rs",
+        ]
+    );
+
+    set_filter(&panel, "-iname *.rs", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    v nested",
+            "        v deep",
+            "              inner.rs",
+            "      big.rs",
+            "      small.rs",
+        ],
+        "`-iname *.rs` should reach into collapsed directories, keep the \
+         directories leading to a match, and drop `other/` entirely"
+    );
+
+    set_filter(&panel, "-name *.RS", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root"],
+        "`-name` is case-sensitive, so an upper-case glob matches nothing here"
+    );
+
+    set_filter(&panel, "-size +1k", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "      big.rs"],
+        "`-size +1k` should keep only the file over 1 KiB"
+    );
+
+    // An unsigned `-size` means "greater than", and counts KiB: `-size 1` is
+    // the same as `-size +1k`.
+    set_filter(&panel, "-size 1", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "      big.rs"],
+        "`-size 1` should behave as `+1k`"
+    );
+
+    set_filter(&panel, "-iname *.rs -size +1k", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root", "      big.rs"],
+        "predicates should combine with AND"
+    );
+
+    set_filter(&panel, "-iname *.nope", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &["v root"],
+        "a filter matching nothing should leave only the worktree root"
+    );
+
+    // Invalid input leaves the tree unfiltered rather than blanking it while
+    // the user is still typing, and surfaces the parse error.
+    set_filter(&panel, "-iname *.rs -size bogus", cx);
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > nested",
+            "    > other",
+            "      big.rs",
+            "      notes.md",
+            "      small.rs",
+        ]
+    );
+    panel.update(cx, |panel, _| {
+        assert!(
+            panel.filter_error.is_some(),
+            "an unparseable filter should be reported"
+        );
+    });
+
+    // Toggling the filter off clears it and restores the user's own expansion
+    // state -- the filter must not have expanded anything permanently.
+    panel.update_in(cx, |panel, window, cx| {
+        panel.toggle_filter(&ToggleFilter, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > nested",
+            "    > other",
+            "      big.rs",
+            "      notes.md",
+            "      small.rs",
+        ],
+        "clearing the filter should restore the original collapsed tree"
+    );
+}
+
+fn set_filter(panel: &Entity<ProjectPanel>, text: &str, cx: &mut VisualTestContext) {
+    panel.update_in(cx, |panel, window, cx| {
+        panel.filter_enabled = true;
+        panel
+            .filter_editor
+            .update(cx, |editor, cx| editor.set_text(text, window, cx));
+    });
+    cx.run_until_parked();
+}
+
 pub(crate) fn select_path(panel: &Entity<ProjectPanel>, path: &str, cx: &mut VisualTestContext) {
     let path = rel_path(path);
     panel.update_in(cx, |panel, window, cx| {

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -307,6 +307,9 @@ message SearchQuery {
   bool include_ignored = 8;
   string files_to_include_legacy = 6;
   string files_to_exclude_legacy = 7;
+  // `find(1)`-style file metadata predicates (-size/-mtime/-mmin), sent
+  // verbatim and re-parsed by the host.
+  string metadata_filters = 12;
 }
 
 message FindSearchCandidates {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1,7 +1,7 @@
 use crate::{
     BufferSearchBar, EXCLUDE_PLACEHOLDER, FocusSearch, HighlightKey, INCLUDE_PLACEHOLDER,
-    NextHistoryQuery, PreviousHistoryQuery, REPLACE_PLACEHOLDER, ReplaceAll, ReplaceNext,
-    SearchOption, SearchOptions, SearchSource, SelectNextMatch, SelectPreviousMatch,
+    METADATA_PLACEHOLDER, NextHistoryQuery, PreviousHistoryQuery, REPLACE_PLACEHOLDER, ReplaceAll,
+    ReplaceNext, SearchOption, SearchOptions, SearchSource, SelectNextMatch, SelectPreviousMatch,
     ToggleCaseSensitive, ToggleIncludeIgnored, ToggleRegex, ToggleReplace, ToggleWholeWord,
     buffer_search::Deploy,
     search_bar::{
@@ -33,7 +33,7 @@ use menu::Confirm;
 use multi_buffer;
 use project::{
     Project, ProjectPath, SearchResults,
-    search::{SearchInputKind, SearchQuery, SearchResult},
+    search::{MetadataFilters, SearchInputKind, SearchQuery, SearchResult},
     search_history::SearchHistoryCursor,
 };
 use settings::Settings;
@@ -299,6 +299,7 @@ enum InputPanel {
     Replacement,
     Exclude,
     Include,
+    Metadata,
 }
 
 pub struct ProjectSearchView {
@@ -314,6 +315,7 @@ pub struct ProjectSearchView {
     search_id: usize,
     included_files_editor: Entity<Editor>,
     excluded_files_editor: Entity<Editor>,
+    metadata_filters_editor: Entity<Editor>,
     filters_enabled: bool,
     replace_enabled: bool,
     pending_replace_all: bool,
@@ -1149,6 +1151,19 @@ impl ProjectSearchView {
             }),
         );
 
+        let metadata_filters_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text(METADATA_PLACEHOLDER, window, cx);
+
+            editor
+        });
+        // Subscribe to metadata_filters_editor in order to reraise editor events for workspace item activation purposes
+        subscriptions.push(
+            cx.subscribe(&metadata_filters_editor, |_, _, event: &EditorEvent, cx| {
+                cx.emit(ViewEvent::EditorEvent(event.clone()))
+            }),
+        );
+
         let focus_handle = cx.focus_handle();
         subscriptions.push(cx.on_focus(&focus_handle, window, |_, window, cx| {
             cx.on_next_frame(window, |this, window, cx| {
@@ -1192,6 +1207,7 @@ impl ProjectSearchView {
             active_match_index: None,
             included_files_editor,
             excluded_files_editor,
+            metadata_filters_editor,
             filters_enabled,
             replace_enabled: false,
             pending_replace_all: false,
@@ -1550,6 +1566,31 @@ impl ProjectSearchView {
             })
             .unwrap_or(PathMatcher::default());
 
+        let metadata_filters = self
+            .filters_enabled
+            .then(
+                || match MetadataFilters::new(&self.metadata_filters_editor.read(cx).text(cx)) {
+                    Ok(metadata_filters) => {
+                        let should_unmark_error =
+                            self.panels_with_errors.remove(&InputPanel::Metadata);
+                        if should_unmark_error.is_some() {
+                            cx.notify();
+                        }
+                        metadata_filters
+                    }
+                    Err(e) => {
+                        let should_mark_error = self
+                            .panels_with_errors
+                            .insert(InputPanel::Metadata, e.to_string());
+                        if should_mark_error.is_none() {
+                            cx.notify();
+                        }
+                        MetadataFilters::default()
+                    }
+                },
+            )
+            .unwrap_or_default();
+
         // If the project contains multiple visible worktrees, we match the
         // include/exclude patterns against full paths to allow them to be
         // disambiguated. For single worktree projects we use worktree relative
@@ -1576,7 +1617,7 @@ impl ProjectSearchView {
                     cx.notify();
                 }
 
-                Some(query)
+                Some(query.with_metadata_filters(metadata_filters))
             }
             Err(e) => {
                 let should_mark_error = self
@@ -1624,6 +1665,18 @@ impl ProjectSearchView {
             .parse_path_matches(self.excluded_files_editor.read(cx).text(cx), cx)
             .unwrap_or_default();
         (included, excluded)
+    }
+
+    /// The `find(1)`-style metadata filters currently configured on this view,
+    /// honoring `filters_enabled`. Read-only counterpart to the parsing done in
+    /// `build_search_query`: it records no errors, and unparseable input falls
+    /// back to no filtering. Shared with the text finder, which is backed by the
+    /// same view.
+    pub(crate) fn metadata_filters(&self, cx: &App) -> MetadataFilters {
+        if !self.filters_enabled {
+            return MetadataFilters::default();
+        }
+        MetadataFilters::new(&self.metadata_filters_editor.read(cx).text(cx)).unwrap_or_default()
     }
 
     fn parse_path_matches(&self, text: String, cx: &App) -> anyhow::Result<PathMatcher> {
@@ -2031,6 +2084,7 @@ impl ProjectSearchBar {
                 views.extend([
                     project_view.included_files_editor.focus_handle(cx),
                     project_view.excluded_files_editor.focus_handle(cx),
+                    project_view.metadata_filters_editor.focus_handle(cx),
                 ]);
             }
             let current_index = match views.iter().position(|focus| focus.is_focused(window)) {
@@ -2108,6 +2162,9 @@ impl ProjectSearchBar {
                     .update(cx, |_, cx| cx.notify());
                 search_view
                     .excluded_files_editor
+                    .update(cx, |_, cx| cx.notify());
+                search_view
+                    .metadata_filters_editor
                     .update(cx, |_, cx| cx.notify());
                 window.refresh();
                 cx.notify();
@@ -2330,7 +2387,9 @@ impl Render for ProjectSearchBar {
         let input_base_styles = |panel: InputPanel| {
             input_base_styles(search.border_color_for(panel, cx), |div| match panel {
                 InputPanel::Query | InputPanel::Replacement => div.w(input_width),
-                InputPanel::Include | InputPanel::Exclude => div.flex_grow_1(),
+                InputPanel::Include | InputPanel::Exclude | InputPanel::Metadata => {
+                    div.flex_grow_1()
+                }
             })
         };
         let theme_colors = cx.theme().colors();
@@ -2627,6 +2686,23 @@ impl Render for ProjectSearchBar {
                 .child(mode_column)
         });
 
+        // The metadata predicates get their own row rather than a third slot in
+        // the filter line: they are free-form `find`-style text, so squeezing
+        // them next to the two glob inputs would leave none of the three legible.
+        let metadata_line = search.filters_enabled.then(|| {
+            let metadata = input_base_styles(InputPanel::Metadata).child(render_text_input(
+                &search.metadata_filters_editor,
+                None,
+                cx,
+            ));
+
+            h_flex()
+                .w_full()
+                .gap_2()
+                .child(alignment_element())
+                .child(h_flex().w(input_width).gap_2().child(metadata))
+        });
+
         let mut key_context = KeyContext::default();
         key_context.add("ProjectSearchBar");
         if search
@@ -2652,6 +2728,7 @@ impl Render for ProjectSearchBar {
             .panels_with_errors
             .get(&InputPanel::Include)
             .or_else(|| search.panels_with_errors.get(&InputPanel::Exclude))
+            .or_else(|| search.panels_with_errors.get(&InputPanel::Metadata))
             .map(|error| {
                 Label::new(error)
                     .size(LabelSize::Small)
@@ -2708,6 +2785,7 @@ impl Render for ProjectSearchBar {
             .children(query_error_line)
             .children(replace_line)
             .children(filter_line)
+            .children(metadata_line)
             .children(filter_error_line)
             .into_any_element()
     }

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -84,6 +84,7 @@ pub enum SearchOption {
 const REPLACE_PLACEHOLDER: &str = "Replace in project…";
 const INCLUDE_PLACEHOLDER: &str = "Include: e.g. src/**/*.rs";
 const EXCLUDE_PLACEHOLDER: &str = "Exclude: e.g. vendor/*, *.lock";
+const METADATA_PLACEHOLDER: &str = "Metadata: e.g. -iname *.rs -size 9 -mtime -7";
 
 pub enum SearchSource<'a, 'b> {
     Buffer,

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -84,7 +84,7 @@ pub enum SearchOption {
 const REPLACE_PLACEHOLDER: &str = "Replace in project…";
 const INCLUDE_PLACEHOLDER: &str = "Include: e.g. src/**/*.rs";
 const EXCLUDE_PLACEHOLDER: &str = "Exclude: e.g. vendor/*, *.lock";
-const METADATA_PLACEHOLDER: &str = "Metadata: e.g. -iname *.rs -size 9 -mtime -7";
+const METADATA_PLACEHOLDER: &str = "Metadata: e.g. -iname *.rs -size 9 -mtime -7 -mmin +30";
 
 pub enum SearchSource<'a, 'b> {
     Buffer,

--- a/crates/search/src/text_finder/delegate.rs
+++ b/crates/search/src/text_finder/delegate.rs
@@ -1408,10 +1408,11 @@ impl Delegate {
             return None;
         }
 
-        // Reuse the include/exclude filters configured on the shared project
-        // search view so the text finder respects them too.
+        // Reuse the include/exclude and metadata filters configured on the
+        // shared project search view so the text finder respects them too.
         let (files_to_include, files_to_exclude) =
             self.project_search_view.read(cx).file_path_filters(cx);
+        let metadata_filters = self.project_search_view.read(cx).metadata_filters(cx);
 
         // If the project contains multiple visible worktrees, we match the
         // include/exclude patterns against full paths to allow them to be
@@ -1428,6 +1429,7 @@ impl Delegate {
                 match_full_paths,
                 open_buffers,
             )
+            .map(|query| query.with_metadata_filters(metadata_filters))
             .log_err()
     }
 

--- a/docs/src/finding-navigating.md
+++ b/docs/src/finding-navigating.md
@@ -33,6 +33,42 @@ Search across all files with {#kb pane::DeploySearch}. Type the query in the sea
 
 Results appear in a [multibuffer](./multibuffers.md), letting you edit matches in place.
 
+### File Metadata Filters
+
+Alongside the "Include" / "Exclude" [glob](./globs.md) filters, the filter row has a
+metadata field that narrows the search by file size and modification time using
+predicates borrowed from `find(1)`:
+
+| Predicate | Meaning                                | Example                             |
+| --------- | -------------------------------------- | ----------------------------------- |
+| `-name`   | Case-sensitive glob on the file name   | `-name *.rs`                        |
+| `-iname`  | Case-insensitive glob on the file name | `-iname *.RS`                       |
+| `-size`   | File size                              | `-size 9` (larger than 9 KiB)       |
+| `-mtime`  | Age in whole days                      | `-mtime -7` (modified in last week) |
+| `-mmin`   | Age in whole minutes                   | `-mmin +30` (untouched for 30 min)  |
+
+`+N` means "greater than N" and `-N` means "less than N". Predicates combine with
+AND, so `-size 1 -mtime -7` matches files that are both larger than 1 KiB and
+modified within the last week. Because predicates are whitespace-separated, a
+glob cannot contain spaces.
+
+`-size` departs from `find` twice, in favour of the common "show me the big
+files" case: its default unit is **KiB**, and an unsigned value means **greater
+than** rather than "equal to". So `-size 9` is the same as `-size +9k`, and
+`-size +1` matches files over 1024 bytes. An explicit unit suffix still wins —
+`c` (bytes), `b` (512-byte blocks), `k`, `M`, `G`. For `-mtime`/`-mmin` an
+unsigned value keeps `find`'s "equal to" meaning.
+
+`-name`/`-iname` overlap the "Include" glob field: they match the file name only,
+where "Include" matches the whole path. The same syntax also drives the
+[project panel's file filter](./project-panel.md#file-filter).
+
+These are matched against metadata Zed's worktree scan already holds, so they
+narrow the candidate set before any file is read.
+
+> Note: the syntax is `find`-inspired, not `find`-compatible. `-size` counts
+> bytes rather than 512-byte blocks by default and rounds down rather than up.
+
 ## Go to Definition
 
 Jump to where a symbol is defined with {#kb editor::GoToDefinition} (or `Cmd+Click` / `Ctrl+Click`). If there are multiple definitions, they open in a multibuffer.

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -158,13 +158,16 @@ A filter input sits above the tree and narrows it down using predicates borrowed
 from `find(1)`. It is shown by default; {#action project_panel::ToggleFilter}
 hides it (and clears whatever was typed).
 
+With the cursor in the input, `escape` clears it; a second `escape` on an
+already-empty input hides the bar.
+
 | Predicate | Meaning                                | Example                             |
 | --------- | -------------------------------------- | ----------------------------------- |
-| `-name`   | Case-sensitive glob on the file name    | `-name *.rs`                        |
-| `-iname`  | Case-insensitive glob on the file name  | `-iname *.RS`                       |
-| `-size`   | File size                               | `-size 9` (larger than 9 KiB)       |
-| `-mtime`  | Age in whole days                       | `-mtime -7` (modified in last week) |
-| `-mmin`   | Age in whole minutes                    | `-mmin +30` (untouched for 30 min)  |
+| `-name`   | Case-sensitive glob on the file name   | `-name *.rs`                        |
+| `-iname`  | Case-insensitive glob on the file name | `-iname *.RS`                       |
+| `-size`   | File size                              | `-size 9` (larger than 9 KiB)       |
+| `-mtime`  | Age in whole days                      | `-mtime -7` (modified in last week) |
+| `-mmin`   | Age in whole minutes                   | `-mmin +30` (untouched for 30 min)  |
 
 `+N` means "greater than N" and `-N` means "less than N". Predicates combine
 with AND, and because they are whitespace-separated a glob cannot contain
@@ -183,6 +186,11 @@ The predicates apply to **files**. Directories are shown only when they lead to
 a matching file, so `-iname src` matches nothing on its own. While a filter is
 active the tree is searched in full, including directories you have not
 expanded; clearing the filter restores your own expansion state untouched.
+
+You can still collapse a directory while a filter is active, to fold away a
+group of matches. Those collapses last only as long as the filter — they are
+kept separate from your own expansion state and are forgotten when the filter
+is cleared.
 
 The same syntax works in the [project search](./finding-navigating.md#file-metadata-filters)
 filter row.

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -152,6 +152,44 @@ See also [Diagnostics & Quick Fixes](./diagnostics.md) for editor and tab diagno
 
 ## Filtering and Sorting
 
+### File Filter
+
+A filter input sits above the tree and narrows it down using predicates borrowed
+from `find(1)`. It is shown by default; {#action project_panel::ToggleFilter}
+hides it (and clears whatever was typed).
+
+| Predicate | Meaning                                | Example                             |
+| --------- | -------------------------------------- | ----------------------------------- |
+| `-name`   | Case-sensitive glob on the file name    | `-name *.rs`                        |
+| `-iname`  | Case-insensitive glob on the file name  | `-iname *.RS`                       |
+| `-size`   | File size                               | `-size 9` (larger than 9 KiB)       |
+| `-mtime`  | Age in whole days                       | `-mtime -7` (modified in last week) |
+| `-mmin`   | Age in whole minutes                    | `-mmin +30` (untouched for 30 min)  |
+
+`+N` means "greater than N" and `-N` means "less than N". Predicates combine
+with AND, and because they are whitespace-separated a glob cannot contain
+spaces.
+
+`-size` is tuned for the common "show me the big files" case and departs from
+`find` twice: its default unit is **KiB**, and an unsigned value means
+**greater than** rather than "equal to". So `-size 9` is the same as
+`-size +9k`, and `-size +1` matches files over 1024 bytes. An explicit unit
+suffix still wins — `c` (bytes), `b` (512-byte blocks), `k`, `M`, `G`.
+
+For `-mtime` and `-mmin` an unsigned value keeps `find`'s "equal to" meaning, so
+`-mtime 7` is "modified 7 days ago", not "older than 7 days".
+
+The predicates apply to **files**. Directories are shown only when they lead to
+a matching file, so `-iname src` matches nothing on its own. While a filter is
+active the tree is searched in full, including directories you have not
+expanded; clearing the filter restores your own expansion state untouched.
+
+The same syntax works in the [project search](./finding-navigating.md#file-metadata-filters)
+filter row.
+
+> Note: files inside a gitignored directory that has never been expanded are not
+> scanned yet, so the filter cannot see them.
+
 ### Hiding Files
 
 - `project_panel.hide_gitignore` hides files matched by `.gitignore`. Toggle


### PR DESCRIPTION
# Objective

Zed can already narrow a project search by path glob, but not by what a file *is* —
its size or how recently it changed. Finding "the big generated files" or "everything I
touched this afternoon" means leaving the editor for `find` or `fd`.

This adds `find(1)`-style metadata predicates to both project search and the project
panel: `-name`, `-iname`, `-size`, `-mtime` and `-mmin`.

No tracked issue — this is a proposal rather than a fix, so there is no `Fixes #X` to
link. Happy to open one first if that is preferred.

## Solution

A single parser, `project::search::MetadataFilters`, backs both call sites so the two
cannot drift apart. Predicates are whitespace-separated and combine with AND:

| Predicate | Meaning                                | Example                             |
| --------- | -------------------------------------- | ----------------------------------- |
| `-name`   | Case-sensitive glob on the file name   | `-name *.rs`                        |
| `-iname`  | Case-insensitive glob on the file name | `-iname *.RS`                       |
| `-size`   | File size                              | `-size 9` (larger than 9 KiB)       |
| `-mtime`  | Age in whole days                      | `-mtime -7` (modified in last week) |
| `-mmin`   | Age in whole minutes                   | `-mmin +30` (untouched for 30 min)  |

Predicates are matched against metadata the worktree scan **already holds**, so they
cost no extra syscalls and prune candidates before any file is read — in project search
the check sits in `handle_scan_path`, ahead of the disk read that looks for a first
match.

**Project search** gets the predicates as their own row in the filter line, rather than
a third slot beside Include/Exclude — the input is free-form text and squeezing three
inputs onto one line would leave none of them legible.

**Project panel** gets a filter input above the tree. Matching is on files; directories
survive only as ancestors of a match. While a filter is active the tree is walked in
full, including collapsed directories, but `expanded_dir_ids` is deliberately left
alone — auto-expanding it would leave the tree blown open once the filter clears.
Collapsing during a filter is recorded in a separate, filter-local set so it is
forgotten when the filter goes away.

Filters cross the wire as the raw string and are re-parsed by the host, so `-mtime` and
`-mmin` age against the same clock the mtimes come from.

### Deliberate departures from `find(1)`, worth a reviewer's opinion

- **`-size` defaults to KiB and to "greater than"**, so `-size 9` means `+9k`. An
  explicit `c`/`b`/`k`/`M`/`G` suffix still wins. This is tuned for the common "show me
  the big files" case; `-mtime`/`-mmin` keep `find`'s "equal to" reading for an unsigned
  value. This is the most arguable decision in the PR — it is `find`-shaped syntax with
  non-`find` semantics, and it is documented in the code, the commit and the user docs.
- **`-name`/`-iname` overlap the existing Include field** in project search (`-name`
  matches the base name, Include matches the whole path). Clearly new capability in the
  panel; arguably redundant in search. Happy to drop them from the search side.

### Open questions I would rather raise than paper over

- **The panel filter input is shown by default and the toggle is not persisted.**
  `project_panel::ToggleFilter` hides it, but the state does not survive a restart and
  there is no default keybinding. If new always-on chrome in a core panel is not
  wanted, say so and I will default it off and/or persist the toggle.
- The filter bar also renders above the "no project open" empty state, where it filters
  nothing.
- **Proto compatibility degrades silently**: a new client talking to an older host drops
  the `metadata_filters` field and gets *unfiltered* results — wrong answers rather than
  an error. Flagging in case version negotiation does not already cover this.
- Known gap: files inside a gitignored directory that has never been expanded are not
  scanned yet, so the panel filter cannot see them.

## Testing

**Automated.** 17 new tests, all passing:

- `crates/project/src/search.rs` — 12 parser unit tests against a fixed clock: every
  size suffix, the unsigned defaults, a malformed-input table, conjunction, an mtime in
  the future (treated as age zero) and an unreadable mtime (rejected by an age filter
  rather than silently passing).
- `crates/project/tests/integration/project_tests.rs` — `test_search_with_metadata_filters`
  covers the project-search path end to end, including that `-size 1` and `-size +1k`
  are the same query.
- `crates/project_panel/src/project_panel_tests.rs` — four tests covering filtering into
  collapsed directories, collapse/expand during a filter via both mouse and keyboard
  (`left`/`right`/collapse-all) leaving `expanded_dir_ids` untouched, and the two-stage
  `escape`.

```
cargo test -p project --lib metadata_filter_tests      # 12 passed
cargo test -p project_panel                            # 118 passed, 0 failed
cargo test -p project --features test-support --test integration \
    test_search_with_metadata_filters                  # 1 passed
```

**What still needs testing — please do not assume this is covered:**

- **I have not run the application.** Everything here is verified by tests and by
  reading. Nothing has been confirmed visually: not the filter bar's appearance in
  light/dark themes, not its behaviour in a narrow sidebar, not the extra row in the
  search bar on a short display.
- **The focus half of the `escape` behaviour is untested.** The panel is never drawn in
  these tests, so its focus handles are not in the dispatch tree and `window.focus` does
  not stick. The two-stage state machine is tested; the requirement it depends on — that
  the first press leaves the cursor in the input, or the `ProjectPanelFilter` key
  context goes with it and the second press never arrives — is reasoned about and
  commented, not verified. This deserves a manual pass.
- Performance on a genuinely large monorepo. The panel's filtered walk visits and
  materialises the whole worktree; it is debounced (150 ms) and yields periodically so a
  superseded walk is actually cancelled, but I have only exercised it on small trees.
- Remote/collab projects. The proto round-trip is implemented and re-parsed host-side
  but has not been exercised against a real host.

**Platforms.** Developed and tested on **Windows 11** only. I cannot test macOS or
Linux. The parser and the panel logic are platform-neutral (paths are keyed through
`as_unix_str()` throughout), and the `escape` binding was added to all three default
keymaps, but the macOS/Linux keymaps are unverified in practice.

**For reviewers**, the quickest way in: open the project panel, type `-iname *.rs -size 9`
into the filter box at the top, and confirm matches appear under directories you never
expanded. Then clear it and confirm your own expansion state is exactly as you left it —
that round trip is the property most of this PR's complexity exists to protect. In
project search, toggle the filters row open and use the third input.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — there are none in this diff
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Leaving the UI box unchecked deliberately: no icons are introduced and the bar uses
theme colours throughout with no hard-coded values, but I have not run the app, so
light/dark appearance and narrow-pane behaviour are unverified — and the two open UI
questions above (default-on chrome, the bar over the empty state) are exactly the kind
of thing that checkbox is asking about.

## Showcase

<img width="1920" height="1369" alt="zed_KMax1u8Hsq" src="https://github.com/user-attachments/assets/8334286b-9323-4472-8483-fd5a7cfda032" />
<img width="965" height="758" alt="zed_7MaTyhiG5u" src="https://github.com/user-attachments/assets/68b8ed07-aab4-47f4-b880-5b230e6cbe98" />


> before this is opened for review: the panel filter narrowing a tree (before/after),
> and the extra metadata row in the project search filter line.

---

Release Notes:

- Added `find(1)`-style file metadata filters (`-name`, `-iname`, `-size`, `-mtime`, `-mmin`) to project search and the project panel.
