### PR TITLE
gpui_wgpu: Add offscreen headless rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8056,6 +8056,7 @@ dependencies = [
  "etagere",
  "gpui",
  "gpui_util",
+ "image",
  "itertools 0.14.0",
  "js-sys",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8055,6 +8055,7 @@ dependencies = [
  "collections",
  "cosmic-text",
  "criterion",
+ "env_logger 0.11.8",
  "etagere",
  "gpui",
  "gpui_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7991,7 +7991,9 @@ dependencies = [
  "gpui_linux",
  "gpui_macos",
  "gpui_web",
+ "gpui_wgpu",
  "gpui_windows",
+ "log",
 ]
 
 [[package]]

--- a/crates/gpui_platform/Cargo.toml
+++ b/crates/gpui_platform/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/gpui_platform.rs"
 [features]
 default = []
 font-kit = ["gpui_macos/font-kit"]
-test-support = ["gpui/test-support", "gpui_macos/test-support"]
+test-support = ["gpui/test-support", "gpui_macos/test-support", "gpui_wgpu/test-support"]
 screen-capture = ["gpui/screen-capture", "gpui_macos/screen-capture", "gpui_windows/screen-capture", "gpui_linux/screen-capture"]
 runtime_shaders = ["gpui_macos/runtime_shaders"]
 wayland = ["gpui_linux/wayland"]
@@ -22,16 +22,21 @@ x11 = ["gpui_linux/x11"]
 
 [dependencies]
 gpui.workspace = true
+log.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 gpui_macos.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 gpui_windows.workspace = true
+gpui_wgpu.workspace = true
 gpui = { workspace = true, features = ["windows-manifest"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 gpui_linux.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gpui_wgpu.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gpui_web.workspace = true

--- a/crates/gpui_platform/src/gpui_platform.rs
+++ b/crates/gpui_platform/src/gpui_platform.rs
@@ -79,7 +79,18 @@ pub fn current_headless_renderer() -> Option<Box<dyn gpui::PlatformHeadlessRende
         ))
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        match gpui_wgpu::WgpuHeadlessRenderer::new() {
+            Ok(renderer) => Some(Box::new(renderer)),
+            Err(error) => {
+                log::error!("Failed to create wgpu headless renderer: {error:#}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         None
     }

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/gpui_wgpu.rs"
 [features]
 default = []
 font-kit = ["dep:font-kit"]
-test-support = ["gpui/test-support"]
+test-support = ["gpui/test-support", "dep:image"]
 
 [dependencies]
 gpui.workspace = true
@@ -24,6 +24,7 @@ collections.workspace = true
 cosmic-text = "0.19.0"
 etagere.workspace = true
 itertools.workspace = true
+image = { workspace = true, optional = true }
 log.workspace = true
 parking_lot.workspace = true
 profiling.workspace = true
@@ -50,6 +51,8 @@ js-sys.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+gpui = { workspace = true, features = ["test-support"] }
+image.workspace = true
 
 [[bench]]
 name = "layout_line"

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/gpui_wgpu.rs"
 [features]
 default = []
 font-kit = ["dep:font-kit"]
+test-support = ["gpui/test-support"]
 
 [dependencies]
 gpui.workspace = true

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -51,6 +51,7 @@ js-sys.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 image.workspace = true
 

--- a/crates/gpui_wgpu/src/gpui_wgpu.rs
+++ b/crates/gpui_wgpu/src/gpui_wgpu.rs
@@ -7,4 +7,6 @@ pub use cosmic_text_system::*;
 pub use wgpu;
 pub use wgpu_atlas::*;
 pub use wgpu_context::*;
+#[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+pub use wgpu_renderer::WgpuHeadlessRenderer;
 pub use wgpu_renderer::{GpuContext, WgpuRenderer, WgpuSurfaceConfig};

--- a/crates/gpui_wgpu/src/gpui_wgpu.rs
+++ b/crates/gpui_wgpu/src/gpui_wgpu.rs
@@ -18,7 +18,7 @@ mod tests {
         App, Context, HeadlessAppContext, IntoElement, Render, Window, div, prelude::*, px, rgb,
         size,
     };
-    use std::{collections::HashSet, path::PathBuf, sync::Arc};
+    use std::{path::PathBuf, sync::Arc};
 
     struct HeadlessTestView;
 
@@ -29,30 +29,38 @@ mod tests {
                 .flex()
                 .items_center()
                 .justify_center()
-                .bg(rgb(0x172033))
-                .font_family("DejaVu Sans")
                 .child(
                     div()
-                        .w(px(280.0))
-                        .h(px(112.0))
-                        .p_5()
-                        .rounded_lg()
-                        .shadow_lg()
-                        .bg(rgb(0xf4f7fb))
-                        .text_color(rgb(0x182230))
+                        .w(px(320.0))
+                        .h(px(176.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .bg(rgb(0x172033))
+                        .font_family("DejaVu Sans")
                         .child(
                             div()
-                                .flex()
-                                .gap_2()
-                                .mb_4()
-                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0xef4444)))
-                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x22c55e)))
-                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x3b82f6))),
-                        )
-                        .child(
-                            div()
-                                .text_size(px(16.0))
-                                .child("Deterministic wgpu rendering"),
+                                .w(px(280.0))
+                                .h(px(112.0))
+                                .p_5()
+                                .rounded_lg()
+                                .shadow_lg()
+                                .bg(rgb(0xf4f7fb))
+                                .text_color(rgb(0x182230))
+                                .child(
+                                    div()
+                                        .flex()
+                                        .gap_2()
+                                        .mb_4()
+                                        .child(div().size(px(20.0)).rounded_sm().bg(rgb(0xef4444)))
+                                        .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x22c55e)))
+                                        .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x3b82f6))),
+                                )
+                                .child(
+                                    div()
+                                        .text_size(px(16.0))
+                                        .child("Deterministic wgpu rendering"),
+                                ),
                         ),
                 )
         }
