### PR TITLE
helix: Add missing code action menus navigation keymaps

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -591,6 +591,13 @@
     },
   },
   {
+    "context": "Editor && (vim_mode == helix_normal || vim_mode == helix_select) && showing_code_actions",
+    "bindings": {
+      "tab": "editor::ContextMenuNext",
+      "shift-tab": "editor::ContextMenuPrevious",
+    },
+  },
+  {
     "context": "vim_mode == insert && !(showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ShowWordCompletions",


### PR DESCRIPTION
# Objective

Helix uses tab/shift-tab to navigate code action menus. Currently, this will indent the code instead of navigating within the menu.

## Solution

Add keymaps.

## Testing

I tested it manually.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added support for using `tab` and `shift-tab` to navigate the code actions menu in Helix mode
