### PR TITLE
deepseek: Support low reasoning effort for V4 models

### DIFF
--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -150,6 +150,7 @@ pub enum ThinkingType {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    Low,
     High,
     Max,
 }

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -295,6 +295,11 @@ impl LanguageModel for DeepSeekLanguageModel {
 
         vec![
             LanguageModelEffortLevel {
+                name: "Low".into(),
+                value: "low".into(),
+                is_default: false,
+            },
+            LanguageModelEffortLevel {
                 name: "High".into(),
                 value: "high".into(),
                 is_default: true,
@@ -518,6 +523,7 @@ fn deepseek_thinking(
 
 fn into_deepseek_reasoning_effort(effort: Option<&str>) -> Option<deepseek::ReasoningEffort> {
     match effort {
+        Some("low") => Some(deepseek::ReasoningEffort::Low),
         Some("high") => Some(deepseek::ReasoningEffort::High),
         Some("max") => Some(deepseek::ReasoningEffort::Max),
         _ => None,


### PR DESCRIPTION
# Objective

DeepSeek has released the GA version of its V4 Pro model, and added a new low reasoning effort level for both V4 Flash and V4 Pro. We need to update Zed's DeepSeek provider to sync with this update.

Reference: https://api-docs.deepseek.com/updates/

## Solution

Added a new Low reasoning effort level for DeepSeek models.

## Testing

Built and ran locally. Screenshots with this change are attached in the Showcase section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase
After this change:

<img width="639" height="169" alt="flash" src="https://github.com/user-attachments/assets/5521f6fe-ced9-4842-8783-24c532bf66f6" />

<img width="640" height="181" alt="pro" src="https://github.com/user-attachments/assets/0293d4a2-03f8-41e1-8a3e-31efce9dea17" />

---

Release Notes:

- Added support for low reasoning effort for DeepSeek V4 Flash and V4 Pro
