### PR TITLE
Add WorkerSend background spawn lint

### DIFF
--- a/tooling/lints/README.md
+++ b/tooling/lints/README.md
@@ -28,6 +28,7 @@ picks them up automatically when run from that directory.
 - `notify_in_render` — `Context::notify()` called inside `Render::render`.
 - `owned_string_into_shared` — `String::from(<lit>).into()` / `<lit>.to_string().into()` / `<lit>.to_owned().into()` whose target is `SharedString`, `Arc<str>`, `Rc<str>`, or `Cow<'_, str>`.
 - `blocking_io_on_foreground` - Catch blocking IO calls that are called on the main thread (but not on closures or background threads)
+- `extern_fn_in_background_spawn` — Catch GPUI background tasks containing data that does not implement `WorkerSend`, while treating closures and futures as if `WorkerSend` were an auto trait.
 
 ## How to run
 

--- a/tooling/lints/src/extern_fn_in_background_spawn.rs
+++ b/tooling/lints/src/extern_fn_in_background_spawn.rs
@@ -1,0 +1,193 @@
+use std::collections::HashSet;
+
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::paths::{PathNS, lookup_path_str};
+use clippy_utils::ty::implements_trait;
+use rustc_hir::attrs::CfgEntry;
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind, HirId};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, Ty};
+use rustc_span::sym;
+
+rustc_session::declare_lint! {
+    /// ### What it does
+    ///
+    /// Flags `gpui::AppContext::background_spawn` calls whose spawned future
+    /// contains state that does not implement `gpui::WorkerSend`.
+    ///
+    /// Closures and futures are treated like auto traits: they satisfy
+    /// `WorkerSend` when all data stored in them satisfies `WorkerSend`.
+    /// Calls in code that is provably excluded from `wasm32` are ignored.
+    pub EXTERN_FN_IN_BACKGROUND_SPAWN,
+    Warn,
+    "non-WorkerSend data captured by a GPUI background task that can compile for wasm"
+}
+
+pub(crate) struct ExternFnInBackgroundSpawn;
+
+rustc_session::impl_lint_pass!(ExternFnInBackgroundSpawn => [EXTERN_FN_IN_BACKGROUND_SPAWN]);
+
+impl<'tcx> LateLintPass<'tcx> for ExternFnInBackgroundSpawn {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let ExprKind::MethodCall(_, _, [spawned], _) = expr.kind else {
+            return;
+        };
+        let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) else {
+            return;
+        };
+        if cx.tcx.crate_name(def_id.krate).as_str() != "gpui"
+            || cx.tcx.item_name(def_id).as_str() != "background_spawn"
+            || is_excluded_from_wasm(cx, expr.hir_id)
+        {
+            return;
+        }
+        let Some(worker_send_trait) = worker_send_trait(cx) else {
+            return;
+        };
+
+        let spawned_type = cx
+            .tcx
+            .erase_and_anonymize_regions(cx.typeck_results().expr_ty(spawned));
+        if !is_worker_send(cx, worker_send_trait, spawned_type, &mut HashSet::new()) {
+            span_lint(
+                cx,
+                EXTERN_FN_IN_BACKGROUND_SPAWN,
+                expr.span,
+                "GPUI background task contains data that does not implement `WorkerSend` for wasm",
+            );
+        }
+    }
+}
+
+fn worker_send_trait(cx: &LateContext<'_>) -> Option<DefId> {
+    lookup_path_str(cx.tcx, PathNS::Type, "gpui::WorkerSend")
+        .into_iter()
+        .find(|def_id| cx.tcx.def_kind(*def_id) == DefKind::Trait)
+}
+
+fn is_worker_send<'tcx>(
+    cx: &LateContext<'tcx>,
+    worker_send_trait: DefId,
+    ty: Ty<'tcx>,
+    checking: &mut HashSet<Ty<'tcx>>,
+) -> bool {
+    let ty = cx.tcx.erase_and_anonymize_regions(ty);
+    if implements_trait(cx, ty, worker_send_trait, &[]) {
+        return true;
+    }
+    if !checking.insert(ty) {
+        return true;
+    }
+
+    let result = match ty.kind() {
+        ty::Closure(_, arguments) => arguments
+            .as_closure()
+            .upvar_tys()
+            .iter()
+            .all(|ty| is_worker_send(cx, worker_send_trait, ty, checking)),
+        ty::CoroutineClosure(_, arguments) => arguments
+            .as_coroutine_closure()
+            .upvar_tys()
+            .iter()
+            .all(|ty| is_worker_send(cx, worker_send_trait, ty, checking)),
+        ty::Coroutine(def_id, arguments) => {
+            let upvars_are_worker_send = arguments
+                .as_coroutine()
+                .upvar_tys()
+                .iter()
+                .all(|ty| is_worker_send(cx, worker_send_trait, ty, checking));
+            let hidden_types = cx
+                .tcx
+                .coroutine_hidden_types(*def_id)
+                .instantiate(cx.tcx, arguments);
+            let hidden_types = cx.tcx.instantiate_bound_regions_with_erased(hidden_types);
+            upvars_are_worker_send
+                && hidden_types
+                    .types
+                    .iter()
+                    .all(|ty| is_worker_send(cx, worker_send_trait, ty, checking))
+        }
+        ty::Alias(ty::Opaque, alias) => {
+            let hidden_type = cx.tcx.type_of(alias.def_id).instantiate(cx.tcx, alias.args);
+            is_worker_send(cx, worker_send_trait, hidden_type, checking)
+        }
+        _ => false,
+    };
+
+    checking.remove(&ty);
+    result
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WasmValue {
+    True,
+    False,
+    Unknown,
+}
+
+fn is_excluded_from_wasm(cx: &LateContext<'_>, hir_id: HirId) -> bool {
+    std::iter::once(hir_id)
+        .chain(cx.tcx.hir_parent_id_iter(hir_id))
+        .filter_map(
+            |hir_id| rustc_hir::find_attr!(cx.tcx.hir_attrs(hir_id), CfgTrace(entries) => entries),
+        )
+        .flatten()
+        .any(|(entry, _)| cfg_value_on_wasm(entry) == WasmValue::False)
+}
+
+fn cfg_value_on_wasm(entry: &CfgEntry) -> WasmValue {
+    match entry {
+        CfgEntry::All(entries, _) => {
+            if entries
+                .iter()
+                .any(|entry| cfg_value_on_wasm(entry) == WasmValue::False)
+            {
+                WasmValue::False
+            } else if entries
+                .iter()
+                .all(|entry| cfg_value_on_wasm(entry) == WasmValue::True)
+            {
+                WasmValue::True
+            } else {
+                WasmValue::Unknown
+            }
+        }
+        CfgEntry::Any(entries, _) => {
+            if entries
+                .iter()
+                .any(|entry| cfg_value_on_wasm(entry) == WasmValue::True)
+            {
+                WasmValue::True
+            } else if entries
+                .iter()
+                .all(|entry| cfg_value_on_wasm(entry) == WasmValue::False)
+            {
+                WasmValue::False
+            } else {
+                WasmValue::Unknown
+            }
+        }
+        CfgEntry::Not(entry, _) => match cfg_value_on_wasm(entry) {
+            WasmValue::True => WasmValue::False,
+            WasmValue::False => WasmValue::True,
+            WasmValue::Unknown => WasmValue::Unknown,
+        },
+        CfgEntry::Bool(value, _) => {
+            if *value {
+                WasmValue::True
+            } else {
+                WasmValue::False
+            }
+        }
+        CfgEntry::NameValue { name, value, .. } if *name == sym::target_arch => {
+            if *value == Some(sym::wasm32) {
+                WasmValue::True
+            } else {
+                WasmValue::False
+            }
+        }
+        CfgEntry::NameValue { .. } | CfgEntry::Version(_, _) => WasmValue::Unknown,
+    }
+}

--- a/tooling/lints/src/lib.rs
+++ b/tooling/lints/src/lib.rs
@@ -28,12 +28,14 @@ use rustc_span::Span;
 
 mod blocking_io_on_foreground;
 mod entity_update_in_render;
+mod extern_fn_in_background_spawn;
 mod notify_in_render;
 mod owned_string_into_shared;
 mod render_helpers;
 
 use blocking_io_on_foreground::BLOCKING_IO_ON_FOREGROUND;
 use entity_update_in_render::ENTITY_UPDATE_IN_RENDER;
+use extern_fn_in_background_spawn::EXTERN_FN_IN_BACKGROUND_SPAWN;
 use notify_in_render::NOTIFY_IN_RENDER;
 use owned_string_into_shared::OWNED_STRING_INTO_SHARED;
 
@@ -54,6 +56,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         ASYNC_BLOCK_WITHOUT_AWAIT,
         BLOCKING_IO_ON_FOREGROUND,
         ENTITY_UPDATE_IN_RENDER,
+        EXTERN_FN_IN_BACKGROUND_SPAWN,
         NOTIFY_IN_RENDER,
         OWNED_STRING_INTO_SHARED,
     ]);
