### PR TITLE
workspace: Add custom labels for editor tabs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2747,6 +2747,30 @@
   //   "W": "workspace::Save"
   // }
   "command_aliases": {},
+  // Customize the labels shown on editor tabs. Keys are glob patterns
+  // (matched against the file path relative to the worktree root) and
+  // values are label templates.
+  //
+  // Available template variables:
+  //   - "${filename}": file name without its extension
+  //   - "${extname}": final extension of the file
+  //   - "${dirname}": name of the file's immediate parent folder
+  //   - "${dirname(N)}": name of the Nth ancestor folder. Positive N walks
+  //     up from the file (1 is the immediate parent, 2 is the grandparent,
+  //     ...). Negative N counts from the worktree root (-1 is the topmost
+  //     folder, -2 is its child, ...).
+  //
+  // Patterns are evaluated in declaration order; the first matching
+  // pattern wins. When a tab has a custom label, the parent directory
+  // hint that Zed normally appends for disambiguation is hidden.
+  //
+  // Examples:
+  // {
+  //   "**/src/routes/**/+page.svelte": "${dirname} - page",
+  //   "**/app/**/page.tsx": "${dirname} - page",
+  //   "**/mod.rs": "${dirname}/mod.rs"
+  // }
+  "custom_labels": {},
   // ssh_connections is an array of ssh connections.
   // You can configure these from `project: Open Remote` in the command palette.
   // Zed's ssh support will pull configuration from your ~/.ssh too.

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -31,7 +31,7 @@ use project::{
 };
 use rope::TextSummary;
 use rpc::proto::{self, update_view};
