### PR TITLE
fs: Add `RecursiveCopyOptions` to `copy_recursive` method

### DIFF
--- a/crates/agent/src/tools/copy_path_tool.rs
+++ b/crates/agent/src/tools/copy_path_tool.rs
@@ -213,7 +213,7 @@ impl AgentTool for CopyPathTool {
                         fs.as_ref(),
                         &source_path,
                         &destination_path,
-                        fs::CopyOptions::default(),
+                        fs::RecursiveCopyOptions::default(),
                     ).fuse() => {
                         result.map_err(|e| format!("Copying {} to {}: {e}", input.source_path, input.destination_path))?;
                     }

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -391,7 +391,7 @@ impl DevContainerManifest {
             return Err(DevContainerError::ResourceFetchFailed);
         }
 
-        let items = fs::read_dir_items(&*self.fs, &source_path)
+        let items = fs::read_dir_items(&*self.fs, &source_path, &fs::NoFilter)
             .await
             .map_err(|e| {
                 log::error!(

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::sync::Arc;
 
-use ::fs::{CopyOptions, Fs, RealFs, RemoveOptions, copy_recursive};
+use ::fs::{CopyOptions, Fs, RealFs, RecursiveCopyOptions, RemoveOptions, copy_recursive};
 use anyhow::{Context as _, Result, anyhow, bail};
 use clap::Parser;
 use cloud_api_types::ExtensionProvides;
@@ -265,9 +265,12 @@ async fn copy_extension_resources(
             fs.as_ref(),
             &extension_path.join("icons"),
             &output_icons_dir,
-            CopyOptions {
-                overwrite: true,
-                ignore_if_exists: false,
+            RecursiveCopyOptions {
+                copy_options: CopyOptions {
+                    overwrite: true,
+                    ignore_if_exists: false,
+                },
+                ..Default::default()
             },
         )
         .await
@@ -287,9 +290,12 @@ async fn copy_extension_resources(
                     &extension_path.join(language_path),
                     &output_languages_dir
                         .join(language_path.file_name().context("invalid language path")?),
-                    CopyOptions {
-                        overwrite: true,
-                        ignore_if_exists: false,
+                    RecursiveCopyOptions {
+                        copy_options: CopyOptions {
+                            overwrite: true,
+                            ignore_if_exists: false,
+                        },
+                        ..Default::default()
                     },
                 )
                 .await
@@ -318,9 +324,12 @@ async fn copy_extension_resources(
                         fs.as_ref(),
                         &extension_path.join(schema_path),
                         &output_dir.join(schema_path),
-                        CopyOptions {
-                            overwrite: true,
-                            ignore_if_exists: false,
+                        RecursiveCopyOptions {
+                            copy_options: CopyOptions {
+                                overwrite: true,
+                                ignore_if_exists: false,
+                            },
+                            ..Default::default()
                         },
                     )
                     .await
@@ -348,9 +357,12 @@ async fn copy_extension_resources(
                     fs.as_ref(),
                     &extension_path.join(&snippets_path),
                     &output_dir.join(&snippets_path),
-                    CopyOptions {
-                        overwrite: true,
-                        ignore_if_exists: false,
+                    RecursiveCopyOptions {
+                        copy_options: CopyOptions {
+                            overwrite: true,
+                            ignore_if_exists: false,
+                        },
+                        ..Default::default()
                     },
                 )
                 .await

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -18,6 +18,7 @@ use gpui::ReadGlobal as _;
 use gpui::SharedString;
 #[cfg(unix)]
 use std::ffi::CString;
+use util::ResultExt as _;
 use util::command::new_command;
 
 #[cfg(unix)]
@@ -3441,7 +3442,7 @@ pub async fn copy_recursive<'a>(
                     anyhow::bail!("{target_item:?} already exists");
                 }
             }
-            if let Err(error) = fs
+            let _ = fs
                 .remove_dir(
                     &target_item,
                     RemoveOptions {
@@ -3450,13 +3451,16 @@ pub async fn copy_recursive<'a>(
                     },
                 )
                 .await
-            {
-                log::error!("failed to remove target directory {target_item:?}: {error:#}");
-            }
-            fs.create_dir(&target_item).await?;
+                .with_context(|| format!("removing target directory {target_item:?}"))
+                .log_err();
+
+            fs.create_dir(&target_item)
+                .await
+                .with_context(|| format!("creating target directory {target_item:?}"))?;
         } else {
             fs.copy_file(&item, &target_item, options.copy_options)
-                .await?;
+                .await
+                .with_context(|| format!("copying file {item:?} to {target_item:?}"))?;
         }
     }
     Ok(())

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -5,7 +5,6 @@ pub use fs_watcher::requires_poll_watcher;
 use parking_lot::Mutex;
 use slotmap::{KeyData, SlotMap};
 use std::ffi::OsString;
-use std::ops::Deref;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::Instant;
 use util::maybe;

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -5,6 +5,7 @@ pub use fs_watcher::requires_poll_watcher;
 use parking_lot::Mutex;
 use slotmap::{KeyData, SlotMap};
 use std::ffi::OsString;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::Instant;
 use util::maybe;
@@ -276,6 +277,34 @@ pub struct CreateOptions {
 pub struct CopyOptions {
     pub overwrite: bool,
     pub ignore_if_exists: bool,
+}
+
+pub trait CopyFilter: Sync {
+    fn should_copy(&self, path: &Path) -> bool;
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct NoFilter;
+
+impl CopyFilter for NoFilter {
+    fn should_copy(&self, _path: &Path) -> bool {
+        true
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct RecursiveCopyOptions<F = NoFilter> {
+    pub copy_options: CopyOptions,
+    pub filter: F,
+}
+
+impl Default for RecursiveCopyOptions {
+    fn default() -> Self {
+        Self {
+            copy_options: CopyOptions::default(),
+            filter: NoFilter,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Default)]
@@ -3388,13 +3417,13 @@ impl Fs for FakeFs {
     }
 }
 
-pub async fn copy_recursive<'a>(
+pub async fn copy_recursive<'a, F: CopyFilter>(
     fs: &'a dyn Fs,
     source: &'a Path,
     target: &'a Path,
-    options: CopyOptions,
+    options: RecursiveCopyOptions<F>,
 ) -> Result<()> {
-    for (item, is_dir) in read_dir_items(fs, source).await? {
+    for (item, is_dir) in read_dir_items(fs, source, &options.filter).await? {
         let Ok(item_relative_path) = item.strip_prefix(source) else {
             continue;
         };
@@ -3404,14 +3433,16 @@ pub async fn copy_recursive<'a>(
             target.join(item_relative_path)
         };
         if is_dir {
-            if !options.overwrite && fs.metadata(&target_item).await.is_ok_and(|m| m.is_some()) {
-                if options.ignore_if_exists {
+            if !options.copy_options.overwrite
+                && fs.metadata(&target_item).await.is_ok_and(|m| m.is_some())
+            {
+                if options.copy_options.ignore_if_exists {
                     continue;
                 } else {
                     anyhow::bail!("{target_item:?} already exists");
                 }
             }
-            let _ = fs
+            if let Err(error) = fs
                 .remove_dir(
                     &target_item,
                     RemoveOptions {
@@ -3419,27 +3450,36 @@ pub async fn copy_recursive<'a>(
                         ignore_if_not_exists: true,
                     },
                 )
-                .await;
+                .await
+            {
+                log::error!("failed to remove target directory {target_item:?}: {error:#}");
+            }
             fs.create_dir(&target_item).await?;
         } else {
-            fs.copy_file(&item, &target_item, options).await?;
+            fs.copy_file(&item, &target_item, options.copy_options)
+                .await?;
         }
     }
     Ok(())
 }
 
-/// Recursively reads all of the paths in the given directory.
+/// Recursively reads all of the paths in the given directory that match the filter.
 ///
-/// Returns a vector of tuples of (path, is_dir).
-pub async fn read_dir_items<'a>(fs: &'a dyn Fs, source: &'a Path) -> Result<Vec<(PathBuf, bool)>> {
+/// Returns a vector of tuples of (path, is_dir). Rejected directories are not traversed.
+pub async fn read_dir_items<'a, F: CopyFilter>(
+    fs: &'a dyn Fs,
+    source: &'a Path,
+    filter: &'a F,
+) -> Result<Vec<(PathBuf, bool)>> {
     let mut items = Vec::new();
-    read_recursive(fs, source, &mut items).await?;
+    read_recursive(fs, source, filter, &mut items).await?;
     Ok(items)
 }
 
-fn read_recursive<'a>(
+fn read_recursive<'a, F: CopyFilter>(
     fs: &'a dyn Fs,
     source: &'a Path,
+    filter: &'a F,
     output: &'a mut Vec<(PathBuf, bool)>,
 ) -> BoxFuture<'a, Result<()>> {
     use futures::future::FutureExt;
@@ -3450,12 +3490,16 @@ fn read_recursive<'a>(
             .await?
             .with_context(|| format!("path does not exist: {source:?}"))?;
 
+        if !filter.should_copy(source) {
+            return Ok(());
+        }
+
         if metadata.is_dir {
             output.push((source.to_path_buf(), true));
             let mut children = fs.read_dir(source).await?;
             while let Some(child_path) = children.next().await {
                 if let Ok(child_path) = child_path {
-                    read_recursive(fs, &child_path, output).await?;
+                    read_recursive(fs, &child_path, filter, output).await?;
                 }
             }
         } else {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -293,16 +293,16 @@ impl CopyFilter for NoFilter {
 }
 
 #[derive(Copy, Clone)]
-pub struct RecursiveCopyOptions<F = NoFilter> {
+pub struct RecursiveCopyOptions<'a> {
     pub copy_options: CopyOptions,
-    pub filter: F,
+    pub filter: &'a dyn CopyFilter,
 }
 
-impl Default for RecursiveCopyOptions {
+impl Default for RecursiveCopyOptions<'_> {
     fn default() -> Self {
         Self {
             copy_options: CopyOptions::default(),
-            filter: NoFilter,
+            filter: &NoFilter,
         }
     }
 }
@@ -3417,13 +3417,13 @@ impl Fs for FakeFs {
     }
 }
 
-pub async fn copy_recursive<'a, F: CopyFilter>(
+pub async fn copy_recursive<'a>(
     fs: &'a dyn Fs,
     source: &'a Path,
     target: &'a Path,
-    options: RecursiveCopyOptions<F>,
+    options: RecursiveCopyOptions<'_>,
 ) -> Result<()> {
-    for (item, is_dir) in read_dir_items(fs, source, &options.filter).await? {
+    for (item, is_dir) in read_dir_items(fs, source, options.filter).await? {
         let Ok(item_relative_path) = item.strip_prefix(source) else {
             continue;
         };
@@ -3466,20 +3466,20 @@ pub async fn copy_recursive<'a, F: CopyFilter>(
 /// Recursively reads all of the paths in the given directory that match the filter.
 ///
 /// Returns a vector of tuples of (path, is_dir). Rejected directories are not traversed.
-pub async fn read_dir_items<'a, F: CopyFilter>(
+pub async fn read_dir_items<'a>(
     fs: &'a dyn Fs,
     source: &'a Path,
-    filter: &'a F,
+    filter: &'a dyn CopyFilter,
 ) -> Result<Vec<(PathBuf, bool)>> {
     let mut items = Vec::new();
     read_recursive(fs, source, filter, &mut items).await?;
     Ok(items)
 }
 
-fn read_recursive<'a, F: CopyFilter>(
+fn read_recursive<'a>(
     fs: &'a dyn Fs,
     source: &'a Path,
-    filter: &'a F,
+    filter: &'a dyn CopyFilter,
     output: &'a mut Vec<(PathBuf, bool)>,
 ) -> BoxFuture<'a, Result<()>> {
     use futures::future::FutureExt;

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -320,7 +320,7 @@ async fn test_copy_recursive_with_filter(executor: BackgroundExecutor) {
         Path::new(path!("/outer copy")),
         RecursiveCopyOptions {
             copy_options: CopyOptions::default(),
-            filter: SkipBAndInner2,
+            filter: &SkipBAndInner2,
         },
     )
     .await

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -17,6 +17,17 @@ use serde_json::json;
 use tempfile::TempDir;
 use util::path;
 
+struct SkipBAndInner2;
+
+impl CopyFilter for SkipBAndInner2 {
+    fn should_copy(&self, path: &Path) -> bool {
+        !matches!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("b" | "inner2")
+        )
+    }
+}
+
 #[gpui::test]
 async fn test_fake_fs(executor: BackgroundExecutor) {
     let fs = FakeFs::new(executor.clone());
@@ -94,7 +105,7 @@ async fn test_copy_recursive_with_single_file(executor: BackgroundExecutor) {
 
     let source = Path::new(path!("/outer/a"));
     let target = Path::new(path!("/outer/a copy"));
-    copy_recursive(fs.as_ref(), source, target, Default::default())
+    copy_recursive(fs.as_ref(), source, target, RecursiveCopyOptions::default())
         .await
         .unwrap();
 
@@ -109,7 +120,7 @@ async fn test_copy_recursive_with_single_file(executor: BackgroundExecutor) {
 
     let source = Path::new(path!("/outer/a"));
     let target = Path::new(path!("/outer/inner/a copy"));
-    copy_recursive(fs.as_ref(), source, target, Default::default())
+    copy_recursive(fs.as_ref(), source, target, RecursiveCopyOptions::default())
         .await
         .unwrap();
 
@@ -158,7 +169,7 @@ async fn test_copy_recursive_with_single_dir(executor: BackgroundExecutor) {
 
     let source = Path::new(path!("/outer/empty"));
     let target = Path::new(path!("/outer/empty copy"));
-    copy_recursive(fs.as_ref(), source, target, Default::default())
+    copy_recursive(fs.as_ref(), source, target, RecursiveCopyOptions::default())
         .await
         .unwrap();
 
@@ -182,7 +193,7 @@ async fn test_copy_recursive_with_single_dir(executor: BackgroundExecutor) {
 
     let source = Path::new(path!("/outer/non-empty"));
     let target = Path::new(path!("/outer/non-empty copy"));
-    copy_recursive(fs.as_ref(), source, target, Default::default())
+    copy_recursive(fs.as_ref(), source, target, RecursiveCopyOptions::default())
         .await
         .unwrap();
 
@@ -251,7 +262,7 @@ async fn test_copy_recursive(executor: BackgroundExecutor) {
 
     let source = Path::new(path!("/outer"));
     let target = Path::new(path!("/outer/inner1/outer"));
-    copy_recursive(fs.as_ref(), source, target, Default::default())
+    copy_recursive(fs.as_ref(), source, target, RecursiveCopyOptions::default())
         .await
         .unwrap();
 
@@ -282,6 +293,57 @@ async fn test_copy_recursive(executor: BackgroundExecutor) {
             PathBuf::from(path!("/outer/inner1/outer/inner2")),
             PathBuf::from(path!("/outer/inner1/outer/inner1/inner3")),
             PathBuf::from(path!("/outer/inner1/outer/inner1/inner4")),
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_copy_recursive_with_filter(executor: BackgroundExecutor) {
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(
+        path!("/outer"),
+        json!({
+            "inner1": {
+                "a": "A",
+                "b": "B",
+            },
+            "inner2": {
+                "c": "C",
+            }
+        }),
+    )
+    .await;
+
+    copy_recursive(
+        fs.as_ref(),
+        Path::new(path!("/outer")),
+        Path::new(path!("/outer copy")),
+        RecursiveCopyOptions {
+            copy_options: CopyOptions::default(),
+            filter: SkipBAndInner2,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        fs.files(),
+        vec![
+            PathBuf::from(path!("/outer/inner1/a")),
+            PathBuf::from(path!("/outer/inner1/b")),
+            PathBuf::from(path!("/outer/inner2/c")),
+            PathBuf::from(path!("/outer copy/inner1/a")),
+        ]
+    );
+    assert_eq!(
+        fs.directories(false),
+        vec![
+            PathBuf::from(path!("/")),
+            PathBuf::from(path!("/outer")),
+            PathBuf::from(path!("/outer copy")),
+            PathBuf::from(path!("/outer/inner1")),
+            PathBuf::from(path!("/outer/inner2")),
+            PathBuf::from(path!("/outer copy/inner1")),
         ]
     );
 }
@@ -330,8 +392,11 @@ async fn test_copy_recursive_with_overwriting(executor: BackgroundExecutor) {
         fs.as_ref(),
         source,
         target,
-        CopyOptions {
-            overwrite: true,
+        RecursiveCopyOptions {
+            copy_options: CopyOptions {
+                overwrite: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
     )
@@ -402,8 +467,11 @@ async fn test_copy_recursive_with_ignoring(executor: BackgroundExecutor) {
         fs.as_ref(),
         source,
         target,
-        CopyOptions {
-            ignore_if_exists: true,
+        RecursiveCopyOptions {
+            copy_options: CopyOptions {
+                ignore_if_exists: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
     )

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -562,7 +562,7 @@ impl WorktreeStore {
                         fs.as_ref(),
                         &old_abs_path,
                         &new_abs_path,
-                        Default::default(),
+                        fs::RecursiveCopyOptions::default(),
                     )
                     .await
                 });

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2042,8 +2042,11 @@ impl LocalWorktree {
                         fs.as_ref(),
                         &source,
                         &target,
-                        fs::CopyOptions {
-                            overwrite: true,
+                        fs::RecursiveCopyOptions {
+                            copy_options: fs::CopyOptions {
+                                overwrite: true,
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                     )
@@ -2473,7 +2476,7 @@ impl RemoteWorktree {
                     continue;
                 };
                 for (abs_path, is_directory) in
-                    read_dir_items(local_fs.as_ref(), &root_path_to_copy).await?
+                    read_dir_items(local_fs.as_ref(), &root_path_to_copy, &fs::NoFilter).await?
                 {
                     let Some(relative_path) = abs_path
                         .strip_prefix(&root_path_to_copy)


### PR DESCRIPTION
Adding this so it will become possible to easily filter out file during a recursive copy process as opposed to needing to re-implement the filtering at all call sites.

Release Notes:

- N/A
