### PR TITLE
project_panel: Confirm before trashing unsaved file on undo

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -649,6 +649,17 @@ enum RemoveEntryTask {
     Delete(Task<Result<()>>),
 }
 
+struct RemovalPrompt {
+    message: String,
+    detail: Option<&'static str>,
+    confirmation_label: &'static str,
+}
+
+enum RemovalKind {
+    Trash,
+    Delete,
+}
+
 impl ProjectPanel {
     fn new(
         workspace: &mut Workspace,
@@ -2549,6 +2560,74 @@ impl ProjectPanel {
         });
     }
 
+    /// Builds the confirmation prompt shared by direct removal and undo/redo.
+    ///
+    /// The `names` slice must contain every path being removed, and this
+    /// function will apply markdown formatting and display truncation. The
+    /// `dirty_buffers` parameter should be the number of those paths that have
+    /// unsaved changes.
+    fn build_removal_prompt<S>(
+        kind: RemovalKind,
+        names: &[S],
+        dirty_buffers: usize,
+    ) -> RemovalPrompt
+    where
+        S: AsRef<str>,
+    {
+        let (message_start, confirmation_label, detail) = match kind {
+            RemovalKind::Trash => ("Do you want to trash", "Trash", None),
+            RemovalKind::Delete => (
+                "Are you sure you want to permanently delete",
+                "Delete",
+                Some("This cannot be undone."),
+            ),
+        };
+
+        let mut message = match names {
+            [name] => format!("{message_start} {}?", MarkdownInlineCode(name.as_ref())),
+            _ => {
+                const CUTOFF_POINT: usize = 10;
+                let mut listed_names = names
+                    .iter()
+                    .take(CUTOFF_POINT)
+                    .map(|name| MarkdownInlineCode(name.as_ref()).to_string())
+                    .collect::<Vec<_>>();
+                let omitted_count = names.len().saturating_sub(CUTOFF_POINT);
+                if omitted_count == 1 {
+                    listed_names.push(".. 1 file not shown".into());
+                } else if omitted_count > 1 {
+                    listed_names.push(format!(".. {omitted_count} files not shown"));
+                }
+
+                format!(
+                    "{message_start} the following {} files?\n{}",
+                    names.len(),
+                    listed_names.join("\n")
+                )
+            }
+        };
+        match dirty_buffers {
+            0 => {}
+            1 if names.len() == 1 => {
+                message.push_str("\n\nIt has unsaved changes, which will be lost.");
+            }
+            1 => {
+                message.push_str("\n\n1 of these has unsaved changes, which will be lost.");
+            }
+            dirty_buffers => {
+                message.push_str(&format!(
+                    "\n\n{dirty_buffers} of these have unsaved changes, which will be lost."
+                ));
+            }
+        }
+
+        RemovalPrompt {
+            message,
+            detail,
+            confirmation_label,
+        }
+    }
+
     // TODO(yara|dino): trashing and deleting are conceptually distinct, even
     // more so with the fact that trashing can now be undone, whereas deleting
     // cannot.
@@ -2587,70 +2666,24 @@ impl ProjectPanel {
                 return None;
             }
             let answer = if !skip_prompt {
-                let operation = if trash { "Trash" } else { "Delete" };
-                let message_start = if trash {
-                    "Do you want to trash"
+                let names = file_paths
+                    .iter()
+                    .map(|(_, _, name)| name.as_str())
+                    .collect::<Vec<_>>();
+
+                let removal_kind = if trash {
+                    RemovalKind::Trash
                 } else {
-                    "Are you sure you want to permanently delete"
+                    RemovalKind::Delete
                 };
-                let prompt = match file_paths.first() {
-                    Some((_, _, path)) if file_paths.len() == 1 => {
-                        let unsaved_warning = if dirty_buffers > 0 {
-                            "\n\nIt has unsaved changes, which will be lost."
-                        } else {
-                            ""
-                        };
 
-                        format!(
-                            "{message_start} {}?{unsaved_warning}",
-                            MarkdownInlineCode(path)
-                        )
-                    }
-                    _ => {
-                        const CUTOFF_POINT: usize = 10;
-                        let names = if file_paths.len() > CUTOFF_POINT {
-                            let truncated_path_counts = file_paths.len() - CUTOFF_POINT;
-                            let mut paths = file_paths
-                                .iter()
-                                .map(|(_, _, path)| MarkdownInlineCode(path).to_string())
-                                .take(CUTOFF_POINT)
-                                .collect::<Vec<String>>();
-                            paths.truncate(CUTOFF_POINT);
-                            if truncated_path_counts == 1 {
-                                paths.push(".. 1 file not shown".into());
-                            } else {
-                                paths.push(format!(".. {} files not shown", truncated_path_counts));
-                            }
-                            paths
-                        } else {
-                            file_paths
-                                .iter()
-                                .map(|(_, _, path)| MarkdownInlineCode(path).to_string())
-                                .collect()
-                        };
-                        let unsaved_warning = if dirty_buffers == 0 {
-                            String::new()
-                        } else if dirty_buffers == 1 {
-                            "\n\n1 of these has unsaved changes, which will be lost.".to_string()
-                        } else {
-                            format!(
-                                "\n\n{dirty_buffers} of these have unsaved changes, which will be lost."
-                            )
-                        };
+                let prompt = Self::build_removal_prompt(removal_kind, &names, dirty_buffers);
 
-                        format!(
-                            "{message_start} the following {} files?\n{}{unsaved_warning}",
-                            file_paths.len(),
-                            names.join("\n")
-                        )
-                    }
-                };
-                let detail = (!trash).then_some("This cannot be undone.");
                 Some(window.prompt(
                     PromptLevel::Info,
-                    &prompt,
-                    detail,
-                    &[operation, "Cancel"],
+                    &prompt.message,
+                    prompt.detail,
+                    &[prompt.confirmation_label, "Cancel"],
                     cx,
                 ))
             } else {

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -51,6 +51,7 @@ impl TestContext {
         });
         self.cx.run_until_parked();
     }
