### PR TITLE
agent: Support for MCP embedded resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "assets",
  "async-channel 2.5.0",
  "async-io",
+ "base64 0.22.1",
  "chrono",
  "client",
  "clock",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -25,6 +25,7 @@ agent_servers.workspace = true
 agent_settings.workspace = true
 agent_skills.workspace = true
 anyhow.workspace = true
+base64.workspace = true
 chrono.workspace = true
 client.workspace = true
 cloud_api_types.workspace = true

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1868,7 +1868,7 @@ impl NativeAgent {
 
             for message in prompt.messages {
                 let context_server::types::PromptMessage { role, content } = message;
-                let block = mcp_message_content_to_acp_content_block(content);
+                let block = mcp_message_content_to_acp_content_block(&thread, cx, content).await?;
 
                 match role {
                     context_server::types::Role::User => {
@@ -6902,34 +6902,38 @@ mod internal_tests {
     }
 }
 
-fn mcp_message_content_to_acp_content_block(
+/// Converts an MCP prompt message's content into an ACP content block.
+/// Resources embedded in the message are downloaded to the thread's downloads
+/// directory and the block is the download summary.
+async fn mcp_message_content_to_acp_content_block(
+    thread: &Entity<Thread>,
+    cx: &mut AsyncApp,
     content: context_server::types::MessageContent,
-) -> acp::ContentBlock {
+) -> Result<acp::ContentBlock> {
     match content {
         context_server::types::MessageContent::Text {
             text,
             annotations: _,
-        } => text.into(),
+        } => Ok(text.into()),
         context_server::types::MessageContent::Image {
             data,
             mime_type,
             annotations: _,
-        } => acp::ContentBlock::Image(acp::ImageContent::new(data, mime_type)),
+        } => Ok(acp::ContentBlock::Image(acp::ImageContent::new(
+            data, mime_type,
+        ))),
         context_server::types::MessageContent::Audio {
             data,
             mime_type,
             annotations: _,
-        } => acp::ContentBlock::Audio(acp::AudioContent::new(data, mime_type)),
-        context_server::types::MessageContent::Resource {
-            resource,
-            annotations: _,
-        } => {
-            let mut link =
-                acp::ResourceLink::new(resource.uri.to_string(), resource.uri.to_string());
-            if let Some(mime_type) = resource.mime_type {
-                link = link.mime_type(mime_type);
-            }
-            acp::ContentBlock::ResourceLink(link)
+        } => Ok(acp::ContentBlock::Audio(acp::AudioContent::new(
+            data, mime_type,
+        ))),
+        context_server::types::MessageContent::Resource { resource, .. } => {
+            let downloads_dir = thread.update(cx, |thread, cx| thread.mcp_downloads_dir(cx))?;
+            let summary =
+                crate::tools::save_mcp_resource_contents(&downloads_dir, resource, cx).await?;
+            Ok(acp::ContentBlock::Text(acp::TextContent::new(summary)))
         }
     }
 }

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -81,6 +81,8 @@ pub struct DbThread {
     pub ui_scroll_position: Option<SerializedScrollPosition>,
     #[serde(default)]
     pub sandboxed_terminal_temp_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub mcp_downloads_dir: Option<PathBuf>,
     /// Sandbox escalations the user approved "for the rest of this thread".
     /// Persisted so reopening a thread keeps its grants. See
     /// [`crate::sandboxing::ThreadSandboxGrants`].
@@ -168,6 +170,7 @@ impl SharedThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
         }
     }
@@ -354,6 +357,7 @@ impl DbThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
         })
     }
@@ -645,24 +649,27 @@ impl ThreadsDatabase {
         DbThread::from_json(json_data.as_bytes())
     }
 
