### PR TITLE
editor: Match invisible character ranges directly

### DIFF
--- a/crates/editor/src/display_map/invisibles.rs
+++ b/crates/editor/src/display_map/invisibles.rs
@@ -37,12 +37,13 @@ pub fn is_invisible(c: char) -> bool {
     } else if c >= '\u{7f}' {
         c <= '\u{9f}'
             || (c.is_whitespace() && c != IDEOGRAPHIC_SPACE)
-            || contains(c, FORMAT)
-            || contains(c, OTHER)
+            || is_format_character(c)
+            || is_other_invisible_character(c)
     } else {
         false
     }
 }
+
 // ASCII control characters have fancy unicode glyphs, everything else
 // is replaced by a space - unless it is used in combining characters in
 // which case we need to leave it in the string.
@@ -51,10 +52,70 @@ pub fn replacement(c: char) -> Option<char> {
         C0_SYMBOLS.get(c as usize).copied()
     } else if c == '\x7f' {
         Some(DEL)
-    } else if contains(c, PRESERVE) {
+    } else if should_preserve_invisible_character(c) {
         None
     } else {
         Some(FIXED_WIDTH_SPACE)
+    }
+}
+
+// Generated using: ucd-generate general-category --include Format --chars ucd-16.0.0
+#[inline(always)]
+fn is_format_character(c: char) -> bool {
+    match c {
+        '\u{ad}'
+        | '\u{600}'..='\u{605}'
+        | '\u{61c}'
+        | '\u{6dd}'
+        | '\u{70f}'
+        | '\u{890}'..='\u{891}'
+        | '\u{8e2}'
+        | '\u{180e}'
+        | '\u{200b}'..='\u{200f}'
+        | '\u{202a}'..='\u{202e}'
+        | '\u{2060}'..='\u{2064}'
+        | '\u{2066}'..='\u{206f}'
+        | '\u{feff}'
+        | '\u{fff9}'..='\u{fffb}'
+        | '\u{110bd}'
+        | '\u{110cd}'
+        | '\u{13430}'..='\u{1343f}'
+        | '\u{1bca0}'..='\u{1bca3}'
+        | '\u{1d173}'..='\u{1d17a}'
+        | '\u{e0001}'
+        | '\u{e0020}'..='\u{e007f}' => true,
+        _ => false,
+    }
+}
+
+// Hand-made based on https://invisible-characters.com, excluding Cf.
+#[inline(always)]
+fn is_other_invisible_character(c: char) -> bool {
+    match c {
+        '\u{034f}'
+        | '\u{115f}'..='\u{1160}'
+        | '\u{17b4}'..='\u{17b5}'
+        | '\u{180b}'..='\u{180d}'
+        | '\u{2800}'
+        | '\u{3164}'
+        | '\u{fe00}'..='\u{fe0d}'
+        | '\u{ffa0}'
+        | '\u{fffc}'
+        | '\u{e0100}'..='\u{e01ef}' => true,
+        _ => false,
+    }
+}
+
+#[inline(always)]
+fn should_preserve_invisible_character(c: char) -> bool {
+    match c {
+        '\u{034f}'
+        | '\u{200d}'
+        | '\u{17b4}'..='\u{17b5}'
+        | '\u{180b}'..='\u{180d}'
+        | '\u{e0061}'..='\u{e007a}'
+        | '\u{e007f}' => true,
+        _ => false,
     }
 }
 
@@ -70,64 +131,3 @@ const C0_SYMBOLS: &[char] = &[
     '␓', '␔', '␕', '␖', '␗', '␘', '␙', '␚', '␛', '␜', '␝', '␞', '␟',
 ];
 const DEL: char = '␡';
