### PR TITLE
Discover capability-advertised LSP runnables

### DIFF
--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -98,7 +98,7 @@ async fn lsp_task_context(
 
 pub fn lsp_tasks(
     project: Entity<Project>,
-    task_sources: &HashMap<LanguageServerName, Vec<BufferId>>,
+    task_sources: &HashMap<LanguageServerId, Vec<BufferId>>,
     for_position: Option<text::Anchor>,
     cx: &mut App,
 ) -> Task<Vec<(TaskSourceKind, Vec<(Option<LocationLink>, ResolvedTask)>)>> {
@@ -113,13 +113,7 @@ pub fn lsp_tasks(
                 })
                 .filter_map(|&buffer_id| project.read(cx).buffer_for_id(buffer_id, cx))
                 .collect::<Vec<_>>();
-
-            let server_id = buffers.iter().find_map(|buffer| {
-                project.read_with(cx, |project, cx| {
-                    project.language_server_id_for_name(buffer.read(cx), name, cx)
-                })
-            });
-            server_id.zip(Some(buffers))
+            (!buffers.is_empty()).then_some((*name, buffers))
         })
         .collect::<Vec<_>>();
 
@@ -151,6 +145,7 @@ pub fn lsp_tasks(
                             GetLspRunnables {
                                 buffer_id,
                                 position: for_position,
+                                server_id: Some(server_id),
                             },
                             cx,
                         )

