### PR TITLE
git_ui: prevent branch name overflow in git details pane

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -1723,6 +1723,10 @@ impl GitGraph {
         Chip::new(name.clone())
             .label_size(LabelSize::Small)
             .truncate()
+            .tooltip({
+                let name = name.clone();
+                move |_, cx| Tooltip::simple(name.clone(), cx)
+            })
             .map(|chip| {
                 if is_head {
                     chip.icon(IconName::Check)
@@ -1752,6 +1756,7 @@ impl GitGraph {
             return chip.into_any_element();
         };
         div()
+            .min_w_0()
             .child(chip)
             .on_mouse_down(
                 MouseButton::Right,


### PR DESCRIPTION
# Objective

- prevent branch name overflow in git details pane
- Fixes #62526 

## Solution

- set min width
- add tooltip for readability

## Testing

- manual testing

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase
### before
- 
<img width="670" height="205" alt="image" src="https://github.com/user-attachments/assets/26716b50-6f09-40c1-bec5-d78bd913d4ec" />

- No tooltip

### After
- 
<img width="499" height="203" alt="image" src="https://github.com/user-attachments/assets/3eee21e8-f9e8-4c30-a21d-0c23bf25c9de" />

- Tooltip: 

<img width="609" height="364" alt="image" src="https://github.com/user-attachments/assets/822d784d-889e-4d26-b8e6-de46f8206569" />

---

Release Notes:

- N/A or Added/Fixed/Improved ...
