### PR TITLE
Fixed Issue : Markdown Preview Line Height

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -209,7 +209,7 @@ impl MarkdownStyle {
         };
 
         let mut text_style = window.text_style();
-        let line_height = buffer_font_size * 1.75;
+        let line_height = buffer_font_size * theme_settings.line_height();
 
         text_style.refine(&TextStyleRefinement {
             font_family: Some(body_font_family),
@@ -6053,6 +6053,29 @@ mod tests {
                 "preview container font size must be rem-based, got {:?}",
                 style.container_style.text.font_size
             );
+        });
+    }
+
+    #[gpui::test]
+    fn test_markdown_preview_respects_line_height(cx: &mut TestAppContext) {
+        ensure_theme_initialized(cx);
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme.buffer_line_height =
+                        Some(settings::BufferLineHeight::Custom(2.0));
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        let (_, cx) = cx.add_window_view(|_, _| TestWindow);
+        cx.update(|window, cx| {
+            let style = MarkdownStyle::themed(MarkdownFont::Preview, window, cx);
+            let font_size = ThemeSettings::get_global(cx).markdown_preview_font_size(cx);
+            let expected_line_height = font_size * 2.0;
+            assert_eq!(style.base_text_style.line_height, Some(expected_line_height.into()));
         });
     }
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -717,7 +717,7 @@ impl MarkdownPreviewView {
 
     fn line_scroll_amount(&self, cx: &App) -> Pixels {
         let settings = ThemeSettings::get_global(cx);
-        settings.markdown_preview_font_size(cx) * settings.buffer_line_height.value()
+        settings.markdown_preview_font_size(cx) * settings.line_height()
     }
 
     fn increase_font_size(


### PR DESCRIPTION
# Objective

Fixes #62528

The Markdown preview panel did not respect user-configured [line_height](cci:1://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/theme_settings/src/settings.rs:525:4-528:5) settings (such as `"comfortable"`, `"standard"`, or custom numerical values in `settings.json`). Instead, it always rendered Markdown body text using a hardcoded line height multiplier of `1.75`.

## Solution

- Updated `MarkdownStyle::themed_with_overrides` in [crates/markdown/src/markdown.rs](cci:7://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:0:0-0:0) to compute line height dynamically via `let line_height = buffer_font_size * theme_settings.line_height();` instead of using the hardcoded `1.75` multiplier.
- Updated [line_scroll_amount](cci:1://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown_preview/src/markdown_preview_view.rs:717:4-720:5) in [crates/markdown_preview/src/markdown_preview_view.rs](cci:7://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown_preview/src/markdown_preview_view.rs:0:0-0:0) to use `settings.line_height()` instead of `settings.buffer_line_height.value()`, ensuring `MIN_LINE_HEIGHT` clamping is applied consistently.
- Added unit test [test_markdown_preview_respects_line_height](cci:1://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:6058:4-6079:5) in [crates/markdown/src/markdown.rs](cci:7://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:0:0-0:0) to verify that custom `buffer_line_height` settings correctly update the base line height in [MarkdownStyle](cci:2://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:106:0-127:1).

## Testing

- Added unit test [test_markdown_preview_respects_line_height](cci:1://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:6058:4-6079:5) in [crates/markdown/src/markdown.rs](cci:7://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/markdown/src/markdown.rs:0:0-0:0).
- Verified logic and correctness across [ThemeSettings](cci:2://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/theme_settings/src/settings.rs:38:0-98:1) and GPUI `TextStyleRefinement`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Markdown preview not respecting the [line_height](cci:1://file:///c:/Users/ABHISUMAT/All%20Projects/zed/crates/theme_settings/src/settings.rs:525:4-528:5) setting.
