### PR TITLE
vim: Move gg to the first non-blank character

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2340,23 +2340,24 @@ fn start_of_next_sentence(
     Some(map.buffer_snapshot().len())
 }
 
-fn go_to_line(map: &DisplaySnapshot, display_point: DisplayPoint, line: usize) -> DisplayPoint {
+fn go_to_line(
+    map: &DisplaySnapshot,
+    display_point: DisplayPoint,
+    line: usize,
+    column: u32,
+) -> Option<DisplayPoint> {
     let point = map.display_point_to_point(display_point, Bias::Left);
     let snapshot = map.buffer_snapshot();
-    let Some((buffer_snapshot, _)) = snapshot.point_to_buffer_point(point) else {
-        return display_point;
-    };
+    let (buffer_snapshot, _) = snapshot.point_to_buffer_point(point)?;
 
-    let Some(anchor) = snapshot.anchor_in_excerpt(buffer_snapshot.anchor_after(
-        buffer_snapshot.clip_point(Point::new((line - 1) as u32, point.column), Bias::Left),
-    )) else {
-        return display_point;
-    };
+    let anchor = snapshot.anchor_in_excerpt(buffer_snapshot.anchor_after(
+        buffer_snapshot.clip_point(Point::new((line - 1) as u32, column), Bias::Left),
+    ))?;
 
-    map.clip_point(
+    Some(map.clip_point(
         map.point_to_display_point(anchor.to_point(snapshot), Bias::Left),
         Bias::Left,
-    )
+    ))
 }
 
 fn start_of_document(
@@ -2365,20 +2366,21 @@ fn start_of_document(
     maybe_times: Option<usize>,
 ) -> DisplayPoint {
     if let Some(times) = maybe_times {
-        return go_to_line(map, display_point, times);
+        let Some(line_end) = go_to_line(map, display_point, times, u32::MAX) else {
+            return display_point;
+        };
+        return first_non_whitespace(map, false, line_end);
     }
 
-    let point = map.display_point_to_point(display_point, Bias::Left);
-    let mut first_point = Point::zero();
-    first_point.column = point.column;
-
-    map.clip_point(
+    let line_end = map.clip_point(
         map.point_to_display_point(
-            map.buffer_snapshot().clip_point(first_point, Bias::Left),
+            map.buffer_snapshot()
+                .clip_point(Point::new(0, u32::MAX), Bias::Left),
             Bias::Left,
         ),
         Bias::Left,
-    )
+    );
+    first_non_whitespace(map, false, line_end)
 }
 
 fn end_of_document(
@@ -2387,7 +2389,8 @@ fn end_of_document(
     maybe_times: Option<usize>,
 ) -> DisplayPoint {
     if let Some(times) = maybe_times {
-        return go_to_line(map, display_point, times);
+        let point = map.display_point_to_point(display_point, Bias::Left);
+        return go_to_line(map, display_point, times, point.column).unwrap_or(display_point);
     };
     let point = map.display_point_to_point(display_point, Bias::Left);
     let mut last_point = map.buffer_snapshot().max_point();

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1431,6 +1431,7 @@ mod test {
     #[gpui::test]
     async fn test_gg(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.set_neovim_option("startofline").await;
         cx.simulate_at_each_offset(
             "g g",
             indoc! {"
@@ -1461,6 +1462,21 @@ mod test {
         )
         .await
         .assert_matches();
+        cx.simulate("g g", "    fiˇrst line\nsecond line")
+            .await
+            .assert_matches();
+        cx.simulate("1 g g", "    first line\nsecond lˇine")
+            .await
+            .assert_matches();
+        cx.simulate("2 g g", "first line\n    second line\nthird lˇine")
+            .await
+            .assert_matches();
+        cx.simulate("g g", "    \nsecond lˇine")
+            .await
+            .assert_matches();
+        cx.simulate("v g g", "    first line\nsecond lˇine")
+            .await
+            .assert_matches();
     }
 
     #[gpui::test]

--- a/crates/vim/test_data/test_gg.json
+++ b/crates/vim/test_data/test_gg.json
@@ -1,15 +1,16 @@
+{"SetOption":{"value":"startofline"}}
 {"Put":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover ˇthe lazy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The quicˇk\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"g"}
 {"Key":"g"}
@@ -19,3 +20,26 @@
 {"Key":"g"}
 {"Key":"g"}
 {"Get":{"state":"\nˇ\nbrown fox jumps\nover the lazydog","mode":"Normal"}}
+{"Put":{"state":"    fiˇrst line\nsecond line"}}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"    ˇfirst line\nsecond line","mode":"Normal"}}
+{"Put":{"state":"    first line\nsecond lˇine"}}
+{"Key":"1"}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"    ˇfirst line\nsecond line","mode":"Normal"}}
+{"Put":{"state":"first line\n    second line\nthird lˇine"}}
+{"Key":"2"}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"first line\n    ˇsecond line\nthird line","mode":"Normal"}}
+{"Put":{"state":"    \nsecond lˇine"}}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"   ˇ \nsecond line","mode":"Normal"}}
+{"Put":{"state":"    first line\nsecond lˇine"}}
+{"Key":"v"}
+{"Key":"g"}
+{"Key":"g"}
+{"Get":{"state":"    «ˇfirst line\nsecond li»ne","mode":"Visual"}}


### PR DESCRIPTION
# Objective

Fixes #38613.

In Vim mode, `gg` retained the cursor column. When used from the first line, that could make the motion a no-op. Vim defaults to moving to the first non-blank character through its `startofline` option.

## Solution

Move bare and counted `gg` to the first non-blank character of the target line. The Neovim-backed test explicitly enables `startofline` because Neovim defaults that option off. `G` keeps its existing column-preserving behavior.

## Testing

- `cargo fmt --all --check`
- `ZED_HEADLESS=1 cargo -q test -p vim normal::test::test_gg -- --nocapture`
- `ZED_HEADLESS=1 cargo -q test -p vim normal::delete::test::test_delete_gg -- --nocapture`
- `ZED_HEADLESS=1 cargo -q test -p vim normal::change::test::test_change_gg -- --nocapture`
- `ZED_HEADLESS=1 cargo -q test -p vim normal::test::test_end_of_document -- --nocapture`
- `ZED_HEADLESS=1 cargo -q test -p vim` (547 passed)

## Self-Review Checklist:

- [x] I have reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed UI standards
- [x] Tests cover the new and changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Vim mode `gg` not moving to the first non-blank character on the first line.