### PR TITLE
agent_ui: Fix restoring uninstalled external agents

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1435,22 +1435,30 @@ impl AgentPanel {
                     // backend; otherwise fall back to the serialized
                     // selection, then the global last-used agent.
                     //
-                    // Only the restored thread keeps an agent that is no
-                    // longer installed, so that it stays resumable if the
-                    // user reinstalls it. A *preference* naming a removed
-                    // agent is dropped instead: the global one outlives the
-                    // workspace it was set in, so every project opened after
-                    // an uninstall would otherwise keep selecting an agent
-                    // that can no longer be launched.
-                    let initial_agent = match &thread_to_restore {
-                        Some((info, _)) => Some(clamp(info.agent_type.clone())),
-                        None => serialized_panel
+                    // Only a restored thread with a session keeps an agent that
+                    // is no longer installed, so that it stays resumable if the
+                    // user reinstalls it. A draft has no session to resume, so
+                    // the binding protects nothing and would only make every
+                    // reopen of this workspace fail to launch the agent — the
+                    // panel opens a draft on its own, so that would be most
+                    // workspaces after an uninstall. A *preference* naming a
+                    // removed agent is dropped for the same reason: the global
+                    // one outlives the workspace it was set in, so every
+                    // project opened after an uninstall would otherwise keep
+                    // selecting an agent that can no longer be launched.
+                    let restored_thread_agent = thread_to_restore.as_ref().and_then(|(info, _)| {
+                        let agent = clamp(info.agent_type.clone());
+                        (info.session_id.is_some() || panel.is_agent_available(&agent, cx))
+                            .then_some(agent)
+                    });
+                    let initial_agent = restored_thread_agent.or_else(|| {
+                        serialized_panel
                             .as_ref()
                             .and_then(|p| p.selected_agent.clone())
                             .map(clamp)
                             .or(global_fallback)
-                            .filter(|agent| panel.is_agent_available(agent, cx)),
-                    };
+                            .filter(|agent| panel.is_agent_available(agent, cx))
+                    });
                     if let Some(agent) = initial_agent {
                         panel.selected_agent = agent;
                     }
@@ -1931,7 +1939,16 @@ impl AgentPanel {
         let agent = if self.project.read(cx).is_via_collab() {
             Agent::NativeAgent
         } else {
-            Agent::from(metadata.agent_id.clone())
+            // The draft's own binding, unless that agent was uninstalled. A
+            // draft has no session to resume, so keeping a dead binding here
+            // would only fail to open the draft; the typed text is restored
+            // either way.
+            let agent = Agent::from(metadata.agent_id.clone());
+            if self.is_agent_available(&agent, cx) {
+                agent
+            } else {
+                self.available_agent_selection(cx)
+            }
         };
         let initial_content = crate::draft_prompt_store::read(thread_id, cx).map(|blocks| {
             AgentInitialContent::ContentBlock {
@@ -11835,14 +11852,17 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_restored_draft_keeps_uninstalled_agent_and_text(cx: &mut TestAppContext) {
+    async fn test_restored_draft_drops_uninstalled_agent_but_keeps_text(cx: &mut TestAppContext) {
         init_test(cx);
+        let fs = FakeFs::new(cx.executor());
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
+            // The draft falls back to the Zed Agent once its own agent is
+            // gone, and building that server needs a global `Fs`.
+            <dyn fs::Fs>::set_global(fs.clone(), cx);
         });
 
-        let fs = FakeFs::new(cx.executor());
         fs.insert_tree("/project", json!({ "file.txt": "" })).await;
         let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
         let multi_workspace =
@@ -11881,8 +11901,10 @@ mod tests {
             .expect("panel load should succeed");
         cx.run_until_parked();
 
-        // A draft keeps both its text and its agent, so reinstalling the agent
-        // lets the user pick the draft back up where they left off.
+        // A draft keeps its text, but not a binding to an agent that is gone:
+        // it has no session to resume, and the panel opens a draft on its own,
+        // so keeping the binding would make this workspace fail to open an
+        // agent for good.
         reloaded_panel.read_with(cx, |panel, cx| {
             let draft = panel
                 .draft_thread
@@ -11895,10 +11917,12 @@ mod tests {
             );
             assert_eq!(
                 *draft.read(cx).agent_key(),
-                Agent::Custom {
-                    id: external_agent_id.clone()
-                },
-                "a restored draft should keep its original agent"
+                Agent::NativeAgent,
+                "a restored draft should drop an uninstalled agent"
+            );
+            assert_eq!(
+                panel.selected_agent, Agent::NativeAgent,
+                "the panel should not stay selected on the uninstalled agent"
             );
         });
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -18,6 +18,7 @@ use agent_settings::UserAgentsMd;
 use collections::HashSet;
 use db::kvp::{Dismissable, KeyValueStore};
 use itertools::Itertools;
+use project::agent_server_store::AllAgentServersSettings;
 use project::{AgentId, ProjectItem};
 use serde::{Deserialize, Serialize};
 
@@ -1433,13 +1434,22 @@ impl AgentPanel {
                     // so the draft survives reload bound to the right
                     // backend; otherwise fall back to the serialized
                     // selection, then the global last-used agent.
+                    //
+                    // Only the restored thread keeps an agent that is no
+                    // longer installed, so that it stays resumable if the
+                    // user reinstalls it. A *preference* naming a removed
+                    // agent is dropped instead: the global one outlives the
+                    // workspace it was set in, so every project opened after
+                    // an uninstall would otherwise keep selecting an agent
+                    // that can no longer be launched.
                     let initial_agent = match &thread_to_restore {
                         Some((info, _)) => Some(clamp(info.agent_type.clone())),
                         None => serialized_panel
                             .as_ref()
                             .and_then(|p| p.selected_agent.clone())
                             .map(clamp)
-                            .or(global_fallback),
+                            .or(global_fallback)
+                            .filter(|agent| panel.is_agent_available(agent, cx)),
                     };
                     if let Some(agent) = initial_agent {
                         panel.selected_agent = agent;
@@ -1654,6 +1664,42 @@ impl AgentPanel {
             Agent::NativeAgent
         } else {
             self.selected_agent.clone()
+        }
+    }
+
+    /// Whether `agent` still exists as far as this panel is concerned.
+    ///
+    /// Both the `agent_servers` setting and the project's [`AgentServerStore`]
+    /// are consulted, because neither is conclusive on its own: registry-backed
+    /// agents only reach the store once the agent registry has finished
+    /// loading, and remote projects register agents that this machine's
+    /// settings don't describe. An agent the user uninstalled is absent from
+    /// both, so only treating it as gone when both agree keeps a slow registry
+    /// load from looking like an uninstall.
+    fn is_agent_available(&self, agent: &Agent, cx: &App) -> bool {
+        let Agent::Custom { id } = agent else {
+            return true;
+        };
+
+        AllAgentServersSettings::get_global(cx).contains_key(id.0.as_ref())
+            || self
+                .project
+                .read(cx)
+                .agent_server_store()
+                .read(cx)
+                .external_agents()
+                .any(|registered| registered == id)
+    }
+
+    /// The panel's selection, or the Zed Agent when the selected agent has
+    /// been uninstalled. Used where the selection is carried over to a panel
+    /// that has yet to pick an agent of its own.
+    fn available_agent_selection(&self, cx: &App) -> Agent {
+        let agent = self.selected_agent(cx);
+        if self.is_agent_available(&agent, cx) {
+            agent
+        } else {
+            Agent::NativeAgent
         }
     }
 
@@ -5239,7 +5285,7 @@ impl AgentPanel {
         let source_panel = source_workspace.read(cx).panel::<AgentPanel>(cx)?;
         let source_panel = source_panel.read(cx);
         Some(SourcePanelInitialization {
-            agent: source_panel.selected_agent(cx),
+            agent: source_panel.available_agent_selection(cx),
             initial_content: source_panel.active_initial_content(cx),
         })
     }
@@ -6849,6 +6895,38 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
+    /// Adds `id` to the `agent_servers` setting, as installing an external
+    /// agent does.
+    fn install_custom_agent(id: &str, cx: &mut App) {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |content| {
+                content.agent_servers.get_or_insert_default().insert(
+                    id.to_string(),
+                    settings::CustomAgentServerSettings::Custom {
+                        path: PathBuf::from("/usr/bin/fake-agent"),
+                        args: Vec::new(),
+                        env: Default::default(),
+                        default_mode: None,
+                        default_config_options: Default::default(),
+                        favorite_config_option_values: Default::default(),
+                    },
+                );
+            });
+        });
+    }
+
+    /// Removes `id` from the `agent_servers` setting, as uninstalling an
+    /// external agent does.
+    fn uninstall_custom_agent(id: &str, cx: &mut App) {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |content| {
+                if let Some(agent_servers) = content.agent_servers.as_mut() {
+                    agent_servers.remove(id);
+                }
+            });
+        });
+    }
+
     #[test]
     fn test_is_known_terminal_agent_command() {
         assert!(is_known_terminal_agent_command("claude"));
@@ -7307,6 +7385,7 @@ mod tests {
             cx.new(|cx| AgentPanel::new(workspace, window, cx))
         });
 
+        cx.update(|_window, cx| install_custom_agent("claude-acp", cx));
         panel_b.update(cx, |panel, _cx| {
             panel.selected_agent = Agent::Custom {
                 id: "claude-acp".into(),
@@ -11471,6 +11550,7 @@ mod tests {
         let custom_agent = Agent::Custom {
             id: "my-preferred-agent".into(),
         };
+        cx.update(|cx| install_custom_agent("my-preferred-agent", cx));
 
         // Write a known agent to the global KVP to simulate a user who has
         // previously used this agent in another workspace.
@@ -11509,6 +11589,325 @@ mod tests {
                 "new workspace should inherit the global last-used agent"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_new_workspace_ignores_uninstalled_global_last_used_agent(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            // Use an isolated DB so parallel tests can't overwrite our global key.
+            cx.set_global(db::AppDatabase::test_new());
+        });
+
+        // The last-used agent was uninstalled, so it is absent from
+        // `agent_servers` — but the global preference still names it.
+        let kvp = cx.update(|cx| KeyValueStore::global(cx));
+        write_global_last_used_agent(
+            kvp,
+            Agent::Custom {
+                id: "uninstalled-agent".into(),
+            },
+        )
+        .await;
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent,
+                Agent::NativeAgent,
+                "a workspace should not inherit a last-used agent that is no longer installed"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_reopened_workspace_ignores_uninstalled_selected_agent(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            install_custom_agent("my-custom-agent", cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        // The workspace remembers a custom agent as its selection...
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            cx.new(|cx| AgentPanel::new(workspace, window, cx))
+        });
+        panel.update(cx, |panel, cx| {
+            panel.selected_agent = Agent::Custom {
+                id: "my-custom-agent".into(),
+            };
+            panel.serialize(cx);
+        });
+        cx.run_until_parked();
+
+        // ...and the user uninstalls it before opening the workspace again.
+        cx.update(|_window, cx| uninstall_custom_agent("my-custom-agent", cx));
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let reloaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        reloaded_panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent,
+                Agent::NativeAgent,
+                "a reopened workspace should not select an agent that is no longer installed"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_opened_workspace_does_not_inherit_uninstalled_agent_from_source(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            install_custom_agent("my-custom-agent", cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project_a", json!({ "file.txt": "" }))
+            .await;
+        fs.insert_tree("/project_b", json!({ "file.txt": "" }))
+            .await;
+        let project_a = Project::test(fs.clone(), [Path::new("/project_a")], cx).await;
+        let project_b = Project::test(fs.clone(), [Path::new("/project_b")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project_a.clone(), window, cx));
+        let workspace_a = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+        let workspace_b = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.test_add_workspace(project_b.clone(), window, cx)
+            })
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel_a = workspace_a.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+        panel_a.update(cx, |panel, _cx| {
+            panel.selected_agent = Agent::Custom {
+                id: "my-custom-agent".into(),
+            };
+        });
+
+        // Opening another project in the same window copies the source
+        // panel's selection into the fresh panel.
+        cx.update(|_window, cx| uninstall_custom_agent("my-custom-agent", cx));
+
+        let panel_b = workspace_b.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+        panel_b.update_in(cx, |panel, window, cx| {
+            panel.initialize_from_source_workspace_if_needed(workspace_a.downgrade(), window, cx);
+        });
+        cx.run_until_parked();
+
+        panel_b.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent,
+                Agent::NativeAgent,
+                "a newly opened project should not inherit an uninstalled agent"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_restored_thread_keeps_uninstalled_agent(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let external_agent_id = StubAgentServer::default_response().agent_id();
+        cx.update(|_window, cx| install_custom_agent(external_agent_id.0.as_ref(), cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        open_thread_with_connection(&panel, StubAgentConnection::new(), cx);
+        send_message(&panel, cx);
+        let thread_id = active_thread_id(&panel, cx);
+        panel.update(cx, |panel, cx| panel.serialize(cx));
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| uninstall_custom_agent(external_agent_id.0.as_ref(), cx));
+        cx.run_until_parked();
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let reloaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        // The thread stays bound to the agent it was created with, so it
+        // reports that agent as unavailable instead of silently reopening as a
+        // Zed Agent thread that can't hold its history. Reinstalling the agent
+        // is enough to make it work again.
+        reloaded_panel.read_with(cx, |panel, cx| {
+            let conversation_view = panel
+                .active_conversation_view()
+                .expect("the last active thread should be restored");
+            assert_eq!(
+                conversation_view.read(cx).thread_id, thread_id,
+                "the same thread should be restored"
+            );
+            assert_eq!(
+                *conversation_view.read(cx).agent_key(),
+                Agent::Custom {
+                    id: external_agent_id.clone()
+                },
+                "a restored thread should keep its original agent"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_restored_draft_keeps_uninstalled_agent_and_text(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let external_agent_id = StubAgentServer::default_response().agent_id();
+        cx.update(|_window, cx| install_custom_agent(external_agent_id.0.as_ref(), cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        crate::test_support::open_draft_with_connection(&panel, StubAgentConnection::new(), cx);
+        crate::test_support::type_draft_prompt(&panel, "Unsent draft", cx);
+        let draft_thread_id = active_thread_id(&panel, cx);
+        panel.update(cx, |panel, cx| panel.serialize(cx));
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| uninstall_custom_agent(external_agent_id.0.as_ref(), cx));
+        cx.run_until_parked();
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let reloaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        // A draft keeps both its text and its agent, so reinstalling the agent
+        // lets the user pick the draft back up where they left off.
+        reloaded_panel.read_with(cx, |panel, cx| {
+            let draft = panel
+                .draft_thread
+                .as_ref()
+                .expect("the draft should be restored");
+            assert_eq!(
+                draft.read(cx).thread_id,
+                draft_thread_id,
+                "the same draft should be restored"
+            );
+            assert_eq!(
+                *draft.read(cx).agent_key(),
+                Agent::Custom {
+                    id: external_agent_id.clone()
+                },
+                "a restored draft should keep its original agent"
+            );
+        });
+
+        let persisted_prompt =
+            cx.update(|_window, cx| crate::draft_prompt_store::read(draft_thread_id, cx));
+        assert!(
+            persisted_prompt.is_some_and(|blocks| !blocks.is_empty()),
+            "a restored draft should keep the text the user had typed"
+        );
     }
 
     #[gpui::test(iterations = 25)]
@@ -11607,6 +12006,10 @@ mod tests {
         let agent_b = Agent::Custom {
             id: "agent-beta".into(),
         };
+        cx.update(|_window, cx| {
+            install_custom_agent("agent-alpha", cx);
+            install_custom_agent("agent-beta", cx);
+        });
 
         // Set up workspace A with agent_a
         let panel_a = workspace_a.update_in(cx, |workspace, window, cx| {
@@ -13183,6 +13586,13 @@ mod tests {
             .unwrap();
 
         let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        // The stub server stands in for an installed external agent, so the
+        // destination panel inherits it rather than falling back to the Zed
+        // Agent.
+        cx.update(|_window, cx| {
+            install_custom_agent(StubAgentServer::default_response().agent_id().0.as_ref(), cx)
+        });
 
         // Set up panel_a with an active thread and type draft text.
         let panel_a = workspace_a.update_in(cx, |workspace, window, cx| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1435,20 +1435,20 @@ impl AgentPanel {
                     // backend; otherwise fall back to the serialized
                     // selection, then the global last-used agent.
                     //
-                    // Only a restored thread with a session keeps an agent that
-                    // is no longer installed, so that it stays resumable if the
-                    // user reinstalls it. A draft has no session to resume, so
-                    // the binding protects nothing and would only make every
-                    // reopen of this workspace fail to launch the agent — the
-                    // panel opens a draft on its own, so that would be most
-                    // workspaces after an uninstall. A *preference* naming a
-                    // removed agent is dropped for the same reason: the global
-                    // one outlives the workspace it was set in, so every
-                    // project opened after an uninstall would otherwise keep
-                    // selecting an agent that can no longer be launched.
+                    // Only a restored thread with a session keeps a locally
+                    // uninstalled agent, so that it stays resumable if the user
+                    // reinstalls it. A draft has no session to resume, so the
+                    // binding protects nothing and would only make every reopen
+                    // of this workspace fail to launch the agent — the panel
+                    // opens a draft on its own, so that would be most workspaces
+                    // after an uninstall. A *preference* naming a removed agent
+                    // is dropped for the same reason: the global one outlives
+                    // the workspace it was set in, so every project opened
+                    // after an uninstall would otherwise keep selecting an
+                    // agent that can no longer be launched.
                     let restored_thread_agent = thread_to_restore.as_ref().and_then(|(info, _)| {
                         let agent = clamp(info.agent_type.clone());
-                        (info.session_id.is_some() || panel.is_agent_available(&agent, cx))
+                        (info.session_id.is_some() || panel.should_restore_agent(&agent, cx))
                             .then_some(agent)
                     });
                     let initial_agent = restored_thread_agent.or_else(|| {
@@ -1457,7 +1457,7 @@ impl AgentPanel {
                             .and_then(|p| p.selected_agent.clone())
                             .map(clamp)
                             .or(global_fallback)
-                            .filter(|agent| panel.is_agent_available(agent, cx))
+                            .filter(|agent| panel.should_restore_agent(agent, cx))
                     });
                     if let Some(agent) = initial_agent {
                         panel.selected_agent = agent;
@@ -1675,36 +1675,25 @@ impl AgentPanel {
         }
     }
 
-    /// Whether `agent` still exists as far as this panel is concerned.
-    ///
-    /// Both the `agent_servers` setting and the project's [`AgentServerStore`]
-    /// are consulted, because neither is conclusive on its own: registry-backed
-    /// agents only reach the store once the agent registry has finished
-    /// loading, and remote projects register agents that this machine's
-    /// settings don't describe. An agent the user uninstalled is absent from
-    /// both, so only treating it as gone when both agree keeps a slow registry
-    /// load from looking like an uninstall.
-    fn is_agent_available(&self, agent: &Agent, cx: &App) -> bool {
+    /// Whether a persisted selection should be restored.
+    fn should_restore_agent(&self, agent: &Agent, cx: &App) -> bool {
         let Agent::Custom { id } = agent else {
             return true;
         };
 
-        AllAgentServersSettings::get_global(cx).contains_key(id.0.as_ref())
-            || self
-                .project
-                .read(cx)
-                .agent_server_store()
-                .read(cx)
-                .external_agents()
-                .any(|registered| registered == id)
+        // This fix only detects local uninstalls. The settings on this machine
+        // do not describe remote agents, and a remote project's server store is
+        // empty until its initial agent list arrives, so absence from either is
+        // not conclusive for a remote project.
+        self.project.read(cx).is_via_remote_server()
+            || AllAgentServersSettings::get_global(cx).contains_key(id.0.as_ref())
     }
 
-    /// The panel's selection, or the Zed Agent when the selected agent has
-    /// been uninstalled. Used where the selection is carried over to a panel
-    /// that has yet to pick an agent of its own.
-    fn available_agent_selection(&self, cx: &App) -> Agent {
+    /// The panel's selection, or the Zed Agent when the selected local agent
+    /// has been uninstalled.
+    fn restorable_agent_selection(&self, cx: &App) -> Agent {
         let agent = self.selected_agent(cx);
-        if self.is_agent_available(&agent, cx) {
+        if self.should_restore_agent(&agent, cx) {
             agent
         } else {
             Agent::NativeAgent
@@ -1944,10 +1933,10 @@ impl AgentPanel {
             // would only fail to open the draft; the typed text is restored
             // either way.
             let agent = Agent::from(metadata.agent_id.clone());
-            if self.is_agent_available(&agent, cx) {
+            if self.should_restore_agent(&agent, cx) {
                 agent
             } else {
-                self.available_agent_selection(cx)
+                self.restorable_agent_selection(cx)
             }
         };
         let initial_content = crate::draft_prompt_store::read(thread_id, cx).map(|blocks| {
@@ -5302,7 +5291,7 @@ impl AgentPanel {
         let source_panel = source_workspace.read(cx).panel::<AgentPanel>(cx)?;
         let source_panel = source_panel.read(cx);
         Some(SourcePanelInitialization {
-            agent: source_panel.available_agent_selection(cx),
+            agent: source_panel.restorable_agent_selection(cx),
             initial_content: source_panel.active_initial_content(cx),
         })
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1456,8 +1456,11 @@ impl AgentPanel {
                             .as_ref()
                             .and_then(|p| p.selected_agent.clone())
                             .map(clamp)
-                            .or(global_fallback)
                             .filter(|agent| panel.should_restore_agent(agent, cx))
+                            .or_else(|| {
+                                global_fallback
+                                    .filter(|agent| panel.should_restore_agent(agent, cx))
+                            })
                     });
                     if let Some(agent) = initial_agent {
                         panel.selected_agent = agent;
@@ -11660,6 +11663,8 @@ mod tests {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
             install_custom_agent("my-custom-agent", cx);
+            // Use an isolated DB so parallel tests can't provide a global fallback.
+            cx.set_global(db::AppDatabase::test_new());
         });
 
         let fs = FakeFs::new(cx.executor());
@@ -11702,6 +11707,67 @@ mod tests {
                 panel.selected_agent,
                 Agent::NativeAgent,
                 "a reopened workspace should not select an agent that is no longer installed"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_reopened_workspace_uses_installed_global_agent_when_selected_agent_was_uninstalled(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            install_custom_agent("workspace-agent", cx);
+            install_custom_agent("global-agent", cx);
+            // Use an isolated DB so parallel tests can't overwrite our global key.
+            cx.set_global(db::AppDatabase::test_new());
+        });
+
+        let global_agent = Agent::Custom {
+            id: "global-agent".into(),
+        };
+        let kvp = cx.update(|cx| KeyValueStore::global(cx));
+        write_global_last_used_agent(kvp, global_agent.clone()).await;
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            cx.new(|cx| AgentPanel::new(workspace, window, cx))
+        });
+        panel.update(cx, |panel, cx| {
+            panel.selected_agent = Agent::Custom {
+                id: "workspace-agent".into(),
+            };
+            panel.serialize(cx);
+        });
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| uninstall_custom_agent("workspace-agent", cx));
+
+        let async_cx = cx.update(|window, cx| window.to_async(cx));
+        let reloaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
+            .await
+            .expect("panel load should succeed");
+        cx.run_until_parked();
+
+        reloaded_panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent, global_agent,
+                "an installed global agent should be used when the workspace agent was uninstalled"
             );
         });
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1434,18 +1434,7 @@ impl AgentPanel {
                     // so the draft survives reload bound to the right
                     // backend; otherwise fall back to the serialized
                     // selection, then the global last-used agent.
-                    //
-                    // Only a restored thread with a session keeps a locally
-                    // uninstalled agent, so that it stays resumable if the user
-                    // reinstalls it. A draft has no session to resume, so the
-                    // binding protects nothing and would only make every reopen
-                    // of this workspace fail to launch the agent — the panel
-                    // opens a draft on its own, so that would be most workspaces
-                    // after an uninstall. A *preference* naming a removed agent
-                    // is dropped for the same reason: the global one outlives
-                    // the workspace it was set in, so every project opened
-                    // after an uninstall would otherwise keep selecting an
-                    // agent that can no longer be launched.
+                    // Keep a session's agent so users can resume it after reinstalling the agent.
                     let restored_thread_agent = thread_to_restore.as_ref().and_then(|(info, _)| {
                         let agent = clamp(info.agent_type.clone());
                         (info.session_id.is_some() || panel.should_restore_agent(&agent, cx))
@@ -1678,22 +1667,16 @@ impl AgentPanel {
         }
     }
 
-    /// Whether a persisted selection should be restored.
     fn should_restore_agent(&self, agent: &Agent, cx: &App) -> bool {
         let Agent::Custom { id } = agent else {
             return true;
         };
 
-        // This fix only detects local uninstalls. The settings on this machine
-        // do not describe remote agents, and a remote project's server store is
-        // empty until its initial agent list arrives, so absence from either is
-        // not conclusive for a remote project.
+        // Local settings do not list remote agents, and the remote list may not have loaded yet.
         self.project.read(cx).is_via_remote_server()
             || AllAgentServersSettings::get_global(cx).contains_key(id.0.as_ref())
     }
 
-    /// The panel's selection, or the Zed Agent when the selected local agent
-    /// has been uninstalled.
     fn restorable_agent_selection(&self, cx: &App) -> Agent {
         let agent = self.selected_agent(cx);
         if self.should_restore_agent(&agent, cx) {
@@ -1931,10 +1914,7 @@ impl AgentPanel {
         let agent = if self.project.read(cx).is_via_collab() {
             Agent::NativeAgent
         } else {
-            // The draft's own binding, unless that agent was uninstalled. A
-            // draft has no session to resume, so keeping a dead binding here
-            // would only fail to open the draft; the typed text is restored
-            // either way.
+            // Draft text is stored locally, so use the selected agent if the original was uninstalled.
             let agent = Agent::from(metadata.agent_id.clone());
             if self.should_restore_agent(&agent, cx) {
                 agent
@@ -6904,8 +6884,6 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
-    /// Adds `id` to the `agent_servers` setting, as installing an external
-    /// agent does.
     fn install_custom_agent(id: &str, cx: &mut App) {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |content| {
@@ -6924,8 +6902,6 @@ mod tests {
         });
     }
 
-    /// Removes `id` from the `agent_servers` setting, as uninstalling an
-    /// external agent does.
     fn uninstall_custom_agent(id: &str, cx: &mut App) {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |content| {
@@ -11612,8 +11588,6 @@ mod tests {
             cx.set_global(db::AppDatabase::test_new());
         });
 
-        // The last-used agent was uninstalled, so it is absent from
-        // `agent_servers` — but the global preference still names it.
         let kvp = cx.update(|cx| KeyValueStore::global(cx));
         write_global_last_used_agent(
             kvp,
@@ -11652,61 +11626,6 @@ mod tests {
                 panel.selected_agent,
                 Agent::NativeAgent,
                 "a workspace should not inherit a last-used agent that is no longer installed"
-            );
-        });
-    }
-
-    #[gpui::test]
-    async fn test_reopened_workspace_ignores_uninstalled_selected_agent(cx: &mut TestAppContext) {
-        init_test(cx);
-        cx.update(|cx| {
-            agent::ThreadStore::init_global(cx);
-            language_model::LanguageModelRegistry::test(cx);
-            install_custom_agent("my-custom-agent", cx);
-            // Use an isolated DB so parallel tests can't provide a global fallback.
-            cx.set_global(db::AppDatabase::test_new());
-        });
-
-        let fs = FakeFs::new(cx.executor());
-        let project = Project::test(fs.clone(), [], cx).await;
-        let multi_workspace =
-            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
-        let workspace = multi_workspace
-            .read_with(cx, |multi_workspace, _cx| {
-                multi_workspace.workspace().clone()
-            })
-            .unwrap();
-        workspace.update(cx, |workspace, _cx| {
-            workspace.set_random_database_id();
-        });
-        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
-
-        // The workspace remembers a custom agent as its selection...
-        let panel = workspace.update_in(cx, |workspace, window, cx| {
-            cx.new(|cx| AgentPanel::new(workspace, window, cx))
-        });
-        panel.update(cx, |panel, cx| {
-            panel.selected_agent = Agent::Custom {
-                id: "my-custom-agent".into(),
-            };
-            panel.serialize(cx);
-        });
-        cx.run_until_parked();
-
-        // ...and the user uninstalls it before opening the workspace again.
-        cx.update(|_window, cx| uninstall_custom_agent("my-custom-agent", cx));
-
-        let async_cx = cx.update(|window, cx| window.to_async(cx));
-        let reloaded_panel = AgentPanel::load(workspace.downgrade(), async_cx)
-            .await
-            .expect("panel load should succeed");
-        cx.run_until_parked();
-
-        reloaded_panel.read_with(cx, |panel, _cx| {
-            assert_eq!(
-                panel.selected_agent,
-                Agent::NativeAgent,
-                "a reopened workspace should not select an agent that is no longer installed"
             );
         });
     }
@@ -11814,8 +11733,6 @@ mod tests {
             };
         });
 
-        // Opening another project in the same window copies the source
-        // panel's selection into the fresh panel.
         cx.update(|_window, cx| uninstall_custom_agent("my-custom-agent", cx));
 
         let panel_b = workspace_b.update_in(cx, |workspace, window, cx| {
@@ -11884,16 +11801,13 @@ mod tests {
             .expect("panel load should succeed");
         cx.run_until_parked();
 
-        // The thread stays bound to the agent it was created with, so it
-        // reports that agent as unavailable instead of silently reopening as a
-        // Zed Agent thread that can't hold its history. Reinstalling the agent
-        // is enough to make it work again.
         reloaded_panel.read_with(cx, |panel, cx| {
             let conversation_view = panel
                 .active_conversation_view()
                 .expect("the last active thread should be restored");
             assert_eq!(
-                conversation_view.read(cx).thread_id, thread_id,
+                conversation_view.read(cx).thread_id,
+                thread_id,
                 "the same thread should be restored"
             );
             assert_eq!(
@@ -11913,8 +11827,7 @@ mod tests {
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
-            // The draft falls back to the Zed Agent once its own agent is
-            // gone, and building that server needs a global `Fs`.
+            // Building the native fallback requires a global `Fs`.
             <dyn fs::Fs>::set_global(fs.clone(), cx);
         });
 
@@ -11956,10 +11869,6 @@ mod tests {
             .expect("panel load should succeed");
         cx.run_until_parked();
 
-        // A draft keeps its text, but not a binding to an agent that is gone:
-        // it has no session to resume, and the panel opens a draft on its own,
-        // so keeping the binding would make this workspace fail to open an
-        // agent for good.
         reloaded_panel.read_with(cx, |panel, cx| {
             let draft = panel
                 .draft_thread
@@ -11976,7 +11885,8 @@ mod tests {
                 "a restored draft should drop an uninstalled agent"
             );
             assert_eq!(
-                panel.selected_agent, Agent::NativeAgent,
+                panel.selected_agent,
+                Agent::NativeAgent,
                 "the panel should not stay selected on the uninstalled agent"
             );
         });
@@ -13666,11 +13576,11 @@ mod tests {
 
         let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
 
-        // The stub server stands in for an installed external agent, so the
-        // destination panel inherits it rather than falling back to the Zed
-        // Agent.
         cx.update(|_window, cx| {
-            install_custom_agent(StubAgentServer::default_response().agent_id().0.as_ref(), cx)
+            install_custom_agent(
+                StubAgentServer::default_response().agent_id().0.as_ref(),
+                cx,
+            )
         });
 
         // Set up panel_a with an active thread and type draft text.


### PR DESCRIPTION
Zed saves the selected external agent per workspace and as an app-wide last-used agent. Uninstalling the agent leaves those saved values in place, so the Agent Panel could restore an agent that no longer exists and fail to start a thread.

For local projects, this changes restoration behavior in these cases:

- A new workspace ignores an uninstalled global last-used agent.
- A reopened workspace ignores its uninstalled agent. It uses an installed global agent if one exists, otherwise it uses the Zed Agent.
- A project opened in the same window does not copy an uninstalled agent from the previous project.
- An unsent draft keeps its text and switches to the selected fallback agent if its original agent was uninstalled.

Two boundaries remain unchanged:

- A thread with a saved session stays bound to its original agent so it can resume after the agent is reinstalled.
- Remote projects keep their saved external-agent selection because this change only detects local uninstalls.

Release Notes:

- Fixed the Agent Panel selecting an uninstalled external agent when opening a project or restoring an unsent draft, which prevented the thread from starting.