### PR TITLE
project_panel: Add sort_direction setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -905,6 +905,16 @@
     //    No case folding, no natural number sorting:
     //    "unicode"
     "sort_order": "default",
+    // Whether sibling entries sort ascending or descending in the project panel.
+    // Composes with "sort_mode" and "sort_order"; "descending" reverses name
+    // order (e.g. date-prefixed entries newest first) without reordering
+    // parents and children:
+    //
+    // 1. Names in increasing order (default):
+    //    "ascending"
+    // 2. Names in decreasing order:
+    //    "descending"
+    "sort_direction": "ascending",
     // Whether to show error and warning count badges next to file names in the project panel.
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -64,7 +64,14 @@ fn criterion_benchmark(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || snapshot.clone(),
-                        |mut snapshot| par_sort_worktree_entries(&mut snapshot, *mode, *order),
+                        |mut snapshot| {
+                            par_sort_worktree_entries(
+                                &mut snapshot,
+                                *mode,
+                                *order,
+                                Default::default(),
+                            )
+                        },
                         criterion::BatchSize::LargeInput,
                     );
                 },

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -827,6 +827,9 @@ impl ProjectPanel {
                     if project_panel_settings.sort_order != new_settings.sort_order {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
+                    if project_panel_settings.sort_direction != new_settings.sort_direction {
+                        this.update_visible_entries(None, false, false, window, cx);
+                    }
                     if project_panel_settings.sticky_scroll && !new_settings.sticky_scroll {
                         this.sticky_items_count = 0;
                     }
@@ -2848,7 +2851,8 @@ impl ProjectPanel {
 
         let sort_mode = ProjectPanelSettings::get_global(cx).sort_mode;
         let sort_order = ProjectPanelSettings::get_global(cx).sort_order;
-        sort_worktree_entries(&mut siblings, sort_mode, sort_order);
+        let sort_direction = ProjectPanelSettings::get_global(cx).sort_direction;
+        sort_worktree_entries(&mut siblings, sort_mode, sort_order, sort_direction);
         let sibling_entry_index = siblings
             .iter()
             .position(|sibling| sibling.id == latest_entry.id)?;
@@ -4269,6 +4273,7 @@ impl ProjectPanel {
         let hide_gitignore = settings.hide_gitignore;
         let sort_mode = settings.sort_mode;
         let sort_order = settings.sort_order;
+        let sort_direction = settings.sort_direction;
         let project = self.project.read(cx);
         let repo_snapshots = project.git_store().read(cx).display_repo_snapshots(cx);
 
@@ -4506,6 +4511,7 @@ impl ProjectPanel {
                             &mut visible_worktree_entries,
                             sort_mode,
                             sort_order,
+                            sort_direction,
                         );
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
@@ -7761,26 +7767,31 @@ fn cmp_worktree_entries(
     b: &Entry,
     mode: &settings::ProjectPanelSortMode,
     order: &settings::ProjectPanelSortOrder,
+    direction: &settings::ProjectPanelSortDirection,
 ) -> cmp::Ordering {
     let a = (&*a.path, a.is_file());
     let b = (&*b.path, b.is_file());
-    util::paths::compare_rel_paths_by(a, b, (*mode).into(), (*order).into())
+    util::paths::compare_rel_paths_by(a, b, (*mode).into(), (*order).into(), (*direction).into())
 }
 
 pub fn sort_worktree_entries(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
     order: settings::ProjectPanelSortOrder,
+    direction: settings::ProjectPanelSortDirection,
 ) {
-    entries.sort_by(|lhs, rhs| cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order));
+    entries.sort_by(|lhs, rhs| {
+        cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order, &direction)
+    });
 }
 
 pub fn par_sort_worktree_entries(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
     order: settings::ProjectPanelSortOrder,
+    direction: settings::ProjectPanelSortDirection,
 ) {
-    entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
+    entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order, &direction));
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,8 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrder,
-    RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
+    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortDirection, ProjectPanelSortMode,
+    ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::{
     px,
@@ -36,6 +36,7 @@ pub struct ProjectPanelSettings {
     pub auto_open: AutoOpenSettings,
     pub sort_mode: ProjectPanelSortMode,
     pub sort_order: ProjectPanelSortOrder,
+    pub sort_direction: ProjectPanelSortDirection,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
 }
@@ -143,6 +144,7 @@ impl Settings for ProjectPanelSettings {
             },
             sort_mode: project_panel.sort_mode.unwrap(),
             sort_order: project_panel.sort_order.unwrap(),
+            sort_direction: project_panel.sort_direction.unwrap_or_default(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
         }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -11597,3 +11597,92 @@ async fn test_restore_file_prompt_escapes_markdown_in_file_name(cx: &mut gpui::T
 
     assert_eq!(message, "Discard changes to `__init__.py`?");
 }
+
+#[gpui::test]
+async fn test_sort_direction_descending(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "2023-01-10-old-post": { "inner.md": "" },
+            "2024-06-01-newer-post": {},
+            "2026-02-14-newest-post": {},
+            "notes.txt": "",
+            "archive.txt": "",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    // Ascending by default.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > 2023-01-10-old-post",
+            "    > 2024-06-01-newer-post",
+            "    > 2026-02-14-newest-post",
+            "      archive.txt",
+            "      notes.txt",
+        ]
+    );
+
+    cx.update(|_, cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project_panel
+                    .get_or_insert_default()
+                    .sort_direction = Some(settings::ProjectPanelSortDirection::Descending);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    let direction = cx.update(|_, cx| ProjectPanelSettings::get_global(cx).sort_direction);
+    assert_eq!(
+        direction,
+        settings::ProjectPanelSortDirection::Descending,
+        "setting should propagate"
+    );
+
+    // Descending reverses sibling names (newest-first) but keeps the
+    // directories-first grouping.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > 2026-02-14-newest-post",
+            "    > 2024-06-01-newer-post",
+            "    > 2023-01-10-old-post",
+            "      notes.txt",
+            "      archive.txt",
+        ]
+    );
+
+    // Children stay under their parents when a directory is expanded.
+    toggle_expand_dir(&panel, "root/2023-01-10-old-post", cx);
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            "v root",
+            "    > 2026-02-14-newest-post",
+            "    > 2024-06-01-newer-post",
+            "    v 2023-01-10-old-post  <== selected",
+            "          inner.md",
+            "      notes.txt",
+            "      archive.txt",
+        ]
+    );
+}

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -843,6 +843,7 @@ impl VsCodeSettings {
                 "filesFirst" => Some(ProjectPanelSortMode::FilesFirst),
                 _ => None,
             }),
