### PR TITLE
gpui: Add frame snapshot oracle and render benchmarks

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -57,3 +57,7 @@ harness = false
 [[bench]]
 name = "markdown_renderer"
 harness = false
+
+[[bench]]
+name = "gpui_frame_production"
+harness = false

--- a/crates/benchmarks/benches/gpui_frame_production.rs
+++ b/crates/benchmarks/benches/gpui_frame_production.rs
@@ -1,0 +1,161 @@
+use std::time::Duration;
+
+use gpui::{
+    Animation, AnimationExt as _, AppContext as _, BenchAppContext, Context, Entity,
+    InteractiveElement as _, IntoElement, ParentElement as _, Render, Styled as _, Window, div,
+    prelude::FluentBuilder as _, px, rgba,
+};
+
+struct PaneLeaf {
+    generation: usize,
+}
+
+impl Render for PaneLeaf {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .h(px(2.))
+            .bg(rgba(0x334455ff + self.generation as u32))
+    }
+}
+
+struct NestedPanes {
+    leaf: Entity<PaneLeaf>,
+    divider: f32,
+}
+
+impl Render for NestedPanes {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let mut tree = div().child(self.leaf.clone()).into_any_element();
+        for depth in 0..500 {
+            tree = div()
+                .flex()
+                .when(depth % 2 == 0, |element| element.flex_row())
+                .when(depth % 2 != 0, |element| element.flex_col())
+                .child(
+                    div()
+                        .w(px(1. + self.divider))
+                        .h(px(1. + self.divider))
+                        .bg(rgba(0x556677ff)),
+                )
+                .child(tree)
+                .into_any_element();
+        }
+        tree
+    }
+}
+
+fn nested_panes(cx: &mut BenchAppContext) -> (Entity<NestedPanes>, Entity<PaneLeaf>) {
+    let mut window = cx.add_empty_window();
+    window.update(|window, cx| {
+        let leaf = cx.new(|_| PaneLeaf { generation: 0 });
+        let root = window.replace_root(cx, |_, _| NestedPanes {
+            leaf: leaf.clone(),
+            divider: 0.,
+        });
+        (root, leaf)
+    })
+}
+
+#[gpui::bench]
+fn layout_leaf_notify(cx: &mut BenchAppContext) {
+    let (root, leaf) = nested_panes(cx);
+    cx.bench_renderer(root, move |_, _, cx| {
+        leaf.update(cx, |leaf, cx| {
+            leaf.generation = leaf.generation.wrapping_add(1);
+            cx.notify();
+        });
+    });
+}
+
+#[gpui::bench(inputs = ["leaf_notify", "divider_drag"], group = "GPUI draw lane")]
+fn draw_lane(variant: &&str, cx: &mut BenchAppContext) {
+    let (root, leaf) = nested_panes(cx);
+    let divider_drag = *variant == "divider_drag";
+    cx.bench_renderer(root, move |root, _, cx| {
+        if divider_drag {
+            root.divider = (root.divider + 1.) % 4.;
+            cx.notify();
+        } else {
+            leaf.update(cx, |leaf, cx| {
+                leaf.generation = leaf.generation.wrapping_add(1);
+                cx.notify();
+            });
+        }
+    });
+}
+
+struct Spinner;
+
+impl Render for Spinner {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div().with_animation(
+            "present-spinner",
+            Animation::new(Duration::from_millis(800)).repeat_synced(),
+            |element, delta| {
+                element
+                    .size(px(16.))
+                    .opacity(0.25 + delta * 0.75)
+                    .bg(rgba(0xff8800ff))
+            },
+        )
+    }
+}
+
+#[gpui::bench]
+fn present_spinner(cx: &mut BenchAppContext) {
+    let mut window = cx.add_empty_window();
+    let spinner = window.update(|window, cx| window.replace_root(cx, |_, _| Spinner));
+    let scene_size = std::rc::Rc::new(std::cell::Cell::new(0));
+    cx.bench_renderer(spinner, {
+        let scene_size = scene_size.clone();
+        move |_, window, cx| {
+            window.refresh();
+            cx.notify();
+            scene_size.set(window.frame_snapshot().scene_len());
+        }
+    });
+    eprintln!(
+        "present spinner scene paint operations: {}",
+        scene_size.get()
+    );
+}
+
+struct StorybookBench {
+    frame: usize,
+}
+
+impl Render for StorybookBench {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div().flex().flex_col().children((0..50).map(|index| {
+            div()
+                .id(index)
+                .h(px(8. + (index % 5) as f32))
+                .bg(rgba(0x102030ff + (self.frame + index) as u32))
+                .child(format!("storybook {index}"))
+        }))
+    }
+}
+
+#[gpui::bench(fps = 120)]
+fn storybook_300_frames(cx: &mut BenchAppContext) {
+    let mut window = cx.add_empty_window();
+    let storybook =
+        window.update(|window, cx| window.replace_root(cx, |_, _| StorybookBench { frame: 0 }));
+    cx.bench_iter(move |cx| {
+        for _ in 0..300 {
+            storybook.update(cx, |storybook, cx| {
+                storybook.frame = storybook.frame.wrapping_add(1);
+                cx.notify();
+            });
+        }
+    });
+}
+
+gpui::bench_group!(
+    benches,
+    layout_leaf_notify,
+    draw_lane,
+    present_spinner,
+    storybook_300_frames
+);
+gpui::bench_main!(benches);

--- a/crates/gpui/docs/frame-snapshots.md
+++ b/crates/gpui/docs/frame-snapshots.md
@@ -1,0 +1,38 @@
+# Frame snapshots and the frame oracle
+
+`FrameSnapshot` is a test-support-only description of a completed GPUI frame.
+It preserves the semantic order of every captured lane:
+
+- scene paint operations
+- hitboxes
+- focus path and dispatch nodes, including key contexts and actions
+- cursor requests
+- tab-stop operations
+- deferred-draw metadata
+- the accessibility tree update when accessibility is active
+
+Snapshot comparison is exact. Floating-point values are included through their
+IEEE-754 bit representation; the oracle does not apply an epsilon. A mismatch
+report labels the lane and index of each reported divergence.
+
+## Atlas canonicalization
+
+Oracle windows use the same `TextSystem` and the same test sprite atlas. The
+test platform allocates one atlas per `TestAppContext` and shares it among that
+context's windows. Consequently, glyph, image, and SVG tiles have identical
+coordinates when both engines request the same semantic atlas keys in the same
+order. The snapshot intentionally preserves scene operation order.
+
+## Adding storybook coverage
+
+The storybook is constructed in `frame_oracle::tests::storybook_script`.
+
+1. Add the element to `Storybook::render`.
+2. If the element owns independently invalidatable state, add its `AnyView` to
+   `FrameScriptUi::new`'s notification-target list.
+3. Add one or more `FrameStep`s that exercise the element's state transition.
+4. Run the storybook test with multiple scheduler seeds and add a compact
+   property-test case when the behavior can be generated safely.
+
+Every `FrameStep` is applied to independent windows. A time advance is applied
+once to the shared deterministic test clock before both windows draw.

