### PR TITLE
project: Fix `SymbolKind` serialization over RPC

### DIFF
--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -5951,6 +5951,7 @@ async fn test_project_symbols(
         .unwrap();
     assert_eq!(symbols.len(), 1);
     assert_eq!(symbols[0].name, "TWO");
+    assert_eq!(symbols[0].kind, language::SymbolKind::Constant);
 
     // Open one of the returned symbols.
     let buffer_b_2 = project_b

--- a/crates/language_core/src/code_label.rs
+++ b/crates/language_core/src/code_label.rs
@@ -31,37 +31,51 @@ pub enum SymbolKind {
     TypeParameter,
 }
 
-impl SymbolKind {
-    pub fn from_proto(i32: i32) -> Self {
-        match i32 {
-            1 => SymbolKind::File,
-            2 => SymbolKind::Module,
-            3 => SymbolKind::Namespace,
-            4 => SymbolKind::Package,
-            5 => SymbolKind::Class,
-            6 => SymbolKind::Method,
-            7 => SymbolKind::Property,
-            8 => SymbolKind::Field,
-            9 => SymbolKind::Constructor,
-            10 => SymbolKind::Enum,
-            11 => SymbolKind::Interface,
-            12 => SymbolKind::Function,
-            13 => SymbolKind::Variable,
-            14 => SymbolKind::Constant,
-            15 => SymbolKind::String,
-            16 => SymbolKind::Number,
-            17 => SymbolKind::Boolean,
-            18 => SymbolKind::Array,
-            19 => SymbolKind::Object,
-            20 => SymbolKind::Key,
-            21 => SymbolKind::Null,
-            22 => SymbolKind::EnumMember,
-            23 => SymbolKind::Struct,
-            24 => SymbolKind::Event,
-            25 => SymbolKind::Operator,
-            26 => SymbolKind::TypeParameter,
-            _ => SymbolKind::Null,
+macro_rules! proto_mapping {
+    ($($kind:ident = $value:literal),* $(,)?) => {
+        pub fn to_proto(self) -> i32 {
+            match self {
+                $(Self::$kind => $value,)*
+            }
         }
+
+        pub fn from_proto(value: i32) -> Self {
+            match value {
+                $($value => Self::$kind,)*
+                _ => Self::Null,
+            }
+        }
+    };
+}
+
+impl SymbolKind {
+    proto_mapping! {
+        File = 1,
+        Module = 2,
+        Namespace = 3,
+        Package = 4,
+        Class = 5,
+        Method = 6,
+        Property = 7,
+        Field = 8,
+        Constructor = 9,
+        Enum = 10,
+        Interface = 11,
+        Function = 12,
+        Variable = 13,
+        Constant = 14,
+        String = 15,
+        Number = 16,
+        Boolean = 17,
+        Array = 18,
+        Object = 19,
+        Key = 20,
+        Null = 21,
+        EnumMember = 22,
+        Struct = 23,
+        Event = 24,
+        Operator = 25,
+        TypeParameter = 26,
     }
 }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2095,7 +2095,7 @@ impl LspCommand for GetDocumentSymbols {
                 fn convert_symbol_to_proto(symbol: DocumentSymbol) -> proto::DocumentSymbol {
                     proto::DocumentSymbol {
                         name: symbol.name.clone(),
-                        kind: symbol.kind as i32,
+                        kind: symbol.kind.to_proto(),
                         start: Some(proto::PointUtf16 {
                             row: symbol.range.start.0.row,
                             column: symbol.range.start.0.column,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -12703,7 +12703,7 @@ impl LspStore {
             source_worktree_id: symbol.source_worktree_id.to_proto(),
             language_server_id: symbol.source_language_server_id.to_proto(),
             name: symbol.name.clone(),
-            kind: symbol.kind as i32,
+            kind: symbol.kind.to_proto(),
             start: Some(proto::PointUtf16 {
                 row: symbol.range.start.0.row,
                 column: symbol.range.start.0.column,


### PR DESCRIPTION
# Objective

I noticed that in workspace symbol search, the function's symbol kind has become `Trait`.


## Solution

Add `to_proto` and a macro to define the mapping instead of `as i32`.

## Testing

Updated the test.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed `SymbolKind` mapping to LSP protocol values
