### PR TITLE
python: Support nested analysis settings for `Pyright` and `basedpyright`

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -265,6 +265,41 @@ fn highlight_id_for_completion(
     }
 }
 
+/// Older pyright-derived servers request a literal `<configuration section>.analysis` section,
+/// while new versions request `<configuration section>` and read its nested `analysis` object.
+///
+/// Basedpyright changed this behavior in v1.39.10, context: https://github.com/DetachHead/basedpyright/pull/1847
+/// Pyright itself changed this behavior in v1.1.411 context: https://github.com/microsoft/pyright/pull/11480
+fn normalize_pyright_analysis_configuration(
+    workspace_configuration: &mut Value,
+    configuration_section: &str,
+) {
+    let Some(workspace_configuration) = workspace_configuration.as_object_mut() else {
+        return;
+    };
+
+    let analysis_section = format!("{configuration_section}.analysis");
+    let analysis = workspace_configuration
+        .get(configuration_section)
+        .and_then(Value::as_object)
+        .and_then(|server_configuration| server_configuration.get("analysis"))
+        .cloned()
+        .or_else(|| workspace_configuration.get(&analysis_section).cloned());
+    let Some(analysis) = analysis else {
+        return;
+    };
+
+    let server_configuration = workspace_configuration
+        .entry(configuration_section)
+        .or_insert_with(|| Value::Object(serde_json::Map::default()));
+    let Some(server_configuration) = server_configuration.as_object_mut() else {
+        return;
+    };
+    server_configuration.insert("analysis".to_owned(), analysis.clone());
+
+    workspace_configuration.insert(analysis_section, analysis);
+}
+
 pub struct TyLspAdapter {
     fs: Arc<dyn Fs>,
 }
@@ -735,6 +770,7 @@ impl LspAdapter for PyrightLspAdapter {
                 );
             }
 
+            normalize_pyright_analysis_configuration(&mut user_settings, "python");
             user_settings
         }))
     }
@@ -2195,6 +2231,7 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 }
             }
 
+            normalize_pyright_analysis_configuration(&mut user_settings, "basedpyright");
             user_settings
         }))
     }
