### PR TITLE
agent_ui: Restore context when navigating inline assistant prompt history

### DIFF
--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -449,7 +449,10 @@ impl<T: 'static> PromptEditor<T> {
                             .log_edit_event("inline assist", is_via_ssh);
                     });
                 }
-                let prompt = snapshot.text();
+                // History entries store the raw buffer text (see `Editor::text`),
+                // so compare against the buffer text rather than the display text,
+                // which may differ (e.g. fold placeholders for mention creases).
+                let prompt = snapshot.buffer_snapshot().text();
                 if self
                     .prompt_history_ix
                     .is_none_or(|ix| self.prompt_history[ix] != prompt)
@@ -1924,6 +1927,27 @@ mod tests {
         });
     }
 
+    fn move_down_history(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        cx: &mut VisualTestContext,
+    ) {
+        prompt_editor.update_in(cx, |editor, window, cx| {
+            editor.move_down(&MoveDown, window, cx);
+        });
+    }
+
+    fn assert_mentions(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        cx: &mut VisualTestContext,
+        expected: collections::HashSet<MentionUri>,
+    ) {
+        let mention_set = mention_set_for(prompt_editor, cx);
+        cx.read(|cx| {
+            assert_eq!(mention_set.read(cx).mentions(), expected);
+            assert_eq!(mention_set.read(cx).creases().len(), expected.len());
+        });
+    }
+
     #[gpui::test]
     async fn test_history_restores_file_context(cx: &mut TestAppContext) {
         init_test(cx);
@@ -2103,5 +2127,72 @@ mod tests {
             );
             assert_eq!(mention_set.read(cx).creases().len(), 1);
         });
+    }
+
+    #[gpui::test]
+    async fn test_history_switches_between_contexts_without_stale_mentions(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            serde_json::json!({
+                "a.txt": "contents of a",
+                "b.txt": "contents of b",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        let draft = "draft without context";
+        let prompt_a = "Use [@a.txt](file:///project/a.txt)";
+        let prompt_b = "Use [@b.txt](file:///project/b.txt)";
+        set_prompt_text(&prompt_editor, draft, cx);
+        push_history(&prompt_editor, prompt_a, cx);
+        push_history(&prompt_editor, prompt_b, cx);
+
+        // Up to the newest history entry: b.
+        move_up_history(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt_b);
+        assert_mentions(
+            &prompt_editor,
+            cx,
+            collections::HashSet::from_iter([MentionUri::File {
+                abs_path: PathBuf::from("/project/b.txt"),
+            }]),
+        );
+
+        // Up to the older entry: a. b's context must not linger.
+        move_up_history(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt_a);
+        assert_mentions(
+            &prompt_editor,
+            cx,
+            collections::HashSet::from_iter([MentionUri::File {
+                abs_path: PathBuf::from("/project/a.txt"),
+            }]),
+        );
+
+        // Down back to b: a's context must not linger.
+        move_down_history(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt_b);
+        assert_mentions(
+            &prompt_editor,
+            cx,
+            collections::HashSet::from_iter([MentionUri::File {
+                abs_path: PathBuf::from("/project/b.txt"),
+            }]),
+        );
+
+        // Down to the pending draft: no context may linger.
+        move_down_history(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), draft);
+        assert_mentions(&prompt_editor, cx, collections::HashSet::default());
     }
 }

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -39,7 +39,8 @@ use crate::completion_provider::{
     PromptCompletionProvider, PromptCompletionProviderDelegate, PromptContextType,
 };
 use crate::mention_set::paste_images_as_context;
-use crate::mention_set::{MentionSet, crease_for_mention};
+use crate::mention_set::{MentionSet, crease_for_mention, insert_mentions_from_links};
+use crate::message_editor::parse_mention_links;
 use crate::terminal_codegen::TerminalCodegen;
 use crate::{
     CycleFavoriteModels, CycleNextInlineAssist, CyclePreviousInlineAssist, ModelUsageContext,
@@ -745,23 +746,68 @@ impl<T: 'static> PromptEditor<T> {
             .ok();
     }
 