+            sort_direction: None,
             sort_order: self.read_enum("explorer.sortOrderLexicographicOptions", |s| match s {
                 "default" => Some(ProjectPanelSortOrder::Default),
                 "upper" => Some(ProjectPanelSortOrder::Upper),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -820,6 +820,12 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: default
     pub sort_order: Option<ProjectPanelSortOrder>,
+    /// Whether sibling entries sort ascending or descending. This composes
+    /// with `sort_mode` (grouping) and `sort_order` (name comparison);
+    /// descending reverses name order without reordering parents and children.
+    ///
+    /// Default: ascending
+    pub sort_direction: Option<ProjectPanelSortDirection>,
     /// Whether to show error and warning count badges next to file names in the project panel.
     ///
     /// Default: false
@@ -907,6 +913,40 @@ pub enum ProjectPanelSortOrder {
     /// Pure Unicode codepoint comparison. No case folding, no natural number sorting.
     /// Uppercase ASCII sorts before lowercase. Accented characters sort after ASCII.
     Unicode,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectPanelSortDirection {
+    /// Sort names in increasing order (the default).
+    #[default]
+    Ascending,
+    /// Sort names in decreasing order, e.g. to show date-prefixed entries
+    /// newest first. Directories still contain their children, and
+    /// `sort_mode` grouping is unaffected.
+    Descending,
+}
+
+impl From<ProjectPanelSortDirection> for util::paths::SortDirection {
+    fn from(direction: ProjectPanelSortDirection) -> Self {
+        match direction {
+            ProjectPanelSortDirection::Ascending => Self::Ascending,
+            ProjectPanelSortDirection::Descending => Self::Descending,
+        }
+    }
 }
 
 impl From<ProjectPanelSortMode> for util::paths::SortMode {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5036,7 +5036,7 @@ fn window_and_layout_page() -> SettingsPage {
 }
 
 fn panels_page() -> SettingsPage {
-    fn project_panel_section() -> [SettingsPageItem; 29] {
+    fn project_panel_section() -> [SettingsPageItem; 30] {
         [
             SettingsPageItem::SectionHeader("Project Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5572,6 +5572,29 @@ fn panels_page() -> SettingsPage {
                             .sort_order = value;
                     },
                     json_path: Some("project_panel.sort_order"),
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Sort Direction",
+                description: "Whether sibling entries sort ascending or descending in the project panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("project_panel.sort_direction"),
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .sort_direction
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .sort_direction = value;
+                    },
                 }),
                 metadata: None,
                 files: USER,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -574,6 +574,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortOrder>(render_dropdown)
+        .add_basic_renderer::<settings::ProjectPanelSortDirection>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)
         .add_basic_renderer::<settings::FormatOnSave>(render_dropdown)
         .add_basic_renderer::<settings::LineEndingSetting>(render_dropdown)

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1034,6 +1034,26 @@ pub enum SortOrder {
     Unicode,
 }
 
+/// Controls whether sibling names sort ascending or descending. Structural
+/// ordering (parents before their children) is unaffected.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum SortDirection {
+    /// Names in increasing order (the default).
+    #[default]
+    Ascending,
+    /// Names in decreasing order.
+    Descending,
+}
+
+impl SortDirection {
+    fn apply(self, ordering: Ordering) -> Ordering {
+        match self {
+            Self::Ascending => ordering,
+            Self::Descending => ordering.reverse(),
+        }
+    }
+}
+
 /// Controls how files and directories are ordered relative to each other.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum SortMode {
@@ -1093,6 +1113,7 @@ pub fn compare_rel_paths(
         (path_b, b_is_file),
         SortMode::DirectoriesFirst,
         SortOrder::Default,
+        SortDirection::Ascending,
     )
 }
 
@@ -1101,6 +1122,7 @@ pub fn compare_rel_paths_by(
     (path_b, b_is_file): (&RelPath, bool),
     mode: SortMode,
     order: SortOrder,
+    direction: SortDirection,
 ) -> Ordering {
     let needs_final_tiebreak =
         mode != SortMode::DirectoriesFirst && !(std::ptr::eq(path_a, path_b) || path_a == path_b);
@@ -1183,14 +1205,18 @@ pub fn compare_rel_paths_by(
                 };
 
                 if !ordering.is_eq() {
-                    return ordering;
+                    return direction.apply(ordering);
                 }
             }
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
                 if needs_final_tiebreak {
-                    return compare_strings(path_a.as_unix_str(), path_b.as_unix_str(), order);
+                    return direction.apply(compare_strings(
+                        path_a.as_unix_str(),
+                        path_b.as_unix_str(),
+                        order,
+                    ));
                 }
                 return Ordering::Equal;
             }
@@ -1568,7 +1594,7 @@ mod tests {
         mode: SortMode,
         order: SortOrder,
     ) -> Vec<(&'static RelPath, bool)> {
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, mode, order));
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, mode, order, SortDirection::Ascending));
         paths
     }
 
