### PR TITLE
http_client: Fully download archives before extracting them

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -305,7 +305,12 @@ impl AgentConnectionStore {
             Ok(connection) => Ok(AgentConnectedState { connection }),
             Err(err) => match err.downcast::<LoadError>() {
                 Ok(load_error) => Err(load_error),
-                Err(err) => Err(LoadError::Other(SharedString::from(err.to_string()))),
+                Err(err) => {
+                    log::error!("failed to connect to agent server: {err:?}");
+                    // `{:#}` keeps the whole context chain; `to_string` would
+                    // keep only the outermost message and hide the root cause.
+                    Err(LoadError::Other(SharedString::from(format!("{err:#}"))))
+                }
             },
         });
         (new_version_rx, loading_status_rx, connect_task)

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1206,11 +1206,17 @@ impl ConversationView {
                         );
                     }
                     Err(err) => {
-                        this.handle_load_error(
-                            LoadError::Other(err.to_string().into()),
-                            window,
-                            cx,
-                        );
+                        let error = match err.downcast::<LoadError>() {
+                            Ok(load_error) => load_error,
+                            Err(err) => {
+                                log::error!("failed to create agent session: {err:?}");
+                                // `{:#}` keeps the whole context chain; `to_string`
+                                // would keep only the outermost message and hide
+                                // the root cause.
+                                LoadError::Other(format!("{err:#}").into())
+                            }
+                        };
+                        this.handle_load_error(error, window, cx);
                     }
                 };
             })

--- a/crates/http_client/src/github_download.rs
+++ b/crates/http_client/src/github_download.rs
@@ -137,45 +137,36 @@ async fn extract_to_staging(
     staging_path: &Path,
     asset_kind: AssetKind,
 ) -> Result<()> {
-    match digest {
-        Some(expected_sha_256) => {
-            let temp_asset_file = tempfile::NamedTempFile::new()
-                .with_context(|| format!("creating a temporary file for {url}"))?;
-            let (temp_asset_file, _temp_guard) = temp_asset_file.into_parts();
-            let mut writer = HashingWriter {
-                writer: async_fs::File::from(temp_asset_file),
-                hasher: Sha256::new(),
-            };
-            futures::io::copy(&mut BufReader::new(body), &mut writer)
-                .await
-                .with_context(|| {
-                    format!("saving archive contents into the temporary file for {url}")
-                })?;
-            let asset_sha_256 = format!("{:x}", writer.hasher.finalize());
+    // Buffer the whole response on disk before extracting, even when there is
+    // no digest to verify. Extracting straight from the network stream turns
+    // an interrupted download into an opaque archive error that is
+    // indistinguishable from a corrupt asset.
+    let temp_asset_file = tempfile::NamedTempFile::new()
+        .with_context(|| format!("creating a temporary file for {url}"))?;
+    let (temp_asset_file, _temp_guard) = temp_asset_file.into_parts();
+    let mut writer = HashingWriter {
+        writer: async_fs::File::from(temp_asset_file),
+        hasher: Sha256::new(),
+    };
+    futures::io::copy(&mut BufReader::new(body), &mut writer)
+        .await
+        .with_context(|| format!("saving archive contents into the temporary file for {url}"))?;
+    let asset_sha_256 = format!("{:x}", writer.hasher.finalize());
 
-            anyhow::ensure!(
-                sha256_matches(&asset_sha_256, expected_sha_256),
-                "{url} asset got SHA-256 mismatch. Expected: {expected_sha_256}, Got: {asset_sha_256}",
-            );
-            writer
-                .writer
-                .seek(std::io::SeekFrom::Start(0))
-                .await
-                .with_context(|| format!("seeking temporary file for {url}"))?;
-            stream_file_archive(&mut writer.writer, url, staging_path, asset_kind)
-                .await
-                .with_context(|| {
-                    format!("extracting downloaded asset for {url} into {staging_path:?}")
-                })?;
-        }
-        None => {
-            stream_response_archive(body, url, staging_path, asset_kind)
-                .await
-                .with_context(|| {
-                    format!("extracting response for asset {url} into {staging_path:?}")
-                })?;
-        }
+    if let Some(expected_sha_256) = digest {
+        anyhow::ensure!(
+            sha256_matches(&asset_sha_256, expected_sha_256),
+            "{url} asset got SHA-256 mismatch. Expected: {expected_sha_256}, Got: {asset_sha_256}",
+        );
     }
+    writer
+        .writer
+        .seek(std::io::SeekFrom::Start(0))
+        .await
+        .with_context(|| format!("seeking temporary file for {url}"))?;
+    stream_file_archive(&mut writer.writer, url, staging_path, asset_kind)
+        .await
+        .with_context(|| format!("extracting downloaded asset for {url} into {staging_path:?}"))?;
     Ok(())
 }
 
@@ -223,23 +214,6 @@ async fn finalize_download(staging_path: &Path, destination_path: &Path) -> Resu
     async_fs::rename(staging_path, destination_path)
         .await
         .with_context(|| format!("renaming {staging_path:?} to {destination_path:?}"))?;
-    Ok(())
-}
-
-async fn stream_response_archive(
-    response: impl AsyncRead + Unpin,
-    url: &str,
-    destination_path: &Path,
-    asset_kind: AssetKind,
-) -> Result<()> {
-    match asset_kind {
-        AssetKind::TarGz => extract_tar_gz(destination_path, url, response).await?,
-        AssetKind::TarBz2 => extract_tar_bz2(destination_path, url, response).await?,
-        AssetKind::Gz => extract_gz(destination_path, url, response).await?,
-        AssetKind::Zip => {
-            util::archive::extract_zip(destination_path, response).await?;
-        }
-    };
     Ok(())
 }
 
