### PR TITLE
Project open tasks

### DIFF
--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -6,11 +6,12 @@ use gpui::{App, AppContext, AsyncApp, Context, Entity, SharedString, Task};
 use http_client::{CustomHeaders, HttpClient};
 use language_model::{
     ApiKeyConfiguration, ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel,
-    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
-    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice,
-    LanguageModelToolResultContent, LanguageModelToolSchemaFormat, LanguageModelToolUse,
-    MessageContent, ProviderSettingsView, RateLimiter, Role, StopReason, TokenUsage, env_var,
+    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelCostInfo,
+    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
+    LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolSchemaFormat,
+    LanguageModelToolUse, MessageContent, ProviderSettingsView, RateLimiter, Role, StopReason,
+    TokenUsage, env_var,
 };
 use open_router::{
     Model, ModelMode as OpenRouterModelMode, OPEN_ROUTER_API_URL, ResponseStreamEvent, list_models,
@@ -229,6 +230,7 @@ impl LanguageModelProvider for OpenRouterLanguageModelProvider {
                 supports_images: model.supports_images,
                 mode: model.mode.unwrap_or_default(),
                 provider: model.provider.clone(),
+                pricing: None,
             });
         }
 
@@ -339,6 +341,24 @@ impl LanguageModel for OpenRouterLanguageModel {
 
     fn provider_name(&self) -> LanguageModelProviderName {
         PROVIDER_NAME
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        let pricing = self.model.pricing.as_ref()?;
+        let input_token_cost_per_1m = pricing.prompt.as_deref()?.parse::<f64>().ok()? * 1_000_000.0;
+        let output_token_cost_per_1m =
+            pricing.completion.as_deref()?.parse::<f64>().ok()? * 1_000_000.0;
+        if !input_token_cost_per_1m.is_finite()
+            || !output_token_cost_per_1m.is_finite()
+            || input_token_cost_per_1m < 0.0
+            || output_token_cost_per_1m < 0.0
+        {
+            return None;
+        }
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m,
+            output_token_cost_per_1m,
+        })
     }
 
     fn supports_tools(&self) -> bool {

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -8,10 +8,11 @@ use http_client::{
 };
 use language_model::{
     ApiKeyConfiguration, ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel,
-    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
-    LanguageModelProviderState, LanguageModelRequest, LanguageModelToolChoice,
-    LanguageModelToolSchemaFormat, ProviderSettingsView, RateLimiter, env_var,
+    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelCostInfo,
+    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
+    LanguageModelToolChoice, LanguageModelToolSchemaFormat, ProviderSettingsView, RateLimiter,
+    env_var,
 };
 use open_ai::ResponseStreamEvent;
 use serde::Deserialize;
@@ -172,6 +173,8 @@ impl VercelAiGatewayLanguageModelProvider {
             max_tokens: 400_000,
             max_output_tokens: Some(128_000),
             max_completion_tokens: None,
+            input_token_cost_per_1m: None,
+            output_token_cost_per_1m: None,
             capabilities: ModelCapabilities::default(),
         }
     }
@@ -370,6 +373,11 @@ fn clean_error_message(message: &str) -> String {
     message.to_string()
 }
 
