### PR TITLE
http_client: Fix extraction of archives containing binary PAX attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,13 +1239,13 @@ dependencies = [
 [[package]]
 name = "async-tar"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6affe71e5b6180fb5eaf9e8127a243694baf6ae1120c199227167302f56c14b"
+source = "git+https://github.com/hooiv/async-tar.git?branch=fix-pax-binary-newlines#42f343bf5ef0c904e51405cde3e29bb35ab05ad3"
 dependencies = [
  "async-std",
  "filetime",
  "futures-core",
  "libc",
+ "pin-project",
  "redox_syscall 0.7.5",
  "xattr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -968,6 +968,7 @@ features = [
 ]
 
 [patch.crates-io]
+async-tar = { git = "https://github.com/hooiv/async-tar.git", branch = "fix-pax-binary-newlines" }
 async-process = { git = "https://github.com/zed-industries/async-process.git", rev = "0b6d6713570af61806e1e5cb40e0f757cb93fd9d" }
 async-task = { git = "https://github.com/smol-rs/async-task.git", rev = "b4486cd71e4e94fbda54ce6302444de14f4d190e" }
 windows-capture = { git = "https://github.com/zed-industries/windows-capture.git", rev = "f0d6c1b6691db75461b732f6d5ff56eed002eeb9" }

--- a/crates/http_client/src/github_download.rs
+++ b/crates/http_client/src/github_download.rs
@@ -529,4 +529,66 @@ mod tests {
             assert_eq!(leftover_entries, 0, "staging directory should be removed");
         });
     }
+
+    #[test]
+    fn downloads_tar_gz_with_binary_pax_headers_and_extracts_contents() {
+        futures::executor::block_on(async {
+            use async_compression::futures::write::GzipEncoder;
+            use futures::AsyncWriteExt as _;
+
+            let mut tar_bytes = Vec::new();
+
+            // 1. PAX Extended Header
+            let pax_record = b"45 SCHILY.xattr.test=binary\nwith\nnewlines\x00data\n";
+            let mut pax_header = async_tar::Header::new_ustar();
+            pax_header.set_path("PaxHeader/test_file").unwrap();
+            pax_header.set_entry_type(async_tar::EntryType::XHeader);
+            pax_header.set_size(pax_record.len() as u64);
+            pax_header.set_cksum();
+            tar_bytes.extend_from_slice(pax_header.as_bytes());
+            tar_bytes.extend_from_slice(pax_record);
+            let pax_pad = (512 - (pax_record.len() % 512)) % 512;
+            tar_bytes.extend(std::iter::repeat(0).take(pax_pad));
+
+            // 2. Regular File Header
+            let mut file_header = async_tar::Header::new_ustar();
+            file_header.set_path("test_file").unwrap();
+            file_header.set_entry_type(async_tar::EntryType::Regular);
+            file_header.set_size(5);
+            file_header.set_cksum();
+            tar_bytes.extend_from_slice(file_header.as_bytes());
+            tar_bytes.extend_from_slice(b"hello");
+            let file_pad = (512 - (5 % 512)) % 512;
+            tar_bytes.extend(std::iter::repeat(0).take(file_pad));
+
+            // 3. End of archive padding (two 512-byte zero blocks)
+            tar_bytes.extend(std::iter::repeat(0).take(1024));
+
+            let mut gz_bytes = Vec::new();
+            {
+                let mut encoder = GzipEncoder::new(&mut gz_bytes);
+                encoder.write_all(&tar_bytes).await.unwrap();
+                encoder.close().await.unwrap();
+            }
+
+            let client = StaticResponseClient { body: gz_bytes };
+            let temp_dir = tempfile::tempdir().unwrap();
+            let destination_path = temp_dir.path().join("extracted");
+
+            download_server_binary(
+                &client,
+                "https://example.com/agent.tar.gz",
+                None,
+                &destination_path,
+                AssetKind::TarGz,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                std::fs::read(destination_path.join("test_file")).unwrap(),
+                b"hello"
+            );
+        });
+    }
 }


### PR DESCRIPTION
Closes #62655

### Description

When downloading and extracting external agent archives (such as the Cursor Agent payload `agent-cli-package.tar.gz`), the archive contains PAX extended header attributes for macOS code signing (e.g., `SCHILY.xattr.com.apple.cs.CodeRequirements`).

These binary extended attributes contain raw binary byte sequences with embedded newline (`\n`, `0x0A`) bytes. Previously, `async-tar` parsed PAX records by splitting the extended header on `\n`. Any embedded newline truncated/fragmented the record, causing length mismatch validation to fail and emitting `pax extensions invalid`, aborting the download/extraction process.

### Changes
1. Updated `async-tar` via patch with a POSIX.1-2001-compliant length-based PAX record parser (see [zed-industries/async-tar#1](https://github.com/zed-industries/async-tar/pull/1)).
2. Added an in-memory unit test in `crates/http_client/src/github_download.rs` verifying that archives with binary PAX extended attributes and embedded newlines extract successfully.