### PR TITLE
diagnostics: Surface related information from other files

### DIFF
--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -43,11 +43,16 @@ impl DiagnosticRenderer {
                 append_source_and_code(&mut markdown, diagnostic);
 
                 for (ix, entry) in diagnostic_group.iter().enumerate() {
-                    if entry.range.start.row.abs_diff(primary.range.start.row) >= 5 {
+                    if let Some(origin) = &entry.diagnostic.related_origin {
+                        markdown.push_str("\n- [");
+                        markdown.push_str(&Markdown::escape(&origin.label));
+                        markdown.push_str(&format!("]({}): ", origin.uri));
+                        markdown.push_str(&Markdown::escape(&entry.diagnostic.message));
+                    } else if entry.range.start.row.abs_diff(primary.range.start.row) >= 5 {
                         markdown.push_str("\n- hint: [");
                         markdown.push_str(&Markdown::escape(&entry.diagnostic.message));
                         markdown.push_str(&format!(
-                            "](file://#diagnostic-{buffer_id}-{group_id}-{ix})\n",
+                            "](file://#diagnostic-{buffer_id}-{group_id}-{ix})",
                         ))
                     }
                 }
@@ -62,6 +67,13 @@ impl DiagnosticRenderer {
                     }),
                 });
             } else {
+                if let Some(origin) = &entry.diagnostic.related_origin {
+                    markdown = format!(
+                        "[{}]({}): {markdown}",
+                        Markdown::escape(&origin.label),
+                        origin.uri
+                    );
+                }
                 append_source_and_code(&mut markdown, entry.diagnostic);
 
                 if entry.range.start.row.abs_diff(primary.range.start.row) >= 5 {

--- a/crates/language/src/diagnostic.rs
+++ b/crates/language/src/diagnostic.rs
@@ -50,6 +50,20 @@ pub struct Diagnostic {
     ///
     /// Kept as sent, since flattening it into non-primary entries is lossy.
     pub related_information: Option<Arc<[DiagnosticRelatedInformation]>>,
+    /// Set when this diagnostic is one of those flattened entries and came from a different
+    /// file. Such a diagnostic is anchored to the range it explains, so this is the only
+    /// record of where it actually came from.
+    pub related_origin: Option<DiagnosticOrigin>,
+}
+
+/// The location of related information that lives in a different file than the diagnostic
+/// it belongs to.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticOrigin {
+    /// Shortened against the file being diagnosed, such as `_content_row.html.erb:7`.
+    pub label: SharedString,
+    /// Carries the line in its fragment.
+    pub uri: SharedString,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +91,7 @@ impl Default for Diagnostic {
             data: None,
             registration_id: None,
             related_information: None,
+            related_origin: None,
         }
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -100,7 +100,7 @@ use util::rel_path::RelPath;
 pub use available_languages::AvailableLanguage;
 pub use buffer::Operation;
 pub use buffer::*;
-pub use diagnostic::{Diagnostic, DiagnosticSourceKind};
+pub use diagnostic::{Diagnostic, DiagnosticOrigin, DiagnosticSourceKind};
 pub use diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup};
 pub use file_content::{
     ByteContent, DecodedText, FILE_ANALYSIS_BYTES, analyze_byte_content, decode_text, encode_text,

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -1,6 +1,8 @@
 //! Handles conversions of `language` items to and from the [`rpc`] protocol.
 
-use crate::{CursorShape, Diagnostic, DiagnosticSourceKind, diagnostic_set::DiagnosticEntry};
+use crate::{
+    CursorShape, Diagnostic, DiagnosticOrigin, DiagnosticSourceKind, diagnostic_set::DiagnosticEntry,
+};
 use anyhow::{Context as _, Result};
 use clock::ReplicaId;
 use gpui::SharedString;
@@ -239,6 +241,16 @@ pub fn serialize_diagnostics<'a>(
                 .map(|s| s.to_string()),
             is_disk_based: entry.diagnostic.is_disk_based,
             is_unnecessary: entry.diagnostic.is_unnecessary,
+            related_origin_label: entry
+                .diagnostic
+                .related_origin
+                .as_ref()
+                .map(|origin| origin.label.to_string()),
+            related_origin_uri: entry
+                .diagnostic
+                .related_origin
+                .as_ref()
+                .map(|origin| origin.uri.to_string()),
             data: entry.diagnostic.data.as_ref().map(|data| data.to_string()),
             registration_id: entry
                 .diagnostic
@@ -464,6 +476,13 @@ pub fn deserialize_diagnostics(
                     is_disk_based: diagnostic.is_disk_based,
                     is_unnecessary: diagnostic.is_unnecessary,
                     underline: diagnostic.underline,
+                    related_origin: diagnostic
+                        .related_origin_label
+                        .zip(diagnostic.related_origin_uri)
+                        .map(|(label, uri)| DiagnosticOrigin {
+                            label: label.into(),
+                            uri: uri.into(),
+                        }),
                     registration_id: diagnostic.registration_id.map(SharedString::from),
                     source_kind: match proto::diagnostic::SourceKind::from_i32(
                         diagnostic.source_kind,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2005,9 +2005,10 @@ impl MarkdownElement {
         builder.push_div(
             div()
                 .when(!self.style.height_is_multiple_of_line_height, |el| {
-                    el.mb_1().gap_1().line_height(rems(1.3))
+                    el.mb_1().line_height(rems(1.3))
                 })
                 .h_flex()
+                .gap_1()
                 .items_start()
                 .child(bullet),
             range,

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2954,6 +2954,9 @@ impl LspCommand for GetCodeActions {
             .snapshot()
             .diagnostics_in_range::<_, language::PointUtf16>(self.range.clone(), false)
         {
+            if entry.diagnostic.related_origin.is_some() {
+                continue;
+            }
             relevant_diagnostics.push(entry.to_lsp_diagnostic_stub()?);
         }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -76,7 +76,8 @@ use http_client::HttpClient;
 use itertools::Itertools as _;
 use language::{
     Bias, BinaryStatus, Buffer, BufferRow, BufferSnapshot, CachedLspAdapter, Capability, CodeLabel,
-    CodeLabelExt, Diagnostic, DiagnosticEntry, DiagnosticSet, DiagnosticSourceKind, Diff,
+    CodeLabelExt, Diagnostic, DiagnosticEntry, DiagnosticOrigin, DiagnosticSet,
+    DiagnosticSourceKind, Diff,
     File as _, Language, LanguageAwareStyling, LanguageName, LanguageRegistry, LocalFile,
     LspAdapter, LspAdapterDelegate, LspInstaller, ManifestDelegate, ManifestName, ModelineSettings,
     OffsetUtf16, Patch, PointUtf16, TextBufferSnapshot, ToOffset, ToOffsetUtf16, ToPointUtf16,
@@ -12226,6 +12227,7 @@ impl LspStore {
                         is_disk_based,
                         is_unnecessary,
                         underline,
+                        related_origin: None,
                         data: diagnostic.data.clone(),
                         registration_id: registration_id.clone(),
                         related_information: diagnostic
@@ -12236,34 +12238,55 @@ impl LspStore {
                 });
                 if let Some(infos) = &diagnostic.related_information {
                     for info in infos {
-                        if info.location.uri == lsp_diagnostics.uri && !info.message.is_empty() {
-                            let range = range_from_lsp(info.location.range);
-                            diagnostics.push(DiagnosticEntry {
-                                range,
-                                diagnostic: Diagnostic {
-                                    source: diagnostic.source.clone(),
-                                    source_kind,
-                                    code: diagnostic.code.clone(),
-                                    code_description: diagnostic
-                                        .code_description
-                                        .as_ref()
-                                        .and_then(|d| d.href.clone()),
-                                    severity: DiagnosticSeverity::INFORMATION,
-                                    markdown: adapter.as_ref().and_then(|adapter| {
-                                        adapter.diagnostic_message_to_markdown(&info.message)
-                                    }),
-                                    message: info.message.trim().to_string(),
-                                    group_id,
-                                    is_primary: false,
-                                    is_disk_based,
-                                    is_unnecessary: false,
-                                    underline,
-                                    data: diagnostic.data.clone(),
-                                    registration_id: registration_id.clone(),
-                                    related_information: None,
-                                },
-                            });
+                        if info.message.is_empty() {
+                            continue;
                         }
+
+                        let is_same_file = info.location.uri == lsp_diagnostics.uri;
+
+                        let range = if is_same_file {
+                            range_from_lsp(info.location.range)
+                        } else {
+                            range_from_lsp(diagnostic.range)
+                        };
+
+                        let message = info.message.trim().to_string();
+
+                        let related_origin = if is_same_file {
+                            None
+                        } else {
+                            Some(DiagnosticOrigin {
+                                label: related_information_origin(&document_abs_path, info).into(),
+                                uri: related_information_origin_uri(info),
+                            })
+                        };
+
+                        diagnostics.push(DiagnosticEntry {
+                            range,
+                            diagnostic: Diagnostic {
+                                source: diagnostic.source.clone(),
+                                source_kind,
+                                code: diagnostic.code.clone(),
+                                code_description: diagnostic
+                                    .code_description
+                                    .as_ref()
+                                    .and_then(|d| d.href.clone()),
+                                severity: DiagnosticSeverity::INFORMATION,
+                                markdown: adapter.as_ref().and_then(|adapter| {
+                                    adapter.diagnostic_message_to_markdown(&message)
+                                }),
+                                message,
+                                group_id,
+                                is_primary: false,
+                                is_disk_based,
+                                is_unnecessary: false,
+                                underline,
+                                related_origin,
+                                data: diagnostic.data.clone(),
+                                registration_id: registration_id.clone(),
+                                related_information: None,
+                            },
+                        });
                     }
                 }
             }
@@ -14974,6 +14997,43 @@ pub(crate) fn collapse_newlines(text: &str, separator: &str) -> String {
         .join(separator)
 }
 
+/// The line goes in the fragment, one-based, which is the form the popover reads when
+/// following the link.
+fn related_information_origin_uri(info: &lsp::DiagnosticRelatedInformation) -> SharedString {
+    SharedString::from(format!(
+        "{}#L{}",
+        info.location.uri,
+        info.location.range.start.line + 1
+    ))
+}
+
+fn related_information_origin(
+    document_abs_path: &Path,
+    info: &lsp::DiagnosticRelatedInformation,
+) -> String {
+    let line = info.location.range.start.line + 1;
+
+    let Ok(path) = info.location.uri.to_file_path() else {
+        return format!("{}:{}", info.location.uri, line);
+    };
+
+    let mut base = document_abs_path.parent();
+
+    while let Some(candidate) = base {
+        if candidate.parent().is_none() {
+            break;
+        }
+
+        if let Ok(relative) = path.strip_prefix(candidate) {
+            return format!("{}:{}", relative.display(), line);
+        }
+
+        base = candidate.parent();
+    }
+
+    format!("{}:{}", path.display(), line)
+}
+
 fn include_text(server: &lsp::LanguageServer) -> Option<bool> {
     match server.capabilities().text_document_sync.as_ref()? {
         lsp::TextDocumentSyncCapability::Options(opts) => match opts.save.as_ref()? {
@@ -15142,5 +15202,55 @@ mod tests {
             "Get diagnostics via rust-analyzer failed: Server reset the connection"
         ));
         assert!(should_log_lsp_request_failure("something else entirely"));
+    }
+
+    fn related_information_at(path: &str, line: u32) -> lsp::DiagnosticRelatedInformation {
+        lsp::DiagnosticRelatedInformation {
+            location: lsp::Location {
+                uri: lsp::Uri::from_file_path(Path::new(path)).unwrap(),
+                range: lsp::Range::new(lsp::Position::new(line, 0), lsp::Position::new(line, 0)),
+            },
+            message: "rendered from here".to_string(),
+        }
+    }
+
+    #[test]
+    fn related_information_origin_shortens_against_the_diagnosed_file() {
+        let document = Path::new("/app/app/views/posts/_card.html.erb");
+
+        assert_eq!(
+            related_information_origin(
+                document,
+                &related_information_at("/app/app/views/posts/index.html.erb", 11)
+            ),
+            "index.html.erb:12"
+        );
+
+        assert_eq!(
+            related_information_origin(
+                document,
+                &related_information_at("/app/app/views/layouts/application.html.erb", 3)
+            ),
+            "layouts/application.html.erb:4"
+        );
+
+        assert_eq!(
+            related_information_origin(
+                document,
+                &related_information_at("/other/place/thing.html.erb", 0)
+            ),
+            "/other/place/thing.html.erb:1"
+        );
+    }
+
+    #[test]
+    fn related_information_origin_uri_carries_a_one_based_line_in_its_fragment() {
+        assert_eq!(
+            related_information_origin_uri(&related_information_at(
+                "/app/app/views/posts/index.html.erb",
+                11
+            )),
+            "file:///app/app/views/posts/index.html.erb#L12"
+        );
     }
 }

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -283,6 +283,8 @@ message Diagnostic {
   bool is_disk_based = 10;
   bool is_unnecessary = 11;
   bool underline = 15;
+  optional string related_origin_label = 18;
+  optional string related_origin_uri = 19;
 
   enum Severity {
     None = 0;


### PR DESCRIPTION
### Objective

When a language server attaches `relatedInformation` to a diagnostic, those entries often point at a file other than the one being diagnosed. Zed dropped all of them. The loop kept only entries whose URI matched the document's own URI, and everything else was discarded before it reached the buffer.

For templating languages that is usually the most useful half of the diagnostic. A diagnostic reported on `_card.html.erb` frequently explains itself by pointing at the `render` call in another template that invoked it, and that pointer never made it to the editor.

This came out of https://github.com/zed-industries/zed/discussions/56082, where the same behaviour appears to explain Clang notes that point into a header rather than the file being edited. Those fail the same URI check, while notes within the same file keep working.

#### Solution

Cross-file related information is now kept, rendered beneath the diagnostic it explains, and each entry links to the file it came from.

Such an entry describes a range in a buffer that may not even be open, so it cannot be anchored to its own location. It is anchored to the primary diagnostic's range instead, and the location it came from is carried alongside it in a new `DiagnosticOrigin`, holding a display label and a `file://` URI whose fragment is the line number.

The label comes from a new `related_information_origin` helper, which shortens the origin path against the file being diagnosed by walking up that file's ancestors. A sibling collapses to a bare file name, something further away keeps as much of its path as it needs to stay unambiguous, and a file with nothing in common falls back to its absolute path. The walk stops before reaching the filesystem root, because every absolute path strips cleanly against `/` and the result would read as a relative path without being one.

Only the label is a link, matching how the same diagnostics render in other editors. The message beside it stays plain text.

Two smaller pieces were needed to make that render correctly.

Existing hint rows are hidden unless they sit at least five rows from the primary, on the reasoning that a nearby hint is already visible on screen. A cross-file entry is anchored to the primary's own range, so that distance is always zero and says nothing about whether the entry is worth showing. Entries carrying an origin bypass the check, since the link is the only way to reach them.

The bullet in `markdown` had no gap between the marker and the item content in any container whose height is locked to a multiple of the line height, which includes the diagnostic popover. `gap_1` was grouped with `mb_1` and `line_height` inside the conditional that skips vertical-rhythm properties in those containers, but on an `h_flex` it is the horizontal space between the bullet and the text. It now sits on the flex container itself. This affects every markdown list zed renders in such a container, not only diagnostics.

Related information that lives in the diagnosed file itself is unchanged. It keeps its own range, its message is left unprefixed, and it stays subject to the five-row rule.

#### Before / After

| Before | After |
| --- | --- |
|  <img width="2048" height="744" alt="CleanShot 2026-08-10 at 03 44 16@2x" src="https://github.com/user-attachments/assets/ffe90647-2055-42fd-a46e-016c35aca69b" /> | <img width="2048" height="744" alt="CleanShot 2026-08-10 at 03 44 01@2x" src="https://github.com/user-attachments/assets/0d727450-3caa-4ff4-bcb8-3cb45cd7e5bf" /> |



Before, the popover carries only the message, and nothing explains which call site caused it. After, each frame of the chain that rendered the partial is listed beneath, and each file name links to the exact line.

#### Testing

Unit tests cover `related_information_origin` across the three cases that matter, which are a sibling file, a file further up the tree, and a file sharing no meaningful prefix, along with the one-based line in the origin URI's fragment.

```
cargo test -p project --lib related_information
```

Verified in a running editor against a language server that emits cross-file `relatedInformation`, on a project where a partial is rendered through two levels of other templates. Both frames of the chain appear beneath the diagnostic, and following a link opens the other file at the reported line. Tested on macOS only.

#### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved diagnostics to show related information that lives in other files, with a link to each origin