@@ -74,7 +82,7 @@ mod tests {
                 WgpuHeadlessRenderer::new().expect("failed to create wgpu headless renderer"),
             ))
         });
-        let window = cx.open_window(size(px(320.0), px(180.0)), |_, cx: &mut App| {
+        let window = cx.open_window(size(px(324.0), px(180.0)), |_, cx: &mut App| {
             cx.new(|_| HeadlessTestView)
         })?;
         let window = window.into();
@@ -86,8 +94,31 @@ mod tests {
         let second = cx.capture_screenshot(window)?;
 
         assert_eq!(first.as_raw(), second.as_raw());
-        let unique_pixels = first.pixels().map(|pixel| pixel.0).collect::<HashSet<_>>();
-        assert!(unique_pixels.len() > 8, "rendered image was blank");
+        assert_eq!(first.dimensions(), (648, 360));
+        assert_eq!(first.get_pixel(0, 0).0, [0, 0, 0, 255]);
+        assert_eq!(first.get_pixel(10, 10).0, [0x17, 0x20, 0x33, 255]);
+        assert_eq!(first.get_pixel(104, 128).0, [0xef, 0x44, 0x44, 255]);
+        assert_eq!(first.get_pixel(160, 128).0, [0x22, 0xc5, 0x5e, 255]);
+        assert_eq!(first.get_pixel(216, 128).0, [0x3b, 0x82, 0xf6, 255]);
+
+        let text_ink_pixels = {
+            let image = &first;
+            (180..250)
+                .flat_map(|y| (90..590).map(move |x| image.get_pixel(x, y).0))
+                .filter(|pixel| pixel[0] < 100 && pixel[1] < 100 && pixel[2] < 100)
+                .count()
+        };
+        assert!(text_ink_pixels > 100, "rendered text was missing");
+
+        let background = [0x17, 0x20, 0x33, 255];
+        let shadow_pixels = {
+            let image = &first;
+            (294..320)
+                .flat_map(|y| (44..604).map(move |x| image.get_pixel(x, y).0))
+                .filter(|pixel| *pixel != background)
+                .count()
+        };
+        assert!(shadow_pixels > 100, "rendered shadow was missing");
 
         if let Some(path) = std::env::var_os("GPUI_HEADLESS_EVIDENCE_PATH") {
             let path = PathBuf::from(path);

--- a/crates/gpui_wgpu/src/gpui_wgpu.rs
+++ b/crates/gpui_wgpu/src/gpui_wgpu.rs
@@ -10,3 +10,93 @@ pub use wgpu_context::*;
 #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
 pub use wgpu_renderer::WgpuHeadlessRenderer;
 pub use wgpu_renderer::{GpuContext, WgpuRenderer, WgpuSurfaceConfig};
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use gpui::{
+        App, Context, HeadlessAppContext, IntoElement, Render, Window, div, prelude::*, px, rgb,
+        size,
+    };
+    use std::{collections::HashSet, path::PathBuf, sync::Arc};
+
+    struct HeadlessTestView;
+
+    impl Render for HeadlessTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(rgb(0x172033))
+                .font_family("DejaVu Sans")
+                .child(
+                    div()
+                        .w(px(280.0))
+                        .h(px(112.0))
+                        .p_5()
+                        .rounded_lg()
+                        .shadow_lg()
+                        .bg(rgb(0xf4f7fb))
+                        .text_color(rgb(0x182230))
+                        .child(
+                            div()
+                                .flex()
+                                .gap_2()
+                                .mb_4()
+                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0xef4444)))
+                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x22c55e)))
+                                .child(div().size(px(20.0)).rounded_sm().bg(rgb(0x3b82f6))),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(16.0))
+                                .child("Deterministic wgpu rendering"),
+                        ),
+                )
+        }
+    }
+
+    #[test]
+    fn test_headless_rendering_is_deterministic() -> anyhow::Result<()> {
+        if let Err(error) = env_logger::builder()
+            .is_test(true)
+            .filter_module("gpui_wgpu", log::LevelFilter::Info)
+            .try_init()
+        {
+            log::debug!("Test logger was already initialized: {error}");
+        }
+
+        let text_system = Arc::new(CosmicTextSystem::new("DejaVu Sans"));
+        let mut cx = HeadlessAppContext::with_platform(text_system, Arc::new(()), || {
+            Some(Box::new(
+                WgpuHeadlessRenderer::new().expect("failed to create wgpu headless renderer"),
+            ))
+        });
+        let window = cx.open_window(size(px(320.0), px(180.0)), |_, cx: &mut App| {
+            cx.new(|_| HeadlessTestView)
+        })?;
+        let window = window.into();
+        cx.update_window(window, |_, window, cx| {
+            window.draw(cx).clear(cx);
+        })?;
+
+        let first = cx.capture_screenshot(window)?;
+        let second = cx.capture_screenshot(window)?;
+
+        assert_eq!(first.as_raw(), second.as_raw());
+        let unique_pixels = first.pixels().map(|pixel| pixel.0).collect::<HashSet<_>>();
+        assert!(unique_pixels.len() > 8, "rendered image was blank");
+
+        if let Some(path) = std::env::var_os("GPUI_HEADLESS_EVIDENCE_PATH") {
+            let path = PathBuf::from(path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            first.save(path)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -71,6 +71,87 @@ impl WgpuContext {
                 reject_software,
             ))?;
 
+        Ok(Self::from_adapter_and_device(
+            instance,
+            adapter,
+            device,
+            queue,
+            dual_source_blending,
+            color_texture_format,
+        ))
+    }
+
+    /// Creates a GPU context without requiring a display or window surface.
+    #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+    pub fn new_headless() -> anyhow::Result<Self> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+
+        let (adapter, device, queue, dual_source_blending, color_texture_format) =
+            gpui::block_on(async {
+                let adapter = match instance
+                    .request_adapter(&wgpu::RequestAdapterOptions {
+                        power_preference: wgpu::PowerPreference::HighPerformance,
+                        compatible_surface: None,
+                        force_fallback_adapter: false,
+                    })
+                    .await
+                {
+                    Ok(adapter) => adapter,
+                    Err(primary_error) => {
+                        log::warn!(
+                            "Failed to request a headless GPU adapter: {primary_error}. \
+                             Retrying with a fallback adapter."
+                        );
+                        instance
+                            .request_adapter(&wgpu::RequestAdapterOptions {
+                                power_preference: wgpu::PowerPreference::HighPerformance,
+                                compatible_surface: None,
+                                force_fallback_adapter: true,
+                            })
+                            .await
+                            .map_err(|fallback_error| {
+                                anyhow::anyhow!(
+                                    "Failed to request a headless GPU adapter: {primary_error}; \
+                                     fallback adapter request also failed: {fallback_error}"
+                                )
+                            })?
+                    }
+                };
+                let (device, queue, dual_source_blending, color_texture_format) =
+                    Self::create_device(&adapter).await?;
+                anyhow::Ok((
+                    adapter,
+                    device,
+                    queue,
+                    dual_source_blending,
+                    color_texture_format,
+                ))
+            })?;
+
+        Ok(Self::from_adapter_and_device(
+            instance,
+            adapter,
+            device,
+            queue,
+            dual_source_blending,
+            color_texture_format,
+        ))
+    }
+
+    fn from_adapter_and_device(
+        instance: wgpu::Instance,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        dual_source_blending: bool,
+        color_texture_format: TextureFormat,
+    ) -> Self {
         let device_lost = Arc::new(AtomicBool::new(false));
         device.set_device_lost_callback({
             let device_lost = Arc::clone(&device_lost);
@@ -88,7 +169,7 @@ impl WgpuContext {
             adapter.get_info().backend
         );
 
-        Ok(Self {
+        Self {
             instance,
             adapter,
             device: Arc::new(device),
@@ -96,7 +177,7 @@ impl WgpuContext {
             dual_source_blending,
             color_texture_format,
             device_lost,
-        })
+        }
     }
 
     #[cfg(target_family = "wasm")]

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1169,11 +1169,21 @@ impl WgpuRenderer {
         let bytes_per_row = width
             .checked_mul(4)
             .ok_or_else(|| anyhow::anyhow!("Headless render target row size overflowed"))?;
-        let padded_bytes_per_row =
-            bytes_per_row.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+        let padded_bytes_per_row = bytes_per_row
+            .checked_next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            .ok_or_else(|| anyhow::anyhow!("Headless padded row size overflowed"))?;
         let buffer_size = u64::from(padded_bytes_per_row)
             .checked_mul(u64::from(height))
             .ok_or_else(|| anyhow::anyhow!("Headless readback buffer size overflowed"))?;
+        if buffer_size > self.max_buffer_size {
+            anyhow::bail!(
+                "Headless readback buffer size {} exceeds maximum buffer size {}",
+                buffer_size,
+                self.max_buffer_size
+            );
+        }
+        let pixel_capacity = usize::try_from(u64::from(bytes_per_row) * u64::from(height))
+            .map_err(|_| anyhow::anyhow!("Headless image size exceeds addressable memory"))?;
         let resources = self.resources();
         let readback_buffer = resources.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("headless_readback_buffer"),
@@ -1235,7 +1245,7 @@ impl WgpuRenderer {
         }
 
         let mapped_data = readback_buffer.slice(..).get_mapped_range();
-        let mut pixels = Vec::with_capacity(bytes_per_row as usize * height as usize);
+        let mut pixels = Vec::with_capacity(pixel_capacity);
         for row in mapped_data
             .chunks_exact(padded_bytes_per_row as usize)
             .take(height as usize)
@@ -1302,7 +1312,7 @@ impl WgpuRenderer {
         let target_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         self.atlas.before_frame();
-        self.draw_to_view(scene, &target_view)?;
+        self.draw_to_view(scene, &target_view, wgpu::Color::BLACK)?;
         Ok(texture)
     }
 
@@ -1385,7 +1395,7 @@ impl WgpuRenderer {
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
 
-        if let Err(error) = self.draw_to_view(scene, &frame_view) {
+        if let Err(error) = self.draw_to_view(scene, &frame_view, wgpu::Color::TRANSPARENT) {
             log::error!("{error}");
         }
         frame.present();
@@ -1396,6 +1406,7 @@ impl WgpuRenderer {
         &mut self,
         scene: &Scene,
         target_view: &wgpu::TextureView,
+        clear_color: wgpu::Color,
     ) -> anyhow::Result<()> {
         self.ensure_intermediate_textures();
 
@@ -1464,7 +1475,7 @@ impl WgpuRenderer {
                         view: target_view,
                         resolve_target: None,
                         ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                            load: wgpu::LoadOp::Clear(clear_color),
                             store: wgpu::StoreOp::Store,
                         },
                         depth_slice: None,

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -108,7 +108,7 @@ pub type GpuContext = Rc<RefCell<Option<WgpuContext>>>;
 struct WgpuResources {
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
-    surface: wgpu::Surface<'static>,
+    surface: Option<wgpu::Surface<'static>>,
     pipelines: WgpuPipelines,
     bind_group_layouts: WgpuBindGroupLayouts,
     atlas_sampler: wgpu::Sampler,
@@ -347,7 +347,81 @@ impl WgpuRenderer {
         // that this adapter can successfully configure this surface.
         surface.configure(&context.device, &surface_config);
 
+        Self::new_with_surface_config(
+            gpu_context,
+            context,
+            Some(surface),
+            surface_config,
+            compositor_gpu,
+            atlas,
+            transparent_alpha_mode,
+            opaque_alpha_mode,
+        )
+    }
+
+    #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+    fn new_headless(context: &WgpuContext, atlas: Arc<WgpuAtlas>) -> anyhow::Result<Self> {
+        let required_usages = wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC;
+        let surface_format = [
+            wgpu::TextureFormat::Bgra8Unorm,
+            wgpu::TextureFormat::Rgba8Unorm,
+        ]
+        .into_iter()
+        .find(|format| {
+            context
+                .adapter
+                .get_texture_format_features(*format)
+                .allowed_usages
+                .contains(required_usages)
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Adapter {:?} has no supported headless render target format",
+                context.adapter.get_info().name
+            )
+        })?;
+        let alpha_mode = wgpu::CompositeAlphaMode::Opaque;
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            format: surface_format,
+            width: 1,
+            height: 1,
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+            alpha_mode,
+            view_formats: vec![],
+        };
+
+        Self::new_with_surface_config(
+            None,
+            context,
+            None,
+            surface_config,
+            None,
+            atlas,
+            alpha_mode,
+            alpha_mode,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_surface_config(
+        gpu_context: Option<GpuContext>,
+        context: &WgpuContext,
+        surface: Option<wgpu::Surface<'static>>,
+        surface_config: wgpu::SurfaceConfiguration,
+        compositor_gpu: Option<CompositorGpuHint>,
+        atlas: Arc<WgpuAtlas>,
+        transparent_alpha_mode: wgpu::CompositeAlphaMode,
+        opaque_alpha_mode: wgpu::CompositeAlphaMode,
+    ) -> anyhow::Result<Self> {
+        let surface_format = surface_config.format;
+        let alpha_mode = surface_config.alpha_mode;
         let queue = Arc::clone(&context.queue);
+        let device = Arc::clone(&context.device);
+        let max_texture_size = device.limits().max_texture_dimension_2d;
         let dual_source_blending = context.supports_dual_source_blending();
 
         let rendering_params = RenderingParameters::new(&context.adapter, surface_format);
@@ -982,9 +1056,9 @@ impl WgpuRenderer {
                 texture.destroy();
             }
 
-            resources
-                .surface
-                .configure(&resources.device, &surface_config);
+            if let Some(surface) = resources.surface.as_ref() {
+                surface.configure(&resources.device, &surface_config);
+            }
 
             // Invalidate intermediate textures - they will be lazily recreated
             // in draw() after we confirm the surface is healthy. This avoids
@@ -1040,9 +1114,9 @@ impl WgpuRenderer {
             let Some(resources) = self.resources.as_mut() else {
                 return;
             };
-            resources
-                .surface
-                .configure(&resources.device, &surface_config);
+            if let Some(surface) = resources.surface.as_ref() {
+                surface.configure(&resources.device, &surface_config);
+            }
             resources.pipelines = Self::create_pipelines(
                 &resources.device,
                 &resources.bind_group_layouts,
@@ -1083,6 +1157,155 @@ impl WgpuRenderer {
         self.max_texture_size
     }
 
+    #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+    fn render_scene_to_image(
+        &mut self,
+        scene: &Scene,
+        size: Size<DevicePixels>,
+    ) -> anyhow::Result<image::RgbaImage> {
+        let texture = self.render_scene_to_texture(scene, size)?;
+        let width = size.width.0 as u32;
+        let height = size.height.0 as u32;
+        let bytes_per_row = width
+            .checked_mul(4)
+            .ok_or_else(|| anyhow::anyhow!("Headless render target row size overflowed"))?;
+        let padded_bytes_per_row =
+            bytes_per_row.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+        let buffer_size = u64::from(padded_bytes_per_row)
+            .checked_mul(u64::from(height))
+            .ok_or_else(|| anyhow::anyhow!("Headless readback buffer size overflowed"))?;
+        let resources = self.resources();
+        let readback_buffer = resources.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("headless_readback_buffer"),
+            size: buffer_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder =
+            resources
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("headless_readback_encoder"),
+                });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        let submission_index = resources.queue.submit(std::iter::once(encoder.finish()));
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        readback_buffer
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                if sender.send(result).is_err() {
+                    log::error!("Headless readback receiver was dropped before mapping completed");
+                }
+            });
+        resources
+            .device
+            .poll(wgpu::PollType::Wait {
+                submission_index: Some(submission_index),
+                timeout: None,
+            })
+            .map_err(|error| anyhow::anyhow!("Failed to wait for headless rendering: {error}"))?;
+        receiver
+            .recv()
+            .map_err(|error| anyhow::anyhow!("Failed to receive headless mapping result: {error}"))?
+            .map_err(|error| anyhow::anyhow!("Failed to map headless readback buffer: {error}"))?;
+
+        if let Some(error) = self.last_error.lock().unwrap().take() {
+            anyhow::bail!("GPU error during headless rendering: {error}");
+        }
+
+        let mapped_data = readback_buffer.slice(..).get_mapped_range();
+        let mut pixels = Vec::with_capacity(bytes_per_row as usize * height as usize);
+        for row in mapped_data
+            .chunks_exact(padded_bytes_per_row as usize)
+            .take(height as usize)
+        {
+            pixels.extend_from_slice(&row[..bytes_per_row as usize]);
+        }
+        drop(mapped_data);
+        readback_buffer.unmap();
+
+        if self.surface_config.format == wgpu::TextureFormat::Bgra8Unorm {
+            for pixel in pixels.chunks_exact_mut(4) {
+                pixel.swap(0, 2);
+            }
+        }
+
+        image::RgbaImage::from_raw(width, height, pixels)
+            .ok_or_else(|| anyhow::anyhow!("Failed to create RgbaImage from headless pixel data"))
+    }
+
+    #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+    fn render_scene_offscreen(
+        &mut self,
+        scene: &Scene,
+        size: Size<DevicePixels>,
+    ) -> anyhow::Result<()> {
+        self.render_scene_to_texture(scene, size).map(drop)
+    }
+
+    #[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+    fn render_scene_to_texture(
+        &mut self,
+        scene: &Scene,
+        size: Size<DevicePixels>,
+    ) -> anyhow::Result<wgpu::Texture> {
+        if size.width.0 <= 0 || size.height.0 <= 0 {
+            anyhow::bail!("Invalid size for headless rendering: {:?}", size);
+        }
+        if size.width.0 as u32 > self.max_texture_size
+            || size.height.0 as u32 > self.max_texture_size
+        {
+            anyhow::bail!(
+                "Headless render size {:?} exceeds maximum texture dimension {}",
+                size,
+                self.max_texture_size
+            );
+        }
+
+        self.update_drawable_size(size);
+        let resources = self.resources();
+        let texture = resources.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("headless_render_target"),
+            size: wgpu::Extent3d {
+                width: size.width.0 as u32,
+                height: size.height.0 as u32,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.surface_config.format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        self.atlas.before_frame();
+        self.draw_to_view(scene, &target_view)?;
+        Ok(texture)
+    }
+
     pub fn draw(&mut self, scene: &Scene) -> bool {
         // Bail out early if the surface has been unconfigured (e.g. during
         // Android background/rotation transitions).  Attempting to acquire
@@ -1118,7 +1341,13 @@ impl WgpuRenderer {
 
         self.atlas.before_frame();
 
-        let frame = match self.resources().surface.get_current_texture() {
+        let frame = match self
+            .resources()
+            .surface
+            .as_ref()
+            .expect("windowed renderer requires a surface")
+            .get_current_texture()
+        {
             wgpu::CurrentSurfaceTexture::Success(frame) => frame,
             wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
                 // Textures must be destroyed before the surface can be reconfigured.
@@ -1127,6 +1356,8 @@ impl WgpuRenderer {
                 let resources = self.resources_mut();
                 resources
                     .surface
+                    .as_ref()
+                    .expect("windowed renderer requires a surface")
                     .configure(&resources.device, &surface_config);
                 return false;
             }
@@ -1135,6 +1366,8 @@ impl WgpuRenderer {
                 let resources = self.resources_mut();
                 resources
                     .surface
+                    .as_ref()
+                    .expect("windowed renderer requires a surface")
                     .configure(&resources.device, &surface_config);
                 return false;
             }
@@ -1148,12 +1381,23 @@ impl WgpuRenderer {
             }
         };
 
-        // Now that we know the surface is healthy, ensure intermediate textures exist
-        self.ensure_intermediate_textures();
-
         let frame_view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
+
+        if let Err(error) = self.draw_to_view(scene, &frame_view) {
+            log::error!("{error}");
+        }
+        frame.present();
+        true
+    }
+
+    fn draw_to_view(
+        &mut self,
+        scene: &Scene,
+        target_view: &wgpu::TextureView,
+    ) -> anyhow::Result<()> {
+        self.ensure_intermediate_textures();
 
         let gamma_params = GammaParams {
             gamma_ratios: self.rendering_params.gamma_ratios,
@@ -1217,7 +1461,7 @@ impl WgpuRenderer {
                 let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("main_pass"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &frame_view,
+                        view: target_view,
                         resolve_target: None,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
@@ -1256,7 +1500,7 @@ impl WgpuRenderer {
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued"),
                                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                    view: &frame_view,
+                                    view: target_view,
                                     resolve_target: None,
                                     ops: wgpu::Operations {
                                         load: wgpu::LoadOp::Load,
@@ -1320,12 +1564,10 @@ impl WgpuRenderer {
             if overflow {
                 drop(encoder);
                 if self.instance_buffer_capacity >= self.max_buffer_size {
-                    log::error!(
+                    anyhow::bail!(
                         "instance buffer size grew too large: {}",
                         self.instance_buffer_capacity
                     );
-                    frame.present();
-                    return true;
                 }
                 self.grow_instance_buffer();
                 continue;
@@ -1334,8 +1576,7 @@ impl WgpuRenderer {
             self.resources()
                 .queue
                 .submit(std::iter::once(encoder.finish()));
-            frame.present();
-            return true;
+            return Ok(());
         }
     }
 
@@ -1745,7 +1986,7 @@ impl WgpuRenderer {
                 .as_mut()
                 .expect("GPU resources not available");
             surface.configure(&res.device, &self.surface_config);
-            res.surface = surface;
+            res.surface = Some(surface);
 
             // Invalidate intermediate textures — they'll be recreated lazily.
             res.invalidate_intermediate_textures();
@@ -1848,6 +2089,40 @@ impl WgpuRenderer {
 
         log::info!("GPU recovery complete");
         Ok(())
+    }
+}
+
+#[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+pub struct WgpuHeadlessRenderer {
+    renderer: WgpuRenderer,
+}
+
+#[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+impl WgpuHeadlessRenderer {
+    pub fn new() -> anyhow::Result<Self> {
+        let context = WgpuContext::new_headless()?;
+        let atlas = Arc::new(WgpuAtlas::from_context(&context));
+        let renderer = WgpuRenderer::new_headless(&context, atlas)?;
+        Ok(Self { renderer })
+    }
+}
+
+#[cfg(all(not(target_family = "wasm"), any(test, feature = "test-support")))]
+impl gpui::PlatformHeadlessRenderer for WgpuHeadlessRenderer {
+    fn render_scene_to_image(
+        &mut self,
+        scene: &Scene,
+        size: Size<DevicePixels>,
+    ) -> anyhow::Result<image::RgbaImage> {
+        self.renderer.render_scene_to_image(scene, size)
+    }
+
+    fn render_scene(&mut self, scene: &Scene, size: Size<DevicePixels>) -> anyhow::Result<()> {
+        self.renderer.render_scene_offscreen(scene, size)
+    }
+
+    fn sprite_atlas(&self) -> Arc<dyn gpui::PlatformAtlas> {
+        self.renderer.sprite_atlas().clone()
     }
 }
 


### PR DESCRIPTION
# gpui_wgpu: Add offscreen headless rendering

## Motivation

GPUI's `PlatformHeadlessRenderer` currently has a Metal implementation, leaving Linux and Windows unable to capture real rendered output in headless visual tests. Add an offscreen wgpu implementation so `HeadlessAppContext` can render and compare scenes without a window surface on those platforms.

## Implementation

- Add surface-free `WgpuContext` construction that first requests a normal adapter and retries with `force_fallback_adapter` when adapter selection fails, allowing software Vulkan adapters when no GPU is available.
- Refactor `WgpuRenderer` scene encoding to render into an arbitrary `TextureView`, preserving the existing surface acquisition and presentation path for windowed rendering.
- Add `WgpuHeadlessRenderer`, including opaque offscreen targets, 256-byte-aligned mapped-buffer readback, row-padding removal, and BGRA-to-RGBA conversion.
- Return the wgpu headless renderer from `gpui_platform::current_headless_renderer()` on Linux and Windows while retaining Metal on macOS.
- Cover colored quads, a rounded card and shadow, text sprites, padded readback rows, channel order, non-blank output, and repeated byte equality with a `HeadlessAppContext` determinism test.

## Verification

- `cargo build -p gpui_wgpu --features test-support`
- `cargo test -p gpui_wgpu --features test-support -- --test-threads=1` — 27 passed, 0 failed
- Linux software-rendering evidence selected `llvmpipe (LLVM 15.0.6, 256 bits)` through Vulkan.
- Two separate test invocations produced byte-identical PNGs with SHA-256 `0968c9b1b5fdd631859ed5db0d6d096eb418665742cbbf382629f0d847af3ec6`.

Release Notes:

- N/A
