### PR TITLE
Add Obsidian-style live preview for markdown buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10824,6 +10824,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown_live_preview"
+version = "0.1.0"
+dependencies = [
+ "collections",
+ "editor",
+ "gpui",
+ "indoc",
+ "language",
+ "log",
+ "markdown",
+ "multi_buffer",
+ "pretty_assertions",
+ "project",
+ "settings",
+ "text",
+ "theme",
+ "theme_settings",
+ "tree-sitter",
+ "tree-sitter-md",
+ "ui",
+ "urlencoding",
+ "util",
+ "workspace",
+ "zlog",
+]
+
+[[package]]
 name = "markdown_preview"
 version = "0.1.0"
 dependencies = [
@@ -23352,6 +23379,7 @@ dependencies = [
  "log",
  "lsp_locations",
  "markdown",
+ "markdown_live_preview",
  "markdown_preview",
  "menu",
  "migrator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "crates/lsp",
     "crates/lsp_locations",
     "crates/markdown",
+    "crates/markdown_live_preview",
     "crates/markdown_preview",
     "crates/mermaid_render",
     "crates/media",
@@ -397,6 +398,7 @@ lmstudio = { path = "crates/lmstudio" }
 lsp = { path = "crates/lsp" }
 lsp_locations = { path = "crates/lsp_locations" }
 markdown = { path = "crates/markdown" }
+markdown_live_preview = { path = "crates/markdown_live_preview" }
 markdown_preview = { path = "crates/markdown_preview" }
 mermaid_render = { path = "crates/mermaid_render" }
 svg_preview = { path = "crates/svg_preview" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -126,6 +126,16 @@
     // limit_content_width is enabled.
     "max_width": 800,
   },
+  // Markdown live preview settings
+  "markdown_live_preview": {
+    // Whether to render markdown inline in the editor (Obsidian-style live
+    // preview): syntax markers are hidden, and elements like headings,
+    // tables, and images are rendered, except on lines the cursor is on.
+    "enabled": true,
+    // Folder for attachments dropped onto a markdown buffer, relative to the
+    // note's folder. An empty string stores attachments in the note's folder.
+    "attachments_folder": "attachments",
+  },
   // Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
   //
   // 1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -86,6 +86,7 @@ pub use block_map::{
 };
 pub use crease_map::*;
 pub use fold_map::{
+    Concealment,
     ChunkRenderer, ChunkRendererContext, ChunkRendererId, Fold, FoldId, FoldPlaceholder, FoldPoint,
 };
 pub use inlay_map::{InlayOffset, InlayPoint};
@@ -177,6 +178,7 @@ pub enum HighlightKey {
     HoveredLinkState,
     InlineAssist,
     InputComposition,
+    MarkdownLivePreview(usize),
     MatchingBracket,
     NavigationOverlay(NavigationOverlayKey),
     PendingInput,
@@ -786,6 +788,35 @@ impl DisplayMap {
             });
 
         self.block_map.write(snapshot, edits, None).insert(blocks);
+    }
+
+    /// Replaces the owner's entire set of rendering-only concealments.
+    #[instrument(skip_all)]
+    pub fn set_concealments(
+        &mut self,
+        owner: TypeId,
+        concealments: Vec<Concealment>,
+        cx: &mut Context<Self>,
+    ) {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let edits = self.buffer_subscription.consume().into_inner();
+        let tab_size = Self::tab_size(&self.buffer, cx);
+
+        let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
+        let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
+        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self
+            .wrap_map
+            .update(cx, |map, cx| map.sync(snapshot, edits, cx));
+        self.block_map.read(snapshot, edits, None);
+
+        let (snapshot, edits) = fold_map.set_concealments(owner, concealments);
+        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (new_wrap_snapshot, new_wrap_edits) = self
+            .wrap_map
+            .update(cx, |map, cx| map.sync(snapshot, edits, cx));
+
+        self.block_map.write(new_wrap_snapshot, new_wrap_edits, None);
     }
 
     /// Removes any folds with the given ranges.

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -19,6 +19,7 @@ use std::{
     sync::Arc,
     usize,
 };
+use collections::HashMap;
 use sum_tree::{Bias, Cursor, Dimensions, FilterCursor, SumTree, Summary, TreeMap};
 use ui::IntoElement as _;
 use util::post_inc;
@@ -163,6 +164,19 @@ impl<'a> sum_tree::Dimension<'a, TransformSummary> for FoldPoint {
     fn add_summary(&mut self, summary: &'a TransformSummary, _: ()) {
         self.0 += &summary.output.lines;
     }
+}
+
+/// A rendering-only concealment: hides or replaces a range's display without
+/// registering a fold. Invisible to the gutter, fold persistence, and fold
+/// actions by construction.
+#[derive(Clone)]
+pub struct Concealment {
+    pub range: Range<Anchor>,
+    pub placeholder: FoldPlaceholder,
+    /// Distinguishes different renders at an identical range (e.g. a
+    /// checkbox's checked state); items whose (range, content_key) are
+    /// unchanged are reused without a resync.
+    pub content_key: u64,
 }
 
 pub(crate) struct FoldMapWriter<'a>(&'a mut FoldMap);
@@ -352,6 +366,112 @@ impl FoldMapWriter<'_> {
         let edits = self.0.sync(inlay_snapshot, edits);
         (self.0.snapshot.clone(), edits)
     }
+
+    /// Replaces the owner's entire concealment set. Items whose
+    /// (range, content_key) are unchanged are reused without a resync, so
+    /// callers can idempotently pass the full desired set on every update.
+    #[ztracing::instrument(skip_all)]
+    pub(crate) fn set_concealments(
+        &mut self,
+        owner: TypeId,
+        concealments: Vec<Concealment>,
+    ) -> (FoldSnapshot, Vec<FoldEdit>) {
+        let snapshot = self.0.snapshot.inlay_snapshot.clone();
+        let buffer = snapshot.buffer.clone();
+        let mut edits = Vec::new();
+
+        let mut existing: HashMap<(usize, usize), Fold> = HashMap::default();
+        let mut new_items: Vec<Fold> = Vec::new();
+        for item in self.0.snapshot.concealments.iter() {
+            if item.placeholder.type_tag == Some(owner) {
+                let start = item.range.start.to_offset(&buffer);
+                let end = item.range.end.to_offset(&buffer);
+                existing.insert((start.0, end.0), item.clone());
+            } else {
+                new_items.push(item.clone());
+            }
+        }
+
+        for mut concealment in concealments {
+            let range = concealment.range.start.to_offset(&buffer)
+                ..concealment.range.end.to_offset(&buffer);
+            if range.start >= range.end {
+                continue;
+            }
+            concealment.placeholder.type_tag = Some(owner);
+            match existing.remove(&(range.start.0, range.end.0)) {
+                Some(old)
+                    if self.0.concealment_content_keys.get(&old.id).copied()
+                        == Some(concealment.content_key) =>
+                {
+                    new_items.push(old);
+                }
+                old => {
+                    if let Some(old) = old {
+                        self.0.snapshot.fold_metadata_by_id.remove(&old.id);
+                        self.0.concealment_content_keys.remove(&old.id);
+                    }
+                    let fold_range =
+                        FoldRange(buffer.anchor_after(range.start)..buffer.anchor_before(range.end));
+                    if buffer
+                        .anchor_range_to_buffer_anchor_range(fold_range.0.clone())
+                        .is_none()
+                    {
+                        continue;
+                    }
+                    let id = FoldId(post_inc(&mut self.0.next_fold_id.0));
+                    self.0.snapshot.fold_metadata_by_id.insert(
+                        id,
+                        FoldMetadata {
+                            range: fold_range.clone(),
+                            width: None,
+                        },
+                    );
+                    self.0
+                        .concealment_content_keys
+                        .insert(id, concealment.content_key);
+                    new_items.push(Fold {
+                        id,
+                        range: fold_range,
+                        placeholder: concealment.placeholder,
+                    });
+                    let inlay_range = snapshot.to_inlay_offset(range.start)
+                        ..snapshot.to_inlay_offset(range.end);
+                    edits.push(InlayEdit {
+                        old: inlay_range.clone(),
+                        new: inlay_range,
+                    });
+                }
+            }
+        }
+
+        for (_, old) in existing {
+            let start = old.range.start.to_offset(&buffer);
+            let end = old.range.end.to_offset(&buffer);
+            self.0.snapshot.fold_metadata_by_id.remove(&old.id);
+            self.0.concealment_content_keys.remove(&old.id);
+            if end > start {
+                let inlay_range =
+                    snapshot.to_inlay_offset(start)..snapshot.to_inlay_offset(end);
+                edits.push(InlayEdit {
+                    old: inlay_range.clone(),
+                    new: inlay_range,
+                });
+            }
+        }
+
+        new_items
+            .sort_unstable_by(|a, b| sum_tree::SeekTarget::cmp(&a.range, &b.range, &buffer));
+        let mut tree = SumTree::new(&buffer);
+        for item in new_items {
+            tree.push(item, &buffer);
+        }
+        self.0.snapshot.concealments = tree;
+
+        let edits = consolidate_inlay_edits(edits);
+        let edits = self.0.sync(snapshot, edits);
+        (self.0.snapshot.clone(), edits)
+    }
 }
 
 /// Decides where the fold indicators should be; also tracks parts of a source file that are currently folded.
