### PR TITLE
gpui: Attribute slow draws to actions and tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9177,6 +9177,7 @@ dependencies = [
  "collections",
  "gpui",
  "hdrhistogram",
+ "serde",
  "telemetry",
 ]
 

--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -894,6 +894,8 @@ mod tests {
             invalidations: 2,
             draw_start,
             draw_end: draw_start + Duration::from_millis(2),
+            invalidating_task_location: None,
+            invalidating_action_name: None,
         };
 
         report.record_frame_timings([&timing]);

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -16,7 +16,7 @@ use std::{
 
 mod actions;
 pub use actions::{ActionStatistics, ActionTiming, take_action_stats};
-pub(crate) use actions::{save_action_timing, update_running_action};
+pub(crate) use actions::{current_action_name, save_action_timing, update_running_action};
 
 use serde::{Deserialize, Serialize};
 
@@ -657,6 +657,16 @@ impl Drop for ThreadTimings {
     }
 }
 
+#[cfg(feature = "profiler")]
+pub(crate) fn current_task_location() -> Option<&'static std::panic::Location<'static>> {
+    THREAD_TIMINGS.with(|timings| timings.lock().running.map(|timing| timing.location))
+}
+
+#[cfg(not(feature = "profiler"))]
+pub(crate) fn current_task_location() -> Option<&'static std::panic::Location<'static>> {
+    None
+}
+
 #[doc(hidden)]
 pub fn update_running_task(spawned: SpawnTime, location: &'static std::panic::Location<'_>) {
     THREAD_TIMINGS.with(|timings| {
@@ -720,6 +730,12 @@ pub struct FrameTiming {
     pub draw_start: Instant,
     /// When `Window::draw` finished.
     pub draw_end: Instant,
+    /// Spawn location of the task that first invalidated the frame, if one was
+    /// running and task profiling was enabled.
+    pub invalidating_task_location: Option<&'static std::panic::Location<'static>>,
+    /// Name of the action that first invalidated the frame, if one was running
+    /// and action profiling was enabled.
+    pub invalidating_action_name: Option<&'static str>,
 }
 
 impl FrameTiming {
@@ -735,6 +751,11 @@ impl FrameTiming {
             .map(|dirty_at| self.draw_end.duration_since(dirty_at))
     }
 }
+
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+const SLOW_FRAME_ATTRIBUTION_THRESHOLD: Duration = Duration::from_millis(16);
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+const MAX_SLOW_FRAME_ATTRIBUTIONS: usize = 1_000;
 
 /// A point-in-time snapshot of frame timing histograms.
 ///
@@ -754,6 +775,12 @@ pub struct FrameDurationSnapshot {
     pub present_interval_histogram: Histogram<u64>,
     /// Histogram of invalidations coalesced into each frame.
     pub invalidations_per_frame_histogram: Histogram<u64>,
+    /// Counts of slow draws grouped by the task that first invalidated the
+    /// frame.
+    pub slow_draws_by_task_location: HashMap<&'static std::panic::Location<'static>, u64>,
+    /// Counts of slow draws grouped by the action that first invalidated the
+    /// frame.
+    pub slow_draws_by_action_name: HashMap<&'static str, u64>,
 }
 
 #[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
@@ -772,6 +799,8 @@ impl FrameDurationSnapshot {
             invalidations_per_frame_histogram: Histogram::new(3).map_err(|error| {
                 anyhow::anyhow!("Failed to create invalidations-per-frame histogram: {error}")
             })?,
+            slow_draws_by_task_location: HashMap::default(),
+            slow_draws_by_action_name: HashMap::default(),
         })
     }
 
@@ -790,6 +819,16 @@ impl FrameDurationSnapshot {
                 .record(timing.invalidations)
                 .ok();
         }
+
+        if timing.draw_duration() >= SLOW_FRAME_ATTRIBUTION_THRESHOLD {
+            std::hint::cold_path();
+            if let Some(location) = timing.invalidating_task_location {
+                increment_slow_draw_count(&mut self.slow_draws_by_task_location, location);
+            }
+            if let Some(action_name) = timing.invalidating_action_name {
+                increment_slow_draw_count(&mut self.slow_draws_by_action_name, action_name);
+            }
+        }
     }
 
     #[cfg(feature = "frame-duration-histogram")]