+
     async fn redo(&mut self) {
         self.panel.update_in(&mut self.cx, |panel, window, cx| {
             panel.redo(&Redo, window, cx);
@@ -58,7 +59,19 @@ impl TestContext {
         self.cx.run_until_parked();
     }
 
+    #[track_caller]
+    fn answer(&self, answer: &str) {
+        assert!(
+            self.cx.cx.has_pending_prompt(),
+            "should have pending prompt"
+        );
+
+        self.cx.cx.simulate_prompt_answer(answer);
+        self.cx.run_until_parked();
+    }
+
     /// Note this only works when every file has an extension
+    #[track_caller]
     fn assert_fs_state_is(&mut self, state: &[&str]) {
         let state: HashSet<_> = state
             .into_iter()
@@ -95,6 +108,7 @@ impl TestContext {
         );
     }
 
+    #[track_caller]
     fn assert_not_exists(&mut self, file: &str) {
         assert_eq!(
             find_project_entry(&self.panel, &format!("workspace/{file}"), &mut self.cx),
@@ -232,6 +246,7 @@ impl TestContext {
 
     async fn new_with_tree(cx: &mut gpui::TestAppContext, tree: Value) -> TestContext {
         project_panel_tests::init_test(cx);
+        cx.update(register_project_item::<Editor>);
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree("/workspace", tree).await;
@@ -288,6 +303,7 @@ async fn create_undo_redo(cx: &mut gpui::TestAppContext) {
     cx.fs.write(Path::new(&path), b"Hello!").await.unwrap();
 
     cx.undo().await;
+    cx.answer("Trash");
     cx.assert_not_exists("c.txt");
 
     cx.redo().await;
@@ -298,7 +314,6 @@ async fn create_undo_redo(cx: &mut gpui::TestAppContext) {
 #[gpui::test]
 async fn undo_create_prompts_before_trashing_dirty_file(cx: &mut gpui::TestAppContext) {
     let mut cx = TestContext::new(cx).await;
-    cx.update_app(|cx| register_project_item::<Editor>(cx));
 
     cx.create_file("c.txt").await;
     let workspace = cx
@@ -340,6 +355,7 @@ async fn create_dir_undo(cx: &mut gpui::TestAppContext) {
     cx.create_directory("new_dir").await;
     cx.assert_exists("new_dir");
     cx.undo().await;
+    cx.answer("Trash");
     cx.assert_not_exists("new_dir");
 }
 
@@ -404,6 +420,7 @@ async fn two_sequential_undos(cx: &mut gpui::TestAppContext) {
     cx.assert_fs_state_is(&["b.txt", "x.txt", "y.txt"]);
 
     cx.undo().await;
+    cx.answer("Trash");
     cx.assert_fs_state_is(&["b.txt", "x.txt"]);
 
     cx.undo().await;
@@ -431,6 +448,8 @@ async fn trash_undo_redo(cx: &mut gpui::TestAppContext) {
     cx.assert_fs_state_is(&["a.txt", "b.txt"]);
 
     cx.redo().await;
+    cx.answer("Trash");
+    cx.answer("Trash");
     cx.assert_fs_state_is(&[]);
 }
 
@@ -462,6 +481,7 @@ async fn trash_directory_undo_redo(cx: &mut gpui::TestAppContext) {
     );
 
     cx.redo().await;
+    cx.answer("Trash");
     cx.assert_fs_state_is(&["a.txt"]);
 }
 

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -316,35 +316,31 @@ async fn undo_create_prompts_before_trashing_dirty_file(cx: &mut gpui::TestAppCo
     let mut cx = TestContext::new(cx).await;
 
     cx.create_file("c.txt").await;
-    let workspace = cx
+
+    // After `c.txt` is created, it should now be open in the editor, so we'll
+    // simulate inserting some content into the file, without saving, in order
+    // to make it dirty.
+    let editor = cx
         .panel
         .read_with(&cx.cx, |panel, _| panel.workspace.upgrade())
-        .expect("workspace should still exist");
-    let editor = workspace
+        .expect("workspace should still exist")
         .read_with(&cx.cx, |workspace, cx| {
             workspace.active_item_as::<Editor>(cx)
         })
         .expect("created file should be open in an editor");
+
     editor.update_in(&mut cx.cx, |editor, window, cx| {
         editor.handle_input("unsaved changes", window, cx);
     });
     assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
 
-    cx.panel.update_in(&mut cx.cx, |panel, window, cx| {
-        panel.undo(&Undo, window, cx);
-    });
-    cx.cx.run_until_parked();
-    cx.cx.simulate_prompt_answer("Cancel");
-    cx.cx.run_until_parked();
+    cx.undo().await;
+    cx.answer("Cancel");
     cx.assert_exists("c.txt");
     assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
 
-    cx.panel.update_in(&mut cx.cx, |panel, window, cx| {
-        panel.undo(&Undo, window, cx);
-    });
-    cx.cx.run_until_parked();
-    cx.cx.simulate_prompt_answer("Don't Save");
-    cx.cx.run_until_parked();
+    cx.undo().await;
+    cx.answer("Don't Save");
     cx.assert_not_exists("c.txt");
 }
 

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -2,6 +2,7 @@
 
 use client::proto;
 use collections::HashSet;
+use editor::Editor;
 use fs::{FakeFs, Fs};
 use gpui::{App, BorrowAppContext, Entity, VisualTestContext};
 use project::Project;
@@ -9,7 +10,7 @@ use serde_json::{Value, json};
 use settings::SettingsStore;
 use std::path::Path;
 use std::sync::Arc;
-use workspace::{MultiWorkspace, register_project_item};
+use workspace::{Item, MultiWorkspace, register_project_item};
 
 use crate::project_panel_tests::{self, TestProjectItemView, find_project_entry, select_path};
 use crate::{NewDirectory, NewFile, ProjectPanel, Redo, Rename, Trash, Undo};
@@ -292,6 +293,44 @@ async fn create_undo_redo(cx: &mut gpui::TestAppContext) {
     cx.redo().await;
     cx.assert_exists("c.txt");
     assert_eq!(cx.fs.load(Path::new(&path)).await.unwrap(), "Hello!");
+}
+
+#[gpui::test]
+async fn undo_create_prompts_before_trashing_dirty_file(cx: &mut gpui::TestAppContext) {
+    let mut cx = TestContext::new(cx).await;
+    cx.update_app(|cx| register_project_item::<Editor>(cx));
+
+    cx.create_file("c.txt").await;
+    let workspace = cx
+        .panel
+        .read_with(&cx.cx, |panel, _| panel.workspace.upgrade())
+        .expect("workspace should still exist");
+    let editor = workspace
+        .read_with(&cx.cx, |workspace, cx| {
+            workspace.active_item_as::<Editor>(cx)
+        })
+        .expect("created file should be open in an editor");
+    editor.update_in(&mut cx.cx, |editor, window, cx| {
+        editor.handle_input("unsaved changes", window, cx);
+    });
+    assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
+
+    cx.panel.update_in(&mut cx.cx, |panel, window, cx| {
+        panel.undo(&Undo, window, cx);
+    });
+    cx.cx.run_until_parked();
+    cx.cx.simulate_prompt_answer("Cancel");
+    cx.cx.run_until_parked();
+    cx.assert_exists("c.txt");
+    assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
+
+    cx.panel.update_in(&mut cx.cx, |panel, window, cx| {
+        panel.undo(&Undo, window, cx);
+    });
+    cx.cx.run_until_parked();
+    cx.cx.simulate_prompt_answer("Don't Save");
+    cx.cx.run_until_parked();
+    cx.assert_not_exists("c.txt");
 }
 
 #[gpui::test]

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -312,7 +312,22 @@ async fn create_undo_redo(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
-async fn undo_create_prompts_before_trashing_dirty_file(cx: &mut gpui::TestAppContext) {
+async fn undo_create_cancel_trash(cx: &mut gpui::TestAppContext) {
+    let mut cx = TestContext::new(cx).await;
+
+    cx.create_file("c.txt").await;
+
+    cx.undo().await;
+    cx.answer("Cancel");
+    cx.assert_exists("c.txt");
+
+    cx.undo().await;
+    cx.answer("Trash");
+    cx.assert_not_exists("c.txt");
+}
+
+#[gpui::test]
+async fn undo_create_dirty_file(cx: &mut gpui::TestAppContext) {
     let mut cx = TestContext::new(cx).await;
 
     cx.create_file("c.txt").await;

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -4,7 +4,7 @@ use client::proto;
 use collections::HashSet;
 use editor::Editor;
 use fs::{FakeFs, Fs};
-use gpui::{App, BorrowAppContext, Entity, VisualTestContext};
+use gpui::{App, BorrowAppContext, Context, Entity, VisualTestContext, Window};
 use project::Project;
 use serde_json::{Value, json};
 use settings::SettingsStore;
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use workspace::{Item, MultiWorkspace, register_project_item};
 
 use crate::project_panel_tests::{self, TestProjectItemView, find_project_entry, select_path};
-use crate::{NewDirectory, NewFile, ProjectPanel, Redo, Rename, Trash, Undo};
+use crate::{NewDirectory, NewFile, Open, ProjectPanel, Redo, Rename, Trash, Undo};
 
 struct TestContext {
     panel: Entity<ProjectPanel>,
@@ -57,6 +57,27 @@ impl TestContext {
             panel.redo(&Redo, window, cx);
         });
         self.cx.run_until_parked();
+    }
+
+    fn open_path(&mut self, path: &str) {
+        select_path(&self.panel, &format!("workspace/{path}"), &mut self.cx);
+        self.panel.update_in(&mut self.cx, |panel, window, cx| {
+            panel.open(&Open, window, cx)
+        });
+        self.cx.run_until_parked();
+    }
+
+    #[track_caller]
+    fn assert_prompt(&self, expected: &str) {
+        let (prompt, _) = self
+            .cx
+            .cx
+            .pending_prompt()
+            .expect("should have pending prompt");
+        assert!(
+            prompt.contains(expected),
+            "expected prompt to contain {expected:?}, got {prompt:?}"
+        );
     }
 
     #[track_caller]
@@ -272,6 +293,23 @@ impl TestContext {
     fn update_app<R>(&mut self, update: impl FnOnce(&mut App) -> R) -> R {
         self.cx.cx.update(update)
     }
+
+    #[track_caller]
+    fn update_active_editor<R>(
+        &mut self,
+        update: impl FnOnce(&mut Editor, &mut Window, &mut Context<'_, Editor>) -> R,
+    ) -> R {
+        let editor = self
+            .panel
+            .read_with(&self.cx, |panel, _| panel.workspace.upgrade())
+            .expect("workspace should still exist")
+            .read_with(&self.cx, |workspace, cx| {
+                workspace.active_item_as::<Editor>(cx)
+            })
+            .expect("editor should be open");
+
+        editor.update_in(&mut self.cx, update)
+    }
 }
 
 #[gpui::test]
@@ -335,24 +373,15 @@ async fn undo_create_dirty_file(cx: &mut gpui::TestAppContext) {
     // After `c.txt` is created, it should now be open in the editor, so we'll
     // simulate inserting some content into the file, without saving, in order
     // to make it dirty.
-    let editor = cx
-        .panel
-        .read_with(&cx.cx, |panel, _| panel.workspace.upgrade())
-        .expect("workspace should still exist")
-        .read_with(&cx.cx, |workspace, cx| {
-            workspace.active_item_as::<Editor>(cx)
-        })
-        .expect("created file should be open in an editor");
-
-    editor.update_in(&mut cx.cx, |editor, window, cx| {
+    cx.update_active_editor(|editor, window, cx| {
         editor.handle_input("unsaved changes", window, cx);
+        assert!(editor.is_dirty(cx));
     });
-    assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
 
     cx.undo().await;
     cx.answer("Cancel");
     cx.assert_exists("c.txt");
-    assert!(editor.read_with(&cx.cx, |editor, cx| editor.is_dirty(cx)));
+    cx.update_active_editor(|editor, _window, cx| assert!(editor.is_dirty(cx)));
 
     cx.undo().await;
     cx.answer("Don't Save");
@@ -459,7 +488,6 @@ async fn trash_undo_redo(cx: &mut gpui::TestAppContext) {
     cx.assert_fs_state_is(&["a.txt", "b.txt"]);
 
     cx.redo().await;
-    cx.answer("Trash");
     cx.answer("Trash");
     cx.assert_fs_state_is(&[]);
 }
@@ -612,4 +640,42 @@ async fn excluded_create_is_not_recorded(cx: &mut gpui::TestAppContext) {
 
     cx.undo().await;
     cx.assert_fs_state_is(&["a.txt", "token.secret", "banana.secret"]);
+}
+
+#[gpui::test]
+async fn cancel_partial_trash_batch(cx: &mut gpui::TestAppContext) {
+    let mut cx = TestContext::new(cx).await;
+
+    cx.trash(&["a.txt", "b.txt"]).await;
+    cx.undo().await;
+    cx.assert_fs_state_is(&["a.txt", "b.txt"]);
+
+    cx.redo().await;
+    cx.answer("Cancel");
+    cx.assert_fs_state_is(&["a.txt", "b.txt"]);
+
+    cx.redo().await;
+    cx.answer("Trash");
+    cx.assert_fs_state_is(&[]);
+}
+
+#[gpui::test]
+async fn batch_trash_warns_about_unsaved_changes(cx: &mut gpui::TestAppContext) {
+    let mut cx = TestContext::new(cx).await;
+
+    cx.trash(&["a.txt", "b.txt"]).await;
+    cx.undo().await;
+    cx.assert_fs_state_is(&["a.txt", "b.txt"]);
+
+    cx.open_path("a.txt");
+    cx.update_active_editor(|editor, window, cx| {
+        editor.handle_input("unsaved changes", window, cx);
+    });
+
+    cx.redo().await;
+    cx.assert_prompt("1 of these has unsaved changes, which will be lost.");
+
+    cx.answer("Cancel");
+    cx.assert_fs_state_is(&["a.txt", "b.txt"]);
+    cx.update_active_editor(|editor, _window, cx| assert!(editor.is_dirty(cx)));
 }

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -157,17 +157,15 @@ enum Operation {
     Batch(Vec<Operation>),
 }
 
-enum OperationOutcome {
-    Changed(Change),
-    Cancelled(Operation),
-}
-
 impl Operation {
-    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<OperationOutcome> {
-        Ok(OperationOutcome::Changed(match self {
+    /// Attempts to execute the operation, returning an `Err` if the operation
+    /// failed to execute or `Ok(None)` if the operation was cancelled by the
+    /// user, for example, cancelling trashing a file with unsaved edits.
+    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<Option<Change>> {
+        let change = match self {
             Operation::Trash(project_path) => {
                 let Some(trash_id) = undo_manager.trash(&project_path, cx).await? else {
-                    return Ok(OperationOutcome::Cancelled(Operation::Trash(project_path)));
+                    return Ok(None);
                 };
                 Change::Trashed(project_path.worktree_id, trash_id)
             }
@@ -180,21 +178,21 @@ impl Operation {
                 Change::Restored(project_path)
             }
             Operation::Batch(operations) => {
-                let mut res = Vec::new();
-                let mut operations = operations.into_iter();
-                while let Some(operation) = operations.next() {
-                    match Box::pin(operation.execute(undo_manager, cx)).await? {
-                        OperationOutcome::Changed(change) => res.push(change),
-                        OperationOutcome::Cancelled(operation) => {
-                            return Ok(OperationOutcome::Cancelled(Operation::Batch(
-                                std::iter::once(operation).chain(operations).collect(),
-                            )));
-                        }
-                    }
+                let mut changes = Vec::new();
+
+                for operation in operations {
+                    let Some(change) = Box::pin(operation.execute(undo_manager, cx)).await? else {
+                        return Ok(None);
+                    };
+
+                    changes.push(change);
                 }
-                Change::Batched(res)
+
+                Change::Batched(changes)
             }
-        }))
+        };
+
+        Ok(Some(change))
     }
 }
 
@@ -464,20 +462,17 @@ impl Inner {
         // manual intervention would likely be needed in order to undo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let change = self
-            .history
-            .remove(before_cursor)
-            .expect("we can undo");
+        let change = self.history.remove(before_cursor).expect("we can undo");
         let operation = change.clone().to_inverse();
+
         match operation.execute(self, cx).await? {
-            OperationOutcome::Changed(undo_change) => {
-                self.history.insert(before_cursor, undo_change);
-            }
-            OperationOutcome::Cancelled(_) => {
+            Some(undo_change) => self.history.insert(before_cursor, undo_change),
+            None => {
                 self.history.insert(before_cursor, change);
                 self.cursor += 1;
             }
-        }
+        };
+
         Ok(())
     }
 
@@ -490,19 +485,14 @@ impl Inner {
         // manual intervention would likely be needed in order to redo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let change = self
-            .history
-            .remove(self.cursor)
-            .expect("we can redo");
+        let change = self.history.remove(self.cursor).expect("we can redo");
         let operation = change.clone().to_inverse();
         match operation.execute(self, cx).await? {
-            OperationOutcome::Changed(redo_change) => {
+            Some(redo_change) => {
                 self.history.insert(self.cursor, redo_change);
                 self.cursor += 1;
             }
-            OperationOutcome::Cancelled(_) => {
-                self.history.insert(self.cursor, change);
-            }
+            None => self.history.insert(self.cursor, change),
         }
         Ok(())
     }
@@ -595,6 +585,12 @@ impl Inner {
         })
     }
 
+    /// Trashes the specified `project_path`.
+    ///
+    /// In case the `project_path` has unsaved changes, the user will be
+    /// prompted on whether they'd like to save these changes, as well as
+    /// providing an option to just cancel the trashing, in which case,
+    /// `Ok(None)` is returned.
     async fn trash(
         &self,
         project_path: &ProjectPath,

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -588,12 +588,11 @@ impl Inner {
         })
     }
 
-    /// Trashes the specified `project_path`.
+    /// Trashes the specified `project_path` after prompting the user for
+    /// confirmation. If the path has unsaved changes, the prompt also lets the
+    /// user save or discard them.
     ///
-    /// In case the `project_path` has unsaved changes, the user will be
-    /// prompted on whether they'd like to save these changes, as well as
-    /// providing an option to just cancel the trashing, in which case,
-    /// `Ok(None)` is returned.
+    /// Returns `Ok(None)` if the user cancels the operation.
     async fn trash(
         &self,
         project_path: &ProjectPath,
@@ -776,12 +775,7 @@ impl Inner {
             .update_in(cx, |_panel, window, cx| {
                 window.prompt(
                     PromptLevel::Info,
-                    &format!(
-                        // TODO!: Can't just call out "Undoing" here, as this will also get
-                        // called when "Redoing" a trash operation.
-                        "Undoing will move {} to the trash. Do you want to proceed?",
-                        MarkdownInlineCode(name)
-                    ),
+                    &format!("Do you want to trash {}?", MarkdownInlineCode(name)),
                     None,
                     &["Trash", "Cancel"],
                     cx,

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -135,7 +135,7 @@ use anyhow::{Context, Result, anyhow};
 use fs::{TrashId, TrashRestoreError};
 use futures::channel::mpsc;
 use gpui::{
-    AppContext, AsyncApp, IntoElement, PromptLevel, SharedString, Styled, Task, WeakEntity,
+    AppContext, AsyncApp, Entity, IntoElement, PromptLevel, SharedString, Styled, Task, WeakEntity,
 };
 use markdown::{Markdown, MarkdownElement};
 use project::Project;
@@ -603,50 +603,17 @@ impl Inner {
             return Err(anyhow!("Failed to obtain workspace."));
         };
 
-        let (name, open_item) = workspace.update(cx, |workspace, cx| {
+        let name = workspace.update(cx, |workspace, cx| {
             let project = workspace.project().read(cx);
             let path_style = project.path_style(cx);
 
-            let open_item = workspace.panes().iter().find_map(|pane| {
-                pane.read(cx).items().find_map(|item| {
-                    (item.is_dirty(cx)
-                        && item
-                            .project_path(cx)
-                            .iter()
-                            .any(|item_path| item_path == project_path))
-                    .then(|| (pane.clone(), item.boxed_clone()))
-                })
-            });
-
-            (
-                project_path_display(project, project_path, path_style, cx),
-                open_item,
-            )
+            project_path_display(project, project_path, path_style, cx)
         });
 
-        let window_handles = cx.update(|cx| cx.windows());
-        let mut async_window_cx = window_handles
-            .into_iter()
-            .find_map(|window_handle| {
-                cx.update_window(window_handle, |_, window, cx| window.to_async(cx))
-                    .ok()
-            })
-            .with_context(|| format!("Failed to prompt before trashing `{name}`."))?;
-
-        if let Some((pane, item)) = open_item {
-            let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
-            if !Pane::save_item(
-                project,
-                pane,
-                item.as_ref(),
-                SaveIntent::Close,
-                &mut async_window_cx,
-            )
+        if !self
+            .confirm_trash(project_path, &name, &workspace, cx)
             .await?
-            {
-                return Ok(None);
-            }
-        } else if !self.trash_prompt(&name, cx).await? {
+        {
             return Ok(None);
         }
 
@@ -751,6 +718,52 @@ impl Inner {
                 })
             })
             .ok();
+    }
+
+    /// Prompts the user to confirm whether they really want to trash the file.
+    /// In the case the file has unsaved changes, the prompt will ask whether
+    /// the user wants to save or discard these changes.
+    ///
+    /// Returns `true` if the user confirmed they want to trash the file,
+    /// `false` otherwise.
+    async fn confirm_trash(
+        &self,
+        project_path: &ProjectPath,
+        name: &str,
+        workspace: &Entity<Workspace>,
+        cx: &mut AsyncApp,
+    ) -> Result<bool> {
+        let open_item = workspace.update(cx, |workspace, cx| {
+            workspace.panes().iter().find_map(|pane| {
+                pane.read(cx).items().find_map(|item| {
+                    (item.is_dirty(cx)
+                        && item
+                            .project_path(cx)
+                            .iter()
+                            .any(|item_path| item_path == project_path))
+                    .then(|| (pane.clone(), item.boxed_clone()))
+                })
+            })
+        });
+
+        let Some((pane, item)) = open_item else {
+            return self.trash_prompt(name, cx).await;
+        };
+        let mut async_window_cx = self
+            .panel
+            .update_in(cx, |_panel, window, cx| window.to_async(cx))?;
+        let project = self
+            .panel
+            .read_with(cx, |panel, _cx| panel.project.clone())?;
+
+        Pane::save_item(
+            project,
+            pane,
+            item.as_ref(),
+            SaveIntent::Close,
+            &mut async_window_cx,
+        )
+        .await
     }
 
     /// Prompts the user to confirm whether they actually want to trash the

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -135,7 +135,7 @@ use anyhow::{Context, Result, anyhow};
 use fs::{TrashId, TrashRestoreError};
 use futures::channel::mpsc;
 use gpui::{
-    AppContext, AsyncApp, Entity, IntoElement, PromptLevel, SharedString, Styled, Task, WeakEntity,
+    AppContext, AsyncApp, IntoElement, PromptLevel, SharedString, Styled, Task, WeakEntity,
 };
 use markdown::{Markdown, MarkdownElement};
 use project::Project;
@@ -172,6 +172,54 @@ impl Operation {
                 };
                 Change::Trashed(project_path.worktree_id, trash_id)
             }
+            Operation::Batch(operations) => {
+                let mut trash_paths = Vec::new();
+
+                for operation in &operations {
+                    operation.trash_paths(&mut trash_paths);
+                }
+
+                if !trash_paths.is_empty()
+                    && !undo_manager.confirm_batch_trash(trash_paths, cx).await?
+                {
+                    return Ok(None);
+                }
+
+                let mut changes = Vec::new();
+
+                for operation in operations {
+                    changes.push(Box::pin(operation.execute_confirmed(undo_manager, cx)).await?);
+                }
+
+                Change::Batched(changes)
+            }
+            operation => {
+                return operation
+                    .execute_confirmed(undo_manager, cx)
+                    .await
+                    .map(Some);
+            }
+        };
+
+        Ok(Some(change))
+    }
+
+    /// Same as [`Self::execute`], but assumes the operation has already been
+    /// confirmed in order to avoid showing confirmation modals to the user.
+    ///
+    /// Useful in scenarios where undoing a batch of operations would lead to
+    /// multiple files being trashed, in which case we only ask the user once
+    /// whether they'd like to trash the files, and then execute each trash
+    /// operation without confirming each file one by one.
+    async fn execute_confirmed(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<Change> {
+        let change = match self {
+            Operation::Trash(project_path) => {
+                let trash_id = undo_manager
+                    .trash_without_confirmation(&project_path, cx)
+                    .await?;
+
+                Change::Trashed(project_path.worktree_id, trash_id)
+            }
             Operation::Rename(from, to) => {
                 undo_manager.rename(&from, &to, cx).await?;
                 Change::Renamed(from, to)
@@ -184,18 +232,26 @@ impl Operation {
                 let mut changes = Vec::new();
 
                 for operation in operations {
-                    let Some(change) = Box::pin(operation.execute(undo_manager, cx)).await? else {
-                        return Ok(None);
-                    };
-
-                    changes.push(change);
+                    changes.push(Box::pin(operation.execute_confirmed(undo_manager, cx)).await?);
                 }
 
                 Change::Batched(changes)
             }
         };
 
-        Ok(Some(change))
+        Ok(change)
+    }
+
+    fn trash_paths<'a>(&'a self, paths: &mut Vec<&'a ProjectPath>) {
+        match self {
+            Operation::Trash(path) => paths.push(path),
+            Operation::Batch(operations) => {
+                for operation in operations {
+                    operation.trash_paths(paths);
+                }
+            }
+            Operation::Rename(..) | Operation::Restore(..) => {}
+        }
     }
 }
 
@@ -609,12 +665,32 @@ impl Inner {
             project_path_display(project, project_path, path_style, cx)
         });
 
-        if !self
-            .confirm_trash(project_path, &name, &workspace, cx)
-            .await?
-        {
+        if !self.confirm_trash(project_path, &name, cx).await? {
             return Ok(None);
         }
+
+        self.trash_without_confirmation(project_path, cx)
+            .await
+            .map(Some)
+    }
+
+    /// Same as [`Self::trash`] but proceeds without confirming if the user
+    /// wishes to trash the file.
+    async fn trash_without_confirmation(
+        &self,
+        project_path: &ProjectPath,
+        cx: &mut AsyncApp,
+    ) -> Result<TrashId> {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return Err(anyhow!("Failed to obtain workspace."));
+        };
+
+        let name = workspace.update(cx, |workspace, cx| {
+            let project = workspace.project().read(cx);
+            let path_style = project.path_style(cx);
+
+            project_path_display(project, project_path, path_style, cx)
+        });
 
         let task = workspace.update(cx, |workspace, cx| {
             workspace.project().update(cx, |project, cx| {
@@ -630,7 +706,7 @@ impl Inner {
         })?;
 
         match task.await {
-            Ok(trash_id) => Ok(Some(trash_id)),
+            Ok(trash_id) => Ok(trash_id),
             Err(err) => Err(err).context(format!("Failed to trash `{name}`.")),
         }
     }
@@ -729,10 +805,9 @@ impl Inner {
         &self,
         project_path: &ProjectPath,
         name: &str,
-        workspace: &Entity<Workspace>,
         cx: &mut AsyncApp,
     ) -> Result<bool> {
-        let open_item = workspace.update(cx, |workspace, cx| {
+        let open_item = self.workspace.update(cx, |workspace, cx| {
             workspace.panes().iter().find_map(|pane| {
                 pane.read(cx).items().find_map(|item| {
                     (item.is_dirty(cx)
@@ -743,11 +818,12 @@ impl Inner {
                     .then(|| (pane.clone(), item.boxed_clone()))
                 })
             })
-        });
+        })?;
 
         let Some((pane, item)) = open_item else {
-            return self.trash_prompt(name, cx).await;
+            return self.trash_prompt(&[name], 0, cx).await;
         };
+
         let mut async_window_cx = self
             .panel
             .update_in(cx, |_panel, window, cx| window.to_async(cx))?;
@@ -765,21 +841,95 @@ impl Inner {
         .await
     }
 
+    /// Prompts the user to confirm whether they really want to trash all of the
+    /// provided `trash_paths`.
+    ///
+    /// Meant to be used when executing a batch of operations that will lead to
+    /// one or more paths being trashed.
+    ///
+    /// Returns `true` if the user confirmed they want to trash the files,
+    /// `false` otherwise.
+    async fn confirm_batch_trash(
+        &self,
+        trash_paths: Vec<&ProjectPath>,
+        cx: &mut AsyncApp,
+    ) -> Result<bool> {
+        let (names, dirty_buffers) = self.workspace.update(cx, |workspace, cx| {
+            let project = workspace.project().read(cx);
+            let path_style = project.path_style(cx);
+            let dirty_buffers = project
+                .dirty_buffers(cx)
+                .filter(|dirty_path| trash_paths.contains(&dirty_path))
+                .count();
+            let names = trash_paths
+                .iter()
+                .map(|project_path| project_path_display(project, project_path, path_style, cx))
+                .collect::<Vec<_>>();
+
+            (names, dirty_buffers)
+        })?;
+
+        self.trash_prompt(&names, dirty_buffers, cx).await
+    }
+
     /// Prompts the user to confirm whether they actually want to trash the
     /// file.
     ///
     /// Returns `true` if the user confirms, `false` otherwise.
-    async fn trash_prompt(&self, name: &str, cx: &mut AsyncApp) -> Result<bool> {
+    async fn trash_prompt<S>(
+        &self,
+        names: &[S],
+        dirty_buffers: usize,
+        cx: &mut AsyncApp,
+    ) -> Result<bool>
+    where
+        S: AsRef<str>,
+    {
+        let mut prompt = match names {
+            [name] => format!(
+                "Do you want to trash {}?",
+                MarkdownInlineCode(name.as_ref())
+            ),
+            _ => {
+                const CUTOFF_POINT: usize = 10;
+                let mut listed_names = names
+                    .iter()
+                    .take(CUTOFF_POINT)
+                    .map(|name| MarkdownInlineCode(name.as_ref()).to_string())
+                    .collect::<Vec<_>>();
+                let omitted_count = names.len().saturating_sub(CUTOFF_POINT);
+                if omitted_count == 1 {
+                    listed_names.push(".. 1 file not shown".into());
+                } else if omitted_count > 1 {
+                    listed_names.push(format!(".. {omitted_count} files not shown"));
+                }
+
+                format!(
+                    "Do you want to trash {} files?\n{}",
+                    names.len(),
+                    listed_names.join("\n")
+                )
+            }
+        };
+        match dirty_buffers {
+            0 => {}
+            1 if names.len() == 1 => {
+                prompt.push_str("\n\nIt has unsaved changes, which will be lost.");
+            }
+            1 => {
+                prompt.push_str("\n\n1 of these has unsaved changes, which will be lost.");
+            }
+            dirty_buffers => {
+                prompt.push_str(&format!(
+                    "\n\n{dirty_buffers} of these have unsaved changes, which will be lost."
+                ));
+            }
+        }
+
         let answer = self
             .panel
             .update_in(cx, |_panel, window, cx| {
-                window.prompt(
-                    PromptLevel::Info,
-                    &format!("Do you want to trash {}?", MarkdownInlineCode(name)),
-                    None,
-                    &["Trash", "Cancel"],
-                    cx,
-                )
+                window.prompt(PromptLevel::Info, &prompt, None, &["Trash", "Cancel"], cx)
             })?
             .await?;
 

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -130,7 +130,7 @@
 
 //! List of "tainted files" that the user may not operate on
 
-use crate::ProjectPanel;
+use crate::{ProjectPanel, RemovalKind};
 use anyhow::{Context, Result, anyhow};
 use fs::{TrashId, TrashRestoreError};
 use futures::channel::mpsc;
@@ -143,7 +143,6 @@ use project::{ProjectPath, WorktreeId};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::VecDeque, sync::Arc};
 use ui::{App, TextSize};
-use util::markdown::MarkdownInlineCode;
 use util::{paths::PathStyle, rel_path::RelPath};
 use workspace::{
     Pane, SaveIntent, Workspace,
@@ -885,57 +884,20 @@ impl Inner {
     where
         S: AsRef<str>,
     {
-        let mut prompt = match names {
-            [name] => format!(
-                "Do you want to trash {}?",
-                MarkdownInlineCode(name.as_ref())
-            ),
-            _ => {
-                const CUTOFF_POINT: usize = 10;
-                let mut listed_names = names
-                    .iter()
-                    .take(CUTOFF_POINT)
-                    .map(|name| MarkdownInlineCode(name.as_ref()).to_string())
-                    .collect::<Vec<_>>();
-                let omitted_count = names.len().saturating_sub(CUTOFF_POINT);
-                if omitted_count == 1 {
-                    listed_names.push(".. 1 file not shown".into());
-                } else if omitted_count > 1 {
-                    listed_names.push(format!(".. {omitted_count} files not shown"));
-                }
-
-                format!(
-                    "Do you want to trash {} files?\n{}",
-                    names.len(),
-                    listed_names.join("\n")
-                )
-            }
-        };
-        match dirty_buffers {
-            0 => {}
-            1 if names.len() == 1 => {
-                prompt.push_str("\n\nIt has unsaved changes, which will be lost.");
-            }
-            1 => {
-                prompt.push_str("\n\n1 of these has unsaved changes, which will be lost.");
-            }
-            dirty_buffers => {
-                prompt.push_str(&format!(
-                    "\n\n{dirty_buffers} of these have unsaved changes, which will be lost."
-                ));
-            }
-        }
-
+        let prompt = ProjectPanel::build_removal_prompt(RemovalKind::Trash, names, dirty_buffers);
         let answer = self
             .panel
             .update_in(cx, |_panel, window, cx| {
-                window.prompt(PromptLevel::Info, &prompt, None, &["Trash", "Cancel"], cx)
+                window.prompt(
+                    PromptLevel::Info,
+                    &prompt.message,
+                    prompt.detail,
+                    &[prompt.confirmation_label, "Cancel"],
+                    cx,
+                )
             })?
             .await?;
 
-        match answer {
-            0 => Ok(true),
-            _ => Ok(false),
-        }
+        Ok(answer == 0)
     }
 }

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -134,13 +134,16 @@ use crate::ProjectPanel;
 use anyhow::{Context, Result, anyhow};
 use fs::{TrashId, TrashRestoreError};
 use futures::channel::mpsc;
-use gpui::{AppContext, AsyncApp, IntoElement, SharedString, Styled, Task, WeakEntity};
+use gpui::{
+    AppContext, AsyncApp, IntoElement, PromptLevel, SharedString, Styled, Task, WeakEntity,
+};
 use markdown::{Markdown, MarkdownElement};
 use project::Project;
 use project::{ProjectPath, WorktreeId};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::VecDeque, sync::Arc};
 use ui::{App, TextSize};
+use util::markdown::MarkdownInlineCode;
 use util::{paths::PathStyle, rel_path::RelPath};
 use workspace::{
     Pane, SaveIntent, Workspace,
@@ -621,15 +624,16 @@ impl Inner {
             )
         });
 
+        let window_handles = cx.update(|cx| cx.windows());
+        let mut async_window_cx = window_handles
+            .into_iter()
+            .find_map(|window_handle| {
+                cx.update_window(window_handle, |_, window, cx| window.to_async(cx))
+                    .ok()
+            })
+            .with_context(|| format!("Failed to prompt before trashing `{name}`."))?;
+
         if let Some((pane, item)) = open_item {
-            let window_handles = cx.update(|cx| cx.windows());
-            let mut async_window_cx = window_handles
-                .into_iter()
-                .find_map(|window_handle| {
-                    cx.update_window(window_handle, |_, window, cx| window.to_async(cx))
-                        .ok()
-                })
-                .with_context(|| format!("Failed to prompt before trashing `{name}`."))?;
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
             if !Pane::save_item(
                 project,
@@ -642,6 +646,8 @@ impl Inner {
             {
                 return Ok(None);
             }
+        } else if !self.trash_prompt(&name, cx).await? {
+            return Ok(None);
         }
 
         let task = workspace.update(cx, |workspace, cx| {
@@ -745,5 +751,34 @@ impl Inner {
                 })
             })
             .ok();
+    }
+
+    /// Prompts the user to confirm whether they actually want to trash the
+    /// file.
+    ///
+    /// Returns `true` if the user confirms, `false` otherwise.
+    async fn trash_prompt(&self, name: &str, cx: &mut AsyncApp) -> Result<bool> {
+        let answer = self
+            .panel
+            .update_in(cx, |_panel, window, cx| {
+                window.prompt(
+                    PromptLevel::Info,
+                    &format!(
+                        // TODO!: Can't just call out "Undoing" here, as this will also get
+                        // called when "Redoing" a trash operation.
+                        "Undoing will move {} to the trash. Do you want to proceed?",
+                        MarkdownInlineCode(name)
+                    ),
+                    None,
+                    &["Trash", "Cancel"],
+                    cx,
+                )
+            })?
+            .await?;
+
+        match answer {
+            0 => Ok(true),
+            _ => Ok(false),
+        }
     }
 }

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -143,7 +143,7 @@ use std::{collections::VecDeque, sync::Arc};
 use ui::{App, TextSize};
 use util::{paths::PathStyle, rel_path::RelPath};
 use workspace::{
-    Workspace,
+    Pane, SaveIntent, Workspace,
     notifications::{
         NotificationId, markdown_style, simple_message_notification::MessageNotification,
     },
@@ -157,11 +157,18 @@ enum Operation {
     Batch(Vec<Operation>),
 }
 
+enum OperationOutcome {
+    Changed(Change),
+    Cancelled(Operation),
+}
+
 impl Operation {
-    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<Change> {
-        Ok(match self {
+    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<OperationOutcome> {
+        Ok(OperationOutcome::Changed(match self {
             Operation::Trash(project_path) => {
-                let trash_id = undo_manager.trash(&project_path, cx).await?;
+                let Some(trash_id) = undo_manager.trash(&project_path, cx).await? else {
+                    return Ok(OperationOutcome::Cancelled(Operation::Trash(project_path)));
+                };
                 Change::Trashed(project_path.worktree_id, trash_id)
             }
             Operation::Rename(from, to) => {
@@ -174,12 +181,20 @@ impl Operation {
             }
             Operation::Batch(operations) => {
                 let mut res = Vec::new();
-                for op in operations {
-                    res.push(Box::pin(op.execute(undo_manager, cx)).await?);
+                let mut operations = operations.into_iter();
+                while let Some(operation) = operations.next() {
+                    match Box::pin(operation.execute(undo_manager, cx)).await? {
+                        OperationOutcome::Changed(change) => res.push(change),
+                        OperationOutcome::Cancelled(operation) => {
+                            return Ok(OperationOutcome::Cancelled(Operation::Batch(
+                                std::iter::once(operation).chain(operations).collect(),
+                            )));
+                        }
+                    }
                 }
                 Change::Batched(res)
             }
-        })
+        }))
     }
 }
 
@@ -449,14 +464,20 @@ impl Inner {
         // manual intervention would likely be needed in order to undo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let undo_change = self
+        let change = self
             .history
             .remove(before_cursor)
-            .expect("we can undo")
-            .to_inverse()
-            .execute(self, cx)
-            .await?;
-        self.history.insert(before_cursor, undo_change);
+            .expect("we can undo");
+        let operation = change.clone().to_inverse();
+        match operation.execute(self, cx).await? {
+            OperationOutcome::Changed(undo_change) => {
+                self.history.insert(before_cursor, undo_change);
+            }
+            OperationOutcome::Cancelled(_) => {
+                self.history.insert(before_cursor, change);
+                self.cursor += 1;
+            }
+        }
         Ok(())
     }
 
@@ -469,15 +490,20 @@ impl Inner {
         // manual intervention would likely be needed in order to redo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let redo_change = self
+        let change = self
             .history
             .remove(self.cursor)
-            .expect("we can redo")
-            .to_inverse()
-            .execute(self, cx)
-            .await?;
-        self.history.insert(self.cursor, redo_change);
-        self.cursor += 1;
+            .expect("we can redo");
+        let operation = change.clone().to_inverse();
+        match operation.execute(self, cx).await? {
+            OperationOutcome::Changed(redo_change) => {
+                self.history.insert(self.cursor, redo_change);
+                self.cursor += 1;
+            }
+            OperationOutcome::Cancelled(_) => {
+                self.history.insert(self.cursor, change);
+            }
+        }
         Ok(())
     }
 
@@ -569,17 +595,58 @@ impl Inner {
         })
     }
 
-    async fn trash(&self, project_path: &ProjectPath, cx: &mut AsyncApp) -> Result<TrashId> {
+    async fn trash(
+        &self,
+        project_path: &ProjectPath,
+        cx: &mut AsyncApp,
+    ) -> Result<Option<TrashId>> {
         let Some(workspace) = self.workspace.upgrade() else {
             return Err(anyhow!("Failed to obtain workspace."));
         };
 
-        let name = workspace.update(cx, |workspace, cx| {
+        let (name, open_item) = workspace.update(cx, |workspace, cx| {
             let project = workspace.project().read(cx);
             let path_style = project.path_style(cx);
 
-            project_path_display(project, project_path, path_style, cx)
+            let open_item = workspace.panes().iter().find_map(|pane| {
+                pane.read(cx).items().find_map(|item| {
+                    (item.is_dirty(cx)
+                        && item
+                            .project_path(cx)
+                            .iter()
+                            .any(|item_path| item_path == project_path))
+                    .then(|| (pane.clone(), item.boxed_clone()))
+                })
+            });
+
+            (
+                project_path_display(project, project_path, path_style, cx),
+                open_item,
+            )
         });
+
+        if let Some((pane, item)) = open_item {
+            let window_handles = cx.update(|cx| cx.windows());
+            let mut async_window_cx = window_handles
+                .into_iter()
+                .find_map(|window_handle| {
+                    cx.update_window(window_handle, |_, window, cx| window.to_async(cx))
+                        .ok()
+                })
+                .with_context(|| format!("Failed to prompt before trashing `{name}`."))?;
+            let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
+            if !Pane::save_item(
+                project,
+                pane,
+                item.as_ref(),
+                SaveIntent::Close,
+                &mut async_window_cx,
+            )
+            .await?
+            {
+                return Ok(None);
+            }
+        }
 
         let task = workspace.update(cx, |workspace, cx| {
             workspace.project().update(cx, |project, cx| {
@@ -595,7 +662,7 @@ impl Inner {
         })?;
 
         match task.await {
-            Ok(trash_id) => Ok(trash_id),
+            Ok(trash_id) => Ok(Some(trash_id)),
             Err(err) => Err(err).context(format!("Failed to trash `{name}`.")),
         }
     }


### PR DESCRIPTION
# Objective

Ensure that, when users undo project panel operations, we don't trash files with unsaved edits as that could lead to data loss, as outlined [here](https://github.com/zed-industries/zed/issues/62243#issuecomment-5203625087).

Closes #62243

## Solution

Update `UndoManager::trash` to require confirmation before moving files to the trash. For files with unsaved edits, users can save, discard, or cancel the operation while clean files receive a standard trash confirmation, same as shown when trashing a file through the Project Panel.

This helps avoid the issue where, if an user undoes a file creation for a file that has unsaved edits and then quits Zed, the edits that were saved in memory, as well as the Project Panel history, will now be gone and there's no way to recover the data.

Batch operations have also been updated to now show a single confirmation before making filesystem changes, preventing partial execution when cancelled and warning about unsaved edits.

Lastly, the trash/delete prompt building has been refactored in order for the Project Panel and Undo Manager to share the same wording, file-list truncation, and unsaved-change warnings.

## Testing

Tested both manually as well as added the following tests:

*  `project_panel::tests::undo::undo_create_cancel_trash`
*  `project_panel::tests::undo::undo_create_dirty_file`
*  `project_panel::tests::undo::cancel_partial_trash_batch`
*  `project_panel::tests::undo::batch_trash_warns_about_unsaved_changes`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The screen recording below shows the trash confirmation dialog on both a clean and dirty files, on both undo and redo flows.

https://github.com/user-attachments/assets/0f9b96f5-0357-4e3f-8ec2-141486942c89

---

Release Notes:

- Fixed issue with undoing or redoing project panel operations that could lead to a file with unsaved edits being trashed without confirmation.
