### PR TITLE
Merge array settings from extension contributions instead of overwriting

### DIFF
--- a/crates/edit_prediction_context/src/fake_definition_lsp.rs
+++ b/crates/edit_prediction_context/src/fake_definition_lsp.rs
@@ -24,6 +24,8 @@ pub fn register_fake_definition_server(
         language::FakeLspAdapter {
             name: "fake-definition-lsp",
             initialization_options: None,
+            additional_initialization_options: HashMap::default(),
+            additional_workspace_configuration: HashMap::default(),
             prettier_plugins: Vec::new(),
             disk_based_diagnostics_progress_token: None,
             disk_based_diagnostics_sources: Vec::new(),

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -911,6 +911,8 @@ pub struct LanguageScope {
 pub struct FakeLspAdapter {
     pub name: &'static str,
     pub initialization_options: Option<Value>,
+    pub additional_initialization_options: HashMap<LanguageServerName, Value>,
+    pub additional_workspace_configuration: HashMap<LanguageServerName, Value>,
     pub prettier_plugins: Vec<&'static str>,
     pub disk_based_diagnostics_progress_token: Option<String>,
     pub disk_based_diagnostics_sources: Vec<String>,
@@ -1468,6 +1470,8 @@ impl Default for FakeLspAdapter {
             initializer: None,
             disk_based_diagnostics_progress_token: None,
             initialization_options: None,
+            additional_initialization_options: HashMap::default(),
+            additional_workspace_configuration: HashMap::default(),
             disk_based_diagnostics_sources: Vec::new(),
             prettier_plugins: Vec::new(),
             language_server_binary: LanguageServerBinary {
@@ -1543,6 +1547,29 @@ impl LspAdapter for FakeLspAdapter {
         _cx: &mut AsyncApp,
     ) -> Result<Option<Value>> {
         Ok(self.initialization_options.clone())
+    }
+
+    async fn additional_initialization_options(
+        self: Arc<Self>,
+        target_language_server_id: LanguageServerName,
+        _: &Arc<dyn LspAdapterDelegate>,
+    ) -> Result<Option<Value>> {
+        Ok(self
+            .additional_initialization_options
+            .get(&target_language_server_id)
+            .cloned())
+    }
+
+    async fn additional_workspace_configuration(
+        self: Arc<Self>,
+        target_language_server_id: LanguageServerName,
+        _: &Arc<dyn LspAdapterDelegate>,
+        _cx: &mut AsyncApp,
+    ) -> Result<Option<Value>> {
+        Ok(self
+            .additional_workspace_configuration
+            .get(&target_language_server_id)
+            .cloned())
     }
 
     async fn label_for_completion(

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -32,7 +32,7 @@ use std::{
 use task::{TaskTemplate, TaskTemplates, VariableName};
 use util::{
     ResultExt, archive::extract_zip, fs::remove_matching, maybe, merge_json_value_into,
-    paths::PathStyle, rel_path::RelPath,
+    paths::PathStyle, rel_path::RelPath, union_json_value_into,
 };
 
 use crate::PackageJsonData;
@@ -318,7 +318,7 @@ impl LspAdapter for JsonLspAdapter {
         });
 
         if let Some(override_options) = project_options {
-            merge_json_value_into(override_options, &mut config);
+            union_json_value_into(override_options, &mut config);
         }
 
         Ok(config)

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -146,6 +146,7 @@ use util::{
     post_inc,
     redact::redact_command,
     rel_path::RelPath,
+    union_json_value_into,
 };
 
 pub use document_colors::DocumentColors;
@@ -4050,26 +4051,35 @@ impl LocalLspStore {
         delegate: &Arc<dyn LspAdapterDelegate>,
         cx: &mut AsyncApp,
     ) -> Result<Option<serde_json::Value>> {
-        let Some(mut initialization_config) =
-            adapter.clone().initialization_options(delegate, cx).await?
-        else {
-            return Ok(None);
-        };
+        let mut initialization_config =
+            adapter.clone().initialization_options(delegate, cx).await?;
 
         for other_adapter in delegate.registered_lsp_adapters() {
             if other_adapter.name() == adapter.name() {
                 continue;
             }
-            if let Ok(Some(target_config)) = other_adapter
+            if let Some(target_config) = other_adapter
                 .clone()
                 .additional_initialization_options(adapter.name(), delegate)
                 .await
+                .with_context(|| {
+                    format!(
+                        "getting additional initialization options for {} from {}",
+                        adapter.name(),
+                        other_adapter.name()
+                    )
+                })
+                .log_err()
+                .flatten()
             {
-                merge_json_value_into(target_config.clone(), &mut initialization_config);
+                union_json_value_into(
+                    target_config,
+                    initialization_config.get_or_insert_with(|| serde_json::json!({})),
+                );
             }
         }
 
-        Ok(Some(initialization_config))
+        Ok(initialization_config)
     }
 
     async fn workspace_configuration_for_adapter(
@@ -4088,12 +4098,21 @@ impl LocalLspStore {
             if other_adapter.name() == adapter.name() {
                 continue;
             }
-            if let Ok(Some(target_config)) = other_adapter
+            if let Some(target_config) = other_adapter
                 .clone()
                 .additional_workspace_configuration(adapter.name(), delegate, cx)
                 .await
+                .with_context(|| {
+                    format!(
+                        "getting additional workspace configuration for {} from {}",
+                        adapter.name(),
+                        other_adapter.name()
+                    )
+                })
+                .log_err()
+                .flatten()
             {
-                merge_json_value_into(target_config.clone(), &mut workspace_config);
+                union_json_value_into(target_config, &mut workspace_config);
             }
         }
 
@@ -14818,6 +14837,7 @@ impl LspAdapterDelegate for LocalLspAdapterDelegate {
             .all_lsp_adapters()
             .into_iter()
             .map(|adapter| adapter.adapter.clone() as Arc<dyn LspAdapter>)
+            .sorted_by_key(|adapter| adapter.name())
             .collect()
     }
 

--- a/crates/project/tests/integration/lsp_store.rs
+++ b/crates/project/tests/integration/lsp_store.rs
@@ -4,11 +4,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use collections::HashMap;
 use fs::FakeFs;
 use futures::StreamExt;
 use gpui::TestAppContext;
 use language::{CodeLabel, FakeLspAdapter, HighlightId, rust_lang};
-use lsp::Uri;
+use lsp::{LanguageServerName, Uri};
 use parking_lot::Mutex;
 use project::{
     Project,
@@ -411,5 +412,203 @@ async fn test_user_initialization_options_override_adapter_arrays(cx: &mut TestA
             "adapterOnly": [1, 2],
             "userOnly": ["user"],
         })),
+    );
+}
+
+#[gpui::test]
+async fn test_other_adapters_lsp_configuration_contributions_are_unioned(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let user_settings = serde_json::json!({
+        "lsp": {
+            "the-fake-language-server": {
+                "initialization_options": {
+                    "languages": ["user-lang"],
+                    "userOnly": true,
+                },
+            },
+        },
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/the-root"),
+        json!({
+            ".zed": {
+                "settings.json": user_settings.to_string(),
+            },
+            "main.rs": "fn main() {}",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/the-root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+
+    let main_server_name = LanguageServerName("the-fake-language-server".into());
+    for (language, server_name, plugin, lang, memory) in [
+        ("Vue", "vue-language-server", "vue-plugin", "vue", 4096),
+        (
+            "Astro",
+            "astro-language-server",
+            "astro-plugin",
+            "astro",
+            2048,
+        ),
+    ] {
+        let contribution = json!({
+            "tsserver": {
+                "globalPlugins": ["shared-plugin", plugin],
+                "maxMemory": memory,
+            },
+            "languages": [lang],
+        });
+        language_registry.register_fake_lsp_adapter(
+            language,
+            FakeLspAdapter {
+                name: server_name,
+                additional_initialization_options: HashMap::from_iter([(
+                    main_server_name.clone(),
+                    contribution.clone(),
+                )]),
+                additional_workspace_configuration: HashMap::from_iter([(
+                    main_server_name.clone(),
+                    contribution,
+                )]),
+                ..FakeLspAdapter::default()
+            },
+        );
+    }
+
+    let sent_initialization_options = Arc::new(Mutex::new(None));
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "the-fake-language-server",
+            initialization_options: Some(json!({
+                "tsserver": {
+                    "globalPlugins": ["default-plugin"],
+                },
+                "languages": ["default-lang"],
+            })),
+            initializer: Some(Box::new({
+                let sent_initialization_options = sent_initialization_options.clone();
+                move |fake_server| {
+                    let sent_initialization_options = sent_initialization_options.clone();
+                    fake_server.set_request_handler::<lsp::request::Initialize, _, _>(
+                        move |params, _| {
+                            *sent_initialization_options.lock() = params.initialization_options;
+                            async move { Ok(lsp::InitializeResult::default()) }
+                        },
+                    );
+                }
+            })),
+            ..FakeLspAdapter::default()
+        },
+    );
+    cx.run_until_parked();
+
+    project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/the-root/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let mut fake_server = fake_servers.next().await.unwrap();
+    let workspace_configuration = fake_server
+        .receive_notification::<lsp::notification::DidChangeConfiguration>()
+        .await
+        .settings;
+    cx.run_until_parked();
+
+    assert_eq!(
+        sent_initialization_options.lock().take(),
+        Some(json!({
+            "tsserver": {
+                "globalPlugins": ["default-plugin", "shared-plugin", "astro-plugin", "vue-plugin"],
+                "maxMemory": 4096,
+            },
+            "languages": ["user-lang"],
+            "userOnly": true,
+        })),
+    );
+    assert_eq!(
+        workspace_configuration,
+        json!({
+            "tsserver": {
+                "globalPlugins": ["shared-plugin", "astro-plugin", "vue-plugin"],
+                "maxMemory": 4096,
+            },
+            "languages": ["astro", "vue"],
+        }),
+    );
+}
+
+#[gpui::test]
+async fn test_initialization_options_contributions_without_own_options(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/the-root"), json!({ "main.rs": "fn main() {}" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/the-root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+
+    let contribution = json!({
+        "tsserver": {
+            "globalPlugins": ["vue-plugin"],
+        },
+    });
+    language_registry.register_fake_lsp_adapter(
+        "Vue",
+        FakeLspAdapter {
+            name: "vue-language-server",
+            additional_initialization_options: HashMap::from_iter([(
+                LanguageServerName("the-fake-language-server".into()),
+                contribution.clone(),
+            )]),
+            ..FakeLspAdapter::default()
+        },
+    );
+
+    let sent_initialization_options = Arc::new(Mutex::new(None));
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "the-fake-language-server",
+            initialization_options: None,
+            initializer: Some(Box::new({
+                let sent_initialization_options = sent_initialization_options.clone();
+                move |fake_server| {
+                    let sent_initialization_options = sent_initialization_options.clone();
+                    fake_server.set_request_handler::<lsp::request::Initialize, _, _>(
+                        move |params, _| {
+                            *sent_initialization_options.lock() =
+                                Some(params.initialization_options);
+                            async move { Ok(lsp::InitializeResult::default()) }
+                        },
+                    );
+                }
+            })),
+            ..FakeLspAdapter::default()
+        },
+    );
+    cx.run_until_parked();
+
+    project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/the-root/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+    fake_servers.next().await.unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        sent_initialization_options.lock().take(),
+        Some(Some(contribution)),
     );
 }

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -460,6 +460,30 @@ pub fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json:
     }
 }
 
+pub fn union_json_value_into(source: serde_json::Value, target: &mut serde_json::Value) {
+    use serde_json::Value;
+
+    match (source, target) {
+        (Value::Object(source), Value::Object(target)) => {
+            for (key, value) in source {
+                if let Some(target) = target.get_mut(&key) {
+                    union_json_value_into(value, target);
+                } else {
+                    target.insert(key, value);
+                }
+            }
+        }
+        (Value::Array(source), Value::Array(target)) => {
+            for value in source {
+                if !target.contains(&value) {
+                    target.push(value);
+                }
+            }
+        }
+        (source, target) => *target = source,
+    }
+}
+
 pub fn merge_non_null_json_value_into(source: serde_json::Value, target: &mut serde_json::Value) {
     use serde_json::Value;
     if let Value::Object(source_object) = source {
@@ -1121,6 +1145,48 @@ Line 3"#
                     "args": ["--user"],
                     "deeper": { "list": [3], "other": "kept" },
                     "inserted": { "z": true },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_union_json_values() {
+        use serde_json::json;
+
+        let mut target = json!({
+            "unchanged": 1,
+            "replaced_scalar": "old",
+            "unioned_array": ["shared", "first"],
+            "nested": {
+                "kept": true,
+                "plugins": [{ "name": "first-plugin" }],
+                "scalar": 2,
+            },
+        });
+        let source = json!({
+            "replaced_scalar": "new",
+            "unioned_array": ["shared", "second"],
+            "inserted": ["brand-new"],
+            "nested": {
+                "plugins": [{ "name": "second-plugin" }],
+                "scalar": 20,
+            },
+        });
+
+        union_json_value_into(source, &mut target);
+
+        assert_eq!(
+            target,
+            json!({
+                "unchanged": 1,
+                "replaced_scalar": "new",
+                "unioned_array": ["shared", "first", "second"],
+                "inserted": ["brand-new"],
+                "nested": {
+                    "kept": true,
+                    "plugins": [{ "name": "first-plugin" }, { "name": "second-plugin" }],
+                    "scalar": 20,
                 },
             })
         );


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/62572

Reworks https://github.com/zed-industries/zed/pull/54950 — instead of unconditionally replacing the array with a different one, now does the replacement only when the user settings are set.
The rest now merges into the array.


Release Notes:

- Fixed array merging for extensions case