-    fn sandboxed_terminal_temp_dir(data_type: DataType, data: Vec<u8>) -> Option<PathBuf> {
+    fn thread_scratch_dirs(data_type: DataType, data: Vec<u8>) -> Vec<PathBuf> {
         match Self::deserialize_thread(data_type, data) {
-            Ok(thread) => thread.sandboxed_terminal_temp_dir,
+            Ok(thread) => [thread.sandboxed_terminal_temp_dir, thread.mcp_downloads_dir]
+                .into_iter()
+                .flatten()
+                .collect(),
             Err(error) => {
                 log::warn!("failed to deserialize thread before deleting it: {error:#}");
-                None
+                Vec::new()
             }
         }
     }
 
-    fn remove_sandboxed_terminal_temp_dir(temp_dir: PathBuf) {
-        match std::fs::remove_dir_all(&temp_dir) {
+    fn remove_thread_scratch_dir(scratch_dir: PathBuf) {
+        match std::fs::remove_dir_all(&scratch_dir) {
             Ok(()) => {}
             Err(error) if error.kind() == ErrorKind::NotFound => {}
             Err(error) => {
                 log::warn!(
-                    "failed to remove sandboxed terminal temp directory {}: {error}",
-                    temp_dir.display()
+                    "failed to remove thread scratch directory {}: {error}",
+                    scratch_dir.display()
                 );
             }
         }
@@ -672,7 +679,7 @@ impl ThreadsDatabase {
         let connection = self.connection.clone();
 
         self.executor.spawn(async move {
-            let sandboxed_terminal_temp_dirs = {
+            let thread_scratch_dirs = {
                 let connection = connection.lock();
 
                 let mut select_children =
@@ -700,21 +707,20 @@ impl ThreadsDatabase {
                     DELETE FROM threads WHERE id = ?
                 "})?;
 
-                let mut sandboxed_terminal_temp_dirs = Vec::new();
+                let mut thread_scratch_dirs = Vec::new();
                 for thread_id in ids_to_delete {
-                    if let Some(temp_dir) = select(thread_id.clone())?.into_iter().next().and_then(
-                        |(data_type, data)| Self::sandboxed_terminal_temp_dir(data_type, data),
-                    ) {
-                        sandboxed_terminal_temp_dirs.push(temp_dir);
+                    if let Some(scratch_dirs) = select(thread_id.clone())?.into_iter().next() {
+                        thread_scratch_dirs
+                            .extend(Self::thread_scratch_dirs(scratch_dirs.0, scratch_dirs.1));
                     }
                     delete(thread_id)?;
                 }
 
-                sandboxed_terminal_temp_dirs
+                thread_scratch_dirs
             };
 
-            for temp_dir in sandboxed_terminal_temp_dirs {
-                Self::remove_sandboxed_terminal_temp_dir(temp_dir);
+            for scratch_dir in thread_scratch_dirs {
+                Self::remove_thread_scratch_dir(scratch_dir);
             }
 
             Ok(())
@@ -725,18 +731,16 @@ impl ThreadsDatabase {
         let connection = self.connection.clone();
 
         self.executor.spawn(async move {
-            let sandboxed_terminal_temp_dirs = {
+            let thread_scratch_dirs = {
                 let connection = connection.lock();
 
                 let mut select = connection.select_bound::<(), (DataType, Vec<u8>)>(indoc! {"
                     SELECT data_type, data FROM threads
                 "})?;
 
-                let sandboxed_terminal_temp_dirs = select(())?
+                let thread_scratch_dirs = select(())?
                     .into_iter()
-                    .filter_map(|(data_type, data)| {
-                        Self::sandboxed_terminal_temp_dir(data_type, data)
-                    })
+                    .flat_map(|(data_type, data)| Self::thread_scratch_dirs(data_type, data))
                     .collect::<Vec<_>>();
 
                 let mut delete = connection.exec_bound::<()>(indoc! {"
@@ -745,11 +749,11 @@ impl ThreadsDatabase {
 
                 delete(())?;
 
-                sandboxed_terminal_temp_dirs
+                thread_scratch_dirs
             };
 
-            for temp_dir in sandboxed_terminal_temp_dirs {
-                Self::remove_sandboxed_terminal_temp_dir(temp_dir);
+            for scratch_dir in thread_scratch_dirs {
+                Self::remove_thread_scratch_dir(scratch_dir);
             }
 
             Ok(())
@@ -805,6 +809,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
         }
     }
@@ -983,9 +988,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_sandboxed_terminal_temp_dir_roundtrips_through_save_load(
-        cx: &mut TestAppContext,
-    ) {
+    async fn test_scratch_dirs_roundtrip_through_save_load(cx: &mut TestAppContext) {
         let database = ThreadsDatabase::new(cx.executor()).unwrap();
         let thread_id = session_id("sandbox-temp-dir-thread");
         let temp_dir = tempfile::Builder::new()
@@ -998,6 +1001,12 @@ mod tests {
             Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
         );
         thread.sandboxed_terminal_temp_dir = Some(temp_dir.clone());
+        let downloads_dir = tempfile::Builder::new()
+            .prefix("zed-agent-mcp-test-")
+            .tempdir()
+            .unwrap()
+            .keep();
+        thread.mcp_downloads_dir = Some(downloads_dir.clone());
 
         database
             .save_thread(thread_id.clone(), thread, PathList::default())
@@ -1010,24 +1019,33 @@ mod tests {
             .unwrap()
             .expect("thread should exist");
         assert_eq!(loaded.sandboxed_terminal_temp_dir, Some(temp_dir.clone()));
+        assert_eq!(loaded.mcp_downloads_dir, Some(downloads_dir.clone()));
         std::fs::remove_dir_all(temp_dir).unwrap();
+        std::fs::remove_dir_all(downloads_dir).unwrap();
     }
 
     #[gpui::test]
-    async fn test_delete_thread_removes_sandboxed_terminal_temp_dir(cx: &mut TestAppContext) {
+    async fn test_delete_thread_removes_scratch_dirs(cx: &mut TestAppContext) {
         let database = ThreadsDatabase::new(cx.executor()).unwrap();
         let thread_id = session_id("sandbox-temp-dir-delete-thread");
+        let mut thread = make_thread(
+            "Sandbox Temp Dir Delete Thread",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
         let temp_dir = tempfile::Builder::new()
             .prefix("zed-agent-terminal-test-")
             .tempdir()
             .unwrap()
             .keep();
         std::fs::write(temp_dir.join("sentinel"), b"content").unwrap();
-        let mut thread = make_thread(
-            "Sandbox Temp Dir Delete Thread",
-            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
-        );
         thread.sandboxed_terminal_temp_dir = Some(temp_dir.clone());
+        let downloads_dir = tempfile::Builder::new()
+            .prefix("zed-agent-mcp-test-")
+            .tempdir()
+            .unwrap()
+            .keep();
+        std::fs::write(downloads_dir.join("sentinel"), b"content").unwrap();
+        thread.mcp_downloads_dir = Some(downloads_dir.clone());
 
         database
             .save_thread(thread_id.clone(), thread, PathList::default())
@@ -1036,6 +1054,7 @@ mod tests {
         database.delete_thread(thread_id).await.unwrap();
 
         assert!(!temp_dir.exists());
+        assert!(!downloads_dir.exists());
     }
 
     #[gpui::test]

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -2081,6 +2081,169 @@ async fn test_mcp_tool_multi_content_response(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_mcp_tool_resource_saved_to_downloads_dir(cx: &mut TestAppContext) {
+    use base64::Engine as _;
+
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {}
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mut mcp_tool_calls = setup_context_server(
+        "resource_server",
+        vec![context_server::types::Tool {
+            name: "get_report".into(),
+            title: None,
+            description: None,
+            input_schema: json!({ "type": "object", "properties": {} }),
+            output_schema: None,
+            annotations: None,
+        }],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(ClientUserMessageId::new(), ["Get the report"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: "get_report".into(),
+            raw_input: json!({}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+    let _ = completion;
+
+    let png_blob = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+    let (tool_call_params, tool_call_response) = mcp_tool_calls.next().await.unwrap();
+    assert_eq!(tool_call_params.name, "get_report");
+    tool_call_response
+        .send(context_server::types::CallToolResponse {
+            content: vec![
+                context_server::types::ToolResponseContent::Text {
+                    text: "Report:".into(),
+                },
+                context_server::types::ToolResponseContent::Resource {
+                    resource: context_server::types::ResourceContents::Text(
+                        context_server::types::TextResourceContents {
+                            uri: "file:///report.md".parse().unwrap(),
+                            mime_type: Some("text/markdown".into()),
+                            text: "# Findings\n\nEverything is fine.".into(),
+                        },
+                    ),
+                },
+                context_server::types::ToolResponseContent::Resource {
+                    resource: context_server::types::ResourceContents::Blob(
+                        context_server::types::BlobResourceContents {
+                            uri: "file:///logo.png".parse().unwrap(),
+                            mime_type: Some("image/png".into()),
+                            blob: png_blob.into(),
+                        },
+                    ),
+                },
+            ],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // The model receives the download paths (plus MIME type, size, URI) rather
+    // than the resource contents.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r.clone()),
+            _ => None,
+        })
+        .expect("expected a tool result");
+    let text_parts: Vec<&str> = tool_result
+        .content
+        .iter()
+        .filter_map(|part| match part {
+            language_model::LanguageModelToolResultContent::Text(text) => Some(text.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text_parts[0], "Report:");
+
+    let downloads_dir = thread
+        .update(cx, |thread, cx| thread.mcp_downloads_dir(cx))
+        .unwrap();
+    let markdown_path = downloads_dir.join("report.md");
+    let png_path = downloads_dir.join("logo.png");
+
+    assert!(text_parts[1].starts_with(&format!(
+        "Saved MCP resource to {}",
+        markdown_path.display()
+    )));
+    assert!(text_parts[1].contains("(mime: text/markdown"));
+    assert!(text_parts[1].contains("uri: file:///report.md"));
+    assert!(text_parts[2].starts_with(&format!("Saved MCP resource to {}", png_path.display())));
+    assert!(text_parts[2].contains("(mime: image/png"));
+
+    assert!(markdown_path.exists());
+    assert_eq!(
+        std::fs::read_to_string(&markdown_path).unwrap(),
+        "# Findings\n\nEverything is fine."
+    );
+    assert!(png_path.exists());
+    assert_eq!(
+        std::fs::read(&png_path).unwrap(),
+        base64::engine::general_purpose::STANDARD
+            .decode(png_blob)
+            .unwrap()
+    );
+
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
 async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAppContext) {
     let ThreadTest {
         model,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1281,6 +1281,9 @@ pub struct Thread {
     running_subagents: Vec<WeakEntity<Thread>>,
     inherits_parent_model_settings: bool,
     sandboxed_terminal_temp_dir: Option<PathBuf>,
+    /// Read-only directory where MCP resources are downloaded for the agent to
+    /// process.
+    mcp_downloads_dir: Option<PathBuf>,
     /// Sandbox permissions the user approved "for the rest of the thread".
     /// Shared with each tool call's event stream so repeated requests for
     /// already-granted permissions skip the approval prompt.
@@ -1421,6 +1424,7 @@ impl Thread {
             running_subagents: Vec::new(),
             inherits_parent_model_settings: true,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::default())),
         }
     }
@@ -1493,6 +1497,39 @@ impl Thread {
         self.sandboxed_terminal_temp_dir = Some(temp_dir.clone());
         cx.notify();
         Ok(temp_dir)
+    }
+
+    /// Per-thread directory for MCP resource downloads, created on first use.
+    pub(crate) fn mcp_downloads_dir(&mut self, cx: &mut Context<Self>) -> Result<PathBuf> {
+        if let Some(downloads_dir) = &self.mcp_downloads_dir {
+            std::fs::create_dir_all(downloads_dir).with_context(|| {
+                format!(
+                    "failed to recreate MCP downloads directory {}",
+                    downloads_dir.display()
+                )
+            })?;
+            return Ok(downloads_dir.clone());
+        }
+
+        let root = if cfg!(not(any(target_os = "linux", target_os = "windows"))) {
+            std::env::temp_dir()
+        } else {
+            paths::state_dir().join("mcp-downloads")
+        };
+        std::fs::create_dir_all(&root).with_context(|| {
+            format!(
+                "failed to create MCP downloads root directory {}",
+                root.display()
+            )
+        })?;
+        let downloads_dir = tempfile::Builder::new()
+            .prefix("zed-agent-mcp-")
+            .tempdir_in(&root)
+            .context("failed to create MCP downloads directory")?;
+        let downloads_dir = downloads_dir.keep();
+        self.mcp_downloads_dir = Some(downloads_dir.clone());
+        cx.notify();
+        Ok(downloads_dir)
     }
 
     pub fn replay(
@@ -1803,6 +1840,7 @@ impl Thread {
             running_subagents: Vec::new(),
             inherits_parent_model_settings: true,
             sandboxed_terminal_temp_dir: db_thread.sandboxed_terminal_temp_dir,
+            mcp_downloads_dir: db_thread.mcp_downloads_dir,
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::from_db(
                 &db_thread.sandbox_grants,
             ))),
@@ -1902,6 +1940,7 @@ impl Thread {
                 }
             }),
             sandboxed_terminal_temp_dir: self.sandboxed_terminal_temp_dir.clone(),
+            mcp_downloads_dir: self.mcp_downloads_dir.clone(),
             sandbox_grants: self.sandbox_grants.borrow().to_db(),
         };
 
@@ -5582,6 +5621,20 @@ impl ToolCallEventStream {
         cx.update(|cx| {
             thread.update(cx, |_thread, cx| cx.notify()).ok();
         });
+    }
+
+    /// The owning thread's MCP downloads directory, resolved for a tool call.
+    /// Fails when the tool call isn't tied to a live thread (e.g. in tests),
+    /// or when the directory can't be created.
+    pub(crate) fn mcp_downloads_dir(&self, cx: &AsyncApp) -> Result<PathBuf> {
+        cx.update(|cx| {
+            let thread = self
+                .thread
+                .as_ref()
+                .and_then(|thread| thread.upgrade())
+                .ok_or_else(|| anyhow!("MCP tool call is not tied to a thread"))?;
+            thread.update(cx, |thread, cx| thread.mcp_downloads_dir(cx))
+        })
     }
 
     /// Returns a future that resolves when the user cancels the tool call.

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -167,6 +167,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: Default::default(),
         }
     }

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -1,13 +1,16 @@
 use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
 use agent_client_protocol::schema::v1 as acp;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
+use base64::Engine as _;
 use collections::{BTreeMap, HashMap};
 use context_server::{ContextServerId, client::NotificationSubscription};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
 use language_model::{LanguageModelImage, LanguageModelImageExt, LanguageModelToolResultContent};
 use project::context_server_store::{ContextServerStatus, ContextServerStore};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use url::Url;
 use util::{ResultExt, markdown::MarkdownEscaped};
 
 /// Maximum number of characters to show from a tool argument in the
@@ -400,11 +403,9 @@ impl AnyAgentTool for ContextServerTool {
 
             let mut llm_output = Vec::new();
             let mut tool_call_content = Vec::new();
-            let mut concatenated_text = String::new();
             for content in response.content {
                 match content {
                     context_server::types::ToolResponseContent::Text { text } => {
-                        concatenated_text.push_str(&text);
                         tool_call_content.push(acp::ToolCallContent::Content(acp::Content::new(
                             acp::ContentBlock::Text(acp::TextContent::new(text.clone())),
                         )));
@@ -447,11 +448,67 @@ impl AnyAgentTool for ContextServerTool {
                     context_server::types::ToolResponseContent::Audio { .. } => {
                         log::warn!("Ignoring audio content from tool response");
                     }
-                    context_server::types::ToolResponseContent::Resource { .. } => {
-                        log::warn!("Ignoring resource content from tool response");
+                    context_server::types::ToolResponseContent::Resource { resource } => {
+                        tool_call_content.push(acp::ToolCallContent::Content(acp::Content::new(
+                            acp::ContentBlock::Resource(match &resource {
+                                context_server::types::ResourceContents::Text(text) => {
+                                    acp::EmbeddedResource::new(
+                                        acp::EmbeddedResourceResource::TextResourceContents(
+                                            acp::TextResourceContents::new(
+                                                text.text.clone(),
+                                                text.uri.to_string(),
+                                            ).mime_type(text.mime_type.clone()),
+                                        ),
+                                    )
+                                }
+                                context_server::types::ResourceContents::Blob(blob) => {
+                                    acp::EmbeddedResource::new(
+                                        acp::EmbeddedResourceResource::BlobResourceContents(
+                                            acp::BlobResourceContents::new(
+                                                blob.blob.clone(),
+                                                blob.uri.to_string(),
+                                            ).mime_type(blob.mime_type.clone()),
+                                        ),
+                                    )
+                                }
+                            }),
+                        )));
+
+                        match save_mcp_resource(&event_stream, resource, cx).await {
+                            Ok(summary) => {
+                                llm_output.push(LanguageModelToolResultContent::Text(summary.into()));
+                            }
+                            Err(error) => {
+                                log::warn!("Failed to save MCP resource from tool response: {error:#}");
+                            }
+                        }
                     }
-                    context_server::types::ToolResponseContent::ResourceLink { .. } => {
-                        log::warn!("Ignoring resource link content from tool response");
+                    context_server::types::ToolResponseContent::ResourceLink {
+                        uri,
+                        name,
+                        title,
+                        description,
+                        mime_type,
+                    } => {
+                        let text = [
+                            Some(format!("MCP resource link: {}", title.as_deref().unwrap_or(&name))),
+                            Some(format!("URI: {uri}")),
+                            mime_type.as_deref().map(|mime_type| format!("MIME type: {mime_type}")),
+                            description.as_deref().map(|description| format!("Description: {description}")),
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                        tool_call_content.push(acp::ToolCallContent::Content(acp::Content::new(
+                            acp::ContentBlock::ResourceLink(
+                                acp::ResourceLink::new(name, uri.as_str())
+                                    .title(title)
+                                    .description(description)
+                                    .mime_type(mime_type),
+                            ),
+                        )));
+                        llm_output.push(LanguageModelToolResultContent::Text(text.into()));
                     }
                 }
             }
@@ -459,7 +516,14 @@ impl AnyAgentTool for ContextServerTool {
                 event_stream
                     .update_fields(acp::ToolCallUpdateFields::new().content(tool_call_content));
             }
-            let raw_output = serde_json::Value::String(concatenated_text);
+            let raw_output = serde_json::Value::String(llm_output
+                .iter()
+                .filter_map(|part| match part {
+                    LanguageModelToolResultContent::Text(text) => Some(text.as_ref()),
+                    LanguageModelToolResultContent::Image(_) => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"));
             Ok(AgentToolOutput {
                 raw_output,
                 llm_output,
@@ -476,6 +540,121 @@ impl AnyAgentTool for ContextServerTool {
     ) -> Result<()> {
         Ok(())
     }
+}
+
+/// Saves an MCP resource embedded in a tool response to the thread's downloads
+/// directory and returns a one-line summary (path, MIME type, size, URI) that
+/// is handed to the model instead of the resource's contents.
+async fn save_mcp_resource(
+    event_stream: &ToolCallEventStream,
+    resource: context_server::types::ResourceContents,
+    cx: &mut AsyncApp,
+) -> Result<String> {
+    let downloads_dir = event_stream.mcp_downloads_dir(cx)?;
+    save_mcp_resource_contents(&downloads_dir, resource, cx).await
+}
+
+/// Saves an MCP resource embedded in a tool response or prompt to the thread's
+/// downloads directory and returns a one-line summary for the model.
+pub(crate) async fn save_mcp_resource_contents(
+    downloads_dir: &Path,
+    resource: context_server::types::ResourceContents,
+    cx: &mut AsyncApp,
+) -> Result<String> {
+    let (uri, mime_type, bytes) = match resource {
+        context_server::types::ResourceContents::Text(text) => {
+            (text.uri, text.mime_type, text.text.into_bytes())
+        }
+        context_server::types::ResourceContents::Blob(blob) => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(&blob.blob)
+                .context("failed to decode base64 MCP resource blob")?;
+            (blob.uri, blob.mime_type, bytes)
+        }
+    };
+
+    let file_name = mcp_resource_file_name(&uri);
+    let path = unique_download_path(downloads_dir, &file_name);
+    let size = bytes.len();
+
+    cx.background_spawn({
+        let path = path.clone();
+        async move {
+            std::fs::write(&path, &bytes)
+                .with_context(|| format!("failed to write MCP resource to {}", path.display()))
+        }
+    })
+    .await?;
+
+    let mime_type = mime_type.unwrap_or_else(|| "unknown".to_string());
+    Ok(format!(
+        "Saved MCP resource to {} (mime: {}, size: {} bytes, uri: {})",
+        path.display(),
+        mime_type,
+        size,
+        uri
+    ))
+}
+
+/// Derives a file name for a downloaded MCP resource from its URI, preferring
+/// the last path segment and falling back to a hash of the URI. Path segments
+/// are sanitized for use as file names.
+fn mcp_resource_file_name(uri: &Url) -> String {
+    uri.path()
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty() && *name != "." && *name != "..")
+        .map(sanitize_file_name)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            use std::hash::{Hash as _, Hasher as _};
+            uri.as_str().hash(&mut hasher);
+            format!("resource-{:016x}", hasher.finish())
+        })
+}
+
+fn sanitize_file_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    sanitized
+        .trim_start_matches('.')
+        .chars()
+        .take(100)
+        .collect()
+}
+
+/// Picks a path in `downloads_dir` that doesn't already exist, appending a
+/// numeric suffix on collision.
+fn unique_download_path(downloads_dir: &Path, file_name: &str) -> PathBuf {
+    let candidate = downloads_dir.join(file_name);
+    if !candidate.exists() {
+        return candidate;
+    }
+    let (stem, extension) = match file_name.rsplit_once('.') {
+        Some((stem, extension)) if !extension.is_empty() => (stem, extension),
+        _ => (file_name, ""),
+    };
+    for index in 1.. {
+        let name = if extension.is_empty() {
+            format!("{stem}-{index}")
+        } else {
+            format!("{stem}-{index}.{extension}")
+        };
+        let candidate = downloads_dir.join(name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!("the loop above only exits by returning a non-colliding path")
 }
 
 /// Builds the header label shown for an MCP tool call. When the input is an
@@ -654,5 +833,17 @@ mod tests {
         // "no args at all".
         let input = serde_json::json!({ "q": "" });
         assert_eq!(single_string_arg(&input), Some(""));
+    }
+
+    #[test]
+    fn test_unique_download_path_appends_suffix_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("report.md"), b"existing").unwrap();
+        let first = unique_download_path(dir.path(), "report.md");
+        assert_eq!(first, dir.path().join("report-1.md"));
+        assert_eq!(
+            unique_download_path(dir.path(), "report.md"),
+            dir.path().join("report-1.md")
+        );
     }
 }

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -92,14 +92,14 @@ fn write_lines_numbered<'a>(
     }
 }
 
-/// Read a file under the global skills directory directly via the filesystem,
-/// bypassing project/worktree resolution. Used for skill resources that live
-/// outside any worktree.
+/// Read a file that lives outside any worktree but has been explicitly
+/// allowlisted for the agent. Used for skill resources and MCP downloads that
+/// live outside any worktree.
 ///
-/// Skill resources are expected to be plain text (Markdown, scripts, configs).
+/// Files are expected to be plain text (Markdown, scripts, configs).
 /// Image rendering, the action log, and the buffer-backed outline path are
 /// intentionally not exercised here — those are project concerns.
-async fn read_global_skill_file(
+async fn read_external_file(
     canonical_path: &Path,
     fs: &dyn fs::Fs,
     start_line: Option<u32>,
@@ -143,7 +143,7 @@ async fn read_global_skill_file(
 
 use super::tool_permissions::{
     ResolvedProjectPath, authorize_symlink_access, canonicalize_worktree_roots,
-    resolve_global_skill_path, resolve_project_path,
+    resolve_global_skill_path, resolve_mcp_downloads_path, resolve_project_path,
 };
 use crate::{AgentTool, ToolCallEventStream, ToolInput, outline};
 
@@ -156,7 +156,9 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput, outline};
 /// - This tool supports reading image files. Supported formats: PNG, JPEG, WebP, GIF, BMP, TIFF.
 ///   Image files are returned as visual content that you can analyze directly.
 ///
-/// The only supported path outside the project is `~/.agents/skills` or a descendant, for global agent skills.
+/// The only paths supported outside the project are `~/.agents/skills` (or a
+/// descendant, for global agent skills) and the thread's MCP downloads
+/// directory (absolute paths reported by MCP resource downloads).
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ReadFileToolInput {
     /// The relative path of the file to read.
@@ -264,7 +266,7 @@ impl AgentTool for ReadFileTool {
             if let Some(skill_path) =
                 resolve_global_skill_path(Path::new(&input.path), fs.as_ref()).await
             {
-                return read_global_skill_file(
+                return read_external_file(
                     &skill_path,
                     fs.as_ref(),
                     input.start_line,
@@ -273,6 +275,27 @@ impl AgentTool for ReadFileTool {
                     &event_stream,
                 )
                 .await;
+            }
+
+            // Fast path: if the model passes a path that resolves under this
+            // thread's MCP downloads directory, read it directly via the
+            // filesystem. MCP resource downloads live outside any worktree, so
+            // the standard project-path machinery would refuse them.
+            if let Ok(downloads_dir) = event_stream.mcp_downloads_dir(cx) {
+                if let Some(downloads_path) =
+                    resolve_mcp_downloads_path(Path::new(&input.path), &downloads_dir, fs.as_ref())
+                        .await
+                {
+                    return read_external_file(
+                        &downloads_path,
+                        fs.as_ref(),
+                        input.start_line,
+                        input.end_line,
+                        &input.path,
+                        &event_stream,
+                    )
+                    .await;
+                }
             }
 
             let canonical_roots = canonicalize_worktree_roots(&project, &fs, cx).await;

--- a/crates/agent/src/tools/tool_permissions.rs
+++ b/crates/agent/src/tools/tool_permissions.rs
@@ -178,6 +178,28 @@ async fn is_in_linked_global_skill_dir(
             .await
 }
 
+/// If `path` resolves inside `downloads_dir`, return the canonicalized
+/// absolute path. Returns `None` for any path that resolves outside it —
+/// including `..` traversal and symlink escapes — or that can't be
+/// canonicalized (fail closed: better to refuse access than to compare
+/// against a non-canonical path).
+///
+/// This is the gate that lets `read_file` reach into a thread's MCP
+/// downloads directory — which lives outside any worktree — without also
+/// opening up arbitrary external paths. The directory is created by the
+/// thread itself and only ever contains files the thread wrote there.
+pub async fn resolve_mcp_downloads_path(
+    path: &Path,
+    downloads_dir: &Path,
+    fs: &dyn Fs,
+) -> Option<PathBuf> {
+    let canonical_path = fs.canonicalize(path).await.ok()?;
+    let canonical_downloads_dir = fs.canonicalize(downloads_dir).await.ok()?;
+    canonical_path
+        .starts_with(&canonical_downloads_dir)
+        .then_some(canonical_path)
+}
+
 fn expand_home_prefix(path: &Path) -> Option<PathBuf> {
     if path.is_absolute() {
         return Some(path.to_path_buf());
@@ -1184,6 +1206,94 @@ mod tests {
                 .await
                 .is_none(),
             "creatable absolute paths outside the lexical global skills tree should not resolve",
+        );
+    }
+
+    #[gpui::test]
+    async fn test_resolve_mcp_downloads_path_allows_files_inside(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let downloads_dir = PathBuf::from(path!("/tmp/zed-agent-mcp-test"));
+        fs.insert_tree(
+            &downloads_dir,
+            json!({ "report.md": "# Report", "logo.png": "fake-png-bytes" }),
+        )
+        .await;
+
+        let resolved = resolve_mcp_downloads_path(
+            &downloads_dir.join("report.md"),
+            &downloads_dir,
+            fs.as_ref(),
+        )
+        .await
+        .expect("file inside the downloads dir should resolve");
+        assert_eq!(resolved, downloads_dir.join("report.md"));
+    }
+
+    #[gpui::test]
+    async fn test_resolve_mcp_downloads_path_rejects_files_outside(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let downloads_dir = PathBuf::from(path!("/tmp/zed-agent-mcp-test"));
+        fs.insert_tree(&downloads_dir, json!({})).await;
+        let secret_path = PathBuf::from(path!("/tmp/secret.txt"));
+        fs.insert_file(&secret_path, b"secret".to_vec()).await;
+
+        assert!(
+            resolve_mcp_downloads_path(&secret_path, &downloads_dir, fs.as_ref())
+                .await
+                .is_none(),
+            "files outside the downloads dir must not resolve",
+        );
+    }
+
+    #[gpui::test]
+    async fn test_resolve_mcp_downloads_path_rejects_parent_traversal(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let downloads_dir = PathBuf::from(path!("/tmp/zed-agent-mcp-test"));
+        fs.insert_tree(&downloads_dir, json!({ "report.md": "# Report" }))
+            .await;
+        let secret_path = PathBuf::from(path!("/tmp/secret.txt"));
+        fs.insert_file(&secret_path, b"secret".to_vec()).await;
+
+        // `..` in the requested path normalizes outside the downloads dir.
+        let traversal = downloads_dir.join("..").join("secret.txt");
+        assert!(
+            resolve_mcp_downloads_path(&traversal, &downloads_dir, fs.as_ref())
+                .await
+                .is_none(),
+            "parent traversal must not resolve",
+        );
+    }
+
+    #[gpui::test]
+    async fn test_resolve_mcp_downloads_path_rejects_symlink_escape(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let downloads_dir = PathBuf::from(path!("/tmp/zed-agent-mcp-test"));
+        fs.insert_tree(&downloads_dir, json!({})).await;
+        let secret_path = PathBuf::from(path!("/tmp/secret.txt"));
+        fs.insert_file(&secret_path, b"secret".to_vec()).await;
+        fs.insert_symlink(
+            downloads_dir.join("leak.txt"),
+            PathBuf::from(path!("/tmp/secret.txt")),
+        )
+        .await;
+
+        assert!(
+            resolve_mcp_downloads_path(
+                &downloads_dir.join("leak.txt"),
+                &downloads_dir,
+                fs.as_ref()
+            )
+            .await
+            .is_none(),
+            "a symlink inside the downloads dir must not escape it",
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -10900,6 +10900,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: Default::default(),
         };
 

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1851,6 +1851,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            mcp_downloads_dir: None,
             sandbox_grants: Default::default(),
         }
     }

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -284,16 +284,9 @@ pub struct InitializeResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourcesReadResponse {
-    pub contents: Vec<ResourceContentsType>,
+    pub contents: Vec<ResourceContents>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     pub meta: Option<HashMap<String, serde_json::Value>>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ResourceContentsType {
-    Text(TextResourceContents),
-    Blob(BlobResourceContents),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -584,11 +577,26 @@ pub struct Resource {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ResourceContents {
-    pub uri: Url,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mime_type: Option<String>,
+#[serde(untagged)]
+pub enum ResourceContents {
+    Text(TextResourceContents),
+    Blob(BlobResourceContents),
+}
+
+impl ResourceContents {
+    pub fn uri(&self) -> &Url {
+        match self {
+            Self::Text(text) => &text.uri,
+            Self::Blob(blob) => &blob.uri,
+        }
+    }
+
+    pub fn mime_type(&self) -> Option<&str> {
+        match self {
+            Self::Text(text) => text.mime_type.as_deref(),
+            Self::Blob(blob) => blob.mime_type.as_deref(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -2739,6 +2739,7 @@ fn run_multi_workspace_sidebar_visual_tests(
                             ui_scroll_position: None,
                             draft_prompt: None,
                             sandboxed_terminal_temp_dir: None,
+                            mcp_downloads_dir: None,
                             sandbox_grants: Default::default(),
                         },
                         path_list,


### PR DESCRIPTION
# Objective

- This PR adds support for embedded resources [in MCP tool calls](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#embedded-resources) and [in MCP prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#embedded-resources).
- This PR is a continuation of https://github.com/zed-industries/zed/pull/56874 which was closed due to inactivity. The solution in this PR is a little different though.
- My specific motivation is to support the `get_file_contents` tool in the [GitHub MCP Server](https://github.com/github/github-mcp-server). The tool returns a file as an embedded resource. Going by https://github.com/github/github-mcp-server/issues/607 and https://github.com/github/github-mcp-server/issues/1383 this seems to be by design and is not a bug in the MCP server.

For my specific use case (the `get_file_contents` tool) there are currently 2 workarounds I know of:
- Using the `fetch` tool. Requires network access to raw.githubusercontent.com and only fetches the entire file. Especially for large files this can fill up the agent's context very quickly. The model usually only knows that it is dealing with a large file after it is already too late.
- Using the CLI tool `gh repo read-file`. Allows the agent to chain other CLI tools to process a file partially. But requires network access to `api.github.com`, which is quite broad. Results in either overly broad permissions or many manual approvals.

## Solution

The agent maintains an `mcp_downloads_dir` per thread (similar to the temporary directory for the terminal). If an MCP prompt or tool call response contains an embedded resource, the resource is saved to the `mcp_downloads_dir`. The agent is given the path to the downloaded resource as well as some metadata (file size, mime type). The agent can then decide how to proceed (read the file, process it partially, do other things). The `mcp_downloads_dir` is deleted when the thread is deleted.

In contrast https://github.com/zed-industries/zed/pull/56874 dumped the entire resource into the context. That approach saves on tool calls but has a risk of filling up the context very quickly (potentially including non-text data). That issue was also noted by a reviewer.

For the implementation I made some design decisions:
- I added an exception for the `read_file` tool so that it can access the MCP downloads directory without approval (similar to skills in the home directory). This seems like a very common use case. However, the special handling for images is currently not implemented for MCP downloads.
- During implementation the agent suggested adding a heuristic to determine the file extension for embedded resources based on mime type. I have not added this for now, to keep the diff smaller.
- Some LLMs support file resources. It might make sense to allow LLMs to process resources as "file" inputs. I decided against this approach to keep the PR smaller and to maximize compatibility (because not all LLMs support that).

Out of scope / Future work:
- I did modify any UI code. I think there's room for improvement here. Currently embedded resources are displayed somewhat inconsistently:
  - In prompts they are not shown at all. Instead the summary showing the download location is shown
  - In tool calls text resources and images are shown inline. Binary resources are not shown at all. When a thread is replayed instead the summary is shown.
  - I think it could make sense to build a dedicated UI for embedded resources that makes more clear what is happening and that can be replayed consistently.
- There are other tools for which it might make sense to let them access the MCP downloads (e.g. `copy_path` or `grep`). I only added an exception for `read_file` because that seems to be particularly useful.
- This PR is not a generalized implementation of MCP [resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources). It only adds support for embedded resources in prompts and tool calls.

Let me know If you want me to add any of these things to this PR or if you are interested in future PRs for these additions.

## Testing

Some unit tests are part of the PR. To this PR manually, start a debug instance via `cargo run`. Change the following settings:

```json
{
  "context_servers": {
    "everything": {
      "enabled": true,
      "command": "docker",
      "args": ["run", "-i", "--rm", "mcp/everything"],
    },
    "GitHub": {
      "enabled": true,
      "url": "https://api.githubcopilot.com/mcp/",
      "headers": {
        "Authorization": "Bearer <GitHub PAT>"
      },
    }
  }
}
```

Try the following:

<details><summary>Ask the agent to use MCP tools to fetch a file from GitHub</summary>
<img width="508" height="812" alt="Bildschirmfoto 2026-08-08 um 17 54 41" src="https://github.com/user-attachments/assets/c44ff56d-eae2-4e20-8564-0068a76db440" />
</details> 

<details><summary>Use the <code>/resource_prompt 1</code> slash command (part of the everything MCP)</summary>
<img width="509" height="632" alt="Bildschirmfoto 2026-08-08 um 17 55 47" src="https://github.com/user-attachments/assets/ddf7db47-f006-4865-aebd-a7b5f859248f" />
</details> 

I did all my tests on macOS. The changes should work on Windows and Linux as well (the downloads folder just lives at another location there), but I wasn't able to test that yet.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Note: I used DeepSeek V4 Flash 0731 for all of the tests in this PR.

<details>
  <summary>Fetching Files From GitHub</summary>

Before: The  agent tries the `get_file_contents` but doesn't receive the file contents. It fails to find the downloaded file in the project files and has to fall back to other tools. In this case the model needed additional guidance to try the `fetch` tool.
<img width="633" height="1028" alt="Bildschirmfoto 2026-08-08 um 18 11 18" src="https://github.com/user-attachments/assets/4b6e07bb-138a-48e5-b7a2-a281bd7d040e" />

After: The agent downloads the file and is able to process it immediately:
<img width="508" height="812" alt="Bildschirmfoto 2026-08-08 um 17 54 41" src="https://github.com/user-attachments/assets/c44ff56d-eae2-4e20-8564-0068a76db440" />

</details>

---

Release Notes:

- Added support for embedded resources in MCP responses
