### PR TITLE
project: Allow public client OAuth flow with pre-registered client IDs

### DIFF
--- a/crates/context_server/src/oauth.rs
+++ b/crates/context_server/src/oauth.rs
@@ -2473,6 +2473,85 @@ mod tests {
     }
 
     #[test]
+    fn test_discover_and_token_exchange_with_preregistered_public_client() {
+        gpui::block_on(async {
+            let client = make_fake_http_client(|req| {
+                Box::pin(async move {
+                    let uri = req.uri().to_string();
+                    if uri.contains("oauth-protected-resource") {
+                        json_response(
+                            200,
+                            r#"{
+                                "resource": "https://mcp.example.com",
+                                "authorization_servers": ["https://auth.example.com"],
+                                "scopes_supported": ["mcp:read"]
+                            }"#,
+                        )
+                    } else if uri.contains("oauth-authorization-server") {
+                        json_response(
+                            200,
+                            r#"{
+                                "issuer": "https://auth.example.com",
+                                "authorization_endpoint": "https://auth.example.com/authorize",
+                                "token_endpoint": "https://auth.example.com/token",
+                                "code_challenge_methods_supported": ["plain", "S256"],
+                                "client_id_metadata_document_supported": false,
+                                "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"]
+                            }"#,
+                        )
+                    } else if uri.contains("/token") {
+                        json_response(
+                            200,
+                            r#"{
+                                "access_token": "public_client_access_token",
+                                "refresh_token": "public_client_refresh_token",
+                                "expires_in": 3600,
+                                "token_type": "Bearer"
+                            }"#,
+                        )
+                    } else {
+                        json_response(404, "{}")
+                    }
+                })
+            });
+
+            let server_url = Url::parse("https://mcp.example.com").unwrap();
+            let www_auth = WwwAuthenticate {
+                resource_metadata: None,
+                scope: None,
+                error: None,
+                error_description: None,
+            };
+
+            let discovery = discover(&client, &server_url, &www_auth).await.unwrap();
+            assert_eq!(
+                determine_registration_strategy(&discovery.auth_server_metadata),
+                ClientRegistrationStrategy::Unavailable
+            );
+
+            let preregistered_client_id = "my-preregistered-public-client";
+            let tokens = exchange_code(
+                &client,
+                &discovery.auth_server_metadata,
+                "auth_code_123",
+                preregistered_client_id,
+                "http://127.0.0.1:9999/callback",
+                "verifier_abc",
+                "https://mcp.example.com",
+                None,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(tokens.access_token, "public_client_access_token");
+            assert_eq!(
+                tokens.refresh_token.as_deref(),
+                Some("public_client_refresh_token")
+            );
+        });
+    }
+
+    #[test]
     fn test_refresh_tokens_success() {
         gpui::block_on(async {
             let client = make_fake_http_client(|req| {

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -1227,12 +1227,8 @@ impl ContextServerStore {
             _ => anyhow::bail!("Server is not in AuthRequired state"),
         };
 
-        let needs_keychain_check = match configuration.as_ref() {
-            ContextServerConfiguration::Http {
-                url,
-                oauth: Some(oauth_settings),
-                ..
-            } if oauth_settings.client_secret.is_none() => Some(url.clone()),
+        let server_url = match configuration.as_ref() {
+            ContextServerConfiguration::Http { url, .. } => Some(url.clone()),
             _ => None,
         };
 
@@ -1243,33 +1239,6 @@ impl ContextServerStore {
             let server = server.clone();
             let configuration = configuration.clone();
             async move |this, cx| {
-                if let Some(server_url) = needs_keychain_check {
-                    let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
-                    let has_keychain_secret =
-                        Self::load_client_secret(&credentials_provider, &server_url, cx)
-                            .await
-                            .ok()
-                            .flatten()
-                            .is_some();
-
-                    if !has_keychain_secret {
-                        this.update(cx, |this, cx| {
-                            this.update_server_state(
-                                id.clone(),
-                                ContextServerState::ClientSecretRequired {
-                                    server,
-                                    configuration,
-                                    discovery,
-                                    error: None,
-                                },
-                                cx,
-                            );
-                        })
-                        .log_err();
-                        return;
-                    }
-                }
-
                 let result = Self::run_oauth_flow(
                     this.clone(),
                     id.clone(),
@@ -1282,18 +1251,57 @@ impl ContextServerStore {
 
                 if let Err(err) = &result {
                     log::error!("{} OAuth authentication failed: {:?}", id, err);
-                    this.update(cx, |this, cx| {
-                        this.update_server_state(
-                            id.clone(),
-                            ContextServerState::Error {
-                                server,
-                                configuration,
-                                error: format!("{err:#}").into(),
-                            },
-                            cx,
-                        )
-                    })
-                    .log_err();
+
+                    let is_bad_client_credentials = err
+                        .downcast_ref::<oauth::OAuthTokenError>()
+                        .is_some_and(|e| {
+                            e.error == "unauthorized_client" || e.error == "invalid_client"
+                        });
+
+                    let has_preregistered_oauth = matches!(
+                        configuration.as_ref(),
+                        ContextServerConfiguration::Http {
+                            oauth: Some(_),
+                            ..
+                        }
+                    );
+
+                    if is_bad_client_credentials && has_preregistered_oauth {
+                        if let Some(server_url) = server_url {
+                            let credentials_provider =
+                                cx.update(|cx| zed_credentials_provider::global(cx));
+                            Self::clear_client_secret(&credentials_provider, &server_url, cx)
+                                .await
+                                .log_err();
+                        }
+
+                        this.update(cx, |this, cx| {
+                            this.update_server_state(
+                                id.clone(),
+                                ContextServerState::ClientSecretRequired {
+                                    server,
+                                    configuration,
+                                    discovery,
+                                    error: Some(format!("{err:#}").into()),
+                                },
+                                cx,
+                            );
+                        })
+                        .log_err();
+                    } else {
+                        this.update(cx, |this, cx| {
+                            this.update_server_state(
+                                id.clone(),
+                                ContextServerState::Error {
+                                    server,
+                                    configuration,
+                                    error: format!("{err:#}").into(),
+                                },
+                                cx,
+                            )
+                        })
+                        .log_err();
+                    }
                 }
             }
         });
@@ -1373,7 +1381,9 @@ impl ContextServerStore {
 
                     let is_bad_client_credentials = err
                         .downcast_ref::<oauth::OAuthTokenError>()
-                        .is_some_and(|e| e.error == "unauthorized_client");
+                        .is_some_and(|e| {
+                            e.error == "unauthorized_client" || e.error == "invalid_client"
+                        });
 
                     if is_bad_client_credentials {
                         // Clear the bad secret from the keychain so the user


### PR DESCRIPTION
Release Notes:

- Fixed an issue where connecting to an MCP server with a pre-registered public client ID incorrectly required a client secret (#62637).

---

### Description

Closes #62637

When authenticating with an MCP server using a pre-registered `client_id` where the authorization server supports PKCE (`S256`) but not DCR or CIMD (such as Authentik, Keycloak, Auth0, Okta, etc.), Zed previously demanded a client secret pre-emptively, preventing public clients from starting the authorization code flow.

#### Solution:
- Removed the pre-emptive client secret requirement in `ContextServerStore::authenticate_server`, allowing public clients with PKCE to proceed with authorization directly without needing a secret.
- Automatically transitions to `ContextServerState::ClientSecretRequired` if the authorization server returns `unauthorized_client` or `invalid_client` during token exchange when connecting to confidential clients that genuinely require a secret.
- Added unit test `test_discover_and_token_exchange_with_preregistered_public_client` in `crates/context_server/src/oauth.rs`.