### PR TITLE
terminal: Close process groups on shutdown, only when intended

### DIFF
--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
 use std::num::NonZeroU32;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
+use std::os::fd::OwnedFd;
 use std::{borrow::Cow, io, ops::RangeInclusive, path::PathBuf, sync::Arc};
 
 mod hyperlinks;
@@ -64,7 +64,13 @@ pub(super) struct AlacrittySearch {
 #[cfg(unix)]
 impl From<&AlacrittyPty> for ProcessIdGetter {
     fn from(pty: &AlacrittyPty) -> Self {
-        Self::new(pty.file().as_raw_fd(), pty.child().id())
+        let handle = pty
+            .file()
+            .try_clone()
+            .map(|file| Arc::new(OwnedFd::from(file)))
+            .map_err(|error| log::warn!("failed to duplicate the PTY master fd: {error}"))
+            .ok();
+        Self::new(handle, pty.child().id())
     }
 }
 

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -1,5 +1,7 @@
 use gpui::{Context, Task};
 use parking_lot::{MappedRwLockReadGuard, Mutex, RwLock, RwLockReadGuard};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::{path::PathBuf, sync::Arc};
 
 #[cfg(target_os = "windows")]
@@ -9,20 +11,19 @@ use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System, Updat
 
 use crate::{Event, Terminal};
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct ProcessIdGetter {
+    /// Zed's own dup of the PTY master: the event loop closes its fd as soon
+    /// as the child exits, after which the raw number can be recycled for a
+    /// newer terminal's PTY (#62095, #62286).
+    #[cfg(unix)]
+    handle: Option<Arc<OwnedFd>>,
+    #[cfg(not(unix))]
     handle: i32,
     fallback_pid: u32,
 }
 
 impl ProcessIdGetter {
-    pub(crate) fn new(handle: i32, fallback_pid: u32) -> ProcessIdGetter {
-        ProcessIdGetter {
-            handle,
-            fallback_pid,
-        }
-    }
-
     pub fn fallback_pid(&self) -> Pid {
         Pid::from_u32(self.fallback_pid)
     }
@@ -30,13 +31,16 @@ impl ProcessIdGetter {
 
 #[cfg(unix)]
 impl ProcessIdGetter {
+    pub(crate) fn new(handle: Option<Arc<OwnedFd>>, fallback_pid: u32) -> ProcessIdGetter {
+        ProcessIdGetter {
+            handle,
+            fallback_pid,
+        }
+    }
+
     fn pid(&self) -> Option<Pid> {
-        // Negative pid means error.
-        // Zero pid means no foreground process group is set on the PTY yet.
-        // Avoid killing the current process by returning a zero pid.
-        let pid = unsafe { libc::tcgetpgrp(self.handle) };
-        if pid > 0 {
-            return Some(Pid::from_u32(pid as u32));
+        if let Some(foreground) = self.foreground_process_group_id() {
+            return Some(Pid::from_u32(foreground as u32));
         }
 
         if self.fallback_pid > 0 {
@@ -45,10 +49,26 @@ impl ProcessIdGetter {
 
         None
     }
+
+    fn foreground_process_group_id(&self) -> Option<libc::pid_t> {
+        let handle = self.handle.as_ref()?;
+        // Negative means error; zero means no foreground group is set or the
+        // session is dead — filtered so callers never killpg(0), i.e. Zed's
+        // own group.
+        let pid = unsafe { libc::tcgetpgrp(handle.as_raw_fd()) };
+        (pid > 0).then_some(pid)
+    }
 }
 
 #[cfg(windows)]
 impl ProcessIdGetter {
+    pub(crate) fn new(handle: i32, fallback_pid: u32) -> ProcessIdGetter {
+        ProcessIdGetter {
+            handle,
+            fallback_pid,
+        }
+    }
+
     fn pid(&self) -> Option<Pid> {
         let pid = unsafe { GetProcessId(HANDLE(self.handle as _)) };
         // the GetProcessId may fail and returns zero, which will lead to a stack overflow issue
@@ -70,6 +90,68 @@ pub(crate) struct ProcessInfo {
     pub(crate) name: String,
     pub(crate) cwd: PathBuf,
     pub(crate) argv: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TerminalProcessIds {
+    #[cfg(unix)]
+    child: Option<libc::pid_t>,
+    #[cfg(unix)]
+    foreground: Option<libc::pid_t>,
+}
+
+#[cfg(unix)]
+impl TerminalProcessIds {
+    fn process_group_ids(&self) -> impl Iterator<Item = libc::pid_t> {
+        [self.child, self.foreground].into_iter().flatten()
+    }
+
+    /// `killpg` failing with `ESRCH` (the group already exited) is expected,
+    /// so failures only surface as an unsuccessful signal.
+    fn signal_process_groups(&self, signal: i32) -> bool {
+        let mut signalled = false;
+        for process_group_id in self.process_group_ids() {
+            signalled |= unsafe { libc::killpg(process_group_id, signal) } == 0;
+        }
+        signalled
+    }
+
+    pub(crate) fn terminate(&self) -> bool {
+        self.signal_process_groups(libc::SIGTERM)
+    }
+
+    pub(crate) fn kill(&self) -> bool {
+        self.signal_process_groups(libc::SIGKILL)
+    }
+}
+
+#[cfg(not(unix))]
+impl TerminalProcessIds {
+    pub(crate) fn terminate(&self) -> bool {
+        false
+    }
+
+    // Windows has no process groups to escalate on; killing the child relies
+    // on [`PtyProcessInfo::kill_child_process`] instead.
+    pub(crate) fn kill(&self) -> bool {
+        false
+    }
+}
+
+/// The ids passed here may be long dead with their pid recycled by an
+/// unrelated process, so an unvalidated `killpg` can kill an innocent process
+/// group (#62095, #62286). The spawned child called `setsid`, so its pid
+/// doubles as the session id every candidate group must still belong to. This
+/// errs safe: a group whose leader exited is skipped even if members live on.
+#[cfg(unix)]
+fn process_group_in_session(
+    process_group_id: libc::pid_t,
+    session_id: libc::pid_t,
+) -> Option<libc::pid_t> {
+    // killpg(0) signals Zed's own process group, so never let a non-positive
+    // id through.
+    (process_group_id > 0 && unsafe { libc::getsid(process_group_id) } == session_id)
+        .then_some(process_group_id)
 }
 
 /// Fetches Zed-relevant Pseudo-Terminal (PTY) process information
@@ -148,10 +230,18 @@ impl PtyProcessInfo {
 
     #[cfg(unix)]
     pub(crate) fn kill_current_process(&self) -> bool {
-        let Some(pid) = self.pid_getter.pid() else {
+        // The foreground group read through our own PTY dup can only name this
+        // terminal's session (guarding it would even skip jobs whose group
+        // leader already exited); only the fallback pid can be stale.
+        let child_pid = self.pid_getter.fallback_pid().as_u32() as libc::pid_t;
+        let process_group_id = self
+            .pid_getter
+            .foreground_process_group_id()
+            .or_else(|| process_group_in_session(child_pid, child_pid));
+        let Some(process_group_id) = process_group_id else {
             return false;
         };
-        unsafe { libc::killpg(pid.as_u32() as i32, libc::SIGKILL) == 0 }
+        unsafe { libc::killpg(process_group_id, libc::SIGKILL) == 0 }
     }
 
     #[cfg(not(unix))]
@@ -160,18 +250,36 @@ impl PtyProcessInfo {
     }
 
     pub(crate) fn kill_child_process(&self) -> bool {
+        #[cfg(unix)]
+        {
+            let child_pid = self.pid_getter.fallback_pid().as_u32() as libc::pid_t;
+            if process_group_in_session(child_pid, child_pid).is_none() {
+                return false;
+            }
+        }
         self.get_child().is_some_and(|process| process.kill())
     }
 
+    /// Under job control the foreground job runs in a separate process group
+    /// that `killpg` on the shell's group never reaches, so both groups are
+    /// captured (#47412). A terminal whose child already exited captures
+    /// nothing, keeping its cleanup signal-free.
     #[cfg(unix)]
-    pub(crate) fn terminate_child_process(&self) -> bool {
-        let pid = self.pid_getter.fallback_pid();
-        unsafe { libc::killpg(pid.as_u32() as i32, libc::SIGTERM) == 0 }
+    pub(crate) fn capture_process_ids(&self) -> TerminalProcessIds {
+        let child_pid = self.pid_getter.fallback_pid().as_u32() as libc::pid_t;
+        TerminalProcessIds {
+            child: process_group_in_session(child_pid, child_pid),
+            foreground: self
+                .pid_getter
+                .foreground_process_group_id()
+                .filter(|foreground| *foreground != child_pid)
+                .and_then(|foreground| process_group_in_session(foreground, child_pid)),
+        }
     }
 
     #[cfg(not(unix))]
-    pub(crate) fn terminate_child_process(&self) -> bool {
-        false
+    pub(crate) fn capture_process_ids(&self) -> TerminalProcessIds {
+        TerminalProcessIds {}
     }
 
     fn load(&self) -> Option<ProcessInfo> {
@@ -259,7 +367,7 @@ mod tests {
         reason = "the test needs real short-lived child processes and may block"
     )]
     fn process_map_stays_bounded() {
-        let mut info = PtyProcessInfo::new(ProcessIdGetter::new(-1, std::process::id()));
+        let mut info = PtyProcessInfo::new(ProcessIdGetter::new(None, std::process::id()));
         assert!(
             info.get_child().is_some(),
             "the spawned child must be inspectable for kill_child_process \
@@ -277,7 +385,7 @@ mod tests {
                 .arg("30")
                 .spawn()
                 .expect("failed to spawn child process");
-            info.pid_getter = ProcessIdGetter::new(-1, child.id());
+            info.pid_getter = ProcessIdGetter::new(None, child.id());
             assert!(info.load_for_test().is_some());
             child.kill().expect("failed to kill child process");
             child.wait().expect("failed to wait for child process");

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -50,6 +50,17 @@ impl ProcessIdGetter {
         None
     }
 
+    /// Rebuilds the pre-#62095 hazard deterministically: a getter whose fd
+    /// number was recycled behaved exactly like one holding another live
+    /// terminal's PTY handle next to its own long-dead fallback pid.
+    #[cfg(test)]
+    pub(crate) fn with_fallback_pid(&self, fallback_pid: u32) -> ProcessIdGetter {
+        ProcessIdGetter {
+            handle: self.handle.clone(),
+            fallback_pid,
+        }
+    }
+
     fn foreground_process_group_id(&self) -> Option<libc::pid_t> {
         let handle = self.handle.as_ref()?;
         // Negative means error; zero means no foreground group is set or the

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -5257,8 +5257,10 @@ mod tests {
             "replacement foreground process should run separately from its shell"
         );
 
-        let stale_info =
-            PtyProcessInfo::new(ProcessIdGetter::new(None, replacement_foreground_pid as u32));
+        let stale_info = PtyProcessInfo::new(ProcessIdGetter::new(
+            None,
+            replacement_foreground_pid as u32,
+        ));
         let cleanup_signal_sent = stale_info.capture_process_ids().terminate();
         // `kill_active_task` reaches the same stale pid via `kill_current_process`.
         let kill_task_signal_sent = stale_info.kill_current_process();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -40,6 +40,7 @@ use std::{
     borrow::Cow,
     cmp::{self, min},
     fmt::{self, Display, Formatter},
+    future::Future,
     ops::{BitOr, BitOrAssign, Deref, Range as StdRange},
     path::{Path, PathBuf},
     process::ExitStatus,
@@ -74,6 +75,27 @@ use crate::alacritty::{
 };
 use crate::mappings::colors::to_vte_rgb;
 use crate::mappings::keys::to_esc_str;
+
+/// Must stay comfortably below [`gpui::SHUTDOWN_TIMEOUT`] so the SIGKILL
+/// escalation also completes when the whole app is quitting.
+const PROCESS_KILL_GRACE_PERIOD: Duration = Duration::from_millis(100);
+
+/// Closing the PTY only delivers SIGHUP, and a foreground job that ignores
+/// SIGHUP/SIGTERM would otherwise be orphaned (#47412). The groups are
+/// captured and validated once, up front, because the SIGKILL after the grace
+/// period must reach groups whose leader the SIGTERM already killed.
+fn terminate_processes_with_grace_period(
+    info: Arc<PtyProcessInfo>,
+    executor: BackgroundExecutor,
+) -> impl Future<Output = ()> {
+    let process_ids = info.capture_process_ids();
+    process_ids.terminate();
+    async move {
+        executor.timer(PROCESS_KILL_GRACE_PERIOD).await;
+        process_ids.kill();
+        info.kill_child_process();
+    }
+}
 
 /// Process-wide flag set by headless hosts (e.g. the eval CLI) that have no
 /// controlling TTY. In such sandboxes PTY allocation and acquiring a
@@ -1330,6 +1352,29 @@ impl TerminalBuilder {
     }
 
     pub fn subscribe(mut self, cx: &Context<Terminal>) -> Terminal {
+        // `Terminal::drop`'s detached SIGKILL escalation never runs when the
+        // whole app quits — the process exits once the `on_app_quit` futures
+        // resolve — so this quit observer repeats it with a future that keeps
+        // the app alive through the grace period (#47412). `Subscription` is
+        // not `Send`, so it can't be stored on `Terminal` (built on a
+        // background thread); its lifetime is tied to the entity's release.
+        let app_quit_subscription = cx.on_app_quit(|terminal, cx| {
+            let kill_processes = match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => Some(terminate_processes_with_grace_period(
+                    info.clone(),
+                    cx.background_executor().clone(),
+                )),
+                TerminalType::DisplayOnly => None,
+            };
+            async move {
+                if let Some(kill_processes) = kill_processes {
+                    kill_processes.await;
+                }
+            }
+        });
+        cx.on_release(move |_, _| drop(app_quit_subscription))
+            .detach();
+
         //Event loop
         self.terminal.event_loop_task = cx.spawn(async move |terminal, cx| {
             while let Some(event) = self.events_rx.next().await {
@@ -3230,16 +3275,10 @@ impl Drop for Terminal {
         if let TerminalType::Pty { pty_tx, info } =
             std::mem::replace(&mut self.terminal_type, TerminalType::DisplayOnly)
         {
+            let kill_processes =
+                terminate_processes_with_grace_period(info, self.background_executor.clone());
             pty_tx.shutdown();
-            info.terminate_child_process();
-
-            let timer = self.background_executor.timer(Duration::from_millis(100));
-            self.background_executor
-                .spawn(async move {
-                    timer.await;
-                    info.kill_child_process();
-                })
-                .detach();
+            self.background_executor.spawn(kill_processes).detach();
         }
     }
 }
@@ -4988,6 +5027,212 @@ mod tests {
         assert!(
             content.contains("test_output_before_kill"),
             "Output from before kill should be captured, got: {content}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn parse_pid_marker(content: &str, prefix: &str, suffix: &str) -> i32 {
+        content
+            .split(prefix)
+            .nth(1)
+            .and_then(|rest| rest.split(suffix).next())
+            .and_then(|pid| pid.trim().parse().ok())
+            .unwrap_or_else(|| {
+                panic!("failed to parse pid between {prefix:?} and {suffix:?} from: {content}")
+            })
+    }
+
+    /// Regression test for <https://github.com/zed-industries/zed/issues/47412>:
+    /// the shell ignores SIGHUP/SIGTERM and the `sleep`s inherit that, so only
+    /// the SIGKILL escalation can terminate them. The background `sleep` stays
+    /// in the shell's own group, while `set -m` places the foreground job in a
+    /// separate group that only the foreground-group capture reaches.
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_dropping_terminal_kills_processes_ignoring_sighup_and_sigterm(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (terminal, _completion_rx) = build_test_terminal_with_arguments(
+            cx,
+            "/bin/sh".to_string(),
+            vec![
+                "-c".to_string(),
+                "trap '' HUP TERM; sleep 300 & echo bg_marker_${!}_bgend; set -m; \
+                 /bin/sh -c 'echo fg_marker_$$_fgend; exec sleep 300'"
+                    .to_string(),
+            ],
+        )
+        .await;
+
+        assert_content_eventually(&terminal, "_fgend", cx).await;
+        let content = terminal.update(cx, |term, _| term.get_content());
+        let background_sleep_pid = parse_pid_marker(&content, "bg_marker_", "_bgend");
+        let foreground_sleep_pid = parse_pid_marker(&content, "fg_marker_", "_fgend");
+
+        let (shell_pid, captured_foreground_pid) =
+            terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => (
+                    info.pid_getter().fallback_pid().as_u32() as i32,
+                    info.pid().map(|pid| pid.as_u32() as i32),
+                ),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_eq!(
+            captured_foreground_pid,
+            Some(foreground_sleep_pid),
+            "the PTY should report the active foreground process group"
+        );
+
+        for pid in [background_sleep_pid, foreground_sleep_pid] {
+            assert_eq!(
+                unsafe { libc::kill(pid, 0) },
+                0,
+                "process {pid} should be running before the terminal is dropped"
+            );
+        }
+
+        // Assert the job-control arrangement so this test fails loudly instead
+        // of silently degrading into a shell-group-only test.
+        let shell_pgid = unsafe { libc::getpgid(shell_pid) };
+        let foreground_pgid = unsafe { libc::getpgid(foreground_sleep_pid) };
+        assert!(shell_pgid > 0 && foreground_pgid > 0);
+        assert_ne!(
+            foreground_pgid, shell_pgid,
+            "job control should place the foreground sleep in its own process group"
+        );
+        assert_eq!(
+            unsafe { libc::getpgid(background_sleep_pid) },
+            shell_pgid,
+            "the background sleep should stay in the shell's process group"
+        );
+
+        drop(terminal);
+        // Flush effects so the released terminal entity is actually dropped.
+        cx.update(|_| {});
+
+        for _ in 0..300 {
+            let background_dead = unsafe { libc::kill(background_sleep_pid, 0) } != 0;
+            let foreground_dead = unsafe { libc::kill(foreground_sleep_pid, 0) } != 0;
+            if background_dead && foreground_dead {
+                return;
+            }
+            cx.background_executor
+                .timer(Duration::from_millis(10))
+                .await;
+        }
+        panic!(
+            "processes survived dropping the terminal: background sleep {background_sleep_pid} \
+             alive: {}, foreground sleep {foreground_sleep_pid} alive: {}",
+            unsafe { libc::kill(background_sleep_pid, 0) } == 0,
+            unsafe { libc::kill(foreground_sleep_pid, 0) } == 0,
+        );
+    }
+
+    /// Regression test for <https://github.com/zed-industries/zed/issues/62095>
+    /// and <https://github.com/zed-industries/zed/issues/62286>: dropping a
+    /// terminal whose child has already exited (a completed task) must not
+    /// signal anything — in particular not the terminal that replaced it,
+    /// whose PTY may have recycled the same master fd number.
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_dropping_completed_terminal_does_not_kill_new_terminal(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (completed_terminal, completion_rx) = build_test_terminal(cx, "true", &[]).await;
+        completion_rx
+            .recv()
+            .await
+            .expect("completed terminal should report its exit status");
+
+        let (new_terminal, _completion_rx) = build_test_terminal(cx, "sleep", &["300"]).await;
+        let new_shell_pid = new_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+            TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32() as i32,
+            TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+        });
+
+        let (completed_child_pid, completed_foreground_pid) =
+            completed_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => (info.pid_getter().fallback_pid(), info.pid()),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_eq!(
+            completed_foreground_pid,
+            Some(completed_child_pid),
+            "a completed terminal whose PTY descriptor may have been reused must \
+             report its own child, not another terminal's foreground group"
+        );
+
+        drop(completed_terminal);
+        cx.update(|_| {});
+        cx.background_executor
+            .timer(PROCESS_KILL_GRACE_PERIOD + Duration::from_millis(50))
+            .await;
+
+        assert_eq!(
+            unsafe { libc::kill(new_shell_pid, 0) },
+            0,
+            "dropping a completed terminal should not kill a newly spawned terminal"
+        );
+    }
+
+    /// Even when a dead terminal's child pid has been recycled as the
+    /// process-group id of a live foreground job (simulated here by
+    /// constructing stale process info pointing at the replacement's
+    /// foreground group), neither cleanup nor killing the active task must
+    /// signal that group: the recycled id belongs to a different session.
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_stale_process_info_does_not_kill_reused_fallback_process_group(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (replacement_terminal, replacement_completion_rx) = build_test_terminal(
+            cx,
+            "/bin/sh -c 'echo replacement_fg_marker_$$_fgend; exec sleep 5'; echo done",
+            &[],
+        )
+        .await;
+        assert_content_eventually(&replacement_terminal, "_fgend", cx).await;
+        let content = replacement_terminal.update(cx, |terminal, _| terminal.get_content());
+        let replacement_foreground_pid =
+            parse_pid_marker(&content, "replacement_fg_marker_", "_fgend");
+        let replacement_shell_pid =
+            replacement_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32() as i32,
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        assert_ne!(
+            unsafe { libc::getpgid(replacement_foreground_pid) },
+            unsafe { libc::getpgid(replacement_shell_pid) },
+            "replacement foreground process should run separately from its shell"
+        );
+
+        let stale_info =
+            PtyProcessInfo::new(ProcessIdGetter::new(None, replacement_foreground_pid as u32));
+        let cleanup_signal_sent = stale_info.capture_process_ids().terminate();
+        // `kill_active_task` reaches the same stale pid via `kill_current_process`.
+        let kill_task_signal_sent = stale_info.kill_current_process();
+
+        cx.background_executor
+            .timer(Duration::from_millis(50))
+            .await;
+        let completed_early = replacement_completion_rx.try_recv().ok();
+        let content = replacement_terminal.update(cx, |terminal, _| terminal.get_content());
+
+        drop(replacement_terminal);
+        cx.update(|_| {});
+        cx.background_executor
+            .timer(PROCESS_KILL_GRACE_PERIOD + Duration::from_millis(50))
+            .await;
+
+        assert!(
+            !cleanup_signal_sent && !kill_task_signal_sent && completed_early.is_none(),
+            "stale process info signalled a new foreground process group that reused its \
+             fallback process-group id (cleanup: {cleanup_signal_sent}, kill task: \
+             {kill_task_signal_sent}); completion: {completed_early:?}; content: {content}"
         );
     }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -5283,6 +5283,78 @@ mod tests {
         );
     }
 
+    /// Deterministic counterpart to the rerun stress test: instead of looping
+    /// until the OS happens to recycle a freed master fd number
+    /// (<https://github.com/zed-industries/zed/issues/62095>), the
+    /// post-recycling state is constructed directly — stale process info whose
+    /// PTY handle is the replacement's live master while its fallback pid is
+    /// the dead child. The session guard must reject everything that handle
+    /// reads, so the real drop-path cleanup stays signal-free.
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_stale_process_info_with_recycled_pty_fd_does_not_kill_replacement(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+
+        let (completed_terminal, completion_rx) = build_test_terminal(cx, "true", &[]).await;
+        completion_rx
+            .recv()
+            .await
+            .expect("completed terminal should report its exit status");
+        let dead_child_pid =
+            completed_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => info.pid_getter().fallback_pid().as_u32(),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+        drop(completed_terminal);
+        cx.update(|_| {});
+        // The exit status arrives after the child watcher reaps the child, so
+        // the pid must already be fully dead, not a zombie (a zombie would
+        // still validate as its own session leader).
+        assert_ne!(
+            unsafe { libc::kill(dead_child_pid as i32, 0) },
+            0,
+            "the completed terminal's child should be dead and reaped"
+        );
+
+        let (replacement_terminal, replacement_completion_rx) =
+            build_test_terminal(cx, "sleep", &["300"]).await;
+        let (replacement_getter, replacement_shell_pid) =
+            replacement_terminal.update(cx, |terminal, _| match &terminal.terminal_type {
+                TerminalType::Pty { info, .. } => (
+                    info.pid_getter().clone(),
+                    info.pid_getter().fallback_pid().as_u32() as i32,
+                ),
+                TerminalType::DisplayOnly => panic!("expected a PTY-backed terminal"),
+            });
+
+        let stale_info = Arc::new(PtyProcessInfo::new(
+            replacement_getter.with_fallback_pid(dead_child_pid),
+        ));
+        // Prove the hazard is really present: the stale handle reads a live
+        // group in the replacement's session, exactly what a recycled fd
+        // number exposed. Without this the test could silently degrade into
+        // exercising only the dead-fallback path.
+        let read_through_stale_handle = stale_info.pid().map(|pid| pid.as_u32() as libc::pid_t);
+        assert_eq!(
+            read_through_stale_handle.map(|pid| unsafe { libc::getsid(pid) }),
+            Some(replacement_shell_pid),
+            "the stale handle should read the replacement's foreground group"
+        );
+
+        terminate_processes_with_grace_period(stale_info, cx.background_executor.clone()).await;
+
+        let completed_early = replacement_completion_rx.try_recv().ok();
+        let replacement_alive = unsafe { libc::kill(replacement_shell_pid, 0) } == 0;
+        assert!(
+            replacement_alive && completed_early.is_none(),
+            "cleanup through stale process info signalled the replacement terminal whose PTY \
+             the recycled handle reads (alive: {replacement_alive}, completion: \
+             {completed_early:?})"
+        );
+    }
+
     /// Test that kill_active_task on a task that's not running is a no-op
     #[gpui::test]
     async fn test_kill_active_task_on_completed_task_is_noop(cx: &mut TestAppContext) {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -5177,6 +5177,53 @@ mod tests {
         );
     }
 
+    /// Repeats the rerun cycle from <https://github.com/zed-industries/zed/issues/62095>
+    /// (spawn the replacement first, then drop the replaced terminal, as
+    /// `replace_terminal` does): every freed PTY fd number is immediately up
+    /// for reuse, so each iteration is a fresh chance for a stale-fd or
+    /// stale-pid race to kill the new task.
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_repeated_task_reruns_survive_previous_terminal_cleanup(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (mut previous_terminal, completion_rx) = build_test_terminal(cx, "true", &[]).await;
+        completion_rx
+            .recv()
+            .await
+            .expect("the initial terminal should report its exit status");
+
+        for iteration in 0..10 {
+            let (replacement_terminal, replacement_completion_rx) =
+                build_test_terminal(cx, "sleep 0.3 && echo rerun_survived", &[]).await;
+
+            drop(previous_terminal);
+            cx.update(|_| {});
+            // Let the dropped terminal's SIGKILL escalation land while the
+            // replacement's task is still running.
+            cx.background_executor
+                .timer(PROCESS_KILL_GRACE_PERIOD + Duration::from_millis(50))
+                .await;
+
+            let exit_status = replacement_completion_rx
+                .recv()
+                .await
+                .expect("the replacement task should report its exit status");
+            let succeeded = exit_status.as_ref().is_some_and(|status| status.success());
+            let content = replacement_terminal.update(cx, |terminal, _| terminal.get_content());
+            assert!(
+                succeeded,
+                "iteration {iteration}: the rerun task was killed by the previous terminal's \
+                 cleanup; exit status: {exit_status:?}; content: {content}"
+            );
+            // A shell may reap a signalled foreground job and still exit 0, so
+            // also require the marker only a surviving `sleep` prints.
+            assert_content_eventually(&replacement_terminal, "rerun_survived", cx).await;
+
+            previous_terminal = replacement_terminal;
+        }
+    }
+
     /// Even when a dead terminal's child pid has been recycled as the
     /// process-group id of a live foreground job (simulated here by
     /// constructing stale process info pointing at the replacement's


### PR DESCRIPTION
# Objective

Re-fixes: #47412
Fixes https://github.com/zed-industries/zed/issues/62286
Fixes https://github.com/zed-industries/zed/issues/62095
Fixes the bug introduced in https://github.com/zed-industries/zed/pull/61467

## Solution

#47412 was an issue where some processes were not being dropped after zed closed, I fixed that issue in #61467, but then introduced the issues in #62286 and #62095, tldr: I added something to send additional SIGKILL/SIGTERM signals after the terminal was closed, but when running tasks, these signals were firing on the wrong processes, due to race conditions regarding FD reuse.

The big design change this time around is moving `ProcessIdGetter` to having an `OwnedFD`, this categorically prevents the FD race that was observed in previous iterations. Checks for which process to kill are run through the `OwnedFD`, so there cannot be a race where the raw FD we are holding has been reassigned to a new process group. Where the original process group is created, the session id is set, when we go to tear down the process group, we ensure that the current process group has the correct, matching session id, this prevents the admittedly much less likely pid reuse race.

## Testing

Manually tested the process exiting changes, and manually tested the task spawning (many times in a row this time, some overlapped).

Additionally this adds a test for #47412, as well as a simple test for #62286/#62095, and a test for those that creates tasks 10x in a row. There is also a new test for the PID reuse case, this one is deterministic.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- terminal: fixed an issue where long running processes in the are not dropped on Zed closing.
- tasks: fixed an issue where tasks would kill the process of the next spawned task after being dropped.
