### PR TITLE
gpui_util: Respect custom Scoop installation paths

### DIFF
--- a/crates/gpui_util/src/lib.rs
+++ b/crates/gpui_util/src/lib.rs
@@ -94,8 +94,12 @@ pub fn get_powershell() -> Option<String> {
     }
 
     fn find_pwsh_in_scoop() -> Option<PathBuf> {
-        let pwsh_exe =
-            PathBuf::from(std::env::var_os("USERPROFILE")?).join("scoop\\shims\\pwsh.exe");
+        // Scoop can be installed to a custom location; $SCOOP points at the
+        // scoop root in that case and defaults to %USERPROFILE%\scoop otherwise.
+        let scoop_dir = std::env::var_os("SCOOP").map(PathBuf::from).or_else(|| {
+            std::env::var_os("USERPROFILE").map(|home| PathBuf::from(home).join("scoop"))
+        })?;
+        let pwsh_exe = scoop_dir.join("shims").join("pwsh.exe");
         pwsh_exe.is_file().then_some(pwsh_exe)
     }
 


### PR DESCRIPTION
# Objective

- Fix PowerShell discovery when Scoop is installed outside the default `%USERPROFILE%\scoop` directory.
- Zed currently ignores Scoop's `SCOOP` environment variable, so it can miss `pwsh.exe` and fall back to another shell.

## Solution

- Use the `SCOOP` environment variable as the Scoop root when it is set.
- Fall back to `%USERPROFILE%\scoop` when `SCOOP` is unset.
- Preserve the PowerShell discovery order and file validation from the current `main` branch.

The original change also covered Git Bash. That is no longer needed after #63339 changed Git Bash discovery to follow the active Git installation.

## Testing

- `cargo fmt --all --check`
- `cargo test -p gpui_util` — 2 passed, 0 failed.
- `cargo check -p gpui_util --tests --target x86_64-pc-windows-msvc` — passed.
- Did not runtime-test the Windows-specific path on this macOS host because Windows test binaries cannot run natively here.
- To test manually on Windows, set `SCOOP` to a custom Scoop root containing `shims\pwsh.exe`, launch Zed, and verify that PowerShell is selected.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed PowerShell installed by Scoop not being detected when Scoop uses a custom installation directory.
- [GPUI] Fixed PowerShell discovery for custom Scoop installations on Windows.
