### PR TITLE
gpui_linux(x11): Fix crash when XInput 2 is unavailable

### DIFF
--- a/crates/gpui_linux/src/linux.rs
+++ b/crates/gpui_linux/src/linux.rs
@@ -46,8 +46,12 @@ pub fn current_platform(headless: bool) -> Rc<dyn gpui::Platform> {
         #[cfg(feature = "x11")]
         "X11" => Rc::new(LinuxPlatform {
             inner: X11Client::new()
-                .context("Failed to initialize X11 client.")
-                .unwrap(),
+                .context("Failed to initialize X11 client")
+                .unwrap_or_else(|error| {
+                    log::error!("Zed failed to launch: {error:?}");
+                    eprintln!("Zed failed to launch: {error:#}");
+                    std::process::exit(1);
+                }),
         }),
 
         "Headless" => Rc::new(LinuxPlatform {

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -357,10 +357,13 @@ impl X11Client {
         let xinput_version = get_reply(
             || "XInput XiQueryVersion failed",
             xcb_connection.xinput_xi_query_version(2, 4),
-        )?;
-        assert!(
+        )
+        .context("Failed to initialize XInput 2. Zed requires XInput 2 or newer")?;
+        anyhow::ensure!(
             xinput_version.major_version >= 2,
-            "XInput version >= 2 required."
+            "This X server only supports XInput {}.{}. Zed requires XInput 2 or newer",
+            xinput_version.major_version,
+            xinput_version.minor_version,
         );
         let supports_xinput_gestures = xinput_version.major_version > 2
             || (xinput_version.major_version == 2 && xinput_version.minor_version >= 4);


### PR DESCRIPTION
# Objective

Closes #59972

Zed panics during X11 startup when `XIQueryVersion` fails. This occurs with `x2goagent`, which only exposes XInput 1.3.

## Solution

Report X11 initialization failures and exit with status 1 instead of panicking. The XInput version check now returns an error explaining that Zed requires XInput 2 rather than asserting on the negotiated version.

For X2Go sessions, running Zed under a nested Xephyr display remains a workaround because Xephyr provides XInput 2.

## Testing

- X2Go / XI 1.3: Zed exits with the XInput requirement and no panic or
  backtrace
- Xephyr / XI 2.4 inside the same X2Go session: Zed launches
- Xorg / XI 2.3: Zed launches

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fix panic on the startup when the X server does not support XInput 2, such as x2go.