@@ -360,6 +480,7 @@ impl FoldMapWriter<'_> {
 pub struct FoldMap {
     snapshot: FoldSnapshot,
     next_fold_id: FoldId,
+    concealment_content_keys: HashMap<FoldId, u64>,
 }
 
 impl FoldMap {
@@ -368,6 +489,7 @@ impl FoldMap {
         let this = Self {
             snapshot: FoldSnapshot {
                 folds: SumTree::new(&inlay_snapshot.buffer),
+                concealments: SumTree::new(&inlay_snapshot.buffer),
                 transforms: SumTree::from_item(
                     Transform {
                         summary: TransformSummary {
@@ -383,6 +505,7 @@ impl FoldMap {
                 fold_metadata_by_id: TreeMap::default(),
             },
             next_fold_id: FoldId::default(),
+            concealment_content_keys: HashMap::default(),
         };
         let snapshot = this.snapshot.clone();
         (this, snapshot)
@@ -513,20 +636,44 @@ impl FoldMap {
                     .folds
                     .cursor::<FoldRange>(&inlay_snapshot.buffer);
                 folds_cursor.seek(&FoldRange(anchor..Anchor::Max), Bias::Left);
+                let mut concealments_cursor = self
+                    .snapshot
+                    .concealments
+                    .cursor::<FoldRange>(&inlay_snapshot.buffer);
+                concealments_cursor.seek(&FoldRange(anchor..Anchor::Max), Bias::Left);
 
                 let mut folds = iter::from_fn({
                     let inlay_snapshot = &inlay_snapshot;
                     move || {
-                        let item = folds_cursor.item().map(|fold| {
+                        // Merge real folds and concealments in range order.
+                        let next_is_fold =
+                            match (folds_cursor.item(), concealments_cursor.item()) {
+                                (Some(fold), Some(concealment)) => sum_tree::SeekTarget::cmp(
+                                    &fold.range,
+                                    &concealment.range,
+                                    &inlay_snapshot.buffer,
+                                )
+                                .is_le(),
+                                (Some(_), None) => true,
+                                (None, Some(_)) => false,
+                                (None, None) => true,
+                            };
+                        let active_cursor = if next_is_fold {
+                            &mut folds_cursor
+                        } else {
+                            &mut concealments_cursor
+                        };
+                        let item = active_cursor.item().map(|fold| {
                             let buffer_start = fold.range.start.to_offset(&inlay_snapshot.buffer);
                             let buffer_end = fold.range.end.to_offset(&inlay_snapshot.buffer);
                             (
                                 fold.clone(),
                                 inlay_snapshot.to_inlay_offset(buffer_start)
                                     ..inlay_snapshot.to_inlay_offset(buffer_end),
+                                !next_is_fold,
                             )
                         });
-                        folds_cursor.next();
+                        active_cursor.next();
                         item
                     }
                 })
@@ -534,20 +681,25 @@ impl FoldMap {
 
                 while folds
                     .peek()
-                    .is_some_and(|(_, fold_range)| fold_range.start < edit.new.end)
+                    .is_some_and(|(_, fold_range, _)| fold_range.start < edit.new.end)
                 {
-                    let (fold, mut fold_range) = folds.next().unwrap();
+                    let (fold, mut fold_range, mut is_concealment) = folds.next().unwrap();
                     let sum = new_transforms.summary();
 
                     assert!(fold_range.start.0 >= sum.input.len);
 
-                    while folds.peek().is_some_and(|(next_fold, next_fold_range)| {
-                        next_fold_range.start < fold_range.end
-                            || (next_fold_range.start == fold_range.end
-                                && fold.placeholder.merge_adjacent
-                                && next_fold.placeholder.merge_adjacent)
-                    }) {
-                        let (_, next_fold_range) = folds.next().unwrap();
+                    while folds
+                        .peek()
+                        .is_some_and(|(next_fold, next_fold_range, _)| {
+                            next_fold_range.start < fold_range.end
+                                || (next_fold_range.start == fold_range.end
+                                    && fold.placeholder.merge_adjacent
+                                    && next_fold.placeholder.merge_adjacent)
+                        })
+                    {
+                        let (_, next_fold_range, next_is_concealment) = folds.next().unwrap();
+                        // A region containing a real fold is a fold.
+                        is_concealment &= next_is_concealment;
                         if next_fold_range.end > fold_range.end {
                             fold_range.end = next_fold_range.end;
                         }
@@ -584,6 +736,7 @@ impl FoldMap {
                                 placeholder: Some(TransformPlaceholder {
                                     text: placeholder_text,
                                     chars: chars_bitmap,
+                                    is_concealment,
                                     renderer: ChunkRenderer {
                                         id: ChunkRendererId::Fold(fold.id),
                                         render: Arc::new(move |cx| {
@@ -681,6 +834,10 @@ pub struct FoldSnapshot {
     pub inlay_snapshot: InlaySnapshot,
     transforms: SumTree<Transform>,
     folds: SumTree<Fold>,
+    /// Rendering-only concealments; deliberately excluded from every fold
+    /// query so fold consumers (gutter, persistence, unfold actions) cannot
+    /// observe them.
+    concealments: SumTree<Fold>,
     fold_metadata_by_id: TreeMap<FoldId, FoldMetadata>,
     pub version: usize,
 }
@@ -881,7 +1038,12 @@ impl FoldSnapshot {
         let (_, _, item) = self
             .transforms
             .find::<InlayOffset, _>((), &inlay_offset, Bias::Right);
-        item.is_some_and(|t| t.placeholder.is_some())
+        item.is_some_and(|transform| {
+            transform
+                .placeholder
+                .as_ref()
+                .is_some_and(|placeholder| !placeholder.is_concealment)
+        })
     }
 
     #[ztracing::instrument(skip_all)]
@@ -897,7 +1059,11 @@ impl FoldSnapshot {
                     let buffer_point = self.inlay_snapshot.to_buffer_point(inlay_point);
                     if buffer_point.row != buffer_row.0 {
                         return false;
-                    } else if transform.placeholder.is_some() {
+                    } else if transform
+                        .placeholder
+                        .as_ref()
+                        .is_some_and(|placeholder| !placeholder.is_concealment)
+                    {
                         return true;
                     }
                 }
@@ -1179,6 +1345,10 @@ struct TransformPlaceholder {
     text: SharedString,
     chars: u128,
     renderer: ChunkRenderer,
+    /// True when produced by a concealment rather than a fold; excluded from
+    /// fold queries like `is_line_folded` so the gutter and cursor placement
+    /// treat concealed text as ordinary text.
+    is_concealment: bool,
 }
 
 impl Transform {
@@ -1538,6 +1708,14 @@ impl<'a> Iterator for FoldChunks<'a> {
                 && self.transform_cursor.item().is_some()
             {
                 self.transform_cursor.next();
+            }
+
+            // A zero-width placeholder (e.g. a fold that conceals markdown
+            // syntax) contributes no display text; emitting an empty chunk
+            // would break downstream consumers that assume chunks are
+            // non-empty.
+            if placeholder.text.is_empty() {
+                return self.next();
             }
 
             self.output_offset.0 += placeholder.text.len();

--- a/crates/editor/src/fold.rs
+++ b/crates/editor/src/fold.rs
@@ -18,7 +18,11 @@ impl EditorSnapshot {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
-        let folded = self.is_line_folded(buffer_row);
+        // Query the fold map directly rather than `is_line_folded`, which
+        // also reports rows replaced by custom blocks (e.g. rendered markdown
+        // widgets); the toggle this chevron drives only unfolds fold-map
+        // folds.
+        let folded = self.fold_snapshot().is_line_folded(buffer_row);
         let mut is_foldable = false;
 
         if let Some(crease) = self
@@ -714,6 +718,20 @@ impl Editor {
 
     pub fn default_fold_placeholder(&self, cx: &App) -> FoldPlaceholder {
         self.display_map.read(cx).fold_placeholder.clone()
+    }
+
+    /// Replaces the owner's entire set of rendering-only concealments:
+    /// display substitutions that are invisible to the gutter, fold
+    /// persistence, and fold actions.
+    pub fn set_concealments(
+        &mut self,
+        owner: TypeId,
+        concealments: Vec<crate::display_map::Concealment>,
+        cx: &mut Context<Self>,
+    ) {
+        self.display_map
+            .update(cx, |map, cx| map.set_concealments(owner, concealments, cx));
+        cx.notify();
     }
 
     pub fn insert_creases(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -627,6 +627,26 @@ fn deserialize_anchor(anchor: proto::EditorAnchor, buffer: &MultiBufferSnapshot)
 impl Item for Editor {
     type Event = EditorEvent;
 
+    fn handle_drop(
+        &self,
+        _active_pane: &workspace::Pane,
+        dropped: &dyn std::any::Any,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        // Drops anywhere on a markdown buffer insert links (Obsidian-style);
+        // the pane's split zones cover wide edge bands that made insertion
+        // unreliable when they took precedence. Splitting is still available
+        // via the tab bar or with non-markdown drops.
+        if let Some(paths) = dropped.downcast_ref::<gpui::ExternalPaths>() {
+            return handle_image_drop_on_markdown(self, paths.paths(), cx);
+        }
+        if let Some(selection) = dropped.downcast_ref::<workspace::DraggedSelection>() {
+            return handle_project_entry_drop_on_markdown(self, selection, cx);
+        }
+        false
+    }
+
     fn act_as_type<'a>(
         &'a self,
         type_id: TypeId,
@@ -2455,6 +2475,267 @@ fn compute_modified_ranges(
         merged.push(expanded);
     }
     merged
+}
+
+/// Attachment formats accepted on drop, mirroring Obsidian's list. Images
+/// embed with `![](...)` (they render inline); the rest link with `[](...)`
+/// since neither live preview nor the markdown preview can embed them.
+const DROPPABLE_IMAGE_EXTENSIONS: &[&str] =
+    &["avif", "bmp", "gif", "jpeg", "jpg", "png", "svg", "webp"];
+const DROPPABLE_FILE_EXTENSIONS: &[&str] = &[
+    "flac", "m4a", "mp3", "ogg", "wav", "webm", "3gp", "mkv", "mov", "mp4", "ogv", "pdf",
+];
+
+/// Folder for dropped attachments, from `markdown_live_preview.attachments_folder`.
+#[derive(Clone, Debug, Default, settings::RegisterSetting)]
+struct MarkdownAttachmentSettings {
+    folder: String,
+}
+
+impl settings::Settings for MarkdownAttachmentSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let content = content.markdown_live_preview.clone().unwrap_or_default();
+        Self {
+            folder: content
+                .attachments_folder
+                .unwrap_or_else(|| "attachments".to_string()),
+        }
+    }
+}
+
+
+/// Inserts block-level markdown at the cursor, padded with blank lines so it
+/// cannot fuse with its neighbors: a following `---` would otherwise turn an
+/// inserted link line into a setext heading underline, and a preceding text
+/// line would absorb an inserted image into its paragraph.
+fn insert_dropped_markdown(editor: &Editor, mut markdown: String, cx: &mut App) {
+    use multi_buffer::{MultiBufferRow, ToOffset as _, ToPoint as _};
+
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let cursor = editor.selections.newest_anchor().head();
+    let offset = cursor.to_offset(&snapshot);
+    let point = cursor.to_point(&snapshot);
+
+    if point.column > 0 {
+        markdown.insert_str(0, "\n\n");
+    } else if point.row > 0 && snapshot.line_len(MultiBufferRow(point.row - 1)) > 0 {
+        markdown.insert(0, '\n');
+    }
+    let followed_by_text = snapshot
+        .chars_at(offset)
+        .next()
+        .is_some_and(|character| character != '\n');
+    if followed_by_text {
+        markdown.push('\n');
+    }
+
+    editor.buffer().update(cx, |multibuffer, cx| {
+        multibuffer.edit([(offset..offset, markdown)], None, cx);
+    });
+}
+
+/// The note's folder for a saved, local, singleton markdown buffer; the
+/// gate for all markdown drop handling.
+fn markdown_note_directory(editor: &Editor, cx: &App) -> Option<std::path::PathBuf> {
+    let buffer = editor.buffer().read(cx).as_singleton()?;
+    if buffer
+        .read(cx)
+        .language()
+        .is_none_or(|language| language.name().as_ref() != "Markdown")
+    {
+        return None;
+    }
+    let mut path = buffer.read(cx).file()?.as_local()?.abs_path(cx);
+    path.pop();
+    Some(path)
+}
+
+/// Obsidian-style note linking: project-panel entries dropped onto a markdown
+/// buffer insert relative links at the cursor (images embed with `![]`),
+/// instead of opening the files. The files already live in the project, so
+/// nothing is copied.
+fn handle_project_entry_drop_on_markdown(
+    editor: &Editor,
+    selection: &workspace::DraggedSelection,
+    cx: &mut App,
+) -> bool {
+    let Some(note_directory) = markdown_note_directory(editor, cx) else {
+        return false;
+    };
+    let Some(project) = editor.project().cloned() else {
+        return false;
+    };
+
+    let mut markdown_links = String::new();
+    for entry in selection.items() {
+        let Some(project_path) = project.read(cx).path_for_entry(entry.entry_id, cx) else {
+            continue;
+        };
+        let Some(absolute_path) = project.read(cx).absolute_path(&project_path, cx) else {
+            continue;
+        };
+        if absolute_path.is_dir() {
+            continue;
+        }
+        let relative = relative_path(&note_directory, &absolute_path);
+        let is_image = absolute_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                DROPPABLE_IMAGE_EXTENSIONS.contains(&extension.to_ascii_lowercase().as_str())
+            });
+        let link_name = absolute_path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let link_target = relative.to_string_lossy().replace(' ', "%20");
+        if is_image {
+            markdown_links.push_str(&format!("![]({link_target})\n"));
+        } else {
+            markdown_links.push_str(&format!("[{link_name}]({link_target})\n"));
+        }
+    }
+    if markdown_links.is_empty() {
+        return false;
+    }
+
+    insert_dropped_markdown(editor, markdown_links, cx);
+    true
+}
+
+/// A relative path from `from_directory` to `to`, using `..` where needed.
+fn relative_path(from_directory: &std::path::Path, to: &std::path::Path) -> std::path::PathBuf {
+    let from_components: Vec<_> = from_directory.components().collect();
+    let to_components: Vec<_> = to.components().collect();
+    let common = from_components
+        .iter()
+        .zip(&to_components)
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut result = std::path::PathBuf::new();
+    for _ in common..from_components.len() {
+        result.push("..");
+    }
+    for component in &to_components[common..] {
+        result.push(component);
+    }
+    result
+}
+
+/// Obsidian-style attachment drop: accepted files dropped onto a markdown
+/// buffer are copied beside the note (into the configured attachments folder)
+/// and referenced at the cursor, instead of being opened as workspace items.
+fn handle_image_drop_on_markdown(
+    editor: &Editor,
+    paths: &[std::path::PathBuf],
+    cx: &mut App,
+) -> bool {
+
+    let Some(buffer) = editor.buffer().read(cx).as_singleton() else {
+        return false;
+    };
+    if buffer
+        .read(cx)
+        .language()
+        .is_none_or(|language| language.name().as_ref() != "Markdown")
+    {
+        return false;
+    }
+    let Some(note_directory) = buffer.read(cx).file().and_then(|file| {
+        let mut path = file.as_local()?.abs_path(cx);
+        path.pop();
+        Some(path)
+    }) else {
+        return false;
+    };
+
+    let extension_of = |path: &std::path::Path| {
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| extension.to_ascii_lowercase())
+    };
+    let all_attachments = !paths.is_empty()
+        && paths.iter().all(|path| {
+            extension_of(path).is_some_and(|extension| {
+                DROPPABLE_IMAGE_EXTENSIONS.contains(&extension.as_str())
+                    || DROPPABLE_FILE_EXTENSIONS.contains(&extension.as_str())
+            })
+        });
+    if !all_attachments {
+        return false;
+    }
+
+    let attachments_folder = <MarkdownAttachmentSettings as settings::Settings>::get_global(cx)
+        .folder
+        .trim()
+        .trim_matches('/')
+        .to_string();
+
+    let mut markdown_links = String::new();
+    for path in paths {
+        let link_target = if let Ok(relative) = path.strip_prefix(&note_directory) {
+            relative.to_path_buf()
+        } else {
+            let attachments_directory = if attachments_folder.is_empty() {
+                note_directory.clone()
+            } else {
+                note_directory.join(&attachments_folder)
+            };
+            if std::fs::create_dir_all(&attachments_directory)
+                .log_err()
+                .is_none()
+            {
+                continue;
+            }
+            let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let stem = std::path::Path::new(file_name)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("image");
+            let extension = std::path::Path::new(file_name)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("png");
+            let mut candidate = attachments_directory.join(file_name);
+            let mut suffix = 1;
+            while candidate.exists() {
+                candidate = attachments_directory.join(format!("{stem}-{suffix}.{extension}"));
+                suffix += 1;
+            }
+            if std::fs::copy(path, &candidate).log_err().is_none() {
+                continue;
+            }
+            let copied_name = candidate
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if attachments_folder.is_empty() {
+                std::path::PathBuf::from(copied_name)
+            } else {
+                std::path::Path::new(&attachments_folder).join(copied_name)
+            }
+        };
+        let is_image = extension_of(&link_target)
+            .is_some_and(|extension| DROPPABLE_IMAGE_EXTENSIONS.contains(&extension.as_str()));
+        let link_name = link_target
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let link_target = link_target.to_string_lossy().replace(' ', "%20");
+        if is_image {
+            markdown_links.push_str(&format!("![]({link_target})\n"));
+        } else {
+            markdown_links.push_str(&format!("[{link_name}]({link_target})\n"));
+        }
+    }
+    if markdown_links.is_empty() {
+        return false;
+    }
+
+    insert_dropped_markdown(editor, markdown_links, cx);
+    true
 }
 
 #[cfg(test)]

--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "markdown_live_preview"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/markdown_live_preview.rs"
+
+[dependencies]
+collections.workspace = true
+editor.workspace = true
+gpui.workspace = true
+log.workspace = true
+language.workspace = true
+markdown.workspace = true
+multi_buffer.workspace = true
+settings.workspace = true
+text.workspace = true
+theme.workspace = true
+theme_settings.workspace = true
+tree-sitter.workspace = true
+ui.workspace = true
+urlencoding.workspace = true
+util.workspace = true
+
+[dev-dependencies]
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+indoc.workspace = true
+language = { workspace = true, features = ["test-support"] }
+pretty_assertions.workspace = true
+project = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+theme = { workspace = true, features = ["test-support"] }
+theme_settings.workspace = true
+tree-sitter-md.workspace = true
+util = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -1,0 +1,3330 @@
+//! Obsidian-style live preview for markdown buffers.
+//!
+//! When enabled, markdown syntax markers (`**`, `*`, `~~`, backticks, link
+//! targets, list bullets) are hidden and rendered inline, and block elements
+//! (headings, tables, images, mermaid diagrams, horizontal rules) are replaced
+//! with rendered widgets. Raw markdown is revealed for editing per token: an
+//! inline construct reveals when the selection touches it, and a block
+//! reveals when the selection reaches its lines, mirroring Obsidian's Live
+//! Preview mode. Tables and images are the exception: they are edited
+//! through their widgets and only reveal source via their `</>` button.
+
+use std::{any::TypeId, ops::Range, path::PathBuf, sync::Arc};
+
+use collections::{HashMap, HashSet};
+use editor::{
+    Addon, Editor, EditorEvent, FoldPlaceholder, HighlightKey,
+    display_map::{
+        BlockPlacement, BlockProperties, BlockStyle, Concealment, CustomBlockId, RenderBlock,
+    },
+};
+use gpui::{
+    App, AppContext as _, Context, Empty, Entity, Focusable as _, FontWeight, HighlightStyle,
+    ImageSource, IntoElement, MouseButton, Resource, SharedString, SharedUri, StrikethroughStyle,
+    Subscription, TextStyleRefinement, WeakEntity, Window, actions, rems,
+};
+use language::LanguageName;
+use markdown::{HeadingLevelStyles, Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
+use multi_buffer::{
+    Anchor, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot, ToOffset as _, ToPoint as _,
+};
+use settings::{RegisterSetting, Settings};
+use text::Point;
+use ui::{Checkbox, ToggleState, prelude::*};
+use util::ResultExt as _;
+
+actions!(
+    markdown,
+    [
+        /// Toggles Obsidian-style live preview rendering in the current markdown buffer.
+        ToggleLivePreview
+    ]
+);
+
+/// Type tag used to scope this crate's folds so they can be added and removed
+/// without disturbing user folds or other fold consumers.
+struct LivePreviewFoldTag;
+
+const MARKDOWN: &str = "Markdown";
+const MARKDOWN_INLINE: &str = "Markdown-Inline";
+
+#[derive(Clone, Copy, Debug, Default, RegisterSetting)]
+pub struct MarkdownLivePreviewSettings {
+    pub enabled: bool,
+}
+
+impl Settings for MarkdownLivePreviewSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let content = content.markdown_live_preview.clone().unwrap_or_default();
+        Self {
+            enabled: content.enabled.unwrap_or(true),
+        }
+    }
+}
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(register_editor).detach();
+}
+
+fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Context<Editor>) {
+    let Some(window) = window else {
+        return;
+    };
+    if !editor.mode().is_full() {
+        return;
+    }
+
+    let mut subscriptions = Vec::new();
+    subscriptions.push(cx.subscribe_self(|editor, event: &EditorEvent, cx| match event {
+        EditorEvent::Reparsed(_) => recompute(editor, cx),
+        EditorEvent::SelectionsChanged { .. } => {
+            if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                let resizing = addon
+                    .last_resize_at
+                    .is_some_and(|at| at.elapsed() < std::time::Duration::from_millis(500));
+                if !resizing {
+                    addon.selected_image = None;
+                }
+            }
+            apply_decorations(editor, cx);
+        }
+        _ => {}
+    }));
+
+    subscriptions.push(cx.observe_global::<theme::GlobalTheme>(|editor, cx| {
+        let markers = editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.markers.clone());
+        apply_emphasis_highlights(editor, markers.as_deref(), cx);
+    }));
+
+    let weak_editor = cx.weak_entity();
+    subscriptions.push(
+        editor.register_action::<ToggleLivePreview>(move |_, _window, cx| {
+            weak_editor
+                .update(cx, |editor, cx| {
+                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                        let enabled = addon.enabled_override.unwrap_or_else(|| {
+                            MarkdownLivePreviewSettings::get_global(cx).enabled
+                        });
+                        addon.enabled_override = Some(!enabled);
+                    }
+                    recompute(editor, cx);
+                })
+                .log_err();
+        }),
+    );
+
+    // Backspace/Delete removes a selected table row/column (Obsidian-style)
+    // instead of editing text; without a selection they pass through.
+    let weak_editor = cx.weak_entity();
+    subscriptions.push(
+        editor.register_action::<editor::actions::Backspace>(move |_, _window, cx| {
+            if !delete_selected_table_unit(&weak_editor, cx) {
+                cx.propagate();
+            }
+        }),
+    );
+    let weak_editor = cx.weak_entity();
+    subscriptions.push(
+        editor.register_action::<editor::actions::Delete>(move |_, _window, cx| {
+            if !delete_selected_table_unit(&weak_editor, cx) {
+                cx.propagate();
+            }
+        }),
+    );
+
+    editor.register_addon(LivePreviewAddon {
+        enabled_override: None,
+        markers: None,
+        applied_blocks: Vec::new(),
+        selected_image: None,
+        active_cell: None,
+        selected_table_unit: None,
+        drag_source: None,
+        drop_boundary: None,
+        handle_press: None,
+        source_revealed: None,
+        last_resize_at: None,
+        _subscriptions: subscriptions,
+    });
+
+    // The buffer may already be parsed by the time this editor is created, in
+    // which case no `Reparsed` event will arrive; compute an initial pass.
+    let weak_editor = cx.weak_entity();
+    window.defer(cx, move |_window, cx| {
+        weak_editor
+            .update(cx, |editor, cx| recompute(editor, cx))
+            .ok();
+    });
+}
+
+struct LivePreviewAddon {
+    /// Per-editor override set by the toggle action; falls back to the setting.
+    enabled_override: Option<bool>,
+    markers: Option<Arc<MarkerSet>>,
+    applied_blocks: Vec<AppliedBlock>,
+    /// The image widget currently selected (Obsidian-style click state),
+    /// identified by its marker range.
+    selected_image: Option<Range<Anchor>>,
+    /// The table cell currently being edited in place.
+    active_cell: Option<ActiveTableCell>,
+    selected_table_unit: Option<TableUnitSelection>,
+    /// Unit being dragged (outlined in place, Obsidian-style) and the unit
+    /// the pointer is currently over (gets the insertion line). Rendered
+    /// only while a drag is active.
+    drag_source: Option<TableUnitSelection>,
+    /// Insertion point the pointer currently indicates, with half-cell
+    /// precision: hovering the near half of a unit targets the boundary
+    /// before it, the far half the boundary after it.
+    drop_boundary: Option<(Range<Anchor>, TableBoundary)>,
+    /// Position of the last mouse-down on a table handle. Selection commits
+    /// on mouse-up only if the pointer barely moved; recording this must NOT
+    /// notify — a re-render between press and move would drop gpui's
+    /// per-frame drag-arming listeners and kill the drag gesture.
+    handle_press: Option<gpui::Point<gpui::Pixels>>,
+    /// Block explicitly revealed via its `</>` button. Tables and images
+    /// only show source through this, never from cursor overlap alone.
+    source_revealed: Option<Range<Anchor>>,
+    /// When a resize drag last wrote a width, so selection isn't cleared by
+    /// the selection refresh that buffer edits trigger mid-drag.
+    last_resize_at: Option<std::time::Instant>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl Addon for LivePreviewAddon {
+    fn to_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn to_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+struct MarkerSet {
+    inline: Vec<InlineMarker>,
+    blocks: Vec<BlockMarker>,
+    /// Ranges that get an always-on strikethrough text decoration: themes
+    /// color `~~struck~~` spans but do not apply the actual line-through, and
+    /// with the delimiters hidden there would otherwise be no visual cue.
+    strikethrough: Vec<Range<Anchor>>,
+    /// Emphasis content, restyled preview-like (plain text color, true
+    /// italic/bold) instead of source-mode syntax-highlight colors.
+    italic: Vec<Range<Anchor>>,
+    bold: Vec<Range<Anchor>>,
+    /// Link text, restyled to upright accent color so links read as
+    /// clickable color while italics remain the only slanted text.
+    link_text: Vec<Range<Anchor>>,
+    /// All `[label]: url` reference definitions in the document, appended to
+    /// each widget's mini-document so reference links and images resolve.
+    definitions: String,
+    /// Definition lines are muted: the preview hides them entirely, but
+    /// invisible text is confusing in an editor, so they recede instead.
+    definition_ranges: Vec<Range<Anchor>>,
+    /// Ordered-list markers, restyled to the plain text color for
+    /// consistency with bullet glyphs.
+    ordered_markers: Vec<Range<Anchor>>,
+}
+
+#[derive(Clone)]
+struct InlineMarker {
+    range: Range<Anchor>,
+    kind: InlineKind,
+}
+
+#[derive(Clone)]
+enum InlineKind {
+    /// Pure syntax to hide: emphasis delimiters, backticks, link brackets and
+    /// destinations, etc. Reveals when the selection touches the enclosing
+    /// construct (per-token reveal), not the whole line.
+    Hide {
+        /// The whole construct (e.g. `**bold**` including delimiters); the
+        /// marker reveals when the selection touches this span.
+        reveal_span: Range<Anchor>,
+    },
+    /// An unordered list marker, rendered as a bullet glyph.
+    Bullet,
+    /// A task list marker (`- [ ]` / `- [x]`), rendered as a clickable checkbox.
+    Checkbox {
+        checked: bool,
+        /// The range of the `[ ]`/`[x]` marker itself, edited on toggle.
+        marker_range: Range<Anchor>,
+    },
+}
+
+struct BlockMarker {
+    range: Range<Anchor>,
+    height_estimate: u32,
+    kind: BlockRenderKind,
+    /// Leading-whitespace columns of the first line, so nested widgets (e.g.
+    /// a code block inside a list item) keep their indentation.
+    indent_columns: u32,
+}
+
+#[derive(Clone, PartialEq)]
+enum BlockRenderKind {
+    /// Rendered through `MarkdownElement`.
+    Markdown,
+    /// A horizontal rule, rendered as a plain divider: a lone `---` fed to
+    /// the markdown parser would be misread as a frontmatter opener.
+    Rule,
+    /// YAML/TOML frontmatter, rendered as a compact properties card instead
+    /// of the markdown crate's oversized metadata table.
+    Frontmatter,
+    /// A pipe table rendered as an editable grid: clicking a cell mounts a
+    /// single-line editor over it, and structural buttons add rows/columns.
+    Table(TableStructure),
+    /// A standalone image, width-capped and honoring Obsidian's
+    /// `![alt|640](path)` size syntax. When the destination is known the
+    /// widget renders a bare image element (which the selection border hugs
+    /// exactly); reference-style images fall back to the markdown renderer.
+    Image {
+        display_width: Option<f32>,
+        destination: Option<String>,
+        alt: String,
+    },
+}
+
+#[derive(Clone, PartialEq)]
+struct TableStructure {
+    header: Vec<Range<Anchor>>,
+    alignments: Vec<CellAlignment>,
+    rows: Vec<Vec<Range<Anchor>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CellAlignment {
+    None,
+    Left,
+    Center,
+    Right,
+}
+
+impl TableStructure {
+    /// All cell ranges in reading order, for Tab navigation.
+    fn cells_in_order(&self) -> Vec<Range<Anchor>> {
+        self.header
+            .iter()
+            .chain(self.rows.iter().flatten())
+            .cloned()
+            .collect()
+    }
+}
+
+/// Payload for dragging a row handle to reorder rows within one table.
+/// Table identity is an anchor resolved at drop time: the payload and the
+/// drop target are captured on different frames, so raw offsets diverge as
+/// soon as anything edits the buffer.
+struct TableRowDrag {
+    table_start: Anchor,
+    row: usize,
+}
+
+/// Payload for dragging a column handle to reorder columns within one table.
+struct TableColumnDrag {
+    table_start: Anchor,
+    column: usize,
+}
+
+/// An insertion point between rows or columns: `Row(i)`/`Column(i)` means
+/// "insert before index i", with i == count meaning after the last.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TableBoundary {
+    Row(usize),
+    Column(usize),
+}
+
+/// A whole row or column selected via its hover handle, Obsidian-style.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TableUnit {
+    /// Data row index (the header is not selectable).
+    Row(usize),
+    Column(usize),
+}
+
+struct TableUnitSelection {
+    table_range: Range<Anchor>,
+    unit: TableUnit,
+}
+
+/// The single-line editor mounted over a table cell.
+struct ActiveTableCell {
+    cell_range: Range<Anchor>,
+    editor: Entity<Editor>,
+    _subscriptions: Vec<Subscription>,
+}
+
+struct AppliedBlock {
+    range: Range<Anchor>,
+    source: String,
+    block_id: CustomBlockId,
+}
+
+fn is_enabled(addon: &LivePreviewAddon, cx: &App) -> bool {
+    addon
+        .enabled_override
+        .unwrap_or_else(|| MarkdownLivePreviewSettings::get_global(cx).enabled)
+}
+
+fn recompute(editor: &mut Editor, cx: &mut Context<Editor>) {
+    let Some(addon) = editor.addon::<LivePreviewAddon>() else {
+        return;
+    };
+    let enabled = is_enabled(addon, cx);
+
+    let markers = if enabled && !editor.read_only(cx) {
+        extract_markers(editor, cx).map(Arc::new)
+    } else {
+        None
+    };
+
+    let Some(addon) = editor.addon_mut::<LivePreviewAddon>() else {
+        return;
+    };
+    addon.markers = markers.clone();
+    apply_emphasis_highlights(editor, markers.as_deref(), cx);
+    apply_decorations(editor, cx);
+}
+
+/// Emphasis spans get preview-like typography: the plain text color with true
+/// bold/italic styling, overriding the theme's source-mode markup colors
+/// (e.g. blue non-slanted italics, orange bold), plus a real line-through for
+/// strikethrough, which themes color but never strike.
+fn apply_emphasis_highlights(editor: &mut Editor, markers: Option<&MarkerSet>, cx: &mut Context<Editor>) {
+    const STRIKE: usize = 0;
+    const ITALIC: usize = 1;
+    const BOLD: usize = 2;
+    const LINK: usize = 3;
+    const DEFINITION: usize = 4;
+    const ORDERED_MARKER: usize = 5;
+    let text_color = cx.theme().colors().text;
+    let accent_color = cx.theme().colors().text_accent;
+    let muted_color = cx.theme().colors().text_muted;
+    let sets = [
+        (
+            STRIKE,
+            markers.map(|markers| markers.strikethrough.clone()),
+            HighlightStyle {
+                strikethrough: Some(StrikethroughStyle {
+                    thickness: gpui::px(1.),
+                    color: None,
+                }),
+                ..Default::default()
+            },
+        ),
+        (
+            ITALIC,
+            markers.map(|markers| markers.italic.clone()),
+            HighlightStyle {
+                color: Some(text_color),
+                font_style: Some(gpui::FontStyle::Italic),
+                ..Default::default()
+            },
+        ),
+        (
+            BOLD,
+            markers.map(|markers| markers.bold.clone()),
+            HighlightStyle {
+                color: Some(text_color),
+                font_weight: Some(FontWeight::BOLD),
+                ..Default::default()
+            },
+        ),
+        (
+            LINK,
+            markers.map(|markers| markers.link_text.clone()),
+            HighlightStyle {
+                color: Some(accent_color),
+                font_style: Some(gpui::FontStyle::Normal),
+                ..Default::default()
+            },
+        ),
+        (
+            DEFINITION,
+            markers.map(|markers| markers.definition_ranges.clone()),
+            HighlightStyle {
+                color: Some(muted_color),
+                font_style: Some(gpui::FontStyle::Normal),
+                ..Default::default()
+            },
+        ),
+        (
+            ORDERED_MARKER,
+            markers.map(|markers| markers.ordered_markers.clone()),
+            HighlightStyle {
+                color: Some(text_color),
+                ..Default::default()
+            },
+        ),
+    ];
+    for (key, ranges, style) in sets {
+        match ranges {
+            Some(ranges) if !ranges.is_empty() => {
+                editor.highlight_text(HighlightKey::MarkdownLivePreview(key), ranges, style, cx);
+            }
+            _ => editor.clear_highlights(HighlightKey::MarkdownLivePreview(key), cx),
+        }
+    }
+}
+
+fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
+    let Some(addon) = editor.addon_mut::<LivePreviewAddon>() else {
+        return;
+    };
+    let markers = addon.markers.clone();
+    let applied_blocks = std::mem::take(&mut addon.applied_blocks);
+
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let Some(markers) = markers else {
+        clear_decorations(editor, applied_blocks, cx);
+        return;
+    };
+
+    // Session restore can resurrect concealments saved as folds by older
+    // builds as plain `⋯` folds this addon does not own; heal them whenever
+    // decorations refresh.
+    remove_stale_restored_folds(editor, cx);
+
+    let selection_rows = selection_row_ranges(editor, &snapshot);
+    let source_revealed = editor
+        .addon::<LivePreviewAddon>()
+        .and_then(|addon| addon.source_revealed.clone())
+        .filter(|revealed| {
+            let start = revealed.start.to_point(&snapshot).row;
+            let end = revealed.end.to_point(&snapshot).row;
+            rows_intersect(&selection_rows, start, end)
+        });
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        addon.source_revealed = source_revealed.clone();
+    }
+    let selection_offsets = selection_offset_ranges(editor, &snapshot);
+
+    // --- Inline concealments ---
+
+    let weak_editor = cx.weak_entity();
+    let mut concealments = Vec::new();
+    for marker in &markers.inline {
+        let start = marker.range.start.to_point(&snapshot);
+        let end = marker.range.end.to_point(&snapshot);
+        if start >= end {
+            continue;
+        }
+        // Per-token: reveal only when the selection touches the marker's
+        // enclosing construct (for list markers, the marker itself), leaving
+        // the rest of the line rendered.
+        let reveal_span = match &marker.kind {
+            InlineKind::Hide { reveal_span } => reveal_span,
+            InlineKind::Bullet | InlineKind::Checkbox { .. } => &marker.range,
+        };
+        let span =
+            reveal_span.start.to_offset(&snapshot).0..reveal_span.end.to_offset(&snapshot).0;
+        let revealed = selection_offsets
+            .iter()
+            .any(|selection| selection.start <= span.end && span.start <= selection.end);
+        if revealed {
+            continue;
+        }
+        concealments.push(Concealment {
+            range: marker.range.clone(),
+            placeholder: fold_placeholder(marker, weak_editor.clone()),
+            content_key: marker_content_key(&marker.kind),
+        });
+    }
+    editor.set_concealments(TypeId::of::<LivePreviewFoldTag>(), concealments, cx);
+
+    // --- Block widgets ---
+
+    let mut desired_blocks: HashMap<(usize, usize), (&BlockMarker, String)> = HashMap::default();
+    for marker in &markers.blocks {
+        let start = marker.range.start.to_point(&snapshot);
+        let end = marker.range.end.to_point(&snapshot);
+        if start > end {
+            continue;
+        }
+        if rows_intersect(&selection_rows, start.row, end.row) {
+            // Casual clicks land the cursor on widget rows constantly, which
+            // made tables and images explode into source; those two reveal
+            // only via their explicit `</>` button.
+            let needs_explicit_reveal = matches!(
+                marker.kind,
+                BlockRenderKind::Table(_) | BlockRenderKind::Image { .. }
+            );
+            let explicitly_revealed = source_revealed.as_ref().is_some_and(|revealed| {
+                let revealed_start = revealed.start.to_point(&snapshot).row;
+                let revealed_end = revealed.end.to_point(&snapshot).row;
+                revealed_start <= end.row && start.row <= revealed_end
+            });
+            if !needs_explicit_reveal || explicitly_revealed {
+                continue;
+            }
+        }
+        let start_offset = marker.range.start.to_offset(&snapshot);
+        let end_offset = marker.range.end.to_offset(&snapshot);
+        let mut source: String = snapshot.text_for_range(start_offset..end_offset).collect();
+        if source.trim().is_empty() {
+            continue;
+        }
+        // Reference links/images inside a widget resolve against the whole
+        // document's definitions, which live outside the widget's slice.
+        if matches!(
+            marker.kind,
+            BlockRenderKind::Markdown | BlockRenderKind::Image { .. }
+        ) && !markers.definitions.is_empty()
+        {
+            source.push_str("\n\n");
+            source.push_str(&markers.definitions);
+        }
+        desired_blocks.insert((start_offset.0, end_offset.0), (marker, source));
+    }
+
+    let mut new_applied_blocks = Vec::new();
+    let mut block_ids_to_remove = HashSet::default();
+    for applied in applied_blocks {
+        let start = applied.range.start.to_offset(&snapshot).0;
+        let end = applied.range.end.to_offset(&snapshot).0;
+        let keep = desired_blocks
+            .get(&(start, end))
+            .is_some_and(|(_, source)| *source == applied.source);
+        if keep {
+            desired_blocks.remove(&(start, end));
+            new_applied_blocks.push(applied);
+        } else {
+            block_ids_to_remove.insert(applied.block_id);
+        }
+    }
+
+    let mut blocks_to_insert = Vec::new();
+    let mut pending_applied = Vec::new();
+    let base_directory = buffer_base_directory(editor, cx);
+    // The language registry lets rendered code blocks (and code spans in
+    // tables/quotes) get syntax highlighting.
+    let language_registry = editor
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .and_then(|buffer| buffer.read(cx).language_registry());
+    for (marker, source) in desired_blocks.into_values() {
+        let render = match &marker.kind {
+            BlockRenderKind::Markdown => {
+                let markdown = cx.new(|cx| {
+                    Markdown::new_with_options(
+                        SharedString::from(source.clone()),
+                        language_registry.clone(),
+                        None,
+                        markdown::MarkdownOptions {
+                            parse_html: true,
+                            render_mermaid_diagrams: true,
+                            ..Default::default()
+                        },
+                        cx,
+                    )
+                });
+                render_markdown_block(
+                    markdown,
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    base_directory.clone(),
+                    marker.indent_columns,
+                )
+            }
+            BlockRenderKind::Table(structure) => {
+                let cell_markdown = |range: &Range<Anchor>, cx: &mut Context<Editor>| {
+                    let start = range.start.to_offset(&snapshot);
+                    let end = range.end.to_offset(&snapshot);
+                    let text: String = snapshot.text_for_range(start..end).collect();
+                    cx.new(|cx| {
+                        Markdown::new(
+                            SharedString::from(text.trim().to_string()),
+                            language_registry.clone(),
+                            None,
+                            cx,
+                        )
+                    })
+                };
+                let header_markdown: Vec<Entity<Markdown>> = structure
+                    .header
+                    .iter()
+                    .map(|range| cell_markdown(range, cx))
+                    .collect();
+                let rows_markdown: Vec<Vec<Entity<Markdown>>> = structure
+                    .rows
+                    .iter()
+                    .map(|row| row.iter().map(|range| cell_markdown(range, cx)).collect())
+                    .collect();
+                let column_weights = table_column_weights(structure, &snapshot);
+                render_table_block(
+                    structure.clone(),
+                    header_markdown,
+                    rows_markdown,
+                    column_weights,
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    marker.indent_columns,
+                )
+            }
+            BlockRenderKind::Image {
+                display_width,
+                destination,
+                alt,
+            } => {
+                let markdown = cx.new(|cx| {
+                    Markdown::new_with_options(
+                        SharedString::from(source.clone()),
+                        language_registry.clone(),
+                        None,
+                        markdown::MarkdownOptions {
+                            parse_html: true,
+                            render_mermaid_diagrams: true,
+                            ..Default::default()
+                        },
+                        cx,
+                    )
+                });
+                render_image_block(
+                    markdown,
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    base_directory.clone(),
+                    marker.indent_columns,
+                    *display_width,
+                    destination.clone(),
+                    SharedString::from(alt.clone()),
+                )
+            }
+            BlockRenderKind::Rule => {
+                render_rule_block(weak_editor.clone(), marker.range.clone(), marker.indent_columns)
+            }
+            BlockRenderKind::Frontmatter => {
+                render_frontmatter_block(weak_editor.clone(), marker.range.clone(), source.clone())
+            }
+
+        };
+        blocks_to_insert.push(BlockProperties {
+            placement: BlockPlacement::Replace(marker.range.start..=marker.range.end),
+            height: Some(marker.height_estimate),
+            style: BlockStyle::Flex,
+            render,
+            priority: 0,
+        });
+        pending_applied.push((marker.range.clone(), source));
+    }
+
+    if !block_ids_to_remove.is_empty() {
+        editor.remove_blocks(block_ids_to_remove, None, cx);
+    }
+    if !blocks_to_insert.is_empty() {
+        let block_ids = editor.insert_blocks(blocks_to_insert, None, cx);
+        for ((range, source), block_id) in pending_applied.into_iter().zip(block_ids) {
+            new_applied_blocks.push(AppliedBlock {
+                range,
+                source,
+                block_id,
+            });
+        }
+    }
+
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        addon.applied_blocks = new_applied_blocks;
+    }
+}
+
+/// Sessions saved before concealment folds were excluded from persistence
+/// restore them as plain `⋯` folds this addon does not own; remove any
+/// untagged fold that sits exactly on a marker range.
+fn remove_stale_restored_folds(editor: &mut Editor, cx: &mut Context<Editor>) {
+    let Some(markers) = editor
+        .addon::<LivePreviewAddon>()
+        .and_then(|addon| addon.markers.clone())
+    else {
+        return;
+    };
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let marker_offsets: HashSet<(usize, usize)> = markers
+        .inline
+        .iter()
+        .map(|marker| {
+            (
+                marker.range.start.to_offset(&snapshot).0,
+                marker.range.end.to_offset(&snapshot).0,
+            )
+        })
+        .collect();
+
+    let display_snapshot = editor.display_snapshot(cx);
+    let stale: Vec<Range<MultiBufferOffset>> = display_snapshot
+        .folds_in_range(MultiBufferOffset(0)..snapshot.len())
+        .filter(|fold| fold.placeholder.type_tag.is_none())
+        .filter_map(|fold| {
+            let start = fold.range.start.to_offset(&snapshot);
+            let end = fold.range.end.to_offset(&snapshot);
+            marker_offsets
+                .contains(&(start.0, end.0))
+                .then_some(start..end)
+        })
+        .collect();
+    if !stale.is_empty() {
+        editor.unfold_ranges(&stale, false, false, cx);
+    }
+}
+
+fn clear_decorations(
+    editor: &mut Editor,
+    applied_blocks: Vec<AppliedBlock>,
+    cx: &mut Context<Editor>,
+) {
+    editor.set_concealments(TypeId::of::<LivePreviewFoldTag>(), Vec::new(), cx);
+    if !applied_blocks.is_empty() {
+        let block_ids = applied_blocks
+            .into_iter()
+            .map(|block| block.block_id)
+            .collect();
+        editor.remove_blocks(block_ids, None, cx);
+    }
+}
+
+/// Inclusive row ranges covered by the current selections.
+fn selection_row_ranges(editor: &Editor, snapshot: &MultiBufferSnapshot) -> Vec<Range<u32>> {
+    let mut rows = Vec::new();
+    for selection in editor.selections.disjoint_anchors().iter() {
+        let range = selection.range();
+        rows.push(range.start.to_point(snapshot).row..range.end.to_point(snapshot).row);
+    }
+    if let Some(pending) = editor.selections.pending_anchor() {
+        let range = pending.range();
+        rows.push(range.start.to_point(snapshot).row..range.end.to_point(snapshot).row);
+    }
+    rows
+}
+
+/// Selection ranges as offsets, including the pending mouse selection.
+fn selection_offset_ranges(editor: &Editor, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
+    let mut offsets = Vec::new();
+    for selection in editor.selections.disjoint_anchors().iter() {
+        let range = selection.range();
+        offsets.push(range.start.to_offset(snapshot).0..range.end.to_offset(snapshot).0);
+    }
+    if let Some(pending) = editor.selections.pending_anchor() {
+        let range = pending.range();
+        offsets.push(range.start.to_offset(snapshot).0..range.end.to_offset(snapshot).0);
+    }
+    offsets
+}
+
+fn rows_intersect(selection_rows: &[Range<u32>], start_row: u32, end_row: u32) -> bool {
+    selection_rows
+        .iter()
+        .any(|rows| rows.start <= end_row && start_row <= rows.end)
+}
+
+fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPlaceholder {
+    // Pure hides collapse to zero-width text; bullets and checkboxes keep the
+    // default placeholder text, whose visual is replaced by the rendered
+    // element at its measured width.
+    let collapsed_text = match &marker.kind {
+        InlineKind::Hide { .. } => Some(SharedString::new_static("")),
+        InlineKind::Bullet | InlineKind::Checkbox { .. } => None,
+    };
+    let render: Arc<dyn Send + Sync + Fn(_, _, &mut App) -> gpui::AnyElement> = match &marker.kind {
+        InlineKind::Hide { .. } => Arc::new(|_, _, _| Empty.into_any_element()),
+        InlineKind::Bullet => Arc::new(|_, _, cx| {
+            let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+            div()
+                .font(theme_settings.buffer_font.clone())
+                .text_size(theme_settings.buffer_font_size(cx))
+                .text_color(cx.theme().colors().text)
+                .child("•")
+                .into_any_element()
+        }),
+        InlineKind::Checkbox {
+            checked,
+            marker_range,
+        } => {
+            let checked = *checked;
+            let marker_range = marker_range.clone();
+            Arc::new(move |fold_id, _, _| {
+                let editor = editor.clone();
+                let marker_range = marker_range.clone();
+                Checkbox::new(
+                    fold_id,
+                    if checked {
+                        ToggleState::Selected
+                    } else {
+                        ToggleState::Unselected
+                    },
+                )
+                .on_click(move |_, _, cx| {
+                    toggle_task_marker(&editor, &marker_range, checked, cx);
+                })
+                .into_any_element()
+            })
+        }
+    };
+    FoldPlaceholder {
+        render,
+        constrain_width: false,
+        merge_adjacent: false,
+        type_tag: Some(TypeId::of::<LivePreviewFoldTag>()),
+        collapsed_text,
+    }
+}
+
+fn marker_content_key(kind: &InlineKind) -> u64 {
+    match kind {
+        InlineKind::Hide { .. } => 0,
+        InlineKind::Bullet => 1,
+        InlineKind::Checkbox { checked, .. } => 2 + u64::from(*checked),
+    }
+}
+
+fn toggle_task_marker(
+    editor: &WeakEntity<Editor>,
+    marker_range: &Range<Anchor>,
+    currently_checked: bool,
+    cx: &mut App,
+) {
+    editor
+        .update(cx, |editor, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let range =
+                marker_range.start.to_offset(&snapshot)..marker_range.end.to_offset(&snapshot);
+            let existing: String = snapshot.text_for_range(range.clone()).collect();
+            let expected = if currently_checked { "[x]" } else { "[ ]" };
+            if existing.eq_ignore_ascii_case(expected) {
+                let replacement = if currently_checked { "[ ]" } else { "[x]" };
+                editor.edit([(range, replacement)], cx);
+            }
+        })
+        .log_err();
+}
+
+fn buffer_base_directory(editor: &Editor, cx: &App) -> Option<PathBuf> {
+    let buffer = editor.buffer().read(cx).as_singleton()?;
+    let file = buffer.read(cx).file()?;
+    let local = file.as_local()?;
+    let mut path = local.abs_path(cx);
+    path.pop();
+    Some(path)
+}
+
+fn render_markdown_block(
+    markdown: Entity<Markdown>,
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    base_directory: Option<PathBuf>,
+    indent_columns: u32,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let style = block_markdown_style(block_cx.window, block_cx.app);
+        let editor = editor.clone();
+        let start = range.start;
+        let base_directory = base_directory.clone();
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        let max_width = block_cx.max_width;
+        div()
+            .pl(gutter_width)
+            .w(max_width)
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                editor
+                    .update(cx, |editor, cx| {
+                        let snapshot = editor.buffer().read(cx).snapshot(cx);
+                        let offset = start.to_offset(&snapshot);
+                        editor.change_selections(Default::default(), window, cx, |selections| {
+                            selections.select_ranges([offset..offset]);
+                        });
+                    })
+                    .log_err();
+            })
+            .child(
+                MarkdownElement::new(markdown.clone(), style).image_resolver(move |destination, _cx| {
+                    resolve_image_source(destination, base_directory.as_deref())
+                }),
+            )
+            .into_any_element()
+    })
+}
+
+
+/// Per-column flex weights approximating content-based column sizing.
+fn table_column_weights(structure: &TableStructure, snapshot: &MultiBufferSnapshot) -> Vec<f32> {
+    let columns = structure
+        .header
+        .len()
+        .max(structure.rows.iter().map(|row| row.len()).max().unwrap_or(0));
+    let mut weights = vec![3.0_f32; columns];
+    let mut measure = |cells: &[Range<Anchor>]| {
+        for (index, range) in cells.iter().enumerate() {
+            let start = range.start.to_offset(snapshot);
+            let end = range.end.to_offset(snapshot);
+            let length: usize = snapshot
+                .text_for_range(start..end)
+                .map(|chunk| chunk.trim().chars().count())
+                .sum();
+            if let Some(weight) = weights.get_mut(index) {
+                *weight = weight.max((length as f32).clamp(3., 60.));
+            }
+        }
+    };
+    measure(&structure.header);
+    for row in &structure.rows {
+        measure(row);
+    }
+    weights
+}
+
+/// Starts editing a table cell: mounts a focused single-line editor over it,
+/// committing on enter/tab/blur and cancelling on escape.
+fn start_cell_edit(
+    weak_editor: WeakEntity<Editor>,
+    cell_range: Range<Anchor>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let Some(main_editor) = weak_editor.upgrade() else {
+        return;
+    };
+    // Commit any cell already being edited.
+    main_editor.update(cx, |editor, cx| commit_active_cell(editor, cx));
+
+    // Re-resolve the clicked cell from live text: the widget's captured
+    // ranges go stale whenever an edit lands before the widget refreshes.
+    let snapshot = main_editor.read(cx).buffer().read(cx).snapshot(cx);
+    let stale_start = cell_range.start.to_offset(&snapshot);
+    let Some((_, structure)) = parse_table_at(&snapshot, stale_start) else {
+        return;
+    };
+    let all_cells = structure.cells_in_order();
+    let Some(cell_range) = all_cells
+        .iter()
+        .find(|candidate| {
+            let start = candidate.start.to_offset(&snapshot);
+            let end = candidate.end.to_offset(&snapshot);
+            start <= stale_start && stale_start <= end
+        })
+        .cloned()
+    else {
+        return;
+    };
+    let start = cell_range.start.to_offset(&snapshot);
+    let end = cell_range.end.to_offset(&snapshot);
+    let text: String = snapshot.text_for_range(start..end).collect();
+
+    let cell_editor = cx.new(|cx| {
+        let mut editor = Editor::single_line(window, cx);
+        editor.set_text(text.trim(), window, cx);
+        editor
+    });
+
+    let mut subscriptions = Vec::new();
+    main_editor.update(cx, |_, cx| {
+        subscriptions.push(cx.subscribe(
+            &cell_editor,
+            |editor, blurred, event: &EditorEvent, cx| {
+                // Only commit if this editor is still the active cell: when
+                // Tab moves editing to the next cell, the old editor's blur
+                // must not commit (and clear) the new one.
+                if matches!(event, EditorEvent::Blurred)
+                    && editor
+                        .addon::<LivePreviewAddon>()
+                        .and_then(|addon| addon.active_cell.as_ref())
+                        .is_some_and(|cell| cell.editor == blurred)
+                {
+                    commit_active_cell(editor, cx);
+                }
+            },
+        ));
+    });
+
+    let next_cell = all_cells
+        .iter()
+        .position(|candidate| {
+            candidate.start.to_offset(&snapshot) == start
+                && candidate.end.to_offset(&snapshot) == end
+        })
+        .and_then(|index| all_cells.get(index + 1).cloned());
+
+    cell_editor.update(cx, |editor, _| {
+        let weak = weak_editor.clone();
+        subscriptions.push(editor.register_action::<editor::actions::Newline>(
+            move |_, window, cx| {
+                weak.update(cx, |editor, cx| {
+                    commit_active_cell(editor, cx);
+                    refocus_main_editor(editor, window, cx);
+                })
+                .log_err();
+            },
+        ));
+        let weak = weak_editor.clone();
+        subscriptions.push(editor.register_action::<editor::actions::Tab>(
+            move |_, window, cx| {
+                let next = next_cell.clone();
+                weak.update(cx, |editor, cx| {
+                    commit_active_cell(editor, cx);
+                })
+                .log_err();
+                match next {
+                    Some(next) => {
+                        start_cell_edit(weak.clone(), next, window, cx)
+                    }
+                    None => {
+                        weak.update(cx, |editor, cx| refocus_main_editor(editor, window, cx))
+                            .log_err();
+                    }
+                }
+            },
+        ));
+        let weak = weak_editor.clone();
+        subscriptions.push(editor.register_action::<editor::actions::Cancel>(
+            move |_, window, cx| {
+                weak.update(cx, |editor, cx| {
+                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                        addon.active_cell = None;
+                    }
+                    refocus_main_editor(editor, window, cx);
+                    cx.notify();
+                })
+                .log_err();
+            },
+        ));
+    });
+
+    let focus_handle = cell_editor.read(cx).focus_handle(cx);
+    window.focus(&focus_handle, cx);
+
+    main_editor.update(cx, |editor, cx| {
+        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+            addon.selected_table_unit = None;
+            addon.active_cell = Some(ActiveTableCell {
+                cell_range,
+                editor: cell_editor,
+                _subscriptions: subscriptions,
+            });
+        }
+        cx.notify();
+    });
+}
+
+fn refocus_main_editor(editor: &Editor, window: &mut Window, cx: &mut Context<Editor>) {
+    let focus_handle = editor.focus_handle(cx);
+    window.focus(&focus_handle, cx);
+}
+
+/// Records the insertion boundary the pointer indicates, notifying only on
+/// change.
+fn set_drop_boundary(
+    weak_editor: &WeakEntity<Editor>,
+    table_range: &Range<Anchor>,
+    boundary: TableBoundary,
+    cx: &mut App,
+) {
+    weak_editor
+        .update(cx, |editor, cx| {
+            if let Some(addon) = editor.addon_mut::<LivePreviewAddon>()
+                && addon.drop_boundary.as_ref().map(|(_, current)| *current) != Some(boundary)
+            {
+                addon.drop_boundary = Some((table_range.clone(), boundary));
+                cx.notify();
+            }
+        })
+        .log_err();
+}
+
+/// Marks the unit a handle drag just started from; the widget outlines it
+/// in place while the drag is active.
+fn record_drag_source(
+    weak_editor: &WeakEntity<Editor>,
+    table_range: &Range<Anchor>,
+    unit: TableUnit,
+    cx: &mut App,
+) {
+    weak_editor
+        .update(cx, |editor, cx| {
+            if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                addon.selected_table_unit = None;
+                addon.drag_source = Some(TableUnitSelection {
+                    table_range: table_range.clone(),
+                    unit,
+                });
+                addon.drop_boundary = None;
+            }
+            cx.notify();
+        })
+        .log_err();
+}
+
+/// Deletes the row/column currently selected via its handle, if any.
+/// Returns false when there is no selection so the caller can propagate.
+fn delete_selected_table_unit(weak_editor: &WeakEntity<Editor>, cx: &mut App) -> bool {
+    let Some(editor) = weak_editor.upgrade() else {
+        return false;
+    };
+    let Some(selection) = editor.read_with(cx, |editor, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.selected_table_unit.as_ref())
+            .map(|selection| (selection.table_range.clone(), selection.unit))
+    }) else {
+        return false;
+    };
+    let (table_range, unit) = selection;
+    editor.update(cx, |editor, cx| {
+        let change = match unit {
+            TableUnit::Row(row) => TableStructuralChange::DeleteRow(row),
+            TableUnit::Column(column) => TableStructuralChange::DeleteColumn(column),
+        };
+        apply_table_structural_change(editor, &table_range, change, cx);
+        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+            addon.selected_table_unit = None;
+        }
+        cx.notify();
+    });
+    true
+}
+
+/// Writes the active cell editor's text back into the table source.
+fn commit_active_cell(editor: &mut Editor, cx: &mut Context<Editor>) {
+    let Some(active) = editor
+        .addon_mut::<LivePreviewAddon>()
+        .and_then(|addon| addon.active_cell.take())
+    else {
+        return;
+    };
+    let text = active
+        .editor
+        .read(cx)
+        .text(cx)
+        .replace('\n', " ")
+        .replace('|', "\\|");
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let start = active.cell_range.start.to_offset(&snapshot);
+    let end = active.cell_range.end.to_offset(&snapshot);
+    if start > end {
+        return;
+    }
+    let current: String = snapshot.text_for_range(start..end).collect();
+    if current.trim() == text.trim() {
+        cx.notify();
+        return;
+    }
+    let replacement = format!(" {} ", text.trim());
+    editor.buffer().update(cx, |multibuffer, cx| {
+        multibuffer.edit([(start..end, replacement)], None, cx);
+    });
+    cx.notify();
+}
+
+/// Splits one table row line into cell ranges at unescaped pipes (the GFM
+/// rule). Each range spans the full text between two pipes, padding included,
+/// so a cell edit can rewrite it in place. Segments outside the outer pipes
+/// are kept only when non-blank (tables without outer pipes).
+fn split_table_row_text(
+    text: &str,
+    base_offset: usize,
+    snapshot: &MultiBufferSnapshot,
+) -> Vec<Range<Anchor>> {
+    let mut boundaries = Vec::new();
+    let mut escaped = false;
+    for (offset, byte) in text.bytes().enumerate() {
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'|' {
+            boundaries.push(base_offset + offset);
+        }
+    }
+    let mut segments = Vec::new();
+    let mut segment_start = base_offset;
+    for boundary in boundaries {
+        segments.push(segment_start..boundary);
+        segment_start = boundary + 1;
+    }
+    segments.push(segment_start..base_offset + text.len());
+    let is_blank = |range: &Range<usize>| {
+        text.get(range.start - base_offset..range.end - base_offset)
+            .is_none_or(|segment| segment.trim().is_empty())
+    };
+    if segments.len() > 1 && is_blank(&segments[0]) {
+        segments.remove(0);
+    }
+    if segments.len() > 1 && segments.last().is_some_and(is_blank) {
+        segments.pop();
+    }
+    segments
+        .into_iter()
+        .map(|range| {
+            // Outward bias: the range must survive its own rewrite when a
+            // cell edit commits.
+            snapshot.anchor_before(MultiBufferOffset(range.start))
+                ..snapshot.anchor_after(MultiBufferOffset(range.end))
+        })
+        .collect()
+}
+
+fn is_delimiter_row(line: &str) -> bool {
+    let mut cells = line
+        .trim()
+        .trim_start_matches('|')
+        .trim_end_matches('|')
+        .split('|')
+        .peekable();
+    cells.peek().is_some()
+        && cells.all(|cell| {
+            let cell = cell.trim();
+            let dashes = cell.trim_start_matches(':').trim_end_matches(':');
+            !dashes.is_empty() && dashes.bytes().all(|byte| byte == b'-')
+        })
+}
+
+/// Parses the pipe table containing `near` straight from buffer text. Widget
+/// click handlers must use this instead of the syntax tree: reparses are
+/// asynchronous, so right after an edit the tree describes text that no
+/// longer exists.
+fn parse_table_at(
+    snapshot: &MultiBufferSnapshot,
+    near: MultiBufferOffset,
+) -> Option<(Range<MultiBufferOffset>, TableStructure)> {
+    let near = near.min(snapshot.len());
+    let click_row = near.to_point(snapshot).row;
+    let max_row = snapshot.max_point().row;
+    let line_at = |row: u32| -> (String, MultiBufferOffset, MultiBufferOffset) {
+        let start = Point::new(row, 0).to_offset(snapshot);
+        let end = Point::new(row, snapshot.line_len(MultiBufferRow(row))).to_offset(snapshot);
+        (snapshot.text_for_range(start..end).collect(), start, end)
+    };
+    let is_table_line = |row: u32| -> bool {
+        let (text, ..) = line_at(row);
+        !text.trim().is_empty() && text.contains('|')
+    };
+
+    if !is_table_line(click_row) {
+        return None;
+    }
+    let mut first_row = click_row;
+    while first_row > 0 && is_table_line(first_row - 1) {
+        first_row -= 1;
+    }
+    let mut last_row = click_row;
+    while last_row < max_row && is_table_line(last_row + 1) {
+        last_row += 1;
+    }
+    // The block may over-extend into adjacent prose that happens to contain a
+    // pipe; anchor on the delimiter row and take the line above as header.
+    let delimiter_row = (first_row + 1..=last_row)
+        .find(|row| is_delimiter_row(&line_at(*row).0))?;
+    let header_row = delimiter_row - 1;
+
+    let split_row = |row: u32| -> Vec<Range<Anchor>> {
+        let (text, start, _) = line_at(row);
+        split_table_row_text(&text, start.0, snapshot)
+    };
+    let header = split_row(header_row);
+    if header.is_empty() {
+        return None;
+    }
+    let alignments = split_row(delimiter_row)
+        .into_iter()
+        .map(|range| {
+            let start = range.start.to_offset(snapshot);
+            let end = range.end.to_offset(snapshot);
+            let text: String = snapshot.text_for_range(start..end).collect();
+            let text = text.trim();
+            match (text.starts_with(':'), text.ends_with(':')) {
+                (true, true) => CellAlignment::Center,
+                (true, false) => CellAlignment::Left,
+                (false, true) => CellAlignment::Right,
+                (false, false) => CellAlignment::None,
+            }
+        })
+        .collect();
+    let mut rows: Vec<Vec<Range<Anchor>>> = (delimiter_row + 1..=last_row).map(split_row).collect();
+
+    let mut header = header;
+    let columns = header.len().max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
+    let sentinel = || Anchor::Min..Anchor::Min;
+    header.resize_with(columns, sentinel);
+    for row in &mut rows {
+        row.resize_with(columns, sentinel);
+    }
+
+    let table_start = Point::new(header_row, 0).to_offset(snapshot);
+    let table_end = Point::new(last_row, snapshot.line_len(MultiBufferRow(last_row))).to_offset(snapshot);
+    Some((
+        table_start..table_end,
+        TableStructure {
+            header,
+            alignments,
+            rows,
+        },
+    ))
+}
+
+#[derive(Clone, Copy)]
+enum TableStructuralChange {
+    AddColumn,
+    AddRow,
+    MoveRow { from: usize, to: usize },
+    MoveColumn { from: usize, to: usize },
+    DeleteRow(usize),
+    DeleteColumn(usize),
+    /// Rewrites the table without structural additions, materializing any
+    /// cells the source omitted.
+    Normalize,
+}
+
+/// Finds the table currently at `table_range` by parsing live buffer text.
+fn fresh_table_at(
+    editor: &Editor,
+    table_range: &Range<Anchor>,
+    cx: &App,
+) -> Option<(Range<MultiBufferOffset>, TableStructure)> {
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    parse_table_at(&snapshot, table_range.start.to_offset(&snapshot))
+        .or_else(|| parse_table_at(&snapshot, table_range.end.to_offset(&snapshot)))
+}
+
+/// Rebuilds the whole table source with an added row or column, normalized.
+/// Resolves the table fresh at call time rather than trusting the caller's
+/// captured structure.
+fn apply_table_structural_change(
+    editor: &mut Editor,
+    stale_table_range: &Range<Anchor>,
+    change: TableStructuralChange,
+    cx: &mut Context<Editor>,
+) {
+    commit_active_cell(editor, cx);
+    let Some((table_offsets, structure)) = fresh_table_at(editor, stale_table_range, cx) else {
+        log::warn!("markdown live preview: no table found at click position; ignoring structural change");
+        return;
+    };
+    let structure = &structure;
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let cell_text = |range: &Range<Anchor>| -> String {
+        let start = range.start.to_offset(&snapshot);
+        let end = range.end.to_offset(&snapshot);
+        let text: String = snapshot.text_for_range(start..end).collect();
+        text.trim().to_string()
+    };
+
+    let mut header: Vec<String> = structure.header.iter().map(&cell_text).collect();
+    let mut alignments = structure.alignments.clone();
+    let mut rows: Vec<Vec<String>> = structure
+        .rows
+        .iter()
+        .map(|row| row.iter().map(&cell_text).collect())
+        .collect();
+
+    match change {
+        TableStructuralChange::AddColumn => {
+            header.push(String::new());
+            alignments.push(CellAlignment::None);
+            for row in &mut rows {
+                row.push(String::new());
+            }
+        }
+        TableStructuralChange::AddRow => {
+            rows.push(vec![String::new(); header.len()]);
+        }
+        TableStructuralChange::MoveRow { from, to } => {
+            if from < rows.len() && to < rows.len() {
+                let row = rows.remove(from);
+                rows.insert(to, row);
+            }
+        }
+        TableStructuralChange::MoveColumn { from, to } => {
+            if from < header.len() && to < header.len() {
+                let cell = header.remove(from);
+                header.insert(to, cell);
+                if from < alignments.len() && to < alignments.len() {
+                    let alignment = alignments.remove(from);
+                    alignments.insert(to, alignment);
+                }
+                for row in &mut rows {
+                    if from < row.len() && to < row.len() {
+                        let cell = row.remove(from);
+                        row.insert(to, cell);
+                    }
+                }
+            }
+        }
+        TableStructuralChange::DeleteRow(index) => {
+            if index < rows.len() {
+                rows.remove(index);
+            }
+        }
+        TableStructuralChange::DeleteColumn(index) => {
+            if header.len() > 1 && index < header.len() {
+                header.remove(index);
+                if index < alignments.len() {
+                    alignments.remove(index);
+                }
+                for row in &mut rows {
+                    if index < row.len() {
+                        row.remove(index);
+                    }
+                }
+            }
+        }
+        TableStructuralChange::Normalize => {}
+    }
+
+    let columns = header.len();
+    alignments.resize(columns, CellAlignment::None);
+    for row in &mut rows {
+        row.resize(columns, String::new());
+    }
+
+    let format_row = |cells: &[String]| -> String {
+        let mut line = String::from("|");
+        for cell in cells {
+            line.push(' ');
+            if cell.is_empty() {
+                line.push(' ');
+            } else {
+                line.push_str(cell);
+            }
+            line.push_str(" |");
+        }
+        line
+    };
+    let delimiter: String = {
+        let mut line = String::from("|");
+        for alignment in &alignments {
+            let marker = match alignment {
+                CellAlignment::None => " --- ",
+                CellAlignment::Left => " :-- ",
+                CellAlignment::Center => " :-: ",
+                CellAlignment::Right => " --: ",
+            };
+            line.push_str(marker);
+            line.push('|');
+        }
+        line
+    };
+
+    let mut source = format_row(&header);
+    source.push('\n');
+    source.push_str(&delimiter);
+    for row in &rows {
+        source.push('\n');
+        source.push_str(&format_row(row));
+    }
+
+    editor.buffer().update(cx, |multibuffer, cx| {
+        multibuffer.edit([(table_offsets.start..table_offsets.end, source)], None, cx);
+    });
+}
+
+/// The editable table widget: rendered grid, click-to-edit cells, and
+/// add-row/add-column affordances.
+#[allow(clippy::too_many_arguments)]
+fn render_table_block(
+    structure: TableStructure,
+    header_markdown: Vec<Entity<Markdown>>,
+    rows_markdown: Vec<Vec<Entity<Markdown>>>,
+    column_weights: Vec<f32>,
+    editor: WeakEntity<Editor>,
+    table_range: Range<Anchor>,
+    indent_columns: u32,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let style = {
+            let mut style = block_markdown_style(block_cx.window, block_cx.app);
+            style.height_is_multiple_of_line_height = true;
+            style
+        };
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        let max_width = block_cx.max_width;
+        let colors = block_cx.app.theme().colors().clone();
+
+        let (active_range, active_editor) = editor
+            .upgrade()
+            .and_then(|entity| {
+                let editor_ref = entity.read(block_cx.app);
+                let snapshot = editor_ref
+                    .buffer()
+                    .read(block_cx.app)
+                    .snapshot(block_cx.app);
+                editor_ref
+                    .addon::<LivePreviewAddon>()
+                    .and_then(|addon| addon.active_cell.as_ref())
+                    .map(|cell| {
+                        (
+                            Some(
+                                cell.cell_range.start.to_offset(&snapshot).0
+                                    ..cell.cell_range.end.to_offset(&snapshot).0,
+                            ),
+                            Some(cell.editor.clone()),
+                        )
+                    })
+            })
+            .unwrap_or((None, None));
+        let resolved = editor.upgrade().map(|entity| {
+            entity
+                .read(block_cx.app)
+                .buffer()
+                .read(block_cx.app)
+                .snapshot(block_cx.app)
+        });
+        let (selected_unit, drag_source_unit, drop_boundary) = editor
+            .upgrade()
+            .zip(resolved.as_ref())
+            .and_then(|(entity, snapshot)| {
+                let addon = entity.read(block_cx.app).addon::<LivePreviewAddon>()?;
+                let table_start = table_range.start.to_offset(snapshot);
+                let unit_in_this_table = |selection: &Option<TableUnitSelection>| {
+                    selection
+                        .as_ref()
+                        .filter(|selection| {
+                            selection.table_range.start.to_offset(snapshot) == table_start
+                        })
+                        .map(|selection| selection.unit)
+                };
+                let dragging = block_cx.app.has_active_drag();
+                let boundary = addon
+                    .drop_boundary
+                    .as_ref()
+                    .filter(|(range, _)| range.start.to_offset(snapshot) == table_start)
+                    .map(|(_, boundary)| *boundary)
+                    .filter(|_| dragging);
+                Some((
+                    unit_in_this_table(&addon.selected_table_unit),
+                    unit_in_this_table(&addon.drag_source).filter(|_| dragging),
+                    boundary,
+                ))
+            })
+            .unwrap_or((None, None, None));
+
+        let render_cell = |cell_range: &Range<Anchor>,
+                           markdown: &Entity<Markdown>,
+                           column: usize,
+                           data_row: Option<usize>| {
+            let is_header = data_row.is_none();
+            let unit_covers_cell = |unit: Option<TableUnit>| match unit {
+                Some(TableUnit::Row(row)) => data_row == Some(row),
+                Some(TableUnit::Column(unit_column)) => column == unit_column,
+                None => false,
+            };
+            let in_selected_unit = unit_covers_cell(selected_unit);
+            // The dragged unit gets the tint only: recoloring its borders
+            // reads as a second insertion line.
+            let is_drag_source_cell = unit_covers_cell(drag_source_unit);
+            // Full-height line exactly on the insertion boundary. Boundary b
+            // draws on the left edge of column b; the end boundary draws on
+            // the right edge of the last column.
+            let column_insertion = match (drag_source_unit, drop_boundary) {
+                (Some(TableUnit::Column(_)), Some(TableBoundary::Column(boundary))) => {
+                    if boundary == column {
+                        Some(false)
+                    } else if boundary == structure.header.len() && column + 1 == structure.header.len() {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            let weight = column_weights.get(column).copied().unwrap_or(8.);
+            let is_active = match (&resolved, &active_range) {
+                (Some(snapshot), Some(active)) => {
+                    let start = cell_range.start.to_offset(snapshot).0;
+                    let end = cell_range.end.to_offset(snapshot).0;
+                    *active == (start..end)
+                }
+                _ => false,
+            };
+            let alignment = structure
+                .alignments
+                .get(column)
+                .copied()
+                .unwrap_or(CellAlignment::None);
+
+            let is_sentinel = cell_range.start == Anchor::Min && cell_range.end == Anchor::Min;
+            let mut cell = div()
+                .debug_selector(|| {
+                    format!(
+                        "mdlp-cell-{}-{column}",
+                        data_row.map(|row| row.to_string()).unwrap_or_else(|| "h".into())
+                    )
+                })
+                .flex_grow(1.)
+                .flex_basis(gpui::px(weight * 8.))
+                .min_w(gpui::px(48.))
+                .px_2()
+                .py_1()
+                .min_h(block_cx.line_height + gpui::px(10.))
+                .border_r_1()
+                .border_b_1()
+                .when(column == 0, |this| this.border_l_1())
+                .when(is_header, |this| this.border_t_1())
+                .border_color(colors.border_variant)
+                .flex()
+                .items_center()
+                .map(|this| match alignment {
+                    CellAlignment::Center => this.justify_center(),
+                    CellAlignment::Right => this.justify_end(),
+                    _ => this,
+                })
+                .when(is_header, |this| {
+                    this.bg(colors.elevated_surface_background).font_weight(FontWeight::BOLD)
+                })
+                .when(in_selected_unit, |this| {
+                    this.bg(colors.element_selected)
+                        .border_color(colors.border_focused)
+                })
+                .when(is_drag_source_cell, |this| this.bg(colors.element_selected))
+                .when_some(column_insertion, |this, after| {
+                    // Overlay, not a border: borders recolor the cell's own
+                    // grid lines and shift layout; an absolute bar draws one
+                    // continuous line on the boundary.
+                    let bar = div()
+                        .absolute()
+                        .top_0()
+                        .bottom_0()
+                        .w(gpui::px(3.))
+                        .bg(colors.border_focused);
+                    this.relative().child(if after {
+                        bar.right(gpui::px(-2.))
+                    } else {
+                        bar.left(gpui::px(-2.))
+                    })
+                })
+                .on_drag_move::<TableColumnDrag>({
+                    let weak = editor.clone();
+                    let cell_table_range = table_range.clone();
+                    move |event, _, cx| {
+                        if !event.bounds.contains(&event.event.position) {
+                            return;
+                        }
+                        if event.drag(cx).table_start != cell_table_range.start {
+                            return;
+                        }
+                        // Pointer-side precision: the near half of a column
+                        // targets the boundary before it, the far half after.
+                        let after = event.event.position.x > event.bounds.center().x;
+                        let boundary = TableBoundary::Column(column + usize::from(after));
+                        set_drop_boundary(&weak, &cell_table_range, boundary, cx);
+                    }
+                });
+
+            if is_active && let Some(active_editor) = active_editor.clone() {
+                cell = cell.child(div().w_full().child(active_editor));
+            } else if is_sentinel {
+                // Clicking a cell the source omitted first rewrites the table
+                // in normalized form so the cell exists to edit.
+                let weak = editor.clone();
+                let normalize_range = table_range.clone();
+                cell = cell.cursor_text().on_mouse_down(
+                    MouseButton::Left,
+                    move |_, _window, cx| {
+                        cx.stop_propagation();
+                        weak.update(cx, |editor, cx| {
+                            apply_table_structural_change(
+                                editor,
+                                &normalize_range,
+                                TableStructuralChange::Normalize,
+                                cx,
+                            );
+                        })
+                        .log_err();
+                    },
+                );
+            } else {
+                let weak = editor.clone();
+                let cell_range = cell_range.clone();
+                cell = cell
+                    .child(MarkdownElement::new(markdown.clone(), style.clone()))
+                    .cursor_text()
+                    .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                        cx.stop_propagation();
+                        start_cell_edit(weak.clone(), cell_range.clone(), window, cx);
+                    });
+            }
+            cell
+        };
+
+        let handle_width = gpui::px(14.);
+        let record_press = {
+            let weak = editor.clone();
+            move |event: &gpui::MouseDownEvent, _: &mut Window, cx: &mut App| {
+                // Record only — no notify. A re-render here would tear down
+                // the per-frame listeners that arm the drag gesture.
+                let position = event.position;
+                weak.update(cx, |editor, _| {
+                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                        addon.handle_press = Some(position);
+                    }
+                })
+                .log_err();
+            }
+        };
+        let select_unit = |unit: TableUnit| {
+            let weak = editor.clone();
+            let unit_table_range = table_range.clone();
+            move |event: &gpui::MouseUpEvent, _: &mut Window, cx: &mut App| {
+                weak.update(cx, |editor, cx| {
+                    let Some(press) = editor
+                        .addon_mut::<LivePreviewAddon>()
+                        .and_then(|addon| addon.handle_press.take())
+                    else {
+                        return;
+                    };
+                    // A real drag ends far from where it started; only a
+                    // click (press + release in place) selects.
+                    if (event.position - press).magnitude() > 4. {
+                        return;
+                    }
+                    commit_active_cell(editor, cx);
+                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                        let already = addon
+                            .selected_table_unit
+                            .as_ref()
+                            .is_some_and(|selection| selection.unit == unit);
+                        addon.selected_table_unit = (!already).then(|| TableUnitSelection {
+                            table_range: unit_table_range.clone(),
+                            unit,
+                        });
+                    }
+                    cx.notify();
+                })
+                .log_err();
+            }
+        };
+        let handle_pill = |selected: bool| {
+            div()
+                .rounded_sm()
+                .bg(if selected {
+                    colors.border_focused
+                } else {
+                    colors.element_hover
+                })
+                .when(!selected, |this| {
+                    this.opacity(0.)
+                        .group_hover("mdlp-table", |this| this.opacity(1.))
+                })
+        };
+
+        let mut grid = v_flex().flex_grow(1.);
+        // Column handles.
+        grid = grid.child(
+            h_flex().child(div().w(handle_width)).children(
+                structure.header.iter().enumerate().map(|(column, _)| {
+                    let weight = column_weights.get(column).copied().unwrap_or(8.);
+                    let selected = selected_unit == Some(TableUnit::Column(column));
+                    div()
+                        .id(("mdlp-column-handle", column))
+                        .debug_selector(|| format!("mdlp-column-handle-{column}"))
+                        .flex_grow(1.)
+                        .flex_basis(gpui::px(weight * 8.))
+                        .min_w(gpui::px(48.))
+                        .h(gpui::px(10.))
+                        .px_2()
+                        .cursor_pointer()
+                        .child(handle_pill(selected).w_full().h(gpui::px(4.)).mt(gpui::px(3.)))
+                        .on_mouse_down(MouseButton::Left, record_press.clone())
+                        .on_mouse_up(MouseButton::Left, select_unit(TableUnit::Column(column)))
+                        .on_drag_move::<TableColumnDrag>({
+                            let weak = editor.clone();
+                            let strip_table_range = table_range.clone();
+                            move |event, _, cx| {
+                                if !event.bounds.contains(&event.event.position) {
+                                    return;
+                                }
+                                if event.drag(cx).table_start != strip_table_range.start {
+                                    return;
+                                }
+                                let after = event.event.position.x > event.bounds.center().x;
+                                let boundary =
+                                    TableBoundary::Column(column + usize::from(after));
+                                set_drop_boundary(&weak, &strip_table_range, boundary, cx);
+                            }
+                        })
+                        .on_drag(
+                            TableColumnDrag {
+                                table_start: table_range.start,
+                                column,
+                            },
+                            {
+                                let weak = editor.clone();
+                                let drag_table_range = table_range.clone();
+                                move |_, _, _, cx| {
+                                    record_drag_source(
+                                        &weak,
+                                        &drag_table_range,
+                                        TableUnit::Column(column),
+                                        cx,
+                                    );
+                                    cx.new(|_| EmptyDragPreview)
+                                }
+                            },
+                        )
+                }),
+            ),
+        );
+        let row_handle = |data_row: Option<usize>| {
+            let container = div().w(handle_width).py_1().pr(gpui::px(4.)).flex();
+            match data_row {
+                None => container.into_any_element(),
+                Some(row_index) => {
+                    let selected = selected_unit == Some(TableUnit::Row(row_index));
+                    container
+                        .id(("mdlp-row-handle", row_index))
+                        .debug_selector(|| format!("mdlp-row-handle-{row_index}"))
+                        .cursor_pointer()
+                        .child(handle_pill(selected).w(gpui::px(4.)).h_full())
+                        .on_mouse_down(MouseButton::Left, record_press.clone())
+                        .on_mouse_up(MouseButton::Left, select_unit(TableUnit::Row(row_index)))
+                        .on_drag(
+                            TableRowDrag {
+                                table_start: table_range.start,
+                                row: row_index,
+                            },
+                            {
+                                let weak = editor.clone();
+                                let drag_table_range = table_range.clone();
+                                move |_, _, _, cx| {
+                                    record_drag_source(
+                                        &weak,
+                                        &drag_table_range,
+                                        TableUnit::Row(row_index),
+                                        cx,
+                                    );
+                                    cx.new(|_| EmptyDragPreview)
+                                }
+                            },
+                        )
+                        .into_any_element()
+                }
+            }
+        };
+        let rows_len = structure.rows.len();
+        let row_track_drag = |data_row: Option<usize>| {
+            let weak = editor.clone();
+            let row_table_range = table_range.clone();
+            move |event: &gpui::DragMoveEvent<TableRowDrag>, _: &mut Window, cx: &mut App| {
+                if !event.bounds.contains(&event.event.position) {
+                    return;
+                }
+                if event.drag(cx).table_start != row_table_range.start {
+                    return;
+                }
+                // Rows can only land below the header, so the header always
+                // targets boundary 0; data rows use pointer-side precision.
+                let boundary = match data_row {
+                    None => 0,
+                    Some(row) => {
+                        let after = event.event.position.y > event.bounds.center().y;
+                        row + usize::from(after)
+                    }
+                };
+                set_drop_boundary(&weak, &row_table_range, TableBoundary::Row(boundary), cx);
+            }
+        };
+        // Boundary b sits above data row b; b == 0 is the header's bottom
+        // edge and b == rows_len the last row's bottom edge. `Some(true)`
+        // draws at the container's bottom, `Some(false)` at its top.
+        let row_insertion = |data_row: Option<usize>| {
+            let boundary = match (drag_source_unit, drop_boundary) {
+                (Some(TableUnit::Row(_)), Some(TableBoundary::Row(boundary))) => boundary,
+                _ => return None,
+            };
+            match data_row {
+                None => (boundary == 0).then_some(true),
+                Some(row) => {
+                    if boundary == row && row > 0 {
+                        Some(false)
+                    } else if boundary == rows_len && row + 1 == rows_len {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                }
+            }
+        };
+        let accent = colors.border_focused;
+        grid = grid.child(
+            h_flex()
+                .items_stretch()
+                .when_some(row_insertion(None), |this, after| {
+                    let bar = div()
+                        .absolute()
+                        .left_0()
+                        .right_0()
+                        .h(gpui::px(3.))
+                        .bg(accent);
+                    this.relative().child(if after {
+                        bar.bottom(gpui::px(-2.))
+                    } else {
+                        bar.top(gpui::px(-2.))
+                    })
+                })
+                .on_drag_move::<TableRowDrag>(row_track_drag(None))
+                .child(row_handle(None))
+                .child(h_flex().flex_grow(1.).children(
+                    header_markdown.iter().enumerate().map(|(column, markdown)| {
+                        let empty = Range {
+                            start: Anchor::Min,
+                            end: Anchor::Min,
+                        };
+                        let range = structure.header.get(column).unwrap_or(&empty);
+                        render_cell(range, markdown, column, None)
+                    }),
+                )),
+        );
+        for (row_index, row_markdown) in rows_markdown.iter().enumerate() {
+            grid = grid.child(
+                h_flex()
+                    .items_stretch()
+                    .when_some(row_insertion(Some(row_index)), |this, after| {
+                        let bar = div()
+                            .absolute()
+                            .left_0()
+                            .right_0()
+                            .h(gpui::px(3.))
+                            .bg(accent);
+                        this.relative().child(if after {
+                            bar.bottom(gpui::px(-2.))
+                        } else {
+                            bar.top(gpui::px(-2.))
+                        })
+                    })
+                    .on_drag_move::<TableRowDrag>(row_track_drag(Some(row_index)))
+                    .child(row_handle(Some(row_index)))
+                    .child(
+                        h_flex().flex_grow(1.).children(row_markdown.iter().enumerate().map(
+                            |(column, markdown)| {
+                                let empty = Range {
+                                    start: Anchor::Min,
+                                    end: Anchor::Min,
+                                };
+                                let range = structure
+                                    .rows
+                                    .get(row_index)
+                                    .and_then(|row| row.get(column))
+                                    .unwrap_or(&empty);
+                                render_cell(range, markdown, column, Some(row_index))
+                            },
+                        )),
+                    ),
+            );
+        }
+
+        let add_column_editor = editor.clone();
+        let add_column_range = table_range.clone();
+        let add_row_editor = editor.clone();
+        let add_row_range = table_range.clone();
+        let reveal_source_editor = editor.clone();
+        let reveal_source_range = table_range.clone();
+
+        let unit_button = |id: &'static str,
+                           icon: IconName,
+                           action: Option<(TableStructuralChange, Option<TableUnit>)>| {
+            let weak = editor.clone();
+            let action_range = table_range.clone();
+            let enabled = action.is_some();
+            div()
+                .id(id)
+                .px_1()
+                .py_0p5()
+                .rounded_sm()
+                .child(Icon::new(icon).size(IconSize::XSmall).color(if enabled {
+                    Color::Muted
+                } else {
+                    Color::Disabled
+                }))
+                .when_some(action, move |this, (change, new_unit)| {
+                    this.cursor_pointer()
+                        .hover(|this| this.bg(colors.element_hover))
+                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                            cx.stop_propagation();
+                            weak.update(cx, |editor, cx| {
+                                apply_table_structural_change(editor, &action_range, change, cx);
+                                if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                                    addon.selected_table_unit =
+                                        new_unit.map(|unit| TableUnitSelection {
+                                            table_range: action_range.clone(),
+                                            unit,
+                                        });
+                                }
+                                cx.notify();
+                            })
+                            .log_err();
+                        })
+                })
+        };
+        let controls = selected_unit.map(|unit| {
+            let rows_len = structure.rows.len();
+            let columns_len = structure.header.len();
+            let delete = match unit {
+                TableUnit::Row(row) => {
+                    (row < rows_len).then_some((TableStructuralChange::DeleteRow(row), None))
+                }
+                TableUnit::Column(column) => (columns_len > 1 && column < columns_len)
+                    .then_some((TableStructuralChange::DeleteColumn(column), None)),
+            };
+            h_flex()
+                .gap_1()
+                .pb_1()
+                .pl(handle_width)
+                .child(unit_button("mdlp-unit-delete", IconName::Trash, delete))
+        });
+
+        let apply_boundary_drop = |weak: WeakEntity<Editor>,
+                                   container_table_range: Range<Anchor>,
+                                   from_unit: TableUnit| {
+            move |cx: &mut App| {
+                weak.update(cx, |editor, cx| {
+                    let Some(boundary) = editor
+                        .addon::<LivePreviewAddon>()
+                        .and_then(|addon| addon.drop_boundary.as_ref())
+                        .filter(|(range, _)| range.start == container_table_range.start)
+                        .map(|(_, boundary)| *boundary)
+                    else {
+                        return;
+                    };
+                    // Boundary b means "insert before index b". Removing the
+                    // source first shifts later indices down by one; the two
+                    // boundaries flanking the source are no-ops.
+                    let move_to = |from: usize, boundary: usize| {
+                        if boundary == from || boundary == from + 1 {
+                            None
+                        } else if boundary > from {
+                            Some(boundary - 1)
+                        } else {
+                            Some(boundary)
+                        }
+                    };
+                    let (change, unit) = match (from_unit, boundary) {
+                        (TableUnit::Row(from), TableBoundary::Row(boundary)) => {
+                            match move_to(from, boundary) {
+                                Some(to) => (
+                                    TableStructuralChange::MoveRow { from, to },
+                                    TableUnit::Row(to),
+                                ),
+                                None => return,
+                            }
+                        }
+                        (TableUnit::Column(from), TableBoundary::Column(boundary)) => {
+                            match move_to(from, boundary) {
+                                Some(to) => (
+                                    TableStructuralChange::MoveColumn { from, to },
+                                    TableUnit::Column(to),
+                                ),
+                                None => return,
+                            }
+                        }
+                        _ => return,
+                    };
+                    apply_table_structural_change(editor, &container_table_range, change, cx);
+                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                        addon.drag_source = None;
+                        addon.drop_boundary = None;
+                        addon.selected_table_unit = Some(TableUnitSelection {
+                            table_range: container_table_range.clone(),
+                            unit,
+                        });
+                    }
+                    cx.notify();
+                })
+                .log_err();
+            }
+        };
+        let container_row_drop = {
+            let weak = editor.clone();
+            let container_table_range = table_range.clone();
+            move |drag: &TableRowDrag, _: &mut Window, cx: &mut App| {
+                if drag.table_start != container_table_range.start {
+                    return;
+                }
+                apply_boundary_drop(
+                    weak.clone(),
+                    container_table_range.clone(),
+                    TableUnit::Row(drag.row),
+                )(cx);
+            }
+        };
+        let container_column_drop = {
+            let weak = editor.clone();
+            let container_table_range = table_range.clone();
+            move |drag: &TableColumnDrag, _: &mut Window, cx: &mut App| {
+                if drag.table_start != container_table_range.start {
+                    return;
+                }
+                apply_boundary_drop(
+                    weak.clone(),
+                    container_table_range.clone(),
+                    TableUnit::Column(drag.column),
+                )(cx);
+            }
+        };
+
+        div()
+            .pl(gutter_width)
+            .w(max_width)
+            .group("mdlp-table")
+            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                cx.stop_propagation();
+            })
+            .on_drop::<TableRowDrag>(container_row_drop)
+            .on_drop::<TableColumnDrag>(container_column_drop)
+            .child(
+                v_flex()
+                    .max_w(max_width * 0.95)
+                    .children(controls)
+                    .child(
+                        h_flex()
+                            .items_stretch()
+                            .child(grid)
+                            .child(
+                                v_flex()
+                                    .w(gpui::px(22.))
+                                    .child(
+                                        // Reveal the table's markdown source.
+                                        div()
+                                            .id("mdlp-table-source")
+                                            .h(gpui::px(22.))
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .cursor_pointer()
+                                            .text_color(colors.text_muted)
+                                            .opacity(0.)
+                                            .group_hover("mdlp-table", |this| this.opacity(0.7))
+                                            .hover(|this| this.opacity(1.))
+                                            .child(
+                                                Icon::new(IconName::Code)
+                                                    .size(IconSize::XSmall)
+                                                    .color(Color::Muted),
+                                            )
+                                            .tooltip(ui::Tooltip::text("Edit table source"))
+                                            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                                                cx.stop_propagation();
+                                                reveal_source_editor
+                                                    .update(cx, |editor, cx| {
+                                                        if let Some(addon) =
+                                                            editor.addon_mut::<LivePreviewAddon>()
+                                                        {
+                                                            addon.source_revealed =
+                                                                Some(reveal_source_range.clone());
+                                                        }
+                                                        let snapshot =
+                                                            editor.buffer().read(cx).snapshot(cx);
+                                                        let offset = reveal_source_range
+                                                            .start
+                                                            .to_offset(&snapshot);
+                                                        editor.change_selections(
+                                                            Default::default(),
+                                                            window,
+                                                            cx,
+                                                            |selections| {
+                                                                selections
+                                                                    .select_ranges([offset..offset]);
+                                                            },
+                                                        );
+                                                    })
+                                                    .log_err();
+                                            }),
+                                    )
+                                    .child(
+                                        // Add column to the right.
+                                        div()
+                                            .id("mdlp-add-column")
+                                            .flex_grow(1.)
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .cursor_pointer()
+                                            .text_color(colors.text_muted)
+                                            .opacity(0.)
+                                            .group_hover("mdlp-table", |this| this.opacity(0.7))
+                                            .hover(|this| this.opacity(1.))
+                                            .child("+")
+                                            .tooltip(ui::Tooltip::text("Add column to the right"))
+                                            .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                                cx.stop_propagation();
+                                                add_column_editor
+                                                    .update(cx, |editor, cx| {
+                                                        apply_table_structural_change(
+                                                            editor,
+                                                            &add_column_range,
+                                                            TableStructuralChange::AddColumn,
+                                                            cx,
+                                                        );
+                                                    })
+                                                    .log_err();
+                                            }),
+                                    ),
+                            ),
+                    )
+                    .child(
+                        // Add row below.
+                        div()
+                            .id("mdlp-add-row")
+                            .h(gpui::px(18.))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .cursor_pointer()
+                            .text_color(colors.text_muted)
+                            .opacity(0.)
+                            .group_hover("mdlp-table", |this| this.opacity(0.7))
+                            .hover(|this| this.opacity(1.))
+                            .child("+")
+                            .tooltip(ui::Tooltip::text("Add row below"))
+                            .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                cx.stop_propagation();
+                                add_row_editor
+                                    .update(cx, |editor, cx| {
+                                        apply_table_structural_change(
+                                            editor,
+                                            &add_row_range,
+                                            TableStructuralChange::AddRow,
+                                            cx,
+                                        );
+                                    })
+                                    .log_err();
+                            }),
+                    ),
+            )
+            .into_any_element()
+    })
+}
+
+/// Drag payload for the image resize handle; renders no preview.
+struct ImageResizeDrag {
+    range: Range<Anchor>,
+    content_left_offset: gpui::Pixels,
+}
+
+struct EmptyDragPreview;
+
+impl gpui::Render for EmptyDragPreview {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+/// Rewrites (or inserts) Obsidian's `|width` suffix in an image's alt text.
+fn with_image_width(image_markdown: &str, width: u32) -> Option<String> {
+    let alt_start = image_markdown.find("![")? + 2;
+    let alt_end = alt_start + image_markdown.get(alt_start..)?.find(']')?;
+    let alt = image_markdown.get(alt_start..alt_end)?;
+    let base_alt = alt.rsplit_once('|').map_or(alt, |(base, suffix)| {
+        if suffix.chars().all(|c| c.is_ascii_digit() || c == 'x') && !suffix.is_empty() {
+            base
+        } else {
+            alt
+        }
+    });
+    Some(format!(
+        "{}{}|{}{}",
+        &image_markdown[..alt_start],
+        base_alt,
+        width,
+        &image_markdown[alt_end..]
+    ))
+}
+
+/// An Obsidian-style image widget: click to select, showing a border, a
+/// corner drag handle that resizes by rewriting `|width` into the source,
+/// and a code button that reveals the raw markdown.
+fn render_image_block(
+    markdown: Entity<Markdown>,
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    base_directory: Option<PathBuf>,
+    indent_columns: u32,
+    display_width: Option<f32>,
+    destination: Option<String>,
+    alt: SharedString,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let mut style = block_markdown_style(block_cx.window, block_cx.app);
+        // Suppress the paragraph's trailing margin so the selection border
+        // hugs the image instead of leaving a gap beneath it.
+        style.height_is_multiple_of_line_height = true;
+        let start = range.start;
+        let base_directory = base_directory.clone();
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        let max_width = block_cx.max_width;
+        let accent = block_cx.app.theme().colors().text_accent;
+        let surface = block_cx.app.theme().colors().elevated_surface_background;
+
+        // Images render at their explicit width, or capped at two thirds of
+        // the pane so screenshots do not dominate the note.
+        let content_width = display_width
+            .map(|width| gpui::px(width).min(max_width))
+            .map(gpui::Length::from);
+
+        let selected = editor
+            .upgrade()
+            .map(|editor_entity| {
+                let editor_ref = editor_entity.read(block_cx.app);
+                let snapshot = editor_ref.buffer().read(block_cx.app).snapshot(block_cx.app);
+                editor_ref
+                    .addon::<LivePreviewAddon>()
+                    .and_then(|addon| addon.selected_image.as_ref())
+                    .is_some_and(|selection| {
+                        selection.start.to_offset(&snapshot) == range.start.to_offset(&snapshot)
+                            && selection.end.to_offset(&snapshot) == range.end.to_offset(&snapshot)
+                    })
+            })
+            .unwrap_or(false);
+
+        let select_editor = editor.clone();
+        let select_range = range.clone();
+        let reveal_editor = editor.clone();
+        let reveal_range = range.clone();
+        let drag_editor = editor.clone();
+        let drag_range = range.clone();
+
+        // A direct image element lets the selection border hug the image
+        // exactly; reference-style images (no inline destination) fall back
+        // to the markdown renderer.
+        let resolved = destination
+            .as_deref()
+            .and_then(|destination| resolve_image_source(destination, base_directory.as_deref()));
+        let muted = block_cx.app.theme().colors().text_muted;
+        let image_content: gpui::AnyElement = match (&destination, resolved) {
+            (Some(_), Some(source)) => {
+                let fallback_alt = alt.clone();
+                gpui::img(source)
+                    .id(("mdlp-image", f32::from(max_width) as u64))
+                    .max_w_full()
+                    .rounded_sm()
+                    .when(content_width.is_some(), |this| this.w_full())
+                    .with_fallback(move || {
+                        div()
+                            .text_color(muted)
+                            .child(fallback_alt.clone())
+                            .into_any_element()
+                    })
+                    .into_any_element()
+            }
+            (Some(_), None) => div()
+                .text_color(muted)
+                .child(alt.clone())
+                .into_any_element(),
+            (None, _) => MarkdownElement::new(markdown.clone(), style)
+                .image_resolver(move |destination, _cx| {
+                    resolve_image_source(destination, base_directory.as_deref())
+                })
+                .into_any_element(),
+        };
+
+        let mut content = div()
+            .relative()
+            .border_2()
+            .rounded_sm()
+            .map(|this| {
+                if selected {
+                    this.border_color(accent)
+                } else {
+                    this.border_color(gpui::transparent_black())
+                }
+            })
+            .when_some(content_width, |this, width| this.w(width))
+            .when(content_width.is_none(), |this| {
+                this.max_w(max_width * 0.66)
+            })
+            .child(image_content);
+
+        if selected {
+            content = content
+                .child(
+                    // Reveal-source button, top right.
+                    div()
+                        .absolute()
+                        .top_1()
+                        .right_1()
+                        .child(
+                            IconButton::new("mdlp-show-source", IconName::Code)
+                                .style(ButtonStyle::Filled)
+                                .on_click(move |_, window, cx| {
+                                    cx.stop_propagation();
+                                    reveal_editor
+                                        .update(cx, |editor, cx| {
+                                            if let Some(addon) =
+                                                editor.addon_mut::<LivePreviewAddon>()
+                                            {
+                                                addon.source_revealed =
+                                                    Some(reveal_range.clone());
+                                            }
+                                            let snapshot =
+                                                editor.buffer().read(cx).snapshot(cx);
+                                            let offset = start.to_offset(&snapshot);
+                                            editor.change_selections(
+                                                Default::default(),
+                                                window,
+                                                cx,
+                                                |selections| {
+                                                    selections
+                                                        .select_ranges([offset..offset]);
+                                                },
+                                            );
+                                        })
+                                        .log_err();
+                                }),
+                        ),
+                )
+                .child(
+                    // Resize handle, bottom right.
+                    div()
+                        .id("mdlp-resize-handle")
+                        .absolute()
+                        .bottom_neg_1()
+                        .right_neg_1()
+                        .size_3()
+                        .rounded_full()
+                        .border_2()
+                        .border_color(accent)
+                        .bg(surface)
+                        .cursor_col_resize()
+                        .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                            cx.stop_propagation();
+                        })
+                        .on_drag(
+                            ImageResizeDrag {
+                                range: drag_range,
+                                content_left_offset: gutter_width,
+                            },
+                            |_, _, _, cx| cx.new(|_| EmptyDragPreview),
+                        ),
+                );
+        }
+
+        div()
+            .pl(gutter_width)
+            .w(max_width)
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, move |_, _window, cx| {
+                cx.stop_propagation();
+                select_editor
+                    .update(cx, |editor, cx| {
+                        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                            addon.selected_image = Some(select_range.clone());
+                        }
+                        cx.notify();
+                    })
+                    .log_err();
+            })
+            .on_drag_move::<ImageResizeDrag>(move |event, _window, cx| {
+                let drag = event.drag(cx);
+                let width = (event.event.position.x
+                    - event.bounds.left()
+                    - drag.content_left_offset)
+                    .max(gpui::px(64.));
+                let width = (f32::from(width) / 4.).round() * 4.;
+                let drag_range = drag.range.clone();
+                drag_editor
+                    .update(cx, |editor, cx| {
+                        resize_image_to_width(editor, &drag_range, width as u32, cx);
+                    })
+                    .log_err();
+            })
+            .child(div().max_w(max_width).child(content))
+            .into_any_element()
+    })
+}
+
+/// Writes `|width` into the image markdown at `range`, throttled to actual
+/// changes; the edit round-trips through the normal reparse pipeline, so the
+/// widget re-renders at the new size and the whole drag undoes as one step.
+fn resize_image_to_width(
+    editor: &mut Editor,
+    range: &Range<Anchor>,
+    width: u32,
+    cx: &mut Context<Editor>,
+) {
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let start = range.start.to_offset(&snapshot);
+    let end = range.end.to_offset(&snapshot);
+    if start >= end {
+        return;
+    }
+    let current: String = snapshot.text_for_range(start..end).collect();
+    let Some(updated) = with_image_width(current.trim(), width) else {
+        return;
+    };
+    if updated == current.trim() {
+        return;
+    }
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        addon.last_resize_at = Some(std::time::Instant::now());
+        // Keep the widget selected across the rewrite.
+        addon.selected_image = Some(range.clone());
+    }
+    editor.buffer().update(cx, |multibuffer, cx| {
+        multibuffer.edit([(start..end, updated)], None, cx);
+    });
+}
+
+fn render_rule_block(
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    indent_columns: u32,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let editor = editor.clone();
+        let start = range.start;
+        let border_color = block_cx.app.theme().colors().border;
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        div()
+            .pl(gutter_width)
+            .w(block_cx.max_width)
+            .h(block_cx.line_height)
+            .flex()
+            .items_center()
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                editor
+                    .update(cx, |editor, cx| {
+                        let snapshot = editor.buffer().read(cx).snapshot(cx);
+                        let offset = start.to_offset(&snapshot);
+                        editor.change_selections(Default::default(), window, cx, |selections| {
+                            selections.select_ranges([offset..offset]);
+                        });
+                    })
+                    .log_err();
+            })
+            .child(div().flex_1().h(gpui::px(2.)).bg(border_color))
+            .into_any_element()
+    })
+}
+
+fn render_frontmatter_block(
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    source: String,
+) -> RenderBlock {
+    let properties: Vec<(String, String)> = source
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed == "---" || trimmed == "+++" {
+                return None;
+            }
+            let (key, value) = trimmed
+                .split_once(':')
+                .or_else(|| trimmed.split_once('='))
+                .unwrap_or(("", trimmed));
+            Some((key.trim().to_string(), value.trim().to_string()))
+        })
+        .collect();
+
+    Arc::new(move |block_cx| {
+        let editor = editor.clone();
+        let start = range.start;
+        let colors = block_cx.app.theme().colors().clone();
+        let gutter_width = block_cx.margins.gutter.full_width();
+        div()
+            .pl(gutter_width)
+            .w(block_cx.max_width)
+            .py(gpui::px(2.))
+            .cursor_pointer()
+            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                editor
+                    .update(cx, |editor, cx| {
+                        let snapshot = editor.buffer().read(cx).snapshot(cx);
+                        let offset = start.to_offset(&snapshot);
+                        editor.change_selections(Default::default(), window, cx, |selections| {
+                            selections.select_ranges([offset..offset]);
+                        });
+                    })
+                    .log_err();
+            })
+            .child(
+                v_flex()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(colors.border_variant)
+                    .bg(colors.elevated_surface_background)
+                    .px_3()
+                    .py_1p5()
+                    .gap_0p5()
+                    .text_size(rems(0.85))
+                    .children(properties.iter().map(|(key, value)| {
+                        h_flex()
+                            .gap_3()
+                            .items_start()
+                            .child(
+                                div()
+                                    .min_w(rems(7.))
+                                    .text_color(colors.text_muted)
+                                    .child(SharedString::from(key.clone())),
+                            )
+                            .child(div().flex_1().child(SharedString::from(value.clone())))
+                    })),
+            )
+            .into_any_element()
+    })
+}
+
+fn resolve_image_source(
+    destination: &str,
+    base_directory: Option<&std::path::Path>,
+) -> Option<ImageSource> {
+    if destination.starts_with("data:") {
+        return None;
+    }
+    if destination.starts_with("http://") || destination.starts_with("https://") {
+        return Some(ImageSource::Resource(Resource::Uri(SharedUri::from(
+            destination.to_string(),
+        ))));
+    }
+    // Markdown links percent-encode spaces; the filesystem stores them raw.
+    let decoded = urlencoding::decode(destination)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| destination.to_string());
+    let path = std::path::Path::new(&decoded);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_directory?.join(path)
+    };
+    path.exists()
+        .then(|| ImageSource::Resource(Resource::Path(Arc::from(path.as_path()))))
+}
+
+fn block_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
+    let mut style = MarkdownStyle::themed(MarkdownFont::Editor, window, cx);
+    let heading = |size: f32, weight: FontWeight| {
+        Some(TextStyleRefinement {
+            font_size: Some(rems(size).into()),
+            font_weight: Some(weight),
+            ..Default::default()
+        })
+    };
+    style.heading_level_styles = Some(HeadingLevelStyles {
+        h1: heading(1.6, FontWeight::BOLD),
+        h2: heading(1.4, FontWeight::BOLD),
+        h3: heading(1.2, FontWeight::SEMIBOLD),
+        h4: heading(1.1, FontWeight::SEMIBOLD),
+        h5: heading(1.0, FontWeight::SEMIBOLD),
+        h6: heading(0.9, FontWeight::SEMIBOLD),
+    });
+    style
+}
+
+// --- Marker extraction ---
+
+fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
+    let buffer = editor.buffer().read(cx).as_singleton()?;
+    let buffer = buffer.read(cx);
+    let language = buffer.language()?;
+    if language.name() != LanguageName::new(MARKDOWN) {
+        return None;
+    }
+    let buffer_snapshot = buffer.snapshot();
+    let multibuffer_snapshot = editor.buffer().read(cx).snapshot(cx);
+    let text = buffer_snapshot.text();
+
+    let mut extraction = Extraction {
+        text: &text,
+        snapshot: &multibuffer_snapshot,
+        prose_regions: Vec::new(),
+        code_spans: Vec::new(),
+        last_table_end_row: None,
+        inline: Vec::new(),
+        blocks: Vec::new(),
+        strikethrough: Vec::new(),
+        italic: Vec::new(),
+        bold: Vec::new(),
+        link_text: Vec::new(),
+        definitions: Vec::new(),
+        definition_ranges: Vec::new(),
+        ordered_markers: Vec::new(),
+    };
+
+    for layer in buffer_snapshot.syntax_layers() {
+        let root = layer.node();
+        match layer.language.name().as_ref() {
+            MARKDOWN => extraction.walk_block_layer(root),
+            MARKDOWN_INLINE => extraction.walk_inline_layer(root),
+            _ => {}
+        }
+    }
+
+    extraction.scan_wikilinks();
+
+    let Extraction {
+        inline,
+        mut blocks,
+        strikethrough,
+        italic,
+        bold,
+        link_text,
+        definitions,
+        definition_ranges,
+        ordered_markers,
+        ..
+    } = extraction;
+
+    // Blocks from different layers can overlap (e.g. an image inside a table
+    // row); keep the outermost region and drop any block nested in or
+    // overlapping a previous one.
+    blocks.sort_by(|a, b| {
+        let a_start = a.range.start.to_offset(&multibuffer_snapshot);
+        let b_start = b.range.start.to_offset(&multibuffer_snapshot);
+        a_start.cmp(&b_start).then_with(|| {
+            let a_end = a.range.end.to_offset(&multibuffer_snapshot);
+            let b_end = b.range.end.to_offset(&multibuffer_snapshot);
+            b_end.cmp(&a_end)
+        })
+    });
+    let mut last_end = 0;
+    blocks.retain(|block| {
+        let start = block.range.start.to_offset(&multibuffer_snapshot).0;
+        let end = block.range.end.to_offset(&multibuffer_snapshot).0;
+        if start < last_end {
+            false
+        } else {
+            last_end = end;
+            true
+        }
+    });
+
+    Some(MarkerSet {
+        inline,
+        blocks,
+        strikethrough,
+        italic,
+        bold,
+        link_text,
+        definitions: definitions.join("\n"),
+        definition_ranges,
+        ordered_markers,
+    })
+}
+
+struct Extraction<'a> {
+    text: &'a str,
+    snapshot: &'a MultiBufferSnapshot,
+    /// Prose regions (the block grammar's `inline` nodes) and code spans,
+    /// used to scan for wikilinks only where they can occur.
+    prose_regions: Vec<Range<usize>>,
+    code_spans: Vec<Range<usize>>,
+    /// End row of the last table block pushed, for deduplicating table nodes
+    /// that fall inside an already-claimed textual table.
+    last_table_end_row: Option<u32>,
+    inline: Vec<InlineMarker>,
+    blocks: Vec<BlockMarker>,
+    strikethrough: Vec<Range<Anchor>>,
+    italic: Vec<Range<Anchor>>,
+    bold: Vec<Range<Anchor>>,
+    link_text: Vec<Range<Anchor>>,
+    definitions: Vec<String>,
+    definition_ranges: Vec<Range<Anchor>>,
+    ordered_markers: Vec<Range<Anchor>>,
+}
+
+impl Extraction<'_> {
+    fn anchor_range(&self, range: Range<usize>) -> Range<Anchor> {
+        // Bias the anchors inward so text inserted at the boundaries falls
+        // outside the hidden range rather than growing it.
+        self.snapshot
+            .anchor_after(MultiBufferOffset(range.start))
+            ..self.snapshot.anchor_before(MultiBufferOffset(range.end))
+    }
+
+    fn hide(&mut self, range: Range<usize>, reveal_span: Range<usize>) {
+        if range.start < range.end {
+            self.inline.push(InlineMarker {
+                range: self.anchor_range(range),
+                kind: InlineKind::Hide {
+                    reveal_span: self.anchor_range(reveal_span),
+                },
+            });
+        }
+    }
+
+    /// The row extent of a node, excluding a trailing newline that tree-sitter
+    /// includes in block constructs.
+    fn node_rows(&self, node: tree_sitter::Node) -> (u32, u32) {
+        let start_row = node.start_position().row as u32;
+        let mut end_row = node.end_position().row as u32;
+        if node.end_position().column == 0 && end_row > start_row {
+            end_row -= 1;
+        }
+        (start_row, end_row)
+    }
+
+    fn push_block_rows(
+        &mut self,
+        start_row: u32,
+        end_row: u32,
+        height_estimate: u32,
+        kind: BlockRenderKind,
+    ) {
+        let start = Point::new(start_row, 0);
+        let end = Point::new(end_row, self.snapshot.line_len(MultiBufferRow(end_row)));
+        let line_start = self.snapshot.point_to_offset(start);
+        let line_end = self.snapshot.point_to_offset(end);
+        let first_line: String = self.snapshot.text_for_range(line_start..line_end).collect();
+        let indent_columns = first_line
+            .chars()
+            .take_while(|character| character.is_whitespace())
+            .map(|character| if character == '\t' { 4 } else { 1 })
+            .sum();
+        let range = self.snapshot.anchor_before(start)..self.snapshot.anchor_after(end);
+        self.blocks.push(BlockMarker {
+            range,
+            height_estimate,
+            kind,
+            indent_columns,
+        });
+    }
+
+    fn walk_block_layer(&mut self, root: tree_sitter::Node) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            match node.kind() {
+                "atx_heading" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    let level = heading_level(node);
+                    let height = if level <= 2 { 2 } else { 1 };
+                    self.push_block_rows(start_row, end_row, height, BlockRenderKind::Markdown);
+                }
+                "setext_heading" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(start_row, end_row, 2, BlockRenderKind::Markdown);
+                }
+                "thematic_break" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(start_row, end_row, 1, BlockRenderKind::Rule);
+                }
+                "pipe_table" => {
+                    // Extent and structure come from the text parser, not the
+                    // tree: tree-sitter-md chokes on valid GFM like a row of
+                    // all-empty cells, ending the table node early.
+                    let near = MultiBufferOffset(node.start_byte());
+                    match parse_table_at(self.snapshot, near) {
+                        Some((offsets, structure)) => {
+                            let start_row = offsets.start.to_point(self.snapshot).row;
+                            let end_row = offsets.end.to_point(self.snapshot).row;
+                            // One textual table can contain several table
+                            // nodes; only the first one produces the block.
+                            let claimed =
+                                self.last_table_end_row.is_some_and(|last| start_row <= last);
+                            if !claimed {
+                                self.last_table_end_row = Some(end_row);
+                                self.push_block_rows(
+                                    start_row,
+                                    end_row,
+                                    end_row - start_row + 2,
+                                    BlockRenderKind::Table(structure),
+                                );
+                            }
+                        }
+                        None => {
+                            let (start_row, end_row) = self.node_rows(node);
+                            self.push_block_rows(
+                                start_row,
+                                end_row,
+                                end_row - start_row + 2,
+                                BlockRenderKind::Markdown,
+                            );
+                        }
+                    }
+                }
+                "fenced_code_block" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(
+                        start_row,
+                        end_row,
+                        end_row - start_row + 2,
+                        BlockRenderKind::Markdown,
+                    );
+                }
+                "minus_metadata" | "plus_metadata" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(
+                        start_row,
+                        end_row,
+                        end_row - start_row,
+                        BlockRenderKind::Frontmatter,
+                    );
+                }
+                "html_block" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(
+                        start_row,
+                        end_row,
+                        end_row - start_row + 1,
+                        BlockRenderKind::Markdown,
+                    );
+                }
+                "block_quote" => {
+                    let (start_row, end_row) = self.node_rows(node);
+                    self.push_block_rows(
+                        start_row,
+                        end_row,
+                        end_row - start_row + 1,
+                        BlockRenderKind::Markdown,
+                    );
+                    push_children(node, &mut stack);
+                }
+                "link_reference_definition" => {
+                    if let Some(text) = self.text.get(node.byte_range()) {
+                        self.definitions.push(text.trim_end().to_string());
+                    }
+                    let trimmed_len = self
+                        .text
+                        .get(node.byte_range())
+                        .map_or(0, |text| text.trim_end().len());
+                    if trimmed_len > 0 {
+                        let start = node.start_byte();
+                        let range = self.anchor_range(start..start + trimmed_len);
+                        self.definition_ranges.push(range);
+                    }
+                }
+                "list_item" => {
+                    self.list_item_markers(node);
+                    push_children(node, &mut stack);
+                }
+                "inline" => self.prose_regions.push(node.byte_range()),
+                _ => push_children(node, &mut stack),
+            }
+        }
+    }
+
+    fn list_item_markers(&mut self, node: tree_sitter::Node) {
+        let mut list_marker = None;
+        let mut task_marker = None;
+        for index in 0..node.child_count() as u32 {
+            let Some(child) = node.child(index) else {
+                continue;
+            };
+            match child.kind() {
+                "list_marker_minus" | "list_marker_plus" | "list_marker_star" => {
+                    list_marker = Some(child);
+                }
+                "list_marker_dot" | "list_marker_parenthesis" => {
+                    let Some(marker_text) = self.text.get(child.byte_range()) else {
+                        continue;
+                    };
+                    let trimmed_len = marker_text.trim_end().len();
+                    if trimmed_len > 0 {
+                        let start = child.start_byte();
+                        let range = self.anchor_range(start..start + trimmed_len);
+                        self.ordered_markers.push(range);
+                    }
+                }
+                "task_list_marker_checked" => task_marker = Some((child, true)),
+                "task_list_marker_unchecked" => task_marker = Some((child, false)),
+                _ => {}
+            }
+        }
+
+        let Some(list_marker) = list_marker else {
+            return;
+        };
+
+        if let Some((task_node, checked)) = task_marker {
+            let range = list_marker.start_byte()..task_node.end_byte();
+            let marker_range = self.anchor_range(task_node.byte_range());
+            self.inline.push(InlineMarker {
+                range: self.anchor_range(range),
+                kind: InlineKind::Checkbox {
+                    checked,
+                    marker_range,
+                },
+            });
+        } else {
+            let Some(marker_text) = self.text.get(list_marker.byte_range()) else {
+                return;
+            };
+            let trimmed_len = marker_text.trim_end().len();
+            if trimmed_len == 0 {
+                return;
+            }
+            let start = list_marker.start_byte();
+            self.inline.push(InlineMarker {
+                range: self.anchor_range(start..start + trimmed_len),
+                kind: InlineKind::Bullet,
+            });
+        }
+    }
+
+    fn walk_inline_layer(&mut self, root: tree_sitter::Node) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            match node.kind() {
+                "emphasis" | "strong_emphasis" | "strikethrough" => {
+                    let range = self.anchor_range(node.byte_range());
+                    match node.kind() {
+                        "strikethrough" => self.strikethrough.push(range),
+                        "emphasis" => self.italic.push(range),
+                        _ => self.bold.push(range),
+                    }
+                    for index in 0..node.child_count() as u32 {
+                        let Some(child) = node.child(index) else {
+                            continue;
+                        };
+                        if child.kind() == "emphasis_delimiter" {
+                            self.hide(child.byte_range(), node.byte_range());
+                        }
+                    }
+                    push_children(node, &mut stack);
+                }
+                "code_span" => {
+                    self.code_spans.push(node.byte_range());
+                    for index in 0..node.child_count() as u32 {
+                        let Some(child) = node.child(index) else {
+                            continue;
+                        };
+                        if child.kind() == "code_span_delimiter" {
+                            self.hide(child.byte_range(), node.byte_range());
+                        }
+                    }
+                }
+                "inline_link" | "full_reference_link" | "collapsed_reference_link" => {
+                    let mut open_bracket = None;
+                    let mut close_bracket = None;
+                    for index in 0..node.child_count() as u32 {
+                        let Some(child) = node.child(index) else {
+                            continue;
+                        };
+                        match child.kind() {
+                            "[" if open_bracket.is_none() => open_bracket = Some(child),
+                            "]" => close_bracket = Some(child),
+                            _ => {}
+                        }
+                    }
+                    if let Some(open) = open_bracket {
+                        self.hide(open.byte_range(), node.byte_range());
+                    }
+                    if let Some(close) = close_bracket {
+                        self.hide(close.start_byte()..node.end_byte(), node.byte_range());
+                    }
+                    if let (Some(open), Some(close)) = (open_bracket, close_bracket)
+                        && open.end_byte() < close.start_byte()
+                    {
+                        let range = self.anchor_range(open.end_byte()..close.start_byte());
+                        self.link_text.push(range);
+                    }
+                    // A standalone link wrapping an image renders as an image
+                    // widget built from just the inner image markdown: the
+                    // markdown renderer degrades a link-wrapped image to
+                    // literal text (the preview pane has the same limit). The
+                    // image sits under a `link_text` node, not directly under
+                    // the link.
+                    let wrapped_image = (0..node.child_count() as u32)
+                        .filter_map(|index| node.child(index))
+                        .find_map(|child| {
+                            if child.kind() == "image" {
+                                Some(child)
+                            } else if child.kind() == "link_text" {
+                                (0..child.child_count() as u32)
+                                    .filter_map(|index| child.child(index))
+                                    .find(|grandchild| grandchild.kind() == "image")
+                            } else {
+                                None
+                            }
+                        });
+                    if let Some(image_node) = wrapped_image
+                        && self.is_alone_on_line(node)
+                    {
+                        let image_range = image_node.byte_range();
+                        let range = self
+                            .snapshot
+                            .anchor_before(MultiBufferOffset(image_range.start))
+                            ..self
+                                .snapshot
+                                .anchor_after(MultiBufferOffset(image_range.end));
+                        let kind = self.image_kind(image_node);
+                        self.blocks.push(BlockMarker {
+                            range,
+                            height_estimate: 8,
+                            kind,
+                            indent_columns: 0,
+                        });
+                    }
+                    push_children(node, &mut stack);
+                }
+                "uri_autolink" | "email_autolink" => {
+                    let range = node.byte_range();
+                    if range.len() >= 2 {
+                        self.hide(range.start..range.start + 1, range.clone());
+                        self.hide(range.end - 1..range.end, range.clone());
+                    }
+                }
+                "image" => {
+                    // `![[...]]` is an Obsidian embed, not a markdown image;
+                    // leave it raw rather than concealing it half-way.
+                    if self
+                        .text
+                        .get(node.byte_range())
+                        .is_some_and(|text| text.starts_with("![["))
+                    {
+                        continue;
+                    }
+                    if self.is_alone_on_line(node) {
+                        self.image_block(node);
+                    } else if let Some(description) = (0..node.child_count() as u32)
+                        .filter_map(|index| node.child(index))
+                        .find(|child| child.kind() == "image_description")
+                    {
+                        // The image itself cannot render mid-line, but the
+                        // alt text can: conceal `![` and `](url)` like links.
+                        self.hide(
+                            node.start_byte()..description.start_byte(),
+                            node.byte_range(),
+                        );
+                        self.hide(description.end_byte()..node.end_byte(), node.byte_range());
+                    }
+                }
+                _ => push_children(node, &mut stack),
+            }
+        }
+    }
+
+    /// Conceal Obsidian-style wikilinks: `[[Note]]`, `[[Note|alias]]`, and
+    /// `[[Note#heading]]`. Zed's markdown grammar has no wikilink nodes, so
+    /// this scans the prose regions directly, skipping code spans; embeds
+    /// (`![[...]]`) are left raw.
+    fn scan_wikilinks(&mut self) {
+        let regions = std::mem::take(&mut self.prose_regions);
+        for region in &regions {
+            let Some(region_text) = self.text.get(region.clone()) else {
+                continue;
+            };
+            let mut search_from = 0;
+            while let Some(open_offset) = region_text[search_from..].find("[[") {
+                let open = search_from + open_offset;
+                let Some(close_offset) = region_text[open + 2..].find("]]") else {
+                    break;
+                };
+                let close = open + 2 + close_offset;
+                search_from = close + 2;
+
+                let inner = &region_text[open + 2..close];
+                if inner.is_empty() || inner.contains('\n') || inner.contains("[[") {
+                    continue;
+                }
+                let is_embed = region_text[..open].ends_with('!');
+                let start = region.start + open;
+                let end = region.start + close + 2;
+                if is_embed
+                    || self
+                        .code_spans
+                        .iter()
+                        .any(|span| span.start < end && start < span.end)
+                {
+                    continue;
+                }
+
+                let reveal = start..end;
+                if let Some(pipe) = inner.find('|') {
+                    // `[[target|alias]]`: show only the alias.
+                    self.hide(start..start + 2 + pipe + 1, reveal.clone());
+                    self.hide(end - 2..end, reveal.clone());
+                    let alias_start = start + 2 + pipe + 1;
+                    let range = self.anchor_range(alias_start..end - 2);
+                    self.link_text.push(range);
+                } else {
+                    self.hide(start..start + 2, reveal.clone());
+                    self.hide(end - 2..end, reveal.clone());
+                    let range = self.anchor_range(start + 2..end - 2);
+                    self.link_text.push(range);
+                }
+            }
+        }
+        self.prose_regions = regions;
+    }
+
+    /// Whether this single-line node is the only content on its line.
+    fn is_alone_on_line(&self, node: tree_sitter::Node) -> bool {
+        if node.start_position().row != node.end_position().row {
+            return false;
+        }
+        let row = node.start_position().row as u32;
+        let line_start = self.snapshot.point_to_offset(Point::new(row, 0));
+        let line_end = self
+            .snapshot
+            .point_to_offset(Point::new(row, self.snapshot.line_len(MultiBufferRow(row))));
+        let line_text: String = self.snapshot.text_for_range(line_start..line_end).collect();
+        self.text
+            .get(node.byte_range())
+            .is_some_and(|node_text| line_text.trim() == node_text.trim())
+    }
+
+    /// Obsidian's image size syntax: `![alt|640](p)` or `![alt|640x480](p)`.
+    fn image_display_width(&self, image_node: tree_sitter::Node) -> Option<f32> {
+        let (_, size) = self.image_alt(image_node)?.rsplit_once('|')?;
+        let width: String = size.chars().take_while(|c| c.is_ascii_digit()).collect();
+        width.parse::<f32>().ok().filter(|width| *width > 0.)
+    }
+
+    fn image_alt(&self, image_node: tree_sitter::Node) -> Option<&str> {
+        let description = (0..image_node.child_count() as u32)
+            .filter_map(|index| image_node.child(index))
+            .find(|child| child.kind() == "image_description")?;
+        self.text.get(description.byte_range())
+    }
+
+    fn image_destination(&self, image_node: tree_sitter::Node) -> Option<String> {
+        let destination = (0..image_node.child_count() as u32)
+            .filter_map(|index| image_node.child(index))
+            .find(|child| child.kind() == "link_destination")?;
+        self.text
+            .get(destination.byte_range())
+            .map(|text| text.to_string())
+    }
+
+    fn image_kind(&self, image_node: tree_sitter::Node) -> BlockRenderKind {
+        let alt = self
+            .image_alt(image_node)
+            .map(|alt| alt.rsplit_once('|').map_or(alt, |(base, _)| base))
+            .unwrap_or_default()
+            .to_string();
+        BlockRenderKind::Image {
+            display_width: self.image_display_width(image_node),
+            destination: self.image_destination(image_node),
+            alt,
+        }
+    }
+
+    /// Renders an image as a block widget when it is the only content on its
+    /// line; inline images are left as raw markdown.
+    fn image_block(&mut self, node: tree_sitter::Node) {
+        if self.is_alone_on_line(node) {
+            let row = node.start_position().row as u32;
+            let kind = self.image_kind(node);
+            self.push_block_rows(row, row, 8, kind);
+        }
+    }
+}
+
+fn push_children<'a>(node: tree_sitter::Node<'a>, stack: &mut Vec<tree_sitter::Node<'a>>) {
+    for index in (0..node.child_count() as u32).rev() {
+        if let Some(child) = node.child(index) {
+            stack.push(child);
+        }
+    }
+}
+
+fn heading_level(node: tree_sitter::Node) -> u32 {
+    for index in 0..node.child_count() as u32 {
+        if let Some(child) = node.child(index) {
+            match child.kind() {
+                "atx_h1_marker" => return 1,
+                "atx_h2_marker" => return 2,
+                "atx_h3_marker" => return 3,
+                "atx_h4_marker" => return 4,
+                "atx_h5_marker" => return 5,
+                "atx_h6_marker" => return 6,
+                _ => {}
+            }
+        }
+    }
+    6
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -1,0 +1,1466 @@
+use super::*;
+use editor::test::editor_test_context::EditorTestContext;
+use gpui::TestAppContext;
+use language::{Language, LanguageConfig};
+use settings::SettingsStore;
+use std::sync::Arc;
+
+fn init_test(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        zlog::init_test();
+        let settings = SettingsStore::test(cx);
+        cx.set_global(settings);
+        theme_settings::init(theme::LoadThemes::JustBase, cx);
+        editor::init(cx);
+        crate::init(cx);
+    });
+}
+
+fn markdown_inline_lang() -> Arc<Language> {
+    Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown-Inline".into(),
+            hidden: true,
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_md::INLINE_LANGUAGE.into()),
+    ))
+}
+
+async fn markdown_test_context(cx: &mut TestAppContext) -> EditorTestContext {
+    init_test(cx);
+    let mut cx = EditorTestContext::new(cx).await;
+    let registry = cx.language_registry();
+    let markdown = language::markdown_lang();
+    registry.add(markdown.clone());
+    registry.add(markdown_inline_lang());
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(Some(markdown), cx);
+    });
+    cx.executor().run_until_parked();
+    cx
+}
+
+#[gpui::test]
+async fn test_inline_markers_hidden_off_cursor_line(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        some **bold** and *italic* and `code` here
+        a [label](https://example.com) link
+    "});
+    cx.executor().run_until_parked();
+
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some bold and italic and code here
+            a label link
+        "}
+    );
+}
+
+#[gpui::test]
+async fn test_per_token_reveal(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        some **bold** and *italic* text
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some bold and italic text
+        "}
+    );
+
+    // Cursor inside the bold span reveals only that span's markers; the
+    // italic further along the same line stays rendered.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        some **boˇld** and *italic* text
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some **bold** and italic text
+        "}
+    );
+
+    // Cursor in plain text on the same line reveals nothing.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        some **bold** anˇd *italic* text
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some bold and italic text
+        "}
+    );
+
+    // A selection sweeping the line reveals everything it touches.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        «some **bold** and *italic* textˇ»
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some **bold** and *italic* text
+        "}
+    );
+
+    // A list marker stays rendered while editing elsewhere on its line,
+    // and reveals only when the cursor touches it.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        - bullet with **bold** insideˇ
+    "});
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("⋯ bullet with bold inside"));
+    cx.set_state(indoc::indoc! {"
+        plain line
+        ˇ- bullet with **bold** inside
+    "});
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("- bullet with bold inside"));
+
+    // The boundary just past the marker's trailing space does not reveal it.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        - ˇbullet with **bold** inside
+    "});
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("⋯ bullet with bold inside"));
+
+    // A checkbox stays rendered while editing the task text.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        - [ ] task textˇ
+    "});
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("⋯ task text"));
+
+    // Moving to another line hides everything again.
+    cx.set_state(indoc::indoc! {"
+        plainˇ line
+        some **bold** and *italic* text
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            some bold and italic text
+        "}
+    );
+}
+
+#[gpui::test]
+async fn test_list_markers(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        - bullet item
+        - [ ] open task
+        - [x] done task
+    "});
+    cx.executor().run_until_parked();
+
+    // Bullet and checkbox folds keep the default `⋯` placeholder text; the
+    // rendered element replaces it visually.
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            ⋯ bullet item
+            ⋯ open task
+            ⋯ done task
+        "}
+    );
+
+    let markers = cx.update_editor(|editor, _, cx| {
+        let markers = extract_markers(editor, cx).expect("markdown buffer should produce markers");
+        markers
+            .inline
+            .iter()
+            .filter(|marker| matches!(marker.kind, InlineKind::Checkbox { .. }))
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(markers.len(), 2);
+
+    // Toggling the open task checks it.
+    let InlineKind::Checkbox {
+        checked,
+        marker_range,
+    } = markers[0].kind.clone()
+    else {
+        panic!("expected checkbox marker");
+    };
+    assert!(!checked);
+    let editor = cx.editor.clone();
+    cx.update(|_, cx| {
+        toggle_task_marker(&editor.downgrade(), &marker_range, checked, cx);
+    });
+    cx.executor().run_until_parked();
+    assert!(cx.buffer_text().contains("- [x] open task"));
+
+    // Toggling the done task unchecks it.
+    let InlineKind::Checkbox {
+        checked,
+        marker_range,
+    } = markers[1].kind.clone()
+    else {
+        panic!("expected checkbox marker");
+    };
+    assert!(checked);
+    let editor = cx.editor.clone();
+    cx.update(|_, cx| {
+        toggle_task_marker(&editor.downgrade(), &marker_range, checked, cx);
+    });
+    cx.executor().run_until_parked();
+    assert!(cx.buffer_text().contains("- [ ] done task"));
+}
+
+#[gpui::test]
+async fn test_block_widgets(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain first line
+        extra spacing line
+
+        # Heading
+
+        | a | b |
+        | - | - |
+        | 1 | 2 |
+
+        ---
+
+        ```python
+        import pandas as pd
+        ```
+
+        > a quote
+
+        last line
+    "});
+    cx.executor().run_until_parked();
+
+    // Heading, table, horizontal rule, code block, and blockquote.
+    assert_eq!(applied_block_count(&mut cx), 5);
+
+    // Moving the cursor onto the heading's row reveals it (removes its
+    // block), while everything else stays rendered; an adjacent row does not
+    // reveal it.
+    cx.set_state(indoc::indoc! {"
+        plain first line
+        extra spacing line
+        ˇ
+        # Heading
+
+        | a | b |
+        | - | - |
+        | 1 | 2 |
+
+        ---
+
+        ```python
+        import pandas as pd
+        ```
+
+        > a quote
+
+        last line
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 5);
+
+    cx.set_state(indoc::indoc! {"
+        plain first line
+        extra spacing line
+
+        # Headingˇ
+
+        | a | b |
+        | - | - |
+        | 1 | 2 |
+
+        ---
+
+        ```python
+        import pandas as pd
+        ```
+
+        > a quote
+
+        last line
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 4);
+}
+
+#[gpui::test]
+async fn test_frontmatter_renders_as_block(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ---
+        title: Some Note
+        parent: lectures
+        ---
+
+        body ˇtext
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+
+    // Cursor inside the frontmatter reveals the raw YAML.
+    cx.set_state(indoc::indoc! {"
+        ---
+        title: Some Noteˇ
+        parent: lectures
+        ---
+
+        body text
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 0);
+}
+
+fn applied_block_count(cx: &mut EditorTestContext) -> usize {
+    cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .unwrap()
+            .applied_blocks
+            .len()
+    })
+}
+
+#[gpui::test]
+async fn test_keyboard_navigation_reaches_blocks(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇalpha
+
+        # Heading
+
+        omega
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+
+    // Arrow down until the cursor reaches the heading's buffer row; the
+    // rendered block must dissolve so the heading is editable with the
+    // keyboard alone.
+    let mut reached = false;
+    for _ in 0..4 {
+        cx.update_editor(|editor, window, cx| {
+            editor.move_down(&Default::default(), window, cx);
+        });
+        cx.executor().run_until_parked();
+        let row = cx.update_editor(|editor, _, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            editor
+                .selections
+                .newest_anchor()
+                .head()
+                .to_point(&snapshot)
+                .row
+        });
+        if row == 2 {
+            reached = true;
+            break;
+        }
+    }
+    assert!(reached, "cursor never reached the heading row");
+    assert_eq!(applied_block_count(&mut cx), 0);
+    assert!(cx.display_text().contains("# Heading"));
+}
+
+#[gpui::test]
+async fn test_heading_renders_after_typing(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    // Simulate typing a heading then pressing enter: the cursor ends up on
+    // the line below, and the heading should render immediately.
+    cx.set_state("# helloˇ");
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 0);
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline(&Default::default(), window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+}
+
+#[gpui::test]
+async fn test_disabling_restores_raw_markdown(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    let source = indoc::indoc! {"
+        ˇplain line
+        some **bold** text
+
+        # Heading
+    "};
+    cx.set_state(source);
+    cx.executor().run_until_parked();
+    assert_ne!(cx.display_text(), cx.buffer_text());
+
+    cx.update_editor(|editor, _window, cx| {
+        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+            addon.enabled_override = Some(false);
+        }
+        recompute(editor, cx);
+    });
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(cx.display_text(), cx.buffer_text());
+
+    cx.update_editor(|editor, _window, cx| {
+        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+            addon.enabled_override = Some(true);
+        }
+        recompute(editor, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_ne!(cx.display_text(), cx.buffer_text());
+}
+
+#[gpui::test]
+async fn test_extended_markdown_coverage(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        visit <https://example.com> or [text][ref] or [collapsed][]
+
+        Setext Title
+        ============
+
+        <div>html block</div>
+    "});
+    cx.executor().run_until_parked();
+
+    // Autolink angle brackets and reference-link syntax are concealed.
+    assert!(
+        cx.display_text()
+            .contains("visit https://example.com or text or collapsed")
+    );
+    // Setext heading and HTML block render as widgets.
+    assert_eq!(applied_block_count(&mut cx), 2);
+
+    // Plain bracketed prose is NOT treated as a link: tree-sitter cannot
+    // resolve reference definitions, so `[TODO]` must keep its brackets.
+    cx.set_state("ˇplain line\nthis is [TODO] for later\n");
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("this is [TODO] for later"));
+
+    // Mid-sentence images conceal their syntax, leaving the alt text.
+    cx.set_state("ˇplain line\nbroken: ![missing image](nonexistent.png) here\n");
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("broken: missing image here"));
+}
+
+#[gpui::test]
+async fn test_restored_generic_folds_are_removed(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇplain\nsome **bold** text\n");
+    cx.executor().run_until_parked();
+
+    // Simulate a fold restored from a session saved before concealment folds
+    // were excluded from persistence: a default `⋯` placeholder sitting
+    // exactly on the `**` marker before "bold".
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_ranges(
+            vec![MultiBufferOffset(11)..MultiBufferOffset(13)],
+            false,
+            window,
+            cx,
+        );
+    });
+    assert!(cx.display_text().contains('⋯'));
+
+    // The next reparse heals it: the stale fold is removed and the marker is
+    // concealed again.
+    cx.set_state("editedˇ\nsome **bold** text\n");
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(cx.display_text(), "edited\nsome bold text\n");
+}
+
+#[gpui::test]
+async fn test_non_markdown_buffers_untouched(cx: &mut TestAppContext) {
+    init_test(cx);
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇsome **text** that is not markdown\n");
+    cx.executor().run_until_parked();
+
+    pretty_assertions::assert_eq!(cx.display_text(), cx.buffer_text());
+    let has_decorations = cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .is_some_and(|addon| !addon.applied_blocks.is_empty())
+    });
+    assert!(!has_decorations);
+}
+
+#[gpui::test]
+async fn test_linked_image_renders_as_block(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(
+        "ˇplain line\n\n[![Clickable image](https://example.com/a.png)](https://example.com)\n",
+    );
+    cx.executor().run_until_parked();
+    let block_count = applied_block_count(&mut cx);
+    if block_count != 1 {
+        let debug: Vec<String> = cx.update_editor(|editor, _, cx| {
+            let buffer = editor.buffer().read(cx).as_singleton().unwrap();
+            let snapshot = buffer.read(cx).snapshot();
+            snapshot
+                .syntax_layers()
+                .flat_map(|layer| {
+                    let mut nodes = Vec::new();
+                    let mut stack = vec![layer.node()];
+                    while let Some(node) = stack.pop() {
+                        nodes.push(format!("{} {:?}", node.kind(), node.byte_range()));
+                        for index in (0..node.child_count() as u32).rev() {
+                            if let Some(child) = node.child(index) {
+                                stack.push(child);
+                            }
+                        }
+                    }
+                    nodes
+                })
+                .collect()
+        });
+        panic!(
+            "expected 1 linked-image block, got {block_count}; tree was:\n{}",
+            debug.join("\n")
+        );
+    }
+}
+
+
+#[gpui::test]
+async fn test_images_section_context(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {r#"
+        ˇ## 9. Images
+
+        Inline image:
+
+        ![Placeholder image](https://placehold.co/300x150.png "A placeholder")
+
+        Reference-style image:
+
+        ![Placeholder ref][img]
+
+        Image as a link:
+
+        [![Clickable image](https://placehold.co/150x60.png)](https://example.com)
+
+        Broken image (alt text should show): ![missing image](nonexistent.png)
+
+        [img]: https://placehold.co/200x100.png
+    "#});
+    cx.executor().run_until_parked();
+    let (blocks, rows): (usize, Vec<(u32, u32)>) = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let addon = editor.addon::<LivePreviewAddon>().unwrap();
+        let rows = addon
+            .applied_blocks
+            .iter()
+            .map(|block| {
+                (
+                    block.range.start.to_point(&snapshot).row,
+                    block.range.end.to_point(&snapshot).row,
+                )
+            })
+            .collect();
+        (addon.applied_blocks.len(), rows)
+    });
+    // Inline image, reference image, and linked image; the heading is
+    // revealed because the cursor sits on it.
+    assert_eq!(blocks, 3, "applied block rows: {rows:?}");
+    assert!(rows.contains(&(12, 12)), "linked image row missing: {rows:?}");
+}
+
+#[gpui::test]
+async fn test_concealments_invisible_to_fold_machinery(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇplain line\nsome **bold** text\n");
+    cx.executor().run_until_parked();
+    assert!(cx.display_text().contains("some bold text"));
+
+    // "Unfold All" must not reveal concealments: they are not folds.
+    cx.update_editor(|editor, window, cx| {
+        editor.unfold_all(&Default::default(), window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert!(
+        cx.display_text().contains("some bold text"),
+        "unfold-all revealed concealments: {}",
+        cx.display_text()
+    );
+
+    // Fold queries (what the gutter and fold persistence read) see nothing.
+    let fold_count = cx.update_editor(|editor, window, cx| {
+        let _ = &window;
+        let snapshot = editor.snapshot(window, cx);
+        let len = snapshot.buffer_snapshot().len();
+        snapshot.folds_in_range(MultiBufferOffset(0)..len).count()
+    });
+    assert_eq!(fold_count, 0);
+
+    // No row reads as folded (the gutter's chevron predicate), across
+    // concealed inline markers, bullets, headings, and rules.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        # Heading
+
+        ---
+
+        - bullet with **bold** text
+        - [ ] a task
+
+        [a link](https://example.com)
+    "});
+    cx.executor().run_until_parked();
+    // The gutter's chevron predicate: fold-map folds only.
+    let folded_rows: Vec<u32> = cx.update_editor(|editor, window, cx| {
+        let _ = &window;
+        let snapshot = editor.snapshot(window, cx);
+        let max_row = snapshot.buffer_snapshot().max_point().row;
+        (0..=max_row)
+            .filter(|row| {
+                snapshot
+                    .fold_snapshot()
+                    .is_line_folded(multi_buffer::MultiBufferRow(*row))
+            })
+            .collect()
+    });
+    assert_eq!(folded_rows, Vec::<u32>::new());
+}
+
+#[test]
+fn test_image_source_resolution_decodes_percent_encoding() {
+    let dir = std::env::temp_dir().join("mdlp-resolver-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    // macOS screenshot names mix ASCII spaces (percent-encoded in links)
+    // with a raw narrow no-break space before "AM".
+    let file_name = "Screenshot 2026-08-09 at 11.38.37\u{202f}AM.png";
+    std::fs::write(dir.join(file_name), b"png").unwrap();
+
+    let destination = "Screenshot%202026-08-09%20at%2011.38.37\u{202f}AM.png";
+    assert!(
+        resolve_image_source(destination, Some(&dir)).is_some(),
+        "percent-encoded path failed to resolve"
+    );
+    assert!(resolve_image_source("missing%20file.png", Some(&dir)).is_none());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[gpui::test]
+async fn test_image_size_syntax(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        ![sized|640](a.png)
+
+        ![sized dims|320x200](b.png)
+
+        ![unsized](c.png)
+    "});
+    cx.executor().run_until_parked();
+    let widths: Vec<Option<f32>> = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .filter_map(|block| match block.kind {
+                BlockRenderKind::Image { display_width, .. } => Some(display_width),
+                _ => None,
+            })
+            .collect()
+    });
+    assert_eq!(widths, vec![Some(640.), Some(320.), None]);
+}
+
+#[test]
+fn test_with_image_width_rewrites_alt() {
+    assert_eq!(
+        with_image_width("![alt](a.png)", 500).as_deref(),
+        Some("![alt|500](a.png)")
+    );
+    assert_eq!(
+        with_image_width("![alt|300](a.png)", 500).as_deref(),
+        Some("![alt|500](a.png)")
+    );
+    assert_eq!(
+        with_image_width("![alt|320x200](a.png)", 500).as_deref(),
+        Some("![alt|500](a.png)")
+    );
+    assert_eq!(
+        with_image_width("![](a.png)", 500).as_deref(),
+        Some("![|500](a.png)")
+    );
+    assert_eq!(
+        with_image_width("![ref style|300][img]", 500).as_deref(),
+        Some("![ref style|500][img]")
+    );
+    // A pipe that is not a size suffix stays intact.
+    assert_eq!(
+        with_image_width("![a|b](a.png)", 500).as_deref(),
+        Some("![a|b|500](a.png)")
+    );
+}
+
+#[gpui::test]
+async fn test_wikilinks_conceal(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        see [[CLAUDE]] and [[notes/plan|the plan]] here
+        embed stays raw: ![[image.png]]
+        code stays raw: `[[not a link]]`
+    "});
+    cx.executor().run_until_parked();
+    let display = cx.display_text();
+    assert!(display.contains("see CLAUDE and the plan here"), "{display}");
+    assert!(display.contains("embed stays raw: ![[image.png]]"), "{display}");
+    assert!(display.contains("code stays raw: [[not a link]]"), "{display}");
+}
+
+#[gpui::test]
+async fn test_table_structure_extraction(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | Left | Center | Right |
+        |:-----|:------:|------:|
+        | a    |   b    |     c |
+        | d    |   e    |     f |
+    "});
+    cx.executor().run_until_parked();
+    let (structure, cell_texts) = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let markers = extract_markers(editor, cx).unwrap();
+        let structure = markers
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(structure) => Some(structure.clone()),
+                _ => None,
+            })
+            .expect("table structure");
+        let texts: Vec<String> = structure
+            .cells_in_order()
+            .iter()
+            .map(|range| {
+                let start = range.start.to_offset(&snapshot);
+                let end = range.end.to_offset(&snapshot);
+                snapshot
+                    .text_for_range(start..end)
+                    .collect::<String>()
+                    .trim()
+                    .to_string()
+            })
+            .collect();
+        (structure, texts)
+    });
+    assert_eq!(structure.header.len(), 3);
+    assert_eq!(structure.rows.len(), 2);
+    assert_eq!(
+        structure.alignments,
+        vec![
+            CellAlignment::Left,
+            CellAlignment::Center,
+            CellAlignment::Right
+        ]
+    );
+    assert_eq!(
+        cell_texts,
+        vec!["Left", "Center", "Right", "a", "b", "c", "d", "e", "f"]
+    );
+
+    // Empty cells omitted from the syntax tree are padded to a rectangle.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B | C |
+        |---|---|---|
+        | 1 |   | 3 |
+        |   | 2 |   |
+    "});
+    cx.executor().run_until_parked();
+    let structure = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(structure) => Some(structure.clone()),
+                _ => None,
+            })
+            .expect("table structure")
+    });
+    assert_eq!(structure.header.len(), 3);
+    assert!(structure.rows.iter().all(|row| row.len() == 3));
+    // Empty cells sit between pipes, so they are real editable ranges with
+    // correct column identity — never sentinels shifted to the row's end.
+    let row_texts: Vec<Vec<String>> = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        structure
+            .rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| {
+                        assert!(cell.start != Anchor::Min, "unexpected sentinel cell");
+                        let start = cell.start.to_offset(&snapshot);
+                        let end = cell.end.to_offset(&snapshot);
+                        snapshot
+                            .text_for_range(start..end)
+                            .collect::<String>()
+                            .trim()
+                            .to_string()
+                    })
+                    .collect()
+            })
+            .collect()
+    });
+    assert_eq!(row_texts, vec![vec!["1", "", "3"], vec!["", "2", ""]]);
+}
+
+#[gpui::test]
+async fn test_table_structural_changes(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | 1 | 2 |
+    "});
+    cx.executor().run_until_parked();
+    let range = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table")
+    });
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddColumn, cx);
+    });
+    cx.executor().run_until_parked();
+    assert!(cx.buffer_text().contains("| A | B |   |"), "{}", cx.buffer_text());
+
+    // Reuse the now-stale range on purpose: structural ops must re-resolve the
+    // table from the live tree, since widget closures outlive edits.
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddRow, cx);
+    });
+    cx.executor().run_until_parked();
+    let text = cx.buffer_text();
+    let table_lines: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(table_lines.len(), 4, "{text}");
+    assert!(
+        text.lines().filter(|line| line.starts_with('|')).all(|line| line.matches('|').count() == 4),
+        "every table line should have 3 columns after the changes: {text}"
+    );
+    assert_eq!(table_lines.len(), 4, "{text}");
+}
+
+
+#[gpui::test]
+async fn test_add_row_no_outer_pipes(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        Name | Value
+        --- | ---
+        alpha | 1
+        beta | 2
+
+        after
+    "});
+    cx.executor().run_until_parked();
+    let range = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table")
+    });
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddRow, cx);
+    });
+    cx.executor().run_until_parked();
+    let text = cx.buffer_text();
+    let table_lines: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(
+        table_lines,
+        vec![
+            "| Name | Value |",
+            "| --- | --- |",
+            "| alpha | 1 |",
+            "| beta | 2 |",
+            "|   |   |",
+        ],
+        "full text: {text:?}"
+    );
+    assert!(text.contains("\n\nafter"), "must not eat the blank line: {text:?}");
+}
+
+#[gpui::test]
+async fn test_rapid_structural_changes_between_reparses(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | 1 | 2 |
+    "});
+    cx.executor().run_until_parked();
+    let range = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table")
+    });
+    // Two clicks in quick succession: no run_until_parked between them, so
+    // the second acts before any reparse — it must still resolve the table
+    // from live text instead of the stale tree.
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddRow, cx);
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddRow, cx);
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddColumn, cx);
+    });
+    cx.executor().run_until_parked();
+    let text = cx.buffer_text();
+    let table_lines: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(
+        table_lines,
+        vec![
+            "| A | B |   |",
+            "| --- | --- | --- |",
+            "| 1 | 2 |   |",
+            "|   |   |   |",
+            "|   |   |   |",
+        ],
+        "full text: {text:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_add_row_extends_widget_over_empty_row(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇMinimal table without outer pipes:
+
+        Name | Value
+        --- | ---
+        alpha | 1
+        beta | 2
+
+        Table with empty cells:
+    "});
+    cx.executor().run_until_parked();
+    let range = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table")
+    });
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::AddRow, cx);
+    });
+    cx.executor().run_until_parked();
+    // tree-sitter-md errors on the all-empty row and ends its table node
+    // early; the widget must still span the full textual table.
+    let tables: Vec<(u32, u32, usize)> = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .filter_map(|block| match &block.kind {
+                BlockRenderKind::Table(structure) => Some((
+                    block.range.start.to_point(&snapshot).row,
+                    block.range.end.to_point(&snapshot).row,
+                    structure.rows.len(),
+                )),
+                _ => None,
+            })
+            .collect()
+    });
+    assert_eq!(tables, vec![(2, 6, 3)], "text: {:?}", cx.buffer_text());
+}
+
+#[gpui::test]
+async fn test_table_reveals_only_via_button(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | 1 | 2 |
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+
+    // Cursor inside the table does NOT reveal its source.
+    cx.set_state(indoc::indoc! {"
+        plain line
+
+        | A | B |
+        | --- | --- |
+        | 1 |ˇ 2 |
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+
+    // Marking the block explicitly revealed (what the `</>` button does)
+    // removes the widget while the cursor stays inside.
+    cx.update_editor(|editor, _, cx| {
+        let range = extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table");
+        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+            addon.source_revealed = Some(range);
+        }
+        apply_decorations(editor, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 0);
+
+    // Moving the cursor out re-renders the widget and clears the reveal.
+    cx.set_state(indoc::indoc! {"
+        plain lineˇ
+
+        | A | B |
+        | --- | --- |
+        | 1 | 2 |
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+    let cleared = cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.source_revealed.clone())
+            .is_none()
+    });
+    assert!(cleared, "reveal must clear when the selection leaves the block");
+}
+
+#[gpui::test]
+async fn test_move_and_delete_rows_columns(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B | C |
+        | --- | --- | --- |
+        | 1 | 2 | 3 |
+        | x | y | z |
+    "});
+    cx.executor().run_until_parked();
+    let range = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .unwrap()
+            .blocks
+            .iter()
+            .find_map(|block| match &block.kind {
+                BlockRenderKind::Table(_) => Some(block.range.clone()),
+                _ => None,
+            })
+            .expect("table")
+    });
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(
+            editor,
+            &range,
+            TableStructuralChange::MoveRow { from: 0, to: 1 },
+            cx,
+        );
+    });
+    cx.executor().run_until_parked();
+    assert!(
+        cx.buffer_text().contains("| x | y | z |\n| 1 | 2 | 3 |"),
+        "{}",
+        cx.buffer_text()
+    );
+
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(
+            editor,
+            &range,
+            TableStructuralChange::MoveColumn { from: 0, to: 2 },
+            cx,
+        );
+    });
+    cx.executor().run_until_parked();
+    // Move semantics: remove+insert (drag across positions), not swap.
+    assert!(
+        cx.buffer_text().contains("| B | C | A |"),
+        "{}",
+        cx.buffer_text()
+    );
+
+    cx.update_editor(|editor, _, cx| {
+        apply_table_structural_change(editor, &range, TableStructuralChange::DeleteRow(1), cx);
+        apply_table_structural_change(editor, &range, TableStructuralChange::DeleteColumn(1), cx);
+    });
+    cx.executor().run_until_parked();
+    let text = cx.buffer_text();
+    assert!(text.contains("| B | A |"), "{text}");
+    assert!(text.contains("| y | x |"), "{text}");
+    assert!(!text.contains("| 1 |"), "deleted row should be gone: {text}");
+}
+
+#[gpui::test]
+async fn test_drag_row_reorders_via_mouse(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | one | 1 |
+        | two | 2 |
+    "});
+    cx.executor().run_until_parked();
+
+    let handle = cx
+        .cx
+        .debug_bounds("mdlp-row-handle-0")
+        .expect("row handle rendered");
+    let target = cx
+        .cx
+        .debug_bounds("mdlp-cell-1-0")
+        .expect("target cell rendered");
+
+    let start = handle.center();
+    cx.cx
+        .simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::none());
+    // Cross the drag threshold, then hover the target row.
+    cx.cx.simulate_mouse_move(
+        start + gpui::point(gpui::px(0.), gpui::px(6.)),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    let below_target = target.center() + gpui::point(gpui::px(0.), target.size.height * 0.3);
+    cx.cx.simulate_mouse_move(
+        below_target,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+
+    let (drag_active, source_set, boundary_set) = cx.update_editor(|editor, _, cx| {
+        let addon = editor.addon::<LivePreviewAddon>().expect("addon");
+        (
+            cx.has_active_drag(),
+            addon.drag_source.as_ref().map(|s| s.unit),
+            addon.drop_boundary.as_ref().map(|(_, boundary)| *boundary),
+        )
+    });
+    assert!(drag_active, "drag should be active after moving past threshold");
+    assert_eq!(source_set, Some(TableUnit::Row(0)), "source should be recorded");
+    assert_eq!(
+        boundary_set,
+        Some(TableBoundary::Row(2)),
+        "lower half of row 1 should target the boundary below it"
+    );
+
+    cx.cx.simulate_mouse_up(
+        below_target,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+
+    let text = cx.buffer_text();
+    let rows: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(
+        rows,
+        vec!["| A | B |", "| --- | --- |", "| two | 2 |", "| one | 1 |"],
+        "rows should be reordered by the drop: {text:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_drag_row_drop_anywhere_on_table(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | one | 1 |
+        | two | 2 |
+    "});
+    cx.executor().run_until_parked();
+
+    let handle = cx
+        .cx
+        .debug_bounds("mdlp-row-handle-0")
+        .expect("row handle rendered");
+    let target_cell = cx
+        .cx
+        .debug_bounds("mdlp-cell-1-0")
+        .expect("target cell rendered");
+    let target_handle = cx
+        .cx
+        .debug_bounds("mdlp-row-handle-1")
+        .expect("target row handle rendered");
+
+    let start = handle.center();
+    cx.cx
+        .simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::none());
+    cx.cx.simulate_mouse_move(
+        start + gpui::point(gpui::px(0.), gpui::px(6.)),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    // Hover the target row's lower half (tracks the below-boundary), then
+    // drift onto the row HANDLE and release there — like a user following
+    // the pill column.
+    cx.cx.simulate_mouse_move(
+        target_cell.center() + gpui::point(gpui::px(0.), target_cell.size.height * 0.3),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    let handle_lower = target_handle.center()
+        + gpui::point(gpui::px(0.), target_handle.size.height * 0.3);
+    cx.cx.simulate_mouse_move(
+        handle_lower,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.cx.simulate_mouse_up(
+        handle_lower,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+
+    let text = cx.buffer_text();
+    let rows: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(
+        rows,
+        vec!["| A | B |", "| --- | --- |", "| two | 2 |", "| one | 1 |"],
+        "release anywhere over the table should still apply the tracked drop: {text:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_drag_column_release_on_handle_strip(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | one | 1 |
+    "});
+    cx.executor().run_until_parked();
+
+    let source = cx
+        .cx
+        .debug_bounds("mdlp-column-handle-0")
+        .expect("column handle rendered");
+    let target = cx
+        .cx
+        .debug_bounds("mdlp-column-handle-1")
+        .expect("second column handle rendered");
+
+    let start = source.center();
+    cx.cx
+        .simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::none());
+    cx.cx.simulate_mouse_move(
+        start + gpui::point(gpui::px(6.), gpui::px(0.)),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    let right_half = target.center() + gpui::point(target.size.width * 0.3, gpui::px(0.));
+    cx.cx.simulate_mouse_move(
+        right_half,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.cx.simulate_mouse_up(
+        right_half,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+
+    let text = cx.buffer_text();
+    assert!(
+        text.contains("| B | A |"),
+        "dragging a column along the handle strip should reorder: {text:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_drag_survives_mid_gesture_repaint(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B |
+        | --- | --- |
+        | one | 1 |
+        | two | 2 |
+    "});
+    cx.executor().run_until_parked();
+
+    let handle = cx
+        .cx
+        .debug_bounds("mdlp-row-handle-0")
+        .expect("row handle rendered");
+    let target = cx
+        .cx
+        .debug_bounds("mdlp-cell-1-0")
+        .expect("target cell rendered");
+
+    let start = handle.center();
+    cx.cx
+        .simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::none());
+    // A repaint lands between press and first movement (cursor blink, agent
+    // panel updates, etc.) — the armed gesture must survive it.
+    cx.update_editor(|_, _, cx| cx.notify());
+    cx.executor().run_until_parked();
+    cx.cx.simulate_mouse_move(
+        start + gpui::point(gpui::px(0.), gpui::px(6.)),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.update_editor(|_, _, cx| cx.notify());
+    cx.executor().run_until_parked();
+    let below_target = target.center() + gpui::point(gpui::px(0.), target.size.height * 0.3);
+    cx.cx.simulate_mouse_move(
+        below_target,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.cx.simulate_mouse_up(
+        below_target,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+
+    let text = cx.buffer_text();
+    let rows: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
+    assert_eq!(
+        rows,
+        vec!["| A | B |", "| --- | --- |", "| two | 2 |", "| one | 1 |"],
+        "drag should survive repaints mid-gesture: {text:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_drag_column_between_others(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | A | B | C |
+        | --- | --- | --- |
+        | 1 |   | 3 |
+    "});
+    cx.executor().run_until_parked();
+
+    let source = cx
+        .cx
+        .debug_bounds("mdlp-column-handle-0")
+        .expect("column handle rendered");
+    let target = cx.cx.debug_bounds("mdlp-cell-h-2").expect("header C rendered");
+
+    let start = source.center();
+    cx.cx
+        .simulate_mouse_down(start, gpui::MouseButton::Left, gpui::Modifiers::none());
+    cx.cx.simulate_mouse_move(
+        start + gpui::point(gpui::px(6.), gpui::px(0.)),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    // Left half of column C targets the boundary between B and C.
+    let left_half = target.center() - gpui::point(target.size.width * 0.3, gpui::px(0.));
+    cx.cx.simulate_mouse_move(
+        left_half,
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    let boundary = cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.drop_boundary.as_ref().map(|(_, boundary)| *boundary))
+    });
+    assert_eq!(
+        boundary,
+        Some(TableBoundary::Column(2)),
+        "left half of C should target the B|C boundary"
+    );
+    cx.cx
+        .simulate_mouse_up(left_half, gpui::MouseButton::Left, gpui::Modifiers::none());
+    cx.executor().run_until_parked();
+
+    let text = cx.buffer_text();
+    assert!(
+        text.contains("| B | A | C |"),
+        "A dropped between B and C: {text:?}"
+    );
+}

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -194,6 +194,7 @@ impl VsCodeSettings {
             helix_mode: None,
             hide_mouse: None,
             image_viewer: None,
+            markdown_live_preview: None,
             markdown_preview: None,
             journal: None,
             language_models: None,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -208,6 +208,9 @@ pub struct SettingsContent {
     /// The settings for the markdown preview.
     pub markdown_preview: Option<MarkdownPreviewSettingsContent>,
 
+    /// The settings for markdown live preview in the editor.
+    pub markdown_live_preview: Option<MarkdownLivePreviewSettingsContent>,
+
     pub repl: Option<ReplSettingsContent>,
 
     /// Whether or not to enable Helix mode.
@@ -1211,6 +1214,24 @@ pub struct MarkdownPreviewSettingsContent {
     ///
     /// Default: 800
     pub max_width: Option<f32>,
+}
+
+/// The settings for markdown live preview in the editor.
+#[with_fallible_options]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, Default, PartialEq)]
+pub struct MarkdownLivePreviewSettingsContent {
+    /// Whether to render markdown inline in the editor (Obsidian-style live
+    /// preview): syntax markers are hidden, and elements like headings,
+    /// tables, and images are rendered, except on lines the cursor is on.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+    /// Folder for attachments dropped onto a markdown buffer, relative to
+    /// the note's folder. An empty string stores attachments directly in
+    /// the note's folder.
+    ///
+    /// Default: "attachments"
+    pub attachments_folder: Option<String>,
 }
 
 /// The settings for the image viewer.

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -158,6 +158,7 @@ line_ending_selector.workspace = true
 log.workspace = true
 lsp_locations.workspace = true
 markdown.workspace = true
+markdown_live_preview.workspace = true
 markdown_preview.workspace = true
 menu.workspace = true
 migrator.workspace = true
@@ -285,7 +286,7 @@ repl = { workspace = true, features = ["test-support"] }
 
 
 
-[package.metadata.bundle-dev]
+[package.metadata.bundle]
 icon = ["resources/app-icon-dev@2x.png", "resources/app-icon-dev.png"]
 identifier = "dev.zed.Zed-Dev"
 name = "Zed Dev"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -772,6 +772,7 @@ fn main() {
         git_ui::init(cx);
         feedback::init(cx);
         markdown_preview::init(cx);
+        markdown_live_preview::init(cx);
         csv_preview::init(cx);
         svg_preview::init(cx);
         onboarding::init(cx);


### PR DESCRIPTION
Implements Obsidian-style live preview for markdown buffers, as requested in #21717 (demo video and prebuilt test binaries in [this comment](https://github.com/zed-industries/zed/issues/21717#issuecomment-5247269964)).

The buffer stays a plain text editor throughout — no separate mode, no lossy conversion:

- Syntax markers (`**`, `*`, `~~`, backticks, link targets, list bullets, checkboxes) are concealed and rendered inline, revealing per token when the selection touches them
- Headings, tables, images, code blocks, mermaid diagrams, blockquotes, rules, and frontmatter render as block widgets on lines the cursor isn't on
- Tables are editable in place: click a cell to edit (Tab/Enter/Esc to navigate/commit/cancel), hover `+` to add rows/columns, drag handles to reorder with insertion indicators, Delete to remove a selected row/column
- Images: click to select, drag a corner to resize (writes `|width` alt-text syntax), `</>` reveals source; files dropped onto a markdown buffer are copied to a configurable attachments folder and inserted as links
- Controlled by a `markdown_live_preview.enabled` setting (default on) and a per-buffer `markdown: toggle live preview` action

## Architecture

Nearly everything lives in a new `markdown_live_preview` crate, implemented as an editor `Addon` driven by `Reparsed`/`SelectionsChanged` events. The editor-core changes are deliberately small and general-purpose:

- **A concealment store in `FoldMap`**: display-only replacements that fold queries never observe — no gutter chevrons, no cursor interference, no persistence, bulk-diffed by `(range, content_key)` so unchanged concealments are reused across updates. This primitive is independent of markdown and would also serve #18420 (visual text substitutions). I'm happy to split it into a standalone PR first if that's a better shape for review.
- A parameterized `HighlightKey::MarkdownLivePreview` variant, and an `Item::handle_drop` implementation for `Editor`.

Tables are parsed from buffer text (GFM's unescaped-pipe rule) rather than tree-sitter nodes, because the tree-sitter markdown grammar omits empty cells and errors on all-empty rows; the tree is used only to locate tables. All widget interactions re-resolve state from the live buffer at action time, since reparses are async and widget-captured state can describe stale text.

## Testing

- 30 unit/integration tests in the crate, including full mouse-gesture drag simulations (via `debug_selector` bounds + simulated mouse events) and pinned invariants for the editor-core contracts (concealments invisible to fold machinery, highlight-key namespace independence)
- Manually dogfooded for note-taking against a kitchen-sink GFM document

Release Notes:

- Added an Obsidian-style live preview for markdown buffers, with inline syntax concealment, rendered block widgets, editable tables, and image resize (`markdown_live_preview.enabled` setting, `markdown: toggle live preview` action)
