### PR TITLE
agent_ui: Show full model name on hover in model selectors

### DIFF
--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -839,6 +839,7 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
                 Some(
                     div()
                         .id(("config-option-picker-item", ix))
+                        .tooltip(Tooltip::text(option_name.clone()))
                         .when_some(description, |this, desc| {
                             let desc: SharedString = desc.into();
                             this.on_hover(cx.listener(move |menu, hovered, _, cx| {

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
 use settings::SettingsStore;
-use ui::{DocumentationAside, IntoElement, prelude::*};
+use ui::{DocumentationAside, IntoElement, Tooltip, prelude::*};
 use util::ResultExt;
 use zed_actions::agent::OpenSettings;
 
@@ -317,6 +317,7 @@ impl PickerDelegate for ModelPickerDelegate {
                 Some(
                     div()
                         .id(("model-picker-menu-child", ix))
+                        .tooltip(Tooltip::text(model_info.name.clone()))
                         .when_some(model_info.description.clone(), |this, description| {
                             this.on_hover(cx.listener(move |menu, hovered, _, cx| {
                                 if *hovered {


### PR DESCRIPTION
# Objective

Model names in picker items are truncated when they exceed the available
width, displaying a prefix followed by "..." in place of the truncated
text. If the user has multiple models have a similar prefix and only differ
in the truncated text, it can be difficult for the user to distinguish
between models in the model selector.

## Solution

To address this, make it so that hovering over a truncated model name in the
model selector now shows the full name via tooltip.

Applies to both the built-in agent (ModelPickerDelegate) and external ACP
agents (ConfigOptionPickerDelegate).

## Testing

built and ran zed and connected it to a local provider that has models with long names.

verified tooltip displaying full name both worked in the Zed agent model selector AND
also worked in the OpenCode ACP external agent model selector.

(NOTE: these model selector have separate implementations add we added tooltips for
each, so we must verify both)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

### Before:

<img width="661" height="211" alt="image" src="https://github.com/user-attachments/assets/6c6b0c78-088e-4d34-a31e-f12aff0d1437" />


### After:

<img width="661" height="211" alt="image" src="https://github.com/user-attachments/assets/b597e2e2-5480-4170-b3bb-731553e4534b" />


---

Release Notes:

- Agent: Show full model name on hover when truncated in the model selector
