### PR TITLE
Fix package manager detection for nested package scripts

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -12,7 +12,7 @@ use language::{
 };
 use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
-use project::lsp_store::language_server_settings;
+use project::{Fs, lsp_store::language_server_settings};
 use semver::Version;
 use serde_json::{Value, json};
 use settings::SettingsLocation;
@@ -40,7 +40,15 @@ use crate::PackageJsonData;
 const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-json-language-server";
 
-pub(crate) struct JsonTaskProvider;
+pub(crate) struct JsonTaskProvider {
+    fs: Arc<dyn Fs>,
+}
+
+impl JsonTaskProvider {
+    pub fn new(fs: Arc<dyn Fs>) -> Self {
+        Self { fs }
+    }
+}
 
 impl ContextProvider for JsonTaskProvider {
     fn associated_tasks(
@@ -62,12 +70,15 @@ impl ContextProvider for JsonTaskProvider {
             return Task::ready(None);
         }
 
+        let fs = self.fs.clone();
+        let worktree_root = file.worktree.read(cx).root_dir();
         cx.spawn(async move |cx| {
             let contents = file
                 .worktree
                 .update(cx, |this, cx| this.load_file(&file.path, cx))
                 .await
                 .ok()?;
+
             let path = cx.update(|cx| file.abs_path(cx)).as_path().into();
             let contents_text = contents.text.to_string();
 
@@ -76,8 +87,13 @@ impl ContextProvider for JsonTaskProvider {
                     HashMap<String, serde_json_lenient::Value>,
                 >(&contents_text)
                 .ok()?;
-                let package_json = PackageJsonData::new(path, package_json);
-                let command = package_json.package_manager.unwrap_or("npm").to_owned();
+                let package_json = PackageJsonData::new(path.clone(), package_json);
+                let package_dir = path.parent().unwrap_or(Path::new("/"));
+                let worktree_root = worktree_root.as_deref().unwrap_or(package_dir);
+
+                let command = crate::detect_package_manager(fs.clone(), package_dir, worktree_root)
+                    .await
+                    .to_owned();
                 package_json
                     .scripts
                     .into_iter()

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -31,7 +31,7 @@ mod typescript;
 mod vtsls;
 mod yaml;
 
-pub(crate) use package_json::{PackageJson, PackageJsonData};
+pub(crate) use package_json::{PackageJson, PackageJsonData, detect_package_manager};
 
 /// A shared grammar for plain text, exposed for reuse by downstream crates.
 #[cfg(feature = "tree-sitter-gitcommit")]
@@ -64,7 +64,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
     let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone(), fs.clone()));
     let go_context_provider = Arc::new(go::GoContextProvider);
     let go_lsp_adapter = Arc::new(go::GoLspAdapter);
-    let json_context_provider = Arc::new(JsonTaskProvider);
+    let json_context_provider = Arc::new(JsonTaskProvider::new(fs.clone()));
     let json_lsp_adapter = Arc::new(json::JsonLspAdapter::new(languages.clone(), node.clone()));
     let node_version_lsp_adapter = Arc::new(json::NodeVersionAdapter);
     let py_lsp_adapter = Arc::new(python::PyLspAdapter::new());

--- a/crates/languages/src/package_json.rs
+++ b/crates/languages/src/package_json.rs
@@ -152,6 +152,52 @@ fn package_manager_name(value: &str) -> Option<&'static str> {
     }
 }
 
+pub(crate) async fn detect_package_manager(
+    fs: Arc<dyn project::Fs>,
+    package_dir: &Path,
+    worktree_root: &Path,
+) -> &'static str {
+    let mut directory = package_dir;
+
+    loop {
+        let package_json_path = directory.join("package.json");
+
+        if fs.is_file(&package_json_path).await {
+            if let Ok(contents) = fs.load(&package_json_path).await {
+                if let Ok(package_json) =
+                    serde_json_lenient::from_str::<HashMap<String, Value>>(&contents)
+                {
+                    if let Some(package_manager) =
+                        PackageJsonData::new(package_json_path.into(), package_json).package_manager
+                    {
+                        return package_manager;
+                    }
+                }
+            }
+        }
+
+        if directory == worktree_root {
+            break;
+        }
+
+        let Some(parent) = directory.parent() else {
+            break;
+        };
+
+        directory = parent;
+    }
+
+    if fs.is_file(&worktree_root.join("pnpm-lock.yaml")).await {
+        return "pnpm";
+    }
+
+    if fs.is_file(&worktree_root.join("yarn.lock")).await {
+        return "yarn";
+    }
+
+    "npm"
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -197,6 +243,155 @@ mod tests {
         assert_eq!(
             package_manager(r#"{"devEngines": {"packageManager": {"version": "^11.1.3"}}}"#),
             None,
+        );
+    }
+
+    #[gpui::test]
+    async fn detect_package_manager_from_ancestor_package_json(executor: gpui::BackgroundExecutor) {
+        let fs = project::FakeFs::new(executor);
+
+        fs.insert_tree(
+            std::path::Path::new("/root"),
+            serde_json::json!({
+                "package.json": r#"{
+                    "name": "root",
+                    "private": true,
+                    "packageManager": "pnpm@11.17.0"
+                }"#,
+                "packages": {
+                    "example": {
+                        "package.json": r#"{
+                            "name": "example",
+                            "private": true,
+                            "scripts": {
+                                "show-runner": "node -p \"process.env.npm_execpath\""
+                            }
+                        }"#
+                    }
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            super::detect_package_manager(
+                fs,
+                std::path::Path::new("/root/packages/example"),
+                std::path::Path::new("/root"),
+            )
+            .await,
+            "pnpm"
+        );
+    }
+
+    #[gpui::test]
+    async fn detect_package_manager_prefers_nearest_package_json(
+        executor: gpui::BackgroundExecutor,
+    ) {
+        let fs = project::FakeFs::new(executor);
+
+        fs.insert_tree(
+            std::path::Path::new("/root"),
+            serde_json::json!({
+                "package.json": r#"{
+                    "packageManager": "pnpm@11.17.0"
+                }"#,
+                "packages": {
+                    "example": {
+                        "package.json": r#"{
+                            "packageManager": "yarn@4.9.1"
+                        }"#
+                    }
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            super::detect_package_manager(
+                fs,
+                std::path::Path::new("/root/packages/example"),
+                std::path::Path::new("/root"),
+            )
+            .await,
+            "yarn"
+        );
+    }
+
+    #[gpui::test]
+    async fn detect_package_manager_from_pnpm_lockfile(executor: gpui::BackgroundExecutor) {
+        let fs = project::FakeFs::new(executor);
+
+        fs.insert_tree(
+            std::path::Path::new("/root"),
+            serde_json::json!({
+                "pnpm-lock.yaml": "",
+                "packages": {
+                    "example": {}
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            super::detect_package_manager(
+                fs,
+                std::path::Path::new("/root/packages/example"),
+                std::path::Path::new("/root"),
+            )
+            .await,
+            "pnpm"
+        );
+    }
+
+    #[gpui::test]
+    async fn detect_package_manager_from_yarn_lockfile(executor: gpui::BackgroundExecutor) {
+        let fs = project::FakeFs::new(executor);
+
+        fs.insert_tree(
+            std::path::Path::new("/root"),
+            serde_json::json!({
+                "yarn.lock": "",
+                "packages": {
+                    "example": {}
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            super::detect_package_manager(
+                fs,
+                std::path::Path::new("/root/packages/example"),
+                std::path::Path::new("/root"),
+            )
+            .await,
+            "yarn"
+        );
+    }
+
+    #[gpui::test]
+    async fn detect_package_manager_defaults_to_npm(executor: gpui::BackgroundExecutor) {
+        let fs = project::FakeFs::new(executor);
+
+        fs.insert_tree(
+            std::path::Path::new("/root"),
+            serde_json::json!({
+                "packages": {
+                    "example": {}
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            super::detect_package_manager(
+                fs,
+                std::path::Path::new("/root/packages/example"),
+                std::path::Path::new("/root"),
+            )
+            .await,
+            "npm"
         );
     }
 }

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -404,25 +404,6 @@ impl TypeScriptContextProvider {
     }
 }
 
-async fn detect_package_manager(
-    worktree_root: PathBuf,
-    fs: Arc<dyn Fs>,
-    package_json_data: Option<PackageJsonData>,
-) -> &'static str {
-    if let Some(package_json_data) = package_json_data
-        && let Some(package_manager) = package_json_data.package_manager
-    {
-        return package_manager;
-    }
-    if fs.is_file(&worktree_root.join("pnpm-lock.yaml")).await {
-        return "pnpm";
-    }
-    if fs.is_file(&worktree_root.join("yarn.lock")).await {
-        return "yarn";
-    }
-    "npm"
-}
-
 impl ContextProvider for TypeScriptContextProvider {
     fn associated_tasks(
         &self,
@@ -511,15 +492,19 @@ impl ContextProvider for TypeScriptContextProvider {
                     self.combined_package_json_data(fs.clone(), &worktree_root, file_path, cx),
                     worktree_root,
                     fs,
+                    file_path.clone(),
                 )
             },
         );
         cx.background_spawn(async move {
-            if let Some((task, worktree_root, fs)) = args {
+            if let Some((task, worktree_root, fs, file_path)) = args {
                 let package_json_data = task.await.log_err();
+                let package_dir = worktree_root.join(file_path.as_std_path());
+                let package_dir = package_dir.parent().unwrap_or(worktree_root.as_ref());
+
                 vars.insert(
                     TYPESCRIPT_RUNNER_VARIABLE,
-                    detect_package_manager(worktree_root, fs, package_json_data.clone())
+                    crate::detect_package_manager(fs, package_dir, &worktree_root)
                         .await
                         .to_owned(),
                 );


### PR DESCRIPTION
# Objective

Fixes #61902.

When a `package.json` belongs to a nested workspace package, Zed's generated package-script tasks can incorrectly fall back to npm even when the workspace root specifies pnpm or another package manager. This affects both the package-script task and the package.json gutter runnable.

## Solution

- Add shared package-manager detection for package scripts.
- Walk from the nested package directory through its ancestor directories and use the nearest `package.json` that declares a package manager.
- Fall back to the worktree's `pnpm-lock.yaml` or `yarn.lock` when no package manager is declared.
- Keep the existing npm fallback when no package manager can be detected.
- Reuse the shared detection logic for both JSON and TypeScript task providers.
- Preserve the nested package directory as the task working directory.

## Testing

- Added regression coverage for:
  - package manager detection from an ancestor `package.json`
  - preferring the nearest `package.json`
  - pnpm lockfile detection
  - yarn lockfile detection
  - npm fallback
- Ran `cargo test -p languages --lib` successfully: 95 tests passed.
- Ran `cargo fmt -p languages --check`.
- Ran `git diff --check`.

Reviewers can reproduce the issue using the workspace described in #61902: open a nested workspace `package.json` with a script while the root `package.json` declares `packageManager: "pnpm@11.17.0"`, then run the script from the gutter or task picker.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed package-script tasks in nested workspaces incorrectly using npm instead of the workspace's detected package manager.