-use settings::Settings;
+use settings::{Settings, SettingsLocation};
 use std::{
     any::{Any, TypeId},
     borrow::Cow,
@@ -710,7 +710,9 @@ impl Item for Editor {
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
-        if let Some(path) = path_for_buffer(&self.buffer, detail, true, cx) {
+        if let Some(label) = custom_label_for_buffer(&self.buffer, cx) {
+            label.into()
+        } else if let Some(path) = path_for_buffer(&self.buffer, detail, true, cx) {
             path.to_string().into()
         } else {
             // Use the same logic as the displayed title for consistency
@@ -775,19 +777,25 @@ impl Item for Editor {
             entry_label_color(params.selected)
         };
 
-        let description = params.detail.and_then(|detail| {
-            let path = path_for_buffer(&self.buffer, detail, false, cx)?;
-            let description = path.trim();
+        let custom_label = custom_label_for_buffer(&self.buffer, cx);
 
-            if description.is_empty() {
-                return None;
-            }
+        let description = if custom_label.is_some() {
+            None
+        } else {
+            params.detail.and_then(|detail| {
+                let path = path_for_buffer(&self.buffer, detail, false, cx)?;
+                let description = path.trim();
 
-            Some(util::truncate_and_trailoff(
-                description,
-                params.max_title_len.unwrap_or(MAX_TAB_TITLE_LEN),
-            ))
-        });
+                if description.is_empty() {
+                    return None;
+                }
+
+                Some(util::truncate_and_trailoff(
+                    description,
+                    params.max_title_len.unwrap_or(MAX_TAB_TITLE_LEN),
+                ))
+            })
+        };
 
         // Whether the file was saved in the past but is now deleted.
         let was_deleted: bool = self
@@ -797,26 +805,37 @@ impl Item for Editor {
             .and_then(|buffer| buffer.read(cx).file())
             .is_some_and(|file| file.disk_state().is_deleted());
 
+        let title = if let Some(custom_label) = custom_label.as_deref() {
+            if params.truncate_title_middle {
+                custom_label.to_string()
+            } else {
+                util::truncate_and_trailoff(
+                    custom_label,
+                    params.max_title_len.unwrap_or(MAX_TAB_TITLE_LEN),
+                )
+            }
+        } else if params.truncate_title_middle {
+            self.title(cx).to_string()
+        } else {
+            util::truncate_and_trailoff(
+                &self.title(cx),
+                params.max_title_len.unwrap_or(MAX_TAB_TITLE_LEN),
+            )
+        };
+
         h_flex()
             .gap_1()
             .when(params.truncate_title_middle, |this| {
                 this.w_full().min_w_0().overflow_hidden()
             })
             .child(
-                Label::new(if params.truncate_title_middle {
-                    self.title(cx).to_string()
-                } else {
-                    util::truncate_and_trailoff(
-                        &self.title(cx),
-                        params.max_title_len.unwrap_or(MAX_TAB_TITLE_LEN),
-                    )
-                })
-                .color(label_color)
-                .when(params.truncate_title_middle, |this| {
-                    this.truncate_middle().flex_1()
-                })
-                .when(params.preview, |this| this.italic())
-                .when(was_deleted, |this| this.strikethrough()),
+                Label::new(title)
+                    .color(label_color)
+                    .when(params.truncate_title_middle, |this| {
+                        this.truncate_middle().flex_1()
+                    })
+                    .when(params.preview, |this| this.italic())
+                    .when(was_deleted, |this| this.strikethrough()),
             )
             .when_some(description, |this, description| {
                 this.child(
@@ -2227,6 +2246,23 @@ fn path_for_buffer<'a>(
 ) -> Option<Cow<'a, str>> {
     let file = buffer.read(cx).as_singleton()?.read(cx).file()?;
     path_for_file(file, height, include_filename, cx)
+}
+
+fn custom_label_for_buffer(buffer: &Entity<MultiBuffer>, cx: &App) -> Option<String> {
+    let file = buffer.read(cx).as_singleton()?.read(cx).file()?;
+    let file = project::File::from_dyn(Some(file))?;
+    let labels = &WorkspaceSettings::get(
+        Some(SettingsLocation {
+            worktree_id: file.worktree_id(cx),
+            path: &file.path,
+        }),
+        cx,
+    )
+    .custom_labels;
+    if labels.is_empty() {
+        return None;
+    }
+    labels.label_for(&file.path)
 }
 
 fn path_for_file<'a>(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -528,6 +528,15 @@ impl VsCodeSettings {
             load_direnv: None,
             git_hosting_providers: None,
             disable_ai: None,
+            custom_labels: self
+                .read_value("workbench.editor.customLabels.patterns")
+                .and_then(|v| v.as_object())
+                .map(|map| {
+                    map.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use collections::{BTreeMap, HashMap};
+use collections::{BTreeMap, HashMap, IndexMap};
 use gpui::Rgba;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -85,6 +85,28 @@ pub struct ProjectSettingsContent {
     ///
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
+
+    /// Custom labels for editor tabs. Maps glob patterns (relative to the
+    /// worktree root) to label templates that are rendered instead of the
+    /// file name.
+    ///
+    /// Available template variables:
+    ///
+    /// - `${filename}`: the file name without its extension
+    /// - `${extname}`: the final extension of the file
+    /// - `${dirname}`: the name of the file's immediate parent folder
+    /// - `${dirname(N)}`: the name of the Nth ancestor folder. Positive `N`
+    ///   walks up from the file (`1` is the immediate parent, `2` is the
+    ///   grandparent, ...). Negative `N` counts from the worktree root
+    ///   (`-1` is the topmost folder, `-2` is its child, ...).
+    ///
+    /// Patterns are evaluated in declaration order and the first match wins.
+    /// Templates that reference a variable which cannot be resolved for a
+    /// given file are skipped.
+    ///
+    /// Default: {}
+    #[serde(default)]
+    pub custom_labels: IndexMap<String, String>,
 }
 
 /// When to scan content of linked directories.

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use collections::{BTreeMap, HashMap, IndexMap};
+use collections::{BTreeMap, HashMap};
 use gpui::Rgba;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -13,8 +13,8 @@ use settings_macros::{MergeFrom, with_fallible_options};
 use util::serde::default_true;
 
 use crate::{
-    AllLanguageSettingsContent, DelayMs, ExtendingVec, ParseStatus, ProjectTerminalSettingsContent,
-    RootUserSettings, SaturatingBool, fallible_options,
+    AllLanguageSettingsContent, CustomLabelsContent, DelayMs, ExtendingVec, ParseStatus,
+    ProjectTerminalSettingsContent, RootUserSettings, SaturatingBool, fallible_options,
 };
 
 #[with_fallible_options]
@@ -101,12 +101,13 @@ pub struct ProjectSettingsContent {
     ///   (`-1` is the topmost folder, `-2` is its child, ...).
     ///
     /// Patterns are evaluated in declaration order and the first match wins.
-    /// Templates that reference a variable which cannot be resolved for a
-    /// given file are skipped.
+    /// When `custom_labels` is set in multiple scopes, project-local patterns
+    /// take precedence over global ones. Templates that reference a variable
+    /// which cannot be resolved for a given file are skipped.
     ///
     /// Default: {}
     #[serde(default)]
-    pub custom_labels: IndexMap<String, String>,
+    pub custom_labels: CustomLabelsContent,
 }
 
 /// When to scan content of linked directories.

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1420,6 +1420,45 @@ impl<T: Clone + std::hash::Hash + Eq> merge_from::MergeFrom for ExtendingSet<T> 
     }
 }
 
+/// A map of glob patterns to editor tab label templates (see
+/// [`ProjectSettingsContent::custom_labels`]).
+///
+/// Unlike a plain map, merging places entries from the more specific settings
+/// scope before entries from the less specific one. Custom labels are matched
+/// in iteration order with the first match winning, so this makes project-local
+/// patterns take precedence over global ones while each scope keeps its own
+/// declaration order.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomLabelsContent(pub IndexMap<String, String>);
+
+impl From<IndexMap<String, String>> for CustomLabelsContent {
+    fn from(map: IndexMap<String, String>) -> Self {
+        CustomLabelsContent(map)
+    }
+}
+
+impl FromIterator<(String, String)> for CustomLabelsContent {
+    fn from_iter<I: IntoIterator<Item = (String, String)>>(iter: I) -> Self {
+        CustomLabelsContent(iter.into_iter().collect())
+    }
+}
+
+impl merge_from::MergeFrom for CustomLabelsContent {
+    fn merge_from(&mut self, other: &Self) {
+        // `other` is the more specific scope (e.g. project-local settings
+        // merged onto global settings). Keep its entries first so they win
+        // first-match evaluation, then append entries only the less specific
+        // scope defines. Each scope retains its declaration order.
+        let mut merged = other.0.clone();
+        for (pattern, template) in &self.0 {
+            merged
+                .entry(pattern.clone())
+                .or_insert_with(|| template.clone());
+        }
+        self.0 = merged;
+    }
+}
+
 // A SaturatingBool in the settings can only ever be set to true,
 // later attempts to set it to false will be ignored.
 //
@@ -1472,5 +1511,48 @@ impl From<u64> for DelayMs {
 impl std::fmt::Display for DelayMs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}ms", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge_from::MergeFrom;
+
+    #[test]
+    fn custom_labels_merge_prefers_more_specific_scope() {
+        // `global` is the less specific scope, `local` the more specific one.
+        let global: CustomLabelsContent = [
+            ("**/*.svelte".to_string(), "global svelte".to_string()),
+            ("**/a.ts".to_string(), "global a".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let local: CustomLabelsContent = [
+            ("**/*.svelte".to_string(), "local svelte".to_string()),
+            ("**/b.ts".to_string(), "local b".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let mut merged = global;
+        merged.merge_from(&local);
+
+        let entries: Vec<(&str, &str)> = merged
+            .0
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        // Local entries come first (so they win first-match), in their own
+        // declaration order; the same key keeps the local value; entries only
+        // the global scope defines are appended afterwards.
+        assert_eq!(
+            entries,
+            vec![
+                ("**/*.svelte", "local svelte"),
+                ("**/b.ts", "local b"),
+                ("**/a.ts", "global a"),
+            ]
+        );
     }
 }

--- a/crates/workspace/src/custom_labels.rs
+++ b/crates/workspace/src/custom_labels.rs
@@ -123,12 +123,19 @@ impl CustomLabels {
         let labels = patterns
             .into_iter()
             .filter_map(|(pattern, template)| {
-                let matcher =
-                    PathMatcher::new([pattern.as_ref()], PathStyle::Posix).ok()?;
-                Some(CustomLabel {
-                    matcher,
-                    template: LabelTemplate::parse(template.as_ref()),
-                })
+                let pattern = pattern.as_ref();
+                match PathMatcher::new([pattern], PathStyle::Posix) {
+                    Ok(matcher) => Some(CustomLabel {
+                        matcher,
+                        template: LabelTemplate::parse(template.as_ref()),
+                    }),
+                    Err(error) => {
+                        log::warn!(
+                            "ignoring invalid `custom_labels` glob pattern {pattern:?}: {error}"
+                        );
+                        None
+                    }
+                }
             })
             .collect();
         Self { labels }

--- a/crates/workspace/src/custom_labels.rs
+++ b/crates/workspace/src/custom_labels.rs
@@ -1,0 +1,258 @@
+use std::sync::Arc;
+
+use util::paths::{PathMatcher, PathStyle};
+use util::rel_path::RelPath;
+
+#[derive(Debug, Clone, PartialEq)]
+enum Segment {
+    Literal(Arc<str>),
+    Filename,
+    Extname,
+    Dirname(i32),
+}
+
+#[derive(Debug, Clone)]
+pub struct LabelTemplate {
+    segments: Vec<Segment>,
+}
+
+impl LabelTemplate {
+    pub fn parse(template: &str) -> Self {
+        let mut segments = Vec::new();
+        let mut literal = String::new();
+        let mut remaining = template;
+        while !remaining.is_empty() {
+            if let Some(rest) = remaining.strip_prefix("${")
+                && let Some(end) = rest.find('}')
+                && let Some(variable) = parse_variable(&rest[..end])
+            {
+                if !literal.is_empty() {
+                    segments.push(Segment::Literal(Arc::from(literal.as_str())));
+                    literal.clear();
+                }
+                segments.push(variable);
+                remaining = &rest[end + 1..];
+                continue;
+            }
+            let mut chars = remaining.chars();
+            if let Some(ch) = chars.next() {
+                literal.push(ch);
+            }
+            remaining = chars.as_str();
+        }
+        if !literal.is_empty() {
+            segments.push(Segment::Literal(Arc::from(literal.as_str())));
+        }
+        Self { segments }
+    }
+
+    pub fn render(&self, path: &RelPath) -> Option<String> {
+        let mut output = String::new();
+        for segment in &self.segments {
+            match segment {
+                Segment::Literal(text) => output.push_str(text),
+                Segment::Filename => {
+                    output.push_str(path.file_stem()?);
+                }
+                Segment::Extname => {
+                    output.push_str(path.extension()?);
+                }
+                Segment::Dirname(n) => {
+                    output.push_str(dirname_nth(path, *n)?);
+                }
+            }
+        }
+        Some(output)
+    }
+}
+
+fn parse_variable(inner: &str) -> Option<Segment> {
+    let (name, arg) = if let Some(paren) = inner.find('(') {
+        if !inner.ends_with(')') {
+            return None;
+        }
+        let arg = &inner[paren + 1..inner.len() - 1];
+        let n = arg.trim().parse::<i32>().ok()?;
+        (&inner[..paren], Some(n))
+    } else {
+        (inner, None)
+    };
+    match (name.trim(), arg) {
+        ("filename", None) => Some(Segment::Filename),
+        ("extname", None) => Some(Segment::Extname),
+        ("dirname", None) => Some(Segment::Dirname(1)),
+        ("dirname", Some(n)) => Some(Segment::Dirname(n)),
+        _ => None,
+    }
+}
+
+fn dirname_nth(path: &RelPath, n: i32) -> Option<&str> {
+    let parent = path.parent()?;
+    let components: Vec<&str> = parent.components().collect();
+    if components.is_empty() {
+        return None;
+    }
+    let idx = if n > 0 {
+        components.len().checked_sub(n as usize)?
+    } else if n < 0 {
+        let from_root = (-n) as usize;
+        from_root.checked_sub(1)?
+    } else {
+        components.len() - 1
+    };
+    components.get(idx).copied()
+}
+
+#[derive(Debug, Clone)]
+struct CustomLabel {
+    matcher: PathMatcher,
+    template: LabelTemplate,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CustomLabels {
+    labels: Vec<CustomLabel>,
+}
+
+impl CustomLabels {
+    pub fn from_patterns<I, S>(patterns: I) -> Self
+    where
+        I: IntoIterator<Item = (S, S)>,
+        S: AsRef<str>,
+    {
+        let labels = patterns
+            .into_iter()
+            .filter_map(|(pattern, template)| {
+                let matcher =
+                    PathMatcher::new([pattern.as_ref()], PathStyle::Posix).ok()?;
+                Some(CustomLabel {
+                    matcher,
+                    template: LabelTemplate::parse(template.as_ref()),
+                })
+            })
+            .collect();
+        Self { labels }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.labels.is_empty()
+    }
+
+    pub fn label_for(&self, path: &RelPath) -> Option<String> {
+        for label in &self.labels {
+            if label.matcher.is_match(path)
+                && let Some(rendered) = label.template.render(path)
+            {
+                return Some(rendered);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::rel_path::RelPath;
+
+    fn rel(path: &str) -> Arc<RelPath> {
+        RelPath::unix(path).unwrap().into_arc()
+    }
+
+    #[test]
+    fn parses_literal_template() {
+        let t = LabelTemplate::parse("hello world");
+        assert_eq!(t.render(&rel("a/b.txt")).as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn renders_filename_and_extname() {
+        let t = LabelTemplate::parse("${filename}.${extname}");
+        assert_eq!(t.render(&rel("a/b/page.tsx")).as_deref(), Some("page.tsx"));
+    }
+
+    #[test]
+    fn renders_dirname_variants() {
+        let path = rel("src/routes/blog/+page.svelte");
+        assert_eq!(
+            LabelTemplate::parse("${dirname}").render(&path).as_deref(),
+            Some("blog")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(1)}")
+                .render(&path)
+                .as_deref(),
+            Some("blog")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(2)}")
+                .render(&path)
+                .as_deref(),
+            Some("routes")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(3)}")
+                .render(&path)
+                .as_deref(),
+            Some("src")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(-1)}")
+                .render(&path)
+                .as_deref(),
+            Some("src")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(-2)}")
+                .render(&path)
+                .as_deref(),
+            Some("routes")
+        );
+        assert_eq!(
+            LabelTemplate::parse("${dirname(-3)}")
+                .render(&path)
+                .as_deref(),
+            Some("blog")
+        );
+    }
+
+    #[test]
+    fn unknown_placeholder_left_as_literal() {
+        let t = LabelTemplate::parse("[${unknown}] ${filename}");
+        assert_eq!(
+            t.render(&rel("a/b/page.tsx")).as_deref(),
+            Some("[${unknown}] page")
+        );
+    }
+
+    #[test]
+    fn dirname_out_of_range_drops_label() {
+        let path = rel("a/b.txt");
+        assert!(
+            LabelTemplate::parse("${dirname(5)}")
+                .render(&path)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn label_for_picks_first_matching_pattern() {
+        let labels = CustomLabels::from_patterns([
+            (
+                "**/src/routes/**/+page.svelte",
+                "/${dirname} - Page",
+            ),
+            ("**/*.svelte", "${filename} (svelte)"),
+        ]);
+        assert_eq!(
+            labels
+                .label_for(&rel("src/routes/blog/+page.svelte"))
+                .as_deref(),
+            Some("/blog - Page")
+        );
+        assert_eq!(
+            labels.label_for(&rel("lib/widget.svelte")).as_deref(),
+            Some("widget (svelte)")
+        );
+    }
+}

--- a/crates/workspace/src/custom_labels.rs
+++ b/crates/workspace/src/custom_labels.rs
@@ -245,10 +245,7 @@ mod tests {
     #[test]
     fn label_for_picks_first_matching_pattern() {
         let labels = CustomLabels::from_patterns([
-            (
-                "**/src/routes/**/+page.svelte",
-                "/${dirname} - Page",
-            ),
+            ("**/src/routes/**/+page.svelte", "/${dirname} - Page"),
             ("**/*.svelte", "${filename} (svelte)"),
         ]);
         assert_eq!(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1,4 +1,5 @@
 pub mod active_file_name;
+pub mod custom_labels;
 pub mod dock;
 pub mod history_manager;
 pub mod invalid_item_view;

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -134,6 +134,7 @@ impl Settings for WorkspaceSettings {
                 content
                     .project
                     .custom_labels
+                    .0
                     .iter()
                     .map(|(pattern, template)| (pattern.as_str(), template.as_str())),
             ),

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -1,6 +1,7 @@
 use std::{num::NonZeroUsize, time::Duration};
 
 use crate::DockPosition;
+use crate::custom_labels::CustomLabels;
 use collections::HashMap;
 use gpui::{App, Subscription};
 use serde::Deserialize;
@@ -41,6 +42,7 @@ pub struct WorkspaceSettings {
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
     pub focus_follows_mouse: FocusFollowsMouse,
+    pub custom_labels: CustomLabels,
 }
 
 #[derive(Copy, Clone, Deserialize)]
@@ -128,6 +130,13 @@ impl Settings for WorkspaceSettings {
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
+            custom_labels: CustomLabels::from_patterns(
+                content
+                    .project
+                    .custom_labels
+                    .iter()
+                    .map(|(pattern, template)| (pattern.as_str(), template.as_str())),
+            ),
             focus_follows_mouse: FocusFollowsMouse {
                 enabled: workspace
                     .focus_follows_mouse

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -785,6 +785,34 @@ List of `string` values
 
 `boolean` values
 
+## Custom Labels
+
+- Description: Customize the labels displayed on editor tabs. Keys are glob patterns (matched against the file path relative to the worktree root) and values are label templates.
+- Setting: `custom_labels`
+- Default: `{}`
+
+**Template variables**
+
+- `${filename}`: file name without its extension.
+- `${extname}`: final extension of the file.
+- `${dirname}`: name of the file's immediate parent folder.
+- `${dirname(N)}`: name of the Nth ancestor folder. Positive `N` walks up from the file (`1` is the immediate parent, `2` is the grandparent, ...). Negative `N` counts from the worktree root (`-1` is the topmost folder, `-2` is its child, ...).
+
+Patterns are evaluated in declaration order; the first matching pattern wins. When a tab has a custom label, the parent directory hint that Zed normally appends for disambiguation is hidden.
+
+**Example**
+
+```json [settings]
+{
+  "custom_labels": {
+    "**/src/routes/**/+page.svelte": "${dirname} - page",
+    "**/src/routes/**/+layout.svelte": "${dirname} - layout",
+    "**/app/**/page.tsx": "${dirname} - page",
+    "**/mod.rs": "${dirname}/mod.rs"
+  }
+}
+```
+
 ## Cursor Shape
 
 - Description: Cursor shape for the default editor.


### PR DESCRIPTION
## Summary

Adds a `custom_labels` setting for editor tabs. The setting maps worktree-relative glob patterns to label templates and uses the first matching pattern as the tab label.

Supported template variables:

- `${filename}`: file name without its extension
- `${extname}`: final extension of the file
- `${dirname}`: immediate parent folder name
- `${dirname(N)}`: ancestor folder lookup from the file for positive `N`, or from the worktree root for negative `N`

The setting applies from global and project-local settings. Project-local entries take precedence over global entries while preserving declaration order within each scope. VS Code imports map `workbench.editor.customLabels.patterns` to `custom_labels`.

When a custom label is used, Zed hides the parent-directory hint normally appended for tab disambiguation.

## Showcase

See the comparison screenshot in #57383, which shows duplicate framework route tab labels before and after applying custom labels.

## Issue relation

Closes #11021
Refs #57383

## Related PRs

- Follow-up to #57383: this rebases the same implementation onto current `main` and addresses its two unresolved review comments by warning on invalid glob patterns and giving project-local `custom_labels` precedence over global entries.

## External knowledge buffer

[external-knowledge:skip] This PR targets the upstream Zed repository and does not modify this machine's dotfiles knowledge base.

## Validation

- `cargo fmt --all -- --check`
- `npx prettier --check src/reference/all-settings.md`

Blocked locally:

- `cargo test -p workspace custom_labels --lib`
- `cargo test -p settings_content custom_labels_merge_prefers_more_specific_scope --lib`

Both targeted cargo test commands stopped before test execution in this local environment because `cmake` is unavailable while building `wasmtime-c-api-impl`.

Release Notes:

- Added `custom_labels` setting that customizes editor tab labels via glob patterns.
