### PR TITLE
gpui_linux: Handle zero-sized Wayland surfaces

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1286,8 +1286,13 @@ impl WaylandWindowStatePtr {
         {
             let state = self.state.borrow();
             if let Some(viewport) = &state.viewport {
-                viewport
-                    .set_destination(f32::from(size.width) as i32, f32::from(size.height) as i32);
+                let width = f32::from(size.width) as i32;
+                let height = f32::from(size.height) as i32;
+                if width > 0 && height > 0 {
+                    viewport.set_destination(width, height);
+                } else {
+                    viewport.set_destination(-1, -1);
+                }
             }
         }
     }
@@ -1972,29 +1977,33 @@ fn update_window(mut state: RefMut<WaylandWindowState>) {
     let opaque = !state.is_transparent();
 
     state.renderer.update_transparency(!opaque);
-    let opaque_area = state.window_bounds.map(|v| f32::from(v) as i32);
-    opaque_area.inset(f32::from(state.inset()) as i32);
-
-    let region = state
-        .globals
-        .compositor
-        .create_region(&state.globals.qh, ());
-    region.add(
-        opaque_area.origin.x,
-        opaque_area.origin.y,
-        opaque_area.size.width,
-        opaque_area.size.height,
-    );
-
     // Note that rounded corners make this rectangle API hard to work with.
     // As this is common when using CSD, let's just disable this API.
     if state.background_appearance == WindowBackgroundAppearance::Opaque
         && state.decorations == WindowDecorations::Server
     {
-        // Promise the compositor that this region of the window surface
-        // contains no transparent pixels. This allows the compositor to skip
-        // updating whatever is behind the surface for better performance.
-        state.surface.set_opaque_region(Some(&region));
+        let opaque_area = state.window_bounds.map(|v| f32::from(v) as i32);
+        opaque_area.inset(f32::from(state.inset()) as i32);
+
+        if opaque_area.size.width > 0 && opaque_area.size.height > 0 {
+            let region = state
+                .globals
+                .compositor
+                .create_region(&state.globals.qh, ());
+            region.add(
+                opaque_area.origin.x,
+                opaque_area.origin.y,
+                opaque_area.size.width,
+                opaque_area.size.height,
+            );
+            // Promise the compositor that this region of the window surface
+            // contains no transparent pixels. This allows the compositor to skip
+            // updating whatever is behind the surface for better performance.
+            state.surface.set_opaque_region(Some(&region));
+            region.destroy();
+        } else {
+            state.surface.set_opaque_region(None);
+        }
     } else {
         state.surface.set_opaque_region(None);
     }
@@ -2014,8 +2023,6 @@ fn update_window(mut state: RefMut<WaylandWindowState>) {
             }
         }
     }
-
-    region.destroy();
 }
 
 pub(crate) trait WindowDecorationsExt {


### PR DESCRIPTION
# Objective

- Avoid invalid Wayland requests while a zero-sized layer-shell surface waits for its first compositor configure.

## Solution

- Unset the viewport destination when the logical surface size is non-positive.
- Create an opaque region only when it will be used and has positive dimensions.

## Testing

- Built a downstream GPUI application against this commit.
- On KWin Wayland with 125% fractional scaling, verified a `0x0` layer-shell request is configured to `3072x1728`, remains connected, receives pointer and keyboard input, and renders successfully.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A