### PR TITLE
language: Only invalidate injections owned by the reparsed layer

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -247,6 +247,9 @@ enum ParseMode {
 struct ChangedRegion {
     depth: usize,
     range: Range<Anchor>,
+    /// The range of the layer whose injections are being invalidated. Only layers nested
+    /// inside of it can be invalidated, because only that layer will recreate them.
+    owner_range: Range<Anchor>,
 }
 
 #[derive(Default)]
@@ -625,6 +628,7 @@ impl SyntaxSnapshot {
                             ChangedRegion {
                                 depth: layer.depth + 1,
                                 range: layer.range.clone(),
+                                owner_range: layer.range.clone(),
                             },
                             text,
                         );
@@ -810,24 +814,14 @@ impl SyntaxSnapshot {
                         grammar.injection_config.as_ref().zip(registry.as_ref()),
                         changed_ranges.is_empty(),
                     ) {
-                        // Handle invalidation and reactivation of injections on comment update.
-                        // The expanded ranges are clamped to this layer's own range, because a
-                        // layer only owns the injections nested inside of it. Without clamping,
-                        // reparsing one layer would invalidate the injections of sibling layers
-                        // on the adjacent rows, which nothing would then reparse.
+                        // Handle invalidation and reactivation of injections on comment update
                         let mut expanded_ranges: Vec<_> = changed_ranges
                             .iter()
-                            .filter_map(|range| {
+                            .map(|range| {
                                 let start_row = range.start.to_point(text).row.saturating_sub(1);
                                 let end_row = range.end.to_point(text).row.saturating_add(2);
-                                let start = text
-                                    .point_to_offset(Point::new(start_row, 0))
-                                    .max(step_start_byte);
-                                let end = text
-                                    .point_to_offset(Point::new(end_row, 0))
-                                    .min(text.len())
-                                    .min(step_end_byte);
-                                (start < end).then_some(start..end)
+                                text.point_to_offset(Point::new(start_row, 0))
+                                    ..text.point_to_offset(Point::new(end_row, 0)).min(text.len())
                             })
                             .collect();
                         expanded_ranges.sort_unstable_by_key(|r| r.start);
@@ -845,6 +839,7 @@ impl SyntaxSnapshot {
                                     depth: step.depth + 1,
                                     range: text.anchor_before(range.start)
                                         ..text.anchor_after(range.end),
+                                    owner_range: step.range.clone(),
                                 },
                                 text,
                             );
@@ -1960,6 +1955,10 @@ impl ChangedRegion {
         Ord::cmp(&self.depth, &other.depth)
             .then_with(|| range_a.start.cmp(&range_b.start, buffer))
             .then_with(|| range_b.end.cmp(&range_a.end, buffer))
+            // Regions that differ only in their owner must both be kept, as they
+            // invalidate different layers.
+            .then_with(|| self.owner_range.start.cmp(&other.owner_range.start, buffer))
+            .then_with(|| other.owner_range.end.cmp(&self.owner_range.end, buffer))
     }
 }
 
@@ -1990,6 +1989,17 @@ impl ChangeRegionSet {
             }
             if region.range.start.cmp(&layer.range.end, text).is_ge() {
                 break;
+            }
+            // Only the layer that owns an injection will recreate it, so a layer that
+            // merely abuts or overlaps the owner must be left alone.
+            if region
+                .owner_range
+                .start
+                .cmp(&layer.range.start, text)
+                .is_gt()
+                || region.owner_range.end.cmp(&layer.range.end, text).is_lt()
+            {
+                continue;
             }
             return true;
         }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -810,14 +810,24 @@ impl SyntaxSnapshot {
                         grammar.injection_config.as_ref().zip(registry.as_ref()),
                         changed_ranges.is_empty(),
                     ) {
-                        // Handle invalidation and reactivation of injections on comment update
+                        // Handle invalidation and reactivation of injections on comment update.
+                        // The expanded ranges are clamped to this layer's own range, because a
+                        // layer only owns the injections nested inside of it. Without clamping,
+                        // reparsing one layer would invalidate the injections of sibling layers
+                        // on the adjacent rows, which nothing would then reparse.
                         let mut expanded_ranges: Vec<_> = changed_ranges
                             .iter()
-                            .map(|range| {
+                            .filter_map(|range| {
                                 let start_row = range.start.to_point(text).row.saturating_sub(1);
                                 let end_row = range.end.to_point(text).row.saturating_add(2);
-                                text.point_to_offset(Point::new(start_row, 0))
-                                    ..text.point_to_offset(Point::new(end_row, 0)).min(text.len())
+                                let start = text
+                                    .point_to_offset(Point::new(start_row, 0))
+                                    .max(step_start_byte);
+                                let end = text
+                                    .point_to_offset(Point::new(end_row, 0))
+                                    .min(text.len())
+                                    .min(step_end_byte);
+                                (start < end).then_some(start..end)
                             })
                             .collect();
                         expanded_ranges.sort_unstable_by_key(|r| r.start);

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -992,12 +992,12 @@ fn test_injections_are_preserved_when_a_sibling_layer_is_reparsed(cx: &mut App) 
     registry.add(Arc::new(markdown_inline_lang_with_html_injections()));
     registry.add(Arc::new(html_lang_with_injections()));
 
-    // Each list item is a separate inline layer, so each HTML comment lives in its own
-    // injection layer.
+    // Each list item is a separate inline layer, so the inline HTML of each item lives
+    // in its own injection layer.
     let mut buffer = Buffer::new(
         ReplicaId::LOCAL,
         BufferId::new(1).unwrap(),
-        "- one <!--first-->\n- two <!--second-->\n- three <!--third-->".to_string(),
+        "- one <!--first-->\n- two <!--second-->\n- three <b>3</b>".to_string(),
     );
 
     let mut syntax_map = SyntaxMap::new(&buffer);
@@ -1007,8 +1007,8 @@ fn test_injections_are_preserved_when_a_sibling_layer_is_reparsed(cx: &mut App) 
     assert_capture_ranges(
         &syntax_map,
         &buffer,
-        &["comment"],
-        "- one «<!--first-->»\n- two «<!--second-->»\n- three «<!--third-->»",
+        &["comment", "tag"],
+        "- one «<!--first-->»\n- two «<!--second-->»\n- three <«b»>3</«b»>",
     );
 
     // Editing one list item must not invalidate the injections of the adjacent items,
@@ -1021,8 +1021,8 @@ fn test_injections_are_preserved_when_a_sibling_layer_is_reparsed(cx: &mut App) 
     assert_capture_ranges(
         &syntax_map,
         &buffer,
-        &["comment"],
-        "- one «<!--first-->»\n- two «<!--second-->» \n- three «<!--third-->»",
+        &["comment", "tag"],
+        "- one «<!--first-->»\n- two «<!--second-->» \n- three <«b»>3</«b»>",
     );
 }
 

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1027,6 +1027,51 @@ fn test_injections_are_preserved_when_a_sibling_layer_is_reparsed(cx: &mut App) 
 }
 
 #[gpui::test]
+fn test_injections_are_preserved_when_an_abutting_layer_is_reparsed(cx: &mut App) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    let markdown = markdown_lang();
+    registry.add(markdown.clone());
+    registry.add(Arc::new(markdown_inline_lang_with_html_injections()));
+    registry.add(Arc::new(html_lang_with_injections()));
+
+    // A line starting with a comment is an HTML block, so the first two lines become HTML
+    // layers of their own, while the last two lines are one paragraph whose inline layer
+    // has HTML injected into it. The second HTML block ends exactly where that paragraph
+    // begins.
+    let text = "<!--first--> a\n<!--second--> b\n<b>c</b> d\n<i>e</i> f";
+    let mut buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        text.to_string(),
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(markdown.clone(), &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["comment", "tag"],
+        "«<!--first-->» a\n«<!--second-->» b\n<«b»>c</«b»> d\n<«i»>e</«i»> f",
+    );
+
+    // Reparsing the second HTML block must not invalidate the HTML injected into the
+    // paragraph that starts at its end offset.
+    let second_block_end = text.find("\n<b>").unwrap();
+    buffer.edit([(second_block_end..second_block_end, " ")]);
+    syntax_map.interpolate(&buffer);
+    syntax_map.reparse(markdown, &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["comment", "tag"],
+        "«<!--first-->» a\n«<!--second-->» b \n<«b»>c</«b»> d\n<«i»>e</«i»> f",
+    );
+}
+
+#[gpui::test]
 fn test_syntax_map_languages_loading_with_erb(cx: &mut App) {
     let text = r#"
         <body>

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -985,6 +985,48 @@ fn test_comment_triggered_injection_toggle(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_injections_are_preserved_when_a_sibling_layer_is_reparsed(cx: &mut App) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    let markdown = markdown_lang();
+    registry.add(markdown.clone());
+    registry.add(Arc::new(markdown_inline_lang_with_html_injections()));
+    registry.add(Arc::new(html_lang_with_injections()));
+
+    // Each list item is a separate inline layer, so each HTML comment lives in its own
+    // injection layer.
+    let mut buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        "- one <!--first-->\n- two <!--second-->\n- three <!--third-->".to_string(),
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(markdown.clone(), &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["comment"],
+        "- one «<!--first-->»\n- two «<!--second-->»\n- three «<!--third-->»",
+    );
+
+    // Editing one list item must not invalidate the injections of the adjacent items,
+    // whose own layers are not reparsed and would therefore never be restored.
+    let second_item_end = buffer.as_rope().to_string().rfind('\n').unwrap();
+    buffer.edit([(second_item_end..second_item_end, " ")]);
+    syntax_map.interpolate(&buffer);
+    syntax_map.reparse(markdown, &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["comment"],
+        "- one «<!--first-->»\n- two «<!--second-->» \n- three «<!--third-->»",
+    );
+}
+
+#[gpui::test]
 fn test_syntax_map_languages_loading_with_erb(cx: &mut App) {
     let text = r#"
         <body>
@@ -1411,6 +1453,56 @@ fn html_lang() -> Language {
             (tag_name) @tag
             (erroneous_end_tag_name) @tag
             (attribute_name) @property
+        "#,
+    )
+    .unwrap()
+}
+
+/// Like [`markdown_inline_lang`], but injecting HTML into inline HTML tags, the way
+/// the real Markdown-Inline queries do.
+fn markdown_inline_lang_with_html_injections() -> Language {
+    Language::new(
+        LanguageConfig {
+            name: "Markdown-Inline".into(),
+            hidden: true,
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_md::INLINE_LANGUAGE.into()),
+    )
+    .with_highlights_query("(emphasis) @emphasis")
+    .unwrap()
+    .with_injection_query(
+        r#"
+            ((html_tag) @injection.content
+              (#set! injection.language "html")
+              (#set! injection.combined))
+        "#,
+    )
+    .unwrap()
+}
+
+/// Like [`html_lang`], but with an injection query, so that reparsing an HTML layer
+/// invalidates the layers injected into it.
+fn html_lang_with_injections() -> Language {
+    Language::new(
+        LanguageConfig {
+            name: "HTML".into(),
+            matcher: (LanguageMatcher {
+                path_suffixes: vec!["html".to_string()],
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_html::LANGUAGE.into()),
+    )
+    .with_highlights_query("(comment) @comment (tag_name) @tag")
+    .unwrap()
+    .with_injection_query(
+        r#"
+            (script_element
+              (raw_text) @injection.content
+              (#set! injection.language "javascript"))
         "#,
     )
     .unwrap()


### PR DESCRIPTION
# Objective

Syntax highlighting inside nested language injections can be lost permanently after editing a nearby line. It only comes back after editing the affected line again or restarting Zed; saving the file does not help.

This is most visible with inline HTML in Markdown, where every paragraph and list item is a separate injection layer:

* Typing in one list item removes the highlighting of the inline HTML in the items above and below it.
* Typing at the end of an HTML block removes the highlighting of the inline HTML in the paragraph on the next line.

https://github.com/user-attachments/assets/82e3abd9-4e76-432c-a796-1b4f493b9dc0

After a layer is reparsed, `SyntaxMap` registers its changed rows, expanded by one row in each direction, as invalidated regions for the next nesting depth. Nothing checks that the layers those regions discard actually belong to the reparsed layer. A layer only recomputes its injections when its own content changed, so a neighbouring layer whose text was untouched skips `get_injections`, and the child layer discarded on its behalf is never recreated.

## Solution

Record which layer each `ChangedRegion` belongs to, and only invalidate layers nested inside of it. A layer owns exactly the injections inside its own range, and it is the only layer that will recreate them.

Two narrower fixes were tried first and are not sufficient:

| Change | Sibling layers on adjacent rows | Layer starting where the reparsed layer ends | `ITERATIONS=300` random edits |
| --- | --- | --- | --- |
| none | broken | broken | passes |
| clamp the expanded ranges to the reparsed layer's range | fixed | broken | passes |
| bias the invalidated region's endpoints inwards | fixed | fixed | fails |
| **Only invalidate layers owned by the reparsed layer (this PR)** | fixed | fixed | passes |

Clamping leaves the second case, because the clamped range and the abutting layer still touch at the same offset. Biasing the endpoints inwards cannot distinguish a child that legitimately begins at that offset from an unrelated layer that does, so it keeps stale layers alive: with that variant, a 300-seed sweep of `test_random_syntax_map_edits_rust_macros` ends up with three layers surviving where a fresh parse has one. Ownership distinguishes the two: a child is nested inside the owner, an abutting layer is not.

Ownership subsumes clamping, so the expanded ranges themselves are unchanged from `main`.

#62370 changes `splice_included_ranges`, which is a different function and a different bug: it produces a wrong range list within a single layer, so a full reparse repairs it. The tests added here fail with it applied.

## Testing

* `test_injections_are_preserved_when_a_sibling_layer_is_reparsed` edits one Markdown list item and asserts that the inline HTML of the adjacent items keeps its highlighting, for both comments and tags.
* `test_injections_are_preserved_when_an_abutting_layer_is_reparsed` edits the last line of an HTML block and asserts that the HTML injected into the following paragraph keeps its highlighting.
* `cargo test -p language` (154 tests)
* `ITERATIONS=300 cargo test -p language test_random_syntax_map_edits`

## Self-Review Checklist:

* [x] I've reviewed my own diff for quality, security, and reliability
* [x] Unsafe blocks (if any) have justifying comments
* [x] The content adheres to Zed's UI standards (UX/UI and icon guidelines)
* [x] Tests cover the new/changed behavior
* [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed syntax highlighting inside nested language injections being lost after editing a nearby line, such as inline HTML in Markdown.