### PR TITLE
vim: Fix ctrl-s not saving in insert mode on Linux and Windows

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -379,6 +379,11 @@
       "ctrl-r": "vim::PushRegister",
       "insert": "vim::ToggleReplace",
       "ctrl-o": "vim::TemporaryNormal",
+    },
+  },
+  {
+    "context": "vim_mode == insert && os == macos",
+    "bindings": {
       "ctrl-s": "editor::ShowSignatureHelp",
     },
   },

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -578,7 +578,6 @@ If you're using vim mode on Linux or Windows, you may find it overrides keybindi
     "ctrl-y": "editor::Undo",               // vim default: line up
     "ctrl-t": "project_symbols::Toggle",    // vim default: go to older tag
     "ctrl-o": "workspace::Open",            // vim default: go back
-    "ctrl-s": "workspace::Save",            // vim default: show signature
     "ctrl-b": "workspace::ToggleLeftDock"   // vim default: down
   }
 },


### PR DESCRIPTION
# Objective

Fixes #45722

`ctrl-s` silently did nothing in vim insert mode on Linux and Windows.

## Solution

Scope the neovim binding to `os == macos`, keeping vim parity there while
`ctrl-s` falls through to `workspace::Save` everywhere else



Release Notes:

- Fixed `ctrl-s` not saving in Vim insert mode on Linux and Windows.
