### PR TITLE
remote_server: Avoid kill for server liveness checks

### DIFF
--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -1137,12 +1137,24 @@ pub struct CheckPidError {
     pid: u32,
 }
 async fn check_server_running(pid: u32) -> std::io::Result<bool> {
-    new_command("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .output()
-        .await
-        .map(|output| output.status.success())
+    Ok(process_exists(pid))
+}
+
+fn process_exists(pid: u32) -> bool {
+    let system = sysinfo::System::new_with_specifics(
+        sysinfo::RefreshKind::nothing().with_processes(sysinfo::ProcessRefreshKind::nothing()),
+    );
+    system.process(sysinfo::Pid::from_u32(pid)).is_some()
+}
+
+#[cfg(test)]
+mod process_tests {
+    use super::process_exists;
+
+    #[test]
+    fn process_exists_finds_current_process() {
+        assert!(process_exists(std::process::id()));
+    }
 }
 
 fn check_pid_file(path: &Path) -> Result<Option<u32>, CheckPidError> {
@@ -1155,11 +1167,7 @@ fn check_pid_file(path: &Path) -> Result<Option<u32>, CheckPidError> {
 
     log::debug!("Checking if process with PID {} exists...", pid);
 
-    let system = sysinfo::System::new_with_specifics(
-        sysinfo::RefreshKind::nothing().with_processes(sysinfo::ProcessRefreshKind::nothing()),
-    );
-
-    if system.process(sysinfo::Pid::from_u32(pid)).is_some() {
+    if process_exists(pid) {
         log::debug!(
             "Process with PID {} exists. NOT spawning new server, but attaching to existing one.",
             pid


### PR DESCRIPTION
# Objective

`check_server_running` currently uses `kill -0 <pid>` to check whether the remote server is still alive.

That works on Unix, but `kill` is not available on native Windows hosts, so this check is not cross-platform.

This is related to: #55292 Windows SSH remote-server work.

## Solution

Use the existing `sysinfo` process lookup instead of spawning `kill`.

The same process lookup was already used elsewhere in `server.rs`, so this also avoids having two different ways of checking whether a PID exists.

## Testing

Added a test that verifies the process lookup detects the current process.

- `cargo fmt --all -- --check`
- `cargo test -p remote_server process_exists_finds_current_process`
- `cargo clippy -p remote_server --all-targets -- -D warnings`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed remote server liveness checks on Windows hosts.