### PR TITLE
gpui: Break frame timings down by draw phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9177,6 +9177,7 @@ dependencies = [
  "collections",
  "gpui",
  "hdrhistogram",
+ "log",
  "serde",
  "telemetry",
 ]

--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -142,6 +142,15 @@ impl BenchReport {
             &frame_snapshot.dirty_to_draw_duration_histogram,
         );
         self.print_histogram("window draw", &frame_snapshot.draw_duration_histogram);
+        self.print_histogram(
+            "window prepaint",
+            &frame_snapshot.prepaint_duration_histogram,
+        );
+        self.print_histogram("window paint", &frame_snapshot.paint_duration_histogram);
+        self.print_histogram(
+            "window postpaint",
+            &frame_snapshot.postpaint_duration_histogram,
+        );
         if !frame_snapshot.invalidations_per_frame_histogram.is_empty() {
             eprintln!(
                 "  invalidations per frame: mean {:.2}, max {}",
@@ -893,9 +902,11 @@ mod tests {
             dirty_at: Some(draw_start - Duration::from_millis(3)),
             invalidations: 2,
             draw_start,
-            draw_end: draw_start + Duration::from_millis(2),
+            draw_end: draw_start + Duration::from_millis(4),
             invalidating_task_location: None,
             invalidating_action_name: None,
+            paint_started_at: Some(draw_start + Duration::from_millis(1)),
+            paint_finished_at: Some(draw_start + Duration::from_millis(3)),
         };
 
         report.record_frame_timings([&timing]);
@@ -904,6 +915,9 @@ mod tests {
         assert_eq!(snapshot.draw_duration_histogram.len(), 1);
         assert_eq!(snapshot.dirty_to_draw_duration_histogram.len(), 1);
         assert_eq!(snapshot.invalidations_per_frame_histogram.max(), 2);
+        assert_eq!(snapshot.prepaint_duration_histogram.len(), 1);
+        assert_eq!(snapshot.paint_duration_histogram.len(), 1);
+        assert_eq!(snapshot.postpaint_duration_histogram.len(), 1);
     }
 
     #[test]

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -736,6 +736,11 @@ pub struct FrameTiming {
     /// Name of the action that first invalidated the frame, if one was running
     /// and action profiling was enabled.
     pub invalidating_action_name: Option<&'static str>,
+    /// When element painting started, after layout and prepaint completed.
+    pub paint_started_at: Option<Instant>,
+    /// When element painting finished, before accessibility and frame
+    /// finalization.
+    pub paint_finished_at: Option<Instant>,
 }
 
 impl FrameTiming {
@@ -749,6 +754,27 @@ impl FrameTiming {
     pub fn dirty_to_draw_duration(&self) -> Option<Duration> {
         self.dirty_at
             .map(|dirty_at| self.draw_end.duration_since(dirty_at))
+    }
+
+    /// Time from the start of `Window::draw` through layout and prepaint.
+    pub fn prepaint_duration(&self) -> Option<Duration> {
+        self.paint_started_at
+            .map(|paint_started_at| paint_started_at.duration_since(self.draw_start))
+    }
+
+    /// Time spent painting elements.
+    pub fn paint_duration(&self) -> Option<Duration> {
+        self.paint_started_at.zip(self.paint_finished_at).map(
+            |(paint_started_at, paint_finished_at)| {
+                paint_finished_at.duration_since(paint_started_at)
+            },
+        )
+    }
+
+    /// Time from the end of element painting through the end of `Window::draw`.
+    pub fn postpaint_duration(&self) -> Option<Duration> {
+        self.paint_finished_at
+            .map(|paint_finished_at| self.draw_end.duration_since(paint_finished_at))
     }
 }
 
@@ -770,6 +796,12 @@ pub struct FrameDurationSnapshot {
     pub dirty_to_draw_duration_histogram: Histogram<u64>,
     /// Histogram of `Window::draw` durations, in nanoseconds.
     pub draw_duration_histogram: Histogram<u64>,
+    /// Histogram of layout and prepaint durations, in nanoseconds.
+    pub prepaint_duration_histogram: Histogram<u64>,
+    /// Histogram of element paint durations, in nanoseconds.
+    pub paint_duration_histogram: Histogram<u64>,
+    /// Histogram of postpaint finalization durations, in nanoseconds.
+    pub postpaint_duration_histogram: Histogram<u64>,
     /// Histogram of intervals between consecutively presented frames while the
     /// window was animating, in nanoseconds.
     pub present_interval_histogram: Histogram<u64>,
@@ -793,6 +825,15 @@ impl FrameDurationSnapshot {
             draw_duration_histogram: Histogram::new(3).map_err(|error| {
                 anyhow::anyhow!("Failed to create draw duration histogram: {error}")
             })?,
+            prepaint_duration_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create prepaint duration histogram: {error}")
+            })?,
+            paint_duration_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create paint duration histogram: {error}")
+            })?,
+            postpaint_duration_histogram: Histogram::new(3).map_err(|error| {
+                anyhow::anyhow!("Failed to create postpaint duration histogram: {error}")
+            })?,
             present_interval_histogram: Histogram::new(3).map_err(|error| {
                 anyhow::anyhow!("Failed to create present interval histogram: {error}")
             })?,
@@ -812,6 +853,21 @@ impl FrameDurationSnapshot {
         if let Some(dirty_to_draw_duration) = timing.dirty_to_draw_duration() {
             self.dirty_to_draw_duration_histogram
                 .record(dirty_to_draw_duration.as_nanos() as u64)
+                .ok();
+        }
+        if let Some(prepaint_duration) = timing.prepaint_duration() {
+            self.prepaint_duration_histogram
+                .record(prepaint_duration.as_nanos() as u64)
+                .ok();
+        }
+        if let Some(paint_duration) = timing.paint_duration() {
+            self.paint_duration_histogram
+                .record(paint_duration.as_nanos() as u64)
+                .ok();
+        }
+        if let Some(postpaint_duration) = timing.postpaint_duration() {
+            self.postpaint_duration_histogram
+                .record(postpaint_duration.as_nanos() as u64)
                 .ok();
         }
         if timing.invalidations > 0 {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1391,6 +1391,12 @@ impl FrameDurationTracker {
     }
 }
 
+#[derive(Default)]
+struct FramePhaseTiming {
+    paint_started_at: Option<Instant>,
+    paint_finished_at: Option<Instant>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DrawPhase {
     None,
@@ -2988,9 +2994,11 @@ impl Window {
                 self.rendered_frame.input_handlers.push(Some(input_handler));
             }
         }
-        if !cx.mode.skip_drawing() {
-            self.draw_roots(cx);
-        }
+        let frame_phase_timing = if !cx.mode.skip_drawing() {
+            self.draw_roots(cx, draw_started_at.is_some())
+        } else {
+            FramePhaseTiming::default()
+        };
         self.dirty_views.clear();
         self.next_frame.window_active = self.active.get();
 
@@ -3077,6 +3085,8 @@ impl Window {
                 draw_end,
                 invalidating_task_location: frame_dirty.invalidating_task_location,
                 invalidating_action_name: frame_dirty.invalidating_action_name,
+                paint_started_at: frame_phase_timing.paint_started_at,
+                paint_finished_at: frame_phase_timing.paint_finished_at,
             };
             #[cfg(feature = "frame-duration-histogram")]
             self.frame_duration_tracker
@@ -3153,7 +3163,7 @@ impl Window {
         self.frame_duration_tracker.snapshot()
     }
 
-    fn draw_roots(&mut self, cx: &mut App) {
+    fn draw_roots(&mut self, cx: &mut App, collect_frame_timing: bool) -> FramePhaseTiming {
         self.invalidator.set_phase(DrawPhase::Prepaint);
         self.tooltip_bounds.take();
 
@@ -3223,6 +3233,7 @@ impl Window {
         self.mouse_hit_test = self.next_frame.hit_test(self.mouse_position);
 
         // Now actually paint the elements.
+        let paint_started_at = collect_frame_timing.then(Instant::now);
         self.invalidator.set_phase(DrawPhase::Paint);
         root_element.paint(self, cx);
 
@@ -3241,6 +3252,7 @@ impl Window {
 
         #[cfg(any(feature = "inspector", debug_assertions))]
         self.paint_inspector_hitbox(cx);
+        let paint_finished_at = collect_frame_timing.then(Instant::now);
 
         // a11y may have been activated/deactivated halfway through the frame
         let a11y_active_start_of_frame = self.a11y.is_active();
@@ -3267,6 +3279,11 @@ impl Window {
                 );
                 self.platform_window.a11y_tree_update(tree_update);
             }
+        }
+
+        FramePhaseTiming {
+            paint_started_at,
+            paint_finished_at,
         }
     }
 
@@ -7674,6 +7691,8 @@ mod tests {
                 draw_end: draw_start + Duration::from_millis(20),
                 invalidating_task_location: Some(task_location),
                 invalidating_action_name: Some("test::SlowAction"),
+                paint_started_at: Some(draw_start + Duration::from_millis(2)),
+                paint_finished_at: Some(draw_start + Duration::from_millis(5)),
             };
 
             tracker.record_frame_timing(&timing);
@@ -7695,6 +7714,12 @@ mod tests {
                     .get("test::SlowAction"),
                 Some(&1)
             );
+            assert_eq!(tracker.snapshot.prepaint_duration_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.paint_duration_histogram.len(), 1);
+            assert_eq!(tracker.snapshot.postpaint_duration_histogram.len(), 1);
+            assert!(tracker.snapshot.prepaint_duration_histogram.max() >= 1_900_000);
+            assert!(tracker.snapshot.paint_duration_histogram.max() >= 2_900_000);
+            assert!(tracker.snapshot.postpaint_duration_histogram.max() >= 14_900_000);
         }
 
         #[test]
@@ -7709,6 +7734,8 @@ mod tests {
                 draw_end: draw_start + Duration::from_millis(15),
                 invalidating_task_location: Some(Location::caller()),
                 invalidating_action_name: Some("test::FastAction"),
+                paint_started_at: None,
+                paint_finished_at: None,
             });
 
             assert!(tracker.snapshot.slow_draws_by_task_location.is_empty());
@@ -7725,6 +7752,8 @@ mod tests {
                 draw_end: draw_start + duration,
                 invalidating_task_location: None,
                 invalidating_action_name: None,
+                paint_started_at: None,
+                paint_finished_at: None,
             });
         }
     }

