### PR TITLE
ui: Disable the Save All menu button when there are no saved changes (like VS Code)

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3407,6 +3407,10 @@ impl Workspace {
         })
     }
 
+    fn has_dirty_saveable_items(&self, cx: &App) -> bool {
+        self.items(cx).any(|item| item.can_autosave(cx))
+    }
+
     fn save_all(&mut self, action: &SaveAll, window: &mut Window, cx: &mut Context<Self>) {
         self.save_all_internal(
             action.save_intent.unwrap_or(SaveIntent::SaveAll),
@@ -7505,7 +7509,9 @@ impl Workspace {
             .on_action(cx.listener(Self::close_inactive_items_and_panes))
             .on_action(cx.listener(Self::close_all_items_and_panes))
             .on_action(cx.listener(Self::close_item_in_all_panes))
-            .on_action(cx.listener(Self::save_all))
+            .when(self.has_dirty_saveable_items(cx), |div| {
+                div.on_action(cx.listener(Self::save_all))
+            })
             .on_action(cx.listener(Self::send_keystrokes))
             .on_action(cx.listener(Self::add_folder_to_project))
             .on_action(cx.listener(Self::follow_next_collaborator))


### PR DESCRIPTION
# Objective

- Replicate the same "Save All" menu functionality as VS Code and VS Code forks where as if there are no dirty file changes then the "Save All" menu item will be disabled.

## Solution

- Updated `workspace.rs` to add a has_dirty_saveable_items function to check for any dirty saveable items
- Updated the `on_action` for Save All to be a `when` that uses the above function:

## Testing

- Did you test these changes? If so, how?

Only in the UI, no tests have been updated to check the changes.

- Are there any parts that need more testing?

I don't believe so.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

1. Clone and run the 
2. Observe the disabled  File > Save All button (if you don't have dirty changes)
3. Make some changes to a file in a project (indicated by the blue circle on the left of the file name)
4. Observe that File > Save All is now enabled and can be used to save all changes

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

`Mac OS 15.7.5` - I am unable to check on other platforms

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before (no dirty changes):

<img width="488" height="353" alt="Screenshot 2026-08-08 at 7 53 53 pm" src="https://github.com/user-attachments/assets/9a3657f3-eb72-4ec8-acfd-dfb9ef9dedb1" />

After (dirty changes):

<img width="438" height="343" alt="Screenshot 2026-08-08 at 7 54 01 pm" src="https://github.com/user-attachments/assets/31feec14-0a92-44b7-8f5a-1fe080f1a95b" />

---

Release Notes:

- Updated the Save All menu button to be disabled if there are no saved changes 
