### PR TITLE
gpui_windows: Keep DirectWrite's default ligatures when no font features are set

### DIFF
--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1765,9 +1765,6 @@ fn apply_font_features(
     features: &FontFeatures,
 ) -> Result<()> {
     let tag_values = features.tag_value_list();
-    if tag_values.is_empty() {
-        return Ok(());
-    }
 
     // All of these features are enabled by default by DirectWrite.
     // If you want to (and can) peek into the source of DirectWrite


### PR DESCRIPTION
On Windows, ligatures are off by default: they only show up if `buffer_font_features` is set to something non-empty.

`generate_font_features` always creates an `IDWriteTypography` and passes it to `apply_font_features` (`direct_write.rs:446-452`), and the layout code calls `SetTypography` with it unconditionally (`:567`, `:605`). `apply_font_features` returned early when no features were configured, so an empty typography object reached DirectWrite. `SetTypography` replaces the default feature set with exactly what the typography contains, so `liga`, `clig` and `calt` ended up disabled.

Dropping the early return lets the rest of the function run, which adds `liga`, `clig` and `calt` at 1. Users who configure features explicitly are unaffected: that path already ran before this change, and an explicit `liga: 0` still resolves to 0 through the same loop.

I went with this rather than guarding the two `SetTypography` calls, because the function already owns the knowledge of which features DirectWrite enables by default for the non-empty case, and guarding the call sites would duplicate it in two places.

Other platforms are not affected: `generate_feature_array` on macOS (`gpui_macos/src/open_type.rs:77`) appends one dictionary per configured tag and does not replace the default feature set when the list is empty.

No test here: `apply_font_features` takes a live `IDWriteTypography` from `CreateTypography()`, so covering it needs a real DirectWrite factory and cannot run off Windows. I can extract the tag resolution into a pure function and unit test that separately if you would prefer it.

Checked on a Windows build with no `buffer_font_features` set: ligatures render with this change and are absent without it.

Release Notes:

- Fixed ligatures being disabled on Windows unless `buffer_font_features` was set
- [GPUI] N/A