### PR TITLE
openai_subscribed: Use full context windows for subscription models

### DIFF
--- a/crates/openai_subscribed/src/openai_subscribed.rs
+++ b/crates/openai_subscribed/src/openai_subscribed.rs
@@ -295,17 +295,19 @@ impl ChatGptModel {
         }
     }
 
+    /// Subscription requests are billed by OpenAI, so use the models' full
+    /// public API context windows instead of long-context pricing thresholds.
     fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
-            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 => {
+                1_050_000
+            }
+            Self::Gpt54Mini => 400_000,
         }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
-        // Codex model metadata does not expose a max output token cap for these
-        // models. Source: openai/codex models-manager/models.json.
-        None
+        Some(128_000)
     }
 
     fn supports_images(&self) -> bool {


### PR DESCRIPTION
ChatGPT subscription models currently report the short-context billing thresholds (272k or 372k tokens) as their maximum context windows. Those thresholds matter when Zed is paying metered API costs, but subscription requests are billed directly by OpenAI.

This updates the subscribed models to report the full context windows supported by the corresponding public API models: 1.05M tokens for GPT-5.4, GPT-5.5, and GPT-5.6, and 400k tokens for GPT-5.4 Mini. It also reports the 128k output limit so context accounting reserves capacity for the response. Request serialization is unchanged; the unsupported `max_output_tokens` parameter is still omitted from requests to the Codex backend.

Release Notes:

- Improved context window usage for GPT models accessed through a ChatGPT subscription.