@@ -471,17 +445,7 @@ mod tests {
     #[test]
     fn downloads_archive_with_uppercase_digest_and_extracts_contents() {
         futures::executor::block_on(async {
-            let archive = vec![
-                0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
-                0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
-                0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x50, 0x4b,
-                0x01, 0x02, 0x14, 0x03, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
-                0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x01, 0x00, 0x00,
-                0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00,
-                0x00, 0x01, 0x00, 0x01, 0x00, 0x33, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00,
-                0x00,
-            ];
+            let archive = zip_archive_containing_agent_file();
             let expected_sha_256 = format!("{:X}", Sha256::digest(&archive));
             let client = StaticResponseClient { body: archive };
             let temp_dir = tempfile::tempdir().unwrap();
@@ -501,6 +465,64 @@ mod tests {
                 std::fs::read(destination_path.join("agent")).unwrap(),
                 b"hello"
             );
+        });
+    }
+
+    #[test]
+    fn downloads_archive_without_digest_and_extracts_contents() {
+        futures::executor::block_on(async {
+            let client = StaticResponseClient {
+                body: zip_archive_containing_agent_file(),
+            };
+            let temp_dir = tempfile::tempdir().unwrap();
+            let destination_path = temp_dir.path().join("v_1");
+
+            download_server_binary(
+                &client,
+                "https://example.com/agent.zip",
+                None,
+                &destination_path,
+                AssetKind::Zip,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                std::fs::read(destination_path.join("agent")).unwrap(),
+                b"hello"
+            );
+        });
+    }
+
+    #[test]
+    fn interrupted_download_without_digest_reports_download_error_and_cleans_up_staging() {
+        futures::executor::block_on(async {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let destination_path = temp_dir.path().join("v_1");
+            let mut truncated_archive = zip_archive_containing_agent_file();
+            truncated_archive.truncate(10);
+            let client = InterruptedResponseClient {
+                prefix: truncated_archive,
+            };
+
+            let error = download_server_binary(
+                &client,
+                "https://example.com/agent.zip",
+                None,
+                &destination_path,
+                AssetKind::Zip,
+            )
+            .await
+            .unwrap_err();
+
+            let error_chain = format!("{error:#}");
+            assert!(
+                error_chain.contains("saving archive contents"),
+                "error should point at the download, got: {error_chain}"
+            );
+            assert!(!destination_path.exists());
+            let leftover_entries = std::fs::read_dir(temp_dir.path()).unwrap().count();
+            assert_eq!(leftover_entries, 0, "staging directory should be removed");
         });
     }
 
@@ -528,5 +550,74 @@ mod tests {
             let leftover_entries = std::fs::read_dir(temp_dir.path()).unwrap().count();
             assert_eq!(leftover_entries, 0, "staging directory should be removed");
         });