--- a/crates/input_latency_ui/Cargo.toml
+++ b/crates/input_latency_ui/Cargo.toml
@@ -19,5 +19,6 @@ gpui = { workspace = true, features = [
     "input-latency-histogram",
 ] }
 hdrhistogram.workspace = true
+log.workspace = true
 serde.workspace = true
 telemetry.workspace = true

--- a/crates/input_latency_ui/src/input_latency_ui.rs
+++ b/crates/input_latency_ui/src/input_latency_ui.rs
@@ -200,10 +200,10 @@ const MIN_DRAWS_TO_REPORT: u64 = 1_000;
 /// Computes and sends a `Frame Duration Report` telemetry event for the given
 /// window if enough frames were drawn since the last report.
 ///
-/// The report contains bucketed draw durations (how long `Window::draw` took)
-/// and bucketed present intervals (the achieved frame-to-frame cadence while
-/// the window was animating), so missed frames are visible in the fleet even
-/// when no input was involved.
+/// The report contains bucketed draw and phase durations, plus bucketed
+/// present intervals (the achieved frame-to-frame cadence while the window was
+/// animating), so missed frames are visible in the fleet even when no input was
+/// involved.
 ///
 /// Call this periodically (e.g. every five minutes) from a spawned task.
 pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
@@ -235,30 +235,29 @@ pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
         previous.map(|(_, snapshot)| &snapshot.slow_draws_by_action_name),
         |action_name| (*action_name).to_string(),
     );
