### PR TITLE
terminal: Avoid killing rerun task process groups

### DIFF
--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -35,7 +35,12 @@ impl ProcessIdGetter {
         // Zero pid means no foreground process group is set on the PTY yet.
         // Avoid killing the current process by returning a zero pid.
         let pid = unsafe { libc::tcgetpgrp(self.handle) };
-        if pid > 0 {
+        // The event loop may close this file descriptor before the `Terminal`
+        // is dropped, allowing a newer terminal to reuse the same descriptor.
+        // A foreground group belongs to this PTY only when it is in the
+        // session led by the child that was originally spawned for it.
+        let session_id = unsafe { libc::tcgetsid(self.handle) };
+        if pid > 0 && session_id == self.fallback_pid as libc::pid_t {
             return Some(Pid::from_u32(pid as u32));
         }
 

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -39,6 +39,8 @@ impl ProcessIdGetter {
         // is dropped, allowing a newer terminal to reuse the same descriptor.
         // A foreground group belongs to this PTY only when it is in the
         // session led by the child that was originally spawned for it.
+        // `tcgetsid` returns -1 on a stale descriptor (EBADF/ENOTTY), which
+        // also fails this check.
         let session_id = unsafe { libc::tcgetsid(self.handle) };
         if pid > 0 && session_id == self.fallback_pid as libc::pid_t {
             return Some(Pid::from_u32(pid as u32));

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -5043,6 +5043,18 @@ mod tests {
             TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
         });
 
+        let (completed_child_pid, completed_foreground_pid) =
+            completed_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => (info.pid_getter().fallback_pid(), info.pid()),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_eq!(
+            completed_foreground_pid,
+            Some(completed_child_pid),
+            "a completed terminal whose PTY descriptor may have been reused must \
+             report its own child, not another terminal's foreground group"
+        );
+
         drop(completed_terminal);
         cx.update(|_| {});
         cx.background_executor

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -5026,6 +5026,36 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_dropping_completed_terminal_does_not_kill_new_terminal(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (completed_terminal, completion_rx) = build_test_terminal(cx, "true", &[]).await;
+        completion_rx
+            .recv()
+            .await
+            .expect("completed terminal should report its exit status");
+
+        let (new_terminal, _completion_rx) = build_test_terminal(cx, "sleep", &["300"]).await;
+        let new_shell_pid = new_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+            TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32() as i32,
+            TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+        });
+
+        drop(completed_terminal);
+        cx.update(|_| {});
+        cx.background_executor
+            .timer(PROCESS_KILL_GRACE_PERIOD + Duration::from_millis(50))
+            .await;
+
+        assert_eq!(
+            unsafe { libc::kill(new_shell_pid, 0) },
+            0,
+            "dropping a completed terminal should not kill a newly spawned terminal"
+        );
+    }
+
     /// Test that kill_active_task on a task that's not running is a no-op
     #[gpui::test]
     async fn test_kill_active_task_on_completed_task_is_noop(cx: &mut TestAppContext) {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -4974,10 +4974,19 @@ mod tests {
         let background_sleep_pid = parse_pid_marker(&content, "bg_marker_", "_bgend");
         let foreground_sleep_pid = parse_pid_marker(&content, "fg_marker_", "_fgend");
 
-        let shell_pid = terminal.update(cx, |terminal, _| match &terminal.terminal_type {
-            TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32() as i32,
-            TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
-        });
+        let (shell_pid, captured_foreground_pid) =
+            terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => (
+                    info.pid_getter().fallback_pid().as_u32() as i32,
+                    info.pid().map(|pid| pid.as_u32() as i32),
+                ),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_eq!(
+            captured_foreground_pid,
+            Some(foreground_sleep_pid),
+            "the PTY should report the active foreground process group"
+        );
 
         for pid in [background_sleep_pid, foreground_sleep_pid] {
             assert_eq!(
@@ -5065,6 +5074,58 @@ mod tests {
             unsafe { libc::kill(new_shell_pid, 0) },
             0,
             "dropping a completed terminal should not kill a newly spawned terminal"
+        );
+    }
+
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_stale_process_info_does_not_kill_reused_fallback_process_group(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (replacement_terminal, replacement_completion_rx) = build_test_terminal(
+            cx,
+            "/bin/sh -c 'echo replacement_fg_marker_$$_fgend; exec sleep 5'; echo done",
+            &[],
+        )
+        .await;
+        assert_content_eventually(&replacement_terminal, "_fgend", cx).await;
+        let content = replacement_terminal.update(cx, |terminal, _| terminal.get_content());
+        let replacement_foreground_pid =
+            parse_pid_marker(&content, "replacement_fg_marker_", "_fgend");
+        let replacement_shell_pid =
+            replacement_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32() as i32,
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_ne!(
+            unsafe { libc::getpgid(replacement_foreground_pid) },
+            unsafe { libc::getpgid(replacement_shell_pid) },
+            "replacement foreground process should run separately from its shell"
+        );
+
+        let stale_info =
+            PtyProcessInfo::new(ProcessIdGetter::new(-1, replacement_foreground_pid as u32));
+        let signal_sent = stale_info.capture_process_ids().terminate();
+
+        cx.background_executor
+            .timer(Duration::from_millis(50))
+            .await;
+        let completed_early = replacement_completion_rx.try_recv().ok();
+        let content = replacement_terminal.update(cx, |terminal, _| terminal.get_content());
+
+        drop(replacement_terminal);
+        cx.update(|_| {});
+        cx.background_executor
+            .timer(PROCESS_KILL_GRACE_PERIOD + Duration::from_millis(50))
+            .await;
+
+        assert!(
+            !signal_sent && completed_early.is_none(),
+            "cleanup for stale process info killed a new foreground process group \
+             that reused its fallback process-group id; completion: {completed_early:?}; \
+             content: {content}"
         );
     }
 


### PR DESCRIPTION
# Objective

Closes #62286
Closes #62095
Fixes behavior I introduced in #61467 (whoops).

Right now tasks are being killed by the terminal cleanup process when they are being rerun. This is happening because the after the task completes, the PTY frees the FD, but `ProcessIdGetter` retains the raw FD. The new task's PTY can be given the same FD by the OS, so when the old terminal is dropped, which happens not when the original task ends, but when the new one starts, it sends a signal to the new task that kills it.

## Solution

The solution is to validate that the PTY FD still belongs to the original terminal session before using the PGID returned by `tcgetpgrp`. The PTY child calls `setsid`, so its PID—stored as `fallback_pid`—is also the ID of the terminal's session. We compare `tcgetsid(handle)` against `fallback_pid`:
- If they match, the file descriptor still belongs to the original terminal, and the foreground process-group ID returned by `tcgetpgrp` is safe to use.
- If they do not match, the file descriptor has been closed or reused. In that case, we reject the queried foreground process group and fall back to the original child process group.

<details><summary>My first (worse) description of the solution</summary>
<p>

My previous PR introduced a path where the FD was used to get the PGID to kill, while fallback_pid is captured when the terminal was created, we are capturing the main pid by the FD value `ProcessIdGetter.handle` with `tcgetpgrp`, if that FD has been reused than we get the new PGID. To avoid this race we check the `session_id` of the handle, if it has not been reused, then `session_id == self.fallback_pid`, and we can return the PGID we got from `tcgetpgrp` to be killed, however, if it has been reassigned, then `session_id != self.fallback_pid`, and we dont let that new PGID get killed.

</p>
</details> 


## Testing

I added a test that was failing originally, but with the new changes is passing. I also manually reproduced the bug and then manually checked that its fixed with these changes:

https://github.com/user-attachments/assets/190d27a7-f314-4f0e-866d-8b6334d124a7

I also verified that the session_id -> fallback_pid check was working:
<img width="594" height="340" alt="Screenshot 2026-08-07 at 9 33 14 AM" src="https://github.com/user-attachments/assets/633ff771-01ea-417b-aaf0-1cf02633e5df" />


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- terminal: fixed tasks being instantly killed on rerun.
