### PR TITLE
gpui: Keep closing punctuation attached when wrapping text

### DIFF
--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -170,7 +170,15 @@ impl LineLayout {
                     last_candidate_x = x;
                 }
             } else {
-                if ch != ' ' && first_non_whitespace_ix.is_some() {
+                // Break before a non-word char only when the previous char is
+                // a space or another non-word char (CJK sequences). A non-word
+                // char directly after a word char is closing punctuation
+                // (`powerless."`, `word)`, `done!`) — breaking there orphans
+                // the punctuation at the start of the next line.
+                if ch != ' '
+                    && !LineWrapper::is_word_char(prev_ch)
+                    && first_non_whitespace_ix.is_some()
+                {
                     last_candidate_ix = Some(boundary);
                     last_candidate_x = x;
                 }
@@ -991,6 +999,28 @@ mod tests {
             .iter()
             .map(|g| f32::from(g.position.x))
             .collect()
+    }
+
+    #[test]
+    fn test_wrap_boundaries_keep_closing_punctuation_attached() {
+        // `aaa aaaa."` shaped at 8px cells, wrapped at 72px: the `"` is the
+        // overflow glyph. The old any-non-word-char rule put a boundary right
+        // before it, orphaning the quote on the next line; the break must
+        // fall back to the word boundary at glyph 4 instead.
+        let text = "aaa aaaa.\"";
+        let glyphs = (0..text.len())
+            .map(|i| glyph_at(i as f32 * 8., i))
+            .collect::<Vec<_>>();
+        let mut layout = make_layout(glyphs);
+        layout.width = px(80.);
+        let boundaries = layout.compute_wrap_boundaries(text, px(72.), None);
+        assert_eq!(
+            boundaries.as_slice(),
+            &[WrapBoundary {
+                run_ix: 0,
+                glyph_ix: 4
+            }]
+        );
     }
 
     #[test]

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -71,8 +71,17 @@ impl LineWrapper {
                                 last_candidate_width = width;
                             }
                         } else {
-                            // CJK may not be space separated, e.g.: `Hello world你好世界`
-                            if c != ' ' && first_non_whitespace_ix.is_some() {
+                            // CJK may not be space separated, e.g.: `Hello world你好世界`,
+                            // so a non-word char is a break opportunity — but only when
+                            // the PREVIOUS char is a space or another non-word char. A
+                            // non-word char directly after a word char is closing
+                            // punctuation (`powerless."`, `word)`, `done!`); breaking
+                            // there orphans the punctuation at the start of the next
+                            // line.
+                            if c != ' '
+                                && !Self::is_word_char(prev_c)
+                                && first_non_whitespace_ix.is_some()
+                            {
                                 last_candidate_ix = ix;
                                 last_candidate_width = width;
                             }
@@ -855,6 +864,43 @@ mod tests {
                 )
                 .collect::<Vec<_>>(),
             &[Boundary::new(12, 0),], // special chars above take up 3, 2 and 3 bytes, so boundary ends up at 12
+        );
+    }
+
+    #[test]
+    fn test_wrap_line_keeps_closing_punctuation_attached() {
+        let mut wrapper = build_wrapper();
+
+        // `aaa aaaa."` at 72px (9 chars/line): the `"` is the overflow char.
+        // A break candidate directly before it (the old any-non-word-char
+        // rule) orphaned the quote at the start of the next line; the break
+        // must fall back to the space instead, keeping `aaaa."` together.
+        assert_eq!(
+            wrapper
+                .wrap_line(&[LineFragment::text("aaa aaaa.\"")], px(72.))
+                .collect::<Vec<_>>(),
+            &[Boundary::new(4, 0)],
+        );
+        // Same shape for other closing punctuation.
+        assert_eq!(
+            wrapper
+                .wrap_line(&[LineFragment::text("aaa aaaaa!")], px(72.))
+                .collect::<Vec<_>>(),
+            &[Boundary::new(4, 0)],
+        );
+        assert_eq!(
+            wrapper
+                .wrap_line(&[LineFragment::text("aaa (aaaa)")], px(72.))
+                .collect::<Vec<_>>(),
+            &[Boundary::new(4, 0)],
+        );
+        // Non-word chars after a SPACE (opening punctuation) still wrap with
+        // the word they introduce: the final line is `"cc"`, quote attached.
+        assert_eq!(
+            wrapper
+                .wrap_line(&[LineFragment::text("aaaa bbb \"cc\"")], px(72.))
+                .collect::<Vec<_>>(),
+            &[Boundary::new(5, 0), Boundary::new(9, 0)],
         );
     }
 


### PR DESCRIPTION
## What

When wrapping text, a closing punctuation character (`"` `'` `)` `]` `}` `!` `?` `,` `.` `:` `;` and their CJK fullwidth forms) no longer gets orphaned at the start of the next line. The wrap boundary moves back so the punctuation stays attached to the word it closes, e.g. `powerless."` wraps as a unit instead of leaving `"` alone on the next line.

The rule is applied in both wrapping paths:

- `line_wrapper.rs`: the unshaped boundary scanner skips wrap candidates that would strand closing punctuation.
- `line_layout.rs`: shaped-text wrap boundary computation applies the same rule, so editor and rendered-element text agree.

CJK per-character wrap opportunities are preserved; only the position immediately before closing punctuation is suppressed.

## Why

Typographic line breaking should not begin a line with a closing quote or bracket. This matches CSS `line-break` / Unicode UAX #14 class CL/QU behavior and fixes visibly wrong wraps in rendered markdown and editor soft-wrap.

## Tests

- `text_system::line_wrapper::tests` — wrap-boundary cases including closing punctuation after words and CJK text (all passing).
- `text_system::line_layout::tests::test_wrap_boundaries_keep_closing_punctuation_attached` — shaped-path coverage.

`cargo test -p gpui --lib text_system`: 27 passed, 0 failed.

Release Notes:

- Fixed text wrapping so closing punctuation (quotes, brackets, terminal punctuation) stays attached to the preceding word instead of starting the next line.

## Provenance

This upstreams work by Wing (@wingleeio) from the zed fork used by the comet project, reworked against current `main`. GPUI is Apache-2.0; upstream attribution is preserved in the commit messages.
