### PR TITLE
recent_projects: Improve performance of recent_projects dropdown with lots of entries

### DIFF
--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -206,9 +206,7 @@ fn migrate_thread_remote_connections(cx: &mut App, migration_task: Task<anyhow::
             return Ok(());
         }
 
-        let recent_workspaces = workspace_db
-            .recent_project_workspaces_ungrouped(fs.as_ref())
-            .await?;
+        let recent_workspaces = workspace_db.recent_project_workspaces_ungrouped(fs).await?;
 
         let mut local_path_lists = HashSet::<PathList>::default();
         let mut remote_path_lists = HashMap::<PathList, RemoteConnectionOptions>::default();

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -206,7 +206,14 @@ fn migrate_thread_remote_connections(cx: &mut App, migration_task: Task<anyhow::
             return Ok(());
         }
 
-        let recent_workspaces = workspace_db.recent_project_workspaces_ungrouped(fs).await?;
+        let executor = cx.background_executor().clone();
+        let recent_workspaces = cx
+            .background_spawn(async move {
+                workspace_db
+                    .recent_project_workspaces_ungrouped(fs, executor)
+                    .await
+            })
+            .await?;
 
         let mut local_path_lists = HashSet::<PathList>::default();
         let mut remote_path_lists = HashMap::<PathList, RemoteConnectionOptions>::default();

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1151,7 +1151,7 @@ impl ProjectPickerModal {
         let db = WorkspaceDb::global(cx);
         cx.spawn_in(window, async move |this, cx| {
             let workspaces = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces(fs)
                 .await
                 .log_err()
                 .unwrap_or_default();

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1151,7 +1151,7 @@ impl ProjectPickerModal {
         let db = WorkspaceDb::global(cx);
         cx.spawn_in(window, async move |this, cx| {
             let workspaces = db
-                .recent_project_workspaces(fs)
+                .recent_project_workspaces(fs, cx.background_executor().clone())
                 .await
                 .log_err()
                 .unwrap_or_default();

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -124,10 +124,7 @@ pub async fn get_recent_projects(
     fs: Arc<dyn fs::Fs>,
     db: &WorkspaceDb,
 ) -> Vec<RecentProjectEntry> {
-    let workspaces = db
-        .recent_project_workspaces(fs.as_ref())
-        .await
-        .unwrap_or_default();
+    let workspaces = db.recent_project_workspaces(fs).await.unwrap_or_default();
 
     let filtered: Vec<_> = workspaces
         .into_iter()
@@ -661,7 +658,7 @@ impl RecentProjects {
         cx.spawn_in(window, async move |this, cx| {
             let Some(fs) = fs else { return };
             let workspaces = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces(f)
                 .await
                 .log_err()
                 .unwrap_or_default();
@@ -2339,10 +2336,7 @@ impl RecentProjectsDelegate {
                     .await
                     .log_err()
                     .unwrap_or_default();
-                let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
-                    .await
-                    .unwrap_or_default();
+                let workspaces = db.recent_project_workspaces(fs).await.unwrap_or_default();
                 this.update_in(cx, move |picker, window, cx| {
                     Self::update_picker_after_recent_project_deletion(
                         picker, ix, workspaces, window, cx,

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -118,71 +118,6 @@ enum ProjectPickerStyle {
     Popover,
 }
 
-pub async fn get_recent_projects(
-    current_workspace_id: Option<WorkspaceId>,
-    limit: Option<usize>,
-    fs: Arc<dyn fs::Fs>,
-    db: &WorkspaceDb,
-) -> Vec<RecentProjectEntry> {
-    let workspaces = db.recent_project_workspaces(fs).await.unwrap_or_default();
-
-    let filtered: Vec<_> = workspaces
-        .into_iter()
-        .filter(|workspace| Some(workspace.workspace_id) != current_workspace_id)
-        .filter(|workspace| matches!(workspace.location, SerializedWorkspaceLocation::Local))
-        .collect();
-
-    let mut all_paths: Vec<PathBuf> = filtered
-        .iter()
-        .flat_map(|workspace| workspace.identity_paths.paths().iter().cloned())
-        .collect();
-    all_paths.sort_unstable();
-    all_paths.dedup();
-    let path_details =
-        util::disambiguate::compute_disambiguation_details(&all_paths, |path, detail| {
-            project::path_suffix(path, detail)
-        });
-    let path_detail_map: std::collections::HashMap<PathBuf, usize> =
-        all_paths.into_iter().zip(path_details).collect();
-
-    let entries: Vec<RecentProjectEntry> = filtered
-        .into_iter()
-        .map(|workspace| {
-            let paths: Vec<PathBuf> = workspace.paths.paths().to_vec();
-            let ordered_paths: Vec<&PathBuf> = workspace.identity_paths.ordered_paths().collect();
-
-            let name = ordered_paths
-                .iter()
-                .map(|p| {
-                    let detail = path_detail_map.get(*p).copied().unwrap_or(0);
-                    project::path_suffix(p, detail)
-                })
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            let full_path = ordered_paths
-                .iter()
-                .map(|p| p.to_string_lossy().to_string())
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            RecentProjectEntry {
-                name: SharedString::from(name),
-                full_path: SharedString::from(full_path),
-                paths,
-                workspace_id: workspace.workspace_id,
-                timestamp: workspace.timestamp,
-            }
-        })
-        .collect();
-
-    match limit {
-        Some(n) => entries.into_iter().take(n).collect(),
-        None => entries,
-    }
-}
-
 pub async fn delete_recent_project(workspace_id: WorkspaceId, db: &WorkspaceDb) {
     let _ = db.delete_workspace_by_id(workspace_id).await;
 }
@@ -657,8 +592,9 @@ impl RecentProjects {
         let db = WorkspaceDb::global(cx);
         cx.spawn_in(window, async move |this, cx| {
             let Some(fs) = fs else { return };
-            let workspaces = db
-                .recent_project_workspaces(f)
+            let executor = cx.background_executor().clone();
+            let workspaces = cx
+                .background_spawn(async move { db.recent_project_workspaces(fs, executor).await })
                 .await
                 .log_err()
                 .unwrap_or_default();
@@ -2336,7 +2272,13 @@ impl RecentProjectsDelegate {
                     .await
                     .log_err()
                     .unwrap_or_default();
-                let workspaces = db.recent_project_workspaces(fs).await.unwrap_or_default();
+                let executor = cx.background_executor().clone();
+                let workspaces = cx
+                    .background_spawn(
+                        async move { db.recent_project_workspaces(fs, executor).await },
+                    )
+                    .await
+                    .unwrap_or_default();
                 this.update_in(cx, move |picker, window, cx| {
                     Self::update_picker_after_recent_project_deletion(
                         picker, ix, workspaces, window, cx,

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -70,7 +70,7 @@ impl SidebarRecentProjects {
             cx.spawn_in(window, async move |this, cx| {
                 let Some(fs) = fs else { return };
                 let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
+                    .recent_project_workspaces(fs)
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -69,8 +69,11 @@ impl SidebarRecentProjects {
             let db = WorkspaceDb::global(cx);
             cx.spawn_in(window, async move |this, cx| {
                 let Some(fs) = fs else { return };
-                let workspaces = db
-                    .recent_project_workspaces(fs)
+                let executor = cx.background_executor().clone();
+                let workspaces = cx
+                    .background_spawn(
+                        async move { db.recent_project_workspaces(fs, executor).await },
+                    )
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/workspace/src/history_manager.rs
+++ b/crates/workspace/src/history_manager.rs
@@ -44,7 +44,7 @@ impl HistoryManager {
         let db = WorkspaceDb::global(cx);
         cx.spawn(async move |cx| {
             let recent_folders = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces(fs)
                 .await
                 .unwrap_or_default()
                 .into_iter()

--- a/crates/workspace/src/history_manager.rs
+++ b/crates/workspace/src/history_manager.rs
@@ -43,8 +43,9 @@ impl HistoryManager {
     fn init(this: Entity<HistoryManager>, fs: Arc<dyn Fs>, cx: &App) {
         let db = WorkspaceDb::global(cx);
         cx.spawn(async move |cx| {
-            let recent_folders = db
-                .recent_project_workspaces(fs)
+            let executor = cx.background_executor().clone();
+            let recent_folders = cx
+                .background_spawn(async move { db.recent_project_workspaces(fs, executor).await })
                 .await
                 .unwrap_or_default()
                 .into_iter()

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2019,22 +2019,22 @@ impl WorkspaceDb {
     pub async fn recent_project_workspaces_ungrouped(
         &self,
         fs: Arc<dyn Fs>,
-        _: BackgroundExecutor,
+        executor: BackgroundExecutor,
     ) -> Result<Vec<RecentWorkspace>> {
         let remote_connections = self.remote_connections()?;
-        let mut result = Vec::new();
+        let mut tasks = Vec::new();
         for (id, paths, identity_paths_hint, remote_connection_id, _session_id, timestamp) in
             self.recent_workspaces()?
         {
             if let Some(remote_connection_id) = remote_connection_id {
                 if let Some(connection_options) = remote_connections.get(&remote_connection_id) {
-                    result.push(RecentWorkspace {
+                    tasks.push(Task::ready(Some(RecentWorkspace {
                         workspace_id: id,
                         location: SerializedWorkspaceLocation::Remote(connection_options.clone()),
                         paths: paths.clone(),
                         identity_paths: identity_paths_hint.unwrap_or(paths),
                         timestamp,
-                    });
+                    })));
                 }
                 continue;
             }
@@ -2043,22 +2043,32 @@ impl WorkspaceDb {
                 continue;
             }
 
-            if Self::all_paths_exist_with_a_directory(paths.paths(), fs.as_ref()).await {
-                let identity_paths = resolve_local_workspace_identity(fs.as_ref(), &paths)
-                    .await
-                    .or(identity_paths_hint)
-                    .unwrap_or_else(|| paths.clone());
-                result.push(RecentWorkspace {
-                    workspace_id: id,
-                    location: SerializedWorkspaceLocation::Local,
-                    paths,
-                    identity_paths,
-                    timestamp,
-                });
-            }
+            tasks.push(executor.spawn({
+                let fs = fs.clone();
+                async move {
+                    if !Self::all_paths_exist_with_a_directory(paths.paths(), fs.as_ref()).await {
+                        return None;
+                    }
+                    let identity_paths = resolve_local_workspace_identity(fs.as_ref(), &paths)
+                        .await
+                        .or(identity_paths_hint)
+                        .unwrap_or_else(|| paths.clone());
+                    Some(RecentWorkspace {
+                        workspace_id: id,
+                        location: SerializedWorkspaceLocation::Local,
+                        paths,
+                        identity_paths,
+                        timestamp,
+                    })
+                }
+            }));
         }
 
-        Ok(result)
+        Ok(futures::future::join_all(tasks)
+            .await
+            .into_iter()
+            .flatten()
+            .collect())
     }
 
     // Returns the recent project workspaces suitable for recent-project UIs.

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2018,7 +2018,7 @@ impl WorkspaceDb {
     // out because they are restored separately by `last_session_workspace_locations`.
     pub async fn recent_project_workspaces_ungrouped(
         &self,
-        fs: &dyn Fs,
+        fs: Arc<dyn Fs>,
     ) -> Result<Vec<RecentWorkspace>> {
         let remote_connections = self.remote_connections()?;
         let mut result = Vec::new();
@@ -2042,8 +2042,8 @@ impl WorkspaceDb {
                 continue;
             }
 
-            if Self::all_paths_exist_with_a_directory(paths.paths(), fs).await {
-                let identity_paths = resolve_local_workspace_identity(fs, &paths)
+            if Self::all_paths_exist_with_a_directory(paths.paths(), &fs).await {
+                let identity_paths = resolve_local_workspace_identity(&fs, &paths)
                     .await
                     .or(identity_paths_hint)
                     .unwrap_or_else(|| paths.clone());
@@ -2063,7 +2063,7 @@ impl WorkspaceDb {
     // Returns the recent project workspaces suitable for recent-project UIs.
     // Entries are deduplicated by git worktree identity, but preserve the original
     // serialized paths for reopening.
-    pub async fn recent_project_workspaces(&self, fs: &dyn Fs) -> Result<Vec<RecentWorkspace>> {
+    pub async fn recent_project_workspaces(&self, fs: Arc<dyn Fs>) -> Result<Vec<RecentWorkspace>> {
         Ok(dedupe_recent_workspaces(
             self.recent_project_workspaces_ungrouped(fs).await?,
         ))
@@ -2169,7 +2169,7 @@ impl WorkspaceDb {
         Ok(())
     }
 
-    pub async fn last_workspace(&self, fs: &dyn Fs) -> Result<Option<RecentWorkspace>> {
+    pub async fn last_workspace(&self, fs: Arc<dyn Fs>) -> Result<Option<RecentWorkspace>> {
         Ok(self.recent_project_workspaces(fs).await?.into_iter().next())
     }
 
@@ -3853,7 +3853,7 @@ mod tests {
         assert_eq!(sessions[0].workspace_id, WorkspaceId(1));
         assert!(sessions[0].paths.is_empty());
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
         assert!(
             recents
                 .iter()
@@ -5446,7 +5446,7 @@ mod tests {
             .await
             .unwrap();
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
 
         assert_eq!(recents.len(), 1);
         assert_eq!(recents[0].workspace_id, WorkspaceId(2));
@@ -5473,7 +5473,7 @@ mod tests {
         })
         .await;
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
 
         assert_eq!(recents.len(), 1);
         assert_eq!(
@@ -5525,7 +5525,7 @@ mod tests {
         ))
         .await;
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
 
         assert_eq!(recents.len(), 1);
         assert_eq!(
@@ -5554,7 +5554,7 @@ mod tests {
             .await
             .unwrap();
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
 
         assert_eq!(recents.len(), 2);
         assert_eq!(recents[0].workspace_id, WorkspaceId(2));
@@ -5619,13 +5619,13 @@ mod tests {
             .await
             .unwrap();
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
         assert_eq!(recents.len(), 1);
 
         let deleted = db.delete_recent_workspace_group(&recents[0]).await.unwrap();
         assert_eq!(deleted, vec![WorkspaceId(2), WorkspaceId(1)]);
 
-        let recents = db.recent_project_workspaces(fs.as_ref()).await.unwrap();
+        let recents = db.recent_project_workspaces(fs).await.unwrap();
         assert!(recents.is_empty());
     }
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -19,7 +19,7 @@ use db::{
     sqlez::{connection::Connection, domain::Domain},
     sqlez_macros::sql,
 };
-use gpui::{Axis, Bounds, Task, WindowBounds, WindowId, point, size};
+use gpui::{Axis, BackgroundExecutor, Bounds, Task, WindowBounds, WindowId, point, size};
 use project::{
     ProjectGroupKey,
     bookmark_store::SerializedBookmark,
@@ -2019,6 +2019,7 @@ impl WorkspaceDb {
     pub async fn recent_project_workspaces_ungrouped(
         &self,
         fs: Arc<dyn Fs>,
+        _: BackgroundExecutor,
     ) -> Result<Vec<RecentWorkspace>> {
         let remote_connections = self.remote_connections()?;
         let mut result = Vec::new();
@@ -2042,8 +2043,8 @@ impl WorkspaceDb {
                 continue;
             }
 
-            if Self::all_paths_exist_with_a_directory(paths.paths(), &fs).await {
-                let identity_paths = resolve_local_workspace_identity(&fs, &paths)
+            if Self::all_paths_exist_with_a_directory(paths.paths(), fs.as_ref()).await {
+                let identity_paths = resolve_local_workspace_identity(fs.as_ref(), &paths)
                     .await
                     .or(identity_paths_hint)
                     .unwrap_or_else(|| paths.clone());
@@ -2063,9 +2064,14 @@ impl WorkspaceDb {
     // Returns the recent project workspaces suitable for recent-project UIs.
     // Entries are deduplicated by git worktree identity, but preserve the original
     // serialized paths for reopening.
-    pub async fn recent_project_workspaces(&self, fs: Arc<dyn Fs>) -> Result<Vec<RecentWorkspace>> {
+    pub async fn recent_project_workspaces(
+        &self,
+        fs: Arc<dyn Fs>,
+        executor: BackgroundExecutor,
+    ) -> Result<Vec<RecentWorkspace>> {
         Ok(dedupe_recent_workspaces(
-            self.recent_project_workspaces_ungrouped(fs).await?,
+            self.recent_project_workspaces_ungrouped(fs, executor)
+                .await?,
         ))
     }
 
@@ -2169,8 +2175,16 @@ impl WorkspaceDb {
         Ok(())
     }
 
-    pub async fn last_workspace(&self, fs: Arc<dyn Fs>) -> Result<Option<RecentWorkspace>> {
-        Ok(self.recent_project_workspaces(fs).await?.into_iter().next())
+    pub async fn last_workspace(
+        &self,
+        fs: Arc<dyn Fs>,
+        cx: BackgroundExecutor,
+    ) -> Result<Option<RecentWorkspace>> {
+        Ok(self
+            .recent_project_workspaces(fs, cx)
+            .await?
+            .into_iter()
+            .next())
     }
 
     // Returns the locations of the workspaces that were still opened when the last

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -263,7 +263,7 @@ impl WelcomePage {
             cx.spawn_in(window, async move |this: WeakEntity<Self>, cx| {
                 let Some(fs) = fs else { return };
                 let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
+                    .recent_project_workspaces(fs)
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -263,7 +263,7 @@ impl WelcomePage {
             cx.spawn_in(window, async move |this: WeakEntity<Self>, cx| {
                 let Some(fs) = fs else { return };
                 let workspaces = db
-                    .recent_project_workspaces(fs)
+                    .recent_project_workspaces(fs, cx.background_executor().clone())
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9629,8 +9629,9 @@ impl WorkspaceHandle for Entity<Workspace> {
 pub async fn last_opened_workspace_location(
     db: &WorkspaceDb,
     fs: Arc<dyn fs::Fs>,
+    executor: gpui::BackgroundExecutor,
 ) -> Option<(WorkspaceId, SerializedWorkspaceLocation, PathList)> {
-    db.last_workspace(fs)
+    db.last_workspace(fs, executor)
         .await
         .log_err()
         .flatten()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9628,7 +9628,7 @@ impl WorkspaceHandle for Entity<Workspace> {
 
 pub async fn last_opened_workspace_location(
     db: &WorkspaceDb,
-    fs: &dyn fs::Fs,
+    fs: Arc<dyn fs::Fs>,
 ) -> Option<(WorkspaceId, SerializedWorkspaceLocation, PathList)> {
     db.last_workspace(fs)
         .await

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1614,7 +1614,7 @@ pub(crate) async fn restorable_workspace_locations(
 
     match restore_behavior {
         workspace::RestoreOnStartupBehavior::LastWorkspace => {
-            workspace::last_opened_workspace_location(&db, app_state.fs.as_ref())
+            workspace::last_opened_workspace_location(&db, app_state.fs.clone())
                 .await
                 .map(|(workspace_id, location, paths)| {
                     vec![SessionWorkspace {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1614,16 +1614,20 @@ pub(crate) async fn restorable_workspace_locations(
 
     match restore_behavior {
         workspace::RestoreOnStartupBehavior::LastWorkspace => {
-            workspace::last_opened_workspace_location(&db, app_state.fs.clone())
-                .await
-                .map(|(workspace_id, location, paths)| {
-                    vec![SessionWorkspace {
-                        workspace_id,
-                        location,
-                        paths,
-                        window_id: None,
-                    }]
-                })
+            workspace::last_opened_workspace_location(
+                &db,
+                app_state.fs.clone(),
+                cx.background_executor().clone(),
+            )
+            .await
+            .map(|(workspace_id, location, paths)| {
+                vec![SessionWorkspace {
+                    workspace_id,
+                    location,
+                    paths,
+                    window_id: None,
+                }]
+            })
         }
         workspace::RestoreOnStartupBehavior::LastSession => {
             if let Some(last_session_id) = last_session_id {


### PR DESCRIPTION

# Objective

This PR addresses #55236, but it does not fully fix it. Our recent_projects code is quite inefficient when it comes to interacting with DB and rendering. We sat down with @MrSubidubi and parallelized DB fetching, but the heavy part - that being rendering of ALL entries in a list due to use of list API, introduced in #48989, makes it nigh impossible to make the experience buttery smooth for arbitrary project list.

## Solution


We've parallelized DB accesses.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- Improved performance of Recent Projects list.
