### PR TITLE
editor: Align selections on rendered position rather than byte offsets

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6247,9 +6247,32 @@ impl Editor {
 
         let display_snapshot = self.display_snapshot(cx);
 
+        // Align on x pixels rather than byte columns. `Point::column` is a byte
+        // offset, so a row containing multi-byte characters reports a larger
+        // column than it occupies on screen and receives too few (or too many)
+        // padding spaces. Measuring where the cursor actually renders keeps
+        // rows aligned regardless of how many bytes, code points or grapheme
+        // clusters precede it. Same reasoning as the columnar selection fix in
+        // `Editor::update_selection` (#57097).
+        let text_layout_details = self.text_layout_details(window, cx);
+        let font_id = text_layout_details
+            .text_system
+            .resolve_font(&text_layout_details.editor_style.text.font());
+        let font_size = text_layout_details
+            .editor_style
+            .text
+            .font_size
+            .to_pixels(text_layout_details.rem_size);
+        // Padding is always inserted as spaces, so the accumulated shift for a
+        // row is exactly `space_count * space_width`.
+        let space_width = text_layout_details
+            .text_system
+            .em_layout_width(font_id, font_size);
+
         struct CursorData {
             anchor: Anchor,
             point: Point,
+            x: Pixels,
         }
         let cursor_data: Vec<CursorData> = self
             .selections
@@ -6261,9 +6284,14 @@ impl Editor {
                 } else {
                     selection.tail()
                 };
+                let point = anchor.to_point(&display_snapshot.buffer_snapshot());
                 CursorData {
                     anchor: anchor,
-                    point: anchor.to_point(&display_snapshot.buffer_snapshot()),
+                    point,
+                    x: display_snapshot.x_for_display_point(
+                        point.to_display_point(&display_snapshot),
+                        &text_layout_details,
+                    ),
                 }
             })
             .collect();
