### PR TITLE
git_ui: Hide staged section when no files are staged

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4737,15 +4737,13 @@ impl GitPanel {
             ]
         };
 
-        // Keep Staged/Unstaged headers pinned even when empty (as long as there's
-        // anything to show at all) so the layout stays stable while staging.
+        // Keep the Unstaged section pinned even when empty (as long as there's
+        // anything to show at all) so it never disappears mid-staging workflow.
         let has_any_section_entries = section_entries
             .iter()
             .any(|(_, entries)| !entries.is_empty());
         let show_when_empty = |section: Section| {
-            group_by_staging_state
-                && has_any_section_entries
-                && matches!(section, Section::Staged | Section::Unstaged)
+            group_by_staging_state && has_any_section_entries && section == Section::Unstaged
         };
 
         match &mut self.view_mode {
@@ -9987,10 +9985,6 @@ mod tests {
                         ..
                     }),
                     Header(GitHeaderEntry {
-                        header: Section::Staged
-                    }),
-                    EmptySection(Section::Staged),
-                    Header(GitHeaderEntry {
                         header: Section::Unstaged
                     }),
                     EmptySection(Section::Unstaged),
@@ -10020,10 +10014,6 @@ mod tests {
                         status: FileStatus::Unmerged(..),
                         ..
                     }),
-                    Header(GitHeaderEntry {
-                        header: Section::Staged
-                    }),
-                    EmptySection(Section::Staged),
                     Header(GitHeaderEntry {
                         header: Section::Unstaged
                     }),


### PR DESCRIPTION
# Objective

Introduced in #60976, there is now a placeholder showing all the time in the Git Panel when there is no staged files, so the "Stage all" button is placed below the Staged section.

When Staging all files, the OG cursor position often hovers on 2nd/3rd item which might lead to bad UX design.

## Solution

- Automatically hides the staged section when there is no files staged to reduce item movement, like how VSCode does.
- The unstaged section remains the same.

## Testing

- Tests have been run on git_ui.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>
Before:
<img width="358" height="129" alt="截屏2026-08-10 08 07 12" src="https://github.com/user-attachments/assets/7c04762d-b48c-4058-8589-a9ea32bf26f8" />

After:
<img width="354" height="277" alt="截屏2026-08-10 07 56 29" src="https://github.com/user-attachments/assets/ad724c5e-09ea-4b49-8f40-704197b8f2e5" />


</details>

---

Release Notes:

- Hide staged section when no files are staged
