### PR TITLE
openai_subscribed: Log compaction response errors

### DIFF
--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -623,7 +623,7 @@ fn guess_rust_code_from_style(goal_style: &StyleRefinement) -> (String, StyleRef
         let before_change = style.clone();
         style = method.invoke(style);
         if before_change != style {
-            let _ = write!(code, "\n        .{}()", &method.name);
+            let _ = write!(code, "\n        .{}()", method.name);
         }
     }
     code.push_str("\n}");

--- a/crates/openai_subscribed/src/openai_subscribed.rs
+++ b/crates/openai_subscribed/src/openai_subscribed.rs
@@ -497,7 +497,13 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
                         compact_request,
                         &extra_headers,
                     )
-                    .await?;
+                    .await
+                    .inspect_err(|error| {
+                        log::error!(
+                            "ChatGPT subscription compaction request to \
+                             {CODEX_BASE_URL}/responses/compact failed: {error}"
+                        );
+                    })?;
                     let usage = token_usage_from_response_usage(&response.usage);
                     let context = response
                         .into_compacted_context(PROVIDER_ID)


### PR DESCRIPTION
ChatGPT subscription compaction failures currently flow through the generic HTTP status conversion before callers can inspect the provider response. A 404 therefore becomes `ApiEndpointNotFound`, which drops the response body and leaves logs with only the inferred endpoint-not-found message.

Log the original `RequestError` at the subscription compaction call site before returning it unchanged. The log identifies the compact endpoint and preserves the HTTP status and response body for diagnosis, without logging credentials, request contents, or response headers. Error classification, retry behavior, and user-facing presentation remain unchanged.

Testing:

- `cargo fmt --all --check`
- `cargo nextest run -p openai_subscribed --lib`

Release Notes:

- N/A
