### PR TITLE
gpui: Prevent texture atlas bleeding at image edges

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4448,10 +4448,10 @@ impl Window {
             let max_x = tile_origin_x + tile_width;
             let max_y = tile_origin_y + tile_height;
 
-            let clamped_origin_x = sub_origin_x.clamp(tile_origin_x, max_x);
-            let clamped_origin_y = sub_origin_y.clamp(tile_origin_y, max_y);
-            let clamped_width = sub_width.min(max_x - clamped_origin_x).max(0);
-            let clamped_height = sub_height.min(max_y - clamped_origin_y).max(0);
+            let clamped_origin_x = sub_origin_x.clamp(tile_origin_x, max_x - 1);
+            let clamped_origin_y = sub_origin_y.clamp(tile_origin_y, max_y - 1);
+            let clamped_width = sub_width.min(max_x - clamped_origin_x).max(1);
+            let clamped_height = sub_height.min(max_y - clamped_origin_y).max(1);
 
             AtlasTile {
                 bounds: Bounds {

--- a/crates/gpui_apple/src/shaders.metal
+++ b/crates/gpui_apple/src/shaders.metal
@@ -715,8 +715,13 @@ fragment float4 polychrome_sprite_fragment(
   PolychromeSprite sprite = sprites[input.sprite_id];
   constexpr sampler atlas_texture_sampler(mag_filter::linear,
                                           min_filter::linear);
+  float2 atlas_size = float2(atlas_texture.get_width(), atlas_texture.get_height());
+  float2 tile_origin = float2(sprite.tile.bounds.origin.x, sprite.tile.bounds.origin.y);
+  float2 tile_size = float2(sprite.tile.bounds.size.width, sprite.tile.bounds.size.height);
+  float2 tile_min = (tile_origin + 0.5) / atlas_size;
+  float2 tile_max = (tile_origin + tile_size - 0.5) / atlas_size;
   float4 sample =
-      atlas_texture.sample(atlas_texture_sampler, input.tile_position);
+      atlas_texture.sample(atlas_texture_sampler, clamp(input.tile_position, tile_min, tile_max));
   float distance =
       quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1293,13 +1293,22 @@ fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
 @fragment
 fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
-    let sample = textureSample(t_sprite, s_sprite, input.tile_position);
+    let sprite = load_poly_sprite(input.sprite_id);
+    let atlas_size = vec2<f32>(textureDimensions(t_sprite, 0));
+    let tile_origin = vec2<f32>(sprite.tile.bounds.origin);
+    let tile_size = vec2<f32>(sprite.tile.bounds.size);
+    let tile_min = (tile_origin + vec2<f32>(0.5)) / atlas_size;
+    let tile_max = (tile_origin + tile_size - vec2<f32>(0.5)) / atlas_size;
+    let sample = textureSample(
+        t_sprite,
+        s_sprite,
+        clamp(input.tile_position, tile_min, tile_max),
+    );
     // Alpha clip after using the derivatives.
     if (any(input.clip_distances < vec4<f32>(0.0))) {
         return vec4<f32>(0.0);
     }
 
-    let sprite = load_poly_sprite(input.sprite_id);
     let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 
     var color = sample;

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -1255,7 +1255,13 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
 
 float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Target {
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
-    float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
+    float2 atlas_size;
+    t_sprite.GetDimensions(atlas_size.x, atlas_size.y);
+    float2 tile_origin = float2(sprite.tile.bounds.origin);
+    float2 tile_size = float2(sprite.tile.bounds.size);
+    float2 tile_min = (tile_origin + 0.5) / atlas_size;
+    float2 tile_max = (tile_origin + tile_size - 0.5) / atlas_size;
+    float4 sample = t_sprite.Sample(s_sprite, clamp(input.tile_position, tile_min, tile_max));
     float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 
     float4 color = sample;


### PR DESCRIPTION
  # Objective

  Fixes #62456.

  `RenderImage` can show a thin border along its edges when linear texture filtering samples outside the image's tile in the texture atlas.

  ## Solution

  - Clamp polychrome sprite UV coordinates to the centers of the first and last texels in the atlas tile.
  - Apply the same sampling bounds in the Metal, DirectX, and WGPU shaders.
  - Ensure cropped image sub-tiles remain at least one texel wide and high so the sampling bounds are always valid.

  ## Testing

  - Reproduced the issue on macOS using the example from #62456.
  - Confirmed that the visible right and bottom borders disappear with the Metal renderer.
  - Ran `cargo check` against the reproduction project.
  - Ran `cargo test -p gpui_wgpu shader_is_valid_wgsl`; all three shader validation tests passed.
  - Ran `cargo fmt --package gpui -- --check`.
  - DirectX runtime rendering was not tested because a Windows environment was not available.

  ## Self-Review Checklist:

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [x] Unsafe blocks (if any) have justifying comments
  - [x] The content adheres to Zed's UI standards
  - [ ] Tests cover the new/changed behavior — verified manually on Metal, but no pixel-level automated regression test was added
  - [x] Performance impact has been considered and is acceptable

  ## Showcase

  Before: a thin border is visible along the right and bottom edges of an image matching the background color.
<img width="1186" height="844" alt="CleanShot20260813105244" src="https://github.com/user-attachments/assets/6e3e0ddc-df48-404f-a038-3b71415c7af9" />


  After: the image blends uniformly with the background, with no visible border.
<img width="1182" height="840" alt="CleanShot20260813105325" src="https://github.com/user-attachments/assets/4c6ae043-e41c-40cf-91d1-c55813890a7e" />


  ---

  Release Notes:

  - Fixed unwanted borders around images rendered from GPUI texture atlases.