### PR TITLE
gpui: disable hinting in swash rasterization

### DIFF
--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -378,7 +378,7 @@ impl CosmicTextSystemState {
             .swash_scale_context
             .builder(font_ref)
             .size(pixel_size * params.scale_factor)
-            .hint(true)
+            .hint(false)
             .build();
 
         let sources: &[Source] = if params.is_emoji {


### PR DESCRIPTION
## Objective

I noticed that in some cases, GPUI text rendering on wgpu can differ quite significantly from HTML/CSS when using the exact same fonts, sizes, weights, etc. 

I narrowed this down due to hinting being enabled during rasterization, but not shaping. Hinting should be disabled everywhere, since we use sub-pixel positioning instead.

## Solution

The issue was due to how GPUI does text rasterization on the cosmic backend. When it shapes the glyphs, it does so without any hinting:
https://github.com/zed-industries/zed/blob/1271f8b0e8f3278eed5dd3fc12ad4bd30dce2c5d/crates/gpui_wgpu/src/cosmic_text_system.rs#L644

But it then rasterizes using hinting:
https://github.com/zed-industries/zed/blob/1271f8b0e8f3278eed5dd3fc12ad4bd30dce2c5d/crates/gpui_wgpu/src/cosmic_text_system.rs#L381

This causes the rasterized text to be incorrect by a noticeable margin in some situations.

## Testing

I tested this by creating a small gpui program and html file which rendered identical text with the same font, font-size, line-height, weight, and colors and lining them up. Here is the before and after of the two situations (html/css on the left, GPUI on the right):

Before (the glyphs in gpui appear taller. This is particularly noticeable on the `L`):
<img width="651" height="196" alt="image" src="https://github.com/user-attachments/assets/0ef1581f-da83-4073-82ee-31df075668af" />

After (glyphs appear to match in shape, particularity noticeable in the `L`):
<img width="643" height="176" alt="image" src="https://github.com/user-attachments/assets/b2849076-0f23-4584-99ae-f50029fb6ca4" />

<details>
  <summary>Comparison details/repro</summary>
  
  Left: HTML/CSS captured from Firefox 153.0 (Linux/Gnome). Chrome appears the same.
  Right: GPUI (Linux/Gnome Wayland)
  
  GPUI-Code:
  ```rust
use std::borrow::Cow;

use gpui::{
    App, Bounds, Context, FontWeight, Window, WindowBounds, WindowOptions, div, prelude::*, px,
    size,
};
use gpui_platform::application;

struct TextComparison;

impl Render for TextComparison {
    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
        div()
            .size_full()
            .pt(px(40.0))
            .pl(px(40.0))
            .bg(gpui::white())
            .text_color(gpui::black())
            .font_family("Inter")
            .font_weight(FontWeight::NORMAL)
            .text_size(px(13.0))
            .line_height(px(21.0))
            .child("Lateen")
    }
}

fn main() {
    application().run(|cx: &mut App| {
        cx.text_system()
            .add_fonts(vec![Cow::Borrowed(include_bytes!("Inter-Regular.ttf"))])
            .expect("failed to load embedded Inter-Regular.ttf");

        let bounds = Bounds::centered(None, size(px(320.0), px(160.0)), cx);
        cx.open_window(
            WindowOptions {
                window_bounds: Some(WindowBounds::Windowed(bounds)),
                ..Default::default()
            },
            |_, cx| cx.new(|_| TextComparison),
        )
        .unwrap();
        cx.activate(true);
    });
}
  ```
  
  Html Code (run command below to insert font data, so that the font is identical):
  ```html
  <!doctype html>
<html>
    <head>
        <meta charset="utf-8" />
        <title>Text comparison</title>
        <style>
            @font-face {
                font-family: "Inter";
                font-weight: 400;
                font-style: normal;
                src: url("data:font/ttf;base64,__INTER_B64__")
                    format("truetype");
            }
            body {
                margin: 0;
                padding-top: 40px;
                padding-left: 40px;
                background: #ffffff;
                color: #000000;
                font-family: "Inter";
                font-weight: 400;
                font-size: 13px;
                line-height: 21px;
            }
        </style>
    </head>
    <body>
        Lateen
    </body>
</html>
  ```
  
  Use this command to insert the font-data:
  ```bash
  python3 -c 'import base64;print(open("text_comparison.template.html").read().replace("__INTER_B64__",base64.b64encode(open("Inter-Regular.ttf","rb").read()).decode()),end="")' > text_comparison.html
  ```
  
</details>

---

I additionally ran Zed and did not notice any changes in text-rendering.

---

Release Notes:

- N/A
