### PR TITLE
openai_subscribed: Restore Codex context limits

### DIFF
--- a/crates/openai_subscribed/src/openai_subscribed.rs
+++ b/crates/openai_subscribed/src/openai_subscribed.rs
@@ -295,19 +295,17 @@ impl ChatGptModel {
         }
     }
 
-    /// Subscription requests are billed by OpenAI, so use the models' full
-    /// public API context windows instead of long-context pricing thresholds.
     fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 => {
-                1_050_000
-            }
-            Self::Gpt54Mini => 400_000,
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
+            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
         }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
-        Some(128_000)
+        // Codex model metadata does not expose a max output token cap for these
+        // models. Source: openai/codex models-manager/models.json.
+        None
     }
 
     fn supports_images(&self) -> bool {


### PR DESCRIPTION
PR #62502 changed the ChatGPT subscription models to report the corresponding public API context windows. That was based on a mistaken assumption: subscription requests go through the separate Codex backend, which still rejects requests around the previous context limit.

Because the advertised context window also determines when Zed compacts a conversation, reporting 1.05M tokens delays compaction until after the Codex backend rejects the request. This reverts #62502 and restores the previous conservative limits. Longer term, we should load the account-specific model metadata from the Codex `/models` endpoint rather than maintaining this list by hand.

Release Notes:

- Fixed automatic context compaction for GPT models accessed through a ChatGPT subscription.
