### PR TITLE
gpui_macos: Fix window blur on macOS 26+ by using UnderWindowBackground

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -11,9 +11,10 @@ use cocoa::{
     appkit::{
         NSApplication, NSBackingStoreBuffered, NSColor, NSEvent, NSEventModifierFlags, NSEventType,
         NSFilenamesPboardType, NSPasteboard, NSRequestUserAttentionType, NSScreen, NSView,
-        NSViewHeightSizable, NSViewWidthSizable, NSVisualEffectMaterial, NSVisualEffectState,
-        NSVisualEffectView, NSWindow, NSWindowCollectionBehavior, NSWindowOcclusionState,
-        NSWindowOrderingMode, NSWindowStyleMask, NSWindowTitleVisibility,
+        NSViewHeightSizable, NSViewWidthSizable, NSVisualEffectBlendingMode,
+        NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView, NSWindow,
+        NSWindowCollectionBehavior, NSWindowOcclusionState, NSWindowOrderingMode,
+        NSWindowStyleMask, NSWindowTitleVisibility,
     },
     base::{id, nil},
     foundation::{
@@ -3269,7 +3270,15 @@ extern "C" fn blurred_view_init_with_frame(this: &Object, _: Sel, frame: NSRect)
         let view = msg_send![super(this, class!(NSVisualEffectView)), initWithFrame: frame];
         // Use a colorless semantic material. The default value `AppearanceBased`, though not
         // manually set, is deprecated.
-        NSVisualEffectView::setMaterial_(view, NSVisualEffectMaterial::Selection);
+        //
+        // `UnderWindowBackground` rather than `Selection`: on macOS 26+, `Selection` no longer
+        // vends the `CABackdropLayer` that `remove_layer_background` walks, so the view renders
+        // with no blur at all. `UnderWindowBackground` still vends one, and is the material
+        // AppKit documents for the area behind a window's own background.
+        NSVisualEffectView::setMaterial_(view, NSVisualEffectMaterial::UnderWindowBackground);
+        // Behind-window blending is what samples the desktop rather than the window's own
+        // content. It is already the default, but this view exists only for that mode.
+        NSVisualEffectView::setBlendingMode_(view, NSVisualEffectBlendingMode::BehindWindow);
         NSVisualEffectView::setState_(view, NSVisualEffectState::Active);
         view
     }


### PR DESCRIPTION
## Summary

`WindowBackgroundAppearance::Blurred` renders with no blur on macOS 26 and 27.

`BlurredView` is an `NSVisualEffectView` set to `NSVisualEffectMaterial::Selection`, and `blurred_view_update_layer` walks the resulting layer tree to strip the material's own backgrounds and its `colorSaturate` filter.

On macOS 26+, `Selection` no longer vends a `CABackdropLayer` — so there is nothing to walk, and nothing to blur.

## Evidence

Probed on macOS 27.0, reading the live layer tree of the `BlurredView` in a running GPUI app configured with `WindowBackgroundAppearance::Blurred`:

```
layer    = NSViewBackingLayer
filters  = 0
sublayers = 1  → ["CALayer"]
```

No `CABackdropLayer`, and no filters for `remove_layer_background` to find. On macOS 25 and earlier the same view carries a backdrop sublayer plus the `Blur` and `colorSaturate` filters that code is written against.

## Fix

Use `NSVisualEffectMaterial::UnderWindowBackground`, which still vends a backdrop on macOS 26+ and is the material AppKit documents for the area behind a window's own background.

Also state `NSVisualEffectBlendingMode::BehindWindow` explicitly. It is already the default, but sampling the desktop rather than the window's own content is this view's entire purpose, and leaving it implicit makes the view's behaviour depend on a default that has now changed once.

`remove_layer_background` is untouched and still applies to the new material's layer tree.

## Verification

Built and run on macOS 27.0 against a GPUI application using `WindowBackgroundAppearance::Blurred` — solid/unblurred window before, blur restored after. macOS 25 and earlier are unaffected in the same build.

Release Notes:

- Fixed blurred window backgrounds rendering unblurred on macOS 26 and later.