--- a/crates/editor/src/runnables.rs
+++ b/crates/editor/src/runnables.rs
@@ -576,7 +576,10 @@ impl Editor {
             .filter_map(|buffer| {
                 let buffer_read = buffer.read(cx);
                 let buffer_id = buffer_read.remote_id();
-                if skip_cached && self.runnables.has_cached(buffer_id, &buffer_read.version()) {
+                if skip_cached
+                    && !self.runnables.invalidate_buffer_data.contains(&buffer_id)
+                    && self.runnables.has_cached(buffer_id, &buffer_read.version())
+                {
                     return None;
                 }
 
@@ -1340,6 +1343,22 @@ mod tests {
                 .expect("editor update"),
             vec![(buffer_id, 0, vec!["LSP main".to_string()])],
             "capability-advertised LSP runnables should not need a language context provider"
+        );
+
+        editor
+            .update(cx, |editor, window, cx| {
+                editor.refresh_runnables(Some(buffer_id), window, cx);
+            })
+            .expect("editor update");
+        cx.executor().advance_clock(UPDATE_DEBOUNCE);
+        cx.executor().run_until_parked();
+
+        assert_eq!(
+            editor
+                .update(cx, |editor, _, _| collect_runnable_labels(editor))
+                .expect("editor update"),
+            vec![(buffer_id, 0, vec!["LSP main".to_string()])],
+            "invalidating cached runnables should fetch LSP runnables again"
         );
     }
 

--- a/crates/editor/src/runnables.rs
+++ b/crates/editor/src/runnables.rs
@@ -7,7 +7,7 @@ use gpui::{
     MouseButton, Task, Window,
 };
 use language::{Buffer, BufferRow, Runnable};
-use lsp::LanguageServerName;
+use lsp::LanguageServerId;
 use multi_buffer::{Anchor, BufferOffset, MultiBufferRow, MultiBufferSnapshot, ToPoint as _};
 use project::{Location, Project, TaskSourceKind, project_settings::ProjectSettings};
 use settings::Settings as _;
@@ -556,7 +556,7 @@ impl Editor {
         visible_only: bool,
         skip_cached: bool,
         cx: &mut Context<Self>,
-    ) -> HashMap<LanguageServerName, Vec<BufferId>> {
+    ) -> HashMap<LanguageServerId, Vec<BufferId>> {
         if !self.lsp_data_enabled() {
             return HashMap::default();
         }
@@ -574,38 +574,61 @@ impl Editor {
         buffers
             .into_iter()
             .filter_map(|buffer| {
-                let lsp_tasks_source = buffer
-                    .read(cx)
-                    .language()?
-                    .context_provider()?
-                    .lsp_task_source()?;
-                if lsp_settings
-                    .get(&lsp_tasks_source)
-                    .is_none_or(|s| s.enable_lsp_tasks)
-                {
-                    let buffer_id = buffer.read(cx).remote_id();
-                    if skip_cached
-                        && self
-                            .runnables
-                            .has_cached(buffer_id, &buffer.read(cx).version())
-                    {
-                        None
-                    } else {
-                        Some((lsp_tasks_source, buffer_id))
-                    }
-                } else {
-                    None
+                let buffer_read = buffer.read(cx);
+                let buffer_id = buffer_read.remote_id();
+                if skip_cached && self.runnables.has_cached(buffer_id, &buffer_read.version()) {
+                    return None;
                 }
-            })
-            .fold(
-                HashMap::default(),
-                |mut acc, (lsp_task_source, buffer_id)| {
-                    acc.entry(lsp_task_source)
+
+                let mut sources = HashMap::default();
+                if let Some(lsp_task_source) = buffer_read
+                    .language()
+                    .and_then(|language| language.context_provider())
+                    .and_then(|provider| provider.lsp_task_source())
+                    && lsp_settings
+                        .get(&lsp_task_source)
+                        .is_none_or(|settings| settings.enable_lsp_tasks)
+                    && let Some(server_id) = self.project().and_then(|project| {
+                        project.read(cx).language_server_id_for_name(
+                            &buffer_read,
+                            &lsp_task_source,
+                            cx,
+                        )
+                    })
+                {
+                    sources
+                        .entry(server_id)
                         .or_insert_with(Vec::new)
                         .push(buffer_id);
-                    acc
-                },
-            )
+                }
+
+                if let Some(project) = self.project() {
+                    for (server_id, server_name) in project
+                        .read(cx)
+                        .language_servers_supporting_runnables(&buffer, cx)
+                    {
+                        if lsp_settings
+                            .get(&server_name)
+                            .is_none_or(|settings| settings.enable_lsp_tasks)
+                        {
+                            let buffer_ids = sources.entry(server_id).or_insert_with(Vec::new);
+                            if !buffer_ids.contains(&buffer_id) {
+                                buffer_ids.push(buffer_id);
+                            }
+                        }
+                    }
+                }
+
+                Some(sources)
+            })
+            .fold(HashMap::default(), |mut acc, sources| {
+                for (server_id, buffer_ids) in sources {
+                    acc.entry(server_id)
+                        .or_insert_with(Vec::new)
+                        .extend(buffer_ids);
+                }
+                acc
+            })
     }
 
     pub fn find_enclosing_node_task(
@@ -865,7 +888,7 @@ mod tests {
     use project::{
         FakeFs, Project, ProjectPath,
         lsp_store::lsp_ext_command::{
-            CargoRunnableArgs, Runnable, RunnableArgs, ShellRunnableArgs,
+            CargoRunnableArgs, Runnable, RunnableArgs, Runnables, ShellRunnableArgs,
         },
     };
     use serde_json::json;
@@ -1231,6 +1254,92 @@ mod tests {
             labels,
             Vec::<(text::BufferId, language::BufferRow, Vec<String>)>::new(),
             "Runnables should be removed after #[test] is deleted and LSP returns empty"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_capability_advertised_lsp_runnables_without_language_context(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx, |_| {});
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                "main.rs": "fn main() {}\n",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+        language_registry.add(rust_lang());
+
+        let mut capabilities = lsp::ServerCapabilities::default();
+        capabilities.experimental = Some(json!({"runnables": true}));
+        let mut fake_servers = language_registry.register_fake_lsp(
+            "Rust",
+            FakeLspAdapter {
+                name: FAKE_LSP_NAME,
+                capabilities,
+                ..FakeLspAdapter::default()
+            },
+        );
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+        let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+
+        let multi_buffer = cx.new(|cx| MultiBuffer::singleton(buffer.clone(), cx));
+        let editor = cx.add_window(|window, cx| {
+            build_editor_with_project(project.clone(), multi_buffer, window, cx)
+        });
+
+        let fake_server = fake_servers.next().await.expect("fake LSP server");
+        fake_server.set_request_handler::<Runnables, _, _>(move |params, _| async move {
+            let uri = params.text_document.uri;
+            Ok(vec![Runnable {
+                label: "LSP main".into(),
+                location: Some(lsp::LocationLink {
+                    origin_selection_range: None,
+                    target_uri: uri,
+                    target_range: lsp::Range::new(
+                        lsp::Position::new(0, 0),
+                        lsp::Position::new(0, 12),
+                    ),
+                    target_selection_range: lsp::Range::new(
+                        lsp::Position::new(0, 0),
+                        lsp::Position::new(0, 12),
+                    ),
+                }),
+                args: RunnableArgs::Shell(ShellRunnableArgs {
+                    environment: Default::default(),
+                    cwd: path!("/project").into(),
+                    program: "uv".into(),
+                    args: vec!["run".into(), "karva".into(), "test".into()],
+                }),
+            }])
+        });
+
+        editor
+            .update(cx, |editor, window, cx| {
+                editor.refresh_runnables(None, window, cx);
+            })
+            .expect("editor update");
+        cx.executor().advance_clock(UPDATE_DEBOUNCE);
+        cx.executor().run_until_parked();
+
+        assert_eq!(
+            editor
+                .update(cx, |editor, _, _| collect_runnable_labels(editor))
+                .expect("editor update"),
+            vec![(buffer_id, 0, vec!["LSP main".to_string()])],
+            "capability-advertised LSP runnables should not need a language context provider"
         );
     }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -99,6 +99,10 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
         None
     }
 
+    fn language_server_id(&self) -> Option<LanguageServerId> {
+        None
+    }
+
     fn to_lsp_params_or_response(
         &self,
         path: &Path,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5528,6 +5528,19 @@ impl LspStore {
             .collect()
     }
 
+    /// Returns language servers that advertise Zed's experimental runnable request.
+    pub fn language_servers_supporting_runnables(
+        &self,
+        buffer: &Entity<Buffer>,
+        cx: &App,
+    ) -> Vec<(LanguageServerId, LanguageServerName)> {
+        self.all_capable_for_proto_request(
+            buffer,
+            |_, capabilities| server_capabilities_support_runnables(capabilities),
+            cx,
+        )
+    }
+
     pub fn request_lsp<R>(
         &mut self,
         buffer: Entity<Buffer>,
@@ -9669,14 +9682,13 @@ impl LspStore {
             cx.clone(),
         )
         .await?;
+        let server = request.language_server_id().map_or(
+            LanguageServerToQuery::FirstCapable,
+            LanguageServerToQuery::Other,
+        );
         let response = this
             .update(&mut cx, |this, cx| {
-                this.request_lsp(
-                    buffer_handle.clone(),
-                    LanguageServerToQuery::FirstCapable,
-                    request,
-                    cx,
-                )
+                this.request_lsp(buffer_handle.clone(), server, request, cx)
             })
             .await?;
         this.update(&mut cx, |this, cx| {
@@ -14956,6 +14968,20 @@ fn include_text(server: &lsp::LanguageServer) -> Option<bool> {
     }
 }
 
+fn server_capabilities_support_runnables(capabilities: &lsp::ServerCapabilities) -> bool {
+    capabilities
+        .experimental
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|experimental| experimental.get("runnables"))
+        .and_then(|runnables| match runnables {
+            Value::Bool(enabled) => Some(*enabled),
+            Value::Object(_) => Some(true),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
 /// Completion items are displayed in a `UniformList`.
 /// Usually, those items are single-line strings, but in LSP responses,
 /// completion items `label`, `detail` and `label_details.description` may contain newlines or long spaces.
@@ -15107,5 +15133,22 @@ mod tests {
             "Get diagnostics via rust-analyzer failed: Server reset the connection"
         ));
         assert!(should_log_lsp_request_failure("something else entirely"));
+    }
+
+    #[test]
+    fn runnable_capability_is_advertised_experimentally() {
+        let mut capabilities = lsp::ServerCapabilities::default();
+        assert!(!server_capabilities_support_runnables(&capabilities));
+
+        capabilities.experimental = Some(serde_json::json!({"runnables": true}));
+        assert!(server_capabilities_support_runnables(&capabilities));
+
+        capabilities.experimental = Some(serde_json::json!({
+            "runnables": {"kinds": ["shell"]}
+        }));
+        assert!(server_capabilities_support_runnables(&capabilities));
+
+        capabilities.experimental = Some(serde_json::json!({"runnables": false}));
+        assert!(!server_capabilities_support_runnables(&capabilities));
     }
 }

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -606,6 +606,7 @@ pub struct ShellRunnableArgs {
 pub struct GetLspRunnables {
     pub buffer_id: BufferId,
     pub position: Option<text::Anchor>,
+    pub server_id: Option<LanguageServerId>,
 }
 
 #[derive(Debug, Default)]
@@ -677,6 +678,10 @@ impl LspCommand for GetLspRunnables {
         true
     }
 
+    fn language_server_id(&self) -> Option<LanguageServerId> {
+        self.server_id
+    }
+
     fn to_lsp(
         &self,
         path: &Path,
@@ -723,6 +728,7 @@ impl LspCommand for GetLspRunnables {
             project_id,
             buffer_id: buffer.remote_id().to_proto(),
             position: self.position.as_ref().map(serialize_anchor),
+            server_id: self.server_id.map(LanguageServerId::to_proto),
         }
     }
 
@@ -737,6 +743,7 @@ impl LspCommand for GetLspRunnables {
         Ok(Self {
             buffer_id,
             position,
+            server_id: message.server_id.map(LanguageServerId::from_proto),
         })
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -6192,6 +6192,17 @@ impl Project {
         self.lsp_store.read(cx).supplementary_language_servers()
     }
 
+    /// Returns language servers for a buffer that advertise experimental runnables.
+    pub fn language_servers_supporting_runnables(
+        &self,
+        buffer: &Entity<Buffer>,
+        cx: &App,
+    ) -> Vec<(LanguageServerId, LanguageServerName)> {
+        self.lsp_store
+            .read(cx)
+            .language_servers_supporting_runnables(buffer, cx)
+    }
+
     pub fn any_language_server_supports_inlay_hints(&self, buffer: &Buffer, cx: &mut App) -> bool {
         let Some(language) = buffer.language().cloned() else {
             return false;

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -17,7 +17,7 @@ use language::{
     Buffer, ContextLocation, ContextProvider, File, Language, LanguageToolchainStore, Location,
     language_settings::LanguageSettings,
 };
-use lsp::{LanguageServerId, LanguageServerName};
+use lsp::LanguageServerId;
 use paths::{debug_task_file_name, task_file_name};
 use settings::{InvalidSettingsError, parse_json_with_comments};
 use task::{
@@ -178,7 +178,7 @@ pub struct TaskContexts {
     pub active_worktree_context: Option<(WorktreeId, TaskContext)>,
     /// If there are multiple worktrees in the workspace, all non-active ones are included here.
     pub other_worktree_contexts: Vec<(WorktreeId, TaskContext)>,
-    pub lsp_task_sources: HashMap<LanguageServerName, Vec<BufferId>>,
+    pub lsp_task_sources: HashMap<LanguageServerId, Vec<BufferId>>,
     pub latest_selection: Option<text::Anchor>,
 }
 

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -1011,6 +1011,7 @@ message LspExtRunnables {
   uint64 project_id = 1;
   uint64 buffer_id = 2;
   optional Anchor position = 3;
+  optional uint64 server_id = 4;
 }
 
 message LspExtRunnablesResponse {


### PR DESCRIPTION
# Objective

Allow language servers to opt into Zed’s existing experimental runnable-task pipeline without hardcoding their names in language context providers. This lets extension-provided servers for existing languages expose native gutter and task-picker actions.

## Solution

Discover relevant servers whose initialize result advertises `experimental.runnables`, key requests by exact server ID, and preserve existing explicit context-provider sources. Carry the optional server ID across the remote protocol so SSH and collaboration route requests to the intended server. Existing `enable_lsp_tasks` settings remain effective.

## Testing

```text
cargo test -p project runnable_capability_is_advertised_experimentally
cargo test -p editor lsp_runnables
cargo check -p tasks_ui -p debugger_ui
```

Release Notes:

- Improved language-server extensions by allowing runnable-capable servers to provide native run tasks.