--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -101,6 +101,15 @@ impl BenchReport {
                 .draw
                 .record(timing.draw_duration().as_nanos() as u64)
                 .ok();
+            if let Some(layout_duration) = timing.layout_duration() {
+                snapshot
+                    .layout
+                    .record(layout_duration.as_nanos() as u64)
+                    .ok();
+            }
+            if let Some(paint_duration) = timing.paint_duration() {
+                snapshot.paint.record(paint_duration.as_nanos() as u64).ok();
+            }
             if let Some(dirty_to_draw) = timing.dirty_to_draw_duration() {
                 snapshot
                     .dirty_to_draw
@@ -152,6 +161,8 @@ impl BenchReport {
         eprintln!("  note: includes Criterion warmup/calibration");
         self.print_histogram("window dirty-to-draw", &frame_snapshot.dirty_to_draw);
         self.print_histogram("window draw", &frame_snapshot.draw);
+        self.print_histogram("layout and prepaint", &frame_snapshot.layout);
+        self.print_histogram("scene assembly", &frame_snapshot.paint);
         if !frame_snapshot.invalidations_per_frame.is_empty() {
             eprintln!(
                 "  invalidations per frame: mean {:.2}, max {}",
@@ -204,6 +215,8 @@ impl BenchReport {
 struct WindowFrameSnapshot {
     dirty_to_draw: Histogram<u64>,
     draw: Histogram<u64>,
+    layout: Histogram<u64>,
+    paint: Histogram<u64>,
     invalidations_per_frame: Histogram<u64>,
 }
 
@@ -212,6 +225,8 @@ impl WindowFrameSnapshot {
         Self {
             dirty_to_draw: Histogram::new(3).expect("3 significant digits is valid"),
             draw: Histogram::new(3).expect("3 significant digits is valid"),
+            layout: Histogram::new(3).expect("3 significant digits is valid"),
+            paint: Histogram::new(3).expect("3 significant digits is valid"),
             invalidations_per_frame: Histogram::new(3).expect("3 significant digits is valid"),
         }
     }
@@ -764,6 +779,11 @@ impl<'a, 'measurement> BenchWindowContext<'a, 'measurement> {
         self.cx
             .update_window(self.window, |_, window, cx| update(window, cx))
             .expect("benchmark window was unexpectedly closed")
+    }
+
+    /// Returns the primitive paint-operation count in the last rendered scene.
+    pub fn scene_len(&mut self) -> usize {
+        self.update(|window, _| window.rendered_frame.scene.len())
     }
 }
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -403,6 +403,16 @@ impl TestAppContext {
         self.test_window(window_handle).simulate_resize(size);
     }
 
+    /// Simulates a platform appearance change for a test window.
+    pub fn simulate_window_appearance(
+        &self,
+        window_handle: AnyWindowHandle,
+        appearance: crate::WindowAppearance,
+    ) {
+        self.test_window(window_handle)
+            .simulate_appearance_change(appearance);
+    }
+
     /// Returns true if there's an alert dialog open.
     pub fn expect_restart(&self) -> oneshot::Receiver<Option<PathBuf>> {
         let (tx, rx) = futures::channel::oneshot::channel();

--- a/crates/gpui/src/elements/animation.rs
+++ b/crates/gpui/src/elements/animation.rs
@@ -165,7 +165,7 @@ impl<E: IntoElement + 'static> Element for AnimationElement<E> {
     ) -> (crate::LayoutId, Self::RequestLayoutState) {
         window.with_element_state(global_id.unwrap(), |state, window| {
             let mut state = state.unwrap_or_else(|| AnimationState {
-                start: Instant::now(),
+                start: cx.background_executor().now(),
                 animation_ix: 0,
             });
             let (animation_ix, delta, done) = if cx.reduce_motion() {
@@ -185,7 +185,7 @@ impl<E: IntoElement + 'static> Element for AnimationElement<E> {
                     // Reduce modulo the duration before f32 conversion, which loses sub-second precision at scale.
                     Duration::from_nanos((elapsed.as_nanos() % duration.as_nanos()) as u64)
                 } else {
-                    state.start.elapsed()
+                    cx.background_executor().now() - state.start
                 };
                 let mut delta = elapsed.as_secs_f32() / duration.as_secs_f32();
 
@@ -195,7 +195,7 @@ impl<E: IntoElement + 'static> Element for AnimationElement<E> {
                         if animation_ix >= self.animations.len() - 1 {
                             done = true;
                         } else {
-                            state.start = Instant::now();
+                            state.start = cx.background_executor().now();
                             state.animation_ix += 1;
                         }
                         delta = 1.0;

--- a/crates/gpui/src/frame_oracle.rs
+++ b/crates/gpui/src/frame_oracle.rs
@@ -1,0 +1,520 @@
+use std::{rc::Rc, time::Duration};
+
+use crate::{
+    AnyView, AnyWindowHandle, App, Context, FrameSnapshot, InputEvent, IntoElement, Keystroke,
+    Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, Render,
+    ScrollDelta, ScrollWheelEvent, Size, TestAppContext, TouchPhase, Window, WindowAppearance,
+    WindowHandle,
+};
+
+/// A frame producer selectable by the oracle harness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Engine {
+    /// GPUI's current element-walking frame producer.
+    Walk,
+}
+
+/// An input or invalidation applied to a scripted frame.
+#[derive(Clone, Debug)]
+pub enum FrameStep {
+    /// Moves the synthetic pointer.
+    MouseMove {
+        /// Pointer position in window coordinates.
+        position: Point<Pixels>,
+        /// Keyboard modifiers held during the move.
+        modifiers: Modifiers,
+    },
+    /// Presses a mouse button.
+    MouseDown {
+        /// Mouse button to press.
+        button: MouseButton,
+        /// Pointer position in window coordinates.
+        position: Point<Pixels>,
+        /// Keyboard modifiers held during the press.
+        modifiers: Modifiers,
+    },
+    /// Releases a mouse button.
+    MouseUp {
+        /// Mouse button to release.
+        button: MouseButton,
+        /// Pointer position in window coordinates.
+        position: Point<Pixels>,
+        /// Keyboard modifiers held during the release.
+        modifiers: Modifiers,
+    },
+    /// Scrolls at a synthetic pointer position.
+    Scroll {
+        /// Pointer position in window coordinates.
+        position: Point<Pixels>,
+        /// Pixel scroll delta.
+        delta: Point<Pixels>,
+        /// Keyboard modifiers held during the scroll.
+        modifiers: Modifiers,
+    },
+    /// Dispatches one parsed keystroke.
+    Key(String),
+    /// Notifies a view returned by the script builder.
+    Notify(usize),
+    /// Changes the window's viewport size.
+    Resize(Size<Pixels>),
+    /// Changes the platform appearance.
+    Appearance(WindowAppearance),
+    /// Advances the deterministic test clock.
+    AdvanceTime(Duration),
+}
+
+/// The view graph and notification targets produced by a [`FrameScript`].
+pub struct FrameScriptUi {
+    root: AnyView,
+    notification_targets: Vec<AnyView>,
+}
+
+impl FrameScriptUi {
+    /// Creates scripted UI with an ordered list of targets for [`FrameStep::Notify`].
+    pub fn new(root: impl Into<AnyView>, notification_targets: Vec<AnyView>) -> Self {
+        Self {
+            root: root.into(),
+            notification_targets,
+        }
+    }
+}
+
+type FrameScriptBuilder = dyn Fn(&mut Window, &mut App) -> FrameScriptUi;
+
+/// A deterministic UI builder and ordered sequence of frame-producing steps.
+#[derive(Clone)]
+pub struct FrameScript {
+    build: Rc<FrameScriptBuilder>,
+    steps: Vec<FrameStep>,
+}
+
+impl FrameScript {
+    /// Creates a frame script.
+    pub fn new(
+        build: impl Fn(&mut Window, &mut App) -> FrameScriptUi + 'static,
+        steps: Vec<FrameStep>,
+    ) -> Self {
+        Self {
+            build: Rc::new(build),
+            steps,
+        }
+    }
+
+    /// Returns the script's ordered steps.
+    pub fn steps(&self) -> &[FrameStep] {
+        &self.steps
+    }
+}
+
+struct FrameScriptRoot {
+    ui: FrameScriptUi,
+}
+
+impl Render for FrameScriptRoot {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        self.ui.root.clone()
+    }
+}
+
+/// Drives one independently-created window through a [`FrameScript`].
+pub struct Harness {
+    engine: Engine,
+    window: WindowHandle<FrameScriptRoot>,
+    snapshot: FrameSnapshot,
+}
+
+impl Harness {
+    /// Builds an independent window and captures its initial frame.
+    pub fn new(
+        engine: Engine,
+        script: &FrameScript,
+        cx: &mut TestAppContext,
+    ) -> anyhow::Result<Self> {
+        let build = script.build.clone();
+        let window = cx.add_window(move |window, cx| FrameScriptRoot {
+            ui: build(window, cx),
+        });
+        let snapshot = draw_and_snapshot(window.into(), cx)?;
+        Ok(Self {
+            engine,
+            window,
+            snapshot,
+        })
+    }
+
+    /// Applies one step, drains deterministic work, and captures the resulting frame.
+    pub fn apply(&mut self, step: &FrameStep, cx: &mut TestAppContext) -> anyhow::Result<()> {
+        match self.engine {
+            Engine::Walk => self.apply_walk(step, cx)?,
+        }
+        cx.run_until_parked();
+        self.snapshot = draw_and_snapshot(self.window.into(), cx)?;
+        Ok(())
+    }
+
+    /// Returns the most recently captured frame.
+    pub fn snapshot(&self) -> &FrameSnapshot {
+        &self.snapshot
+    }
+
+    fn apply_walk(&self, step: &FrameStep, cx: &mut TestAppContext) -> anyhow::Result<()> {
+        match step {
+            FrameStep::MouseMove {
+                position,
+                modifiers,
+            } => dispatch_input(
+                self.window.into(),
+                MouseMoveEvent {
+                    position: *position,
+                    pressed_button: None,
+                    modifiers: *modifiers,
+                },
+                cx,
+            )?,
+            FrameStep::MouseDown {
+                button,
+                position,
+                modifiers,
+            } => dispatch_input(
+                self.window.into(),
+                MouseDownEvent {
+                    button: *button,
+                    position: *position,
+                    modifiers: *modifiers,
+                    click_count: 1,
+                    first_mouse: false,
+                },
+                cx,
+            )?,
+            FrameStep::MouseUp {
+                button,
+                position,
+                modifiers,
+            } => dispatch_input(
+                self.window.into(),
+                MouseUpEvent {
+                    button: *button,
+                    position: *position,
+                    modifiers: *modifiers,
+                    click_count: 1,
+                },
+                cx,
+            )?,
+            FrameStep::Scroll {
+                position,
+                delta,
+                modifiers,
+            } => dispatch_input(
+                self.window.into(),
+                ScrollWheelEvent {
+                    position: *position,
+                    delta: ScrollDelta::Pixels(*delta),
+                    modifiers: *modifiers,
+                    touch_phase: TouchPhase::Moved,
+                },
+                cx,
+            )?,
+            FrameStep::Key(key) => {
+                let keystroke = Keystroke::parse(key)?;
+                self.window.update(cx, |_, window, cx| {
+                    window.dispatch_keystroke(keystroke, cx);
+                })?;
+            }
+            FrameStep::Notify(index) => {
+                self.window.update(cx, |root, _, cx| {
+                    let target = root.ui.notification_targets.get(*index).ok_or_else(|| {
+                        anyhow::anyhow!("notification target {index} is not defined")
+                    })?;
+                    App::notify(cx, target.entity_id());
+                    Ok::<_, anyhow::Error>(())
+                })??;
+            }
+            FrameStep::Resize(size) => {
+                cx.simulate_window_resize(self.window.into(), *size);
+            }
+            FrameStep::Appearance(appearance) => {
+                cx.simulate_window_appearance(self.window.into(), *appearance);
+            }
+            FrameStep::AdvanceTime(duration) => {
+                cx.executor().advance_clock(*duration);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Applies all steps to two independent harnesses and compares every frame.
+pub fn assert_walk_vs_walk(script: &FrameScript, cx: &mut TestAppContext) -> anyhow::Result<()> {
+    let mut left = Harness::new(Engine::Walk, script, cx)?;
+    let mut right = Harness::new(Engine::Walk, script, cx)?;
+    assert_snapshots_equal("initial frame", left.snapshot(), right.snapshot())?;
+
+    for (index, step) in script.steps().iter().enumerate() {
+        if let FrameStep::AdvanceTime(duration) = step {
+            cx.executor().advance_clock(*duration);
+            cx.run_until_parked();
+            left.snapshot = draw_and_snapshot(left.window.into(), cx)?;
+            right.snapshot = draw_and_snapshot(right.window.into(), cx)?;
+        } else {
+            left.apply(step, cx)?;
+            right.apply(step, cx)?;
+        }
+        assert_snapshots_equal(
+            &format!("step {index}: {step:?}"),
+            left.snapshot(),
+            right.snapshot(),
+        )?;
+    }
+    Ok(())
+}
+
+fn dispatch_input(
+    window: AnyWindowHandle,
+    event: impl InputEvent,
+    cx: &mut TestAppContext,
+) -> anyhow::Result<()> {
+    window.update(cx, |_, window, cx| {
+        window.dispatch_event(event.to_platform_input(), cx);
+    })?;
+    Ok(())
+}
+
+fn draw_and_snapshot(
+    window: AnyWindowHandle,
+    cx: &mut TestAppContext,
+) -> anyhow::Result<FrameSnapshot> {
+    window.update(cx, |_, window, cx| {
+        window.draw(cx).clear(cx);
+        window.frame_snapshot()
+    })
+}
+
+fn assert_snapshots_equal(
+    label: &str,
+    left: &FrameSnapshot,
+    right: &FrameSnapshot,
+) -> anyhow::Result<()> {
+    if left == right {
+        return Ok(());
+    }
+    anyhow::bail!("{label}\n{}", left.pretty_diff(right, 32))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use crate::{
+        Animation, AnimationExt as _, AppContext as _, FocusHandle, InteractiveElement as _,
+        ListAlignment, ListState, ParentElement as _, RenderImage, StatefulInteractiveElement as _,
+        Styled as _, UniformListScrollHandle, anchored, assert_walk_vs_walk, canvas, deferred, div,
+        fill, img, list, point, px, rgba, size, svg, uniform_list,
+    };
+    use image::{Frame, ImageBuffer, Rgba};
+    use smallvec::SmallVec;
+
+    use super::*;
+
+    struct StorybookLeaf {
+        value: usize,
+    }
+
+    impl Render for StorybookLeaf {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("leaf")
+                .h(px(24.))
+                .bg(rgba(0x334455ff))
+                .child(format!("leaf {}", self.value))
+        }
+    }
+
+    struct Storybook {
+        leaf: crate::Entity<StorybookLeaf>,
+        focus: FocusHandle,
+        list_state: ListState,
+        uniform_scroll: UniformListScrollHandle,
+        image: Arc<RenderImage>,
+        clicks: usize,
+    }
+
+    impl Render for Storybook {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            let list_state = self.list_state.clone();
+            div()
+                .id("storybook")
+                .key_context("Storybook")
+                .track_focus(&self.focus)
+                .focus(|style| style.bg(rgba(0x224466ff)))
+                .size_full()
+                .overflow_y_scroll()
+                .child(
+                    div()
+                        .id("interactive")
+                        .w(px(160.))
+                        .h(px(48.))
+                        .bg(rgba(0x222222ff))
+                        .hover(|style| style.bg(rgba(0x444444ff)))
+                        .active(|style| style.bg(rgba(0x666666ff)))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.clicks += 1;
+                            window.focus(&this.focus, cx);
+                            cx.notify();
+                        }))
+                        .child(format!("clicks {}", self.clicks)),
+                )
+                .child(self.leaf.clone())
+                .child(
+                    uniform_list(
+                        "uniform",
+                        8,
+                        cx.processor(|_, range: std::ops::Range<usize>, _, _| {
+                            range
+                                .map(|index| div().h(px(20.)).child(format!("uniform {index}")))
+                                .collect()
+                        }),
+                    )
+                    .h(px(60.))
+                    .track_scroll(&self.uniform_scroll),
+                )
+                .child(
+                    list(list_state, |index, _, _| {
+                        div()
+                            .h(px(18. + index as f32))
+                            .child(format!("list {index}"))
+                            .into_any_element()
+                    })
+                    .h(px(64.)),
+                )
+                .child(img(self.image.clone()).size(px(12.)))
+                .child(
+                    svg()
+                        .path("icons/arrow_circle.svg")
+                        .size(px(12.))
+                        .text_color(rgba(0xffffffff)),
+                )
+                .child(
+                    canvas(
+                        |bounds, _, _| bounds,
+                        |bounds, _, window, _| {
+                            window.paint_quad(fill(bounds, rgba(0x8899aaff)));
+                        },
+                    )
+                    .size(px(20.)),
+                )
+                .child(deferred(
+                    anchored()
+                        .position(point(px(8.), px(8.)))
+                        .child(div().id("anchor").size(px(16.)).bg(rgba(0xaabbccff))),
+                ))
+                .child(div().with_animation(
+                    "storybook-spinner",
+                    Animation::new(Duration::from_secs(1)).repeat(),
+                    |element, delta| {
+                        element
+                            .size(px(14.))
+                            .bg(rgba(0xff8800ff))
+                            .opacity(0.5 + delta * 0.5)
+                    },
+                ))
+        }
+    }
+
+    fn storybook_script() -> FrameScript {
+        let image = Arc::new(RenderImage::new(SmallVec::from_elem(
+            Frame::new(ImageBuffer::from_pixel(1, 1, Rgba([64, 128, 192, 255]))),
+            1,
+        )));
+        FrameScript::new(
+            move |_, cx| {
+                let leaf = cx.new(|_| StorybookLeaf { value: 0 });
+                let root = cx.new(|cx| Storybook {
+                    leaf: leaf.clone(),
+                    focus: cx.focus_handle(),
+                    list_state: ListState::new(6, ListAlignment::Top, px(8.)),
+                    uniform_scroll: UniformListScrollHandle::new(),
+                    image: image.clone(),
+                    clicks: 0,
+                });
+                FrameScriptUi::new(root.clone(), vec![leaf.into(), root.into()])
+            },
+            vec![
+                FrameStep::Notify(0),
+                FrameStep::Notify(1),
+                FrameStep::MouseMove {
+                    position: point(px(20.), px(20.)),
+                    modifiers: Modifiers::default(),
+                },
+                FrameStep::MouseDown {
+                    button: MouseButton::Left,
+                    position: point(px(20.), px(20.)),
+                    modifiers: Modifiers::default(),
+                },
+                FrameStep::MouseUp {
+                    button: MouseButton::Left,
+                    position: point(px(20.), px(20.)),
+                    modifiers: Modifiers::default(),
+                },
+                FrameStep::Scroll {
+                    position: point(px(40.), px(120.)),
+                    delta: point(px(0.), px(-24.)),
+                    modifiers: Modifiers::default(),
+                },
+                FrameStep::AdvanceTime(Duration::from_millis(16)),
+                FrameStep::Resize(size(px(720.), px(480.))),
+                FrameStep::Appearance(WindowAppearance::Dark),
+                FrameStep::MouseMove {
+                    position: point(px(300.), px(300.)),
+                    modifiers: Modifiers::default(),
+                },
+            ],
+        )
+    }
+
+    #[crate::test(iterations = 100)]
+    fn walk_vs_walk_storybook(cx: &mut TestAppContext) {
+        assert_walk_vs_walk(&storybook_script(), cx).unwrap_or_else(|error| panic!("{error:#}"));
+    }
+
+    #[crate::property_test]
+    fn walk_vs_walk_generated(
+        cx: &mut TestAppContext,
+        #[strategy = 1usize..16] node_count: usize,
+        #[strategy = crate::proptest::collection::vec(0u8..4, 0..12)] raw_steps: Vec<u8>,
+    ) {
+        let script = FrameScript::new(
+            move |_, cx| {
+                let root = cx.new(move |_| GeneratedTree { node_count });
+                FrameScriptUi::new(root.clone(), vec![root.into()])
+            },
+            raw_steps
+                .into_iter()
+                .map(|step| match step {
+                    0 => FrameStep::Notify(0),
+                    1 => FrameStep::Resize(size(px(320.), px(240.))),
+                    2 => FrameStep::MouseMove {
+                        position: point(px(8.), px(8.)),
+                        modifiers: Modifiers::default(),
+                    },
+                    _ => FrameStep::AdvanceTime(Duration::from_millis(1)),
+                })
+                .collect(),
+        );
+        assert_walk_vs_walk(&script, cx).unwrap_or_else(|error| panic!("{error:#}"));
+    }
+
+    struct GeneratedTree {
+        node_count: usize,
+    }
+
+    impl Render for GeneratedTree {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().children((0..self.node_count).map(|index| {
+                div()
+                    .id(index)
+                    .h(px(4. + (index % 3) as f32))
+                    .bg(rgba(0x102030ff + index as u32))
+            }))
+        }
+    }
+}

--- a/crates/gpui/src/frame_snapshot.rs
+++ b/crates/gpui/src/frame_snapshot.rs
@@ -1,0 +1,244 @@
+use std::fmt::{self, Write as _};
+
+/// An exact, test-only snapshot of the observable output of one GPUI frame.
+///
+/// The snapshot preserves ordering within every lane. Floating-point values are
+/// encoded using `to_bits`, so `-0.0`, `0.0`, and distinct NaN payloads remain
+/// distinguishable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrameSnapshot {
+    pub(crate) scene: Vec<FrameSnapshotItem>,
+    pub(crate) hitboxes: Vec<FrameSnapshotItem>,
+    pub(crate) window_control_hitboxes: Vec<FrameSnapshotItem>,
+    pub(crate) focus_path: Vec<usize>,
+    pub(crate) dispatch_tree: Vec<FrameSnapshotItem>,
+    pub(crate) mouse_listeners: Vec<bool>,
+    pub(crate) input_handlers: Vec<bool>,
+    pub(crate) tooltip_requests: Vec<bool>,
+    pub(crate) cursor_styles: Vec<FrameSnapshotItem>,
+    pub(crate) tab_stops: Vec<FrameSnapshotItem>,
+    pub(crate) deferred_draws: Vec<FrameSnapshotItem>,
+    pub(crate) accessibility_update: Option<String>,
+}
+
+impl FrameSnapshot {
+    /// Produces a labeled report containing at most `limit` divergences.
+    pub fn pretty_diff(&self, other: &Self, limit: usize) -> FrameSnapshotDiff {
+        let mut divergences = Vec::new();
+
+        compare_lane("scene", &self.scene, &other.scene, limit, &mut divergences);
+        compare_lane(
+            "hitboxes",
+            &self.hitboxes,
+            &other.hitboxes,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "window_control_hitboxes",
+            &self.window_control_hitboxes,
+            &other.window_control_hitboxes,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "focus_path",
+            &self.focus_path,
+            &other.focus_path,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "dispatch_tree",
+            &self.dispatch_tree,
+            &other.dispatch_tree,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "mouse_listeners",
+            &self.mouse_listeners,
+            &other.mouse_listeners,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "input_handlers",
+            &self.input_handlers,
+            &other.input_handlers,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "tooltip_requests",
+            &self.tooltip_requests,
+            &other.tooltip_requests,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "cursor_styles",
+            &self.cursor_styles,
+            &other.cursor_styles,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "tab_stops",
+            &self.tab_stops,
+            &other.tab_stops,
+            limit,
+            &mut divergences,
+        );
+        compare_lane(
+            "deferred_draws",
+            &self.deferred_draws,
+            &other.deferred_draws,
+            limit,
+            &mut divergences,
+        );
+
+        if divergences.len() < limit && self.accessibility_update != other.accessibility_update {
+            divergences.push(FrameSnapshotDivergence {
+                lane: "accessibility_update",
+                index: 0,
+                left: format!("{:?}", self.accessibility_update),
+                right: format!("{:?}", other.accessibility_update),
+            });
+        }
+
+        FrameSnapshotDiff { divergences }
+    }
+
+    /// Returns the number of scene paint operations in the snapshot.
+    pub fn scene_len(&self) -> usize {
+        self.scene.len()
+    }
+}
+
+/// A pretty, lane-aware difference between two frame snapshots.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrameSnapshotDiff {
+    divergences: Vec<FrameSnapshotDivergence>,
+}
+
+impl FrameSnapshotDiff {
+    /// Returns whether the snapshots had no divergences.
+    pub fn is_empty(&self) -> bool {
+        self.divergences.is_empty()
+    }
+}
+
+impl fmt::Display for FrameSnapshotDiff {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.divergences.is_empty() {
+            return formatter.write_str("frames are identical");
+        }
+
+        writeln!(formatter, "{} frame divergence(s):", self.divergences.len())?;
+        for divergence in &self.divergences {
+            writeln!(
+                formatter,
+                "- {}[{}]\n    left:  {}\n    right: {}",
+                divergence.lane, divergence.index, divergence.left, divergence.right
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FrameSnapshotDivergence {
+    lane: &'static str,
+    index: usize,
+    left: String,
+    right: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct FrameSnapshotItem {
+    exact: Vec<u8>,
+    label: String,
+}
+
+impl PartialEq for FrameSnapshotItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.exact == other.exact
+    }
+}
+
+impl Eq for FrameSnapshotItem {}
+
+impl fmt::Debug for FrameSnapshotItem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.label)
+    }
+}
+
+impl FrameSnapshotItem {
+    pub(crate) fn new(label: impl Into<String>) -> Self {
+        Self {
+            exact: Vec::new(),
+            label: label.into(),
+        }
+    }
+
+    pub(crate) fn push_u64(&mut self, value: u64) {
+        self.exact.extend(value.to_le_bytes());
+    }
+
+    pub(crate) fn push_usize(&mut self, value: usize) {
+        self.push_u64(value as u64);
+    }
+
+    pub(crate) fn push_i64(&mut self, value: i64) {
+        self.exact.extend(value.to_le_bytes());
+    }
+
+    pub(crate) fn push_f32(&mut self, value: f32) {
+        self.exact.extend(value.to_bits().to_le_bytes());
+    }
+
+    pub(crate) fn push_str(&mut self, value: &str) {
+        self.push_usize(value.len());
+        self.exact.extend(value.as_bytes());
+    }
+}
+
+fn compare_lane<T: fmt::Debug + PartialEq>(
+    lane: &'static str,
+    left: &[T],
+    right: &[T],
+    limit: usize,
+    divergences: &mut Vec<FrameSnapshotDivergence>,
+) {
+    let common_length = left.len().min(right.len());
+    for index in 0..common_length {
+        if divergences.len() >= limit {
+            return;
+        }
+        if left[index] != right[index] {
+            divergences.push(FrameSnapshotDivergence {
+                lane,
+                index,
+                left: format!("{:?}", left[index]),
+                right: format!("{:?}", right[index]),
+            });
+        }
+    }
+
+    if divergences.len() >= limit || left.len() == right.len() {
+        return;
+    }
+
+    let mut left_label = String::new();
+    let mut right_label = String::new();
+    write!(&mut left_label, "lane length {}", left.len()).ok();
+    write!(&mut right_label, "lane length {}", right.len()).ok();
+    divergences.push(FrameSnapshotDivergence {
+        lane,
+        index: common_length,
+        left: left_label,
+        right: right_label,
+    });
+}

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -21,6 +21,10 @@ pub mod colors;
 mod element;
 mod elements;
 mod executor;
+#[cfg(any(test, feature = "test-support"))]
+mod frame_oracle;
+#[cfg(any(test, feature = "test-support"))]
+mod frame_snapshot;
 mod platform_scheduler;
 pub(crate) use platform_scheduler::PlatformScheduler;
 mod geometry;
@@ -98,6 +102,10 @@ pub use ctor::ctor;
 pub use element::*;
 pub use elements::*;
 pub use executor::*;
+#[cfg(any(test, feature = "test-support"))]
+pub use frame_oracle::*;
+#[cfg(any(test, feature = "test-support"))]
+pub use frame_snapshot::*;
 pub use geometry::*;
 pub use gestures::*;
 pub use global::*;

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -163,6 +163,46 @@ impl DispatchTree {
         self.nodes.len()
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot_nodes(
+        &self,
+    ) -> impl Iterator<Item = (usize, Option<usize>, Option<&KeyContext>, bool, Vec<String>)> {
+        self.nodes.iter().enumerate().map(|(index, node)| {
+            let actions = node
+                .action_listeners
+                .iter()
+                .map(|listener| {
+                    self.action_registry
+                        .build_action_type(&listener.action_type)
+                        .map(|action| action.name().to_string())
+                        .unwrap_or_else(|_| format!("{:?}", listener.action_type))
+                })
+                .collect();
+            (
+                index,
+                node.parent.map(|parent| parent.0),
+                node.context.as_ref(),
+                node.focus_id.is_some(),
+                actions,
+            )
+        })
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot_focus_path(&self, focus_id: FocusId) -> Vec<usize> {
+        self.focusable_node_ids
+            .get(&focus_id)
+            .copied()
+            .map(|node_id| {
+                self.dispatch_path(node_id)
+                    .into_iter()
+                    .filter(|node_id| self.node(*node_id).focus_id.is_some())
+                    .map(|node_id| node_id.0)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn push_node(&mut self) -> DispatchNodeId {
         let parent = self.node_stack.last().copied();
         let node_id = DispatchNodeId(self.nodes.len());

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -3,7 +3,7 @@ use crate::{
     DummyKeyboardMapper, ForegroundExecutor, Keymap, NoopTextSystem, PathPromptOptions, Platform,
     PlatformDisplay, PlatformHeadlessRenderer, PlatformKeyboardLayout, PlatformKeyboardMapper,
     PlatformTextSystem, PromptButton, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream,
-    SharedString, SourceMetadata, SystemNotification, SystemNotificationResponse, Task,
+    SharedString, SourceMetadata, SystemNotification, SystemNotificationResponse, Task, TestAtlas,
     TestDisplay, TestWindow, ThermalState, WindowAppearance, WindowParams, size,
 };
 use anyhow::Result;
@@ -35,6 +35,7 @@ pub(crate) struct TestPlatform {
     pub opened_url: RefCell<Option<String>>,
     pub(crate) system_notifications: RefCell<TestSystemNotifications>,
     pub text_system: Arc<dyn PlatformTextSystem>,
+    sprite_atlas: Arc<TestAtlas>,
     pub expect_restart: RefCell<Option<oneshot::Sender<Option<PathBuf>>>>,
     headless_renderer_factory: Option<Box<dyn Fn() -> Option<Box<dyn PlatformHeadlessRenderer>>>>,
     weak: Weak<Self>,
@@ -146,6 +147,7 @@ impl TestPlatform {
             opened_url: Default::default(),
             system_notifications: Default::default(),
             text_system,
+            sprite_atlas: Arc::new(TestAtlas::new()),
             headless_renderer_factory,
         })
     }
@@ -406,6 +408,7 @@ impl Platform for TestPlatform {
             params,
             self.weak.clone(),
             self.active_display.clone(),
+            self.sprite_atlas.clone(),
             renderer,
         );
         Ok(Box::new(window))

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -70,11 +70,12 @@ impl TestWindow {
         params: WindowParams,
         platform: Weak<TestPlatform>,
         display: Rc<dyn PlatformDisplay>,
+        test_sprite_atlas: Arc<TestAtlas>,
         renderer: Option<Box<dyn PlatformHeadlessRenderer>>,
     ) -> Self {
         let sprite_atlas: Arc<dyn PlatformAtlas> = match &renderer {
             Some(r) => r.sprite_atlas(),
-            None => Arc::new(TestAtlas::new()),
+            None => test_sprite_atlas,
         };
         Self(Rc::new(Mutex::new(TestWindowState {
             bounds: params.bounds,

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -716,6 +716,10 @@ pub struct FrameTiming {
     pub invalidations: u64,
     /// When `Window::draw` started.
     pub draw_start: Instant,
+    /// When root layout and prepaint finished.
+    pub prepaint_end: Option<Instant>,
+    /// When scene assembly finished.
+    pub paint_end: Option<Instant>,
     /// When `Window::draw` finished.
     pub draw_end: Instant,
 }
@@ -724,6 +728,19 @@ impl FrameTiming {
     /// Time spent inside `Window::draw`.
     pub fn draw_duration(&self) -> Duration {
         self.draw_end.duration_since(self.draw_start)
+    }
+
+    /// Time spent in root layout and prepaint.
+    pub fn layout_duration(&self) -> Option<Duration> {
+        self.prepaint_end
+            .map(|prepaint_end| prepaint_end.duration_since(self.draw_start))
+    }
+
+    /// Time spent assembling the scene after prepaint.
+    pub fn paint_duration(&self) -> Option<Duration> {
+        self.prepaint_end
+            .zip(self.paint_end)
+            .map(|(prepaint_end, paint_end)| paint_end.duration_since(prepaint_end))
     }
 
     /// Time from the frame's first invalidation to the end of its draw, if the

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -162,6 +162,58 @@ impl Scene {
         self.surfaces.sort_by_key(|surface| surface.order);
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot(&self) -> Vec<crate::FrameSnapshotItem> {
+        self.paint_operations
+            .iter()
+            .map(|operation| {
+                let label = match operation {
+                    PaintOperation::Primitive(primitive) => match primitive {
+                        Primitive::Shadow(value) => format!("shadow {value:?}"),
+                        Primitive::Quad(value) => format!("quad {value:?}"),
+                        Primitive::Path(value) => format!("path {value:?}"),
+                        Primitive::Underline(value) => format!("underline {value:?}"),
+                        Primitive::MonochromeSprite(value) => {
+                            format!("monochrome_sprite {value:?}")
+                        }
+                        Primitive::SubpixelSprite(value) => format!("subpixel_sprite {value:?}"),
+                        Primitive::PolychromeSprite(value) => {
+                            format!("polychrome_sprite {value:?}")
+                        }
+                        Primitive::Surface(value) => format!("surface {value:?}"),
+                    },
+                    PaintOperation::StartLayer(bounds) => format!("start_layer {bounds:?}"),
+                    PaintOperation::EndLayer => "end_layer".to_string(),
+                };
+                let mut item = crate::FrameSnapshotItem::new(label);
+                match operation {
+                    PaintOperation::Primitive(primitive) => {
+                        item.push_str(match primitive {
+                            Primitive::Shadow(_) => "shadow",
+                            Primitive::Quad(_) => "quad",
+                            Primitive::Path(_) => "path",
+                            Primitive::Underline(_) => "underline",
+                            Primitive::MonochromeSprite(_) => "monochrome_sprite",
+                            Primitive::SubpixelSprite(_) => "subpixel_sprite",
+                            Primitive::PolychromeSprite(_) => "polychrome_sprite",
+                            Primitive::Surface(_) => "surface",
+                        });
+                        push_primitive_snapshot(&mut item, primitive);
+                    }
+                    PaintOperation::StartLayer(bounds) => {
+                        item.push_str("start_layer");
+                        item.push_f32(bounds.origin.x.as_f32());
+                        item.push_f32(bounds.origin.y.as_f32());
+                        item.push_f32(bounds.size.width.as_f32());
+                        item.push_f32(bounds.size.height.as_f32());
+                    }
+                    PaintOperation::EndLayer => item.push_str("end_layer"),
+                }
+                item
+            })
+            .collect()
+    }
+
     #[cfg_attr(
         all(
             any(target_os = "linux", target_os = "freebsd"),
@@ -188,6 +240,163 @@ impl Scene {
             surfaces_start: 0,
             surfaces_iter: self.surfaces.iter().peekable(),
         }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_primitive_snapshot(item: &mut crate::FrameSnapshotItem, primitive: &Primitive) {
+    match primitive {
+        Primitive::Shadow(shadow) => {
+            item.push_usize(shadow.order as usize);
+            item.push_f32(shadow.blur_radius.as_f32());
+            push_scaled_bounds(item, shadow.bounds);
+            push_scaled_corners(item, shadow.corner_radii);
+            push_scaled_bounds(item, shadow.content_mask.bounds);
+            push_hsla(item, shadow.color);
+            push_scaled_bounds(item, shadow.element_bounds);
+            push_scaled_corners(item, shadow.element_corner_radii);
+            item.push_usize(shadow.inset as usize);
+        }
+        Primitive::Quad(quad) => {
+            item.push_usize(quad.order as usize);
+            item.push_str(&format!("{:?}", quad.border_style));
+            push_scaled_bounds(item, quad.bounds);
+            push_scaled_bounds(item, quad.content_mask.bounds);
+            push_background(item, quad.background);
+            push_hsla(item, quad.border_color);
+            push_scaled_corners(item, quad.corner_radii);
+            push_scaled_edges(item, quad.border_widths);
+        }
+        Primitive::Path(path) => {
+            item.push_usize(path.id.0);
+            item.push_usize(path.order as usize);
+            push_scaled_bounds(item, path.bounds);
+            push_scaled_bounds(item, path.content_mask.bounds);
+            item.push_usize(path.vertices.len());
+            for vertex in &path.vertices {
+                push_scaled_point(item, vertex.xy_position);
+                item.push_f32(vertex.st_position.x);
+                item.push_f32(vertex.st_position.y);
+                push_scaled_bounds(item, vertex.content_mask.bounds);
+            }
+            push_background(item, path.color);
+            push_scaled_point(item, path.start);
+            push_scaled_point(item, path.current);
+            item.push_usize(path.contour_count);
+        }
+        Primitive::Underline(underline) => {
+            item.push_usize(underline.order as usize);
+            push_scaled_bounds(item, underline.bounds);
+            push_scaled_bounds(item, underline.content_mask.bounds);
+            push_hsla(item, underline.color);
+            item.push_f32(underline.thickness.as_f32());
+            item.push_usize(underline.wavy.0 as usize);
+        }
+        Primitive::MonochromeSprite(sprite) => {
+            item.push_usize(sprite.order as usize);
+            push_scaled_bounds(item, sprite.bounds);
+            push_scaled_bounds(item, sprite.content_mask.bounds);
+            push_hsla(item, sprite.color);
+            push_atlas_tile(item, sprite.tile);
+            push_transformation(item, sprite.transformation);
+        }
+        Primitive::SubpixelSprite(sprite) => {
+            item.push_usize(sprite.order as usize);
+            push_scaled_bounds(item, sprite.bounds);
+            push_scaled_bounds(item, sprite.content_mask.bounds);
+            push_hsla(item, sprite.color);
+            push_atlas_tile(item, sprite.tile);
+            push_transformation(item, sprite.transformation);
+        }
+        Primitive::PolychromeSprite(sprite) => {
+            item.push_usize(sprite.order as usize);
+            item.push_usize(sprite.grayscale.0 as usize);
+            item.push_f32(sprite.opacity);
+            push_scaled_bounds(item, sprite.bounds);
+            push_scaled_bounds(item, sprite.content_mask.bounds);
+            push_scaled_corners(item, sprite.corner_radii);
+            push_atlas_tile(item, sprite.tile);
+        }
+        Primitive::Surface(surface) => {
+            item.push_usize(surface.order as usize);
+            push_scaled_bounds(item, surface.bounds);
+            push_scaled_bounds(item, surface.content_mask.bounds);
+            #[cfg(target_os = "macos")]
+            item.push_str(&format!("{:?}", surface.image_buffer));
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_scaled_point(item: &mut crate::FrameSnapshotItem, point: Point<ScaledPixels>) {
+    item.push_f32(point.x.as_f32());
+    item.push_f32(point.y.as_f32());
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_scaled_bounds(item: &mut crate::FrameSnapshotItem, bounds: Bounds<ScaledPixels>) {
+    push_scaled_point(item, bounds.origin);
+    item.push_f32(bounds.size.width.as_f32());
+    item.push_f32(bounds.size.height.as_f32());
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_scaled_corners(item: &mut crate::FrameSnapshotItem, corners: Corners<ScaledPixels>) {
+    item.push_f32(corners.top_left.as_f32());
+    item.push_f32(corners.top_right.as_f32());
+    item.push_f32(corners.bottom_right.as_f32());
+    item.push_f32(corners.bottom_left.as_f32());
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_scaled_edges(item: &mut crate::FrameSnapshotItem, edges: Edges<ScaledPixels>) {
+    item.push_f32(edges.top.as_f32());
+    item.push_f32(edges.right.as_f32());
+    item.push_f32(edges.bottom.as_f32());
+    item.push_f32(edges.left.as_f32());
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_hsla(item: &mut crate::FrameSnapshotItem, color: Hsla) {
+    item.push_f32(color.h);
+    item.push_f32(color.s);
+    item.push_f32(color.l);
+    item.push_f32(color.a);
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_background(item: &mut crate::FrameSnapshotItem, background: Background) {
+    item.push_str(&format!("{:?}", background.tag));
+    item.push_str(&format!("{:?}", background.color_space));
+    push_hsla(item, background.solid);
+    item.push_f32(background.gradient_angle_or_pattern_height);
+    for color_stop in background.colors {
+        push_hsla(item, color_stop.color);
+        item.push_f32(color_stop.percentage);
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_atlas_tile(item: &mut crate::FrameSnapshotItem, tile: AtlasTile) {
+    item.push_usize(tile.texture_id.index as usize);
+    item.push_str(&format!("{:?}", tile.texture_id.kind));
+    item.push_usize(tile.tile_id.0 as usize);
+    item.push_usize(tile.padding as usize);
+    item.push_i64(tile.bounds.origin.x.0 as i64);
+    item.push_i64(tile.bounds.origin.y.0 as i64);
+    item.push_i64(tile.bounds.size.width.0 as i64);
+    item.push_i64(tile.bounds.size.height.0 as i64);
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn push_transformation(item: &mut crate::FrameSnapshotItem, value: TransformationMatrix) {
+    for row in value.rotation_scale {
+        for component in row {
+            item.push_f32(component);
+        }
+    }
+    for component in value.translation {
+        item.push_f32(component);
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -20,6 +20,8 @@ use crate::{
     WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, profiler, px, rems, size,
     transparent_black,
 };
+#[cfg(any(test, feature = "test-support"))]
+use crate::{FrameSnapshot, FrameSnapshotItem, TabStopOperation};
 
 use anyhow::{Context as _, Result, anyhow};
 use collections::{FxHashMap, FxHashSet};
@@ -941,6 +943,12 @@ pub(crate) struct DeferredDraw {
     paint_range: Range<PaintIndex>,
 }
 
+#[derive(Clone, Copy)]
+struct FramePhaseTimings {
+    prepaint_end: Instant,
+    paint_end: Instant,
+}
+
 pub(crate) struct Frame {
     pub(crate) focus: Option<FocusId>,
     pub(crate) window_active: bool,
@@ -957,6 +965,8 @@ pub(crate) struct Frame {
     pub(crate) cursor_styles: Vec<CursorStyleRequest>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_bounds: FxHashMap<String, Bounds<Pixels>>,
+    #[cfg(any(test, feature = "test-support"))]
+    accessibility_update: Option<String>,
     #[cfg(any(feature = "inspector", debug_assertions))]
     pub(crate) next_inspector_instance_ids: FxHashMap<Rc<crate::InspectorElementPath>, usize>,
     #[cfg(any(feature = "inspector", debug_assertions))]
@@ -1004,6 +1014,8 @@ impl Frame {
 
             #[cfg(any(test, feature = "test-support"))]
             debug_bounds: FxHashMap::default(),
+            #[cfg(any(test, feature = "test-support"))]
+            accessibility_update: None,
 
             #[cfg(any(feature = "inspector", debug_assertions))]
             next_inspector_instance_ids: FxHashMap::default(),
@@ -1032,6 +1044,7 @@ impl Frame {
         #[cfg(any(test, feature = "test-support"))]
         {
             self.debug_bounds.clear();
+            self.accessibility_update = None;
         }
 
         #[cfg(any(feature = "inspector", debug_assertions))]
@@ -1096,6 +1109,167 @@ impl Frame {
         }
 
         self.scene.finish();
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot(&self) -> FrameSnapshot {
+        FrameSnapshot {
+            scene: self.scene.snapshot(),
+            hitboxes: self
+                .hitboxes
+                .iter()
+                .enumerate()
+                .map(|(index, hitbox)| {
+                    let label = format!(
+                        "hitbox bounds={:?} mask={:?} behavior={:?}",
+                        hitbox.bounds, hitbox.content_mask, hitbox.behavior
+                    );
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item.push_f32(hitbox.bounds.origin.x.as_f32());
+                    item.push_f32(hitbox.bounds.origin.y.as_f32());
+                    item.push_f32(hitbox.bounds.size.width.as_f32());
+                    item.push_f32(hitbox.bounds.size.height.as_f32());
+                    item.push_f32(hitbox.content_mask.bounds.origin.x.as_f32());
+                    item.push_f32(hitbox.content_mask.bounds.origin.y.as_f32());
+                    item.push_f32(hitbox.content_mask.bounds.size.width.as_f32());
+                    item.push_f32(hitbox.content_mask.bounds.size.height.as_f32());
+                    item.push_usize(index);
+                    item
+                })
+                .collect(),
+            window_control_hitboxes: self
+                .window_control_hitboxes
+                .iter()
+                .map(|(area, hitbox)| {
+                    let label = format!(
+                        "window_control area={area:?} bounds={:?} mask={:?} behavior={:?}",
+                        hitbox.bounds, hitbox.content_mask, hitbox.behavior
+                    );
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item
+                })
+                .collect(),
+            focus_path: self
+                .focus
+                .map(|focus| self.dispatch_tree.snapshot_focus_path(focus))
+                .unwrap_or_default(),
+            dispatch_tree: self
+                .dispatch_tree
+                .snapshot_nodes()
+                .map(|(index, parent, context, focusable, actions)| {
+                    let label = format!(
+                        "node parent={parent:?} context={context:?} focusable={focusable} actions={actions:?}"
+                    );
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item.push_usize(index);
+                    item
+                })
+                .collect(),
+            mouse_listeners: self
+                .mouse_listeners
+                .iter()
+                .map(Option::is_some)
+                .collect(),
+            input_handlers: self.input_handlers.iter().map(Option::is_some).collect(),
+            tooltip_requests: self
+                .tooltip_requests
+                .iter()
+                .map(Option::is_some)
+                .collect(),
+            cursor_styles: self
+                .cursor_styles
+                .iter()
+                .map(|request| {
+                    let hitbox_index = request.hitbox_id.and_then(|id| {
+                        self.hitboxes.iter().position(|hitbox| hitbox.id == id)
+                    });
+                    let label = format!(
+                        "cursor style={:?} hitbox={hitbox_index:?}",
+                        request.style
+                    );
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item
+                })
+                .collect(),
+            tab_stops: self
+                .tab_stops
+                .insertion_history
+                .iter()
+                .map(|operation| {
+                    let label = match operation {
+                        TabStopOperation::Insert(handle) => format!(
+                            "insert tab_index={} tab_stop={}",
+                            handle.tab_index, handle.tab_stop
+                        ),
+                        TabStopOperation::Group(index) => format!("group {index}"),
+                        TabStopOperation::GroupEnd => "group_end".to_string(),
+                    };
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item
+                })
+                .collect(),
+            deferred_draws: self
+                .deferred_draws
+                .iter()
+                .map(|draw| {
+                    let element_path = draw
+                        .element_id_stack
+                        .iter()
+                        .map(snapshot_element_id)
+                        .collect::<Vec<_>>();
+                    let label = format!(
+                        "deferred priority={} elements={:?} text={:?} mask={:?} rem={:?} offset={:?} prepaint=({}, {}) paint=({}, {})",
+                        draw.priority,
+                        element_path,
+                        draw.text_style_stack,
+                        draw.content_mask,
+                        draw.rem_size,
+                        draw.absolute_offset,
+                        draw.prepaint_range.start.hitboxes_index,
+                        draw.prepaint_range.end.hitboxes_index,
+                        draw.paint_range.start.scene_index,
+                        draw.paint_range.end.scene_index,
+                    );
+                    let mut item = FrameSnapshotItem::new(label.clone());
+                    item.push_str(&label);
+                    item.push_f32(draw.rem_size.as_f32());
+                    item.push_f32(draw.absolute_offset.x.as_f32());
+                    item.push_f32(draw.absolute_offset.y.as_f32());
+                    item
+                })
+                .collect(),
+            accessibility_update: self.accessibility_update.clone(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn snapshot_element_id(element_id: &ElementId) -> String {
+    match element_id {
+        ElementId::View(_) => "view".to_string(),
+        ElementId::Integer(value) => format!("integer:{value}"),
+        ElementId::Name(value) => format!("name:{value}"),
+        ElementId::Uuid(value) => format!("uuid:{value}"),
+        ElementId::FocusHandle(_) => "focus".to_string(),
+        ElementId::NamedInteger(name, value) => format!("named_integer:{name}:{value}"),
+        ElementId::Path(value) => format!("path:{}", value.display()),
+        ElementId::CodeLocation(value) => {
+            format!(
+                "code_location:{}:{}:{}",
+                value.file(),
+                value.line(),
+                value.column()
+            )
+        }
+        ElementId::NamedChild(parent, name) => {
+            format!("named_child:{}:{name}", snapshot_element_id(parent))
+        }
+        ElementId::OpaqueId(value) => format!("opaque:{value:?}"),
     }
 }
 
@@ -2981,6 +3155,7 @@ impl Window {
         let draw_started_at = Some(Instant::now());
         #[cfg(not(feature = "frame-duration-histogram"))]
         let draw_started_at = profiler::frame_trace_enabled().then(Instant::now);
+        let mut frame_phase_timings = None;
 
         // Set up the per-App arena for element allocation during this draw.
         // This ensures that multiple test Apps have isolated arenas.
@@ -3010,7 +3185,7 @@ impl Window {
             }
         }
         if !cx.mode.skip_drawing() {
-            self.draw_roots(cx);
+            frame_phase_timings = Some(self.draw_roots(cx));
         }
         self.dirty_views.clear();
         self.next_frame.window_active = self.active.get();
@@ -3098,6 +3273,8 @@ impl Window {
                 dirty_at: frame_dirty.dirty_at,
                 invalidations: frame_dirty.invalidations,
                 draw_start,
+                prepaint_end: frame_phase_timings.map(|timings| timings.prepaint_end),
+                paint_end: frame_phase_timings.map(|timings| timings.paint_end),
                 draw_end,
             });
         }
@@ -3171,7 +3348,7 @@ impl Window {
         self.frame_duration_tracker.snapshot()
     }
 
-    fn draw_roots(&mut self, cx: &mut App) {
+    fn draw_roots(&mut self, cx: &mut App) -> FramePhaseTimings {
         self.invalidator.set_phase(DrawPhase::Prepaint);
         self.tooltip_bounds.take();
 
@@ -3239,6 +3416,7 @@ impl Window {
         }
 
         self.mouse_hit_test = self.next_frame.hit_test(self.mouse_position);
+        let prepaint_end = Instant::now();
 
         // Now actually paint the elements.
         self.invalidator.set_phase(DrawPhase::Paint);
@@ -3259,6 +3437,7 @@ impl Window {
 
         #[cfg(any(feature = "inspector", debug_assertions))]
         self.paint_inspector_hitbox(cx);
+        let paint_end = Instant::now();
 
         // a11y may have been activated/deactivated halfway through the frame
         let a11y_active_start_of_frame = self.a11y.is_active();
@@ -3277,6 +3456,10 @@ impl Window {
             };
             // clear the builder state regardless
             let tree_update = self.a11y.end_frame(frame_info);
+            #[cfg(any(test, feature = "test-support"))]
+            {
+                self.next_frame.accessibility_update = self.a11y.snapshot_json();
+            }
 
             if should_send_a11y_update {
                 log::debug!(
@@ -3285,6 +3468,10 @@ impl Window {
                 );
                 self.platform_window.a11y_tree_update(tree_update);
             }
+        }
+        FramePhaseTimings {
+            prepaint_end,
+            paint_end,
         }
     }
 
@@ -6160,6 +6347,12 @@ impl Window {
     /// Debug representation of the last frame's accessibility information.
     pub fn debug_a11y_tree_json(&self) -> Option<String> {
         self.a11y.debug_tree_json()
+    }
+
+    /// Snapshots the output lanes of the most recently produced frame.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn frame_snapshot(&self) -> FrameSnapshot {
+        self.rendered_frame.snapshot()
     }
 
     /// Register a listener for an accessibility action on a specific node.

--- a/crates/gpui/src/window/a11y.rs
+++ b/crates/gpui/src/window/a11y.rs
@@ -293,6 +293,11 @@ impl A11y {
     pub(crate) fn debug_tree_json(&self) -> Option<String> {
         self.debug.to_json()
     }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot_json(&self) -> Option<String> {
+        self.debug.snapshot_json()
+    }
 }
 
 /// Builder API for synthetic children. See the docs for

--- a/crates/gpui/src/window/a11y/debug.rs
+++ b/crates/gpui/src/window/a11y/debug.rs
@@ -99,6 +99,15 @@ impl A11yDebug {
     /// Serialize the last tree update to a readable JSON string. Node ids are
     /// replaced with short ephemeral ids (`a`, `b`, ..., `z`, `aa`, ...).
     pub(crate) fn to_json(&self) -> Option<String> {
+        self.to_json_with_frame(true)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn snapshot_json(&self) -> Option<String> {
+        self.to_json_with_frame(false)
+    }
+
+    fn to_json_with_frame(&self, include_frame: bool) -> Option<String> {
         let update = self.last_tree_update.as_ref()?;
 
         let mut ephemeral: FxHashMap<NodeId, String> = FxHashMap::default();
@@ -131,20 +140,23 @@ impl A11yDebug {
             nodes.insert(key, value);
         }
 
-        let frame = self.last_frame.as_ref().map(|frame| {
-            serde_json::json!({
-                "rendered_at": frame.rendered_at,
-                "frame_number": frame.frame_number,
-                "window_title": frame.window_title.as_ref().map(|title| title.to_string()),
-                "node_count": frame.node_count,
-                "tab_stop_count": frame.tab_stop_count,
-                "viewport_size": {
-                    "width": frame.viewport_size.width.0,
-                    "height": frame.viewport_size.height.0,
-                },
-                "scale_factor": frame.scale_factor,
-            })
-        });
+        let frame = include_frame
+            .then(|| self.last_frame.as_ref())
+            .flatten()
+            .map(|frame| {
+                serde_json::json!({
+                    "rendered_at": frame.rendered_at,
+                    "frame_number": frame.frame_number,
+                    "window_title": frame.window_title.as_ref().map(|title| title.to_string()),
+                    "node_count": frame.node_count,
+                    "tab_stop_count": frame.tab_stop_count,
+                    "viewport_size": {
+                        "width": frame.viewport_size.width.0,
+                        "height": frame.viewport_size.height.0,
+                    },
+                    "scale_factor": frame.scale_factor,
+                })
+            });
 
         let root = update
             .tree


### PR DESCRIPTION
## Summary

- add an exact, test-support-gated `FrameSnapshot` covering scene primitives, hit testing, dispatch/focus state, cursor and tab requests, deferred draws, and accessibility updates
- add a deterministic dual-window frame oracle with a walk-vs-walk storybook and property-test scaffolding
- add GPUI frame-production Criterion benchmarks for layout, scene assembly, presentation proxies, and a scripted 300-frame workload
- report layout/prepaint and scene-assembly phase histograms through the existing GPUI benchmark report
- document snapshot canonicalization and extending storybook coverage

## Canonicalization

Oracle windows share the test context's text system and sprite atlas. Scene order remains semantic, and primitive floating-point fields are compared by their IEEE-754 bit representation.

The oracle work also moved ordinary animation timing onto the GPUI executor clock so deterministic tests do not leak wall-clock time.

## Validation

- walk-vs-walk storybook passed across 100 scheduler seeds
- generated walk-vs-walk property test passed with seeds 0, 1, 7, 42, and 99
- GPUI animation tests passed
- `cargo check -p gpui --features test-support`
- `cargo check -p benchmarks --bench gpui_frame_production`
- `./script/clippy -p gpui --features test-support`
- `cargo fmt --all`
- `git diff --check`

Full Criterion sampling and the <5% machine-local variance check remain to be run on the target benchmark machine.

## Suggested .rules additions

For GPUI code whose behavior depends on elapsed time, use the context executor's clock (`cx.background_executor().now()`) instead of `scheduler::Instant::now()` or `Instant::elapsed()`. The executor clock follows the deterministic test clock while production executors still use real time.

Release Notes:

- N/A
