### PR TITLE
gpui: Avoid allocating cached font resolution failures

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -16,7 +16,7 @@ use crate::{
     Bounds, DevicePixels, Hsla, Pixels, PlatformTextSystem, Point, Result, SharedString, Size,
     StrikethroughStyle, TextRenderingMode, UnderlineStyle, px,
 };
-use anyhow::{Context as _, anyhow};
+use anyhow::Context as _;
 use collections::FxHashMap;
 use core::fmt;
 use derive_more::{Add, Deref, FromStr, Sub};
@@ -50,7 +50,7 @@ pub const SUBPIXEL_VARIANTS_Y: u8 = 1;
 /// The GPUI text rendering sub system.
 pub struct TextSystem {
     platform_text_system: Arc<dyn PlatformTextSystem>,
-    font_ids_by_font: RwLock<FxHashMap<Font, Result<FontId>>>,
+    font_ids_by_font: RwLock<FxHashMap<Font, Option<FontId>>>,
     font_metrics: RwLock<FxHashMap<FontId, FontMetrics>>,
     raster_bounds: RwLock<FxHashMap<RenderGlyphParams, Bounds<DevicePixels>>>,
     wrapper_pool: Mutex<FxHashMap<FontIdWithSize, Vec<LineWrapper>>>,
@@ -104,28 +104,21 @@ impl TextSystem {
     }
 
     /// Get the FontId for the configure font family and style.
-    fn font_id(&self, font: &Font) -> Result<FontId> {
-        fn clone_font_id_result(font_id: &Result<FontId>) -> Result<FontId> {
-            match font_id {
-                Ok(font_id) => Ok(*font_id),
-                Err(err) => Err(anyhow!("{err}")),
-            }
+    fn font_id(&self, font: &Font) -> Option<FontId> {
+        if let Some(font_id) = self.font_ids_by_font.read().get(font) {
+            return *font_id;
         }
 
-        let font_id = self
-            .font_ids_by_font
-            .read()
-            .get(font)
-            .map(clone_font_id_result);
-        if let Some(font_id) = font_id {
-            font_id
-        } else {
-            let font_id = self.platform_text_system.font_id(font);
-            self.font_ids_by_font
-                .write()
-                .insert(font.clone(), clone_font_id_result(&font_id));
-            font_id
-        }
+        let font_id = match self.platform_text_system.font_id(font) {
+            Ok(font_id) => Some(font_id),
+            Err(err) => {
+                log::warn!("failed to resolve font {:?}: {err:#}", font.family);
+                None
+            }
+        };
+
+        self.font_ids_by_font.write().insert(font.clone(), font_id);
+        font_id
     }
 
     /// Get the Font for the Font Id.
@@ -133,7 +126,7 @@ impl TextSystem {
         let lock = self.font_ids_by_font.read();
         lock.iter()
             .filter_map(|(font, result)| match result {
-                Ok(font_id) if *font_id == id => Some(font.clone()),
+                Some(font_id) if *font_id == id => Some(font.clone()),
                 _ => None,
             })
             .next()
@@ -146,11 +139,11 @@ impl TextSystem {
     ///
     /// Panics if the font and none of the fallbacks can be resolved.
     pub fn resolve_font(&self, font: &Font) -> FontId {
-        if let Ok(font_id) = self.font_id(font) {
+        if let Some(font_id) = self.font_id(font) {
             return font_id;
         }
         for fallback in &self.fallback_font_stack {
-            if let Ok(font_id) = self.font_id(fallback) {
+            if let Some(font_id) = self.font_id(fallback) {
                 return font_id;
             }
         }


### PR DESCRIPTION
# Objective

Stop allocating the font lookup failure on every lookup. This was very noticable when launching an app on Linux with `.SystemUIFont` where many of the fonts in this fallback list generally don't exist. I'm not sure Zed was that affected because it bundles the .Zed IBM Plex Sans and Lilex fonts.

## Solution

Previously, each cached font resolution failure allocated a new `anyhow`error on every lookup. Store failures as `None` instead and log the original error when the lookup first fails.

## Testing

- Launched zed with the release profile on Linux
- Profiled another gpui app with samply to make sure it doesn't show up any more

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

N/A