@@ -61,6 +64,8 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store.register_late_pass(|_| Box::new(AsyncBlockWithoutAwait));
     lint_store.register_late_pass(|_| Box::new(blocking_io_on_foreground::BlockingIoOnForeground));
     lint_store.register_late_pass(|_| Box::new(entity_update_in_render::EntityUpdateInRender));
+    lint_store
+        .register_late_pass(|_| Box::new(extern_fn_in_background_spawn::ExternFnInBackgroundSpawn));
     lint_store.register_late_pass(|_| Box::new(notify_in_render::NotifyInRender));
     lint_store.register_late_pass(|_| Box::new(owned_string_into_shared::OwnedStringIntoShared));
 }

--- a/tooling/lints/test_fixture/gpui/src/lib.rs
+++ b/tooling/lints/test_fixture/gpui/src/lib.rs
@@ -2,13 +2,28 @@
 //! name and the type names, so we only need to reproduce the relevant API
 //! surface.
 
+use std::future::Future;
 use std::marker::PhantomData;
 
 // --- AppContext ---
 
 pub trait AppContext {
     fn as_app_mut(&mut self) -> &mut App;
+
+    fn background_spawn<R>(&self, _future: impl Future<Output = R> + Send + 'static) -> Task<R>
+    where
+        R: Send + 'static,
+    {
+        Task(PhantomData)
+    }
 }
+
+pub struct Task<T>(PhantomData<T>);
+
+pub trait WorkerSend {}
+
+impl WorkerSend for String {}
+impl<T: WorkerSend + ?Sized> WorkerSend for Box<T> {}
 
 // --- App ---
 

--- a/tooling/lints/ui/extern_fn_in_background_spawn.rs
+++ b/tooling/lints/ui/extern_fn_in_background_spawn.rs
@@ -1,0 +1,134 @@
+// Tests for the `extern_fn_in_background_spawn` lint.
+
+#![allow(unused, async_block_without_await)]
+
+extern crate gpui;
+
+use gpui::*;
+
+extern "C" fn foreign_callback() {}
+fn rust_callback() {}
+
+struct SendOnlyData;
+
+struct WorkerData;
+impl WorkerSend for WorkerData {}
+
+struct WorkerWrapper<T>(T);
+impl<T: WorkerSend> WorkerSend for WorkerWrapper<T> {}
+
+trait WorkerObject: WorkerSend + Send {}
+impl WorkerObject for WorkerData {}
+
+// SHOULD WARN
+
+fn foreign_function_pointer(cx: &mut App) {
+    let callback: extern "C" fn() = foreign_callback;
+    cx.background_spawn(async move {
+        callback();
+    });
+}
+
+fn rust_function_pointer(cx: &mut App) {
+    let callback: fn() = rust_callback;
+    cx.background_spawn(async move {
+        callback();
+    });
+}
+
+fn send_only_data(cx: &mut App) {
+    let data = SendOnlyData;
+    cx.background_spawn(async move {
+        drop(data);
+    });
+}
+
+fn nested_closure_with_send_only_data(cx: &mut App) {
+    let data = SendOnlyData;
+    let closure = move || drop(data);
+    cx.background_spawn(async move {
+        closure();
+    });
+}
+
+fn nested_future_with_send_only_data(cx: &mut App) {
+    let data = SendOnlyData;
+    let future = async move {
+        drop(data);
+    };
+    cx.background_spawn(async move {
+        future.await;
+    });
+}
+
+// SHOULD NOT WARN
+
+fn worker_send_data(cx: &mut App) {
+    let data = WorkerData;
+    cx.background_spawn(async move {
+        drop(data);
+    });
+}
+
+fn generic_worker_send_data(cx: &mut App) {
+    let data = WorkerWrapper(WorkerData);
+    cx.background_spawn(async move {
+        drop(data);
+    });
+}
+
+fn dyn_worker_send_data(cx: &mut App) {
+    let data: Box<dyn WorkerObject> = Box::new(WorkerData);
+    cx.background_spawn(async move {
+        drop(data);
+    });
+}
+
+fn nested_closure_with_worker_send_data(cx: &mut App) {
+    let data = WorkerData;
+    let closure = move || drop(data);
+    cx.background_spawn(async move {
+        closure();
+    });
+}
+
+fn nested_future_with_worker_send_data(cx: &mut App) {
+    let data = WorkerData;
+    let future = async move {
+        drop(data);
+    };
+    cx.background_spawn(async move {
+        future.await;
+    });
+}
+
+async fn worker_future(data: WorkerData) {
+    drop(data);
+}
+
+fn opaque_worker_future(cx: &mut App) {
+    cx.background_spawn(worker_future(WorkerData));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn wasm_excluded(cx: &mut App) {
+    let callback: extern "C" fn() = foreign_callback;
+    cx.background_spawn(async move {
+        callback();
+    });
+}
+
+struct OtherContext;
+
+impl OtherContext {
+    fn background_spawn(&self, _future: impl std::future::Future<Output = ()>) {}
+}
+
+fn unrelated_method_is_allowed(cx: &OtherContext) {
+    let data = SendOnlyData;
+    cx.background_spawn(async move {
+        drop(data);
+    });
+}
+
+fn main() {}

--- a/tooling/lints/ui/extern_fn_in_background_spawn.stderr
+++ b/tooling/lints/ui/extern_fn_in_background_spawn.stderr
@@ -1,0 +1,44 @@
+error: GPUI background task contains data that does not implement `WorkerSend` for wasm
+  --> $DIR/extern_fn_in_background_spawn.rs:27:5
+   |
+LL | /     cx.background_spawn(async move {
+LL | |         callback();
+LL | |     });
+   | |______^
+   |
+   = note: `-D extern-fn-in-background-spawn` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(extern_fn_in_background_spawn)]`
+
+error: GPUI background task contains data that does not implement `WorkerSend` for wasm
+  --> $DIR/extern_fn_in_background_spawn.rs:34:5
+   |
+LL | /     cx.background_spawn(async move {
+LL | |         callback();
+LL | |     });
+   | |______^
+
+error: GPUI background task contains data that does not implement `WorkerSend` for wasm
+  --> $DIR/extern_fn_in_background_spawn.rs:41:5
+   |
+LL | /     cx.background_spawn(async move {
+LL | |         drop(data);
+LL | |     });
+   | |______^
+
+error: GPUI background task contains data that does not implement `WorkerSend` for wasm
+  --> $DIR/extern_fn_in_background_spawn.rs:49:5
+   |
+LL | /     cx.background_spawn(async move {
+LL | |         closure();
+LL | |     });
+   | |______^
+
+error: GPUI background task contains data that does not implement `WorkerSend` for wasm
+  --> $DIR/extern_fn_in_background_spawn.rs:59:5
+   |
+LL | /     cx.background_spawn(async move {
+LL | |         future.await;
+LL | |     });
+   | |______^
+
+error: aborting due to 5 previous errors


### PR DESCRIPTION
## Summary

- add a Dylint for GPUI background tasks containing data that does not implement `WorkerSend`
- emulate auto-trait behavior for closure captures, coroutine state, nested futures, and opaque futures
- ignore call sites that are provably excluded from wasm and cover positive and negative cases with UI tests

Here's what cases whould be detect and which shouldn't be:

<details><summary>Details</summary>
<p>

```rust
// SHOULD WARN

fn foreign_function_pointer(cx: &mut App) {
    let callback: extern "C" fn() = foreign_callback;
    cx.background_spawn(async move {
        callback();
    });
}

fn rust_function_pointer(cx: &mut App) {
    let callback: fn() = rust_callback;
    cx.background_spawn(async move {
        callback();
    });
}

fn send_only_data(cx: &mut App) {
    let data = SendOnlyData;
    cx.background_spawn(async move {
        drop(data);
    });
}

fn nested_closure_with_send_only_data(cx: &mut App) {
    let data = SendOnlyData;
    let closure = move || drop(data);
    cx.background_spawn(async move {
        closure();
    });
}

fn nested_future_with_send_only_data(cx: &mut App) {
    let data = SendOnlyData;
    let future = async move {
        drop(data);
    };
    cx.background_spawn(async move {
        future.await;
    });
}

// SHOULD NOT WARN

fn worker_send_data(cx: &mut App) {
    let data = WorkerData;
    cx.background_spawn(async move {
        drop(data);
    });
}

fn generic_worker_send_data(cx: &mut App) {
    let data = WorkerWrapper(WorkerData);
    cx.background_spawn(async move {
        drop(data);
    });
}

fn dyn_worker_send_data(cx: &mut App) {
    let data: Box<dyn WorkerObject> = Box::new(WorkerData);
    cx.background_spawn(async move {
        drop(data);
    });
}

fn nested_closure_with_worker_send_data(cx: &mut App) {
    let data = WorkerData;
    let closure = move || drop(data);
    cx.background_spawn(async move {
        closure();
    });
}

fn nested_future_with_worker_send_data(cx: &mut App) {
    let data = WorkerData;
    let future = async move {
        drop(data);
    };
    cx.background_spawn(async move {
        future.await;
    });
}

async fn worker_future(data: WorkerData) {
    drop(data);
}

fn opaque_worker_future(cx: &mut App) {
    cx.background_spawn(worker_future(WorkerData));
}

#[cfg(not(target_arch = "wasm32"))]
fn wasm_excluded(cx: &mut App) {
    let callback: extern "C" fn() = foreign_callback;
    cx.background_spawn(async move {
        callback();
    });
}

struct OtherContext;

impl OtherContext {
    fn background_spawn(&self, _future: impl std::future::Future<Output = ()>) {}
}

fn unrelated_method_is_allowed(cx: &OtherContext) {
    let data = SendOnlyData;
    cx.background_spawn(async move {
        drop(data);
    });
}
```

</p>
</details> 

## Tests

- `cargo fmt --manifest-path tooling/lints/Cargo.toml --all -- --check`
- `cargo +nightly-2026-03-21 test --manifest-path tooling/lints/Cargo.toml`

Release Notes:

- N/A