### PR TITLE
editor: Preserve viewport when pasting visible text

### DIFF
--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -168,7 +168,12 @@ impl Editor {
                 let selections = this
                     .selections
                     .all::<MultiBufferOffset>(&this.display_snapshot(cx));
-                this.change_selections(Default::default(), window, cx, |s| s.select(selections));
+                this.change_selections(
+                    SelectionEffects::scroll(Autoscroll::fit_without_vertical_margin()),
+                    window,
+                    cx,
+                    |s| s.select(selections),
+                );
             } else {
                 let clipboard_is_url = is_standalone_url(&clipboard_text);
 
@@ -233,9 +238,12 @@ impl Editor {
                     anchors
                 });
 
-                this.change_selections(Default::default(), window, cx, |s| {
-                    s.select_anchors(selection_anchors);
-                });
+                this.change_selections(
+                    SelectionEffects::scroll(Autoscroll::fit_without_vertical_margin()),
+                    window,
+                    cx,
+                    |s| s.select_anchors(selection_anchors),
+                );
             }
 
             //   🤔                 |    ..     | show_in_menu |

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10462,6 +10462,86 @@ async fn test_paste_undo_does_not_include_preceding_edits(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_paste_preserves_scroll_position_when_result_is_visible(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let line_height = cx.update_editor(|editor, window, cx| {
+        editor.set_vertical_scroll_margin(4, cx);
+        editor
+            .style(cx)
+            .text
+            .line_height_in_pixels(window.rem_size())
+    });
+    let window = cx.window;
+    cx.simulate_window_resize(window, size(px(1000.), 8. * line_height));
+
+    cx.set_state(
+        "ˇzero\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve\n",
+    );
+    cx.update_editor(|editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+            selections.select_ranges([Point::new(6, 0)..Point::new(9, 0)]);
+        });
+        editor.set_scroll_position(gpui::Point::new(0., 3.), window, cx);
+        editor.copy(&Copy, window, cx);
+    });
+
+    let scroll_position_before =
+        cx.update_editor(|editor, window, cx| editor.snapshot(window, cx).scroll_position());
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    let scroll_position_after =
+        cx.update_editor(|editor, window, cx| editor.snapshot(window, cx).scroll_position());
+
+    assert_eq!(scroll_position_after, scroll_position_before);
+}
+
+#[gpui::test]
+async fn test_paste_scrolls_minimally_to_reveal_result(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let line_height = cx.update_editor(|editor, window, cx| {
+        editor.set_vertical_scroll_margin(4, cx);
+        editor
+            .style(cx)
+            .text
+            .line_height_in_pixels(window.rem_size())
+    });
+    let window = cx.window;
+    cx.simulate_window_resize(window, size(px(1000.), 8. * line_height));
+
+    cx.set_state(
+        "ˇzero\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve\n",
+    );
+    cx.update_editor(|editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+            selections.select_ranges([Point::new(9, 0)..Point::new(9, 0)]);
+        });
+        editor.set_scroll_position(gpui::Point::new(0., 3.), window, cx);
+    });
+    cx.write_to_clipboard(ClipboardItem::new_string("alpha\nbeta\ngamma\n".into()));
+
+    cx.update_editor(|editor, window, cx| editor.paste(&Paste, window, cx));
+    cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let scroll_position = snapshot.scroll_position();
+        let cursor_bottom = editor
+            .selections
+            .newest_display(&snapshot.display_snapshot)
+            .head()
+            .row()
+            .next_row()
+            .as_f64();
+        let visible_lines = editor
+            .visible_line_count()
+            .expect("the test editor should have a measured viewport");
+
+        assert_eq!(scroll_position.y, cursor_bottom - visible_lines);
+    });
+}
+
+#[gpui::test]
 async fn test_paste_content_from_other_app(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -24,6 +24,12 @@ impl Autoscroll {
         Self::Strategy(AutoscrollStrategy::Fit, None)
     }
 
+    /// Scrolls the minimal amount to (try to) fit all cursors onscreen without
+    /// applying the configured vertical scroll margin.
+    pub fn fit_without_vertical_margin() -> Self {
+        Self::Strategy(AutoscrollStrategy::FitWithoutVerticalMargin, None)
+    }
+
     /// scrolls the minimal amount to fit the newest cursor
     pub fn newest() -> Self {
         Self::Strategy(AutoscrollStrategy::Newest, None)
@@ -99,6 +105,7 @@ impl Into<SelectionEffects> for Option<Autoscroll> {
 #[derive(Debug, PartialEq, Default, Clone, Copy)]
 pub enum AutoscrollStrategy {
     Fit,
+    FitWithoutVerticalMargin,
     Newest,
     #[default]
     Center,
@@ -191,8 +198,13 @@ impl Editor {
             if matches!(
                 autoscroll,
                 Autoscroll::Strategy(AutoscrollStrategy::Newest, _)
-            ) || (matches!(autoscroll, Autoscroll::Strategy(AutoscrollStrategy::Fit, _))
-                && !selections_fit)
+            ) || (matches!(
+                autoscroll,
+                Autoscroll::Strategy(
+                    AutoscrollStrategy::Fit | AutoscrollStrategy::FitWithoutVerticalMargin,
+                    _
+                )
+            ) && !selections_fit)
             {
                 target_point = self
                     .selections
@@ -234,8 +246,14 @@ impl Editor {
             self.visible_sticky_header_count_for_point(&display_map, target_point, cx);
 
         let was_autoscrolled = match strategy {
-            AutoscrollStrategy::Fit | AutoscrollStrategy::Newest => {
-                let margin = margin.min(self.scroll_manager.vertical_scroll_margin);
+            AutoscrollStrategy::Fit
+            | AutoscrollStrategy::FitWithoutVerticalMargin
+            | AutoscrollStrategy::Newest => {
+                let margin = if strategy == AutoscrollStrategy::FitWithoutVerticalMargin {
+                    0.
+                } else {
+                    margin.min(self.scroll_manager.vertical_scroll_margin)
+                };
                 let target_top = (target_top - margin - visible_sticky_headers as f64).max(0.0);
                 let target_bottom = target_bottom + margin;
                 let start_row = scroll_position.y;


### PR DESCRIPTION
# Objective

Fixes #62494.

Pasting over text near the bottom of the editor re-applied the configured vertical scroll margin after collapsing the selection, shifting the viewport even when the paste result was already fully visible.

## Solution

Use a fit autoscroll strategy without the vertical margin when paste updates its selections. This keeps the existing viewport when the result is visible, while still scrolling the minimum amount needed when a multiline paste moves the cursor outside the viewport. Both clipboard paths—Zed clipboard metadata and plain external text—use the same behavior. Horizontal cursor reveal remains unchanged.

## Testing

- `cargo test -p editor test_paste_preserves_scroll_position_when_result_is_visible -- --nocapture`
- `cargo test -p editor test_paste_scrolls_minimally_to_reveal_result -- --nocapture`
- `cargo test -p editor --lib` (888 passed, 1 ignored)
- `cargo check -p editor --all-targets`
- `cargo clippy -p editor --all-targets --all-features -- --deny warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The first regression test fails on `upstream/main` because the viewport moves from row 3 to row 5, and passes with this change. The second test verifies that an offscreen paste result is still revealed with only the necessary scroll.

Tested through the editor test harness on macOS arm64. Manual UI verification was not completed: the unbundled debug build launched, but the local UI automation could not address that process.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the editor viewport shifting when pasting over visible text near the bottom of the editor.
