### PR TITLE
mistral: Fetch available models dynamically from the API

### DIFF
--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -45,6 +45,9 @@ pub struct MistralLanguageModelProvider {
 pub struct State {
     api_key_state: ApiKeyState,
     credentials_provider: Arc<dyn CredentialsProvider>,
+    http_client: Arc<dyn HttpClient>,
+    fetched_models: Vec<mistral::Model>,
+    fetch_models_task: Option<Task<Result<()>>>,
 }
 
 impl State {
@@ -55,24 +58,76 @@ impl State {
     fn set_api_key(&mut self, api_key: Option<String>, cx: &mut Context<Self>) -> Task<Result<()>> {
         let credentials_provider = self.credentials_provider.clone();
         let api_url = MistralLanguageModelProvider::api_url(cx);
-        self.api_key_state.store(
+        let should_fetch_models = api_key.is_some();
+        let task = self.api_key_state.store(
             api_url,
             api_key,
             |this| &mut this.api_key_state,
             credentials_provider,
             cx,
-        )
+        );
+        self.fetched_models.clear();
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            if result.is_ok() && should_fetch_models {
+                this.update(cx, |this, cx| this.restart_fetch_models_task(cx))
+                    .ok();
+            }
+            result
+        })
     }
 
     fn authenticate(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
         let credentials_provider = self.credentials_provider.clone();
         let api_url = MistralLanguageModelProvider::api_url(cx);
-        self.api_key_state.load_if_needed(
+        let task = self.api_key_state.load_if_needed(
             api_url,
             |this| &mut this.api_key_state,
             credentials_provider,
             cx,
-        )
+        );
+
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            if result.is_ok() {
+                this.update(cx, |this, cx| this.restart_fetch_models_task(cx))
+                    .ok();
+            }
+            result
+        })
+    }
+
+    fn fetch_models(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let http_client = self.http_client.clone();
+        let api_url = MistralLanguageModelProvider::api_url(cx);
+        let Some(api_key) = self.api_key_state.key(&api_url) else {
+            return Task::ready(Err(anyhow!(
+                "cannot fetch Mistral models without an API key"
+            )));
+        };
+        let extra_headers = MistralLanguageModelProvider::settings(cx)
+            .custom_headers
+            .clone();
+
+        cx.spawn(async move |this, cx| {
+            let models = mistral::list_models(
+                http_client.as_ref(),
+                &api_url,
+                api_key.as_ref(),
+                &extra_headers,
+            )
+            .await?;
+
+            this.update(cx, |this, cx| {
+                this.fetched_models = models;
+                cx.notify();
+            })
+        })
+    }
+
+    fn restart_fetch_models_task(&mut self, cx: &mut Context<Self>) {
+        let task = self.fetch_models(cx);
+        self.fetch_models_task.replace(task);
     }
 }
 
