### PR TITLE
git_ui: Enable navigation for single-hunk diffs

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -323,7 +323,7 @@ impl ProjectDiff {
         let editor = diff.editor().read(cx).rhs_editor().clone();
         let editor = editor.read(cx);
         let snapshot = diff.multibuffer().read(cx).snapshot(cx);
-        let prev_next = snapshot.diff_hunks().nth(1).is_some();
+        let prev_next = snapshot.diff_hunks().next().is_some();
         let (selection, ranges) = diff.selected_ranges(cx);
         let mut has_staged_hunks = false;
         let mut has_unstaged_hunks = false;

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -269,7 +269,7 @@ impl SoloDiffView {
         let editor = self.editor.read(cx).rhs_editor().read(cx);
         let multibuffer = editor.buffer().read(cx);
         let snapshot = multibuffer.snapshot(cx);
-        let prev_next = snapshot.diff_hunks().nth(1).is_some();
+        let prev_next = snapshot.diff_hunks().next().is_some();
         let mut selection = true;
 
         let mut ranges = editor

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -268,7 +268,7 @@ impl StagedDiff {
         let editor = diff.editor().read(cx).rhs_editor().clone();
         let editor = editor.read(cx);
         let snapshot = diff.multibuffer().read(cx).snapshot(cx);
-        let prev_next = snapshot.diff_hunks().nth(1).is_some();
+        let prev_next = snapshot.diff_hunks().next().is_some();
         let (selection, ranges) = diff.selected_ranges(cx);
         let unstage = editor
             .diff_hunks_in_ranges(&ranges, &snapshot)

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -322,7 +322,7 @@ impl UnstagedDiff {
         let editor = diff.editor().read(cx).rhs_editor().clone();
         let editor = editor.read(cx);
         let snapshot = diff.multibuffer().read(cx).snapshot(cx);
-        let prev_next = snapshot.diff_hunks().nth(1).is_some();
+        let prev_next = snapshot.diff_hunks().next().is_some();
         let (selection, ranges) = diff.selected_ranges(cx);
         let stage = editor
             .diff_hunks_in_ranges(&ranges, &snapshot)


### PR DESCRIPTION
## What

Keep the hunk navigation controls available when a diff contains one hunk, so users can return to it after scrolling away. This applies to solo, staged, unstaged, and project diff views.

## Why

The controls were only rendered when `hunk_count > 1`, even though the existing navigation actions already wrap and recenter a single hunk.

## How

Render the previous and next hunk controls whenever `hunk_count > 0`, reusing the existing navigation actions.

Closes #62469

## Testing

- `cargo +stable-x86_64-pc-windows-gnu test -p git_ui --lib` — 130 passed.
- `cargo +stable-x86_64-pc-windows-gnu build -p zed -j 1` — passed.
- `rustfmt --edition 2024 --check` on the four changed files — passed.
- `git diff --check` — passed.
- Manually verified with the branch-built Zed on Windows: opened a tracked file with exactly one diff hunk, expanded the context, scrolled below the hunk, and used **Go to Previous Hunk**. The view returned to the changed line.

## Showcase

https://github.com/user-attachments/assets/e7b63030-50ad-4536-8266-13987ed85f3d

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://zed.dev/docs/development/ux-ui) and [icon guidelines](https://zed.dev/docs/development/ui-icons))
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Enable "Go to Previous Hunk" and "Go to Next Hunk" buttons even if there's a single diff hunk.