### PR TITLE
editor: Fix snippet insertion replayability

### DIFF
--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -810,6 +810,7 @@ impl Editor {
             new_text,
             snippet,
             replace_range,
+            snippet_source,
         } = process_completion_for_edit(&completion, intent, &buffer_handle, &initial_position, cx);
 
         let buffer = buffer_handle.read(cx).snapshot();
@@ -899,10 +900,16 @@ impl Editor {
             .map(|(a, _)| a.len_utf8())
             .sum::<usize>();
 
-        cx.emit(EditorEvent::InputHandled {
-            utf16_range_to_replace: None,
-            text: new_text[common_prefix_len..].into(),
-        });
+        if let Some(snippet_source) = &snippet_source {
+            cx.emit(EditorEvent::SnippetInsertion {
+                snippet_source: snippet_source.as_str().into(),
+            });
+        } else {
+            cx.emit(EditorEvent::InputHandled {
+                utf16_range_to_replace: None,
+                text: new_text[common_prefix_len..].into(),
+            });
+        }
 
         let tx_id = self.transact(window, cx, |editor, window, cx| {
             if let Some(mut snippet) = snippet {

--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -831,19 +831,30 @@ impl Editor {
         let old_text = buffer
             .text_for_range(replace_range.clone())
             .collect::<String>();
-        let (lookbehind, lookahead) = if buffer.remote_id() == buffer_snapshot.remote_id() {
-            let lookbehind = newest_range_buffer
-                .start
-                .to_offset(&buffer)
-                .saturating_sub(replace_range.start.to_offset(&buffer));
-            let lookahead = replace_range
-                .end
-                .to_offset(&buffer)
-                .saturating_sub(newest_range_buffer.end.to_offset(&buffer));
-            (lookbehind, lookahead)
-        } else {
-            (0, 0)
-        };
+        let (lookbehind, lookahead, lookbehind_utf16, lookahead_utf16) =
+            if buffer.remote_id() == buffer_snapshot.remote_id() {
+                let lookbehind = newest_range_buffer
+                    .start
+                    .to_offset(&buffer)
+                    .saturating_sub(replace_range.start.to_offset(&buffer));
+                let lookahead = replace_range
+                    .end
+                    .to_offset(&buffer)
+                    .saturating_sub(newest_range_buffer.end.to_offset(&buffer));
+                let lookbehind_utf16 = newest_range_buffer
+                    .start
+                    .to_offset_utf16(&buffer)
+                    .0
+                    .saturating_sub(replace_range.start.to_offset_utf16(&buffer).0);
+                let lookahead_utf16 = replace_range
+                    .end
+                    .to_offset_utf16(&buffer)
+                    .0
+                    .saturating_sub(newest_range_buffer.end.to_offset_utf16(&buffer).0);
+                (lookbehind, lookahead, lookbehind_utf16, lookahead_utf16)
+            } else {
+                (0, 0, 0, 0)
+            };
         let prefix = &old_text[..old_text.len().saturating_sub(lookahead)];
         let suffix = &old_text[lookbehind.min(old_text.len())..];
 
@@ -903,6 +914,9 @@ impl Editor {
         if let Some(snippet_source) = &snippet_source {
             cx.emit(EditorEvent::SnippetInsertion {
                 snippet_source: snippet_source.as_str().into(),
+                utf16_range_to_replace: Some(
+                    -(lookbehind_utf16 as isize)..(lookahead_utf16 as isize),
+                ),
             });
         } else {
             cx.emit(EditorEvent::InputHandled {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -250,7 +250,9 @@ use std::{
     time::{Duration, Instant},
 };
 use task::TaskVariables;
-use text::{BufferId, FromAnchor, OffsetUtf16, Rope, ToOffset as _, ToPoint as _};
+use text::{
+    BufferId, FromAnchor, OffsetUtf16, Rope, ToOffset as _, ToOffsetUtf16 as _, ToPoint as _,
+};
 use theme::{
     AccentColors, ActiveTheme, GlobalTheme, PlayerColor, StatusColors, SyntaxTheme, Theme,
 };
@@ -4768,6 +4770,11 @@ impl Editor {
 
         let tabstops = self.buffer.update(cx, |buffer, cx| {
             let snippet_text: Arc<str> = snippet.text.clone().into();
+            let snapshot_before_edit = buffer.snapshot(cx);
+            let insertion_points = insertion_ranges
+                .iter()
+                .map(|range| snapshot_before_edit.anchor_before(range.start))
+                .collect::<Vec<_>>();
             let edits = insertion_ranges
                 .iter()
                 .cloned()
@@ -4778,7 +4785,17 @@ impl Editor {
             buffer.edit(edits, Some(autoindent_mode), cx);
 
             let snapshot = &*buffer.read(cx);
+            let insertion_bases = insertion_points
+                .iter()
+                .map(|insertion_point| insertion_point.to_point(snapshot))
+                .collect::<Vec<_>>();
+            let insertion_bases = &insertion_bases;
             let snippet = &snippet;
+            let snippet_rope = Rope::from(snippet.text.as_str());
+            let snippet_rope = &snippet_rope;
+            let snippet_point = |offset: isize| {
+                snippet_rope.offset_to_point((offset.max(0) as usize).min(snippet.text.len()))
+            };
             snippet
                 .tabstops
                 .iter()
@@ -4790,16 +4807,43 @@ impl Editor {
                         .ranges
                         .iter()
                         .flat_map(|tabstop_range| {
-                            let mut delta = 0_isize;
-                            insertion_ranges.iter().map(move |insertion_range| {
-                                let insertion_start = insertion_range.start + delta;
-                                delta += snippet.text.len() as isize
-                                    - (insertion_range.end - insertion_range.start) as isize;
-
-                                let start =
-                                    (insertion_start + tabstop_range.start).min(snapshot.len());
-                                let end = (insertion_start + tabstop_range.end).min(snapshot.len());
-                                snapshot.anchor_before(start)..snapshot.anchor_after(end)
+                            let start = snippet_point(tabstop_range.start);
+                            let end = snippet_point(tabstop_range.end);
+                            insertion_bases.iter().map(move |base| {
+                                let base = *base;
+                                // Only the snippet's first line is offset by `base.column`;
+                                // later lines start at their own line's start, shifted by
+                                // however much `AutoindentMode::Block` re-indented them. That
+                                // shift is 0 if autoindent was deferred to a background task,
+                                // in which case the tabstop lands before the indentation that
+                                // task inserts rather than after it.
+                                let to_offset = |offset: Point| {
+                                    let point = if offset.row == 0 {
+                                        Point::new(base.row, base.column + offset.column)
+                                    } else {
+                                        let actual_row = base.row + offset.row;
+                                        let raw_line_start =
+                                            snippet_rope.point_to_offset(Point::new(offset.row, 0));
+                                        let raw_indent = snippet_rope
+                                            .chars_at(raw_line_start)
+                                            .take_while(|c| *c == ' ' || *c == '\t')
+                                            .count()
+                                            as i64;
+                                        let actual_indent = snapshot
+                                            .indent_size_for_line(MultiBufferRow(actual_row))
+                                            .len
+                                            as i64;
+                                        let column = (offset.column as i64 + actual_indent
+                                            - raw_indent)
+                                            .max(0)
+                                            as u32;
+                                        Point::new(actual_row, column)
+                                    };
+                                    let point = snapshot.clip_point(point, Bias::Left);
+                                    snapshot.point_to_offset(point)
+                                };
+                                snapshot.anchor_before(to_offset(start))
+                                    ..snapshot.anchor_after(to_offset(end))
                             })
                         })
                         .collect::<Vec<_>>();
@@ -11866,6 +11910,7 @@ pub enum EditorEvent {
     },
     SnippetInsertion {
         snippet_source: Arc<str>,
+        utf16_range_to_replace: Option<Range<isize>>,
     },
     BufferRangesUpdated {
         buffer: Entity<Buffer>,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11108,7 +11108,7 @@ fn process_completion_for_edit(
 ) -> CompletionEdit {
     let buffer = buffer.read(cx);
     let buffer_snapshot = buffer.snapshot();
-    let (snippet, new_text) = if completion.is_snippet() {
+    let (snippet, new_text, snippet_source) = if completion.is_snippet() {
         let mut snippet_source = completion.new_text.clone();
         // Workaround for typescript language server issues so that methods don't expand within
         // strings and functions with type expressions. The previous point is used because the query
@@ -11130,11 +11130,15 @@ fn process_completion_for_edit(
             snippet_source = label;
         }
         match Snippet::parse(&snippet_source).log_err() {
-            Some(parsed_snippet) => (Some(parsed_snippet.clone()), parsed_snippet.text),
-            None => (None, completion.new_text.clone()),
+            Some(parsed_snippet) => (
+                Some(parsed_snippet.clone()),
+                parsed_snippet.text,
+                Some(snippet_source),
+            ),
+            None => (None, completion.new_text.clone(), None),
         }
     } else {
-        (None, completion.new_text.clone())
+        (None, completion.new_text.clone(), None)
     };
 
     let mut range_to_replace = {
@@ -11237,6 +11241,7 @@ fn process_completion_for_edit(
         new_text,
         replace_range: range_to_replace,
         snippet,
+        snippet_source,
     }
 }
 
@@ -11244,6 +11249,7 @@ struct CompletionEdit {
     new_text: String,
     replace_range: Range<text::Anchor>,
     snippet: Option<Snippet>,
+    snippet_source: Option<String>,
 }
 
 pub trait CollaborationHub {
@@ -11857,6 +11863,9 @@ pub enum EditorEvent {
     InputHandled {
         utf16_range_to_replace: Option<Range<isize>>,
         text: Arc<str>,
+    },
+    SnippetInsertion {
+        snippet_source: Arc<str>,
     },
     BufferRangesUpdated {
         buffer: Entity<Buffer>,

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -69,6 +69,27 @@ impl Editor {
         self.handle_input(text, window, cx);
     }
 
+    pub fn replay_snippet_insertion(
+        &mut self,
+        snippet_source: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.input_enabled {
+            return;
+        }
+        let Some(snippet) = Snippet::parse(snippet_source).log_err() else {
+            return;
+        };
+        let ranges = self
+            .selections
+            .all::<MultiBufferOffset>(&self.display_snapshot(cx))
+            .into_iter()
+            .map(|selection| selection.range())
+            .collect::<Vec<_>>();
+        self.insert_snippet(&ranges, snippet, window, cx).log_err();
+    }
+
     pub fn handle_input(&mut self, text: &str, window: &mut Window, cx: &mut Context<Self>) {
         let text: Arc<str> = text.into();
 

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -23,6 +23,37 @@ impl Editor {
         self.use_autoclose = autoclose;
     }
 
+    fn shift_selections_by_relative_utf16_range(
+        &mut self,
+        relative_utf16_range: Range<isize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let selections = self
+            .selections
+            .all::<MultiBufferOffsetUtf16>(&self.display_snapshot(cx));
+        self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            let new_ranges = selections.into_iter().map(|range| {
+                let start = MultiBufferOffsetUtf16(OffsetUtf16(
+                    range
+                        .head()
+                        .0
+                        .0
+                        .saturating_add_signed(relative_utf16_range.start),
+                ));
+                let end = MultiBufferOffsetUtf16(OffsetUtf16(
+                    range
+                        .head()
+                        .0
+                        .0
+                        .saturating_add_signed(relative_utf16_range.end),
+                ));
+                start..end
+            });
+            s.select_ranges(new_ranges);
+        });
+    }
+
     pub fn replay_insert_event(
         &mut self,
         text: &str,
@@ -41,29 +72,7 @@ impl Editor {
         });
 
         if let Some(relative_utf16_range) = relative_utf16_range {
-            let selections = self
-                .selections
-                .all::<MultiBufferOffsetUtf16>(&self.display_snapshot(cx));
-            self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                let new_ranges = selections.into_iter().map(|range| {
-                    let start = MultiBufferOffsetUtf16(OffsetUtf16(
-                        range
-                            .head()
-                            .0
-                            .0
-                            .saturating_add_signed(relative_utf16_range.start),
-                    ));
-                    let end = MultiBufferOffsetUtf16(OffsetUtf16(
-                        range
-                            .head()
-                            .0
-                            .0
-                            .saturating_add_signed(relative_utf16_range.end),
-                    ));
-                    start..end
-                });
-                s.select_ranges(new_ranges);
-            });
+            self.shift_selections_by_relative_utf16_range(relative_utf16_range, window, cx);
         }
 
         self.handle_input(text, window, cx);
@@ -72,15 +81,27 @@ impl Editor {
     pub fn replay_snippet_insertion(
         &mut self,
         snippet_source: &str,
+        relative_utf16_range: Option<Range<isize>>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.input_enabled {
-            return;
-        }
+        // Parse before any early return so that the unexpanded source, which still
+        // contains tabstop syntax like `${1:name}`, can never escape as literal text.
         let Some(snippet) = Snippet::parse(snippet_source).log_err() else {
             return;
         };
+        if !self.input_enabled {
+            cx.emit(EditorEvent::InputIgnored {
+                text: snippet.text.as_str().into(),
+            });
+            return;
+        }
+        if self.read_only(cx) {
+            return;
+        }
+        if let Some(relative_utf16_range) = relative_utf16_range {
+            self.shift_selections_by_relative_utf16_range(relative_utf16_range, window, cx);
+        }
         let ranges = self
             .selections
             .all::<MultiBufferOffset>(&self.display_snapshot(cx))

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -52,7 +52,7 @@ fn repeatable_insert(action: &ReplayableAction) -> Option<Box<dyn Action>> {
                 None
             }
         }
-        ReplayableAction::Insertion { .. } => None,
+        ReplayableAction::Insertion { .. } | ReplayableAction::SnippetInsertion { .. } => None,
     }
 }
 
@@ -177,6 +177,21 @@ impl Replayer {
                 };
                 editor.update(cx, |editor, cx| {
                     editor.replay_insert_event(&text, utf16_range_to_replace.clone(), window, cx)
+                })
+            }
+            ReplayableAction::SnippetInsertion { snippet_source } => {
+                let Some(workspace) = Workspace::for_window(window, cx) else {
+                    return;
+                };
+                let Some(editor) = workspace
+                    .read(cx)
+                    .active_item(cx)
+                    .and_then(|item| item.act_as::<Editor>(cx))
+                else {
+                    return;
+                };
+                editor.update(cx, |editor, cx| {
+                    editor.replay_snippet_insertion(&snippet_source, window, cx)
                 })
             }
         }

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -179,7 +179,10 @@ impl Replayer {
                     editor.replay_insert_event(&text, utf16_range_to_replace.clone(), window, cx)
                 })
             }
-            ReplayableAction::SnippetInsertion { snippet_source } => {
+            ReplayableAction::SnippetInsertion {
+                snippet_source,
+                utf16_range_to_replace,
+            } => {
                 let Some(workspace) = Workspace::for_window(window, cx) else {
                     return;
                 };
@@ -191,7 +194,12 @@ impl Replayer {
                     return;
                 };
                 editor.update(cx, |editor, cx| {
-                    editor.replay_snippet_insertion(&snippet_source, window, cx)
+                    editor.replay_snippet_insertion(
+                        &snippet_source,
+                        utf16_range_to_replace.clone(),
+                        window,
+                        cx,
+                    )
                 })
             }
         }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1016,6 +1016,33 @@ impl VimGlobals {
         }
     }
 
+    pub fn observe_snippet_insertion(&mut self, snippet_source: &Arc<str>) {
+        if self.ignore_current_insertion {
+            self.ignore_current_insertion = false;
+            return;
+        }
+        if self.dot_recording {
+            self.recording_actions
+                .push(ReplayableAction::SnippetInsertion {
+                    snippet_source: snippet_source.clone(),
+                });
+            if self.stop_recording_after_next_action {
+                self.dot_recording = false;
+                self.recorded_actions = std::mem::take(&mut self.recording_actions);
+                self.recorded_count = self.recording_count.take();
+                self.recorded_register_for_dot = self.recording_register_for_dot.take();
+                self.stop_recording_after_next_action = false;
+            }
+        }
+        if let Some(recording_register) = self.recording_register {
+            self.recordings.entry(recording_register).or_default().push(
+                ReplayableAction::SnippetInsertion {
+                    snippet_source: snippet_source.clone(),
+                },
+            );
+        }
+    }
+
     pub fn focused_vim(&self) -> Option<Entity<Vim>> {
         self.focused_vim.as_ref().and_then(|vim| vim.upgrade())
     }
@@ -1041,6 +1068,9 @@ pub enum ReplayableAction {
         text: Arc<str>,
         utf16_range_to_replace: Option<Range<isize>>,
     },
+    SnippetInsertion {
+        snippet_source: Arc<str>,
+    },
 }
 
 impl Clone for ReplayableAction {
@@ -1053,6 +1083,9 @@ impl Clone for ReplayableAction {
             } => Self::Insertion {
                 text: text.clone(),
                 utf16_range_to_replace: utf16_range_to_replace.clone(),
+            },
+            Self::SnippetInsertion { snippet_source } => Self::SnippetInsertion {
+                snippet_source: snippet_source.clone(),
             },
         }
     }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -988,16 +988,13 @@ impl VimGlobals {
         }
     }
 
-    pub fn observe_insertion(&mut self, text: &Arc<str>, range_to_replace: Option<Range<isize>>) {
+    fn observe_replayable(&mut self, action: ReplayableAction) {
         if self.ignore_current_insertion {
             self.ignore_current_insertion = false;
             return;
         }
         if self.dot_recording {
-            self.recording_actions.push(ReplayableAction::Insertion {
-                text: text.clone(),
-                utf16_range_to_replace: range_to_replace.clone(),
-            });
+            self.recording_actions.push(action.clone());
             if self.stop_recording_after_next_action {
                 self.dot_recording = false;
                 self.recorded_actions = std::mem::take(&mut self.recording_actions);
@@ -1007,40 +1004,29 @@ impl VimGlobals {
             }
         }
         if let Some(recording_register) = self.recording_register {
-            self.recordings.entry(recording_register).or_default().push(
-                ReplayableAction::Insertion {
-                    text: text.clone(),
-                    utf16_range_to_replace: range_to_replace,
-                },
-            );
+            self.recordings
+                .entry(recording_register)
+                .or_default()
+                .push(action);
         }
     }
 
-    pub fn observe_snippet_insertion(&mut self, snippet_source: &Arc<str>) {
-        if self.ignore_current_insertion {
-            self.ignore_current_insertion = false;
-            return;
-        }
-        if self.dot_recording {
-            self.recording_actions
-                .push(ReplayableAction::SnippetInsertion {
-                    snippet_source: snippet_source.clone(),
-                });
-            if self.stop_recording_after_next_action {
-                self.dot_recording = false;
-                self.recorded_actions = std::mem::take(&mut self.recording_actions);
-                self.recorded_count = self.recording_count.take();
-                self.recorded_register_for_dot = self.recording_register_for_dot.take();
-                self.stop_recording_after_next_action = false;
-            }
-        }
-        if let Some(recording_register) = self.recording_register {
-            self.recordings.entry(recording_register).or_default().push(
-                ReplayableAction::SnippetInsertion {
-                    snippet_source: snippet_source.clone(),
-                },
-            );
-        }
+    pub fn observe_insertion(&mut self, text: &Arc<str>, range_to_replace: Option<Range<isize>>) {
+        self.observe_replayable(ReplayableAction::Insertion {
+            text: text.clone(),
+            utf16_range_to_replace: range_to_replace,
+        });
+    }
+
+    pub fn observe_snippet_insertion(
+        &mut self,
+        snippet_source: &Arc<str>,
+        range_to_replace: Option<Range<isize>>,
+    ) {
+        self.observe_replayable(ReplayableAction::SnippetInsertion {
+            snippet_source: snippet_source.clone(),
+            utf16_range_to_replace: range_to_replace,
+        });
     }
 
     pub fn focused_vim(&self) -> Option<Entity<Vim>> {
@@ -1070,6 +1056,7 @@ pub enum ReplayableAction {
     },
     SnippetInsertion {
         snippet_source: Arc<str>,
+        utf16_range_to_replace: Option<Range<isize>>,
     },
 }
 
@@ -1084,8 +1071,12 @@ impl Clone for ReplayableAction {
                 text: text.clone(),
                 utf16_range_to_replace: utf16_range_to_replace.clone(),
             },
-            Self::SnippetInsertion { snippet_source } => Self::SnippetInsertion {
+            Self::SnippetInsertion {
+                snippet_source,
+                utf16_range_to_replace,
+            } => Self::SnippetInsertion {
                 snippet_source: snippet_source.clone(),
+                utf16_range_to_replace: utf16_range_to_replace.clone(),
             },
         }
     }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1731,7 +1731,8 @@ async fn test_snippet_with_count_insert(cx: &mut gpui::TestAppContext) {
     cx.set_state("ˇ", Mode::Normal);
 
     cx.simulate_keystrokes("3 i");
-    cx.assert_state("ˇ", Mode::Insert);
+    cx.simulate_keystrokes("f n");
+    cx.assert_state("fnˇ", Mode::Insert);
     cx.update_editor(|editor, window, cx| {
         editor.show_completions(&editor::actions::ShowCompletions, window, cx);
     });
@@ -1784,6 +1785,91 @@ async fn test_snippet_with_count_insert(cx: &mut gpui::TestAppContext) {
     cx.simulate_keystrokes("escape");
 
     cx.assert_editor_state("fn foo() {\n    \n}\nfn foo() {\n    \n}\nfn foo() {\n    \n}\nˇ");
+}
+
+#[gpui::test]
+async fn test_snippet_with_count_insert_nested(cx: &mut gpui::TestAppContext) {
+    use editor::test::editor_lsp_test_context::EditorLspTestContext;
+    VimTestContext::init(cx);
+    let mut cx = VimTestContext::new_with_lsp(
+        EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                completion_provider: Some(lsp::CompletionOptions {
+                    resolve_provider: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await,
+        true,
+    );
+
+    cx.set_state("ˇ", Mode::Normal);
+
+    cx.simulate_keystrokes("3 i");
+    cx.simulate_keystrokes("f n");
+    cx.assert_state("fnˇ", Mode::Insert);
+    cx.update_editor(|editor, window, cx| {
+        editor.show_completions(&editor::actions::ShowCompletions, window, cx);
+    });
+
+    let completion_item = lsp::CompletionItem {
+        label: "fn".into(),
+        kind: Some(lsp::CompletionItemKind::SNIPPET),
+        filter_text: Some("fn".to_string()),
+        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: lsp::Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            new_text: "fn ${1:name}() {\n    ${0}\n}".to_string(),
+        })),
+        ..Default::default()
+    };
+
+    let closure_completion_item = completion_item.clone();
+    let mut request = cx.set_request_handler::<lsp::request::Completion, _, _>(move |_, _, _| {
+        let task_completion_item = closure_completion_item.clone();
+        async move {
+            Ok(Some(lsp::CompletionResponse::Array(vec![
+                task_completion_item,
+            ])))
+        }
+    });
+    request.next().await;
+
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+
+    cx.update_editor(|editor, window, cx| {
+        editor
+            .confirm_completion(&editor::actions::ConfirmCompletion::default(), window, cx)
+            .unwrap()
+            .detach();
+    });
+
+    cx.assert_editor_state("fn «nameˇ»() {\n    \n}");
+
+    cx.simulate_keystrokes("f o o");
+    cx.simulate_keystrokes("tab");
+    cx.simulate_keystrokes("escape");
+    cx.assert_editor_state(indoc! {"
+        fn foo() {
+            fn foo() {
+                fn foo() {
+                \x20\x20\x20ˇ\x20
+                }
+            }
+        }"});
 }
 
 #[perf]

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1709,6 +1709,83 @@ async fn test_lsp_completions_with_additional_edits_undo(cx: &mut gpui::TestAppC
     cx.assert_editor_state("fn main() { let a = 2.ˇ; }");
 }
 
+#[gpui::test]
+async fn test_snippet_with_count_insert(cx: &mut gpui::TestAppContext) {
+    use editor::test::editor_lsp_test_context::EditorLspTestContext;
+    VimTestContext::init(cx);
+    let mut cx = VimTestContext::new_with_lsp(
+        EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                completion_provider: Some(lsp::CompletionOptions {
+                    resolve_provider: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await,
+        true,
+    );
+
+    cx.set_state("ˇ", Mode::Normal);
+
+    cx.simulate_keystrokes("3 i");
+    cx.assert_state("ˇ", Mode::Insert);
+    cx.update_editor(|editor, window, cx| {
+        editor.show_completions(&editor::actions::ShowCompletions, window, cx);
+    });
+
+    let completion_item = lsp::CompletionItem {
+        label: "fn".into(),
+        kind: Some(lsp::CompletionItemKind::SNIPPET),
+        filter_text: Some("fn".to_string()),
+        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: lsp::Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            new_text: "fn ${1:name}() {\n    ${0}\n}".to_string(),
+        })),
+        ..Default::default()
+    };
+
+    let closure_completion_item = completion_item.clone();
+    let mut request = cx.set_request_handler::<lsp::request::Completion, _, _>(move |_, _, _| {
+        let task_completion_item = closure_completion_item.clone();
+        async move {
+            Ok(Some(lsp::CompletionResponse::Array(vec![
+                task_completion_item,
+            ])))
+        }
+    });
+    request.next().await;
+
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+
+    cx.update_editor(|editor, window, cx| {
+        editor
+            .confirm_completion(&editor::actions::ConfirmCompletion::default(), window, cx)
+            .unwrap()
+            .detach();
+    });
+    cx.assert_editor_state("fn «nameˇ»() {\n    \n}");
+
+    cx.simulate_keystrokes("f o o");
+    cx.simulate_keystrokes("down down right enter");
+    cx.simulate_keystrokes("escape");
+
+    cx.assert_editor_state("fn foo() {\n    \n}\nfn foo() {\n    \n}\nfn foo() {\n    \n}\nˇ");
+}
+
 #[perf]
 #[gpui::test]
 async fn test_mouse_selection(cx: &mut TestAppContext) {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1159,6 +1159,9 @@ impl Vim {
                 text,
                 utf16_range_to_replace: range_to_replace,
             } => Vim::globals(cx).observe_insertion(text, range_to_replace.clone()),
+            EditorEvent::SnippetInsertion { snippet_source } => {
+                Vim::globals(cx).observe_snippet_insertion(snippet_source)
+            }
             EditorEvent::TransactionBegun { transaction_id } => {
                 self.transaction_begun(*transaction_id, window, cx)
             }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1159,8 +1159,11 @@ impl Vim {
                 text,
                 utf16_range_to_replace: range_to_replace,
             } => Vim::globals(cx).observe_insertion(text, range_to_replace.clone()),
-            EditorEvent::SnippetInsertion { snippet_source } => {
-                Vim::globals(cx).observe_snippet_insertion(snippet_source)
+            EditorEvent::SnippetInsertion {
+                snippet_source,
+                utf16_range_to_replace: range_to_replace,
+            } => {
+                Vim::globals(cx).observe_snippet_insertion(snippet_source, range_to_replace.clone())
             }
             EditorEvent::TransactionBegun { transaction_id } => {
                 self.transaction_begun(*transaction_id, window, cx)


### PR DESCRIPTION
# Objective

- Fixes #21272 

## Solution

- Treat snippets as a special type of replayable action. 

## Testing

- Added test for the problem described in the issue.
- Added test for the problem described in the issue except the additional snippets are nested.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase


https://github.com/user-attachments/assets/1b2925c2-d036-4f06-8c55-8349697b3b98



---

Release Notes:

- Fixes snippet insertion replayability