### PR TITLE
gpui: Add track_caller to gpui_util::log_err

### DIFF
--- a/crates/gpui_util/src/lib.rs
+++ b/crates/gpui_util/src/lib.rs
@@ -320,6 +320,7 @@ where
     );
 }
 
+#[track_caller]
 pub fn log_err<E: std::fmt::Display>(error: &E) {
     log_error_with_caller(*Location::caller(), error, log::Level::Error);
 }


### PR DESCRIPTION
# Objective

Tiny annoyance, the standalone `gpui_util::log_err` was never annotated with `#[track_caller]` so whenever it was called, the source location would be `gpui_util::lib` instead of the appropriate location. 

I checked and this is actually used in Zed in exactly one place: `crates/extension_host/src/extension_host.rs:1095`.  So *technically* this can be considered a bug.

I use it quite frequently in my code, so this is more of a self-serving pr.

## Solution

I added `#[track_caller]` to `gpui_util::log_err`.

## Testing

I ran the tests just in case and they all passed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added track_caller to gpui_util::log_err