### PR TITLE
extensions_ui: Suggest windows-batch extension for Batch files

### DIFF
--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -75,6 +75,7 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("typst", &["typ"]),
     ("vue", &["vue"]),
     ("wgsl", &["wgsl"]),
+    ("windows-batch", &["bat", "cmd"]),
     ("wit", &["wit"]),
     ("xml", &["xml"]),
     ("zig", &["zig"]),


### PR DESCRIPTION
# Objective

Follow-up to zed-industries/extensions#7062.

## Solution

Add `("windows-batch", &["bat", "cmd"])` to `SUGGESTIONS_BY_EXTENSION_ID`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added a suggestion to install the `windows-batch` extension when opening `.bat` and `.cmd` files.