@@ -2721,7 +2758,124 @@ mod tests {
     use settings::SettingsStore;
     use std::num::NonZeroU32;
 
-    use crate::python::python_module_name_from_relative_path;
+    use crate::python::{
+        normalize_pyright_analysis_configuration, python_module_name_from_relative_path,
+    };
+
+    #[test]
+    fn test_normalize_legacy_basedpyright_analysis_configuration() {
+        let mut workspace_configuration = serde_json::json!({
+            "basedpyright.analysis": {
+                "diagnosticMode": "workspace",
+                "typeCheckingMode": "basic"
+            }
+        });
+
+        normalize_pyright_analysis_configuration(&mut workspace_configuration, "basedpyright");
+
+        assert_eq!(
+            workspace_configuration,
+            serde_json::json!({
+                "basedpyright": {
+                    "analysis": {
+                        "diagnosticMode": "workspace",
+                        "typeCheckingMode": "basic"
+                    }
+                },
+                "basedpyright.analysis": {
+                    "diagnosticMode": "workspace",
+                    "typeCheckingMode": "basic"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_normalize_nested_basedpyright_analysis_configuration() {
+        let mut workspace_configuration = serde_json::json!({
+            "basedpyright": {
+                "analysis": {
+                    "diagnosticMode": "workspace"
+                },
+                "unrelated": true
+            }
+        });
+
+        normalize_pyright_analysis_configuration(&mut workspace_configuration, "basedpyright");
+
+        assert_eq!(
+            workspace_configuration,
+            serde_json::json!({
+                "basedpyright": {
+                    "analysis": {
+                        "diagnosticMode": "workspace"
+                    },
+                    "unrelated": true
+                },
+                "basedpyright.analysis": {
+                    "diagnosticMode": "workspace"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_nested_basedpyright_analysis_configuration_takes_precedence() {
+        let mut workspace_configuration = serde_json::json!({
+            "basedpyright": {
+                "analysis": {
+                    "typeCheckingMode": "basic"
+                }
+            },
+            "basedpyright.analysis": {
+                "typeCheckingMode": "strict"
+            }
+        });
+
+        normalize_pyright_analysis_configuration(&mut workspace_configuration, "basedpyright");
+
+        assert_eq!(
+            workspace_configuration,
+            serde_json::json!({
+                "basedpyright": {
+                    "analysis": {
+                        "typeCheckingMode": "basic"
+                    }
+                },
+                "basedpyright.analysis": {
+                    "typeCheckingMode": "basic"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_normalize_pyright_analysis_configuration() {
+        let mut workspace_configuration = serde_json::json!({
+            "python.analysis": {
+                "diagnosticMode": "workspace",
+                "typeCheckingMode": "basic"
+            }
+        });
+
+        normalize_pyright_analysis_configuration(&mut workspace_configuration, "python");
+
+        assert_eq!(
+            workspace_configuration,
+            serde_json::json!({
+                "python": {
+                    "analysis": {
+                        "diagnosticMode": "workspace",
+                        "typeCheckingMode": "basic"
+                    }
+                },
+                "python.analysis": {
+                    "diagnosticMode": "workspace",
+                    "typeCheckingMode": "basic"
+                }
+            })
+        );
+    }
 
     #[gpui::test]
     async fn test_conda_activation_script_injection(cx: &mut TestAppContext) {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -716,54 +716,28 @@ impl LspAdapter for PyrightLspAdapter {
                     .and_then(|s| s.settings.clone())
                     .unwrap_or_default();
 
+            if !user_settings.is_object() {
+                user_settings = Value::Object(serde_json::Map::default());
+            }
+            let object = user_settings.as_object_mut().unwrap();
+
             // If we have a detected toolchain, configure Pyright to use it - unless the user sets it themselves.
             let should_insert_toolchain = || {
-                user_settings.as_object().is_none_or(|object| {
-                    ![
-                        "venvPath",
-                        "venv",
-                        "python",
-                        "pythonPath",
-                        "defaultInterpreterPath",
-                    ]
-                    .into_iter()
-                    .any(|known_key| object.contains_key(known_key))
-                })
+                object
+                    .get("python")
+                    .and_then(Value::as_object)
+                    .is_none_or(|python| {
+                        !["pythonPath", "venvPath"]
+                            .into_iter()
+                            .any(|known_key| python.contains_key(known_key))
+                    })
             };
             if let Some(toolchain) = toolchain
                 && should_insert_toolchain()
-                && let Ok(env) =
-                    serde_json::from_value::<PythonToolchainData>(toolchain.as_json.clone())
+                && serde_json::from_value::<PythonToolchainData>(toolchain.as_json.clone()).is_ok()
             {
-                if !user_settings.is_object() {
-                    user_settings = Value::Object(serde_json::Map::default());
-                }
-                let object = user_settings.as_object_mut().unwrap();
-
                 let interpreter_path = toolchain.path.to_string();
-                if let Some(venv_dir) = &env.environment.prefix {
-                    // Set venvPath and venv at the root level
-                    // This matches the format of a pyrightconfig.json file
-                    if let Some(parent) = venv_dir.parent() {
-                        // Use relative path if the venv is inside the workspace
-                        let venv_path = if parent == adapter.worktree_root_path() {
-                            ".".to_string()
-                        } else {
-                            parent.to_string_lossy().into_owned()
-                        };
-                        object.insert("venvPath".to_string(), Value::String(venv_path));
-                    }
 
-                    if let Some(venv_name) = venv_dir.file_name() {
-                        object.insert(
-                            "venv".to_owned(),
-                            Value::String(venv_name.to_string_lossy().into_owned()),
-                        );
-                    }
-                }
-
-                // Always set the python interpreter path
-                // Get or create the python section
                 let python = object
                     .entry("python")
                     .and_modify(|v| {
@@ -774,15 +748,7 @@ impl LspAdapter for PyrightLspAdapter {
                     .or_insert(Value::Object(serde_json::Map::default()));
                 let python = python.as_object_mut().unwrap();
 
-                // Set both pythonPath and defaultInterpreterPath for compatibility
-                python.insert(
-                    "pythonPath".to_owned(),
-                    Value::String(interpreter_path.clone()),
-                );
-                python.insert(
-                    "defaultInterpreterPath".to_owned(),
-                    Value::String(interpreter_path),
-                );
+                python.insert("pythonPath".to_owned(), Value::String(interpreter_path));
             }
 
             normalize_pyright_analysis_configuration(&mut user_settings, "python");

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2166,23 +2166,22 @@ impl LspAdapter for BasedPyrightLspAdapter {
 
             // If we have a detected toolchain, configure BasedPyright to use it - unless the user sets it themselves.
             let should_insert_toolchain = || {
-                user_settings.as_object().is_none_or(|object| {
-                    ![
-                        "venvPath",
-                        "venv",
-                        "python",
-                        "pythonPath",
-                        "defaultInterpreterPath",
-                    ]
-                    .into_iter()
-                    .any(|known_key| object.contains_key(known_key))
-                })
+                user_settings
+                    .as_object()
+                    .and_then(|object| object.get("python"))
+                    .and_then(Value::as_object)
+                    .is_none_or(|python| {
+                        !["pythonPath", "venvPath"]
+                            .into_iter()
+                            .any(|known_key| python.contains_key(known_key))
+                    })
             };
             if let Some(toolchain) = toolchain
                 && should_insert_toolchain()
-                && let Ok(env) = serde_json::from_value::<
-                    pet_core::python_environment::PythonEnvironment,
-                >(toolchain.as_json.clone())
+                && serde_json::from_value::<pet_core::python_environment::PythonEnvironment>(
+                    toolchain.as_json.clone(),
+                )
+                .is_ok()
             {
                 if !user_settings.is_object() {
                     user_settings = Value::Object(serde_json::Map::default());
@@ -2190,28 +2189,7 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 let object = user_settings.as_object_mut().unwrap();
 
                 let interpreter_path = toolchain.path.to_string();
-                if let Some(venv_dir) = env.prefix {
-                    // Set venvPath and venv at the root level
-                    // This matches the format of a pyrightconfig.json file
-                    if let Some(parent) = venv_dir.parent() {
-                        // Use relative path if the venv is inside the workspace
-                        let venv_path = if parent == adapter.worktree_root_path() {
-                            ".".to_string()
-                        } else {
-                            parent.to_string_lossy().into_owned()
-                        };
-                        object.insert("venvPath".to_string(), Value::String(venv_path));
-                    }
 
-                    if let Some(venv_name) = venv_dir.file_name() {
-                        object.insert(
-                            "venv".to_owned(),
-                            Value::String(venv_name.to_string_lossy().into_owned()),
-                        );
-                    }
-                }
-
-                // Set both pythonPath and defaultInterpreterPath for compatibility
                 if let Some(python) = object
                     .entry("python")
                     .or_insert(Value::Object(serde_json::Map::default()))
@@ -2220,10 +2198,6 @@ impl LspAdapter for BasedPyrightLspAdapter {
                     python.insert(
                         "pythonPath".to_owned(),
                         Value::String(interpreter_path.clone()),
-                    );
-                    python.insert(
-                        "defaultInterpreterPath".to_owned(),
-                        Value::String(interpreter_path),
                     );
                 }
                 // Basedpyright by default uses `strict` type checking, we tone it down as to not surpris users

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2163,12 +2163,34 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 language_server_settings(adapter.as_ref(), &Self::SERVER_NAME, cx)
                     .and_then(|s| s.settings.clone())
                     .unwrap_or_default();
+            if !user_settings.is_object() {
+                user_settings = Value::Object(serde_json::Map::default());
+            }
+            let object = user_settings.as_object_mut().unwrap();
+
+            // Basedpyright by default uses `strict` type checking, we tone it down as to not surpris users
+            maybe!({
+                let analysis = object
+                    .entry("basedpyright.analysis")
+                    .or_insert(Value::Object(serde_json::Map::default()));
+                if let serde_json::map::Entry::Vacant(v) =
+                    analysis.as_object_mut()?.entry("typeCheckingMode")
+                {
+                    v.insert(Value::String("standard".to_owned()));
+                }
+                Some(())
+            });
+            // Disable basedpyright's organizeImports so ruff handles it instead
+            if let serde_json::map::Entry::Vacant(v) =
+                object.entry("basedpyright.disableOrganizeImports")
+            {
+                v.insert(Value::Bool(true));
+            }
 
             // If we have a detected toolchain, configure BasedPyright to use it - unless the user sets it themselves.
             let should_insert_toolchain = || {
-                user_settings
-                    .as_object()
-                    .and_then(|object| object.get("python"))
+                object
+                    .get("python")
                     .and_then(Value::as_object)
                     .is_none_or(|python| {
                         !["pythonPath", "venvPath"]
@@ -2183,11 +2205,6 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 )
                 .is_ok()
             {
-                if !user_settings.is_object() {
-                    user_settings = Value::Object(serde_json::Map::default());
-                }
-                let object = user_settings.as_object_mut().unwrap();
-
                 let interpreter_path = toolchain.path.to_string();
 
                 if let Some(python) = object
@@ -2195,28 +2212,7 @@ impl LspAdapter for BasedPyrightLspAdapter {
                     .or_insert(Value::Object(serde_json::Map::default()))
                     .as_object_mut()
                 {
-                    python.insert(
-                        "pythonPath".to_owned(),
-                        Value::String(interpreter_path.clone()),
-                    );
-                }
-                // Basedpyright by default uses `strict` type checking, we tone it down as to not surpris users
-                maybe!({
-                    let analysis = object
-                        .entry("basedpyright.analysis")
-                        .or_insert(Value::Object(serde_json::Map::default()));
-                    if let serde_json::map::Entry::Vacant(v) =
-                        analysis.as_object_mut()?.entry("typeCheckingMode")
-                    {
-                        v.insert(Value::String("standard".to_owned()));
-                    }
-                    Some(())
-                });
-                // Disable basedpyright's organizeImports so ruff handles it instead
-                if let serde_json::map::Entry::Vacant(v) =
-                    object.entry("basedpyright.disableOrganizeImports")
-                {
-                    v.insert(Value::Bool(true));
+                    python.insert("pythonPath".to_owned(), Value::String(interpreter_path));
                 }
             }
 

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2180,12 +2180,20 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 }
                 Some(())
             });
+
             // Disable basedpyright's organizeImports so ruff handles it instead
-            if let serde_json::map::Entry::Vacant(v) =
-                object.entry("basedpyright.disableOrganizeImports")
-            {
-                v.insert(Value::Bool(true));
-            }
+            maybe!({
+                let basedpyright = object
+                    .entry("basedpyright")
+                    .or_insert(Value::Object(serde_json::Map::default()))
+                    .as_object_mut()?;
+                if let serde_json::map::Entry::Vacant(v) =
+                    basedpyright.entry("disableOrganizeImports")
+                {
+                    v.insert(Value::Bool(true));
+                }
+                Some(())
+            });
 
             // If we have a detected toolchain, configure BasedPyright to use it - unless the user sets it themselves.
             let should_insert_toolchain = || {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -278,15 +278,30 @@ fn normalize_pyright_analysis_configuration(
         return;
     };
 
-    let analysis_section = format!("{configuration_section}.analysis");
-    let analysis = workspace_configuration
+    let flat_analysis_section = format!("{configuration_section}.analysis");
+
+    let nested_analysis = workspace_configuration
         .get(configuration_section)
         .and_then(Value::as_object)
         .and_then(|server_configuration| server_configuration.get("analysis"))
-        .cloned()
-        .or_else(|| workspace_configuration.get(&analysis_section).cloned());
-    let Some(analysis) = analysis else {
-        return;
+        .and_then(Value::as_object);
+    let flat_analysis = workspace_configuration
+        .get(&flat_analysis_section)
+        .and_then(Value::as_object);
+
+    let nested_analysis = match (nested_analysis, flat_analysis) {
+        (Some(nested_analysis), Some(flat_analysis)) => {
+            let mut merged_analysis = nested_analysis.clone();
+            for (key, value) in flat_analysis {
+                merged_analysis
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
+            }
+            Value::Object(merged_analysis)
+        }
+        (Some(nested_analysis), None) => Value::Object(nested_analysis.clone()),
+        (None, Some(flat_analysis)) => Value::Object(flat_analysis.clone()),
+        (None, None) => return,
     };
 
     let server_configuration = workspace_configuration
@@ -295,9 +310,9 @@ fn normalize_pyright_analysis_configuration(
     let Some(server_configuration) = server_configuration.as_object_mut() else {
         return;
     };
-    server_configuration.insert("analysis".to_owned(), analysis.clone());
+    server_configuration.insert("analysis".to_owned(), nested_analysis.clone());
 
-    workspace_configuration.insert(analysis_section, analysis);
+    workspace_configuration.insert(flat_analysis_section, nested_analysis);
 }
 
 pub struct TyLspAdapter {
@@ -2820,30 +2835,34 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_basedpyright_analysis_configuration_takes_precedence() {
+    fn test_normalize_merges_both_analysis_configuration_with_conflicts() {
         let mut workspace_configuration = serde_json::json!({
             "basedpyright": {
                 "analysis": {
-                    "typeCheckingMode": "basic"
+                    "diagnosticMode": "workspace",
                 }
             },
             "basedpyright.analysis": {
-                "typeCheckingMode": "strict"
+                "typeCheckingMode": "standard",
+                "diagnosticMode": "openFilesOnly"
             }
         });
 
         normalize_pyright_analysis_configuration(&mut workspace_configuration, "basedpyright");
 
+        // Settings from both forms survive, with the nested form winning on conflicting keys.
         assert_eq!(
             workspace_configuration,
             serde_json::json!({
                 "basedpyright": {
                     "analysis": {
-                        "typeCheckingMode": "basic"
+                        "diagnosticMode": "workspace",
+                        "typeCheckingMode": "standard",
                     }
                 },
                 "basedpyright.analysis": {
-                    "typeCheckingMode": "basic"
+                    "diagnosticMode": "workspace",
+                    "typeCheckingMode": "standard",
                 }
             })
         );

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -135,10 +135,12 @@ You can use the following configuration:
   "lsp": {
     "basedpyright": {
       "settings": {
-        "basedpyright.analysis": {
-          "diagnosticMode": "workspace",
-          "inlayHints": {
-            "callArgumentNames": false
+        "basedpyright": {
+          "analysis": {
+            "diagnosticMode": "workspace",
+            "inlayHints": {
+              "callArgumentNames": false
+            }
           }
         }
       }
@@ -146,6 +148,8 @@ You can use the following configuration:
   }
 }
 ```
+
+For compatibility with older configurations, Zed also accepts `basedpyright.analysis` as a top-level key within `settings`.
 
 ##### Configuration files
 


### PR DESCRIPTION
# Objective

Closes #62624

Recently, Pyright and BasedPyright changed how they retrieve analysis settings through `workspace/configuration` in microsoft/pyright#11480 and DetachHead/basedpyright#1847, respectively. Older versions requested the dotted `python.analysis` and `basedpyright.analysis` sections directly. Recent versions instead request the parent `python` or `basedpyright` section and read its nested `analysis` object. Because Zed stores many existing configurations under the dotted top-level keys, those settings are not included in its responses to the new parent-section requests and are therefore silently ignored. 

Zed's documentation and many users' settings still use configurations like this:
https://github.com/zed-industries/zed/blob/9bde578ef5afa84920c4300af25f9dee31c96fcf/docs/src/languages/python.md?plain=1#L131-L148
all the configrations in `basedpyright.analysis` won't work now.

## Solution

To maintain compatibility with both old and new servers, we need to support both configuration formats. This PR introduces `normalize_pyright_analysis_configuration`, which copies the analysis settings into both the dotted and nested formats. This ensures that the settings are available regardless of which format the language server requests.

The documentation, however, has been updated to use the nested structure.

## Testing

New unit tests have been added, and the changes have also been built and tested locally.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed some Pyright and BasedPyright settings not being applied properly.
