### PR TITLE
workspace: Reset all configured dock panels

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1004,7 +1004,7 @@ impl Dock {
         cx.notify();
     }
 
-    pub fn resize_active_panel(
+    fn resize_active_panel(
         &mut self,
         size: Option<Pixels>,
         flex: Option<f32>,
@@ -1042,22 +1042,15 @@ impl Dock {
         }
     }
 
-    pub fn reset_active_panel_size(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn reset_panel_sizes(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.should_resize_all_panels(cx) {
-            let Some(active_entry) = self.active_panel_entry() else {
-                return;
-            };
-            let size = (!panel_uses_flexible_width(
-                self.position,
-                active_entry.panel.as_ref(),
-                window,
-                cx,
-            ))
-            .then(|| active_entry.panel.default_size(window, cx));
-            self.resize_all_panels(size, None, window, cx);
-            return;
+            self.reset_all_panel_sizes(window, cx);
+        } else {
+            self.reset_active_panel_size(window, cx);
         }
+    }
 
+    fn reset_active_panel_size(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(entry) = self.active_panel_entry_mut() else {
             return;
         };
@@ -1074,6 +1067,16 @@ impl Dock {
             }
         });
         cx.notify();
+    }
+
+    fn reset_all_panel_sizes(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(active_entry) = self.active_panel_entry() else {
+            return;
+        };
+        let size =
+            (!panel_uses_flexible_width(self.position, active_entry.panel.as_ref(), window, cx))
+                .then(|| active_entry.panel.default_size(window, cx));
+        self.resize_all_panels(size, None, window, cx);
     }
 
     fn should_resize_all_panels(&self, cx: &App) -> bool {
@@ -1209,7 +1212,7 @@ impl Render for Dock {
                         MouseButton::Left,
                         cx.listener(|dock, e: &MouseUpEvent, window, cx| {
                             if e.click_count == 2 {
-                                dock.reset_active_panel_size(window, cx);
+                                dock.reset_panel_sizes(window, cx);
                                 dock.workspace
                                     .update(cx, |workspace, cx| {
                                         workspace.serialize_workspace(window, cx);

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1028,6 +1028,8 @@ impl Dock {
         }
     }
 
+    /// Resizes the active panel and, when this dock is included in
+    /// `resize_all_panels_in_dock`, all panels using the same sizing mode.
     pub fn resize_panel_sizes(
         &mut self,
         size: Option<Pixels>,
@@ -1042,6 +1044,8 @@ impl Dock {
         }
     }
 
+    /// Resets the active panel and, when this dock is included in
+    /// `resize_all_panels_in_dock`, all panels using the same sizing mode.
     pub fn reset_panel_sizes(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.should_resize_all_panels(cx) {
             self.reset_all_panel_sizes(window, cx);
@@ -1051,22 +1055,8 @@ impl Dock {
     }
 
     fn reset_active_panel_size(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(entry) = self.active_panel_entry_mut() else {
-            return;
-        };
-        entry.size_state = PanelSizeState::default();
-        entry.panel.size_state_changed(window, cx);
-
-        let panel_key = entry.panel.panel_key();
-        let workspace = self.workspace.clone();
-        cx.defer(move |cx| {
-            if let Some(workspace) = workspace.upgrade() {
-                workspace.update(cx, |workspace, cx| {
-                    workspace.persist_panel_size_state(panel_key, PanelSizeState::default(), cx);
-                });
-            }
-        });
-        cx.notify();
+        let state = PanelSizeState::default();
+        self.resize_active_panel(state.size, state.flex, window, cx);
     }
 
     fn reset_all_panel_sizes(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1028,7 +1028,7 @@ impl Dock {
         }
     }
 
-    pub fn resize_panels(
+    pub fn resize_panel_sizes(
         &mut self,
         size: Option<Pixels>,
         flex: Option<f32>,

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1035,7 +1035,7 @@ impl Dock {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.resizes_all_panels(cx) {
+        if self.should_resize_all_panels(cx) {
             self.resize_all_panels(size, flex, window, cx);
         } else {
             self.resize_active_panel(size, flex, window, cx);
@@ -1043,7 +1043,7 @@ impl Dock {
     }
 
     pub fn reset_active_panel_size(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.resizes_all_panels(cx) {
+        if self.should_resize_all_panels(cx) {
             let Some(active_entry) = self.active_panel_entry() else {
                 return;
             };
@@ -1076,7 +1076,7 @@ impl Dock {
         cx.notify();
     }
 
-    fn resizes_all_panels(&self, cx: &App) -> bool {
+    fn should_resize_all_panels(&self, cx: &App) -> bool {
         WorkspaceSettings::get_global(cx)
             .resize_all_panels_in_dock
             .contains(&self.position)

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -546,6 +546,11 @@ impl Dock {
             .and_then(|index| self.panel_entries.get(index))
     }
 
+    fn active_panel_entry_mut(&mut self) -> Option<&mut PanelEntry> {
+        self.active_panel_index
+            .and_then(|index| self.panel_entries.get_mut(index))
+    }
+
     pub fn active_panel_index(&self) -> Option<usize> {
         self.active_panel_index
     }
@@ -1006,11 +1011,10 @@ impl Dock {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(index) = self.active_panel_index
-            && let Some(entry) = self.panel_entries.get_mut(index)
-        {
+        let position = self.position;
+        if let Some(entry) = self.active_panel_entry_mut() {
             let (panel_key, size_state) =
-                resize_panel_entry(self.position, entry, size, flex, window, cx);
+                resize_panel_entry(position, entry, size, flex, window, cx);
 
             let workspace = self.workspace.clone();
             cx.defer(move |cx| {
@@ -1024,7 +1028,61 @@ impl Dock {
         }
     }
 
-    pub fn resize_all_panels(
+    pub fn resize_panels(
+        &mut self,
+        size: Option<Pixels>,
+        flex: Option<f32>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.resizes_all_panels(cx) {
+            self.resize_all_panels(size, flex, window, cx);
+        } else {
+            self.resize_active_panel(size, flex, window, cx);
+        }
+    }
+
+    pub fn reset_active_panel_size(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.resizes_all_panels(cx) {
+            let Some(active_entry) = self.active_panel_entry() else {
+                return;
+            };
+            let size = (!panel_uses_flexible_width(
+                self.position,
+                active_entry.panel.as_ref(),
+                window,
+                cx,
+            ))
+            .then(|| active_entry.panel.default_size(window, cx));
+            self.resize_all_panels(size, None, window, cx);
+            return;
+        }
+
+        let Some(entry) = self.active_panel_entry_mut() else {
+            return;
+        };
+        entry.size_state = PanelSizeState::default();
+        entry.panel.size_state_changed(window, cx);
+
+        let panel_key = entry.panel.panel_key();
+        let workspace = self.workspace.clone();
+        cx.defer(move |cx| {
+            if let Some(workspace) = workspace.upgrade() {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.persist_panel_size_state(panel_key, PanelSizeState::default(), cx);
+                });
+            }
+        });
+        cx.notify();
+    }
+
+    fn resizes_all_panels(&self, cx: &App) -> bool {
+        WorkspaceSettings::get_global(cx)
+            .resize_all_panels_in_dock
+            .contains(&self.position)
+    }
+
+    fn resize_all_panels(
         &mut self,
         size: Option<Pixels>,
         flex: Option<f32>,
@@ -1151,7 +1209,7 @@ impl Render for Dock {
                         MouseButton::Left,
                         cx.listener(|dock, e: &MouseUpEvent, window, cx| {
                             if e.click_count == 2 {
-                                dock.resize_active_panel(None, None, window, cx);
+                                dock.reset_active_panel_size(window, cx);
                                 dock.workspace
                                     .update(cx, |workspace, cx| {
                                         workspace.serialize_workspace(window, cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8421,7 +8421,7 @@ impl Workspace {
 
         let flex_grow = self.dock_flex_for_size(DockPosition::Left, size, window, cx);
         self.left_dock.update(cx, |left_dock, cx| {
-            left_dock.resize_panels(Some(size), flex_grow, window, cx);
+            left_dock.resize_panel_sizes(Some(size), flex_grow, window, cx);
         });
     }
 
@@ -8438,14 +8438,14 @@ impl Workspace {
         });
         let flex_grow = self.dock_flex_for_size(DockPosition::Right, size, window, cx);
         self.right_dock.update(cx, |right_dock, cx| {
-            right_dock.resize_panels(Some(size), flex_grow, window, cx);
+            right_dock.resize_panel_sizes(Some(size), flex_grow, window, cx);
         });
     }
 
     fn resize_bottom_dock(&mut self, new_size: Pixels, window: &mut Window, cx: &mut App) {
         let size = new_size.min(self.bounds.bottom() - RESIZE_HANDLE_SIZE - self.bounds.top());
         self.bottom_dock.update(cx, |bottom_dock, cx| {
-            bottom_dock.resize_panels(Some(size), None, window, cx);
+            bottom_dock.resize_panel_sizes(Some(size), None, window, cx);
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7695,32 +7695,20 @@ impl Workspace {
                 |workspace: &mut Workspace, _: &ResetActiveDockSize, window, cx| {
                     for dock in workspace.all_docks() {
                         if dock.focus_handle(cx).contains_focused(window, cx) {
-                            let panel = dock.read(cx).active_panel().cloned();
-                            if let Some(panel) = panel {
-                                dock.update(cx, |dock, cx| {
-                                    dock.set_panel_size_state(
-                                        panel.as_ref(),
-                                        dock::PanelSizeState::default(),
-                                        cx,
-                                    );
-                                });
-                            }
+                            dock.update(cx, |dock, cx| {
+                                dock.reset_active_panel_size(window, cx);
+                            });
                             return;
                         }
                     }
                 },
             ))
             .on_action(cx.listener(
-                |workspace: &mut Workspace, _: &ResetOpenDocksSize, _window, cx| {
+                |workspace: &mut Workspace, _: &ResetOpenDocksSize, window, cx| {
                     for dock in workspace.all_docks() {
-                        let panel = dock.read(cx).visible_panel().cloned();
-                        if let Some(panel) = panel {
+                        if dock.read(cx).visible_panel().is_some() {
                             dock.update(cx, |dock, cx| {
-                                dock.set_panel_size_state(
-                                    panel.as_ref(),
-                                    dock::PanelSizeState::default(),
-                                    cx,
-                                );
+                                dock.reset_active_panel_size(window, cx);
                             });
                         }
                     }
@@ -8433,14 +8421,7 @@ impl Workspace {
 
         let flex_grow = self.dock_flex_for_size(DockPosition::Left, size, window, cx);
         self.left_dock.update(cx, |left_dock, cx| {
-            if WorkspaceSettings::get_global(cx)
-                .resize_all_panels_in_dock
-                .contains(&DockPosition::Left)
-            {
-                left_dock.resize_all_panels(Some(size), flex_grow, window, cx);
-            } else {
-                left_dock.resize_active_panel(Some(size), flex_grow, window, cx);
-            }
+            left_dock.resize_panels(Some(size), flex_grow, window, cx);
         });
     }
 
@@ -8457,28 +8438,14 @@ impl Workspace {
         });
         let flex_grow = self.dock_flex_for_size(DockPosition::Right, size, window, cx);
         self.right_dock.update(cx, |right_dock, cx| {
-            if WorkspaceSettings::get_global(cx)
-                .resize_all_panels_in_dock
-                .contains(&DockPosition::Right)
-            {
-                right_dock.resize_all_panels(Some(size), flex_grow, window, cx);
-            } else {
-                right_dock.resize_active_panel(Some(size), flex_grow, window, cx);
-            }
+            right_dock.resize_panels(Some(size), flex_grow, window, cx);
         });
     }
 
     fn resize_bottom_dock(&mut self, new_size: Pixels, window: &mut Window, cx: &mut App) {
         let size = new_size.min(self.bounds.bottom() - RESIZE_HANDLE_SIZE - self.bounds.top());
         self.bottom_dock.update(cx, |bottom_dock, cx| {
-            if WorkspaceSettings::get_global(cx)
-                .resize_all_panels_in_dock
-                .contains(&DockPosition::Bottom)
-            {
-                bottom_dock.resize_all_panels(Some(size), None, window, cx);
-            } else {
-                bottom_dock.resize_active_panel(Some(size), None, window, cx);
-            }
+            bottom_dock.resize_panels(Some(size), None, window, cx);
         });
     }
 
@@ -14638,6 +14605,133 @@ mod tests {
             dock_size, None,
             "saved size should be cleared after default_size changes"
         );
+    }
+
+    #[gpui::test]
+    async fn test_reset_all_panel_sizes_in_dock(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.resize_all_panels_in_dock =
+                    Some(vec![settings::DockPosition::Left]);
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        workspace.update(cx, |workspace, _| {
+            workspace.bounds.size.width = px(900.);
+        });
+        let (first_panel, second_panel) = workspace.update_in(cx, |workspace, window, cx| {
+            let first_panel = cx.new(|cx| {
+                let mut panel = TestPanel::new(DockPosition::Left, 100, cx);
+                panel.default_size = px(350.);
+                panel
+            });
+            let second_panel = cx.new(|cx| {
+                let mut panel = TestPanel::new(DockPosition::Left, 200, cx);
+                panel.default_size = px(500.);
+                panel
+            });
+            workspace.add_panel(first_panel.clone(), window, cx);
+            workspace.add_panel(second_panel.clone(), window, cx);
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+                dock.set_open(true, window, cx);
+            });
+            workspace.resize_left_dock(px(400.), window, cx);
+            (first_panel, second_panel)
+        });
+
+        cx.dispatch_action(ResetOpenDocksSize);
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let dock = workspace.left_dock().read(cx);
+            assert_eq!(
+                dock.stored_panel_size(&first_panel, window, cx),
+                Some(px(350.))
+            );
+            assert_eq!(
+                dock.stored_panel_size(&second_panel, window, cx),
+                Some(px(350.))
+            );
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.activate_panel(1, window, cx);
+            });
+            workspace.resize_left_dock(px(450.), window, cx);
+        });
+        cx.dispatch_action(ResetOpenDocksSize);
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let dock = workspace.left_dock().read(cx);
+            assert_eq!(
+                dock.stored_panel_size(&first_panel, window, cx),
+                Some(px(500.))
+            );
+            assert_eq!(
+                dock.stored_panel_size(&second_panel, window, cx),
+                Some(px(500.))
+            );
+        });
+
+        first_panel.update(cx, |panel, _| panel.flexible = true);
+        second_panel.update(cx, |panel, _| panel.flexible = true);
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.resize_left_dock(px(350.), window, cx);
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.reset_active_panel_size(window, cx);
+            });
+            let dock = workspace.left_dock().read(cx);
+            assert_eq!(
+                workspace.dock_size(&dock, window, cx),
+                Some(workspace.bounds.size.width / 2.)
+            );
+            assert!(
+                dock.stored_panel_size_state(&first_panel)
+                    .is_some_and(|state| state.flex.is_none())
+            );
+            assert!(
+                dock.stored_panel_size_state(&second_panel)
+                    .is_some_and(|state| state.flex.is_none())
+            );
+        });
+
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.resize_all_panels_in_dock = Some(Vec::new());
+            });
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            first_panel.update(cx, |panel, _| panel.flexible = false);
+            second_panel.update(cx, |panel, _| panel.flexible = false);
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+            });
+            workspace.resize_left_dock(px(400.), window, cx);
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.reset_active_panel_size(window, cx);
+            });
+
+            let dock = workspace.left_dock().read(cx);
+            assert_eq!(
+                dock.stored_panel_size(&first_panel, window, cx),
+                Some(px(350.))
+            );
+            assert_eq!(
+                dock.stored_panel_size(&second_panel, window, cx),
+                Some(px(500.))
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -14621,9 +14621,6 @@ mod tests {
         let workspace =
             multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
 
-        workspace.update(cx, |workspace, _| {
-            workspace.bounds.size.width = px(900.);
-        });
         let (first_panel, second_panel) = workspace.update_in(cx, |workspace, window, cx| {
             let first_panel = cx.new(|cx| {
                 let mut panel = TestPanel::new(DockPosition::Left, 100, cx);
@@ -14646,18 +14643,14 @@ mod tests {
         });
 
         cx.dispatch_action(ResetOpenDocksSize);
-        cx.run_until_parked();
 
         workspace.update_in(cx, |workspace, window, cx| {
             let dock = workspace.left_dock().read(cx);
-            assert_eq!(
-                dock.stored_panel_size(&first_panel, window, cx),
-                Some(px(350.))
-            );
-            assert_eq!(
-                dock.stored_panel_size(&second_panel, window, cx),
-                Some(px(350.))
-            );
+            let first_panel_size = dock.stored_panel_size(&first_panel, window, cx);
+            let second_panel_size = dock.stored_panel_size(&second_panel, window, cx);
+
+            assert_eq!(first_panel_size, Some(px(350.)));
+            assert_eq!(second_panel_size, Some(px(350.)));
         });
 
         workspace.update_in(cx, |workspace, window, cx| {
@@ -14667,18 +14660,14 @@ mod tests {
             workspace.resize_left_dock(px(450.), window, cx);
         });
         cx.dispatch_action(ResetOpenDocksSize);
-        cx.run_until_parked();
 
         workspace.update_in(cx, |workspace, window, cx| {
             let dock = workspace.left_dock().read(cx);
-            assert_eq!(
-                dock.stored_panel_size(&first_panel, window, cx),
-                Some(px(500.))
-            );
-            assert_eq!(
-                dock.stored_panel_size(&second_panel, window, cx),
-                Some(px(500.))
-            );
+            let first_panel_size = dock.stored_panel_size(&first_panel, window, cx);
+            let second_panel_size = dock.stored_panel_size(&second_panel, window, cx);
+
+            assert_eq!(first_panel_size, Some(px(500.)));
+            assert_eq!(second_panel_size, Some(px(500.)));
         });
 
         first_panel.update(cx, |panel, _| panel.flexible = true);
@@ -14689,18 +14678,19 @@ mod tests {
                 dock.reset_panel_sizes(window, cx);
             });
             let dock = workspace.left_dock().read(cx);
+            let first_panel_flex = dock
+                .stored_panel_size_state(&first_panel)
+                .and_then(|state| state.flex);
+            let second_panel_flex = dock
+                .stored_panel_size_state(&second_panel)
+                .and_then(|state| state.flex);
+
             assert_eq!(
                 workspace.dock_size(&dock, window, cx),
                 Some(workspace.bounds.size.width / 2.)
             );
-            assert!(
-                dock.stored_panel_size_state(&first_panel)
-                    .is_some_and(|state| state.flex.is_none())
-            );
-            assert!(
-                dock.stored_panel_size_state(&second_panel)
-                    .is_some_and(|state| state.flex.is_none())
-            );
+            assert!(first_panel_flex.is_none());
+            assert!(second_panel_flex.is_none());
         });
 
         cx.update_global(|store: &mut SettingsStore, cx| {
@@ -14720,14 +14710,143 @@ mod tests {
             });
 
             let dock = workspace.left_dock().read(cx);
-            assert_eq!(
-                dock.stored_panel_size(&first_panel, window, cx),
-                Some(px(350.))
-            );
-            assert_eq!(
-                dock.stored_panel_size(&second_panel, window, cx),
-                Some(px(500.))
-            );
+            let first_panel_size = dock.stored_panel_size(&first_panel, window, cx);
+            let second_panel_size = dock.stored_panel_size(&second_panel, window, cx);
+
+            assert_eq!(first_panel_size, Some(px(350.)));
+            assert_eq!(second_panel_size, Some(px(500.)));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_reset_panel_mixed_modes(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.resize_all_panels_in_dock =
+                    Some(vec![settings::DockPosition::Left]);
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        // Create 4 panels, 2 with fixed width and another 2 with flexible width
+        // so that we can later confirm that updating a flexible width panel
+        // only affects other flexible panels, and the same with fixed width
+        // panels.
+        let (fixed_panel_a, fixed_panel_b, flexible_panel_a, flexible_panel_b) = workspace
+            .update_in(cx, |workspace, window, cx| {
+                let fixed_panel_a = cx.new(|cx| {
+                    let mut panel = TestPanel::new(DockPosition::Left, 100, cx);
+                    panel.default_size = px(350.);
+                    panel
+                });
+
+                let fixed_panel_b = cx.new(|cx| {
+                    let mut panel = TestPanel::new(DockPosition::Left, 200, cx);
+                    panel.default_size = px(375.);
+                    panel
+                });
+
+                let flexible_panel_a =
+                    cx.new(|cx| TestPanel::new_flexible(DockPosition::Left, 300, cx));
+
+                let flexible_panel_b =
+                    cx.new(|cx| TestPanel::new_flexible(DockPosition::Left, 400, cx));
+
+                workspace.add_panel(fixed_panel_a.clone(), window, cx);
+                workspace.add_panel(fixed_panel_b.clone(), window, cx);
+                workspace.add_panel(flexible_panel_a.clone(), window, cx);
+                workspace.add_panel(flexible_panel_b.clone(), window, cx);
+
+                (
+                    fixed_panel_a,
+                    fixed_panel_b,
+                    flexible_panel_a,
+                    flexible_panel_b,
+                )
+            });
+
+        // We'll start by activating one of the flexible panels and ensuring
+        // that resizing the dock will sync the state between the flexible
+        // panels.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.activate_panel(2, window, cx);
+                dock.set_open(true, window, cx);
+            });
+
+            workspace.resize_left_dock(px(450.0), window, cx);
+
+            let dock = workspace.left_dock().read(cx);
+            let fixed_panel_a_size = dock.stored_panel_size(&fixed_panel_a, window, cx);
+            let fixed_panel_b_size = dock.stored_panel_size(&fixed_panel_b, window, cx);
+            let flexible_panel_a_flex = dock
+                .stored_panel_size_state(&flexible_panel_a)
+                .and_then(|state| state.flex);
+            let flexible_panel_b_flex = dock
+                .stored_panel_size_state(&flexible_panel_b)
+                .and_then(|state| state.flex);
+
+            assert_eq!(fixed_panel_a_size, Some(px(350.)));
+            assert_eq!(fixed_panel_b_size, Some(px(375.)));
+            assert!(flexible_panel_a_flex.is_some());
+            assert_eq!(flexible_panel_a_flex, flexible_panel_b_flex);
+        });
+
+        // Resetting the active panel's size should continue syncing the state
+        // between flexible width panels but not affect fixed width panels.
+        cx.dispatch_action(ResetOpenDocksSize);
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let dock = workspace.left_dock().read(cx);
+            let fixed_panel_a_size = dock.stored_panel_size(&fixed_panel_a, window, cx);
+            let fixed_panel_b_size = dock.stored_panel_size(&fixed_panel_b, window, cx);
+            let flexible_panel_a_flex = dock
+                .stored_panel_size_state(&flexible_panel_a)
+                .and_then(|state| state.flex);
+            let flexible_panel_b_flex = dock
+                .stored_panel_size_state(&flexible_panel_b)
+                .and_then(|state| state.flex);
+
+            assert_eq!(fixed_panel_a_size, Some(px(350.)));
+            assert_eq!(fixed_panel_b_size, Some(px(375.)));
+            assert_eq!(flexible_panel_a_flex, None);
+            assert_eq!(flexible_panel_b_flex, None);
+        });
+
+        // Lastly, activate a fixed width panel and ensure that resetting its
+        // size will affect all other fixed width panels.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+            });
+
+            workspace.resize_left_dock(px(450.), window, cx);
+        });
+
+        cx.dispatch_action(ResetOpenDocksSize);
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let dock = workspace.left_dock().read(cx);
+            let fixed_panel_a_size = dock.stored_panel_size(&fixed_panel_a, window, cx);
+            let fixed_panel_b_size = dock.stored_panel_size(&fixed_panel_b, window, cx);
+            let flexible_panel_a_flex = dock
+                .stored_panel_size_state(&flexible_panel_a)
+                .and_then(|state| state.flex);
+            let flexible_panel_b_flex = dock
+                .stored_panel_size_state(&flexible_panel_b)
+                .and_then(|state| state.flex);
+
+            assert_eq!(fixed_panel_a_size, Some(px(350.)));
+            assert_eq!(fixed_panel_b_size, Some(px(350.)));
+            assert_eq!(flexible_panel_a_flex, None);
+            assert_eq!(flexible_panel_b_flex, None);
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7693,13 +7693,10 @@ impl Workspace {
             ))
             .on_action(cx.listener(
                 |workspace: &mut Workspace, _: &ResetActiveDockSize, window, cx| {
-                    for dock in workspace.all_docks() {
-                        if dock.focus_handle(cx).contains_focused(window, cx) {
-                            dock.update(cx, |dock, cx| {
-                                dock.reset_active_panel_size(window, cx);
-                            });
-                            return;
-                        }
+                    if let Some(dock) = workspace.active_dock(window, cx).cloned() {
+                        dock.update(cx, |dock, cx| {
+                            dock.reset_panel_sizes(window, cx);
+                        });
                     }
                 },
             ))
@@ -7708,7 +7705,7 @@ impl Workspace {
                     for dock in workspace.all_docks() {
                         if dock.read(cx).visible_panel().is_some() {
                             dock.update(cx, |dock, cx| {
-                                dock.reset_active_panel_size(window, cx);
+                                dock.reset_panel_sizes(window, cx);
                             });
                         }
                     }
@@ -14689,7 +14686,7 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             workspace.resize_left_dock(px(350.), window, cx);
             workspace.left_dock().update(cx, |dock, cx| {
-                dock.reset_active_panel_size(window, cx);
+                dock.reset_panel_sizes(window, cx);
             });
             let dock = workspace.left_dock().read(cx);
             assert_eq!(
@@ -14719,7 +14716,7 @@ mod tests {
             });
             workspace.resize_left_dock(px(400.), window, cx);
             workspace.left_dock().update(cx, |dock, cx| {
-                dock.reset_active_panel_size(window, cx);
+                dock.reset_panel_sizes(window, cx);
             });
 
             let dock = workspace.left_dock().read(cx);


### PR DESCRIPTION
Closes #57388.

When a dock is listed in `resize_all_panels_in_dock`, reset its compatible panels to the active panel's default size. This applies to the reset actions and resize-handle double-clicks. Docks not listed in the setting continue to reset only the active panel.

Adds regression coverage for fixed panels with different defaults, flexible panels, and active-panel-only resets.

Release Notes:

- Fixed dock size reset commands only resetting the active panel when `resize_all_panels_in_dock` is enabled.