### PR TITLE
terminal: Finish drag selection on mouse up

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2700,6 +2700,14 @@ impl Terminal {
                 self.write_to_pty(bytes);
             }
         } else {
+            if e.button == MouseButton::Left
+                && let Some(mouse_down_position) = self.mouse_down_position
+                && (e.position - mouse_down_position).magnitude() > SELECTION_DRAG_THRESHOLD
+            {
+                self.events
+                    .push_back(InternalEvent::UpdateSelection(position));
+            }
+
             if e.button == MouseButton::Left && setting.copy_on_select {
                 self.copy(Some(true));
             }
@@ -3919,6 +3927,33 @@ mod tests {
                 "a deliberate drag should start a selection"
             );
             assert!(terminal.selection_phase == SelectionPhase::Selecting);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_terminal_mouse_up_finishes_drag_without_mouse_move(cx: &mut TestAppContext) {
+        let terminal = init_ctrl_click_hyperlink_test(cx, b"hello world\r\n");
+
+        cx.update_global(|store: &mut settings::SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.terminal.get_or_insert_default().copy_on_select = Some(true);
+            });
+        });
+
+        terminal.update(cx, |terminal, cx| {
+            left_mouse_down_at(terminal, point(px(50.0), px(10.0)), cx);
+            terminal.events.clear();
+
+            left_mouse_up_at(terminal, point(px(90.0), px(10.0)), cx);
+
+            assert!(matches!(
+                terminal.events.front(),
+                Some(InternalEvent::UpdateSelection(_))
+            ));
+            assert!(matches!(
+                terminal.events.get(1),
+                Some(InternalEvent::Copy(Some(true)))
+            ));
         });
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2706,6 +2706,7 @@ impl Terminal {
             {
                 self.events
                     .push_back(InternalEvent::UpdateSelection(position));
+                self.selection_phase = SelectionPhase::Selecting;
             }
 
             if e.button == MouseButton::Left && setting.copy_on_select {
@@ -3932,7 +3933,10 @@ mod tests {
 
     #[gpui::test]
     async fn test_terminal_mouse_up_finishes_drag_without_mouse_move(cx: &mut TestAppContext) {
-        let terminal = init_ctrl_click_hyperlink_test(cx, b"hello world\r\n");
+        let terminal = init_ctrl_click_hyperlink_test(
+            cx,
+            b"\x1b]8;;https://zed.dev\x1b\\hello world\x1b]8;;\x1b\\\r\n",
+        );
 
         cx.update_global(|store: &mut settings::SettingsStore, cx| {
             store.update_user_settings(cx, |settings| {
@@ -3941,10 +3945,23 @@ mod tests {
         });
 
         terminal.update(cx, |terminal, cx| {
-            left_mouse_down_at(terminal, point(px(50.0), px(10.0)), cx);
+            let release_position = point(px(90.0), px(0.0));
+            let release_index = content_index_for_mouse(
+                release_position - terminal.last_content.terminal_bounds.bounds.origin,
+                &terminal.last_content.terminal_bounds,
+            );
+            assert!(
+                terminal
+                    .last_content
+                    .cells
+                    .get(release_index)
+                    .and_then(|cell| cell.hyperlink())
+                    .is_some()
+            );
+            left_mouse_down_at(terminal, point(px(10.0), px(0.0)), cx);
             terminal.events.clear();
 
-            left_mouse_up_at(terminal, point(px(90.0), px(10.0)), cx);
+            left_mouse_up_at(terminal, release_position, cx);
 
             assert!(matches!(
                 terminal.events.front(),
@@ -3955,6 +3972,8 @@ mod tests {
                 Some(InternalEvent::Copy(Some(true)))
             ));
         });
+
+        assert_eq!(cx.opened_url(), None);
     }
 
     /// With mouse tracking active (e.g. htop), Shift is the escape hatch to


### PR DESCRIPTION
  # Objective

  Fixes #62002.

  With `terminal.copy_on_select` enabled, a drag can reach `mouse_up` before the terminal has processed a movement past the selection threshold. The copy event then runs with the selection still at its starting point, leaving the clipboard unchanged.

  ## Solution

  Use the mouse release position to finish a left-button drag when the pointer moved past the existing selection threshold. The selection update is queued before the copy event, so `copy_on_select` receives the completed range.

  Small pointer movements remain below the threshold and still behave as clicks. A regression test covers a drag where no intermediate mouse-move event is processed.

  ## Testing

  - `cargo test -p terminal test_terminal_mouse_up_finishes_drag_without_mouse_move --lib` — 1 passed
  - `cargo test -p terminal --lib` — 99 passed
  - `script/clippy -p terminal` — passed
  - `cargo fmt --all --check` — passed
  - `git diff --check` — passed

  Tested with the Windows GNU Rust toolchain. I could not manually reproduce the original Wayland environment locally.

  ## Self-Review Checklist:

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [x] Unsafe blocks (if any) have justifying comments
  - [x] The content adheres to Zed's UI standards
  - [x] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

  ---

  Release Notes:

  - Fixed terminal copy-on-select intermittently missing drag selections.