### PR TITLE
gpui: Share frame timing histograms with benchmarks

### DIFF
--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -15,7 +15,7 @@ use crate::{
     PlatformTextSystem, Render, Reservation, Task, TestPlatform, ThreadedDispatcher, VisualContext,
     Window, WindowBounds, WindowHandle, WindowOptions,
     app::GpuiBorrow,
-    profiler::{self, FrameTiming, FrameTimingCollector},
+    profiler::{self, FrameDurationSnapshot, FrameTiming, FrameTimingCollector},
 };
 
 /// Returns a benchmark platform backed by this thread's shared dispatcher.
@@ -66,7 +66,7 @@ const NANOS_PER_SECOND: u128 = 1_000_000_000;
 /// A small report produced by GPUI benchmarks.
 #[derive(Clone)]
 pub struct BenchReport {
-    frame_snapshot: Rc<RefCell<WindowFrameSnapshot>>,
+    frame_snapshot: Rc<RefCell<FrameDurationSnapshot>>,
     frame_budget_nanos: u128,
 }
 
@@ -88,31 +88,18 @@ impl BenchReport {
     /// when counting frame budget overruns.
     pub fn with_frame_budget_nanos(frame_budget_nanos: u128) -> Self {
         Self {
-            frame_snapshot: Rc::new(RefCell::new(WindowFrameSnapshot::new())),
+            frame_snapshot: Rc::new(RefCell::new(
+                FrameDurationSnapshot::new()
+                    .expect("three significant digits should create valid histograms"),
+            )),
             frame_budget_nanos,
         }
     }
 
     fn record_frame_timings<'i>(&self, timings: impl IntoIterator<Item = &'i FrameTiming>) {
         let mut snapshot = self.frame_snapshot.borrow_mut();
-        // `.ok()` on `record`: this operation is infallible (the histograms auto-resize).
         for timing in timings {
-            snapshot
-                .draw
-                .record(timing.draw_duration().as_nanos() as u64)
-                .ok();
-            if let Some(dirty_to_draw) = timing.dirty_to_draw_duration() {
-                snapshot
-                    .dirty_to_draw
-                    .record(dirty_to_draw.as_nanos() as u64)
-                    .ok();
-            }
-            if timing.invalidations > 0 {
-                snapshot
-                    .invalidations_per_frame
-                    .record(timing.invalidations)
-                    .ok();
-            }
+            snapshot.record_frame_timing(timing);
         }
     }
 
