### PR TITLE
title_bar: Fix `test-support` feature mismatch

### DIFF
--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -74,6 +74,7 @@ client = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 notifications = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
+recent_projects = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
 remote = { workspace = true, features = ["test-support"] }
 rpc = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Follow-up to #46337, same fix as #48280.

`title_bar` tests enable `remote/test-support`, which adds `RemoteConnectionOptions::Mock`. But without `recent_projects/test-support`, the match arms for that variant aren't compiled, causing a non-exhaustive match error when testing the crate in isolation:

```
error[E0004]: non-exhaustive patterns: `&RemoteConnectionOptions::Mock(_)` not covered
    --> crates/remote_connection/src/remote_connection.rs:233:76
```

CI doesn't catch this because `collab` and `sidebar` enable `recent_projects/test-support` during workspace-wide tests.

Adding `remote_connection/test-support` instead isn't enough — that just moves the same error into `recent_projects`. `recent_projects/test-support` covers both.

Release Notes:

- N/A