@@ -1701,7 +1727,15 @@ mod tests {
             (RelPath::from_unix_str("Carrot").unwrap(), false),
             (RelPath::from_unix_str("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1725,8 +1759,15 @@ mod tests {
             (RelPath::from_unix_str("Carrot").unwrap(), false),
             (RelPath::from_unix_str("aardvark.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1750,8 +1791,15 @@ mod tests {
             (RelPath::from_unix_str("carrot").unwrap(), false),
             (RelPath::from_unix_str("Aardvark.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1774,8 +1822,15 @@ mod tests {
             (RelPath::from_unix_str("dir10").unwrap(), false),
             (RelPath::from_unix_str("file1.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1796,7 +1851,15 @@ mod tests {
             (RelPath::from_unix_str("readme.txt").unwrap(), true),
             (RelPath::from_unix_str("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1817,7 +1880,15 @@ mod tests {
             (RelPath::from_unix_str("file1.txt").unwrap(), true),
             (RelPath::from_unix_str("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1836,7 +1907,15 @@ mod tests {
             (RelPath::from_unix_str("Hello.txt").unwrap(), true),
             (RelPath::from_unix_str("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1849,7 +1928,15 @@ mod tests {
             (RelPath::from_unix_str("hello").unwrap(), false),
             (RelPath::from_unix_str("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1868,7 +1955,15 @@ mod tests {
             (RelPath::from_unix_str("src").unwrap(), false),
             (RelPath::from_unix_str("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1889,8 +1984,15 @@ mod tests {
             (RelPath::from_unix_str("src").unwrap(), false),
             (RelPath::from_unix_str("tests").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1911,7 +2013,15 @@ mod tests {
             (RelPath::from_unix_str(".github").unwrap(), false),
             (RelPath::from_unix_str("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1932,8 +2042,15 @@ mod tests {
             (RelPath::from_unix_str(".github").unwrap(), false),
             (RelPath::from_unix_str("src").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1953,7 +2070,15 @@ mod tests {
             (RelPath::from_unix_str("file.md").unwrap(), true),
             (RelPath::from_unix_str("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1972,8 +2097,15 @@ mod tests {
             (RelPath::from_unix_str("main.c").unwrap(), true),
             (RelPath::from_unix_str("main").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1993,7 +2125,15 @@ mod tests {
             (RelPath::from_unix_str("a.txt").unwrap(), true),
             (RelPath::from_unix_str("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -3447,6 +3587,65 @@ mod tests {
         assert_eq!(
             url.to_file_path_ext(PathStyle::Windows),
             Ok(PathBuf::from("C:\\Users\\file.txt"))
+        );
+    }
+}
+
+#[cfg(test)]
+mod sort_direction_tests {
+    use super::*;
+    use path::rel_path::rel_path;
+
+    #[test]
+    fn descending_reverses_sibling_names_only() {
+        let a = (rel_path("2023-01-old"), false);
+        let b = (rel_path("2026-02-new"), false);
+        let file = (rel_path("notes.txt"), true);
+        // Ascending baseline.
+        assert_eq!(
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending
+            ),
+            Ordering::Less
+        );
+        // Descending flips sibling names.
+        assert_eq!(
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
+            Ordering::Greater
+        );
+        // Grouping unaffected: dirs still before files in DirectoriesFirst.
+        assert_eq!(
+            compare_rel_paths_by(
+                b,
+                file,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
+            Ordering::Less
+        );
+        // Parents still precede their children.
+        let parent = (rel_path("a"), false);
+        let child = (rel_path("a/b"), true);
+        assert_eq!(
+            compare_rel_paths_by(
+                parent,
+                child,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
+            Ordering::Less
         );
     }
 }

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -175,6 +175,14 @@ The `project_panel.sort_order` setting controls name comparison:
 - `"lower"` — lowercase names grouped first, then uppercase.
 - `"unicode"` — raw Unicode codepoint order with no case folding.
 
+The `project_panel.sort_direction` setting controls whether sibling names sort
+ascending or descending:
+
+- `"ascending"` (default) — names in increasing order.
+- `"descending"` — names in decreasing order, e.g. to show date-prefixed
+  entries newest first. Grouping from `sort_mode` is unaffected, and parents
+  still appear above their children.
+
 ## Other Actions
 
 - {#action project_panel::RevealInFileManager} ({#kb

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5512,6 +5512,34 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 }
 ```
 
+### Sort Direction
+
+- Description: Whether sibling entries in the project panel sort ascending or descending. This composes with `sort_mode` (grouping) and `sort_order` (name comparison): `descending` reverses name order among siblings — for example to show date-prefixed entries newest first — while directories still appear above their own contents.
+- Setting: `sort_direction`
+- Default: `ascending`
+
+**Options**
+
+1. Names in increasing order:
+
+```json [settings]
+{
+  "project_panel": {
+    "sort_direction": "ascending"
+  }
+}
+```
+
+2. Names in decreasing order:
+
+```json [settings]
+{
+  "project_panel": {
+    "sort_direction": "descending"
+  }
+}
+```
+
 ### Auto Open
 
 - Description: Control whether files are opened automatically after different creation flows in the project panel.


### PR DESCRIPTION
Adds `project_panel.sort_direction` (`"ascending"` | `"descending"`), which
composes with the existing `sort_mode` and `sort_order` settings.

Descending reverses name ordering among siblings — for example, to show
date-prefixed notes or dated log directories newest first. Grouping from
`sort_mode` is unaffected, and parents still appear above their own children:
the comparator reverses only the name-derived ordering, never the structural
component ordering, so a directory never sorts below its contents.

```json
{
  "project_panel": {
    "sort_direction": "descending"
  }
}
```

This covers the ascending/descending axis of #53020 (sorting by modified time
is not included).

The setting is registered in the settings UI alongside `sort_mode` and
`sort_order`, documented in the project panel docs, and covered by tests in
`project_panel_tests.rs` and `util::paths`, including that descending does not
reorder parents relative to their children.

Release Notes:

- Added a `project_panel.sort_direction` setting to sort project panel entries in descending name order
