### PR TITLE
repl: Pass project environment to local kernels

### DIFF
--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use collections::HashMap;
 use futures::{
     AsyncBufReadExt as _, StreamExt as _,
     channel::mpsc::{self},
@@ -9,7 +10,7 @@ use jupyter_protocol::{
     ExecutionState, JupyterKernelspec, JupyterMessage, KernelInfoReply,
     connection_info::{ConnectionInfo, Transport},
 };
-use project::Fs;
+use project::{Fs, ProjectEnvironment};
 use runtimelib::dirs;
 use smol::net::TcpListener;
 use std::{
@@ -41,7 +42,11 @@ impl Eq for LocalKernelSpecification {}
 
 impl LocalKernelSpecification {
     #[must_use]
-    fn command(&self, connection_path: &PathBuf) -> Result<std::process::Command> {
+    fn command(
+        &self,
+        connection_path: &PathBuf,
+        project_environment: &HashMap<String, String>,
+    ) -> Result<std::process::Command> {
         let argv = &self.kernelspec.argv;
 
         anyhow::ensure!(!argv.is_empty(), "Empty argv in kernelspec {}", self.name);
@@ -61,6 +66,8 @@ impl LocalKernelSpecification {
                 cmd.arg(arg);
             }
         }
+
+        cmd.envs(project_environment);
 
         if let Some(env) = &self.kernelspec.env {
             log::info!(
@@ -114,6 +121,7 @@ impl NativeRunningKernel {
         kernel_specification: LocalKernelSpecification,
         entity_id: EntityId,
         working_directory: PathBuf,
+        project_environment: Option<Entity<ProjectEnvironment>>,
         fs: Arc<dyn Fs>,
         // todo: convert to weak view
         session: Entity<S>,
@@ -145,7 +153,18 @@ impl NativeRunningKernel {
             let content = serde_json::to_string(&connection_info)?;
             fs.atomic_write(connection_path.clone(), content).await?;
 
-            let mut cmd = kernel_specification.command(&connection_path)?;
+            let project_environment = if let Some(project_environment) = project_environment {
+                project_environment
+                    .update(cx, |environment, cx| {
+                        environment.directory_environment(working_directory.clone().into(), cx)
+                    })
+                    .await
+                    .unwrap_or_default()
+            } else {
+                HashMap::default()
+            };
+
+            let mut cmd = kernel_specification.command(&connection_path, &project_environment)?;
             cmd.current_dir(&working_directory);
 
             let mut process = util::process::Child::spawn(
@@ -400,11 +419,76 @@ pub async fn local_kernel_specifications(fs: Arc<dyn Fs>) -> Result<Vec<LocalKer
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::path::PathBuf;
+    use std::{ffi::OsStr, path::PathBuf};
 
     use gpui::TestAppContext;
     use project::FakeFs;
     use serde_json::json;
+
+    fn command_environment_value<'a>(
+        command: &'a std::process::Command,
+        name: &str,
+    ) -> Option<&'a OsStr> {
+        command.get_envs().find_map(
+            |(key, value)| {
+                if key == OsStr::new(name) { value } else { None }
+            },
+        )
+    }
+
+    #[test]
+    fn test_command_applies_project_environment() -> Result<()> {
+        let kernel_specification = LocalKernelSpecification {
+            name: "python".to_string(),
+            path: PathBuf::from("/jupyter/kernels/python"),
+            kernelspec: JupyterKernelspec {
+                argv: vec![
+                    "python".to_string(),
+                    "-m".to_string(),
+                    "ipykernel_launcher".to_string(),
+                    "-f".to_string(),
+                    "{connection_file}".to_string(),
+                ],
+                display_name: "Python".to_string(),
+                language: "python".to_string(),
+                interrupt_mode: None,
+                metadata: None,
+                env: Some(
+                    [
+                        ("KERNEL_ONLY".to_string(), "from-kernel".to_string()),
+                        ("SHARED_VALUE".to_string(), "from-kernel".to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            },
+        };
+
+        let project_environment = [
+            ("PROJECT_ONLY".to_string(), "from-project".to_string()),
+            ("SHARED_VALUE".to_string(), "from-project".to_string()),
+        ]
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+
+        let command = kernel_specification
+            .command(&PathBuf::from("connection.json"), &project_environment)?;
+
+        assert_eq!(
+            command_environment_value(&command, "PROJECT_ONLY"),
+            Some(OsStr::new("from-project"))
+        );
+        assert_eq!(
+            command_environment_value(&command, "KERNEL_ONLY"),
+            Some(OsStr::new("from-kernel"))
+        );
+        assert_eq!(
+            command_environment_value(&command, "SHARED_VALUE"),
+            Some(OsStr::new("from-kernel"))
+        );
+
+        Ok(())
+    }
 
     #[gpui::test]
     async fn test_get_kernelspecs(cx: &mut TestAppContext) {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -382,6 +382,7 @@ impl NotebookEditor {
             .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
             .unwrap_or_else(std::env::temp_dir);
         let fs = self.project.read(cx).fs().clone();
+        let project_environment = self.project.read(cx).environment().clone();
         let view = cx.entity();
 
         self.kernel_specification = Some(spec.clone());
@@ -415,6 +416,7 @@ impl NotebookEditor {
                 local_spec,
                 entity_id,
                 working_directory,
+                Some(project_environment),
                 fs,
                 view,
                 window,
@@ -424,6 +426,7 @@ impl NotebookEditor {
                 env_spec.as_local_spec(),
                 entity_id,
                 working_directory,
+                Some(project_environment),
                 fs,
                 view,
                 window,

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -297,6 +297,12 @@ impl Session {
                 .unwrap_or_else(temp_dir)
         };
 
+        let project_environment = self
+            .editor
+            .upgrade()
+            .and_then(|editor| editor.read(cx).project().cloned())
+            .map(|project| project.read(cx).environment().clone());
+
         telemetry::event!(
             "Kernel Status Changed",
             kernel_language,
@@ -311,6 +317,7 @@ impl Session {
                 kernel_specification,
                 entity_id,
                 working_directory,
+                project_environment,
                 self.fs.clone(),
                 session_view,
                 window,
@@ -320,6 +327,7 @@ impl Session {
                 env_specification.as_local_spec(),
                 entity_id,
                 working_directory,
+                project_environment,
                 self.fs.clone(),
                 session_view,
                 window,


### PR DESCRIPTION
# Objective

Fixes #61921.

Local REPL kernels currently start without the environment associated with their project directory. As a result, variables provided by tools such as `direnv` are available in Zed's integrated terminal but not in Python and other locally launched Jupyter kernels.

## Solution

Pass the project's `ProjectEnvironment` to the native kernel launcher from both editor and notebook REPL sessions.

Before starting the kernel process, resolve the environment for its working directory and apply those variables to the process command. Environment values explicitly defined by the kernelspec are applied afterward, preserving their precedence over project variables with the same name.

A regression test covers:

- Variables provided only by the project environment
- Variables provided only by the kernelspec
- Duplicate variables where the kernelspec value takes precedence

## Testing

### Manual Reproduction

I manually reproduced the issue on Ubuntu 24.04 through WSL2/WSLg using Zed built from upstream commit `315ea374`.

The reproduction project used direct `direnv` integration and contained:

```bash
# .envrc
export MY_SECRET=hello
```

```python
# repro.py
import os

print(os.environ.get("MY_SECRET"))
```

The Python kernel was provided by the project's `.venv`, which contained `ipykernel`.

#### Before the Fix

Using an unmodified build of the upstream commit:

- Zed's integrated terminal received the project environment and printed `MY_SECRET=hello`.
- The Python REPL used the project's `.venv` but printed `None`.

This confirmed that Zed loaded the `direnv` environment for its terminal but did not pass it to the native REPL kernel.

**Before screenshot:**

<img width="1681" height="781" alt="Zed-Before" src="https://github.com/user-attachments/assets/121630bf-b4aa-4832-8bdc-e73b1d65f66f" />

#### After the Fix

A second build was created from the same upstream commit with this patch applied. Repeating the same workflow produced:

- `MY_SECRET=hello` in Zed's integrated terminal.
- `hello` in the Python REPL.

This confirms that the project environment is now passed to the native REPL kernel.

**After screenshot:**

<img width="1922" height="999" alt="Zed-After" src="https://github.com/user-attachments/assets/a9bede41-3358-4c5d-96a4-b75f95ecfd27" />

### Automated Checks

The following checks completed successfully on Ubuntu 24.04 under WSL2:

- `cargo build -p zed --bin zed`
- `cargo test -p repl` — 39 passed
- `cargo fmt --all -- --check`
- `git diff --check`

The focused regression test was also executed separately:

- `cargo test -p repl test_command_applies_project_environment -- --nocapture` — 1 passed

The following checks had previously completed successfully on Windows:

- `cargo check -p repl`
- `cargo test -p repl` — 39 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p repl --release --all-targets --all-features -- --deny warnings`

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed REPL kernels not inheriting project environment variables.