+fn price_per_token_to_per_million(price: &str) -> Option<f64> {
+    let price = price.parse::<f64>().ok()? * 1_000_000.0;
+    (price.is_finite() && price >= 0.0).then_some(price)
+}
+
 fn has_tag(tags: &[String], expected: &str) -> bool {
     tags.iter()
         .any(|tag| tag.trim().eq_ignore_ascii_case(expected))
@@ -395,6 +403,13 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
 
     fn provider_name(&self) -> LanguageModelProviderName {
         PROVIDER_NAME
+    }
+
+    fn model_cost_info(&self) -> Option<LanguageModelCostInfo> {
+        Some(LanguageModelCostInfo::TokenCost {
+            input_token_cost_per_1m: self.model.input_token_cost_per_1m?,
+            output_token_cost_per_1m: self.model.output_token_cost_per_1m?,
+        })
     }
 
     fn supports_tools(&self) -> bool {
@@ -491,6 +506,13 @@ struct ApiModel {
     #[serde(default)]
     tags: Vec<String>,
     architecture: Option<ApiModelArchitecture>,
+    pricing: Option<ApiModelPricing>,
+}
+
+#[derive(Deserialize)]
+struct ApiModelPricing {
+    input: Option<String>,
+    output: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -589,6 +611,16 @@ async fn list_models(
             max_tokens: model.context_window.or(model.max_tokens).unwrap_or(128_000),
             max_output_tokens: model.max_tokens,
             max_completion_tokens: None,
+            input_token_cost_per_1m: model
+                .pricing
+                .as_ref()
+                .and_then(|pricing| pricing.input.as_deref())
+                .and_then(price_per_token_to_per_million),
+            output_token_cost_per_1m: model
+                .pricing
+                .as_ref()
+                .and_then(|pricing| pricing.output.as_deref())
+                .and_then(price_per_token_to_per_million),
             capabilities: ModelCapabilities {
                 tools: supports_tools,
                 images: supports_images,
@@ -602,4 +634,18 @@ async fn list_models(
     }
 
     Ok(models)
+}
+
+#[cfg(test)]
+mod pricing_tests {
+    #[test]
+    fn converts_token_pricing_to_per_million() {
+        assert_eq!(
+            super::price_per_token_to_per_million("0.0000005"),
+            Some(0.5)
+        );
+        assert_eq!(super::price_per_token_to_per_million("0"), Some(0.0));
+        assert_eq!(super::price_per_token_to_per_million("invalid"), None);
+        assert_eq!(super::price_per_token_to_per_million("-0.1"), None);
+    }
 }

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -72,6 +72,13 @@ impl From<Role> for String {
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ModelPricing {
+    pub prompt: Option<String>,
+    pub completion: Option<String>,
+}
+
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Model {
     pub name: String,
     pub display_name: Option<String>,
@@ -81,6 +88,7 @@ pub struct Model {
     #[serde(default)]
     pub mode: ModelMode,
     pub provider: Option<Provider>,
+    pub pricing: Option<ModelPricing>,
 }
 
 impl Model {
@@ -113,6 +121,7 @@ impl Model {
             supports_images,
             mode: mode.unwrap_or(ModelMode::Default),
             provider,
+            pricing: None,
         }
     }
 
@@ -473,6 +482,8 @@ pub struct ModelEntry {
     pub supported_parameters: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub architecture: Option<ModelArchitecture>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing: Option<ModelPricing>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
@@ -647,6 +658,7 @@ pub async fn list_models(
                     ModelMode::Default
                 },
                 provider: None,
+                pricing: entry.pricing,
             })
             .collect();
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -251,6 +251,7 @@ pub struct Project {
     toolchain_store: Option<Entity<ToolchainStore>>,
     agent_location: Option<AgentLocation>,
     downloading_files: Arc<Mutex<HashMap<(WorktreeId, String), DownloadingFile>>>,
+    worktrees_with_root_tasks_loaded: HashSet<WorktreeId>,
     last_worktree_paths: WorktreePaths,
 }
 
@@ -363,6 +364,7 @@ pub enum Event {
     ActiveEntryChanged(Option<ProjectEntryId>),
     ActivateProjectPanel,
     WorktreeAdded(WorktreeId),
+    WorktreeTasksLoaded(WorktreeId),
     WorktreeOrderChanged,
     WorktreeRemoved(WorktreeId),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),
@@ -1384,6 +1386,7 @@ impl Project {
 
                 agent_location: None,
                 downloading_files: Default::default(),
+                worktrees_with_root_tasks_loaded: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
             }
         })
@@ -1626,6 +1629,7 @@ impl Project {
                 toolchain_store: Some(toolchain_store),
                 agent_location: None,
                 downloading_files: Default::default(),
+                worktrees_with_root_tasks_loaded: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
             };
 
@@ -1914,6 +1918,7 @@ impl Project {
                 toolchain_store: None,
                 agent_location: None,
                 downloading_files: Default::default(),
+                worktrees_with_root_tasks_loaded: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
             };
             project.set_role(role, cx);
@@ -2396,6 +2401,10 @@ impl Project {
         cx: &'a App,
     ) -> impl 'a + DoubleEndedIterator<Item = Entity<Worktree>> {
         self.worktree_store.read(cx).worktrees()
+    }
+
+    pub fn worktrees_with_root_tasks_loaded(&self) -> impl Iterator<Item = WorktreeId> + '_ {
+        self.worktrees_with_root_tasks_loaded.iter().copied()
     }
 
     /// Collect all user-visible worktrees, the ones that appear in the project panel.
@@ -3873,6 +3882,10 @@ impl Project {
                 }),
                 Err(_) => {}
             },
