### PR TITLE
Send Git diff review feedback to agent threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -67,7 +67,7 @@ use chrono::{DateTime, Utc};
 use client::UserStore;
 use cloud_api_types::Plan;
 use collections::HashMap;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, ReviewFeedback};
 use extension_host::ExtensionStore;
 use feature_flags::{CreateThreadToolFeatureFlag, FeatureFlagAppExt as _};
 
@@ -4132,6 +4132,21 @@ impl AgentPanel {
     pub fn active_thread_view(&self, cx: &App) -> Option<Entity<ThreadView>> {
         let server_view = self.active_conversation_view()?;
         server_view.read(cx).root_thread_view()
+    }
+
+    pub fn send_review_feedback(
+        &mut self,
+        feedback: Vec<ReviewFeedback>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<bool> {
+        let Some(thread_view) = self.active_thread_view(cx) else {
+            return Ok(false);
+        };
+        thread_view.update(cx, |thread_view, cx| {
+            thread_view.send_review_feedback(feedback, window, cx)
+        })?;
+        Ok(true)
     }
 
     pub fn active_agent_thread(&self, cx: &App) -> Option<Entity<AcpThread>> {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -4394,6 +4394,57 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_review_feedback_sends_structured_card_when_idle(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let result = active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.send_review_feedback(
+                vec![editor::ReviewFeedback {
+                    worktree_name: Some("zed".to_string()),
+                    file_path: "crates/editor/src/git.rs".to_string(),
+                    start_line: 12,
+                    end_line: 15,
+                    excerpt: "fn example() {}".to_string(),
+                    comment: "Keep the old name".to_string(),
+                    status: editor::ReviewCommentStatus::Draft,
+                }],
+                window,
+                cx,
+            )
+        });
+        assert!(result.is_ok(), "review feedback should be accepted");
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).read_with(cx, |thread, cx| {
+            assert!(
+                thread.message_queue.is_empty(),
+                "idle threads should send review feedback immediately"
+            );
+            let markdown = thread.thread.read(cx).to_markdown(cx);
+            assert!(
+                markdown.contains("### 1. `crates/editor/src/git.rs` L12–15 (`zed`)"),
+                "expected structured review card in agent thread, got:\n{markdown}"
+            );
+            assert!(
+                markdown.contains("Keep the old name"),
+                "expected human comment in agent thread, got:\n{markdown}"
+            );
+            assert!(
+                markdown.contains("<summary>Machine-readable review feedback</summary>"),
+                "expected folded machine-readable payload, got:\n{markdown}"
+            );
+            assert!(
+                markdown.contains("\"file_path\": \"crates/editor/src/git.rs\""),
+                "expected serialized review feedback JSON, got:\n{markdown}"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_notification_for_error(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -4276,6 +4276,124 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_review_feedback_preserves_paused_queue_order(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("first", window, cx);
+        });
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |view, window, cx| view.send(window, cx));
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.add_to_queue(
+                vec![acp::ContentBlock::Text(acp::TextContent::new(
+                    "queued first".to_string(),
+                ))],
+                vec![],
+                window,
+                cx,
+            );
+        });
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |thread, _window, cx| thread.cancel_generation(cx));
+        cx.run_until_parked();
+
+        let result = active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.send_review_feedback(
+                vec![editor::ReviewFeedback {
+                    worktree_name: Some("zed".to_string()),
+                    file_path: "crates/editor/src/git.rs".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                    excerpt: "example".to_string(),
+                    comment: "Address this".to_string(),
+                    status: editor::ReviewCommentStatus::Draft,
+                }],
+                window,
+                cx,
+            )
+        });
+        assert!(result.is_ok(), "review feedback should be accepted");
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).read_with(cx, |thread, _cx| {
+            assert_eq!(thread.message_queue.len(), 1);
+            let remaining_text = thread
+                .message_queue
+                .first()
+                .and_then(|entry| entry.content.first())
+                .and_then(|content| match content {
+                    acp::ContentBlock::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                });
+            assert!(
+                remaining_text.is_some_and(|text| text.contains("Address this")),
+                "review feedback should remain behind the previously queued message"
+            );
+        });
+
+        let session_id = conversation_view.read_with(cx, |view, cx| {
+            view.active_thread()
+                .expect("active thread")
+                .read(cx)
+                .thread
+                .read(cx)
+                .session_id()
+                .clone()
+        });
+        connection.end_turn(session_id, acp::StopReason::EndTurn);
+        cx.run_until_parked();
+
+        let queue_len = active_thread(&conversation_view, cx)
+            .read_with(cx, |thread, _cx| thread.message_queue.len());
+        assert_eq!(queue_len, 0, "review feedback should auto-send next");
+    }
+
+    #[gpui::test]
+    async fn test_review_feedback_queues_while_message_content_is_loading(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let result = active_thread(&conversation_view, cx).update_in(cx, |thread, window, cx| {
+            thread.is_loading_contents = true;
+            thread.send_review_feedback(
+                vec![editor::ReviewFeedback {
+                    worktree_name: Some("zed".to_string()),
+                    file_path: "crates/editor/src/git.rs".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                    excerpt: "example".to_string(),
+                    comment: "Address this".to_string(),
+                    status: editor::ReviewCommentStatus::Draft,
+                }],
+                window,
+                cx,
+            )
+        });
+        assert!(result.is_ok(), "review feedback should be accepted");
+
+        active_thread(&conversation_view, cx).read_with(cx, |thread, cx| {
+            assert_eq!(thread.thread.read(cx).status(), ThreadStatus::Idle);
+            assert_eq!(
+                thread.message_queue.len(),
+                1,
+                "review feedback should wait for the in-flight content to start its turn"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_notification_for_error(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -19,7 +19,7 @@ use agent::{
 use agent_settings::UserAgentsMd;
 use agent_skills::MAX_SKILL_DESCRIPTION_LEN;
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
-use editor::actions::OpenExcerpts;
+use editor::{ReviewFeedback, actions::OpenExcerpts};
 use sandbox::{SandboxFsPolicy, SandboxNetPolicy, SandboxPolicy};
 
 use crate::completion_provider::{AvailableSkill, PromptLocalCommand, pluralize};
@@ -254,6 +254,80 @@ struct ParsedCatNumberedCode {
     code: String,
     first_number: u32,
     line_count: usize,
+}
+
+fn longest_backtick_run(text: &str) -> usize {
+    let mut longest = 0;
+    let mut current = 0;
+    for character in text.chars() {
+        if character == '`' {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+    longest
+}
+
+fn markdown_inline_code(text: &str) -> String {
+    let fence = "`".repeat((longest_backtick_run(text) + 1).max(1));
+    format!("{fence}{text}{fence}")
+}
+
+fn markdown_fenced_block(text: &str, language: Option<&str>) -> String {
+    let fence = "`".repeat(longest_backtick_run(text).saturating_add(1).max(3));
+    let mut block = String::new();
+    block.push_str(&fence);
+    if let Some(language) = language {
+        block.push_str(language);
+    }
+    block.push('\n');
+    block.push_str(text);
+    if !text.is_empty() && !text.ends_with('\n') {
+        block.push('\n');
+    }
+    block.push_str(&fence);
+    block.push('\n');
+    block
+}
+
+fn format_review_feedback_message(feedback: &[ReviewFeedback]) -> anyhow::Result<String> {
+    let mut message = String::from(
+        "Address the following human-authored review feedback. Each card is anchored to a local diff; paths in backticks can be opened from the thread.\n",
+    );
+
+    for (index, item) in feedback.iter().enumerate() {
+        let location = if item.start_line == item.end_line {
+            format!("L{}", item.start_line)
+        } else {
+            format!("L{}–{}", item.start_line, item.end_line)
+        };
+        let worktree = item
+            .worktree_name
+            .as_deref()
+            .map(|name| format!(" ({})", markdown_inline_code(name)))
+            .unwrap_or_default();
+        let excerpt = item.excerpt.trim_end();
+        let excerpt_block = if excerpt.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", markdown_fenced_block(excerpt, None))
+        };
+
+        message.push_str(&format!(
+            "\n### {}. {file} {location}{worktree}\n\n{comment}\n{excerpt_block}",
+            index + 1,
+            file = markdown_inline_code(&item.file_path),
+            comment = item.comment.trim(),
+        ));
+    }
+
+    let payload = serde_json::to_string_pretty(feedback)?;
+    message.push_str("\n<details>\n<summary>Machine-readable review feedback</summary>\n\n");
+    message.push_str(&markdown_fenced_block(&payload, Some("json")));
+    message.push_str("</details>\n");
+    Ok(message)
 }
 
 fn parse_cat_numbered_markdown_code_block(markdown: &str) -> Option<ParsedCatNumberedCode> {
@@ -510,6 +584,51 @@ mod numbered_code_block_tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn formats_review_feedback_as_structured_cards() {
+        let message = format_review_feedback_message(&[ReviewFeedback {
+            worktree_name: Some("app".into()),
+            file_path: "src/example.rs".into(),
+            start_line: 12,
+            end_line: 15,
+            excerpt: "fn main() {}".into(),
+            comment: "Keep the old name".into(),
+            status: editor::ReviewCommentStatus::Draft,
+        }])
+        .expect("review feedback should format");
+
+        assert!(message.contains("### 1. `src/example.rs` L12–15 (`app`)"));
+        assert!(message.contains("Keep the old name"));
+        assert!(message.contains("```\nfn main() {}\n```"));
+        assert!(message.contains("<summary>Machine-readable review feedback</summary>"));
+        assert!(message.contains("\"file_path\": \"src/example.rs\""));
+    }
+
+    #[test]
+    fn formats_review_feedback_with_backticks_and_newlines_safely() {
+        let message = format_review_feedback_message(&[ReviewFeedback {
+            worktree_name: Some("app`name".into()),
+            file_path: "src/`weird`.rs".into(),
+            start_line: 1,
+            end_line: 2,
+            excerpt: "let x = `\ncode\n`;".into(),
+            comment: "Keep fences intact".into(),
+            status: editor::ReviewCommentStatus::Draft,
+        }])
+        .expect("review feedback should format");
+
+        assert!(message.contains("### 1. ``src/`weird`.rs`` L1–2 (``app`name``)"));
+        assert!(message.contains("```\nlet x = `\ncode\n`;\n```\n"));
+        let details = message
+            .split_once("<details>")
+            .map(|(_, rest)| rest)
+            .expect("details section");
+        assert!(details.contains("```json\n"));
+        assert!(details.contains("\"file_path\": \"src/`weird`.rs\""));
+        assert!(details.contains("</details>"));
+        assert!(!details.contains("```\nlet x = `"));
     }
 }
 
@@ -1550,6 +1669,38 @@ impl ThreadView {
 
         cx.emit(AcpThreadViewEvent::Interacted);
         self.send_impl(message_editor, window, cx)
+    }
+
+    pub fn send_review_feedback(
+        &mut self,
+        feedback: Vec<ReviewFeedback>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<()> {
+        let content = vec![acp::ContentBlock::Text(acp::TextContent::new(
+            format_review_feedback_message(&feedback)?,
+        ))];
+        let can_send_immediately =
+            self.thread.read(cx).status() == ThreadStatus::Idle && !self.is_loading_contents;
+        if can_send_immediately && self.message_queue.is_empty() {
+            cx.emit(AcpThreadViewEvent::Interacted);
+            self.send_content(
+                Task::ready(Ok(Some((content, Vec::new())))),
+                false,
+                window,
+                cx,
+            );
+        } else {
+            self.add_to_queue(content, Vec::new(), window, cx);
+            if can_send_immediately {
+                if let Some(id) = self.message_queue.first_id() {
+                    self.send_queued_message_now(id, window, cx);
+                }
+            } else {
+                cx.emit(AcpThreadViewEvent::Interacted);
+            }
+        }
+        Ok(())
     }
 
     /// Sends a bare `/command` turn and queues everything the user typed after

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -112,7 +112,9 @@ pub use element::{
 pub use git::blame::{BlameRenderer, GitBlame};
 pub use git::{
     DefaultDiffHunkRenderer, DiffHunkRenderer, HiddenDiffHunkRenderer,
-    HiddenUnstagedDiffHunkRenderer, render_diff_hunk_controls, set_blame_renderer,
+    HiddenUnstagedDiffHunkRenderer, ReviewComment, ReviewCommentStatus, ReviewFeedback,
+    ReviewSession, ReviewSessionSource, ReviewThread, render_diff_hunk_controls,
+    set_blame_renderer,
 };
 pub(crate) use git::{DiffHunkKey, StoredReviewComment};
 use git::{DiffReviewDragState, DiffReviewOverlay, InlineBlamePopover};

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -43054,6 +43054,51 @@ fn test_review_comment_take_all(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_review_feedback_preserves_anchor_metadata_until_cleared(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| Editor::single_line(window, cx));
+
+    let result = editor.update(cx, |editor, window, cx| {
+        editor.set_text("first\nsecond\n", window, cx);
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let start = snapshot.anchor_before(Point::new(0, 0));
+        let end = snapshot.anchor_after(Point::new(1, 6));
+        editor.add_review_comment(
+            test_hunk_key_with_anchor("src/example.rs", start),
+            "Handle this edge case".to_string(),
+            start..end,
+            cx,
+        );
+
+        let feedback = editor.review_feedback(cx);
+        assert_eq!(feedback.len(), 1);
+        assert_eq!(feedback[0].worktree_name, None);
+        assert_eq!(feedback[0].file_path, "src/example.rs");
+        assert_eq!(feedback[0].start_line, 1);
+        assert_eq!(feedback[0].end_line, 2);
+        assert_eq!(feedback[0].excerpt, "first\nsecond");
+        assert_eq!(feedback[0].comment, "Handle this edge case");
+        assert_eq!(feedback[0].status, ReviewCommentStatus::Draft);
+
+        let session = editor.review_session(cx);
+        assert_eq!(session.source, ReviewSessionSource::LocalDiff);
+        assert_eq!(session.threads.len(), 1);
+        assert_eq!(session.threads[0].file_path, "src/example.rs");
+        assert_eq!(session.threads[0].comments[0].author, "You");
+
+        editor.mark_review_feedback_sent(cx);
+        assert!(editor.review_feedback(cx).is_empty());
+        assert_eq!(editor.total_review_comment_count(), 0);
+
+        editor.clear_review_feedback(cx);
+        assert!(editor.review_feedback(cx).is_empty());
+        assert_eq!(editor.total_review_comment_count(), 0);
+    });
+    assert!(result.is_ok(), "editor window should remain available");
+}
+
+#[gpui::test]
 fn test_diff_review_overlay_show_and_dismiss(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -43099,6 +43099,93 @@ fn test_review_feedback_preserves_anchor_metadata_until_cleared(cx: &mut TestApp
 }
 
 #[gpui::test]
+fn test_review_feedback_marks_orphaned_comments_outdated(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = cx.new(|cx| Buffer::local("line 1\nline 2\nline 3\n", cx));
+        let multi_buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        Editor::new(EditorMode::full(), multi_buffer, None, window, cx)
+    });
+
+    editor
+        .update(cx, |editor, _window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let anchor = snapshot.anchor_after(Point::new(1, 0));
+            let key = DiffHunkKey {
+                file_path: Arc::from(util::rel_path::RelPath::empty()),
+                hunk_start_anchor: anchor,
+            };
+            editor.add_review_comment(
+                key.clone(),
+                "Keep this review note".to_string(),
+                anchor..anchor,
+                cx,
+            );
+            assert_eq!(editor.total_review_comment_count(), 1);
+            assert_eq!(
+                editor.comments_for_hunk(&key, &snapshot)[0].status,
+                ReviewCommentStatus::Draft
+            );
+        })
+        .unwrap();
+
+    editor
+        .update(cx, |editor, window, cx| {
+            editor.select_all(&SelectAll, window, cx);
+            editor.insert("completely new content", window, cx);
+        })
+        .unwrap();
+
+    editor
+        .update(cx, |editor, _window, cx| {
+            editor.cleanup_orphaned_review_comments(cx);
+            assert_eq!(
+                editor.total_review_comment_count(),
+                0,
+                "outdated comments must not remain sendable"
+            );
+            assert!(
+                editor.review_feedback(cx).is_empty(),
+                "outdated comments must not appear in review feedback"
+            );
+
+            let retained = editor.take_all_review_comments(cx);
+            assert_eq!(retained.len(), 1, "outdated comment should be retained");
+            assert_eq!(retained[0].1.len(), 1);
+            assert_eq!(retained[0].1[0].comment, "Keep this review note");
+            assert_eq!(retained[0].1[0].status, ReviewCommentStatus::Outdated);
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+fn test_review_feedback_delete_removes_sendable_comment(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| Editor::single_line(window, cx));
+
+    editor
+        .update(cx, |editor, window, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let anchor = snapshot.anchor_before(Point::new(0, 0));
+            let key = test_hunk_key_with_anchor("src/delete.rs", anchor);
+            let comment_id = add_test_comment(editor, key, "Delete me", cx);
+            assert_eq!(editor.total_review_comment_count(), 1);
+            assert_eq!(editor.review_feedback(cx).len(), 1);
+
+            editor.delete_review_comment(
+                &crate::actions::DeleteReviewComment { id: comment_id },
+                window,
+                cx,
+            );
+            assert_eq!(editor.total_review_comment_count(), 0);
+            assert!(editor.review_feedback(cx).is_empty());
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 fn test_diff_review_overlay_show_and_dismiss(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -166,6 +166,75 @@ pub(super) struct DiffHunkKey {
     pub(super) hunk_start_anchor: Anchor,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewCommentStatus {
+    #[default]
+    Draft,
+    Queued,
+    Sent,
+    Outdated,
+    Resolved,
+}
+
+impl ReviewCommentStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Draft => "Draft",
+            Self::Queued => "Queued",
+            Self::Sent => "Sent",
+            Self::Outdated => "Outdated",
+            Self::Resolved => "Resolved",
+        }
+    }
+
+    pub fn is_sendable(self) -> bool {
+        matches!(self, Self::Draft | Self::Queued)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReviewSessionSource {
+    LocalDiff,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewComment {
+    pub id: String,
+    pub author: String,
+    pub body: String,
+    pub is_draft: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewThread {
+    pub id: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub excerpt: String,
+    pub status: ReviewCommentStatus,
+    pub comments: Vec<ReviewComment>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewSession {
+    pub source: ReviewSessionSource,
+    pub threads: Vec<ReviewThread>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct ReviewFeedback {
+    pub worktree_name: Option<String>,
+    pub file_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub excerpt: String,
+    pub comment: String,
+    #[serde(default)]
+    pub status: ReviewCommentStatus,
+}
+
 /// A review comment stored locally before being sent to the Agent panel.
 #[derive(Clone)]
 pub(super) struct StoredReviewComment {
@@ -177,6 +246,8 @@ pub(super) struct StoredReviewComment {
     pub(super) range: Range<Anchor>,
     /// Whether this comment is currently being edited inline.
     pub(super) is_editing: bool,
+    /// Lifecycle status for the local draft thread.
+    pub(super) status: ReviewCommentStatus,
 }
 
 /// Represents an active diff review overlay that appears when clicking the "Add Review" button.
@@ -221,6 +292,7 @@ impl StoredReviewComment {
             comment,
             range: anchor_range,
             is_editing: false,
+            status: ReviewCommentStatus::Draft,
         }
     }
 }
@@ -745,12 +817,110 @@ impl Editor {
         cx.notify();
     }
 
-    /// Returns the total count of stored review comments across all hunks.
+    /// Returns the total count of sendable review comments across all hunks.
     pub(super) fn total_review_comment_count(&self) -> usize {
         self.stored_review_comments
             .iter()
-            .map(|(_, v)| v.len())
-            .sum()
+            .flat_map(|(_, comments)| comments.iter())
+            .filter(|comment| comment.status.is_sendable())
+            .count()
+    }
+
+    pub fn review_feedback(&self, cx: &App) -> Vec<ReviewFeedback> {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        self.stored_review_comments
+            .iter()
+            .flat_map(|(hunk, comments)| {
+                comments.iter().filter_map(|comment| {
+                    if !comment.status.is_sendable() {
+                        return None;
+                    }
+                    let start_point = comment.range.start.to_point(&snapshot);
+                    let end_point = comment.range.end.to_point(&snapshot);
+                    let buffer_ranges = snapshot.range_to_buffer_ranges(start_point..end_point);
+                    let (Some((first_buffer, first_range, _)), Some((last_buffer, last_range, _))) =
+                        (buffer_ranges.first(), buffer_ranges.last())
+                    else {
+                        log::debug!(
+                            "Skipping review comment {} for {} because its buffer range could not be resolved ({start_point:?}..{end_point:?})",
+                            comment.id,
+                            hunk.file_path.as_unix_str(),
+                        );
+                        return None;
+                    };
+                    let start_line = first_buffer.offset_to_point(first_range.start.0).row;
+                    let end_line = last_buffer.offset_to_point(last_range.end.0).row;
+                    let worktree_name = snapshot
+                        .file_at(start_point)
+                        .and_then(|file| {
+                            self.project
+                                .as_ref()?
+                                .read(cx)
+                                .worktree_for_id(file.worktree_id(cx), cx)
+                        })
+                        .map(|worktree| worktree.read(cx).root_name().as_unix_str().to_string());
+                    Some(ReviewFeedback {
+                        worktree_name,
+                        file_path: hunk.file_path.as_unix_str().to_string(),
+                        start_line: start_line.saturating_add(1),
+                        end_line: end_line.saturating_add(1),
+                        excerpt: snapshot
+                            .text_for_range(start_point..end_point)
+                            .collect::<String>(),
+                        comment: comment.comment.clone(),
+                        status: comment.status,
+                    })
+                })
+            })
+            .collect()
+    }
+
+    /// Builds a provider-agnostic review session from the local draft comments.
+    pub fn review_session(&self, cx: &App) -> ReviewSession {
+        let feedback = self.review_feedback(cx);
+        ReviewSession {
+            source: ReviewSessionSource::LocalDiff,
+            threads: feedback
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| ReviewThread {
+                    id: format!("local-{index}"),
+                    file_path: item.file_path,
+                    start_line: item.start_line,
+                    end_line: item.end_line,
+                    excerpt: item.excerpt,
+                    status: item.status,
+                    comments: vec![ReviewComment {
+                        id: format!("local-comment-{index}"),
+                        author: "You".to_string(),
+                        body: item.comment,
+                        is_draft: item.status == ReviewCommentStatus::Draft,
+                    }],
+                })
+                .collect(),
+        }
+    }
+
+    pub fn mark_review_feedback_sent(&mut self, cx: &mut Context<Self>) {
+        for (_, comments) in &mut self.stored_review_comments {
+            for comment in comments {
+                if comment.status.is_sendable() {
+                    comment.status = ReviewCommentStatus::Sent;
+                }
+            }
+        }
+        cx.emit(EditorEvent::ReviewCommentsChanged {
+            total_count: self.total_review_comment_count(),
+        });
+        cx.notify();
+    }
+
+    pub fn clear_review_feedback(&mut self, cx: &mut Context<Self>) {
+        self.dismiss_all_diff_review_overlays(cx);
+        self.stored_review_comments.clear();
+        self.next_review_comment_id = 0;
+        cx.emit(EditorEvent::ReviewCommentsChanged { total_count: 0 });
+        cx.notify();
     }
 
     /// Adds a new review comment to a specific hunk.
@@ -1215,37 +1385,54 @@ impl Editor {
         }
     }
 
-    /// Removes review comments whose anchors are no longer valid or whose
-    /// associated diff hunks no longer exist.
+    /// Marks review comments outdated when their anchors or hunks are no longer
+    /// valid, instead of silently dropping them.
     ///
-    /// This should be called when the buffer changes to prevent orphaned comments
-    /// from accumulating.
+    /// This should be called when the buffer changes so the UI can surface
+    /// outdated status without losing the author's text.
     pub(super) fn cleanup_orphaned_review_comments(&mut self, cx: &mut Context<Self>) {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let original_count = self.total_review_comment_count();
+        let mut changed = false;
 
-        // Remove comments with invalid hunk anchors
-        self.stored_review_comments
-            .retain(|(hunk_key, _)| hunk_key.hunk_start_anchor.is_valid(&snapshot));
-
-        // Also clean up individual comments with invalid anchor ranges
-        for (_, comments) in &mut self.stored_review_comments {
-            comments.retain(|comment| {
-                comment.range.start.is_valid(&snapshot) && comment.range.end.is_valid(&snapshot)
-            });
+        for (hunk_key, comments) in &mut self.stored_review_comments {
+            let hunk_present = Self::diff_hunk_key_is_present(hunk_key, &snapshot);
+            for comment in comments {
+                let range_valid = comment.range.start.is_valid(&snapshot)
+                    && comment.range.end.is_valid(&snapshot);
+                if (!hunk_present || !range_valid)
+                    && comment.status != ReviewCommentStatus::Outdated
+                    && comment.status != ReviewCommentStatus::Resolved
+                {
+                    comment.status = ReviewCommentStatus::Outdated;
+                    changed = true;
+                }
+            }
         }
 
-        // Remove empty hunk entries
-        self.stored_review_comments
-            .retain(|(_, comments)| !comments.is_empty());
-
         let new_count = self.total_review_comment_count();
-        if new_count != original_count {
+        if changed || new_count != original_count {
             cx.emit(EditorEvent::ReviewCommentsChanged {
                 total_count: new_count,
             });
             cx.notify();
         }
+    }
+
+    fn diff_hunk_key_is_present(hunk_key: &DiffHunkKey, snapshot: &MultiBufferSnapshot) -> bool {
+        if !hunk_key.hunk_start_anchor.is_valid(snapshot) {
+            return false;
+        }
+        let key_point = hunk_key.hunk_start_anchor.to_point(snapshot);
+        snapshot
+            .diff_hunks_in_range(key_point..snapshot.max_point())
+            .any(|hunk| {
+                let hunk_start = hunk.multi_buffer_range.start.to_point(snapshot);
+                hunk_start == key_point
+                    && snapshot
+                        .file_at(hunk.multi_buffer_range.start)
+                        .is_some_and(|file| file.path() == &hunk_key.file_path)
+            })
     }
 
     /// Toggles the expanded state of the comments section in the overlay.
@@ -2572,7 +2759,7 @@ impl Editor {
                 .unwrap_or((Vec::new(), true, HashMap::default(), None, None));
 
         let comment_count = comments.len();
-        let avatar_size = px(20.);
+        let avatar_size = px(16.);
         let action_icon_size = IconSize::XSmall;
 
         v_flex()
@@ -2581,8 +2768,8 @@ impl Editor {
             .border_b_1()
             .border_color(colors.border)
             .px_2()
-            .pb_2()
-            .gap_2()
+            .pb_1p5()
+            .gap_1()
             // Line range indicator (only shown for multi-line selections or multiple excerpts)
             .when_some(line_ranges, |el, ranges| {
                 let label = format_line_ranges(&ranges);
@@ -2602,9 +2789,9 @@ impl Editor {
                 h_flex()
                     .w_full()
                     .items_center()
-                    .gap_2()
+                    .gap_1()
                     .px_2()
-                    .py_1p5()
+                    .py_1()
                     .rounded_md()
                     .bg(colors.surface_background)
                     .child(
@@ -2619,7 +2806,7 @@ impl Editor {
                                     .into_any_element()
                             } else {
                                 Icon::new(IconName::Person)
-                                    .size(IconSize::Small)
+                                    .size(IconSize::XSmall)
                                     .color(ui::Color::Muted)
                                     .into_any_element()
                             }),
@@ -2632,13 +2819,13 @@ impl Editor {
                             .rounded_md()
                             .bg(colors.editor_background)
                             .px_2()
-                            .py_1()
+                            .py_0p5()
                             .child(prompt_editor.clone()),
                     )
                     .child(
                         h_flex()
                             .flex_shrink_0()
-                            .gap_1()
+                            .gap_0p5()
                             .child(
                                 IconButton::new("diff-review-close", IconName::Close)
                                     .icon_color(ui::Color::Muted)
@@ -2755,19 +2942,31 @@ impl Editor {
     ) -> impl IntoElement {
         let comment_id = comment.id;
         let is_editing = inline_editor.is_some();
+        let status = comment.status;
+        let status_color = match status {
+            ReviewCommentStatus::Draft | ReviewCommentStatus::Queued => ui::Color::Muted,
+            ReviewCommentStatus::Sent | ReviewCommentStatus::Resolved => ui::Color::Success,
+            ReviewCommentStatus::Outdated => ui::Color::Warning,
+        };
+        let group_id = SharedString::from(format!("diff-review-comment-{comment_id}"));
 
         h_flex()
+            .id(SharedString::from(format!(
+                "diff-review-comment-row-{comment_id}"
+            )))
             .w_full()
-            .items_center()
-            .gap_2()
+            .items_start()
+            .gap_1()
             .px_2()
-            .py_1p5()
+            .py_1()
             .rounded_md()
             .bg(colors.surface_background)
+            .group(group_id.clone())
             .child(
                 div()
                     .size(avatar_size)
                     .flex_shrink_0()
+                    .mt_0p5()
                     .rounded_full()
                     .overflow_hidden()
                     .child(if let Some(ref avatar_uri) = user_avatar_uri {
@@ -2776,36 +2975,66 @@ impl Editor {
                             .into_any_element()
                     } else {
                         Icon::new(IconName::Person)
-                            .size(IconSize::Small)
+                            .size(IconSize::XSmall)
                             .color(ui::Color::Muted)
                             .into_any_element()
                     }),
             )
-            .child(if let Some(editor) = inline_editor {
-                // Inline edit mode: show an editable text field
-                div()
+            .child(
+                v_flex()
                     .flex_1()
-                    .border_1()
-                    .border_color(colors.border)
-                    .rounded_md()
-                    .bg(colors.editor_background)
-                    .px_2()
-                    .py_1()
-                    .child(editor)
-                    .into_any_element()
-            } else {
-                // Display mode: show the comment text
-                div()
-                    .flex_1()
-                    .text_sm()
-                    .text_color(colors.text)
-                    .child(comment.comment)
-                    .into_any_element()
-            })
+                    .gap_0p5()
+                    .min_w_0()
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .items_center()
+                            .gap_1()
+                            .child(Label::new("You").size(LabelSize::Small).color(Color::Muted))
+                            .child(
+                                h_flex()
+                                    .items_center()
+                                    .gap_0p5()
+                                    .child(
+                                        Icon::new(match status {
+                                            ReviewCommentStatus::Sent
+                                            | ReviewCommentStatus::Resolved => IconName::Check,
+                                            ReviewCommentStatus::Outdated => IconName::Warning,
+                                            _ => IconName::FileDiff,
+                                        })
+                                        .size(IconSize::XSmall)
+                                        .color(status_color),
+                                    )
+                                    .child(
+                                        Label::new(status.label())
+                                            .size(LabelSize::Small)
+                                            .color(status_color),
+                                    ),
+                            ),
+                    )
+                    .child(if let Some(editor) = inline_editor {
+                        div()
+                            .w_full()
+                            .border_1()
+                            .border_color(colors.border)
+                            .rounded_md()
+                            .bg(colors.editor_background)
+                            .px_2()
+                            .py_0p5()
+                            .child(editor)
+                            .into_any_element()
+                    } else {
+                        div()
+                            .w_full()
+                            .text_sm()
+                            .text_color(colors.text)
+                            .child(comment.comment)
+                            .into_any_element()
+                    }),
+            )
             .child(if is_editing {
-                // Editing mode: show close and confirm buttons
                 h_flex()
-                    .gap_1()
+                    .gap_0p5()
                     .child(
                         IconButton::new(
                             format!("diff-review-cancel-edit-{comment_id}"),
@@ -2842,8 +3071,42 @@ impl Editor {
                     )
                     .into_any_element()
             } else {
-                // Display mode: no action buttons for now (edit/delete not yet implemented)
-                gpui::Empty.into_any_element()
+                h_flex()
+                    .gap_0p5()
+                    .visible_on_hover(group_id)
+                    .when(status.is_sendable(), |this| {
+                        this.child(
+                            IconButton::new(
+                                format!("diff-review-edit-{comment_id}"),
+                                IconName::Pencil,
+                            )
+                            .icon_color(ui::Color::Muted)
+                            .icon_size(action_icon_size)
+                            .tooltip(Tooltip::text("Edit comment"))
+                            .on_click(move |_, window, cx| {
+                                window.dispatch_action(
+                                    Box::new(crate::actions::EditReviewComment { id: comment_id }),
+                                    cx,
+                                );
+                            }),
+                        )
+                    })
+                    .child(
+                        IconButton::new(
+                            format!("diff-review-delete-{comment_id}"),
+                            IconName::Trash,
+                        )
+                        .icon_color(ui::Color::Muted)
+                        .icon_size(action_icon_size)
+                        .tooltip(Tooltip::text("Delete comment"))
+                        .on_click(move |_, window, cx| {
+                            window.dispatch_action(
+                                Box::new(crate::actions::DeleteReviewComment { id: comment_id }),
+                                cx,
+                            );
+                        }),
+                    )
+                    .into_any_element()
             })
     }
 

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -1,12 +1,13 @@
 use crate::{
     diff_multibuffer::DiffMultibuffer,
     git_panel::{GitPanel, GitPanelAddon, GitStatusEntry},
+    project_diff::render_send_review_to_agent_button,
 };
 use anyhow::{Context as _, Result};
 use buffer_diff::DiffHunkStatus;
 use editor::{
     DiffHunkRenderer, Editor, EditorEvent, SplittableEditor,
-    actions::{GoToHunk, GoToPreviousHunk},
+    actions::{GoToHunk, GoToPreviousHunk, SendReviewToAgent},
 };
 use git::{Commit, UnstageAll, UnstageAndNext};
 use gpui::{
@@ -582,6 +583,7 @@ impl Render for StagedDiffToolbar {
         let diff = staged_diff.read(cx).diff.read(cx);
         let (additions, deletions) = diff.calculate_changed_lines(cx);
         let is_multibuffer_empty = diff.multibuffer().read(cx).is_empty();
+        let review_count = diff.total_review_comment_count();
 
         h_flex()
             .my_neg_1()
@@ -596,6 +598,16 @@ impl Render for StagedDiffToolbar {
                     deletions as usize,
                 ))
                 .child(Divider::vertical().ml_1())
+            })
+            .when(review_count > 0, |this| {
+                this.child(
+                    render_send_review_to_agent_button(review_count, &focus_handle).on_click(
+                        cx.listener(|this, _, window, cx| {
+                            this.dispatch_action(&SendReviewToAgent, window, cx)
+                        }),
+                    ),
+                )
+                .child(Divider::vertical())
             })
             // n.b. the only reason these arrows are here is because we don't
             // support "undo" for staging so we need a way to go back.

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -1,12 +1,13 @@
 use crate::{
     diff_multibuffer::DiffMultibuffer,
     git_panel::{GitPanel, GitPanelAddon, GitStatusEntry},
+    project_diff::render_send_review_to_agent_button,
 };
 use anyhow::{Context as _, Result};
 use buffer_diff::DiffHunkStatus;
 use editor::{
     DiffHunkRenderer, Editor, EditorEvent, SplittableEditor,
-    actions::{GoToHunk, GoToPreviousHunk},
+    actions::{GoToHunk, GoToPreviousHunk, SendReviewToAgent},
 };
 use git::{StageAll, StageAndNext};
 use gpui::{
@@ -659,6 +660,7 @@ impl Render for UnstagedDiffToolbar {
         let diff = unstaged_diff.read(cx).diff.read(cx);
         let (additions, deletions) = diff.calculate_changed_lines(cx);
         let is_multibuffer_empty = diff.multibuffer().read(cx).is_empty();
+        let review_count = diff.total_review_comment_count();
 
         h_flex()
             .my_neg_1()
@@ -673,6 +675,16 @@ impl Render for UnstagedDiffToolbar {
                     deletions as usize,
                 ))
                 .child(Divider::vertical().ml_1())
+            })
+            .when(review_count > 0, |this| {
+                this.child(
+                    render_send_review_to_agent_button(review_count, &focus_handle).on_click(
+                        cx.listener(|this, _, window, cx| {
+                            this.dispatch_action(&SendReviewToAgent, window, cx)
+                        }),
+                    ),
+                )
+                .child(Divider::vertical())
             })
             // n.b. the only reason these arrows are here is because we don't
             // support "undo" for staging so we need a way to go back.

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -25,7 +25,7 @@ use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
 use debugger_ui::debugger_panel::DebugPanel;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, actions::SendReviewToAgent};
 use extension_host::ExtensionStore;
 use feature_flags::{FeatureFlagAppExt as _, PanicFeatureFlag};
 use fs::Fs;
@@ -918,6 +918,46 @@ fn register_actions(
 ) {
     workspace
         .register_action(|_, _: &OpenDocs, _, cx| cx.open_url(DOCS_URL))
+        .register_action(
+            |workspace: &mut Workspace,
+             _: &SendReviewToAgent,
+             window: &mut Window,
+             cx: &mut Context<Workspace>| {
+                let Some(review_editor) = workspace
+                    .active_item(cx)
+                    .and_then(|item| item.act_as::<Editor>(cx))
+                else {
+                    return;
+                };
+                let feedback = review_editor.read(cx).review_feedback(cx);
+                if feedback.is_empty() {
+                    return;
+                }
+                let Some(agent_panel) = workspace.panel::<agent_ui::AgentPanel>(cx) else {
+                    workspace.show_error(
+                        "Open or create an agent thread before sending review feedback.",
+                        cx,
+                    );
+                    return;
+                };
+                match agent_panel.update(cx, |panel, cx| {
+                    panel.send_review_feedback(feedback, window, cx)
+                }) {
+                    Ok(true) => {
+                        review_editor.update(cx, |editor, cx| {
+                            editor.clear_review_feedback(cx);
+                        });
+                        workspace.reveal_panel::<agent_ui::AgentPanel>(window, cx);
+                    }
+                    Ok(false) => workspace.show_error(
+                        "Open or create an agent thread before sending review feedback.",
+                        cx,
+                    ),
+                    Err(error) => workspace
+                        .show_error(format!("Failed to send review feedback: {error}"), cx),
+                }
+            },
+        )
         .register_action(|_, _: &OpenStatusPage, _, cx| cx.open_url(STATUS_URL))
         .register_action(|_, _: &GetMerch, _, cx| cx.open_url(MERCH_URL))
         .register_action(


### PR DESCRIPTION
# Objective

- Reopen the platform-neutral Diff → Agent path from the closed [#61924](https://github.com/zed-industries/zed/pull/61924), with the showcase materials and clearer human-written description that review asked for.
- Let users leave draft comments on local Git diffs (project / branch / staged / unstaged) and send them to the active agent thread as readable cards plus folded machine-readable JSON.
- Keep this independent of GitHub PR Chrome, OAuth, and extension-provider seams (those stay downstream).

Related to #59157

## Why the earlier PR was closed

[#61924](https://github.com/zed-industries/zed/pull/61924) was closed because it was hard to tell what the change achieved without running the code, the description looked LLM-heavy, and there were no screenshots or recording. This PR is that same local Diff → Agent slice after cleanup: thinner inline review UX (Draft / Sent / Outdated, hover Edit / Delete), structured agent cards, and staged / unstaged send controls — plus the showcase below.

## Solution

- Add serializable `ReviewFeedback` (worktree, path, 1-based lines, excerpt, comment, status) and resolve anchors only when sending.
- Route `SendReviewToAgent` through the active item’s existing `Item::act_as::<Editor>` path instead of adding accessors on every diff item type.
- Format the agent message as markdown cards; keep JSON under a `<details>` block for agents that want it.
- Queue behind a busy / loading thread without replacing the composer draft; clear comments only after the thread accepts the feedback.
- Reuse the existing send-review toolbar control on staged and unstaged diffs.

Out of scope for this PR: connector accounts, OAuth, avatars, pull-request provider WIT / `http:fetch`, and other hosting-platform UI.

## Testing

- [x] `cargo test -p editor test_review_feedback_ -- --nocapture`
- [x] `cargo test -p editor orphaned_comments -- --nocapture`
- [x] `cargo test -p agent_ui formats_review_feedback -- --nocapture`
- [x] `cargo test -p agent_ui test_review_feedback_ -- --nocapture`
- [x] `cargo check -p editor -p agent_ui -p git_ui -p zed`
- [x] Manual: enable `diff-review` → gutter comment → Edit / Delete → **Send Review to Agent (N)** → structured card → open path from the card
- [x] Light / Dark still frames of the inline thread + agent card

Tested on macOS.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

1. Inline diff review thread with Draft status and hover Edit / Delete (still frames).
2. Agent thread showing structured review cards (not a raw JSON wall); machine-readable payload stays folded under details.
3. Short recording: gutter comment → Send Review to Agent → card → jump back via path.


<img width="1024" height="629" alt="showcase-agent-card-dark" src="https://github.com/user-attachments/assets/c9d66a05-3a7d-463c-8f39-45e16c1c7980" />
<img width="1024" height="629" alt="showcase-agent-card-light" src="https://github.com/user-attachments/assets/3f6af6d0-5145-4d6c-a91a-60c86e36dc5e" />

https://github.com/user-attachments/assets/8b37ad58-c80a-4ce4-9ee1-3ffbaf54c184

Due to platform limitations, the video may be too blurry. A clearer version is available at https://x.com/amiya_167/status/2086748922287153539

NOTE: The screenshots and videos were captured using a debug build configuration of our own [distribution](https://github.com/zixiao-labs/Kaltsit-Esperanta), so they may appear somewhat slow.




</details>

## Suggested .rules additions

- For Git diff actions that operate on the displayed right-hand editor, resolve the active pane item through `Item::act_as::<Editor>` instead of adding equivalent accessors to each diff item type.

---

Release Notes:

- Added the ability to send Git diff review comments to the active agent thread as structured feedback cards.
