### PR TITLE
Fix Copilot spawning multiple processes

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -479,6 +479,26 @@ impl Copilot {
         cx.notify();
     }
 
+    /// Attach a project to this Copilot instance so that file-focus changes in the
+    /// project are forwarded to the language server via `textDocument/didFocus`.
+    /// The subscription is stored in `_subscriptions` and becomes a no-op once the
+    /// project entity is released.
+    pub fn attach_project(&mut self, project: Entity<Project>, cx: &mut Context<Self>) {
+        let subscription = cx.subscribe(&project, |this, project, e: &project::Event, cx| {
+            if let project::Event::ActiveEntryChanged(new_entry) = e
+                && let Ok(running) = this.server.as_authenticated()
+            {
+                let uri = new_entry
+                    .and_then(|id| project.read(cx).path_for_entry(id, cx))
+                    .and_then(|entry| project.read(cx).absolute_path(&entry, cx))
+                    .and_then(|abs_path| lsp::Uri::from_file_path(abs_path).ok());
+
+                _ = running.lsp.notify::<DidFocus>(DidFocusParams { uri });
+            }
+        });
+        self._subscriptions.push(subscription);
+    }
+
     fn build_env(&self, copilot_settings: &CopilotSettings) -> Option<HashMap<String, String>> {
         let proxy_url = copilot_settings.proxy.clone()?;
         let no_verify = copilot_settings.proxy_no_verify;
@@ -1836,6 +1856,114 @@ mod tests {
                 "Copilot should be starting after disable_ai is set to false"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_attach_project_forwards_focus_notifications(cx: &mut TestAppContext) {
+        init_test(cx);
+        let (copilot, mut lsp) = Copilot::fake(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                "file.rs": "fn main() {}",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [path!("/root").as_ref()], cx).await;
+        cx.run_until_parked();
+
+        copilot.update(cx, |copilot, cx| {
+            copilot.attach_project(project.clone(), cx);
+        });
+
+        let entry_id = project.read_with(cx, |project, cx| {
+            let worktree = project.visible_worktrees(cx).next().unwrap();
+            worktree
+                .read(cx)
+                .entry_for_path(rel_path("file.rs"))
+                .unwrap()
+                .id
+        });
+
+        // Focusing an entry forwards a `textDocument/didFocus` notification carrying the
+        // absolute path of the focused file.
+        project.update(cx, |_, cx| {
+            cx.emit(project::Event::ActiveEntryChanged(Some(entry_id)));
+        });
+        assert_eq!(
+            lsp.receive_notification::<DidFocus>().await.uri,
+            Some(lsp::Uri::from_file_path(path!("/root/file.rs")).unwrap()),
+        );
+
+        // Clearing the active entry forwards a notification without a URI.
+        project.update(cx, |_, cx| {
+            cx.emit(project::Event::ActiveEntryChanged(None));
+        });
+        assert_eq!(lsp.receive_notification::<DidFocus>().await.uri, None);
+    }
+
+    #[gpui::test]
+    async fn test_attach_project_does_not_forward_when_unauthenticated(cx: &mut TestAppContext) {
+        init_test(cx);
+        let (copilot, mut lsp) = Copilot::fake(cx);
+
+        // Move the fake server into an unauthenticated state so focus changes are ignored.
+        copilot.update(cx, |copilot, _| {
+            if let CopilotServer::Running(server) = &mut copilot.server {
+                server.sign_in_status = SignInStatus::SignedOut {
+                    awaiting_signing_in: false,
+                };
+            }
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                "ignored.rs": "fn ignored() {}",
+                "focused.rs": "fn focused() {}",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [path!("/root").as_ref()], cx).await;
+        cx.run_until_parked();
+
+        copilot.update(cx, |copilot, cx| {
+            copilot.attach_project(project.clone(), cx);
+        });
+
+        let (ignored_entry, focused_entry) = project.read_with(cx, |project, cx| {
+            let worktree = project.visible_worktrees(cx).next().unwrap();
+            let worktree = worktree.read(cx);
+            (
+                worktree.entry_for_path(rel_path("ignored.rs")).unwrap().id,
+                worktree.entry_for_path(rel_path("focused.rs")).unwrap().id,
+            )
+        });
+
+        // This focus change happens while unauthenticated and must be dropped.
+        project.update(cx, |_, cx| {
+            cx.emit(project::Event::ActiveEntryChanged(Some(ignored_entry)));
+        });
+
+        // Once authenticated, the next focus change is forwarded. Because notifications are
+        // delivered in order, receiving the `focused.rs` notification first proves the
+        // earlier `ignored.rs` focus change never produced one.
+        copilot.update(cx, |copilot, _| {
+            if let CopilotServer::Running(server) = &mut copilot.server {
+                server.sign_in_status = SignInStatus::Authorized;
+            }
+        });
+        project.update(cx, |_, cx| {
+            cx.emit(project::Event::ActiveEntryChanged(Some(focused_entry)));
+        });
+
+        assert_eq!(
+            lsp.receive_notification::<DidFocus>().await.uri,
+            Some(lsp::Uri::from_file_path(path!("/root/focused.rs")).unwrap()),
+        );
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -21,7 +21,7 @@ use cloud_llm_client::{
     ZED_VERSION_HEADER_NAME,
 };
 use collections::{HashMap, HashSet};
-use copilot::{Copilot, Reinstall};
+use copilot::{Copilot, GlobalCopilotAuth, Reinstall};
 use credentials_provider::CredentialsProvider;
 use db::kvp::{Dismissable, KeyValueStore};
 use edit_prediction_context::{RelatedExcerptStore, RelatedExcerptStoreEvent, RelatedFile};
@@ -1282,6 +1282,20 @@ impl EditPredictionStore {
         if state.copilot.is_some() {
             return state.copilot.clone();
         }
+
+        // If a GlobalCopilotAuth instance already owns a running language server, reuse
+        // it rather than spawning a second identical process. We attach the project so
+        // the shared server still receives `textDocument/didFocus` notifications for
+        // this project's active entry changes.
+        if let Some(global_auth) = cx.try_global::<GlobalCopilotAuth>().cloned() {
+            let project = project.clone();
+            global_auth.0.update(cx, |copilot, cx| {
+                copilot.attach_project(project, cx);
+            });
+            state.copilot = Some(global_auth.0.clone());
+            return state.copilot.clone();
+        }
+
         let _project = project.clone();
         let project = project.read(cx);
 

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3168,6 +3168,47 @@ async fn test_v3_prediction_strips_cursor_marker_from_edit_text(cx: &mut TestApp
     });
 }
 
+#[gpui::test]
+async fn test_start_copilot_reuses_global_auth_server(cx: &mut TestAppContext) {
+    let (ep_store, _requests) = init_test_with_fake_client(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "foo.rs": "fn main() {}"
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), vec![path!("/root").as_ref()], cx).await;
+
+    // Simulate the singleton Copilot language server owned by the global sign-in flow.
+    let global_auth = cx.update(|cx| {
+        copilot::GlobalCopilotAuth::set_global(
+            LanguageServerId(0),
+            fs,
+            node_runtime::NodeRuntime::unavailable(),
+            cx,
+        )
+    });
+
+    // Starting Copilot for the project must reuse the global server instead of spawning a
+    // second identical process.
+    let copilot = ep_store.update(cx, |store, cx| store.start_copilot_for_project(&project, cx));
+    assert_eq!(
+        copilot.as_ref().map(|copilot| copilot.entity_id()),
+        Some(global_auth.0.entity_id()),
+        "start_copilot_for_project should reuse the global Copilot server"
+    );
+
+    // The reused server is cached for the project, so subsequent lookups return it too.
+    let cached = ep_store.read_with(cx, |store, _| store.copilot_for_project(&project));
+    assert_eq!(
+        cached.map(|copilot| copilot.entity_id()),
+        Some(global_auth.0.entity_id()),
+    );
+}
+
 fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
         cx.set_global(AppDatabase::test_new());


### PR DESCRIPTION
# Objective

Prevent from having duplicated copilot processes spawning when running zed. 

Fixes #55379

## Solution

If a `GlobalCopilotAuth` instance already owns a running language server, reuse it rather than spawning a second identical process.

## Testing

Unit tests

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable


Release Notes:

- Fixed spawning multiple copilot processes