### PR TITLE
editor: Fix align selections with multi-byte characters

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6253,6 +6253,7 @@ impl Editor {
         struct CursorData {
             anchor: Anchor,
             point: Point,
+            char_column: u32,
         }
         let cursor_data: Vec<CursorData> = self
             .selections
@@ -6264,9 +6265,18 @@ impl Editor {
                 } else {
                     selection.tail()
                 };
+                let buffer_snapshot = display_snapshot.buffer_snapshot();
+                let point = anchor.to_point(buffer_snapshot);
+                // `Point` columns are UTF-8 byte offsets, but alignment must count characters
+                // so that a multi-byte character before the cursor occupies a single column.
+                let char_column = buffer_snapshot
+                    .text_for_range(Point::new(point.row, 0)..point)
+                    .flat_map(str::chars)
+                    .count() as u32;
                 CursorData {
-                    anchor: anchor,
-                    point: anchor.to_point(&display_snapshot.buffer_snapshot()),
+                    anchor,
+                    point,
+                    char_column,
                 }
             })
             .collect();
@@ -6294,8 +6304,8 @@ impl Editor {
                     continue;
                 }
 
-                let point = &cursor_data[cursor_index + column_idx].point;
-                let adjusted_column = point.column + rows_column_offset[row_idx];
+                let cursor = &cursor_data[cursor_index + column_idx];
+                let adjusted_column = cursor.char_column + rows_column_offset[row_idx];
                 if adjusted_column > target_column {
                     target_column = adjusted_column;
                 }
@@ -6311,12 +6321,10 @@ impl Editor {
                     continue;
                 }
 
-                let point = &cursor_data[cursor_index + column_idx].point;
-                let spaces_needed = target_column - point.column - rows_column_offset[row_idx];
+                let cursor = &cursor_data[cursor_index + column_idx];
+                let spaces_needed = target_column - cursor.char_column - rows_column_offset[row_idx];
                 if spaces_needed > 0 {
-                    let anchor = cursor_data[cursor_index + column_idx]
-                        .anchor
-                        .bias_left(&display_snapshot);
+                    let anchor = cursor.anchor.bias_left(&display_snapshot);
                     edits.push((anchor..anchor, " ".repeat(spaces_needed as usize)));
                 }
                 rows_column_offset[row_idx] += spaces_needed;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42302,6 +42302,31 @@ async fn test_align_selections_multicolumn(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_align_selections_multibyte(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Cursors preceded by multi-byte characters (`←` is 3 bytes, `π` is 2 bytes) must be
+    // aligned by character column, not by UTF-8 byte offset. The first `#` starts one
+    // character earlier than the second, so a single space aligns them.
+    let before = indoc!(
+        r#"
+            a ← 1  ˇ# one
+            bc ← π  ˇ# two
+        "#
+    );
+    let after = indoc!(
+        r#"
+            a ← 1   ˇ# one
+            bc ← π  ˇ# two
+        "#
+    );
+    cx.set_state(before);
+    cx.update_editor(|e, window, cx| e.align_selections(&AlignSelections, window, cx));
+    cx.assert_editor_state(after);
+}
+
+#[gpui::test]
 async fn test_custom_fallback_highlights(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Closes #60192

## Why

`align_selections` measured each cursor's column with `Point::column`, which is a
UTF-8 byte offset. A row with multi-byte characters before the cursor was therefore
treated as wider than it appears on screen, so the wrong number of spaces was
inserted and the cursors ended up visually misaligned.

## What

Count characters from the start of the row and align on that character column, so
every character occupies exactly one column regardless of its UTF-8 length.

## Testing

Added `test_align_selections_multibyte`, which aligns two cursors preceded by `←`
(3 bytes) and `π` (2 bytes).

I confirmed the test is a genuine reproduction rather than a test that only passes
with the new code. With `crates/editor/src/editor.rs` reverted to `main` and only
the test applied, it fails because an extra space is inserted:

```
< a ← 1    # one
> a ← 1   # one
  bc ← π  # two
```

With the fix applied it passes.

- `cargo test -p editor align_selections` — 3 passed (including the two pre-existing
  align tests, to confirm no regression)
- `./script/clippy -p editor` — clean

Release Notes:

- Fixed `editor: align selections` inserting the wrong number of spaces when multi-byte characters preceded the cursors.
