### PR TITLE
Use the entry API to remove repeated map lookups

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2810,46 +2810,44 @@ impl ThreadView {
     ) {
         let tool_call_id = acp::ToolCallId::new(action.tool_call_id.clone());
 
-        match self.permission_selections.get_mut(&tool_call_id) {
-            Some(PermissionSelection::SelectedPatterns(checked)) => {
-                // Already in pattern mode — toggle the individual pattern.
-                if let Some(pos) = checked.iter().position(|&i| i == action.pattern_index) {
-                    checked.swap_remove(pos);
-                } else {
-                    checked.push(action.pattern_index);
-                }
+        if let Some(PermissionSelection::SelectedPatterns(checked)) =
+            self.permission_selections.get_mut(&tool_call_id)
+        {
+            // Already in pattern mode — toggle the individual pattern.
+            if let Some(pos) = checked.iter().position(|&i| i == action.pattern_index) {
+                checked.swap_remove(pos);
+            } else {
+                checked.push(action.pattern_index);
             }
-            _ => {
-                // First click: activate "Select options" with all patterns checked.
-                let thread = self.thread.read(cx);
-                let pattern_count = thread
-                    .entries()
-                    .iter()
-                    .find_map(|entry| {
-                        if let AgentThreadEntry::ToolCall(call) = entry {
-                            if call.id == tool_call_id {
-                                if let ToolCallStatus::WaitingForConfirmation { options, .. } =
-                                    &call.status
-                                {
-                                    if let PermissionOptions::DropdownWithPatterns {
-                                        patterns,
-                                        ..
-                                    } = options
-                                    {
-                                        return Some(patterns.len());
-                                    }
-                                }
+            cx.notify();
+            return;
+        }
+
+        // First click: activate "Select options" with all patterns checked.
+        let thread = self.thread.read(cx);
+        let pattern_count = thread
+            .entries()
+            .iter()
+            .find_map(|entry| {
+                if let AgentThreadEntry::ToolCall(call) = entry {
+                    if call.id == tool_call_id {
+                        if let ToolCallStatus::WaitingForConfirmation { options, .. } = &call.status
+                        {
+                            if let PermissionOptions::DropdownWithPatterns { patterns, .. } =
+                                options
+                            {
+                                return Some(patterns.len());
                             }
                         }
-                        None
-                    })
-                    .unwrap_or(0);
-                self.permission_selections.insert(
-                    tool_call_id,
-                    PermissionSelection::SelectedPatterns((0..pattern_count).collect()),
-                );
-            }
-        }
+                    }
+                }
+                None
+            })
+            .unwrap_or(0);
+        self.permission_selections.insert(
+            tool_call_id,
+            PermissionSelection::SelectedPatterns((0..pattern_count).collect()),
+        );
         cx.notify();
     }
 

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -258,11 +258,7 @@ impl GroupedModels {
         let mut all_by_provider: IndexMap<_, Vec<ModelInfo>> = IndexMap::default();
         for model in all {
             let provider = model.model.provider_id();
-            if let Some(models) = all_by_provider.get_mut(&provider) {
-                models.push(model);
-            } else {
-                all_by_provider.insert(provider, vec![model]);
-            }
+            all_by_provider.entry(provider).or_default().push(model);
         }
 
         Self {

--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -8,7 +8,7 @@ use client::{
     ChannelId, Client, ParticipantIndex, TypedEnvelope, User, UserStore,
     proto::{self, PeerId},
 };
-use collections::{BTreeMap, HashMap, HashSet};
+use collections::{BTreeMap, HashMap, HashSet, btree_map};
 use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
 use futures::StreamExt;
@@ -857,25 +857,24 @@ impl Room {
                         let role = participant.role();
                         let location = ParticipantLocation::from_proto(participant.location)
                             .unwrap_or(ParticipantLocation::External);
-                        if let Some(remote_participant) =
-                            this.remote_participants.get_mut(&participant.user_id)
-                        {
-                            remote_participant.peer_id = peer_id;
-                            remote_participant.projects = participant.projects;
-                            remote_participant.participant_index = participant_index;
-                            if location != remote_participant.location
-                                || role != remote_participant.role
-                            {
-                                remote_participant.location = location;
-                                remote_participant.role = role;
-                                cx.emit(Event::ParticipantLocationChanged {
-                                    participant_id: peer_id,
-                                });
+                        match this.remote_participants.entry(participant.user_id) {
+                            btree_map::Entry::Occupied(mut entry) => {
+                                let remote_participant = entry.get_mut();
+                                remote_participant.peer_id = peer_id;
+                                remote_participant.projects = participant.projects;
+                                remote_participant.participant_index = participant_index;
+                                if location != remote_participant.location
+                                    || role != remote_participant.role
+                                {
+                                    remote_participant.location = location;
+                                    remote_participant.role = role;
+                                    cx.emit(Event::ParticipantLocationChanged {
+                                        participant_id: peer_id,
+                                    });
+                                }
                             }
-                        } else {
-                            this.remote_participants.insert(
-                                participant.user_id,
-                                RemoteParticipant {
+                            btree_map::Entry::Vacant(entry) => {
+                                entry.insert(RemoteParticipant {
                                     user: user.clone(),
                                     participant_index,
                                     peer_id,
@@ -886,38 +885,38 @@ impl Room {
                                     speaking: false,
                                     video_tracks: Default::default(),
                                     audio_tracks: Default::default(),
-                                },
-                            );
+                                });
 
-                            // When joining a room start_room_connection gets
-                            // called but we have already played the join sound.
-                            // Dont play extra sounds over that.
-                            if this.created.elapsed() > Duration::from_millis(100) {
-                                if let proto::ChannelRole::Guest = role {
-                                    Audio::play_sound(Sound::GuestJoined, cx);
-                                // Do not play join sound in large meetings
-                                } else if this.remote_participants().len() < 10 {
-                                    Audio::play_sound(Sound::Joined, cx);
+                                // When joining a room start_room_connection gets
+                                // called but we have already played the join sound.
+                                // Dont play extra sounds over that.
+                                if this.created.elapsed() > Duration::from_millis(100) {
+                                    if let proto::ChannelRole::Guest = role {
+                                        Audio::play_sound(Sound::GuestJoined, cx);
+                                    // Do not play join sound in large meetings
+                                    } else if this.remote_participants().len() < 10 {
+                                        Audio::play_sound(Sound::Joined, cx);
+                                    }
                                 }
-                            }
 
-                            if let Some(livekit_participants) = &livekit_participants
-                                && let Some(livekit_participant) = livekit_participants
-                                    .get(&ParticipantIdentity(user.legacy_id.to_string()))
-                            {
-                                for publication in
-                                    livekit_participant.track_publications().into_values()
+                                if let Some(livekit_participants) = &livekit_participants
+                                    && let Some(livekit_participant) = livekit_participants
+                                        .get(&ParticipantIdentity(user.legacy_id.to_string()))
                                 {
-                                    if let Some(track) = publication.track() {
-                                        this.livekit_room_updated(
-                                            RoomEvent::TrackSubscribed {
-                                                track,
-                                                publication,
-                                                participant: livekit_participant.clone(),
-                                            },
-                                            cx,
-                                        )
-                                        .warn_on_err();
+                                    for publication in
+                                        livekit_participant.track_publications().into_values()
+                                    {
+                                        if let Some(track) = publication.track() {
+                                            this.livekit_room_updated(
+                                                RoomEvent::TrackSubscribed {
+                                                    track,
+                                                    publication,
+                                                    participant: livekit_participant.clone(),
+                                                },
+                                                cx,
+                                            )
+                                            .warn_on_err();
+                                        }
                                     }
                                 }
                             }

--- a/crates/channel/src/channel_store/channel_index.rs
+++ b/crates/channel/src/channel_store/channel_index.rs
@@ -1,6 +1,6 @@
 use crate::Channel;
 use client::ChannelId;
-use collections::BTreeMap;
+use collections::{BTreeMap, btree_map};
 use rpc::proto;
 use std::sync::Arc;
 
@@ -56,30 +56,30 @@ impl ChannelPathsInsertGuard<'_> {
             .iter()
             .map(|cid| ChannelId(*cid))
             .collect();
-        if let Some(existing_channel) = self.channels_by_id.get_mut(&ChannelId(channel_proto.id)) {
-            let existing_channel = Arc::make_mut(existing_channel);
+        match self.channels_by_id.entry(ChannelId(channel_proto.id)) {
+            btree_map::Entry::Occupied(mut entry) => {
+                let existing_channel = Arc::make_mut(entry.get_mut());
 
-            ret = existing_channel.visibility != channel_proto.visibility()
-                || existing_channel.name != channel_proto.name
-                || existing_channel.parent_path != parent_path
-                || existing_channel.channel_order != channel_proto.channel_order;
+                ret = existing_channel.visibility != channel_proto.visibility()
+                    || existing_channel.name != channel_proto.name
+                    || existing_channel.parent_path != parent_path
+                    || existing_channel.channel_order != channel_proto.channel_order;
 
-            existing_channel.visibility = channel_proto.visibility();
-            existing_channel.name = channel_proto.name.into();
-            existing_channel.parent_path = parent_path;
-            existing_channel.channel_order = channel_proto.channel_order;
-        } else {
-            self.channels_by_id.insert(
-                ChannelId(channel_proto.id),
-                Arc::new(Channel {
+                existing_channel.visibility = channel_proto.visibility();
+                existing_channel.name = channel_proto.name.into();
+                existing_channel.parent_path = parent_path;
+                existing_channel.channel_order = channel_proto.channel_order;
+            }
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Channel {
                     id: ChannelId(channel_proto.id),
                     visibility: channel_proto.visibility(),
                     name: channel_proto.name.into(),
                     parent_path,
                     channel_order: channel_proto.channel_order,
-                }),
-            );
-            self.insert_root(ChannelId(channel_proto.id));
+                }));
+                self.insert_root(ChannelId(channel_proto.id));
+            }
         }
         ret
     }

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -1502,25 +1502,15 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             for port in main_service_ports {
                 // If the main service uses a different service's network bridge, append to that service's ports instead
                 if let Some(network_service_name) = network_mode_service {
-                    if let Some(service) = service_declarations.get_mut(network_service_name) {
-                        service.ports.push(DockerComposeServicePort {
+                    service_declarations
+                        .entry(network_service_name.to_string())
+                        .or_default()
+                        .ports
+                        .push(DockerComposeServicePort {
                             target: port.clone(),
                             published: port.clone(),
                             ..Default::default()
                         });
-                    } else {
-                        service_declarations.insert(
-                            network_service_name.to_string(),
-                            DockerComposeService {
-                                ports: vec![DockerComposeServicePort {
-                                    target: port.clone(),
-                                    published: port.clone(),
-                                    ..Default::default()
-                                }],
-                                ..Default::default()
-                            },
-                        );
-                    }
                 } else {
                     main_service.ports.push(DockerComposeServicePort {
                         target: port.clone(),
@@ -1548,25 +1538,15 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                 })
                 .collect();
             for (service_name, port) in other_service_ports {
-                if let Some(service) = service_declarations.get_mut(service_name) {
-                    service.ports.push(DockerComposeServicePort {
+                service_declarations
+                    .entry(service_name.to_string())
+                    .or_default()
+                    .ports
+                    .push(DockerComposeServicePort {
                         target: port.to_string(),
                         published: port.to_string(),
                         ..Default::default()
                     });
-                } else {
-                    service_declarations.insert(
-                        service_name.to_string(),
-                        DockerComposeService {
-                            ports: vec![DockerComposeServicePort {
-                                target: port.to_string(),
-                                published: port.to_string(),
-                                ..Default::default()
-                            }],
-                            ..Default::default()
-                        },
-                    );
-                }
             }
         }
 

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -501,14 +501,11 @@ impl LineWrapper {
                 self.cached_ascii_char_widths[c as usize] = Some(width);
                 width
             }
-        } else if let Some(cached_width) = self.cached_other_char_widths.get(&c) {
-            *cached_width
         } else {
-            let width = self
-                .text_system
-                .layout_width(self.font_id, self.font_size, c);
-            self.cached_other_char_widths.insert(c, width);
-            width
+            *self.cached_other_char_widths.entry(c).or_insert_with(|| {
+                self.text_system
+                    .layout_width(self.font_id, self.font_size, c)
+            })
         }
     }
 }

--- a/crates/gpui_apple/src/metal_atlas.rs
+++ b/crates/gpui_apple/src/metal_atlas.rs
@@ -43,20 +43,23 @@ impl PlatformAtlas for MetalAtlas {
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
     ) -> Result<Option<AtlasTile>> {
         let mut lock = self.0.lock();
+        // The entry API cannot be used here: a vacant entry would borrow the
+        // map across `allocate`, which needs the whole locked state. The
+        // second search on insertion is fine; it only happens when a new tile
+        // is rasterized and uploaded.
         if let Some(tile) = lock.tiles_by_key.get(key) {
-            Ok(Some(*tile))
-        } else {
-            let Some((size, bytes)) = build()? else {
-                return Ok(None);
-            };
-            let tile = lock
-                .allocate(size, key.texture_kind())
-                .context("failed to allocate")?;
-            let texture = lock.texture(tile.texture_id);
-            texture.upload(tile.bounds, &bytes);
-            lock.tiles_by_key.insert(key.clone(), tile);
-            Ok(Some(tile))
+            return Ok(Some(*tile));
         }
+        let Some((size, bytes)) = build()? else {
+            return Ok(None);
+        };
+        let tile = lock
+            .allocate(size, key.texture_kind())
+            .context("failed to allocate")?;
+        let texture = lock.texture(tile.texture_id);
+        texture.upload(tile.bounds, &bytes);
+        lock.tiles_by_key.insert(key.clone(), tile);
+        Ok(Some(tile))
     }
 
     fn remove(&self, key: &AtlasKey) {

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use cocoa::appkit::CGFloat;
-use collections::{HashMap, HashSet};
+use collections::{HashMap, HashSet, hash_map::Entry};
 use core_foundation::{
     array::{CFArray, CFArrayRef},
     attributed_string::CFMutableAttributedString,
@@ -144,13 +144,18 @@ impl PlatformTextSystem for MacTextSystem {
                 font_features: font.features.clone(),
                 font_fallbacks: font.fallbacks.clone(),
             };
+            // Cloning the `SmallVec` keeps the borrow of `lock` short; its
+            // inline capacity makes the clone cheaper than the map searches
+            // it saves.
             let candidates = if let Some(font_ids) = lock.font_ids_by_font_key.get(&font_key) {
-                font_ids.as_slice()
+                font_ids.clone()
             } else {
                 let font_ids =
                     lock.load_family(&font.family, &font.features, font.fallbacks.as_ref())?;
-                lock.font_ids_by_font_key.insert(font_key.clone(), font_ids);
-                lock.font_ids_by_font_key[&font_key].as_ref()
+                lock.font_ids_by_font_key
+                    .entry(font_key)
+                    .or_insert(font_ids)
+                    .clone()
             };
 
             let candidate_properties = candidates
@@ -394,19 +399,18 @@ impl MacTextSystemState {
 
     fn id_for_native_font(&mut self, requested_font: CTFont) -> FontId {
         let postscript_name = requested_font.postscript_name();
-        if let Some(font_id) = self.font_ids_by_postscript_name.get(&postscript_name) {
-            *font_id
-        } else {
-            let font_id = FontId(self.fonts.len());
-            self.font_ids_by_postscript_name
-                .insert(postscript_name.clone(), font_id);
-            self.postscript_names_by_font_id
-                .insert(font_id, postscript_name);
-            self.fonts
-                .push(font_kit::font::Font::from_core_graphics_font(
-                    requested_font.copy_to_CGFont(),
-                ));
-            font_id
+        match self.font_ids_by_postscript_name.entry(postscript_name) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let font_id = FontId(self.fonts.len());
+                self.postscript_names_by_font_id
+                    .insert(font_id, entry.key().clone());
+                self.fonts
+                    .push(font_kit::font::Font::from_core_graphics_font(
+                        requested_font.copy_to_CGFont(),
+                    ));
+                *entry.insert(font_id)
+            }
         }
     }
 

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -142,16 +142,22 @@ impl PlatformTextSystem for CosmicTextSystem {
             font.features.clone(),
             font.fallbacks.clone(),
         );
+        // Cloning the `SmallVec` keeps the borrow of `state` short; its
+        // inline capacity makes the clone cheaper than the map searches it
+        // saves.
         let candidates = if let Some(font_ids) = state.font_ids_by_family_cache.get(&key) {
-            font_ids.as_slice()
+            font_ids.clone()
         } else {
             let font_ids =
                 state.load_family(&font.family, &font.features, font.fallbacks.as_ref())?;
-            state.font_ids_by_family_cache.insert(key.clone(), font_ids);
-            state.font_ids_by_family_cache[&key].as_ref()
+            state
+                .font_ids_by_family_cache
+                .entry(key)
+                .or_insert(font_ids)
+                .clone()
         };
 
-        let ix = find_best_match(font, candidates, &state)?;
+        let ix = find_best_match(font, &candidates, &state)?;
 
         Ok(candidates[ix])
     }
@@ -306,8 +312,9 @@ impl CosmicTextSystemState {
                     } else {
                         let loaded = self.load_family(fallback_name, features, None)?;
                         self.font_ids_by_family_cache
-                            .insert(fb_key.clone(), loaded.clone());
-                        loaded
+                            .entry(fb_key)
+                            .or_insert(loaded)
+                            .clone()
                     };
                     let Some(&fb_id) = fb_ids.first() else {
                         continue;

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -111,20 +111,23 @@ impl PlatformAtlas for WgpuAtlas {
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
     ) -> Result<Option<AtlasTile>> {
         let mut lock = self.0.lock();
+        // The entry API cannot be used here: a vacant entry would borrow the
+        // map across `allocate`, which needs the whole locked state. The
+        // second search on insertion is fine; it only happens when a new tile
+        // is rasterized and uploaded.
         if let Some(tile) = lock.tiles_by_key.get(key) {
-            Ok(Some(*tile))
-        } else {
-            profiling::scope!("new tile");
-            let Some((size, bytes)) = build()? else {
-                return Ok(None);
-            };
-            let tile = lock
-                .allocate(size, key.texture_kind())
-                .context("failed to allocate")?;
-            lock.upload_texture(tile.texture_id, tile.bounds, &bytes);
-            lock.tiles_by_key.insert(key.clone(), tile);
-            Ok(Some(tile))
+            return Ok(Some(*tile));
         }
+        profiling::scope!("new tile");
+        let Some((size, bytes)) = build()? else {
+            return Ok(None);
+        };
+        let tile = lock
+            .allocate(size, key.texture_kind())
+            .context("failed to allocate")?;
+        lock.upload_texture(tile.texture_id, tile.bounds, &bytes);
+        lock.tiles_by_key.insert(key.clone(), tile);
+        Ok(Some(tile))
     }
 
     fn remove(&self, key: &AtlasKey) {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3353,20 +3353,16 @@ impl Buffer {
     }
 
     fn restore_encoding_for_transaction(&mut self, transaction_id: TransactionId, was_dirty: bool) {
-        if let Some((old_encoding, old_has_bom)) =
-            self.reload_with_encoding_txns.get(&transaction_id)
-        {
-            let current_encoding = self.encoding;
-            let current_has_bom = self.has_bom;
-            self.encoding = *old_encoding;
-            self.has_bom = *old_has_bom;
+        if let Some(entry) = self.reload_with_encoding_txns.get_mut(&transaction_id) {
+            let (old_encoding, old_has_bom) =
+                std::mem::replace(entry, (self.encoding, self.has_bom));
+            self.encoding = old_encoding;
+            self.has_bom = old_has_bom;
             if !was_dirty {
                 self.saved_version = self.version.clone();
                 self.has_unsaved_edits
                     .set((self.saved_version.clone(), false));
             }
-            self.reload_with_encoding_txns
-                .insert(transaction_id, (current_encoding, current_has_bom));
         }
     }
 

--- a/crates/language_models/src/provider/llama_cpp.rs
+++ b/crates/language_models/src/provider/llama_cpp.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use collections::{HashMap, HashSet};
+use collections::{HashMap, HashSet, hash_map};
 use credentials_provider::CredentialsProvider;
 use fs::Fs;
 use futures::Stream;
@@ -1139,34 +1139,35 @@ fn merge_settings_into_models(
     context_window: Option<u64>,
 ) {
     for setting_model in available_models {
-        if let Some(model) = models.get_mut(&setting_model.name) {
-            if context_window.is_none() {
-                model.max_tokens = setting_model.max_tokens;
+        match models.entry(setting_model.name.clone()) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let model = entry.get_mut();
+                if context_window.is_none() {
+                    model.max_tokens = setting_model.max_tokens;
+                }
+                if setting_model.display_name.is_some() {
+                    model.display_name = setting_model.display_name.clone();
+                }
+                if let Some(supports_tools) = setting_model.supports_tools {
+                    model.supports_tools = supports_tools;
+                }
+                if let Some(supports_images) = setting_model.supports_images {
+                    model.supports_images = supports_images;
+                }
+                if let Some(supports_thinking) = setting_model.supports_thinking {
+                    model.supports_thinking = supports_thinking;
+                }
             }
-            if setting_model.display_name.is_some() {
-                model.display_name = setting_model.display_name.clone();
-            }
-            if let Some(supports_tools) = setting_model.supports_tools {
-                model.supports_tools = supports_tools;
-            }
-            if let Some(supports_images) = setting_model.supports_images {
-                model.supports_images = supports_images;
-            }
-            if let Some(supports_thinking) = setting_model.supports_thinking {
-                model.supports_thinking = supports_thinking;
-            }
-        } else {
-            models.insert(
-                setting_model.name.clone(),
-                llama_cpp::Model {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(llama_cpp::Model {
                     name: setting_model.name.clone(),
                     display_name: setting_model.display_name.clone(),
                     max_tokens: context_window.unwrap_or(setting_model.max_tokens),
                     supports_tools: setting_model.supports_tools.unwrap_or(false),
                     supports_images: setting_model.supports_images.unwrap_or(false),
                     supports_thinking: setting_model.supports_thinking.unwrap_or(false),
-                },
-            );
+                });
+            }
         }
     }
 }

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use collections::HashMap;
+use collections::{HashMap, hash_map};
 use credentials_provider::CredentialsProvider;
 use fs::Fs;
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
@@ -1125,19 +1125,20 @@ fn merge_settings_into_models(
     context_window: Option<u64>,
 ) {
     for setting_model in available_models {
-        if let Some(model) = models.get_mut(&setting_model.name) {
-            if context_window.is_none() {
-                model.max_tokens = setting_model.max_tokens;
+        match models.entry(setting_model.name.clone()) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let model = entry.get_mut();
+                if context_window.is_none() {
+                    model.max_tokens = setting_model.max_tokens;
+                }
+                model.display_name = setting_model.display_name.clone();
+                model.keep_alive = setting_model.keep_alive.clone();
+                model.supports_tools = setting_model.supports_tools;
+                model.supports_vision = setting_model.supports_images;
+                model.supports_thinking = setting_model.supports_thinking;
             }
-            model.display_name = setting_model.display_name.clone();
-            model.keep_alive = setting_model.keep_alive.clone();
-            model.supports_tools = setting_model.supports_tools;
-            model.supports_vision = setting_model.supports_images;
-            model.supports_thinking = setting_model.supports_thinking;
-        } else {
-            models.insert(
-                setting_model.name.clone(),
-                ollama::Model {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(ollama::Model {
                     name: setting_model.name.clone(),
                     display_name: setting_model.display_name.clone(),
                     max_tokens: context_window.unwrap_or(setting_model.max_tokens),
@@ -1146,8 +1147,8 @@ fn merge_settings_into_models(
                     supports_vision: setting_model.supports_images,
                     supports_thinking: setting_model.supports_thinking,
                     disabled: None,
-                },
-            );
+                });
+            }
         }
     }
 }

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, hash_map},
     path::{Path, PathBuf},
     rc::Rc,
     time::{Duration, Instant},
@@ -746,19 +746,22 @@ impl LanguageServers {
         message: Option<&str>,
         name: Option<LanguageServerName>,
     ) {
-        if let Some(state) = self.health_statuses.get_mut(&id) {
-            state.health = Some((message.map(SharedString::new), health));
-            if let Some(name) = name {
-                state.name = name;
+        match self.health_statuses.entry(id) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                state.health = Some((message.map(SharedString::new), health));
+                if let Some(name) = name {
+                    state.name = name;
+                }
             }
-        } else if let Some(name) = name {
-            self.health_statuses.insert(
-                id,
-                LanguageServerHealthStatus {
-                    health: Some((message.map(SharedString::new), health)),
-                    name,
-                },
-            );
+            hash_map::Entry::Vacant(entry) => {
+                if let Some(name) = name {
+                    entry.insert(LanguageServerHealthStatus {
+                        health: Some((message.map(SharedString::new), health)),
+                        name,
+                    });
+                }
+            }
         }
     }
 

--- a/crates/multi_buffer/src/transaction.rs
+++ b/crates/multi_buffer/src/transaction.rs
@@ -1,7 +1,7 @@
 use gpui::{App, Context, Entity};
 use language::{self, Buffer, BufferEditSource, TransactionId};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     ops::Range,
     time::{Duration, Instant},
 };
@@ -403,21 +403,20 @@ impl MultiBuffer {
             && let Some(destination) = self.history.transaction_mut(destination)
         {
             for (buffer_id, buffer_transaction_id) in transaction.buffer_transactions {
-                if let Some(destination_buffer_transaction_id) =
-                    destination.buffer_transactions.get(&buffer_id)
-                {
-                    if let Some(state) = self.buffers.get(&buffer_id) {
-                        state.buffer.update(cx, |buffer, _| {
-                            buffer.merge_transactions(
-                                buffer_transaction_id,
-                                *destination_buffer_transaction_id,
-                            )
-                        });
+                match destination.buffer_transactions.entry(buffer_id) {
+                    Entry::Occupied(destination_buffer_transaction_id) => {
+                        if let Some(state) = self.buffers.get(&buffer_id) {
+                            state.buffer.update(cx, |buffer, _| {
+                                buffer.merge_transactions(
+                                    buffer_transaction_id,
+                                    *destination_buffer_transaction_id.get(),
+                                )
+                            });
+                        }
                     }
-                } else {
-                    destination
-                        .buffer_transactions
-                        .insert(buffer_id, buffer_transaction_id);
+                    Entry::Vacant(entry) => {
+                        entry.insert(buffer_transaction_id);
+                    }
                 }
             }
         }

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1170,14 +1170,12 @@ impl BufferStore {
         let remote_id = buffer.read(cx).remote_id();
         if let Some(entry_id) = file.entry_id {
             if let Some(local) = self.as_local_mut() {
-                match local.local_buffer_ids_by_entry_id.get(&entry_id) {
-                    Some(_) => {
+                match local.local_buffer_ids_by_entry_id.entry(entry_id) {
+                    hash_map::Entry::Occupied(_) => {
                         return None;
                     }
-                    None => {
-                        local
-                            .local_buffer_ids_by_entry_id
-                            .insert(entry_id, remote_id);
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(remote_id);
                     }
                 }
             }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1112,20 +1112,24 @@ impl GitStore {
                             while let Some(update) = updates_rx.next().await {
                                 match update {
                                     DownstreamUpdate::UpdateRepository(snapshot) => {
-                                        if let Some(old_snapshot) = snapshots.get_mut(&snapshot.id)
-                                        {
-                                            let update =
-                                                snapshot.build_update(old_snapshot, project_id);
-                                            *old_snapshot = snapshot;
-                                            for update in split_repository_update(update) {
-                                                client.send(update)?;
+                                        match snapshots.entry(snapshot.id) {
+                                            collections::hash_map::Entry::Occupied(
+                                                mut old_snapshot,
+                                            ) => {
+                                                let update = snapshot
+                                                    .build_update(old_snapshot.get(), project_id);
+                                                *old_snapshot.get_mut() = snapshot;
+                                                for update in split_repository_update(update) {
+                                                    client.send(update)?;
+                                                }
                                             }
-                                        } else {
-                                            let update = snapshot.initial_update(project_id);
-                                            for update in split_repository_update(update) {
-                                                client.send(update)?;
+                                            collections::hash_map::Entry::Vacant(entry) => {
+                                                let update = snapshot.initial_update(project_id);
+                                                for update in split_repository_update(update) {
+                                                    client.send(update)?;
+                                                }
+                                                entry.insert(snapshot);
                                             }
-                                            snapshots.insert(snapshot.id, snapshot);
                                         }
                                     }
                                     DownstreamUpdate::RemoveRepository(id) => {

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -910,12 +910,12 @@ impl LocalImageStore {
 
         let image_id = image.id;
         if let Some(entry_id) = file.entry_id {
-            match self.local_image_ids_by_entry_id.get(&entry_id) {
-                Some(_) => {
+            match self.local_image_ids_by_entry_id.entry(entry_id) {
+                hash_map::Entry::Occupied(_) => {
                     return None;
                 }
-                None => {
-                    self.local_image_ids_by_entry_id.insert(entry_id, image_id);
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(image_id);
                 }
             }
         };

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, num::NonZeroU32};
 
-use collections::{HashMap, HashSet};
+use collections::{HashMap, HashSet, hash_map::Entry};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings_macros::{MergeFrom, with_fallible_options};
@@ -71,14 +71,17 @@ impl merge_from::MergeFrom for AllLanguageSettingsContent {
 
         // A user's language-specific settings override default language-specific settings.
         for (language_name, user_language_settings) in &other.languages.0 {
-            if let Some(existing) = self.languages.0.get_mut(language_name) {
-                existing.merge_from(&user_language_settings);
-            } else {
-                let mut new_settings = self.defaults.clone();
-                new_settings.language_servers = None;
-                new_settings.merge_from(&user_language_settings);
+            match self.languages.0.entry(language_name.clone()) {
+                Entry::Occupied(mut existing) => {
+                    existing.get_mut().merge_from(user_language_settings);
+                }
+                Entry::Vacant(entry) => {
+                    let mut new_settings = self.defaults.clone();
+                    new_settings.language_servers = None;
+                    new_settings.merge_from(user_language_settings);
 
-                self.languages.0.insert(language_name.clone(), new_settings);
+                    entry.insert(new_settings);
+                }
             }
         }
     }

--- a/crates/settings_content/src/merge_from.rs
+++ b/crates/settings_content/src/merge_from.rs
@@ -93,11 +93,9 @@ where
 {
     fn merge_from(&mut self, other: &Self) {
         for (key, value) in other {
-            if let Some(existing) = self.get_mut(key) {
-                existing.merge_from(value);
-            } else {
-                self.insert(key.clone(), value.clone());
-            }
+            self.entry(key.clone())
+                .and_modify(|existing| existing.merge_from(value))
+                .or_insert_with(|| value.clone());
         }
     }
 }
@@ -109,11 +107,9 @@ where
 {
     fn merge_from(&mut self, other: &Self) {
         for (key, value) in other {
-            if let Some(existing) = self.get_mut(key) {
-                existing.merge_from(value);
-            } else {
-                self.insert(key.clone(), value.clone());
-            }
+            self.entry(key.clone())
+                .and_modify(|existing| existing.merge_from(value))
+                .or_insert_with(|| value.clone());
         }
     }
 }
@@ -125,11 +121,9 @@ where
 {
     fn merge_from(&mut self, other: &Self) {
         for (key, value) in other {
-            if let Some(existing) = self.get_mut(key) {
-                existing.merge_from(value);
-            } else {
-                self.insert(key.clone(), value.clone());
-            }
+            self.entry(key.clone())
+                .and_modify(|existing| existing.merge_from(value))
+                .or_insert_with(|| value.clone());
         }
     }
 }
@@ -161,11 +155,9 @@ impl MergeFrom for serde_json::Value {
         match (self, other) {
             (serde_json::Value::Object(this), serde_json::Value::Object(other)) => {
                 for (key, value) in other {
-                    if let Some(existing) = this.get_mut(key) {
-                        existing.merge_from(value);
-                    } else {
-                        this.insert(key.clone(), value.clone());
-                    }
+                    this.entry(key.clone())
+                        .and_modify(|existing| existing.merge_from(value))
+                        .or_insert_with(|| value.clone());
                 }
             }
             (this, other) => *this = other.clone(),

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -422,10 +422,13 @@ pub fn merge_json_lenient_value_into(
     match (source, target) {
         (serde_json_lenient::Value::Object(source), serde_json_lenient::Value::Object(target)) => {
             for (key, value) in source {
-                if let Some(target) = target.get_mut(&key) {
-                    merge_json_lenient_value_into(value, target);
-                } else {
-                    target.insert(key, value);
+                match target.entry(key) {
+                    serde_json_lenient::map::Entry::Occupied(mut entry) => {
+                        merge_json_lenient_value_into(value, entry.get_mut());
+                    }
+                    serde_json_lenient::map::Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
                 }
             }
         }
@@ -449,10 +452,13 @@ pub fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json:
     match (source, target) {
         (Value::Object(source), Value::Object(target)) => {
             for (key, value) in source {
-                if let Some(target) = target.get_mut(&key) {
-                    merge_json_value_into(value, target);
-                } else {
-                    target.insert(key, value);
+                match target.entry(key) {
+                    serde_json::map::Entry::Occupied(mut entry) => {
+                        merge_json_value_into(value, entry.get_mut());
+                    }
+                    serde_json::map::Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
                 }
             }
         }
@@ -494,10 +500,15 @@ pub fn merge_non_null_json_value_into(source: serde_json::Value, target: &mut se
             target.as_object_mut().unwrap()
         };
         for (key, value) in source_object {
-            if let Some(target) = target_object.get_mut(&key) {
-                merge_non_null_json_value_into(value, target);
-            } else if !value.is_null() {
-                target_object.insert(key, value);
+            match target_object.entry(key) {
+                serde_json::map::Entry::Occupied(mut entry) => {
+                    merge_non_null_json_value_into(value, entry.get_mut());
+                }
+                serde_json::map::Entry::Vacant(entry) => {
+                    if !value.is_null() {
+                        entry.insert(value);
+                    }
+                }
             }
         }
     } else if !source.is_null() {

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use fs::Fs;
 
 use anyhow::{Context as _, Result, bail};
-use collections::{HashMap, HashSet, IndexSet};
+use collections::{HashMap, HashSet, IndexSet, hash_map};
 use db::{
     kvp::KeyValueStore,
     query,
@@ -2757,13 +2757,17 @@ fn dedupe_recent_workspaces(
             }
         };
         let key = (location_identity, workspace.identity_paths.paths().to_vec());
-        if let Some(&existing_index) = indices_by_key.get(&key) {
-            if workspace.timestamp > result[existing_index].timestamp {
-                result[existing_index] = workspace;
+        match indices_by_key.entry(key) {
+            hash_map::Entry::Occupied(entry) => {
+                let existing_index = *entry.get();
+                if workspace.timestamp > result[existing_index].timestamp {
+                    result[existing_index] = workspace;
+                }
             }
-        } else {
-            indices_by_key.insert(key, result.len());
-            result.push(workspace);
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(result.len());
+                result.push(workspace);
+            }
         }
     }
 


### PR DESCRIPTION
Pushing in draft to have something to get feedback on. 

I'll mark as green/reviewable when I can stand behind all of the fixes.

---

# Objective

- Remove the repeated map searches that the `map_lookup_then_insert` lint found (#62681).
- Each of the 30 locations searched a map or set two times with the same key. One search did the lookup. One search did the insertion.

## Solution

- Use the entry API where the borrow rules permit it. One search now does the work of two.
- Use `entry().or_default()` where both branches push the same value (`language_model_selector.rs`, `devcontainer_manifest.rs`).
- Use `mem::replace` in `Buffer::restore_encoding_for_transaction`. The function now swaps the stored encoding in place with one search.
- Use an early return in the two atlas caches and in the permission-pattern toggle. A vacant entry cannot stay alive across `allocate`, because `allocate` borrows the full locked state. The hit path now does one search. Only the cold miss path searches again, and that path also rasterizes and uploads a new tile.
- Make the font caches return a clone of the `SmallVec` in place of a slice. The clone is a small inline copy. It costs less than the map searches and the `FontKey` clone that it removes. This change also removes a triple search (`get`, `insert`, index) in `gpui_macos/text_system.rs` and `cosmic_text_system.rs`.
- Keep one key clone in the generic merge functions (`merge_from.rs`, the model providers). The entry API needs an owned key. These keys are small strings on cold paths.

The diff removes as many lines as it adds (335 insertions, 336 deletions). The behavior does not change.

## Testing

- `cargo test` passes for all 16 changed crates: `gpui`, `gpui_apple`, `gpui_wgpu`, `gpui_macos`, `settings_content`, `util`, `project`, `multi_buffer`, `language`, `workspace`, `call`, `channel`, `language_tools`, `language_models`, `agent_ui`, and `dev_container` (1,892 tests, 0 failures).
- A full workspace run of the lint found these 30 locations. The rewrites remove all of them.
- Test platform: macOS (Apple Silicon). The `gpui_wgpu` changes also apply to Linux and Windows; CI must confirm those targets.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