-
-    let (delta_draws, delta_intervals, report_window_seconds) =
-        if let Some((prev_instant, prev_snapshot)) = previous {
-            let mut delta_draws = current.draw_duration_histogram.clone();
-            delta_draws
-                .subtract(&prev_snapshot.draw_duration_histogram)
-                .ok();
-            let mut delta_intervals = current.present_interval_histogram.clone();
-            delta_intervals
-                .subtract(&prev_snapshot.present_interval_histogram)
-                .ok();
-            let elapsed = now.duration_since(*prev_instant).as_secs();
-            (delta_draws, delta_intervals, elapsed)
-        } else {
-            // First report for this window: the full cumulative histograms are
-            // the delta from the empty starting state. We don't know how long
-            // the window has been open, so record 0 to signal that this is the
-            // initial accumulation period rather than a fixed-width window.
-            (
-                current.draw_duration_histogram.clone(),
-                current.present_interval_histogram.clone(),
-                0u64,
-            )
-        };
+    let delta_draws = histogram_since(
+        &current.draw_duration_histogram,
+        previous.map(|(_, snapshot)| &snapshot.draw_duration_histogram),
+    );
+    let delta_prepaints = histogram_since(
+        &current.prepaint_duration_histogram,
+        previous.map(|(_, snapshot)| &snapshot.prepaint_duration_histogram),
+    );
+    let delta_paints = histogram_since(
+        &current.paint_duration_histogram,
+        previous.map(|(_, snapshot)| &snapshot.paint_duration_histogram),
+    );
+    let delta_postpaints = histogram_since(
+        &current.postpaint_duration_histogram,
+        previous.map(|(_, snapshot)| &snapshot.postpaint_duration_histogram),
+    );
+    let delta_intervals = histogram_since(
+        &current.present_interval_histogram,
+        previous.map(|(_, snapshot)| &snapshot.present_interval_histogram),
+    );
+    let report_window_seconds = previous
+        .map(|(previous_instant, _)| now.duration_since(*previous_instant).as_secs())
+        .unwrap_or_default();
 
     let total_draws = delta_draws.len();
     if total_draws < MIN_DRAWS_TO_REPORT {
@@ -267,11 +266,10 @@ pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
 
     state.previous.insert(window_id, (now, current));
 
-    let draws_sub4 = count_frames_in_range(&delta_draws, 0, MS4_NS);
-    let draws_4to8 = count_frames_in_range(&delta_draws, MS4_NS, MS8_NS);
-    let draws_8to16 = count_frames_in_range(&delta_draws, MS8_NS, MS16_NS);
-    let draws_16to33 = count_frames_in_range(&delta_draws, MS16_NS, MS33_NS);
-    // draws > 33ms are implicitly total_draws - (sub4 + 4to8 + 8to16 + 16to33)
+    let draw_buckets = duration_buckets(&delta_draws);
+    let prepaint_buckets = duration_buckets(&delta_prepaints);
+    let paint_buckets = duration_buckets(&delta_paints);
+    let postpaint_buckets = duration_buckets(&delta_postpaints);
 
     let total_intervals = delta_intervals.len();
     let intervals_sub9 = count_frames_in_range(&delta_intervals, 0, MS9_NS);
@@ -282,11 +280,26 @@ pub fn report_frame_duration_telemetry(window: &Window, cx: &mut App) {
 
     telemetry::event!(
         "Frame Duration Report",
-        draws_sub4 = draws_sub4,
-        draws_4to8 = draws_4to8,
-        draws_8to16 = draws_8to16,
-        draws_16to33 = draws_16to33,
-        total_draws = total_draws,
+        draws_sub4 = draw_buckets.sub4,
+        draws_4to8 = draw_buckets.from4_to8,
+        draws_8to16 = draw_buckets.from8_to16,
+        draws_16to33 = draw_buckets.from16_to33,
+        total_draws = draw_buckets.total,
+        prepaints_sub4 = prepaint_buckets.sub4,
+        prepaints_4to8 = prepaint_buckets.from4_to8,
+        prepaints_8to16 = prepaint_buckets.from8_to16,
+        prepaints_16to33 = prepaint_buckets.from16_to33,
+        total_prepaints = prepaint_buckets.total,
+        paints_sub4 = paint_buckets.sub4,
+        paints_4to8 = paint_buckets.from4_to8,
+        paints_8to16 = paint_buckets.from8_to16,
+        paints_16to33 = paint_buckets.from16_to33,
+        total_paints = paint_buckets.total,
+        postpaints_sub4 = postpaint_buckets.sub4,
+        postpaints_4to8 = postpaint_buckets.from4_to8,
+        postpaints_8to16 = postpaint_buckets.from8_to16,
+        postpaints_16to33 = postpaint_buckets.from16_to33,
+        total_postpaints = postpaint_buckets.total,
         intervals_sub9 = intervals_sub9,
         intervals_9to18 = intervals_9to18,
         intervals_18to36 = intervals_18to36,
@@ -331,6 +344,34 @@ where
     });
     attributions.truncate(MAX_ATTRIBUTIONS);
     attributions
+}
+
+struct DurationBuckets {
+    sub4: u64,
+    from4_to8: u64,
+    from8_to16: u64,
+    from16_to33: u64,
+    total: u64,
+}
+
+fn duration_buckets(histogram: &Histogram<u64>) -> DurationBuckets {
+    DurationBuckets {
+        sub4: count_frames_in_range(histogram, 0, MS4_NS),
+        from4_to8: count_frames_in_range(histogram, MS4_NS, MS8_NS),
+        from8_to16: count_frames_in_range(histogram, MS8_NS, MS16_NS),
+        from16_to33: count_frames_in_range(histogram, MS16_NS, MS33_NS),
+        total: histogram.len(),
+    }
+}
+
+fn histogram_since(current: &Histogram<u64>, previous: Option<&Histogram<u64>>) -> Histogram<u64> {
+    let mut histogram = current.clone();
+    if let Some(previous) = previous
+        && let Err(error) = histogram.subtract(previous)
+    {
+        log::error!("Failed to subtract frame-duration histogram baseline: {error}");
+    }
+    histogram
 }
 
 fn open_window_ids(cx: &App) -> HashSet<WindowId> {
@@ -564,5 +605,37 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn duration_buckets_group_phase_samples() {
+        let mut histogram = Histogram::new(3).unwrap();
+        for duration in [1_000_000, 5_000_000, 10_000_000, 20_000_000, 40_000_000] {
+            histogram.record(duration).unwrap();
+        }
+
+        let buckets = duration_buckets(&histogram);
+
+        assert_eq!(buckets.sub4, 1);
+        assert_eq!(buckets.from4_to8, 1);
+        assert_eq!(buckets.from8_to16, 1);
+        assert_eq!(buckets.from16_to33, 1);
+        assert_eq!(buckets.total, 5);
+    }
+
+    #[test]
+    fn histogram_since_returns_only_new_samples() {
+        let mut previous = Histogram::new(3).unwrap();
+        previous.record(1_000_000).unwrap();
+        previous.record(2_000_000).unwrap();
+        let mut current = previous.clone();
+        current.record(3_000_000).unwrap();
+        current.record(4_000_000).unwrap();
+
+        let histogram = histogram_since(&current, Some(&previous));
+
+        assert_eq!(histogram.len(), 2);
+        assert!(histogram.min() >= 2_900_000);
+        assert!(histogram.max() >= 3_900_000);
     }
 }


### PR DESCRIPTION
Frame-duration statistics currently report total `Window::draw` time, which tells us that a frame was slow but not whether the work accumulated during layout and prepaint, element painting, or finalization. Benchmark reports have the same limitation.

This change records the boundaries around element painting and folds prepaint, paint, and postpaint durations into the shared `FrameDurationSnapshot`. The benchmark report prints each phase histogram, while frame-duration telemetry emits matching fixed buckets that can be aggregated across reports.

Collection takes two additional `Instant::now` timestamps only when frame timing is already active. This PR is stacked on #62462 and therefore also depends on #62461.

Testing:

- `cargo test -p gpui --features bench,frame-duration-histogram,profiler`
- `cargo test -p input_latency_ui`
- `./script/clippy -p gpui -p input_latency_ui`
- `cargo check -p gpui --features frame-duration-histogram`
- `cargo check -p gpui --features bench`
- `cargo fmt --all -- --check`

Release Notes:

- N/A
