### PR TITLE
Highlight TODO and FIXME comments in built-in languages

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -202,6 +202,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#e6b450ff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#d2a6ffff",
             "font_style": null,
@@ -609,6 +614,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#f2ae49ff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#a37accff",
             "font_style": null,
@@ -1015,6 +1025,11 @@
             "color": "#9b9b99ff",
             "font_style": null,
             "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#ffcc66ff",
+            "font_style": "italic",
+            "font_weight": 700
           },
           "constant": {
             "color": "#dfbfffff",

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -207,6 +207,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#fabd2eff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#fabd2eff",
             "font_style": null,
@@ -628,6 +633,11 @@
             "color": "#c6b697ff",
             "font_style": null,
             "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#fabd2eff",
+            "font_style": "italic",
+            "font_weight": 700
           },
           "constant": {
             "color": "#fabd2eff",
@@ -1051,6 +1061,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#fabd2eff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#fabd2eff",
             "font_style": null,
@@ -1472,6 +1487,11 @@
             "color": "#5d544eff",
             "font_style": null,
             "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#b57613ff",
+            "font_style": "italic",
+            "font_weight": 700
           },
           "constant": {
             "color": "#b57613ff",
@@ -1895,6 +1915,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#b57613ff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#b57613ff",
             "font_style": null,
@@ -2316,6 +2341,11 @@
             "color": "#5d544eff",
             "font_style": null,
             "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#b57613ff",
+            "font_style": "italic",
+            "font_weight": 700
           },
           "constant": {
             "color": "#b57613ff",

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -209,6 +209,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "comment.todo": {
+            "color": "#dfc184ff",
+            "font_style": "italic",
+            "font_weight": 700
+          },
           "constant": {
             "color": "#dfc184ff",
             "font_style": null,
@@ -625,6 +630,11 @@
             "color": "#7c7e86ff",
             "font_style": null,
             "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#c18401ff",
+            "font_style": "italic",
+            "font_weight": 700
           },
           "constant": {
             "color": "#c18401ff",

--- a/crates/grammars/src/bash/highlights.scm
+++ b/crates/grammars/src/bash/highlights.scm
@@ -164,3 +164,6 @@
   value: (_) @string.regex)
 
 (special_variable_name) @variable.special
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/c/highlights.scm
+++ b/crates/grammars/src/c/highlights.scm
@@ -154,3 +154,6 @@
 
 (attribute
   name: (identifier) @attribute)
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/cpp/highlights.scm
+++ b/crates/grammars/src/cpp/highlights.scm
@@ -300,3 +300,6 @@ type: (primitive_type) @type.builtin
 
 (user_defined_literal
   (literal_suffix) @operator)
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/css/highlights.scm
+++ b/crates/grammars/src/css/highlights.scm
@@ -117,3 +117,6 @@
   "["
   "]"
 ] @punctuation.bracket
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/go/highlights.scm
+++ b/crates/grammars/src/go/highlights.scm
@@ -163,3 +163,6 @@
 
 ((comment) @preproc
   (#match? @preproc "^// \\+build"))
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/gomod/highlights.scm
+++ b/crates/grammars/src/gomod/highlights.scm
@@ -18,3 +18,6 @@
   (version)
   (go_version)
 ] @string
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/gowork/highlights.scm
+++ b/crates/grammars/src/gowork/highlights.scm
@@ -12,3 +12,6 @@
   (version)
   (go_version)
 ] @string
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/grammars.rs
+++ b/crates/grammars/src/grammars.rs
@@ -110,3 +110,31 @@ pub fn load_queries(name: &str) -> LanguageQueries {
     }
     result
 }
+
+#[cfg(all(test, feature = "load-grammars"))]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+
+    use super::*;
+
+    #[test]
+    fn test_highlights_queries_compile() {
+        let grammars: HashMap<_, _> = native_grammars().into_iter().collect();
+        let language_names: BTreeSet<String> = GrammarDir::iter()
+            .filter_map(|path| Some(path.split_once('/')?.0.to_string()))
+            .collect();
+
+        for name in language_names {
+            let config = load_config(&name);
+            let grammar_name = config.grammar.as_deref().unwrap_or(&name);
+            let Some(grammar) = grammars.get(grammar_name) else {
+                continue;
+            };
+            if let Some(highlights) = load_queries(&name).highlights {
+                tree_sitter::Query::new(grammar, &highlights).unwrap_or_else(|error| {
+                    panic!("invalid highlights query for language {name:?}: {error}")
+                });
+            }
+        }
+    }
+}

--- a/crates/grammars/src/javascript/highlights.scm
+++ b/crates/grammars/src/javascript/highlights.scm
@@ -445,3 +445,6 @@
 (jsx_text) @text.jsx
 
 (html_character_reference) @string.special
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/jsonc/highlights.scm
+++ b/crates/grammars/src/jsonc/highlights.scm
@@ -27,3 +27,6 @@
   "["
   "]"
 ] @punctuation.bracket
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -384,3 +384,6 @@
     "Warning" "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning"
     "RuntimeWarning" "FutureWarning" "ImportWarning" "UnicodeWarning" "EncodingWarning"
     "BytesWarning" "ResourceWarning"))
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/rust/highlights.scm
+++ b/crates/grammars/src/rust/highlights.scm
@@ -258,3 +258,9 @@ operator: "/" @operator
         "::"
         (#match? @none "^[a-z\\d_]*$"))
     ]))
+
+([
+  (line_comment)
+  (block_comment)
+] @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/tsx/highlights.scm
+++ b/crates/grammars/src/tsx/highlights.scm
@@ -506,3 +506,6 @@
 (jsx_text) @text.jsx
 
 (html_character_reference) @string.special
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/typescript/highlights.scm
+++ b/crates/grammars/src/typescript/highlights.scm
@@ -476,3 +476,6 @@
 
 (switch_default
   "default" @keyword.control)
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))

--- a/crates/grammars/src/yaml/highlights.scm
+++ b/crates/grammars/src/yaml/highlights.scm
@@ -54,3 +54,6 @@ key: (flow_node
   "---"
   "..."
 ] @punctuation.special
+
+((comment) @comment.todo
+  (#match? @comment.todo "(?i)\\b(todo|fixme)\\b"))


### PR DESCRIPTION
Adds GoLand/JetBrains-style highlighting for `TODO` and `FIXME` markers in comments.

- New `@comment.todo` captures in the highlight queries of the built-in grammars (Go, gomod, gowork, Rust, C, C++, Python, JavaScript, TypeScript, TSX, Bash, CSS, YAML, JSONC). A comment containing `TODO` or `FIXME` (case insensitive) is highlighted as a whole, mirroring JetBrains IDE behavior.
- New `comment.todo` style in the bundled One, Ayu, and Gruvbox themes (theme's accent yellow, italic, bold). Themes that do not define the key fall back to the regular `comment` style via the existing dot-prefix fallback, so third-party themes are unaffected; users can also override it via `experimental.theme_overrides`.
- New `test_highlights_queries_compile` test in the `grammars` crate that compiles every built-in highlights query against its grammar.

Release Notes:

- Added highlighting for TODO and FIXME markers in comments for built-in languages, styled by the bundled themes via the new `comment.todo` syntax key.
