### PR TITLE
ci: Ensure assignees can be set for generated PRs

### DIFF
--- a/.github/workflows/bump_zed_version.yml
+++ b/.github/workflows/bump_zed_version.yml
@@ -104,6 +104,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-issues: write
         permission-pull-requests: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -84,6 +84,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-issues: write
         permission-pull-requests: write
     - name: steps::checkout_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -125,8 +125,9 @@ jobs:
         private-key: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
         owner: zed-extensions
         repositories: ${{ matrix.repo }}
-        permission-pull-requests: write
         permission-contents: write
+        permission-issues: write
+        permission-pull-requests: write
         permission-workflows: write
     - name: checkout_extension_repo
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -72,6 +72,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
         permission-contents: write
+        permission-issues: write
         permission-pull-requests: write
         permission-workflows: write
     - name: steps::checkout_repo
@@ -129,6 +130,7 @@ jobs:
         owner: zed-industries
         repositories: extensions
         permission-contents: write
+        permission-issues: write
         permission-pull-requests: write
         permission-workflows: write
     - id: short-sha

--- a/tooling/xtask/src/tasks/workflows/bump_zed_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_zed_version.rs
@@ -141,6 +141,7 @@ fn bump_main(
         .for_repository(steps::RepositoryTarget::current())
         .with_permissions([
             (steps::TokenPermissions::Contents, Level::Write),
+            (steps::TokenPermissions::Issues, Level::Write),
             (steps::TokenPermissions::PullRequests, Level::Write),
         ])
         .into();

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -222,6 +222,7 @@ fn bump_extension_version(
             .for_repository(RepositoryTarget::current())
             .with_permissions([
                 (TokenPermissions::Contents, Level::Write),
+                (TokenPermissions::Issues, Level::Write),
                 (TokenPermissions::PullRequests, Level::Write),
             ])
             .into();

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -298,8 +298,9 @@ fn rollout_workflows_to_extension(
                 &["${{ matrix.repo }}"],
             ))
             .with_permissions([
-                (TokenPermissions::PullRequests, Level::Write),
                 (TokenPermissions::Contents, Level::Write),
+                (TokenPermissions::Issues, Level::Write),
+                (TokenPermissions::PullRequests, Level::Write),
                 (TokenPermissions::Workflows, Level::Write),
             ])
             .into();

--- a/tooling/xtask/src/tasks/workflows/publish_extension_cli.rs
+++ b/tooling/xtask/src/tasks/workflows/publish_extension_cli.rs
@@ -90,6 +90,7 @@ fn update_sha_in_zed(publish_job: &NamedJob, message: &WorkflowInput) -> NamedJo
             .for_repository(RepositoryTarget::current())
             .with_permissions([
                 (TokenPermissions::Contents, Level::Write),
+                (TokenPermissions::Issues, Level::Write),
                 (TokenPermissions::PullRequests, Level::Write),
                 (TokenPermissions::Workflows, Level::Write),
             ])
@@ -159,6 +160,7 @@ fn update_sha_in_extensions(publish_job: &NamedJob, message: &WorkflowInput) -> 
             .for_repository(extensions_repo)
             .with_permissions([
                 (TokenPermissions::Contents, Level::Write),
+                (TokenPermissions::Issues, Level::Write),
                 (TokenPermissions::PullRequests, Level::Write),
                 (TokenPermissions::Workflows, Level::Write),
             ])


### PR DESCRIPTION
Now, this is one of these beautiful cases where GitHubs API ist just so pleasant to work with: Because PRs are treated as issues, assigning an assignee to a PR suddenly requires issue write permissions, despite the issue in question being a PR. Not having that permission resulted in some missing assignees on zed zippy bumps and failures of the workflows as seen in https://github.com/zed-industries/zed/actions/runs/31339736929/job/93311493258. 

In comparison, labelling PRs requires PR write permissions as seen in https://github.com/zed-industries/zed/pull/61525 🤡 

Beautiful API and a pleasure to work with, 10/10 would recommend. 

Release Notes:

- N/A