-
-// generated using ucd-generate: ucd-generate general-category --include Format --chars ucd-16.0.0
-pub const FORMAT: &[(char, char)] = &[
-    ('\u{ad}', '\u{ad}'),
-    ('\u{600}', '\u{605}'),
-    ('\u{61c}', '\u{61c}'),
-    ('\u{6dd}', '\u{6dd}'),
-    ('\u{70f}', '\u{70f}'),
-    ('\u{890}', '\u{891}'),
-    ('\u{8e2}', '\u{8e2}'),
-    ('\u{180e}', '\u{180e}'),
-    ('\u{200b}', '\u{200f}'),
-    ('\u{202a}', '\u{202e}'),
-    ('\u{2060}', '\u{2064}'),
-    ('\u{2066}', '\u{206f}'),
-    ('\u{feff}', '\u{feff}'),
-    ('\u{fff9}', '\u{fffb}'),
-    ('\u{110bd}', '\u{110bd}'),
-    ('\u{110cd}', '\u{110cd}'),
-    ('\u{13430}', '\u{1343f}'),
-    ('\u{1bca0}', '\u{1bca3}'),
-    ('\u{1d173}', '\u{1d17a}'),
-    ('\u{e0001}', '\u{e0001}'),
-    ('\u{e0020}', '\u{e007f}'),
-];
-
-// hand-made base on https://invisible-characters.com (Excluding Cf)
-pub const OTHER: &[(char, char)] = &[
-    ('\u{034f}', '\u{034f}'),
-    ('\u{115F}', '\u{1160}'),
-    ('\u{17b4}', '\u{17b5}'),
-    ('\u{180b}', '\u{180d}'),
-    ('\u{2800}', '\u{2800}'),
-    ('\u{3164}', '\u{3164}'),
-    ('\u{fe00}', '\u{fe0d}'),
-    ('\u{ffa0}', '\u{ffa0}'),
-    ('\u{fffc}', '\u{fffc}'),
-    ('\u{e0100}', '\u{e01ef}'),
-];
-
-// a subset of FORMAT/OTHER that may appear within glyphs
-const PRESERVE: &[(char, char)] = &[
-    ('\u{034f}', '\u{034f}'),
-    ('\u{200d}', '\u{200d}'),
-    ('\u{17b4}', '\u{17b5}'),
-    ('\u{180b}', '\u{180d}'),
-    ('\u{e0061}', '\u{e007a}'),
-    ('\u{e007f}', '\u{e007f}'),
-];
-
-fn contains(c: char, list: &[(char, char)]) -> bool {
-    for &(start, end) in list {
-        if c < start {
-            return false;
-        }
-        if c <= end {
-            return true;
-        }
-    }
-    false
-}

--- a/crates/editor/src/display_map/invisibles.rs
+++ b/crates/editor/src/display_map/invisibles.rs
@@ -37,8 +37,7 @@ pub fn is_invisible(c: char) -> bool {
     } else if c >= '\u{7f}' {
         c <= '\u{9f}'
             || (c.is_whitespace() && c != IDEOGRAPHIC_SPACE)
-            || is_format_character(c)
-            || is_other_invisible_character(c)
+            || is_format_or_other_invisible_character(c)
     } else {
         false
     }
@@ -59,10 +58,10 @@ pub fn replacement(c: char) -> Option<char> {
     }
 }
 
-// Generated using: ucd-generate general-category --include Format --chars ucd-16.0.0
 #[inline(always)]
-fn is_format_character(c: char) -> bool {
+fn is_format_or_other_invisible_character(c: char) -> bool {
     match c {
+        // Generated using: ucd-generate general-category --include Format --chars ucd-16.0.0
         '\u{ad}'
         | '\u{600}'..='\u{605}'
         | '\u{61c}'
@@ -83,16 +82,9 @@ fn is_format_character(c: char) -> bool {
         | '\u{1bca0}'..='\u{1bca3}'
         | '\u{1d173}'..='\u{1d17a}'
         | '\u{e0001}'
-        | '\u{e0020}'..='\u{e007f}' => true,
-        _ => false,
-    }
-}
-
-// Hand-made based on https://invisible-characters.com, excluding Cf.
-#[inline(always)]
-fn is_other_invisible_character(c: char) -> bool {
-    match c {
-        '\u{034f}'
+        | '\u{e0020}'..='\u{e007f}'
+        // Hand-made based on https://invisible-characters.com, excluding Cf.
+        | '\u{034f}'
         | '\u{115f}'..='\u{1160}'
         | '\u{17b4}'..='\u{17b5}'
         | '\u{180b}'..='\u{180d}'


### PR DESCRIPTION
Local benchmark shows this speeds it up by at least 30% and is definitely more reasonable to have like this than compared to iterating over a list for every given char.

Release Notes:

- N/A
