### PR TITLE
docs: Enable smart punctuation

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -17,6 +17,7 @@ extra-watch-dirs = ["../crates/docs_preprocessor"]
 # options that apply to html apply to zed-html
 [output.zed-html]
 command = "cargo run -p docs_preprocessor -- postprocess"
+smart-punctuation = true
 # Set here instead of above as we only use it replace the `#description#` we set in the template
 # when no front-matter is provided value
 default-description = "Learn how to use and customize Zed, the fast, collaborative code editor. Official docs on features, configuration, AI tools, and workflows."


### PR DESCRIPTION
> “Smart quotes” are the ideal form of quotation marks and apostrophes, and are commonly curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard.

Also helps us be consistent. I’m going to make a PR to our marketing site to fix these issues as well, to bring further consistency to our copy (docs / marketing / otherwise). Starting with v0.5.0 and up, [`smart-punctuation`](https://github.com/rust-lang/mdBook/blob/6bf7fadc295a862f1f4b2f2d4a9c4c0b1e998dff/CHANGELOG.md#config-changes) is enabled by default, so we just need this temporarily.

Good read: https://smartquotesforsmartpeople.com/

---

Release Notes:

- N/A