@@ -150,13 +137,16 @@ impl BenchReport {
         let benchmark_name = benchmark_name.unwrap_or("unknown benchmark");
         eprintln!("GPUI bench report (all observed iterations): {benchmark_name}");
         eprintln!("  note: includes Criterion warmup/calibration");
-        self.print_histogram("window dirty-to-draw", &frame_snapshot.dirty_to_draw);
-        self.print_histogram("window draw", &frame_snapshot.draw);
-        if !frame_snapshot.invalidations_per_frame.is_empty() {
+        self.print_histogram(
+            "window dirty-to-draw",
+            &frame_snapshot.dirty_to_draw_duration_histogram,
+        );
+        self.print_histogram("window draw", &frame_snapshot.draw_duration_histogram);
+        if !frame_snapshot.invalidations_per_frame_histogram.is_empty() {
             eprintln!(
                 "  invalidations per frame: mean {:.2}, max {}",
-                frame_snapshot.invalidations_per_frame.mean(),
-                frame_snapshot.invalidations_per_frame.max()
+                frame_snapshot.invalidations_per_frame_histogram.mean(),
+                frame_snapshot.invalidations_per_frame_histogram.max()
             );
         }
     }
@@ -198,26 +188,6 @@ impl BenchReport {
             "    frame budget overruns max: {}",
             self.budget_overruns(max_foreground_time)
         );
-    }
-}
-
-struct WindowFrameSnapshot {
-    dirty_to_draw: Histogram<u64>,
-    draw: Histogram<u64>,
-    invalidations_per_frame: Histogram<u64>,
-}
-
-impl WindowFrameSnapshot {
-    fn new() -> Self {
-        Self {
-            dirty_to_draw: Histogram::new(3).expect("3 significant digits is valid"),
-            draw: Histogram::new(3).expect("3 significant digits is valid"),
-            invalidations_per_frame: Histogram::new(3).expect("3 significant digits is valid"),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.dirty_to_draw.is_empty() && self.draw.is_empty()
     }
 }
 
@@ -913,6 +883,26 @@ mod tests {
     use std::{rc::Rc, sync::Arc};
 
     use super::*;
+
+    #[test]
+    fn frame_timings_use_shared_snapshot() {
+        let report = BenchReport::default();
+        let draw_start = scheduler::Instant::now();
+        let timing = FrameTiming {
+            window_id: crate::WindowId::from(0),
+            dirty_at: Some(draw_start - Duration::from_millis(3)),
+            invalidations: 2,
+            draw_start,
+            draw_end: draw_start + Duration::from_millis(2),
+        };
+
+        report.record_frame_timings([&timing]);
+
+        let snapshot = report.frame_snapshot.borrow();
+        assert_eq!(snapshot.draw_duration_histogram.len(), 1);
+        assert_eq!(snapshot.dirty_to_draw_duration_histogram.len(), 1);
+        assert_eq!(snapshot.invalidations_per_frame_histogram.max(), 2);
+    }
 
     #[test]
     fn task_completion_supports_non_send_foreground_output() {

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+use hdrhistogram::Histogram;
 use itertools::Itertools;
 use scheduler::{Instant, SpawnTime};
 use std::{
@@ -731,6 +733,78 @@ impl FrameTiming {
     pub fn dirty_to_draw_duration(&self) -> Option<Duration> {
         self.dirty_at
             .map(|dirty_at| self.draw_end.duration_since(dirty_at))
+    }
+}
+
+/// A point-in-time snapshot of frame timing histograms.
+///
+/// The snapshot can be populated from profiler timings or maintained by a live
+/// window. Live windows additionally record presentation intervals while
+/// continuously animating.
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+#[derive(Clone)]
+pub struct FrameDurationSnapshot {
+    /// Histogram of durations from the first invalidation through the end of
+    /// `Window::draw`, in nanoseconds.
+    pub dirty_to_draw_duration_histogram: Histogram<u64>,
+    /// Histogram of `Window::draw` durations, in nanoseconds.
+    pub draw_duration_histogram: Histogram<u64>,
+    /// Histogram of intervals between consecutively presented frames while the
+    /// window was animating, in nanoseconds.
+    pub present_interval_histogram: Histogram<u64>,
+    /// Histogram of invalidations coalesced into each frame.
+    pub invalidations_per_frame_histogram: Histogram<u64>,
+}
+
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+impl FrameDurationSnapshot {
+    pub(crate) fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            dirty_to_draw_duration_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create dirty-to-draw duration histogram: {error}")
+            })?,
+            draw_duration_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create draw duration histogram: {error}")
+            })?,
+            present_interval_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create present interval histogram: {error}")
+            })?,
+            invalidations_per_frame_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create invalidations-per-frame histogram: {error}")
+            })?,
+        })
+    }
+
+    pub(crate) fn record_frame_timing(&mut self, timing: &FrameTiming) {
+        // These histograms auto-resize, so recording cannot fail after construction.
+        self.draw_duration_histogram
+            .record(timing.draw_duration().as_nanos() as u64)
+            .ok();
+        if let Some(dirty_to_draw_duration) = timing.dirty_to_draw_duration() {
+            self.dirty_to_draw_duration_histogram
+                .record(dirty_to_draw_duration.as_nanos() as u64)
+                .ok();
+        }
+        if timing.invalidations > 0 {
+            self.invalidations_per_frame_histogram
+                .record(timing.invalidations)
+                .ok();
+        }
+    }
+
+    #[cfg(feature = "frame-duration-histogram")]
+    pub(crate) fn record_present_interval(&mut self, duration: Duration) {
+        // This histogram auto-resizes, so recording cannot fail after construction.
+        self.present_interval_histogram
+            .record(duration.as_nanos() as u64)
+            .ok();
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.dirty_to_draw_duration_histogram.is_empty()
+            && self.draw_duration_histogram.is_empty()
+            && self.present_interval_histogram.is_empty()
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -30,10 +30,7 @@ use futures::FutureExt;
 use futures::channel::oneshot;
 use gpui_util::post_inc;
 use gpui_util::{ResultExt, measure};
-#[cfg(any(
-    feature = "input-latency-histogram",
-    feature = "frame-duration-histogram"
-))]
+#[cfg(feature = "input-latency-histogram")]
 use hdrhistogram::Histogram;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