+    fn restore_mentions_from_text(
+        &mut self,
+        text: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let path_style = workspace.read(cx).project().read(cx).path_style(cx);
+        let parsed_mentions = parse_mention_links(text, path_style);
+        if parsed_mentions.is_empty() {
+            return;
+        }
+
+        let snapshot = self.editor.read(cx).buffer().read(cx).snapshot(cx);
+        let mentions = parsed_mentions
+            .into_iter()
+            .filter_map(|(range, mention_uri)| {
+                let anchor = snapshot.anchor_before(MultiBufferOffset(range.start));
+                Some((
+                    snapshot.anchor_to_buffer_anchor(anchor)?.0,
+                    range.end - range.start,
+                    mention_uri,
+                ))
+            })
+            .collect();
+
+        let supports_images = inline_assistant_model_supports_images(cx);
+        let http_client = workspace.read(cx).client().http_client();
+
+        insert_mentions_from_links(
+            &self.editor,
+            &self.mention_set,
+            workspace.downgrade(),
+            mentions,
+            supports_images,
+            http_client,
+            window,
+            cx,
+        );
+    }
+
     fn move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(ix) = self.prompt_history_ix {
             if ix > 0 {
                 self.prompt_history_ix = Some(ix - 1);
-                let prompt = self.prompt_history[ix - 1].as_str();
+                let prompt = self.prompt_history[ix - 1].clone();
                 self.editor.update(cx, |editor, cx| {
-                    editor.set_text(prompt, window, cx);
+                    editor.set_text(prompt.as_str(), window, cx);
                     editor.move_to_beginning(&Default::default(), window, cx);
                 });
+                self.restore_mentions_from_text(&prompt, window, cx);
             }
         } else if !self.prompt_history.is_empty() {
             self.prompt_history_ix = Some(self.prompt_history.len() - 1);
-            let prompt = self.prompt_history[self.prompt_history.len() - 1].as_str();
+            let prompt = self.prompt_history[self.prompt_history.len() - 1].clone();
             self.editor.update(cx, |editor, cx| {
-                editor.set_text(prompt, window, cx);
+                editor.set_text(prompt.as_str(), window, cx);
                 editor.move_to_beginning(&Default::default(), window, cx);
             });
+            self.restore_mentions_from_text(&prompt, window, cx);
         }
     }
 
@@ -769,18 +815,20 @@ impl<T: 'static> PromptEditor<T> {
         if let Some(ix) = self.prompt_history_ix {
             if ix < self.prompt_history.len() - 1 {
                 self.prompt_history_ix = Some(ix + 1);
-                let prompt = self.prompt_history[ix + 1].as_str();
+                let prompt = self.prompt_history[ix + 1].clone();
                 self.editor.update(cx, |editor, cx| {
-                    editor.set_text(prompt, window, cx);
+                    editor.set_text(prompt.as_str(), window, cx);
                     editor.move_to_end(&Default::default(), window, cx)
                 });
+                self.restore_mentions_from_text(&prompt, window, cx);
             } else {
                 self.prompt_history_ix = None;
-                let prompt = self.pending_prompt.as_str();
+                let prompt = self.pending_prompt.clone();
                 self.editor.update(cx, |editor, cx| {
-                    editor.set_text(prompt, window, cx);
+                    editor.set_text(prompt.as_str(), window, cx);
                     editor.move_to_end(&Default::default(), window, cx)
                 });
+                self.restore_mentions_from_text(&prompt, window, cx);
             }
         }
     }
