### PR TITLE
editor: Judge horizontal on-screen position in rendered space

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42719,3 +42719,45 @@ async fn test_select_delimiters_expansion(cx: &mut TestAppContext) {
     cx.dispatch_action(SelectInsideDelimiters);
     cx.assert_editor_state("foo(«x, { a: 1 }ˇ»);");
 }
+
+#[gpui::test]
+async fn test_newest_selection_on_screen_multibyte(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Two lines of identical *rendered* width inside a window wide enough for both.
+    // They differ only in how many bytes they occupy, which must not affect whether
+    // the cursor counts as on screen.
+    let window_columns = 60.;
+    let rendered_columns = 40;
+
+    // 40 two-byte characters: 80 bytes, 40 rendered columns.
+    let multibyte: String = "ã".repeat(rendered_columns);
+    cx.set_state(&format!("{multibyte}ˇx\n"));
+    let multibyte_result = cx.update_editor(|editor, window, cx| {
+        editor.set_visible_line_count(50., window, cx);
+        editor.set_visible_column_count(window_columns);
+        editor.newest_selection_on_screen(window, cx)
+    });
+
+    // Control: same rendered width, one byte per character.
+    let ascii: String = "a".repeat(rendered_columns);
+    cx.set_state(&format!("{ascii}ˇx\n"));
+    let ascii_result = cx.update_editor(|editor, window, cx| {
+        editor.set_visible_line_count(50., window, cx);
+        editor.set_visible_column_count(window_columns);
+        editor.newest_selection_on_screen(window, cx)
+    });
+
+    assert_eq!(
+        ascii_result,
+        std::cmp::Ordering::Equal,
+        "control: an ASCII cursor {rendered_columns} columns into a {window_columns}-column \
+         window must be on screen"
+    );
+    assert_eq!(
+        multibyte_result, ascii_result,
+        "a multi-byte line and an ASCII line of the same rendered width must agree; \
+         got multibyte={multibyte_result:?} vs ascii={ascii_result:?}"
+    );
+}

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -922,7 +922,7 @@ impl Editor {
     ///     Ordering::Equal => on screen
     ///     Ordering::Less => above or to the left of the screen
     ///     Ordering::Greater => below or to the right of the screen
-    pub fn newest_selection_on_screen(&self, cx: &mut App) -> Ordering {
+    pub fn newest_selection_on_screen(&self, window: &mut Window, cx: &mut App) -> Ordering {
         let snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let newest_head = self
             .selections
@@ -938,9 +938,33 @@ impl Editor {
         if let (Some(visible_lines), Some(visible_columns)) =
             (self.visible_line_count(), self.visible_column_count())
             && newest_head.row() <= DisplayRow(screen_top.row().0 + visible_lines as u32)
-            && newest_head.column() <= screen_top.column() + visible_columns as u32
         {
-            return Ordering::Equal;
+            // The horizontal test has to be made in rendered space. `DisplayPoint::column`
+            // is a byte offset, while `visible_column_count` is `editor_width / em_advance`
+            // (see `EditorElement`), a count of rendered cells. Comparing them directly
+            // reports any sufficiently long non-ASCII line as off screen, because its byte
+            // offsets outrun its columns.
+            //
+            // `autoscroll_horizontally` already resolves the same question by mapping the
+            // column through the line layout, which is what `x_for_display_point` does.
+            let text_layout_details = self.text_layout_details(window, cx);
+            let em_advance = text_layout_details.text_system.em_layout_width(
+                text_layout_details
+                    .text_system
+                    .resolve_font(&text_layout_details.editor_style.text.font()),
+                text_layout_details
+                    .editor_style
+                    .text
+                    .font_size
+                    .to_pixels(text_layout_details.rem_size),
+            );
+
+            let head_x = snapshot.x_for_display_point(newest_head, &text_layout_details);
+            let top_x = snapshot.x_for_display_point(screen_top, &text_layout_details);
+
+            if head_x - top_x <= em_advance * visible_columns as f32 {
+                return Ordering::Equal;
+            }
         }
 
         Ordering::Greater

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -107,7 +107,7 @@ impl Vim {
         cx: &mut Context<Vim>,
     ) {
         self.update_editor(cx, |vim, editor, cx| {
-            let should_move_cursor = editor.newest_selection_on_screen(cx).is_eq();
+            let should_move_cursor = editor.newest_selection_on_screen(window, cx).is_eq();
             let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
             let old_top = editor.scroll_top_display_point(&display_snapshot, cx);
 


### PR DESCRIPTION
Closes #62308.

### Problem

`Editor::newest_selection_on_screen` reports a cursor as off screen when enough multi-byte text precedes it on the line, even though it is plainly visible. Vim's `Ctrl-D` / `Ctrl-U` call it to decide whether to move the cursor, so the cursor is left behind.

### Root cause

`crates/editor/src/scroll.rs` compared two values in different units:

```rust
newest_head.column() <= screen_top.column() + visible_columns as u32
```

`DisplayPoint` wraps `BlockPoint(pub Point)`, so `.column()` is a **byte offset**. `visible_column_count` is set from `editor_width / em_advance` in `EditorElement` (`crates/editor/src/element.rs`), a count of **rendered cells**. Byte offsets meet or exceed rendered columns for any non-ASCII text, so the comparison fails on lines it should accept.

### Fix

`autoscroll_horizontally` already answers the same question correctly, by mapping the column through the line layout with `x_for_index`. `DisplaySnapshot::x_for_display_point` is exactly that mapping, so this uses it for both the head and the screen top and compares the pixel delta against `em_advance * visible_columns` — the same width `visible_column_count` was divided out of.

### Proof

The test pairs a 40-character multi-byte line with an ASCII line of identical rendered width, in a 60-column window. Both must be judged on screen, and both must agree.

Without the change:

```
test result: FAILED. 0 passed; 1 failed
assertion failed: a multi-byte line and an ASCII line of the same rendered width
must agree; got multibyte=Greater vs ascii=Equal
```

With the change:

```
test result: ok. 1 passed; 0 failed
```

The ASCII control is asserted separately, so a harness that silently computed nothing would fail rather than pass.

### Scope and risk

- `cargo test -p editor` — 887 passed, 0 failed
- `cargo test -p vim` — 562 passed, 0 failed
- `cargo fmt --all --check` and `cargo clippy -p editor -p vim --all-targets` clean

Behaviour only changes for the case that was wrong: a cursor whose rendered position is inside the viewport but whose byte column exceeded the column budget. ASCII text is unaffected, since there byte offsets and rendered columns coincide.

### One decision for reviewers

`newest_selection_on_screen` now takes a `&mut Window`, because reaching the text layout requires one. There is a single in-tree caller (`crates/vim/src/normal/scroll.rs`) and it already has a `window` in scope, but this is a `pub fn` on `Editor`, so it is a breaking change for any out-of-tree caller.

The alternative is to store the viewport width in pixels alongside `visible_column_count` and compare against that, which avoids the signature change at the cost of duplicating state that is already derivable. Happy to switch if you prefer that.

### Related

#62305 fixes the same class of bug — byte offsets used where rendered position is meant — in `align_selections`. Different file, different command; the two do not overlap and can land independently.