@@ -128,8 +125,8 @@ struct WindowInvalidatorInner {
 
 /// Per-frame invalidation bookkeeping, drained at draw time and emitted to the
 /// frame profiler. Tracks when the current frame first became dirty and how
-/// many invalidations were coalesced into it. Only populated while
-/// `profiler::frame_trace_enabled()` is set.
+/// many invalidations were coalesced into it. Populated while frame-duration
+/// histograms or frame tracing are enabled.
 #[derive(Default)]
 struct FrameDirtyAccumulator {
     dirty_at: Option<Instant>,
@@ -223,7 +220,7 @@ impl WindowInvalidator {
     }
 
     fn record_frame_dirty(inner: &mut WindowInvalidatorInner) {
-        if profiler::frame_trace_enabled() {
+        if cfg!(feature = "frame-duration-histogram") || profiler::frame_trace_enabled() {
             inner.frame_dirty.dirty_at.get_or_insert_with(Instant::now);
             inner.frame_dirty.invalidations += 1;
         }
@@ -1319,18 +1316,6 @@ impl InputLatencyTracker {
     }
 }
 
-/// A point-in-time snapshot of the frame-duration histograms for a window,
-/// suitable for external formatting.
-#[cfg(feature = "frame-duration-histogram")]
-#[derive(Clone)]
-pub struct FrameDurationSnapshot {
-    /// Histogram of `Window::draw` durations, in nanoseconds.
-    pub draw_duration_histogram: Histogram<u64>,
-    /// Histogram of intervals between consecutively presented frames while the
-    /// window was animating, in nanoseconds.
-    pub present_interval_histogram: Histogram<u64>,
-}
-
 /// Records how long the window takes to produce frames: the duration of every
 /// draw, and the interval between consecutive presents while the window is
 /// animating (a next-frame callback was already scheduled when the previous
@@ -1342,11 +1327,7 @@ pub struct FrameDurationSnapshot {
 /// indistinguishable from missed frames.
 #[cfg(feature = "frame-duration-histogram")]
 struct FrameDurationTracker {
-    /// Histogram of `Window::draw` durations, in nanoseconds.
-    draw_duration_histogram: Histogram<u64>,
-    /// Histogram of intervals between consecutively presented frames while the
-    /// window was animating, in nanoseconds.
-    present_interval_histogram: Histogram<u64>,
+    snapshot: profiler::FrameDurationSnapshot,
     /// When the window last presented a newly drawn frame.
     last_present_at: Option<Instant>,
     /// Whether the window was animating (and active) when the last frame was
@@ -1362,20 +1343,15 @@ struct FrameDurationTracker {
 impl FrameDurationTracker {
     fn new() -> Result<Self> {
         Ok(Self {
-            draw_duration_histogram: Histogram::new(3)
-                .map_err(|e| anyhow!("Failed to create draw duration histogram: {e}"))?,
-            present_interval_histogram: Histogram::new(3)
-                .map_err(|e| anyhow!("Failed to create present interval histogram: {e}"))?,
+            snapshot: profiler::FrameDurationSnapshot::new()?,
             last_present_at: None,
             animating_at_last_present: false,
             drew_since_last_present: false,
         })
     }
 
-    fn record_draw(&mut self, duration: Duration) {
-        self.draw_duration_histogram
-            .record(duration.as_nanos() as u64)
-            .ok();
+    fn record_frame_timing(&mut self, timing: &profiler::FrameTiming) {
+        self.snapshot.record_frame_timing(timing);
         self.drew_since_last_present = true;
     }
 
@@ -1397,18 +1373,15 @@ impl FrameDurationTracker {
             && window_active
             && let Some(last_present_at) = self.last_present_at
         {
-            let interval_nanos = presented_at.duration_since(last_present_at).as_nanos() as u64;
-            self.present_interval_histogram.record(interval_nanos).ok();
+            self.snapshot
+                .record_present_interval(presented_at.duration_since(last_present_at));
         }
         self.last_present_at = Some(presented_at);
         self.animating_at_last_present = next_frame_scheduled && window_active;
     }
 
-    fn snapshot(&self) -> FrameDurationSnapshot {
-        FrameDurationSnapshot {
-            draw_duration_histogram: self.draw_duration_histogram.clone(),
-            present_interval_histogram: self.present_interval_histogram.clone(),
-        }
+    fn snapshot(&self) -> profiler::FrameDurationSnapshot {
+        self.snapshot.clone()
     }
 }
 
@@ -3090,16 +3063,17 @@ impl Window {
 
         if let Some(draw_start) = draw_started_at {
             let draw_end = Instant::now();
-            #[cfg(feature = "frame-duration-histogram")]
-            self.frame_duration_tracker
-                .record_draw(draw_end.duration_since(draw_start));
-            profiler::record_frame_timing(profiler::FrameTiming {
+            let frame_timing = profiler::FrameTiming {
                 window_id: self.handle.window_id(),
                 dirty_at: frame_dirty.dirty_at,
                 invalidations: frame_dirty.invalidations,
                 draw_start,
                 draw_end,
-            });
+            };
+            #[cfg(feature = "frame-duration-histogram")]
+            self.frame_duration_tracker
+                .record_frame_timing(&frame_timing);
+            profiler::record_frame_timing(frame_timing);
         }
 
         // Exit the scope to obtain the arena-clear token this draw owes; the
@@ -3167,7 +3141,7 @@ impl Window {
 
     /// Returns a snapshot of the current frame-duration histograms.
     #[cfg(feature = "frame-duration-histogram")]
-    pub fn frame_duration_snapshot(&self) -> FrameDurationSnapshot {
+    pub fn frame_duration_snapshot(&self) -> profiler::FrameDurationSnapshot {
         self.frame_duration_tracker.snapshot()
     }
 
@@ -7578,7 +7552,7 @@ mod tests {
 
     #[cfg(feature = "frame-duration-histogram")]
     mod frame_duration_tracker {
-        use crate::window::FrameDurationTracker;
+        use crate::{WindowId, profiler::FrameTiming, window::FrameDurationTracker};
         use scheduler::Instant;
         use std::time::Duration;
 
@@ -7590,7 +7564,7 @@ mod tests {
             window_active: bool,
             next_frame_scheduled: bool,
         ) {
-            tracker.record_draw(Duration::from_millis(2));
+            record_draw(tracker, Duration::from_millis(2));
             tracker.record_present(presented_at, window_active, next_frame_scheduled);
         }
 
@@ -7601,20 +7575,20 @@ mod tests {
 
             // The first frame has nothing to measure an interval against.
             draw_and_present(&mut tracker, start, true, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 0);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 0);
 
             draw_and_present(&mut tracker, start + FRAME, true, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 1);
 
             // The animation ends here: no next frame was scheduled when this
             // frame was presented.
             draw_and_present(&mut tracker, start + FRAME * 2, true, false);
-            assert_eq!(tracker.present_interval_histogram.len(), 2);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 2);
 
             // The window sat idle before an input-driven frame; the gap is not
             // an animation interval.
             draw_and_present(&mut tracker, start + FRAME * 100, true, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 2);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 2);
         }
 
         #[test]
@@ -7625,7 +7599,7 @@ mod tests {
             draw_and_present(&mut tracker, start, true, true);
             draw_and_present(&mut tracker, start + FRAME * 5, true, true);
 
-            let recorded = tracker.present_interval_histogram.max();
+            let recorded = tracker.snapshot.present_interval_histogram.max();
             assert!(recorded >= (FRAME * 4).as_nanos() as u64);
         }
 
@@ -7641,9 +7615,12 @@ mod tests {
             tracker.record_present(start + FRAME / 2, true, true);
             draw_and_present(&mut tracker, start + FRAME, true, true);
 
-            assert_eq!(tracker.present_interval_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 1);
             // The interval spans from the drawn frame, not the re-present.
-            assert!(tracker.present_interval_histogram.max() >= (FRAME * 3 / 4).as_nanos() as u64);
+            assert!(
+                tracker.snapshot.present_interval_histogram.max()
+                    >= (FRAME * 3 / 4).as_nanos() as u64
+            );
         }
 
         #[test]
@@ -7653,27 +7630,57 @@ mod tests {
 
             draw_and_present(&mut tracker, start, false, true);
             draw_and_present(&mut tracker, start + FRAME, false, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 0);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 0);
 
             // The first interval after reactivation began while the window was
             // inactive (and possibly throttled), so it is also skipped.
             draw_and_present(&mut tracker, start + FRAME * 2, true, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 0);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 0);
 
             draw_and_present(&mut tracker, start + FRAME * 3, true, true);
-            assert_eq!(tracker.present_interval_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.present_interval_histogram.len(), 1);
         }
 
         #[test]
         fn records_every_draw_duration() {
             let mut tracker = FrameDurationTracker::new().unwrap();
 
-            tracker.record_draw(Duration::from_millis(2));
-            tracker.record_draw(Duration::from_millis(40));
+            record_draw(&mut tracker, Duration::from_millis(2));
+            record_draw(&mut tracker, Duration::from_millis(40));
 
             let snapshot = tracker.snapshot();
             assert_eq!(snapshot.draw_duration_histogram.len(), 2);
             assert!(snapshot.draw_duration_histogram.max() >= 39_000_000);
+        }
+
+        #[test]
+        fn records_profiler_frame_details() {
+            let mut tracker = FrameDurationTracker::new().unwrap();
+            let draw_start = Instant::now();
+            let timing = FrameTiming {
+                window_id: WindowId::from(0),
+                dirty_at: Some(draw_start - Duration::from_millis(3)),
+                invalidations: 4,
+                draw_start,
+                draw_end: draw_start + Duration::from_millis(2),
+            };
+
+            tracker.record_frame_timing(&timing);
+
+            assert_eq!(tracker.snapshot.draw_duration_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.dirty_to_draw_duration_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.invalidations_per_frame_histogram.max(), 4);
+        }
+
+        fn record_draw(tracker: &mut FrameDurationTracker, duration: Duration) {
+            let draw_start = Instant::now();
+            tracker.record_frame_timing(&FrameTiming {
+                window_id: WindowId::from(0),
+                dirty_at: None,
+                invalidations: 0,
+                draw_start,
+                draw_end: draw_start + duration,
+            });
         }
     }
 }


### PR DESCRIPTION
The frame-duration tracker and GPUI benchmark reports both accumulate data from `FrameTiming`, but they previously maintained separate histogram types and separate recording logic. That duplication made it easy for benchmark diagnostics and runtime diagnostics to diverge as frame timing gains more detail.

This moves the histogram snapshot next to `FrameTiming` in the profiler and makes both paths consume it. Each completed draw now creates one `FrameTiming`: live windows record it directly into their cumulative snapshot, while benchmark collectors record the same profiler timings after each measurement. Presentation intervals remain live-window-only because the benchmark harness has no display-vsync cadence to measure meaningfully.

The shared snapshot now also carries dirty-to-draw duration and invalidations-per-frame. Bench reports retain their existing output, while live snapshots can expose the same dimensions to future diagnostics without another parallel accumulator.

Testing performed:

- `cargo test -p gpui --features bench,frame-duration-histogram`
- `cargo check -p input_latency_ui`
- `./script/clippy -p gpui --features bench,frame-duration-histogram`
- `cargo fmt --all -- --check`

Release Notes:

- N/A