@@ -805,6 +844,18 @@ impl FrameDurationSnapshot {
         self.dirty_to_draw_duration_histogram.is_empty()
             && self.draw_duration_histogram.is_empty()
             && self.present_interval_histogram.is_empty()
+    }
+}
+
+#[cfg(any(feature = "bench", feature = "frame-duration-histogram"))]
+fn increment_slow_draw_count<K>(counts: &mut HashMap<K, u64>, key: K)
+where
+    K: Eq + Hash,
+{
+    if let Some(count) = counts.get_mut(&key) {
+        *count = count.saturating_add(1);
+    } else if counts.len() < MAX_SLOW_FRAME_ATTRIBUTIONS {
+        counts.insert(key, 1);
     }
 }
 

--- a/crates/gpui/src/profiler/actions.rs
+++ b/crates/gpui/src/profiler/actions.rs
@@ -181,6 +181,16 @@ impl ActionTiming {
 static ACTION_STATISTICS: spin::Mutex<ActionStatistics> =
     const { spin::Mutex::new(ActionStatistics::new()) };
 
+#[cfg(feature = "profiler")]
+pub(crate) fn current_action_name() -> Option<&'static str> {
+    ACTION_STATISTICS.lock().running.map(|(name, _)| name)
+}
+
+#[cfg(not(feature = "profiler"))]
+pub(crate) fn current_action_name() -> Option<&'static str> {
+    None
+}
+
 #[doc(hidden)]
 #[cfg(feature = "profiler")]
 pub(crate) fn update_running_action(action: &(dyn Action + 'static), cx: &mut crate::App) {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -131,6 +131,8 @@ struct WindowInvalidatorInner {
 struct FrameDirtyAccumulator {
     dirty_at: Option<Instant>,
     invalidations: u64,
+    invalidating_task_location: Option<&'static std::panic::Location<'static>>,
+    invalidating_action_name: Option<&'static str>,
 }
 
 #[derive(Clone)]
@@ -221,7 +223,11 @@ impl WindowInvalidator {
 
     fn record_frame_dirty(inner: &mut WindowInvalidatorInner) {
         if cfg!(feature = "frame-duration-histogram") || profiler::frame_trace_enabled() {
-            inner.frame_dirty.dirty_at.get_or_insert_with(Instant::now);
+            if inner.frame_dirty.dirty_at.is_none() {
+                inner.frame_dirty.dirty_at = Some(Instant::now());
+                inner.frame_dirty.invalidating_task_location = profiler::current_task_location();
+                inner.frame_dirty.invalidating_action_name = profiler::current_action_name();
+            }
             inner.frame_dirty.invalidations += 1;
         }
     }
@@ -3069,6 +3075,8 @@ impl Window {
                 invalidations: frame_dirty.invalidations,
                 draw_start,
                 draw_end,
+                invalidating_task_location: frame_dirty.invalidating_task_location,
+                invalidating_action_name: frame_dirty.invalidating_action_name,
             };
             #[cfg(feature = "frame-duration-histogram")]
             self.frame_duration_tracker
@@ -7554,7 +7562,7 @@ mod tests {
     mod frame_duration_tracker {
         use crate::{WindowId, profiler::FrameTiming, window::FrameDurationTracker};
         use scheduler::Instant;
-        use std::time::Duration;
+        use std::{panic::Location, time::Duration};
 
         const FRAME: Duration = Duration::from_millis(16);
 
@@ -7657,12 +7665,15 @@ mod tests {
         fn records_profiler_frame_details() {
             let mut tracker = FrameDurationTracker::new().unwrap();
             let draw_start = Instant::now();
+            let task_location = Location::caller();
             let timing = FrameTiming {
                 window_id: WindowId::from(0),
                 dirty_at: Some(draw_start - Duration::from_millis(3)),
                 invalidations: 4,
                 draw_start,
-                draw_end: draw_start + Duration::from_millis(2),
+                draw_end: draw_start + Duration::from_millis(20),
+                invalidating_task_location: Some(task_location),
+                invalidating_action_name: Some("test::SlowAction"),
             };
 
             tracker.record_frame_timing(&timing);
@@ -7670,6 +7681,38 @@ mod tests {
             assert_eq!(tracker.snapshot.draw_duration_histogram.len(), 1);
             assert_eq!(tracker.snapshot.dirty_to_draw_duration_histogram.len(), 1);
             assert_eq!(tracker.snapshot.invalidations_per_frame_histogram.max(), 4);
+            assert_eq!(
+                tracker
+                    .snapshot
+                    .slow_draws_by_task_location
+                    .get(task_location),
+                Some(&1)
+            );
+            assert_eq!(
+                tracker
+                    .snapshot
+                    .slow_draws_by_action_name
+                    .get("test::SlowAction"),
+                Some(&1)
+            );
+        }
+
+        #[test]
+        fn ignores_attribution_for_fast_draws() {
+            let mut tracker = FrameDurationTracker::new().unwrap();
+            let draw_start = Instant::now();
+            tracker.record_frame_timing(&FrameTiming {
+                window_id: WindowId::from(0),
+                dirty_at: Some(draw_start),
+                invalidations: 1,
+                draw_start,
+                draw_end: draw_start + Duration::from_millis(15),
+                invalidating_task_location: Some(Location::caller()),
+                invalidating_action_name: Some("test::FastAction"),
+            });
+
+            assert!(tracker.snapshot.slow_draws_by_task_location.is_empty());
+            assert!(tracker.snapshot.slow_draws_by_action_name.is_empty());
         }
 
         fn record_draw(tracker: &mut FrameDurationTracker, duration: Duration) {
@@ -7680,6 +7723,8 @@ mod tests {
                 invalidations: 0,
                 draw_start,
                 draw_end: draw_start + duration,
+                invalidating_task_location: None,
+                invalidating_action_name: None,
             });
         }
     }

--- a/crates/input_latency_ui/Cargo.toml
+++ b/crates/input_latency_ui/Cargo.toml
@@ -19,4 +19,5 @@ gpui = { workspace = true, features = [
     "input-latency-histogram",
 ] }
 hdrhistogram.workspace = true
+serde.workspace = true
 telemetry.workspace = true

--- a/crates/input_latency_ui/src/input_latency_ui.rs
+++ b/crates/input_latency_ui/src/input_latency_ui.rs
@@ -1,7 +1,10 @@
 use collections::{HashMap, HashSet};
 use gpui::{App, FrameDurationSnapshot, Global, InputLatencySnapshot, Window, WindowId, actions};
 use hdrhistogram::Histogram;
-use std::time::Instant;
+use std::{
+    hash::{BuildHasher, Hash},
+    time::Instant,
+};
 
 actions!(
     dev,
@@ -177,6 +180,12 @@ struct FrameDurationTelemetryState {
 
 impl Global for FrameDurationTelemetryState {}
 
+#[derive(Debug, Eq, PartialEq, serde::Serialize)]
+struct SlowFrameAttribution {
+    label: String,
+    slow_draw_count: u64,
+}
+
 /// Nanosecond boundaries for the present-interval buckets used in telemetry:
 /// roughly the 120Hz, 60Hz, and 30Hz frame budgets, with headroom for jitter.
 const MS9_NS: u64 = 9_000_000;
@@ -208,8 +217,27 @@ pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
         .retain(|window_id, _| open_window_ids.contains(window_id));
     let now = Instant::now();
 
+    let previous = state.previous.get(&window_id);
+    let slow_draw_task_locations = top_count_deltas(
+        &current.slow_draws_by_task_location,
+        previous.map(|(_, snapshot)| &snapshot.slow_draws_by_task_location),
+        |location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        },
+    );
+    let slow_draw_action_names = top_count_deltas(
+        &current.slow_draws_by_action_name,
+        previous.map(|(_, snapshot)| &snapshot.slow_draws_by_action_name),
+        |action_name| (*action_name).to_string(),
+    );
+
     let (delta_draws, delta_intervals, report_window_seconds) =
-        if let Some((prev_instant, prev_snapshot)) = state.previous.get(&window_id) {
+        if let Some((prev_instant, prev_snapshot)) = previous {
             let mut delta_draws = current.draw_duration_histogram.clone();
             delta_draws
                 .subtract(&prev_snapshot.draw_duration_histogram)
@@ -264,8 +292,45 @@ pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
         intervals_18to36 = intervals_18to36,
         intervals_36to100 = intervals_36to100,
         total_intervals = total_intervals,
+        slow_draw_task_locations = slow_draw_task_locations,
+        slow_draw_action_names = slow_draw_action_names,
         report_window_seconds = report_window_seconds,
     );
+}
+
+fn top_count_deltas<K, S>(
+    current: &std::collections::HashMap<K, u64, S>,
+    previous: Option<&std::collections::HashMap<K, u64, S>>,
+    format_label: impl Fn(&K) -> String,
+) -> Vec<SlowFrameAttribution>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    const MAX_ATTRIBUTIONS: usize = 5;
+
+    let mut attributions = current
+        .iter()
+        .filter_map(|(key, current_count)| {
+            let previous_count = previous
+                .and_then(|previous| previous.get(key))
+                .copied()
+                .unwrap_or_default();
+            let slow_draw_count = current_count.saturating_sub(previous_count);
+            (slow_draw_count > 0).then(|| SlowFrameAttribution {
+                label: format_label(key),
+                slow_draw_count,
+            })
+        })
+        .collect::<Vec<_>>();
+    attributions.sort_unstable_by(|left, right| {
+        right
+            .slow_draw_count
+            .cmp(&left.slow_draw_count)
+            .then_with(|| left.label.cmp(&right.label))
+    });
+    attributions.truncate(MAX_ATTRIBUTIONS);
+    attributions
 }
 
 fn open_window_ids(cx: &App) -> HashSet<WindowId> {
@@ -467,5 +532,37 @@ fn write_latency_distribution(report: &mut String, heading: &str, histogram: &Hi
             "  {range:>8}  {note:<11}: {count:>6} ({:>5.1}%) {bar}\n",
             fraction * 100.0,
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_count_deltas_returns_ranked_new_counts() {
+        let previous = HashMap::from_iter([("unchanged", 2), ("increased", 1)]);
+        let current =
+            HashMap::from_iter([("unchanged", 2), ("increased", 4), ("new", 5), ("small", 1)]);
+
+        let attributions = top_count_deltas(&current, Some(&previous), |name| name.to_string());
+
+        assert_eq!(
+            attributions,
+            vec![
+                SlowFrameAttribution {
+                    label: "new".to_string(),
+                    slow_draw_count: 5,
+                },
+                SlowFrameAttribution {
+                    label: "increased".to_string(),
+                    slow_draw_count: 3,
+                },
+                SlowFrameAttribution {
+                    label: "small".to_string(),
+                    slow_draw_count: 1,
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
Frame-duration histograms show how often drawing is slow, but they do not identify which application work initiated those frames. Capturing a native call stack after a draw completes would only see the end of GPUI's draw path, while unwinding during every draw would add overhead to the path being measured.

This instead attaches descriptors the profiler already owns to the first invalidation of each frame: the current action name and the running foreground task's spawn location. The descriptors travel with `FrameTiming`, but GPUI only aggregates them when the completed draw takes at least 16 ms. Existing descriptors continue accumulating while each per-window map is capped at 1,000 unique keys, keeping both normal-frame overhead and long-session memory bounded.

The periodic frame-duration report sends the top five new task locations and action names since its previous snapshot. These fields identify the work that initiated recurring slow frames without claiming to be a sampled CPU hot stack; deeper function-level attribution can still be added behind an explicit sampling profiler if needed.

This is stacked on #62461, which provides the shared frame snapshot consumed by both live windows and GPUI benchmarks.

Testing performed:

- `cargo test -p gpui --features bench,frame-duration-histogram,profiler`
- `cargo test -p input_latency_ui`
- `cargo check -p gpui --features frame-duration-histogram`
- `cargo check -p gpui --features bench`
- `./script/clippy -p gpui -p input_latency_ui`
- `cargo fmt --all -- --check`

Release Notes:

- N/A
