### PR TITLE
language: Preserve adjacent HTML ranges while editing Markdown

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1702,32 +1702,50 @@ pub(crate) fn splice_included_ranges(
         let next_new_range = new_ranges.peek();
         let next_removed_range = removed_ranges.peek();
 
-        let (remove, insert) = match (next_removed_range, next_new_range) {
-            (None, None) => break,
-            (Some(_), None) => (removed_ranges.next().unwrap(), None),
-            (Some(next_removed_range), Some(next_new_range)) => {
-                if next_removed_range.end < next_new_range.start_byte {
-                    (removed_ranges.next().unwrap(), None)
-                } else {
-                    let mut start = next_new_range.start_byte;
-                    let mut end = next_new_range.end_byte;
+        if next_removed_range.is_none()
+            && let Some(next_new_range) = next_new_range
+        {
+            let start_ix = ranges_ix
+                + ranges[ranges_ix..]
+                    .partition_point(|range| range.end_byte <= next_new_range.start_byte);
+            let end_ix = start_ix
+                + ranges[start_ix..]
+                    .partition_point(|range| range.start_byte < next_new_range.end_byte);
+            ranges.splice(start_ix..end_ix, new_ranges.next());
+            let changed_start = changed_portion
+                .as_ref()
+                .map_or(start_ix, |range| range.start.min(start_ix));
+            let changed_end = changed_portion
+                .as_ref()
+                .map_or(start_ix + 1, |range| range.end.max(start_ix + 1));
+            changed_portion = Some(changed_start..changed_end);
+            ranges_ix = start_ix;
+            continue;
+        }
 
-                    while let Some(next_removed_range) = removed_ranges.peek() {
-                        if next_removed_range.start > next_new_range.end_byte {
-                            break;
-                        }
-                        let next_removed_range = removed_ranges.next().unwrap();
-                        start = cmp::min(start, next_removed_range.start);
-                        end = cmp::max(end, next_removed_range.end);
+        let Some(next_removed_range) = next_removed_range else {
+            break;
+        };
+        let (remove, insert) = if let Some(next_new_range) = next_new_range {
+            if next_removed_range.end < next_new_range.start_byte {
+                (removed_ranges.next().unwrap(), None)
+            } else {
+                let mut start = next_new_range.start_byte;
+                let mut end = next_new_range.end_byte;
+
+                while let Some(next_removed_range) = removed_ranges.peek() {
+                    if next_removed_range.start > next_new_range.end_byte {
+                        break;
                     }
-
-                    (start..end, Some(new_ranges.next().unwrap()))
+                    let next_removed_range = removed_ranges.next().unwrap();
+                    start = cmp::min(start, next_removed_range.start);
+                    end = cmp::max(end, next_removed_range.end);
                 }
+
+                (start..end, Some(new_ranges.next().unwrap()))
             }
-            (None, Some(next_new_range)) => (
-                next_new_range.start_byte..next_new_range.end_byte,
-                Some(new_ranges.next().unwrap()),
-            ),
+        } else {
+            (removed_ranges.next().unwrap(), None)
         };
 
         let mut start_ix = ranges_ix

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -67,6 +67,22 @@ fn test_splice_included_ranges() {
     );
     assert_eq!(change, 0..1);
 
+    let (new_ranges, change) = splice_included_ranges(
+        vec![ts_range(20..30)],
+        &[0..30],
+        &[ts_range(20..25), ts_range(25..30)],
+    );
+    assert_eq!(new_ranges, &[ts_range(20..25), ts_range(25..30)]);
+    assert_eq!(change, 0..2);
+
+    let (new_ranges, change) = splice_included_ranges(
+        vec![ts_range(10..20)],
+        &[],
+        &[ts_range(20..30), ts_range(25..35)],
+    );
+    assert_eq!(new_ranges, &[ts_range(10..20), ts_range(25..35)]);
+    assert_eq!(change, 1..2);
+
     fn ts_range(range: Range<usize>) -> tree_sitter::Range {
         tree_sitter::Range {
             start_byte: range.start,


### PR DESCRIPTION
Closes #62127

# Objective

Fixes inline HTML highlighting disappearing while editing Markdown.

While updating the ranges parsed as HTML, a newly added range could replace the range immediately before it when the two touched at the same boundary number. This caused the opening tag to be dropped from the parser range until the syntax state was rebuilt.

## Solution

When there are still new ranges after the changed ranges have been handled, only replace ranges that actually overlap.
This keeps adjacent HTML ranges separate instead of removing the previous one.

## Testing

Added a regression for the with range like from #62127 and test testing against that.

Also verified that the incrementally parsed HTML matches a new parse and the function is source of error.

## Self-Review Checklist:

* [x] I've reviewed my own diff for quality, security, and reliability
* [x] Unsafe blocks (if any) have justifying comments
* [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
* [x] Tests cover the new/changed behavior
* [x] Performance impact has been considered and is acceptable


## Release Notes:

* Fixed inline HTML highlighting disappearing when not separated while editing Markdown.