+    }
+
+    /// A zip archive holding a single file named `agent` whose contents are `hello`.
+    fn zip_archive_containing_agent_file() -> Vec<u8> {
+        vec![
+            0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
+            0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
+            0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x50, 0x4b,
+            0x01, 0x02, 0x14, 0x03, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
+            0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x33, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ]
+    }
+
+    /// Serves `prefix` and then fails the stream, like a connection dropped
+    /// partway through a download.
+    struct InterruptedResponseClient {
+        prefix: Vec<u8>,
+    }
+
+    impl HttpClient for InterruptedResponseClient {
+        fn send(
+            &self,
+            _req: http::Request<AsyncBody>,
+        ) -> BoxFuture<'static, anyhow::Result<Response<AsyncBody>>> {
+            let prefix = self.prefix.clone();
+            Box::pin(async move {
+                Ok(Response::builder()
+                    .status(200)
+                    .body(AsyncBody::from_reader(InterruptedReader {
+                        remaining: prefix,
+                    }))
+                    .unwrap())
+            })
+        }
+
+        fn user_agent(&self) -> Option<&HeaderValue> {
+            None
+        }
+
+        fn proxy(&self) -> Option<&Url> {
+            None
+        }
+    }
+
+    struct InterruptedReader {
+        remaining: Vec<u8>,
+    }
+
+    impl AsyncRead for InterruptedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            if self.remaining.is_empty() {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "connection reset mid-download",
+                )));
+            }
+            let byte_count = buf.len().min(self.remaining.len());
+            buf[..byte_count].copy_from_slice(&self.remaining[..byte_count]);
+            self.remaining.drain(..byte_count);
+            Poll::Ready(Ok(byte_count))
+        }
     }
 }


### PR DESCRIPTION
Installing an external agent (or a language server) from an archive that ships without a SHA-256 checksum used a fragile code path: Zed unpacked the archive directly from the network stream, without ever saving the complete file to disk. If the connection dropped partway through the download, the unpacker saw the data stop mid-file and failed with an archive-extraction error that looks identical to a corrupt package. Users hit this with the Cursor agent, whose ACP registry entry has no checksum and whose package is a 71 MB download: any network hiccup produced a confusing "Failed to Install" error with no hint that the download was the problem.

This change makes both paths behave the same way: every archive is now fully downloaded to a temporary file first, and only then unpacked. The checksum verification still runs when a checksum is available, exactly as before; when none is available it is simply skipped. This removes no protection that exists today, since the streaming path performed no verification either. A failed download now reports a download error ("saving archive contents into the temporary file for <url>") instead of a misleading extraction error.

The second commit fixes the reason these failures were undiagnosable: agent connect and session-creation errors were flattened with `to_string`, which keeps only the outermost message of an error chain. The underlying cause (invalid gzip, unexpected end of file, connection reset) never reached the panel, the log, or telemetry. Errors are now formatted with the full context chain for display, logged with their debug representation, and session errors are downcast to `LoadError` first so typed variants keep their specific handling.

The trade-offs are small: the archive briefly occupies temporary disk space, and installation finishes slightly later because unpacking waits for the download to complete.

Intentionally out of scope, as follow-ups: deduplicating concurrent installs of the same version, and cleaning up staging directories left behind by cancelled installs.

Testing:

- Added a test covering the new no-checksum path (download completes, archive extracts correctly).
- Added a test simulating a connection dropped mid-download, asserting the error names the download rather than the extraction, and that the staging directory is cleaned up.
- `cargo nextest run -p http_client --features github-download`: 8 tests, all passing.
- `cargo nextest run -p agent_ui load_error`: 4 tests, all passing.
- `cargo fmt --check` and `script/clippy` pass.

Release Notes:

- Improved installation of external agents and language servers: archives are now fully downloaded before being unpacked, so an interrupted download produces a clear error instead of a confusing extraction failure, and install errors now show the underlying cause.