@@ -1630,8 +1678,12 @@ fn insert_message_creases(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::load_context;
+    use crate::mention_set::Mention;
     use crate::terminal_codegen::TerminalCodegen;
+    use acp_thread::MentionUri;
     use agent::ThreadStore;
+    use agent_client_protocol::schema::v1 as acp;
     use collections::VecDeque;
     use fs::FakeFs;
     use gpui::{TestAppContext, VisualTestContext};
@@ -1639,7 +1691,8 @@ mod tests {
     use project::Project;
     use settings::SettingsStore;
     use std::cell::RefCell;
-    use std::path::Path;
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use terminal::TerminalBuilder;
     use terminal::terminal_settings::CursorShape;
@@ -1824,5 +1877,231 @@ mod tests {
             ),
             "Expected ConfirmRequested with execute: false"
         );
+    }
+
+    fn mention_set_for(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        cx: &mut VisualTestContext,
+    ) -> Entity<MentionSet> {
+        cx.read(|cx| prompt_editor.read(cx).mention_set().clone())
+    }
+
+    fn prompt_text(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        cx: &mut VisualTestContext,
+    ) -> String {
+        cx.read(|cx| prompt_editor.read(cx).editor.read(cx).text(cx))
+    }
+
+    fn set_prompt_text(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        text: &str,
+        cx: &mut VisualTestContext,
+    ) {
+        prompt_editor.update_in(cx, |prompt_editor, window, cx| {
+            prompt_editor.editor.update(cx, |editor, cx| {
+                editor.set_text(text, window, cx);
+            });
+        });
+    }
+
+    fn push_history(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        prompt: &str,
+        cx: &mut VisualTestContext,
+    ) {
+        prompt_editor.update(cx, |editor, _| {
+            editor.prompt_history.push_back(prompt.to_string());
+        });
+    }
+
+    fn move_up_history(
+        prompt_editor: &Entity<PromptEditor<TerminalCodegen>>,
+        cx: &mut VisualTestContext,
+    ) {
+        prompt_editor.update_in(cx, |editor, window, cx| {
+            editor.move_up(&MoveUp, window, cx);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_history_restores_file_context(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            serde_json::json!({
+                "file.txt": "hello from file context",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        // Simulate a submitted prompt whose mention was serialized as a
+        // markdown link in the prompt text.
+        let prompt = "Transform this: [@file.txt](file:///project/file.txt)";
+        set_prompt_text(&prompt_editor, prompt, cx);
+        push_history(&prompt_editor, prompt, cx);
+        move_up_history(&prompt_editor, cx);
+
+        // The restored prompt must keep its structured context: the mention
+        // must be registered with the mention set and rendered as a crease.
+        let mention_set = mention_set_for(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt);
+        cx.read(|cx| {
+            assert_eq!(
+                mention_set.read(cx).mentions(),
+                HashSet::from_iter([MentionUri::File {
+                    abs_path: PathBuf::from("/project/file.txt"),
+                }])
+            );
+            assert_eq!(mention_set.read(cx).creases().len(), 1);
+        });
+
+        // The context must resolve to the file content so the assistant
+        // receives it when the prompt is submitted.
+        let context_task = cx.update(|_, cx| load_context(&mention_set, cx));
+        let loaded = cx.foreground_executor().block_test(context_task);
+        let loaded = loaded.expect("file context should load");
+        assert!(loaded.text.contains("hello from file context"));
+    }
+
+    #[gpui::test]
+    async fn test_history_restores_plain_prompt_without_context(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", serde_json::json!({})).await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        let prompt = "Just a plain prompt";
+        set_prompt_text(&prompt_editor, prompt, cx);
+        push_history(&prompt_editor, prompt, cx);
+        move_up_history(&prompt_editor, cx);
+
+        let mention_set = mention_set_for(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt);
+        cx.read(|cx| {
+            assert!(mention_set.read(cx).mentions().is_empty());
+            assert!(mention_set.read(cx).creases().is_empty());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_history_does_not_treat_regular_markdown_link_as_context(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", serde_json::json!({})).await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        let prompt = "See [docs](https://example.com/docs) for details";
+        set_prompt_text(&prompt_editor, prompt, cx);
+        push_history(&prompt_editor, prompt, cx);
+        move_up_history(&prompt_editor, cx);
+
+        let mention_set = mention_set_for(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt);
+        cx.read(|cx| {
+            assert!(mention_set.read(cx).mentions().is_empty());
+            assert!(mention_set.read(cx).creases().is_empty());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_history_restores_missing_file_context_without_panicking(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            serde_json::json!({
+                "existing.txt": "hello",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        // The referenced file does not exist; restoring must not panic and
+        // must reuse the existing unresolved-mention behavior.
+        let prompt = "Transform this: [@gone.txt](file:///project/gone.txt)";
+        set_prompt_text(&prompt_editor, prompt, cx);
+        push_history(&prompt_editor, prompt, cx);
+        move_up_history(&prompt_editor, cx);
+        cx.run_until_parked();
+
+        let mention_set = mention_set_for(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt);
+        cx.read(|cx| {
+            assert_eq!(
+                mention_set.read(cx).mentions(),
+                HashSet::from_iter([MentionUri::File {
+                    abs_path: PathBuf::from("/project/gone.txt"),
+                }])
+            );
+            assert_eq!(mention_set.read(cx).creases().len(), 1);
+
+            // The missing file uses the existing unresolved-mention behavior
+            // and resolves to an empty text mention instead of content;
+            // restoring must not panic.
+            let crease_id = *mention_set.read(cx).creases().iter().next().unwrap();
+            let (_, mention) = mention_set
+                .read(cx)
+                .resolved_mention_for_crease(&crease_id)
+                .expect("mention should resolve");
+            assert!(matches!(
+                mention,
+                Some(Mention::Text { content, .. }) if content.is_empty()
+            ));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_history_restores_thread_mention_without_panicking(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", serde_json::json!({})).await;
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let prompt_editor = build_terminal_prompt_editor(&workspace, cx);
+
+        let prompt = "Use this thread: [@My Thread](zed:///agent/thread/00000000-0000-0000-0000-000000000001?name=My+Thread)";
+        set_prompt_text(&prompt_editor, prompt, cx);
+        push_history(&prompt_editor, prompt, cx);
+        move_up_history(&prompt_editor, cx);
+        cx.run_until_parked();
+
+        let mention_set = mention_set_for(&prompt_editor, cx);
+        assert_eq!(prompt_text(&prompt_editor, cx), prompt);
+        cx.read(|cx| {
+            assert_eq!(
+                mention_set.read(cx).mentions(),
+                HashSet::from_iter([MentionUri::Thread {
+                    id: acp::SessionId::new("00000000-0000-0000-0000-000000000001"),
+                    name: "My Thread".to_string(),
+                }])
+            );
+            assert_eq!(mention_set.read(cx).creases().len(), 1);
+        });
     }
 }

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -1147,6 +1147,68 @@ pub(crate) fn insert_crease_for_mention(
     Some((crease_id, tx, Some(crease_entity)))
 }
 
+/// Inserts context creases and registers mentions for the given parsed mention
+/// links, loading their content (files, threads, etc.) the same way pasted
+/// mention links are loaded.
+///
+/// `mentions` contains, for each link, the buffer anchor at the start of the
+/// link text, the length of the link text, and the parsed mention URI.
+pub(crate) fn insert_mentions_from_links(
+    editor: &Entity<Editor>,
+    mention_set: &Entity<MentionSet>,
+    workspace: WeakEntity<Workspace>,
+    mentions: Vec<(text::Anchor, usize, MentionUri)>,
+    supports_images: bool,
+    http_client: Arc<HttpClientWithUrl>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    for (anchor, content_len, mention_uri) in mentions {
+        let Some((crease_id, tx, crease_entity)) = insert_crease_for_mention(
+            anchor,
+            content_len,
+            mention_uri.name().into(),
+            mention_uri.icon_path(cx),
+            mention_uri.tooltip_text(),
+            Some(mention_uri.clone()),
+            Some(workspace.clone()),
+            None,
+            editor.clone(),
+            window,
+            cx,
+        ) else {
+            continue;
+        };
+
+        // Create the confirmation task based on the mention URI type.
+        // This properly loads file content, fetches URLs, etc.
+        let task = mention_set.update(cx, |mention_set, cx| {
+            mention_set.confirm_mention_for_uri(
+                mention_uri.clone(),
+                supports_images,
+                http_client.clone(),
+                cx,
+            )
+        });
+        let task = cx
+            .spawn(async move |_| task.await.map_err(|e| e.to_string()))
+            .shared();
+
+        mention_set.update(cx, |mention_set, cx| {
+            mention_set.insert_mention(
+                crease_id,
+                mention_uri.clone(),
+                task.clone(),
+                crease_entity,
+                cx,
+            )
+        });
+
+        // Drop the tx after inserting to signal the crease is ready.
+        drop(tx);
+    }
+}
+
 pub(crate) fn crease_for_mention(
     label: SharedString,
     icon_path: SharedString,

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -7,7 +7,9 @@ use crate::{
         PromptCompletionProviderDelegate, PromptContextAction, PromptContextType,
         PromptLocalCommand, SlashCommandCompletion,
     },
-    mention_set::{Mention, MentionImage, MentionSet, insert_crease_for_mention},
+    mention_set::{
+        Mention, MentionImage, MentionSet, insert_crease_for_mention, insert_mentions_from_links,
+    },
 };
 use acp_thread::MentionUri;
 use agent::ThreadStore;
@@ -1247,7 +1249,8 @@ impl MessageEditor {
                         let mention_start_offset = MultiBufferOffset(start_offset.0 + range.start);
                         let anchor = snapshot.anchor_before(mention_start_offset);
                         let content_len = range.end - range.start;
-                        all_mentions.push((anchor, content_len, mention_uri));
+                        let buffer_anchor = snapshot.anchor_to_buffer_anchor(anchor).unwrap().0;
+                        all_mentions.push((buffer_anchor, content_len, mention_uri));
                     }
                 }
 
@@ -1255,50 +1258,16 @@ impl MessageEditor {
                     let supports_images = self.session_capabilities.read().supports_images();
                     let http_client = workspace.read(cx).client().http_client();
 
-                    for (anchor, content_len, mention_uri) in all_mentions {
-                        let Some((crease_id, tx, crease_entity)) = insert_crease_for_mention(
-                            snapshot.anchor_to_buffer_anchor(anchor).unwrap().0,
-                            content_len,
-                            mention_uri.name().into(),
-                            mention_uri.icon_path(cx),
-                            mention_uri.tooltip_text(),
-                            Some(mention_uri.clone()),
-                            Some(self.workspace.clone()),
-                            None,
-                            self.editor.clone(),
-                            window,
-                            cx,
-                        ) else {
-                            continue;
-                        };
-
-                        // Create the confirmation task based on the mention URI type.
-                        // This properly loads file content, fetches URLs, etc.
-                        let task = self.mention_set.update(cx, |mention_set, cx| {
-                            mention_set.confirm_mention_for_uri(
-                                mention_uri.clone(),
-                                supports_images,
-                                http_client.clone(),
-                                cx,
-                            )
-                        });
-                        let task = cx
-                            .spawn(async move |_, _| task.await.map_err(|e| e.to_string()))
-                            .shared();
-
-                        self.mention_set.update(cx, |mention_set, cx| {
-                            mention_set.insert_mention(
-                                crease_id,
-                                mention_uri.clone(),
-                                task.clone(),
-                                crease_entity,
-                                cx,
-                            )
-                        });
-
-                        // Drop the tx after inserting to signal the crease is ready
-                        drop(tx);
-                    }
+                    insert_mentions_from_links(
+                        &self.editor,
+                        &self.mention_set,
+                        self.workspace.clone(),
+                        all_mentions,
+                        supports_images,
+                        http_client,
+                        window,
+                        cx,
+                    );
                     return;
                 }
             }
@@ -2181,7 +2150,10 @@ fn mention_to_content_block(
 
 /// Parses markdown mention links in the format `[@name](uri)` from text.
 /// Returns a vector of (range, MentionUri) pairs where range is the byte range in the text.
-fn parse_mention_links(text: &str, path_style: PathStyle) -> Vec<(Range<usize>, MentionUri)> {
+pub(crate) fn parse_mention_links(
+    text: &str,
+    path_style: PathStyle,
+) -> Vec<(Range<usize>, MentionUri)> {
     let mut mentions = Vec::new();
     let mut search_start = 0;
 


### PR DESCRIPTION
Fixes #62202

## Problem

When a prompt with structured context (a file or thread mention) is submitted in the Inline Assistant and then restored from prompt history with the Up/Down arrows, the context is not restored. The mention is shown as a plain markdown link (`[@name](uri)`) instead of a context element, and — more importantly — the assistant never receives the context when the prompt is re-submitted (the referenced file or thread is not resolved or passed to the assistant).

## Root cause

Prompt history stores only the flattened prompt text (`InlineAssistant::prompt_history: VecDeque<String>`, populated from the editor text in `start_assist`). The actual context lives in the `MentionSet` (crease → mention URI + loaded content), which is never stored in history. `PromptEditor::move_up` / `move_down` only call `editor.set_text(prompt)`, so the restored text contains the canonical `[@name](uri)` link but no crease and no `MentionSet` entry. On submit, `load_context(&mention_set)` resolves an empty mention set, so the assistant receives no file content or thread rules.

The loss happens in both the save step (only text is saved) and the restore step (only text is re-inserted). History is in-memory (`VecDeque<String>`), so there is no persistence format to migrate.

## Solution

When navigating prompt history, re-parse the canonical mention links from the restored text and rebuild the mentions using the exact machinery that already exists for pasting mention links (the message editor paste path): `parse_mention_links` + `insert_crease_for_mention` + `confirm_mention_for_uri` + `insert_mention`. This re-creates the context UI (crease) and re-registers the mention in the `MentionSet`, so the real assistant context (file contents, thread rules) is loaded again on submit. UI state and the assistant input stay on the same data — the `MentionSet`.

To keep a single source of truth, the paste path's inline loop was extracted into a shared `insert_mentions_from_links` helper in `mention_set.rs`; both the message editor paste handler and the new history-restore path call it. No history data format changes, no persistence or migration, and no string matching beyond Zed's existing strict `[@` link parser.

Restoring a mention creates a folded crease, which changes the editor's display text (the mention renders as a fold placeholder). The prompt history index and the pending prompt were tracked by comparing the display text against the stored history text, so navigating to a prompt with context reset the index and could corrupt the pending prompt. The tracking now compares against the raw buffer text, which is what history entries store.

## Behavior

- File context: restored as a real crease, re-resolved to the actual file, and included in the assistant request (covered by a round-trip test through `load_context`).
- Thread context: uses the same `confirm_mention_for_uri` dispatch; restored as a crease and re-registered.
- Consecutive Up/Down navigation across entries with different context: each restored prompt shows only its own context; no stale mentions linger, and the pending draft restores without stale context.
- Plain prompts without context: unchanged.
- Ordinary markdown links (`[foo](url)`): not treated as context — the parser only matches canonical `[@…]` links.
- Missing/unresolvable context (deleted file, missing thread): uses the existing unresolved-mention behavior (e.g. a missing file resolves to an empty text mention / link placeholder); no panic.

## Tests

New gpui tests in `crates/agent_ui/src/inline_prompt_editor.rs`:
- `test_history_restores_file_context` — full round-trip: history text with a file mention, `move_up`, then assert the mention is registered, a crease is present, and `load_context` resolves the file content.
- `test_history_switches_between_contexts_without_stale_mentions` — consecutive Up/Up/Down/Down across entries with different file context; asserts the `MentionSet` never retains the previous entry's context and the pending draft restores cleanly.
- `test_history_restores_plain_prompt_without_context`
- `test_history_does_not_treat_regular_markdown_link_as_context`
- `test_history_restores_missing_file_context_without_panicking`
- `test_history_restores_thread_mention_without_panicking`

Existing message editor paste/mention tests guard the paste-path refactor.

Checks run:
- `cargo test -p agent_ui --lib` (410 passed)
- `cargo clippy -p agent_ui --all-targets --all-features -- --deny warnings`
- `cargo fmt --check`
- `git diff --check`

## Manual verification

Verified on macOS (debug build, Apple Silicon):

1. Opened a Rust file and triggered the inline assistant.
2. Added a file mention as context, submitted the prompt, then reopened the inline assistant.
3. Pressed Up to restore the previous prompt: the file context is restored as a context element (crease) instead of plain markdown text, and the referenced file is re-resolved.
4. Navigated Up/Down across multiple history entries with different context: each restored prompt shows only its own context, and returning to the pending draft leaves no stale context.

Linux (the issue reporter's platform) was not verified.

Release Notes:

- Fixed the inline assistant not restoring structured context (file/thread mentions) when navigating prompt history with the up/down arrow keys.