+            SettingsObserverEvent::RootTasksUpdated(worktree_id) => {
+                self.worktrees_with_root_tasks_loaded.insert(*worktree_id);
+                cx.emit(Event::WorktreeTasksLoaded(*worktree_id));
+            }
             SettingsObserverEvent::LocalDebugScenariosUpdated(result) => match result {
                 Err(InvalidSettingsError::Debug { message, path }) => {
                     let message =

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -808,6 +808,7 @@ pub enum SettingsObserverMode {
 pub enum SettingsObserverEvent {
     LocalSettingsUpdated(Result<PathBuf, InvalidSettingsError>),
     LocalTasksUpdated(Result<PathBuf, InvalidSettingsError>),
+    RootTasksUpdated(WorktreeId),
     LocalDebugScenariosUpdated(Result<PathBuf, InvalidSettingsError>),
 }
 
@@ -1400,6 +1401,13 @@ impl SettingsObserver {
                             cx.emit(SettingsObserverEvent::LocalTasksUpdated(Ok(directory
                                 .as_std_path()
                                 .join(task_file_name()))));
+                            if local_tasks_file_relative_path().parent().is_some_and(
+                                |root_tasks_directory| {
+                                    directory.as_std_path() == root_tasks_directory.as_std_path()
+                                },
+                            ) {
+                                cx.emit(SettingsObserverEvent::RootTasksUpdated(worktree_id));
+                            }
                         }
                     }
                 }

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -489,6 +489,8 @@ pub struct VercelAiGatewayAvailableModel {
     pub max_tokens: u64,
     pub max_output_tokens: Option<u64>,
     pub max_completion_tokens: Option<u64>,
+    pub input_token_cost_per_1m: Option<f64>,
+    pub output_token_cost_per_1m: Option<f64>,
     #[serde(default)]
     pub capabilities: OpenAiCompatibleModelCapabilities,
 }

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -185,6 +185,8 @@ pub enum VariableName {
     /// For normal checkouts, this equals the worktree root. For linked worktrees,
     /// this is the original repo's working directory.
     MainGitWorktree,
+    /// Whether the workspace was newly opened or restored from the previous session.
+    ProjectOpen,
     /// Full SHA for the Git commit associated with the task context.
     GitSha,
     /// Short SHA for the Git commit associated with the task context.
@@ -231,6 +233,7 @@ impl FromStr for VariableName {
             "ROW" => Self::Row,
             "COLUMN" => Self::Column,
             "MAIN_GIT_WORKTREE" => Self::MainGitWorktree,
+            "PROJECT_OPEN" => Self::ProjectOpen,
             "GIT_SHA" => Self::GitSha,
             "GIT_SHA_SHORT" => Self::GitShaShort,
             "GIT_REPOSITORY_NAME" => Self::GitRepositoryName,
@@ -272,6 +275,7 @@ impl std::fmt::Display for VariableName {
             Self::RunnableSymbol => write!(f, "{ZED_VARIABLE_NAME_PREFIX}RUNNABLE_SYMBOL"),
             Self::PickProcessId => write!(f, "{ZED_VARIABLE_NAME_PREFIX}PICK_PID"),
             Self::MainGitWorktree => write!(f, "{ZED_VARIABLE_NAME_PREFIX}MAIN_GIT_WORKTREE"),
+            Self::ProjectOpen => write!(f, "{ZED_VARIABLE_NAME_PREFIX}PROJECT_OPEN"),
             Self::GitSha => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_SHA"),
             Self::GitShaShort => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_SHA_SHORT"),
             Self::GitRepositoryName => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_REPOSITORY_NAME"),

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -95,6 +95,8 @@ pub enum DebugArgsRequest {
 pub enum TaskHook {
     #[serde(alias = "create_git_worktree")]
     CreateWorktree,
+    ProjectOpen,
+    WorktreeOpen,
 }
 
 /// What to do with the terminal pane and tab, after the command was started.

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -277,9 +277,12 @@ impl TerminalPanel {
         };
 
         if let Some(workspace) = workspace.upgrade() {
-            workspace.update(&mut cx, |workspace, _| {
-                workspace.set_terminal_provider(TerminalProvider(terminal_panel.clone()))
-            });
+            workspace
+                .update_in(&mut cx, |workspace, window, cx| {
+                    workspace.set_terminal_provider(TerminalProvider(terminal_panel.clone()));
+                    workspace.run_pending_project_open_tasks(window, cx);
+                })
+                .log_err();
         }
 
         // Since panels/docks are loaded outside from the workspace, we cleanup here, instead of through the workspace.

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -219,6 +219,36 @@ impl Workspace {
         }
     }
 
+    pub fn queue_project_open_tasks(
+        &mut self,
+        worktree_id: WorktreeId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.started_project_open_worktrees.contains(&worktree_id) {
+            self.pending_project_open_worktrees.insert(worktree_id);
+            self.run_pending_project_open_tasks(window, cx);
+        }
+    }
+
+    pub fn run_pending_project_open_tasks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.terminal_provider.is_none() {
+            return;
+        }
+
+        let worktree_ids = std::mem::take(&mut self.pending_project_open_worktrees)
+            .into_iter()
+            .filter(|worktree_id| self.started_project_open_worktrees.insert(*worktree_id))
+            .collect::<Vec<_>>();
+        self.run_hook_tasks(
+            &worktree_ids,
+            HashSet::from_iter([TaskHook::ProjectOpen, TaskHook::WorktreeOpen]),
+            "project_open",
+            window,
+            cx,
+        );
+    }
+
     pub fn spawn_in_terminal(
         self: &mut Workspace,
         spawn_in_terminal: SpawnInTerminal,
@@ -233,10 +263,33 @@ impl Workspace {
     }
 
     pub fn run_create_worktree_tasks(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let project = self.project().clone();
-        let hooks = HashSet::from_iter([TaskHook::CreateWorktree]);
+        let worktree_ids = self
+            .project()
+            .read(cx)
+            .worktrees(cx)
+            .map(|worktree| worktree.read(cx).id())
+            .collect::<Vec<_>>();
+        self.run_hook_tasks(
+            &worktree_ids,
+            HashSet::from_iter([TaskHook::CreateWorktree]),
+            "worktree_setup",
+            window,
+            cx,
+        );
+    }
 
-        let worktree_tasks: Vec<(WorktreeId, TaskContext, Vec<TaskTemplate>)> = {
+    fn run_hook_tasks(
+        &mut self,
+        worktree_ids: &[WorktreeId],
+        hooks: HashSet<TaskHook>,
+        hook_name: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let project = self.project().clone();
+        let project_open_state = self.project_open_state.as_str();
+
+        let worktree_tasks: Vec<(WorktreeId, TaskContext, Vec<(TaskSourceKind, TaskTemplate)>)> = {
             let project = project.read(cx);
             let task_store = project.task_store();
             let Some(inventory) = task_store.read(cx).task_inventory().cloned() else {
@@ -246,17 +299,15 @@ impl Workspace {
             let git_store = project.git_store().read(cx);
 
             let mut worktree_tasks = Vec::new();
-            for worktree in project.worktrees(cx) {
+            for worktree_id in worktree_ids {
+                let Some(worktree) = project.worktree_for_id(*worktree_id, cx) else {
+                    continue;
+                };
                 let worktree = worktree.read(cx);
                 let worktree_id = worktree.id();
                 let worktree_abs_path = worktree.abs_path();
 
-                let templates: Vec<TaskTemplate> = inventory
-                    .read(cx)
-                    .templates_with_hooks(&hooks, worktree_id)
-                    .into_iter()
-                    .map(|(_, template)| template)
-                    .collect();
+                let templates = inventory.read(cx).templates_with_hooks(&hooks, worktree_id);
 
                 if templates.is_empty() {
                     continue;
@@ -267,6 +318,10 @@ impl Workspace {
                     VariableName::WorktreeRoot,
                     worktree_abs_path.to_string_lossy().into_owned(),
                 );
+                if hook_name == "project_open" {
+                    task_variables
+                        .insert(VariableName::ProjectOpen, project_open_state.to_string());
+                }
 
                 if let Some(path) = git_store.original_repo_path_for_worktree(worktree_id, cx) {
                     task_variables.insert(
@@ -293,16 +348,16 @@ impl Workspace {
         let task = cx.spawn_in(window, async move |workspace, cx| {
             let mut tasks = Vec::new();
             for (worktree_id, task_context, templates) in worktree_tasks {
-                let id_base = format!("worktree_setup_{worktree_id}");
+                for (task_source_kind, task_template) in templates {
+                    let id_base = format!("{hook_name}_{worktree_id}");
 
-                tasks.push(cx.spawn({
-                    let workspace = workspace.clone();
-                    async move |cx| {
-                        for task_template in templates {
-                            let Some(resolved) =
-                                task_template.resolve_task(&id_base, &task_context)
+                    tasks.push(cx.spawn({
+                        let workspace = workspace.clone();
+                        let task_context = task_context.clone();
+                        async move |cx| {
+                            let Some(resolved) = task_template.resolve_task(&id_base, &task_context)
                             else {
-                                continue;
+                                return anyhow::Ok(());
                             };
 
                             let status = workspace.update_in(cx, |workspace, window, cx| {
@@ -313,22 +368,22 @@ impl Workspace {
                                 match result {
                                     Ok(exit_status) if !exit_status.success() => {
                                         log::error!(
-                                            "Git worktree setup task failed with status: {:?}",
+                                            "{hook_name} task from {task_source_kind:?} failed with status: {:?}",
                                             exit_status.code()
                                         );
-                                        break;
                                     }
                                     Err(error) => {
-                                        log::error!("Git worktree setup task error: {error:#}");
-                                        break;
+                                        log::error!(
+                                            "{hook_name} task from {task_source_kind:?} failed: {error:#}"
+                                        );
                                     }
                                     _ => {}
                                 }
                             }
+                            anyhow::Ok(())
                         }
-                        anyhow::Ok(())
-                    }
-                }));
+                    }));
+                }
             }
 
             futures::future::join_all(tasks).await;
@@ -348,16 +403,69 @@ mod tests {
     };
     use gpui::{App, TestAppContext};
     use parking_lot::Mutex;
-    use project::{FakeFs, Project, TaskSourceKind};
+    use project::{FakeFs, Project, TaskSourceKind, task_store::TaskSettingsLocation};
     use serde_json::json;
+    use settings::SettingsLocation;
     use std::sync::Arc;
     use task::TaskTemplate;
+    use util::rel_path::rel_path;
 
     struct Fixture {
         workspace: Entity<Workspace>,
         item: Entity<TestItem>,
         task: ResolvedTask,
         dirty_before_spawn: Arc<Mutex<Option<bool>>>,
+    }
+
+    #[gpui::test]
+    async fn test_project_open_hooks_run_once_per_worktree(cx: &mut TestAppContext) {
+        let (fixture, cx) = create_fixture(cx, SaveStrategy::None).await;
+        let spawned_task_labels = Arc::new(Mutex::new(Vec::new()));
+        fixture.workspace.update_in(cx, |workspace, window, cx| {
+            workspace.terminal_provider = Some(Box::new(CountingTerminalProvider {
+                spawned_task_labels: spawned_task_labels.clone(),
+            }));
+
+            let project = workspace.project().clone();
+            let worktree_id = project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .expect("test project should have a worktree")
+                .read(cx)
+                .id();
+            let task_inventory = project
+                .read(cx)
+                .task_store()
+                .read(cx)
+                .task_inventory()
+                .cloned()
+                .expect("test project should have a task inventory");
+            task_inventory.update(cx, |inventory, _| {
+                inventory
+                    .update_file_based_tasks(
+                        TaskSettingsLocation::Worktree(SettingsLocation {
+                            worktree_id,
+                            path: rel_path(".zed"),
+                        }),
+                        Some(
+                            r#"[
+                                {"label":"project hook","command":"echo","hooks":["project_open"]},
+                                {"label":"worktree hook","command":"echo","hooks":["worktree_open"]}
+                            ]"#,
+                        ),
+                    )
+                    .expect("test hook tasks should parse");
+            });
+
+            workspace.queue_project_open_tasks(worktree_id, window, cx);
+            workspace.queue_project_open_tasks(worktree_id, window, cx);
+        });
+        cx.executor().run_until_parked();
+
+        let mut spawned_task_labels = spawned_task_labels.lock().clone();
+        spawned_task_labels.sort();
+        assert_eq!(spawned_task_labels, ["project hook", "worktree hook"]);
     }
 
     #[gpui::test]
@@ -568,6 +676,22 @@ mod tests {
         cx.run_until_parked();
         assert!(cx.read(|cx| !fixture.item.read(cx).is_dirty));
         assert!(cx.read(|cx| inactive.read(cx).is_dirty));
+    }
+
+    struct CountingTerminalProvider {
+        spawned_task_labels: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TerminalProvider for CountingTerminalProvider {
+        fn spawn(
+            &self,
+            task: task::SpawnInTerminal,
+            _window: &mut ui::Window,
+            _cx: &mut App,
+        ) -> Task<Option<Result<ExitStatus>>> {
+            self.spawned_task_labels.lock().push(task.label);
+            Task::ready(Some(Ok(ExitStatus::default())))
+        }
     }
 
     struct TestTerminalProvider {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1418,6 +1418,9 @@ pub struct Workspace {
     on_prompt_for_new_path: Option<PromptForNewPath>,
     on_prompt_for_open_path: Option<PromptForOpenPath>,
     terminal_provider: Option<Box<dyn TerminalProvider>>,
+    project_open_state: ProjectOpenState,
+    pending_project_open_worktrees: HashSet<WorktreeId>,
+    started_project_open_worktrees: HashSet<WorktreeId>,
     debugger_provider: Option<Arc<dyn DebuggerProvider>>,
     serializable_items_tx: UnboundedSender<Box<dyn SerializableItemHandle>>,
     _items_serializer: Task<Result<()>>,
@@ -1485,11 +1488,44 @@ pub enum OpenMode {
     Activate,
 }
 
+#[derive(Clone, Copy)]
+enum ProjectOpenState {
+    New,
+    Restored,
+}
+
+impl ProjectOpenState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::New => "new",
+            Self::Restored => "restored",
+        }
+    }
+}
+
 impl Workspace {
     pub fn new(
         workspace_id: Option<WorkspaceId>,
         project: Entity<Project>,
         app_state: Arc<AppState>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::new_with_project_open_state(
+            workspace_id,
+            project,
+            app_state,
+            ProjectOpenState::New,
+            window,
+            cx,
+        )
+    }
+
+    fn new_with_project_open_state(
+        workspace_id: Option<WorkspaceId>,
+        project: Entity<Project>,
+        app_state: Arc<AppState>,
+        project_open_state: ProjectOpenState,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -1558,6 +1594,9 @@ impl Workspace {
                         this.serialize_workspace(window, cx);
                         this.update_history(cx);
                     }
+                }
+                &project::Event::WorktreeTasksLoaded(worktree_id) => {
+                    this.queue_project_open_tasks(worktree_id, window, cx);
                 }
                 project::Event::WorktreeUpdatedEntries(..) => {
                     this.update_window_title(window, cx);
@@ -1826,6 +1865,11 @@ impl Workspace {
         center.set_is_center(true);
         center.mark_positions(cx);
 
+        let pending_project_open_worktrees = project
+            .read(cx)
+            .worktrees_with_root_tasks_loaded()
+            .collect();
+
         Workspace {
             weak_self: weak_handle.clone(),
             zoomed: None,
@@ -1877,6 +1921,9 @@ impl Workspace {
             on_prompt_for_new_path: None,
             on_prompt_for_open_path: None,
             terminal_provider: None,
+            project_open_state,
+            pending_project_open_worktrees,
+            started_project_open_worktrees: HashSet::default(),
             debugger_provider: None,
             serializable_items_tx,
             _items_serializer,
@@ -1902,6 +1949,28 @@ impl Workspace {
         env: Option<HashMap<String, String>>,
         init: Option<Box<dyn FnOnce(&mut Workspace, &mut Window, &mut Context<Workspace>) + Send>>,
         open_mode: OpenMode,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<OpenResult>> {
+        Self::new_local_with_project_open_state(
+            abs_paths,
+            app_state,
+            requesting_window,
+            env,
+            init,
+            open_mode,
+            ProjectOpenState::New,
+            cx,
+        )
+    }
+
+    fn new_local_with_project_open_state(
+        abs_paths: Vec<PathBuf>,
+        app_state: Arc<AppState>,
+        requesting_window: Option<WindowHandle<MultiWorkspace>>,
+        env: Option<HashMap<String, String>>,
+        init: Option<Box<dyn FnOnce(&mut Workspace, &mut Window, &mut Context<Workspace>) + Send>>,
+        open_mode: OpenMode,
+        project_open_state: ProjectOpenState,
         cx: &mut App,
     ) -> Task<anyhow::Result<OpenResult>> {
         let project_handle = Project::local(
@@ -2008,10 +2077,11 @@ impl Workspace {
 
                     let workspace = window.update(cx, |multi_workspace, window, cx| {
                         let workspace = cx.new(|cx| {
-                            let mut workspace = Workspace::new(
+                            let mut workspace = Workspace::new_with_project_open_state(
                                 Some(workspace_id),
                                 project_handle.clone(),
                                 app_state.clone(),
+                                project_open_state,
                                 window,
                                 cx,
                             );
@@ -2072,10 +2142,11 @@ impl Workspace {
                         let project_handle = project_handle.clone();
                         move |window, cx| {
                             let workspace = cx.new(|cx| {
-                                let mut workspace = Workspace::new(
+                                let mut workspace = Workspace::new_with_project_open_state(
                                     Some(workspace_id),
                                     project_handle,
                                     app_state,
+                                    project_open_state,
                                     window,
                                     cx,
                                 );
@@ -9668,13 +9739,14 @@ pub async fn restore_multiworkspace(
         .await
     } else {
         cx.update(|cx| {
-            Workspace::new_local(
+            Workspace::new_local_with_project_open_state(
                 active_workspace.paths.paths().to_vec(),
                 app_state.clone(),
                 None,
                 None,
                 None,
                 OpenMode::Activate,
+                ProjectOpenState::Restored,
                 cx,
             )
         })
@@ -9693,13 +9765,14 @@ pub async fn restore_multiworkspace(
                 let paths = key.path_list().paths().to_vec();
                 match cx
                     .update(|cx| {
-                        Workspace::new_local(
+                        Workspace::new_local_with_project_open_state(
                             paths,
                             app_state.clone(),
                             None,
                             None,
                             None,
                             OpenMode::Activate,
+                            ProjectOpenState::Restored,
                             cx,
                         )
                     })

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -236,12 +236,23 @@ In addition to being spawned manually, tasks can be configured to run automatica
 
 The following hooks are currently supported:
 
+- `project_open` — runs once for each opened project worktree after its root `.zed/tasks.json` has loaded.
+- `worktree_open` — an alternative name for `project_open`, useful when a task is specifically scoped to a worktree.
 - `create_worktree` — runs after Zed creates a new linked Git worktree, either directly through the CLI or from the [worktree picker](./git.md#git-worktrees). The task is spawned with `ZED_WORKTREE_ROOT` pointing at the newly created worktree and `ZED_MAIN_GIT_WORKTREE` pointing at the original repository's working directory, which makes these hooks well-suited to copying untracked files (such as `.env` files) or running per-worktree setup commands.
+
+Open hooks run in Zed's integrated terminal and are dispatched only once per workspace worktree, even when task discovery or terminal-panel restoration produces multiple updates. Multiple matching tasks are spawned concurrently; `allow_concurrent_runs` and `use_new_terminal` keep their usual terminal behavior. Open-hook tasks receive `ZED_PROJECT_OPEN` with the value `new` or `restored`, so a command can distinguish a user-opened project from one restored from the previous local session.
 
 Hook tasks are resolved from the same global and worktree-local `tasks.json` files as manually spawned tasks, and multiple tasks may register for the same hook; they all run when the hook fires. A hook task still benefits from the usual task configuration fields — `cwd`, `env`, `reveal`, `hide`, and so on — so you can control how much of the terminal UI is shown while it runs.
 
 ```json [tasks]
 [
+  {
+    "label": "start development environment",
+    "command": "npm run dev",
+    "hooks": ["project_open"],
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
   {
     "label": "copy .env into new worktree",
     "command": "cp",


### PR DESCRIPTION
# Objective

Allow project-local Zed tasks to start development services automatically when
a project worktree opens.

This supports common workflows such as starting Laravel, Node.js, Docker, or
other long-running development environments from a project’s
`.zed/tasks.json`.

## Solution

This PR:

- Adds `project_open` and `worktree_open` task hooks.
- Loads hooks only after the root `.zed/tasks.json` for a worktree has been
  successfully parsed and added to the task inventory.
- Runs matching tasks through Zed’s integrated terminal provider.
- Queues hooks until the terminal panel is available, preventing startup races
  between project scanning and terminal-panel restoration.
- Ensures each worktree’s open hooks are dispatched at most once per workspace,
  even if task discovery or terminal restoration produces multiple updates.
- Starts matching hook tasks in parallel.
- Preserves the existing `use_new_terminal` and `allow_concurrent_runs`
  behavior supplied by the terminal task provider.
- Provides `ZED_PROJECT_OPEN` to open-hook tasks:
  - `new` for normal local project opens
  - `restored` for local workspaces restored from the previous session
- Documents the new hooks and includes an `npm run dev` configuration example.

Example configuration:

```json
[
  {
    "label": "Start development environment",
    "command": "npm run dev",
    "hooks": ["project_open"],
    "use_new_terminal": true,
    "allow_concurrent_runs": false
  }
]
```

## Testing

Automated checks completed successfully:

```text
cargo fmt --check
cargo check -p workspace -p project -p task -p terminal_view
cargo test -p workspace test_project_open_hooks_run_once_per_worktree --lib
```

The regression test verifies that:

- Both `project_open` and `worktree_open` hooks are discovered.
- Matching tasks are spawned through the terminal provider.
- Repeated open-hook notifications do not launch duplicate tasks.

## Reviewer Testing

1. Add the example task to a project’s `.zed/tasks.json`.
2. Open the project in Zed.
3. Confirm that `npm run dev` starts in Zed’s integrated terminal.
4. Reopen or restore the workspace and confirm that the hook runs only once
   for that workspace worktree.
5. Use a command that prints `$ZED_PROJECT_OPEN` to confirm whether the
   workspace was newly opened or restored.

## Self-Review Checklist

- [x] Reviewed the diff for startup ordering and duplicate task execution.
- [x] Added focused regression coverage for hook dispatch and de-duplication.
- [x] Preserved existing terminal task concurrency behavior.
- [x] Updated task-hook documentation.

Release Notes:

- Added support for automatically running project tasks when worktrees open.