@@ -6276,14 +6304,14 @@ impl Editor {
             .map(|(_, group)| group.count())
             .collect();
         let max_columns = rows_anchors_count.iter().max().copied().unwrap_or(0);
-        let mut rows_column_offset = vec![0; rows_anchors_count.len()];
+        let mut rows_x_offset = vec![Pixels::ZERO; rows_anchors_count.len()];
         let mut edits = Vec::new();
 
         for column_idx in 0..max_columns {
             let mut cursor_index = 0;
 
-            // Calculate target_column => position that the selections will go
-            let mut target_column = 0;
+            // Calculate target_x => horizontal position the selections will go
+            let mut target_x = Pixels::ZERO;
             for (row_idx, cursor_count) in rows_anchors_count.iter().enumerate() {
                 // Skip rows that don't have this column
                 if column_idx >= *cursor_count {
@@ -6291,10 +6319,9 @@ impl Editor {
                     continue;
                 }
 
-                let point = &cursor_data[cursor_index + column_idx].point;
-                let adjusted_column = point.column + rows_column_offset[row_idx];
-                if adjusted_column > target_column {
-                    target_column = adjusted_column;
+                let adjusted_x = cursor_data[cursor_index + column_idx].x + rows_x_offset[row_idx];
+                if adjusted_x > target_x {
+                    target_x = adjusted_x;
                 }
                 cursor_index += cursor_count;
             }
@@ -6308,15 +6335,18 @@ impl Editor {
                     continue;
                 }
 
-                let point = &cursor_data[cursor_index + column_idx].point;
-                let spaces_needed = target_column - point.column - rows_column_offset[row_idx];
+                let cursor = &cursor_data[cursor_index + column_idx];
+                let gap = target_x - cursor.x - rows_x_offset[row_idx];
+                let spaces_needed = if space_width > Pixels::ZERO {
+                    (gap / space_width).round().max(0.) as usize
+                } else {
+                    0
+                };
                 if spaces_needed > 0 {
-                    let anchor = cursor_data[cursor_index + column_idx]
-                        .anchor
-                        .bias_left(&display_snapshot);
-                    edits.push((anchor..anchor, " ".repeat(spaces_needed as usize)));
+                    let anchor = cursor.anchor.bias_left(&display_snapshot);
+                    edits.push((anchor..anchor, " ".repeat(spaces_needed)));
                 }
-                rows_column_offset[row_idx] += spaces_needed;
+                rows_x_offset[row_idx] += space_width * spaces_needed as f32;
 
                 cursor_index += *cursor_count;
             }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42035,6 +42035,93 @@ async fn test_align_selections_multicolumn(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_align_selections_multibyte(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Control: pure ASCII, where byte offsets and rendered columns agree. If
+    // this case ever fails, the harness is wrong rather than the alignment.
+    let before = indoc!(
+        r#"
+            aa ˇx
+            bbb ˇx
+        "#
+    );
+    let after = indoc!(
+        r#"
+            aa  ˇx
+            bbb ˇx
+        "#
+    );
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+
+    // A 2-byte character before the cursor. "ãa " is 4 bytes but 3 columns, so
+    // aligning on byte offsets sees both rows as equally wide and inserts
+    // nothing, leaving them visually misaligned.
+    let before = indoc!(
+        r#"
+            ãa ˇx
+            bbb ˇx
+        "#
+    );
+    let after = indoc!(
+        r#"
+            ãa  ˇx
+            bbb ˇx
+        "#
+    );
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+
+    // The reported case: a 3-byte arrow on both rows and a 2-byte pi on one.
+    // "a ← 1  " is 9 bytes / 7 columns and "bc ← π  " is 11 bytes / 8 columns,
+    // so aligning on bytes overshoots the first row by a column.
+    let before = indoc!(
+        r#"
+            a ← 1  ˇ# one
+            bc ← π  ˇ# two
+        "#
+    );
+    let after = indoc!(
+        r#"
+            a ← 1   ˇ# one
+            bc ← π  ˇ# two
+        "#
+    );
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+
+    // Rows that already line up must be left alone. Byte offsets make "ãa " look
+    // one wider than "bb ", so the previous behaviour padded the second row and
+    // pulled apart cursors that were already aligned.
+    let before = indoc!("ãa ˇx\nbb ˇx\n");
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(before);
+
+    // Several cursors per row, with a multi-byte character before the first.
+    // Exercises the running per-row offset across more than one column.
+    let before = indoc!("a ˇxx ˇy\nãã ˇx ˇy\n");
+    let after = indoc!("a  ˇxx ˇy\nãã ˇx  ˇy\n");
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+
+    // Tabs have the same problem for the same reason: "a\t" is two bytes but
+    // renders out to the tab stop, so byte offsets treat it as no wider than
+    // "bb" and no padding is inserted.
+    let before = "a\tˇx\nbbˇx\n";
+    let after = "a\tˇx\nbb  ˇx\n";
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+}
+
+#[gpui::test]
 async fn test_custom_fallback_highlights(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
# Objective

Fixes #60192.

`Editor::align_selections` computed padding from `Point::column`, which is a byte offset. Any
row that is wider in bytes than it is on screen reports a larger column than it occupies, so
the wrong number of spaces is inserted.

Using the example from the issue, where `←` is 3 bytes and `π` is 2:

```
a ← 1  # one          prefix:  9 bytes,  7 columns
bc ← π  # two         prefix: 11 bytes,  8 columns
```

The target is taken as `max(9, 11) = 11` **bytes**, so the first row gains two spaces and lands
at column 9 while the second stays at column 8.

**This turned out to be broader than the report.** The underlying fault is
bytes-versus-rendered-position, and multi-byte characters are one of three ways to reach it:

**Hard tabs.** `a\t` is two bytes but renders out to the tab stop, so byte offsets treat it as
no wider than `bb` and insert no padding at all:

```
before          before this PR         after this PR
a→x             a→x                    a→x
bbx             bbx     (unaligned)    bb  x    (aligned)
```

**Rows that were already aligned get pulled apart.** `ãa ` and `bb ` both render three columns
wide but are 4 and 3 bytes, so the previous behaviour padded the second row and broke a
correct alignment:

```
before          before this PR         after this PR
ãa x            ãa x                   ãa x
bb x            bb  x   (broken)       bb x     (unchanged)
```

# Solution

Measure where each cursor actually renders, using `x_for_display_point`, and convert the gap
back into spaces with the space advance.

This is the same approach as #57097, which fixed the identical problem for columnar selection.
Because padding is always spaces, a row's accumulated shift is exactly
`space_count * space_width`, so the per-column running offset stays exact.

# Testing

`test_align_selections_multibyte` covers, in order:

1. **A pure-ASCII control**, where byte offsets and rendered columns agree. It passes with and
   without the change — it is there to show the test is not simply red.
2. A 2-byte character before the cursor.
3. The exact case from the issue.
4. Rows that are already aligned, which must be left alone.
5. Several cursors per row, exercising the running per-row offset across more than one column.
6. Hard tabs.

Reverting **only** `editor.rs` and re-running gives:

```
test editor_tests::test_align_selections_multibyte ... FAILED

Diff < left / right > :
<ãa x
>ãa  x
 bbb x
```

The two existing align tests (`test_align_selections`, `test_align_selections_multicolumn`)
pass unchanged in both directions, which is consistent with them being ASCII-only and never
having exercised this path.

Tested on macOS (Apple Silicon). `cargo fmt` and `cargo clippy -p editor --tests` are clean.

### Notes for review

- **Monospace assumption.** `space_width` comes from `em_layout_width`, the em advance rather
  than the measured width of U+0020. They are equal in a monospace font and differ in a
  proportional one — though padding with spaces cannot align proportional text in any case.
  #57097 makes the same assumption via the same call.
- **Rounding.** `(gap / space_width).round()` is exact when every glyph advance is a whole
  multiple of the space advance, which holds for monospace. A fallback glyph of unusual width
  would round to the nearest space rather than fail loudly.
- **Cost.** `x_for_display_point` is now called once per cursor, where the previous code was
  integer arithmetic. `LineLayoutCache` (`crates/gpui/src/text_system.rs:365`) means repeated
  layouts of the same row are cached, so this should not be a per-cursor re-layout.
- **Not covered by tests:** folded regions and block rows. Soft wrap was checked manually and
  showed no regression — the previous behaviour was wrong there too — but I did not confirm
  the line had actually wrapped, so I have not shipped that as a test.

### One question for maintainers

The tab case now aligns by inserting **spaces**. Where `hard_tabs` is enabled, spaces may not
be what you want, even though it matches this action's existing behaviour. Happy to change it
to tabs, or to drop the tab case from this PR and raise it separately — whichever you prefer.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — none added
- [x] The content adheres to Zed's UI standards — no UI change
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Aligning the `#` symbols in the issue's example:

```
before                  before this PR          after this PR
a ← 1  # one            a ← 1    # one          a ← 1   # one
bc ← π  # two           bc ← π  # two           bc ← π  # two
```