@@ -95,21 +150,33 @@ impl MistralLanguageModelProvider {
             return this.0.clone();
         }
         let state = cx.new(|cx| {
-            cx.observe_global::<SettingsStore>(|this: &mut State, cx| {
-                let credentials_provider = this.credentials_provider.clone();
-                let api_url = Self::api_url(cx);
-                this.api_key_state.handle_url_change(
-                    api_url,
-                    |this| &mut this.api_key_state,
-                    credentials_provider,
-                    cx,
-                );
-                cx.notify();
+            cx.observe_global::<SettingsStore>({
+                let mut last_api_url = Self::api_url(cx);
+                move |this: &mut State, cx| {
+                    let credentials_provider = this.credentials_provider.clone();
+                    let api_url = Self::api_url(cx);
+                    let url_changed = api_url != last_api_url;
+                    last_api_url = api_url.clone();
+                    this.api_key_state.handle_url_change(
+                        api_url,
+                        |this| &mut this.api_key_state,
+                        credentials_provider,
+                        cx,
+                    );
+                    if url_changed {
+                        this.fetched_models.clear();
+                        this.authenticate(cx).detach();
+                    }
+                    cx.notify();
+                }
             })
             .detach();
             State {
                 api_key_state: ApiKeyState::new(Self::api_url(cx), (*API_KEY_ENV_VAR).clone()),
                 credentials_provider,
+                http_client: http_client.clone(),
+                fetched_models: Vec::new(),
+                fetch_models_task: None,
             }
         });
 
@@ -174,10 +241,18 @@ impl LanguageModelProvider for MistralLanguageModelProvider {
     fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
         let mut models = BTreeMap::default();
 
-        // Add base models from mistral::Model::iter()
-        for model in mistral::Model::iter() {
-            if !matches!(model, mistral::Model::Custom { .. }) {
-                models.insert(model.id().to_string(), model);
+        let fetched_models = &self.state.read(cx).fetched_models;
+        if fetched_models.is_empty() {
+            // Fallback until the first successful fetch (offline,
+            // unauthenticated, or an endpoint without `/models`).
+            for model in mistral::Model::iter() {
+                if !matches!(model, mistral::Model::Custom { .. }) {
+                    models.insert(model.id().to_string(), model);
+                }
+            }
+        } else {
+            for model in fetched_models {
+                models.insert(model.id().to_string(), model.clone());
             }
         }
 

--- a/crates/mistral/src/mistral.rs
+++ b/crates/mistral/src/mistral.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
 use http_client::{
     AsyncBody, CustomHeaders, HttpClient, HttpRequestExt, Method, Request as HttpRequest,
@@ -6,10 +6,13 @@ use http_client::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, hash_map};
 use std::convert::TryFrom;
 use strum::EnumIter;
 
 pub const MISTRAL_API_URL: &str = "https://api.mistral.ai/v1";
+
+pub const DEFAULT_MAX_TOKEN_COUNT: u64 = 128_000;
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -83,6 +86,20 @@ pub enum Model {
 impl Model {
     pub fn default_fast() -> Self {
         Model::MistralSmallLatest
+    }
+
+    pub fn from_listed(entry: ListModelEntry) -> Self {
+        Model::Custom {
+            name: entry.id,
+            // The listing's `name` field duplicates `id`, so it adds nothing.
+            display_name: None,
+            max_tokens: entry.max_context_length.unwrap_or(DEFAULT_MAX_TOKEN_COUNT),
+            max_output_tokens: None,
+            max_completion_tokens: None,
+            supports_tools: Some(entry.capabilities.function_calling),
+            supports_images: Some(entry.capabilities.vision),
+            supports_thinking: Some(entry.capabilities.reasoning),
+        }
     }
 
     pub fn from_id(id: &str) -> Result<Self> {
@@ -366,6 +383,7 @@ pub struct Usage {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StreamResponse {
     pub id: String,
+    #[serde(default)]
     pub object: String,
     pub created: u64,
     pub model: String,
@@ -460,5 +478,343 @@ pub async fn stream_completion(
             response.status(),
             body,
         );
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+pub struct ModelCapabilities {
+    #[serde(default)]
+    pub completion_chat: bool,
+    #[serde(default)]
+    pub function_calling: bool,
+    #[serde(default)]
+    pub vision: bool,
+    #[serde(default)]
+    pub reasoning: bool,
+}
+
+/// A raw model entry returned by `GET {api_url}/models`.
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct ListModelEntry {
+    pub id: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub capabilities: ModelCapabilities,
+    #[serde(default)]
+    pub max_context_length: Option<u64>,
+    #[serde(default)]
+    pub deprecation: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListModelsResponse {
+    data: Vec<ListModelEntry>,
+}
+
+/// Fetch the models available to the given API key, filtered and deduplicated
+/// via [`chat_models_from_listing`].
+///
+/// See https://docs.mistral.ai/api/#tag/models
+pub async fn list_models(
+    client: &dyn HttpClient,
+    api_url: &str,
+    api_key: &str,
+    extra_headers: &CustomHeaders,
+) -> Result<Vec<Model>> {
+    let uri = format!("{api_url}/models");
+
+    let request = HttpRequest::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("Accept", "application/json")
+        .header("Authorization", format!("Bearer {}", api_key.trim()))
+        .extra_headers(extra_headers)
+        .body(AsyncBody::default())
+        .context("failed to build Mistral models list request")?;
+
+    let mut response = client
+        .send(request)
+        .await
+        .context("failed to send Mistral models list request")?;
+
+    let mut body = String::new();
+    response
+        .body_mut()
+        .read_to_string(&mut body)
+        .await
+        .context("failed to read Mistral models list response")?;
+
+    anyhow::ensure!(
+        response.status().is_success(),
+        "failed to list Mistral models: {} {}",
+        response.status(),
+        body,
+    );
+
+    let parsed: ListModelsResponse =
+        serde_json::from_str(&body).context("failed to parse Mistral models list response")?;
+
+    Ok(chat_models_from_listing(parsed.data))
+}
+
+/// Convert the raw `/models` listing into the chat models to offer.
+///
+/// The listing includes non-chat models (embeddings, OCR, transcription) and
+/// repeats each model once per alias, cross-referencing the other names in
+/// `aliases`. Entries are filtered to chat-capable, non-deprecated models and
+/// collapsed to one per alias group, preferring ids ending in `-latest`, then
+/// the shortest id, then the lexicographically smallest.
+pub fn chat_models_from_listing(entries: Vec<ListModelEntry>) -> Vec<Model> {
+    let entries: Vec<ListModelEntry> = entries
+        .into_iter()
+        .filter(|entry| entry.capabilities.completion_chat && entry.deprecation.is_none())
+        .collect();
+
+    fn find(parent: &mut [usize], mut index: usize) -> usize {
+        while parent[index] != index {
+            parent[index] = parent[parent[index]];
+            index = parent[index];
+        }
+        index
+    }
+
+    let mut parent: Vec<usize> = (0..entries.len()).collect();
+    let mut index_by_name: HashMap<&str, usize> = HashMap::new();
+    for (index, entry) in entries.iter().enumerate() {
+        for name in
+            std::iter::once(entry.id.as_str()).chain(entry.aliases.iter().map(String::as_str))
+        {
+            match index_by_name.entry(name) {
+                hash_map::Entry::Occupied(occupied) => {
+                    let root_a = find(&mut parent, index);
+                    let root_b = find(&mut parent, *occupied.get());
+                    parent[root_a] = root_b;
+                }
+                hash_map::Entry::Vacant(vacant) => {
+                    vacant.insert(index);
+                }
+            }
+        }
+    }
+
+    let mut groups: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for index in 0..entries.len() {
+        let root = find(&mut parent, index);
+        groups.entry(root).or_default().push(index);
+    }
+
+    let mut models: Vec<Model> = groups
+        .into_values()
+        .filter_map(|members| {
+            members.into_iter().min_by(|&a, &b| {
+                let a = &entries[a].id;
+                let b = &entries[b].id;
+                (!a.ends_with("-latest"), a.len(), a).cmp(&(!b.ends_with("-latest"), b.len(), b))
+            })
+        })
+        .map(|index| Model::from_listed(entries[index].clone()))
+        .collect();
+    models.sort_by(|a, b| a.id().cmp(b.id()));
+    models
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chat_entry(id: &str, aliases: &[&str]) -> ListModelEntry {
+        ListModelEntry {
+            id: id.to_string(),
+            aliases: aliases.iter().map(|alias| alias.to_string()).collect(),
+            capabilities: ModelCapabilities {
+                completion_chat: true,
+                function_calling: true,
+                vision: false,
+                reasoning: false,
+            },
+            max_context_length: Some(262144),
+            deprecation: None,
+        }
+    }
+
+    fn model_ids(models: &[Model]) -> Vec<&str> {
+        models.iter().map(|model| model.id()).collect()
+    }
+
+    #[test]
+    fn deserializes_models_list_response() {
+        let json = r#"{
+            "object": "list",
+            "data": [
+                {
+                    "id": "mistral-large-latest",
+                    "object": "model",
+                    "created": 1786516708,
+                    "owned_by": "mistralai",
+                    "capabilities": {
+                        "completion_chat": true,
+                        "function_calling": true,
+                        "reasoning": false,
+                        "completion_fim": false,
+                        "fine_tuning": true,
+                        "vision": true,
+                        "ocr": false
+                    },
+                    "name": "mistral-large-latest",
+                    "description": "Frontier-class model.",
+                    "max_context_length": 262144,
+                    "aliases": ["mistral-large-2512"],
+                    "deprecation": null,
+                    "default_model_temperature": 0.3,
+                    "type": "base"
+                },
+                {
+                    "id": "mistral-embed",
+                    "capabilities": {"completion_chat": false},
+                    "max_context_length": 8192,
+                    "aliases": []
+                },
+                {
+                    "id": "mistral-medium-2505",
+                    "capabilities": {"completion_chat": true, "function_calling": true},
+                    "max_context_length": 131072,
+                    "aliases": [],
+                    "deprecation": "2026-08-31T12:00:00Z"
+                },
+                {
+                    "id": "bare-entry"
+                }
+            ]
+        }"#;
+
+        let parsed: ListModelsResponse = serde_json::from_str(json).expect("valid response JSON");
+        assert_eq!(parsed.data.len(), 4);
+
+        let large = &parsed.data[0];
+        assert_eq!(large.id, "mistral-large-latest");
+        assert_eq!(large.aliases, vec!["mistral-large-2512".to_string()]);
+        assert!(large.capabilities.completion_chat);
+        assert!(large.capabilities.function_calling);
+        assert!(large.capabilities.vision);
+        assert!(!large.capabilities.reasoning);
+        assert_eq!(large.max_context_length, Some(262144));
+        assert_eq!(large.deprecation, None);
+
+        let embed = &parsed.data[1];
+        assert!(!embed.capabilities.completion_chat);
+
+        let deprecated = &parsed.data[2];
+        assert_eq!(
+            deprecated.deprecation,
+            Some("2026-08-31T12:00:00Z".to_string())
+        );
+
+        let bare = &parsed.data[3];
+        assert_eq!(bare.capabilities, ModelCapabilities::default());
+        assert!(bare.aliases.is_empty());
+        assert_eq!(bare.max_context_length, None);
+        assert_eq!(bare.deprecation, None);
+    }
+
+    #[test]
+    fn filters_non_chat_and_deprecated_models() {
+        let mut embed = chat_entry("mistral-embed", &[]);
+        embed.capabilities.completion_chat = false;
+        let mut deprecated = chat_entry("mistral-medium-2505", &[]);
+        deprecated.deprecation = Some("2026-08-31T12:00:00Z".to_string());
+        let chat = chat_entry("mistral-large-latest", &[]);
+
+        let models = chat_models_from_listing(vec![embed, deprecated, chat]);
+        assert_eq!(model_ids(&models), vec!["mistral-large-latest"]);
+    }
+
+    #[test]
+    fn dedups_alias_closures_preferring_latest() {
+        let models = chat_models_from_listing(vec![
+            chat_entry(
+                "mistral-medium",
+                &["mistral-medium-latest", "mistral-medium-2604"],
+            ),
+            chat_entry(
+                "mistral-medium-latest",
+                &["mistral-medium", "mistral-medium-2604"],
+            ),
+            chat_entry(
+                "mistral-medium-2604",
+                &["mistral-medium", "mistral-medium-latest"],
+            ),
+            chat_entry("codestral-latest", &["codestral-2508"]),
+            chat_entry("codestral-2508", &["codestral-latest"]),
+        ]);
+        assert_eq!(
+            model_ids(&models),
+            vec!["codestral-latest", "mistral-medium-latest"]
+        );
+    }
+
+    #[test]
+    fn dedups_transitive_alias_closures() {
+        // `a` and `c` never mention each other, but both alias `shared`, so
+        // all three collapse into one group.
+        let models = chat_models_from_listing(vec![
+            chat_entry("model-a", &["shared"]),
+            chat_entry("model-c-latest", &["shared"]),
+        ]);
+        assert_eq!(model_ids(&models), vec!["model-c-latest"]);
+    }
+
+    #[test]
+    fn dedup_tie_breaks_shortest_then_lexicographic() {
+        let models = chat_models_from_listing(vec![
+            chat_entry("magistral-small-latest", &["mistral-small-latest"]),
+            chat_entry("mistral-small-latest", &["magistral-small-latest"]),
+            chat_entry("zai-glm-5-2", &["glm-5-2"]),
+            chat_entry("glm-5-2", &["zai-glm-5-2"]),
+            chat_entry("bb-latest", &["aa-latest"]),
+            chat_entry("aa-latest", &["bb-latest"]),
+        ]);
+        assert_eq!(
+            model_ids(&models),
+            vec!["aa-latest", "glm-5-2", "mistral-small-latest"]
+        );
+    }
+
+    #[test]
+    fn from_listed_maps_capabilities() {
+        let entry = ListModelEntry {
+            id: "magistral-small-latest".to_string(),
+            aliases: Vec::new(),
+            capabilities: ModelCapabilities {
+                completion_chat: true,
+                function_calling: true,
+                vision: false,
+                reasoning: true,
+            },
+            max_context_length: Some(262144),
+            deprecation: None,
+        };
+
+        let model = Model::from_listed(entry);
+        assert_eq!(model.id(), "magistral-small-latest");
+        assert_eq!(model.display_name(), "magistral-small-latest");
+        assert_eq!(model.max_token_count(), 262144);
+        assert_eq!(model.max_output_tokens(), None);
+        assert!(model.supports_tools());
+        assert!(!model.supports_images());
+        assert!(model.supports_thinking());
+    }
+
+    #[test]
+    fn from_listed_defaults_max_tokens_when_missing() {
+        let mut entry = chat_entry("some-model", &[]);
+        entry.max_context_length = None;
+        let model = Model::from_listed(entry);
+        assert_eq!(model.max_token_count(), DEFAULT_MAX_TOKEN_COUNT);
+    }
+
+    #[test]
+    fn empty_listing_produces_no_models() {
+        assert!(chat_models_from_listing(Vec::new()).is_empty());
     }
 }


### PR DESCRIPTION
Add support for dynamically fetching Mistral models from the API when authenticated. Falls back to the static model list when offline or unauthenticated.

This is the implementation of Phase 1 (dynamic model discovery) of the proposal in #62493. Regional endpoint selection, credential handling across regions, the UI selector, and docs are later phases and intentionally out of scope here.

# Objective

The Mistral provider relies on a hardcoded seven-model enum, so every model release (Magistral, Devstral, GLM, ...) requires a PR touching seven match arms, and the catalog goes stale in between. The static dropdown also shows models a configured endpoint may not serve: regional and proxy endpoints only serve a subset, and unavailable models fail at request time. The `available_models` setting is a workaround that pushes context windows and capability flags onto users.

## Solution

Follows the pattern already used by the Anthropic, OpenRouter, and Ollama providers.

`crates/mistral`:
- `list_models()` queries `GET {api_url}/models` with Bearer auth and custom-header support. Response types deserialize only what is needed (`id`, `aliases`, `capabilities`, `max_context_length`, `deprecation`), with `#[serde(default)]` on optional fields so proxies that omit fields still parse.
- Capability mapping is complete from the API: `function_calling` -> tools, `vision` -> images, `reasoning` -> thinking, `max_context_length` -> context window (128k fallback if absent).
- `chat_models_from_listing()` filters to chat-capable, non-deprecated entries and deduplicates alias groups. The listing repeats each model once per alias (the mistral-medium family appears 7 times); a union-find over alias closures collapses each group to one canonical id, preferring ids ending in `-latest`, then the shortest, then the lexicographically smallest.

`crates/language_models`:
- `State` gains `fetched_models` and a `fetch_models_task`. Fetch triggers: successful `authenticate` (covers the `MISTRAL_API_KEY` env var and app startup), `set_api_key`, and `api_url` changes (which clear the fetched list, re-authenticate, and refetch).
- `provided_models()` uses the fetched list as the base when present, so the dropdown reflects what the endpoint actually serves. The static enum remains the fallback before the first successful fetch (offline, unauthenticated, or an endpoint without `/models`). `available_models` from settings still overlays last, unchanged.
- `default_model`/`default_fast_model` keep the static defaults (`codestral-latest`, `mistral-small-latest`); both exist on the live API and survive dedup, avoiding a None-until-fetch regression.

Deliberate behavior notes:
- Entries with a `deprecation` date are dropped even if the date is in the future; any hidden id can be re-added via `available_models`.
- Fetch failures are held in the task and never surface as errors; the provider just keeps the static fallback, matching the Anthropic provider.

## Testing

- 8 new unit tests in `crates/mistral` covering response deserialization (including entries with missing optional fields), chat/deprecation filtering, transitive alias dedup, tie-break rules, capability mapping, and the empty-listing case.
- Existing provider conversion tests in `crates/language_models` pass unchanged.
- `cargo test -p mistral`, `cargo test -p language_models mistral`, and `./script/clippy` are clean.
- Verified the filter/dedup rules against the live API: the 36 raw chat entries collapse to a clean 10-model dropdown (codestral-latest, glm-5-2, labs-leanstral-1-5, ministral-3b/8b/14b-latest, mistral-large/medium/small-latest, voxtral-small-latest) with no duplicates.
- To test as a reviewer: run Zed with `MISTRAL_API_KEY` set and open the agent panel model dropdown; expect the deduped fetched list. Then point `language_models.mistral.api_url` at an unreachable host and confirm the dropdown falls back to the seven static models.
- Tested on macOS only; the change is platform-independent (HTTP + settings plumbing).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved the Mistral provider to fetch the available models from the API, so new Mistral models appear automatically and the model list matches what the configured endpoint serves. The built-in model list is still used when offline or unauthenticated.