### PR TITLE
feat(workspace): introduce Floating Island Layout & Rounded Corners mode

### DIFF
--- a/.agents/memory/features.md
+++ b/.agents/memory/features.md
@@ -1,0 +1,5 @@
+# Feature Map
+
+| Feature | Status | Entrypoint | Notes |
+|---|---|---|---|
+| UI Rounded Corners | In Discussion / Brainstorming | `crates/ui`, `crates/theme`, `crates/workspace` | Exploring rounded corners styling & architecture for Zed UI elements |

--- a/.agents/memory/features.md
+++ b/.agents/memory/features.md
@@ -2,4 +2,4 @@
 
 | Feature | Status | Entrypoint | Notes |
 |---|---|---|---|
-| UI Rounded Corners | In Discussion / Brainstorming | `crates/ui`, `crates/theme`, `crates/workspace` | Exploring rounded corners styling & architecture for Zed UI elements |
+| Floating Island Layout & Rounded Corners | Implemented | `crates/workspace/src/workspace.rs`, `crates/workspace/src/workspace_settings.rs` | Configurable floating island layout, rounded dock cards, rounded editor panes, pill tabs, and floating status bar |

--- a/.agents/memory/index.md
+++ b/.agents/memory/index.md
@@ -1,0 +1,2 @@
+# Lessons Index
+

--- a/.agents/memory/invariants.md
+++ b/.agents/memory/invariants.md
@@ -1,0 +1,4 @@
+# Invariants Registry
+
+## Architecture & Codebase Invariants
+- Rust coding guidelines: Follow `.rules` (no `unwrap()`, prefer `?`, no `mod.rs`, single foreground thread for GPUI entities).

--- a/.agents/memory/short_term/session.md
+++ b/.agents/memory/short_term/session.md
@@ -1,0 +1,3 @@
+# Session Scratchpad
+
+- Initiated conversation exploring rounded corners for Zed editor components in forked repo.

--- a/.agents/plans/2026-08-16-floating-island-rounded-layout.md
+++ b/.agents/plans/2026-08-16-floating-island-rounded-layout.md
@@ -1,0 +1,399 @@
+# Floating Island Layout & Rounded Corners Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a fully configurable Floating Island Layout with rounded corners for editor panes, side/bottom docks, pill tabs, and status bar in Zed Code Editor.
+
+**Architecture:** Add `IslandLayoutSettings` to `WorkspaceSettingsContent` and `WorkspaceSettings` for schema-backed user configuration via `settings.json`. Update `Workspace::render`, `Dock::render`, `Pane::render`, and `Tab::render` to apply rounded corners, overflow clipping, outer canvas depth, and inter-panel gaps when island mode is enabled while maintaining pixel-perfect fidelity with vanilla Zed when disabled.
+
+**Tech Stack:** Rust, GPUI, GPUI Styled trait (`gpui_macros`), Serde, JSON Schema.
+
+## Global Constraints
+
+- Rust coding guidelines: Follow `.rules` (no `unwrap()`, prefer `?`, no `mod.rs`, single foreground thread for GPUI entities).
+- Zero visual regression when `island_layout.enabled` is `false`.
+- Git commit message format: `type(scope): short description` followed by bullet points.
+
+---
+
+### Task 1: Configuration & Settings Schema
+
+**Files:**
+- Modify: `crates/settings_content/src/workspace.rs`
+- Modify: `crates/workspace/src/workspace_settings.rs`
+- Test: `crates/settings/src/settings_store.rs`
+
+**Interfaces:**
+- Produces: `IslandLayoutSettings` struct with fields:
+  ```rust
+  #[derive(Copy, Clone, PartialEq, Debug)]
+  pub struct IslandLayoutSettings {
+      pub enabled: bool,
+      pub corner_radius: f32,
+      pub gap: f32,
+      pub border: bool,
+      pub pill_tabs: bool,
+  }
+  ```
+- Consumes: `SettingsContent`, `WorkspaceSettings::get_global(cx)`.
+
+- [ ] **Step 1: Write unit test for IslandLayoutSettings deserialization**
+
+In `crates/settings_content/src/workspace.rs` (or settings tests):
+```rust
+#[test]
+fn test_island_layout_settings_parsing() {
+    let json = serde_json::json!({
+        "island_layout": {
+            "enabled": true,
+            "corner_radius": 20.0,
+            "gap": 8.0,
+            "border": true,
+            "pill_tabs": true
+        }
+    });
+    let parsed: WorkspaceSettingsContent = serde_json::from_value(json).expect("failed to parse");
+    let island = parsed.island_layout.expect("island_layout was None");
+    assert_eq!(island.enabled, Some(true));
+    assert_eq!(island.corner_radius, Some(20.0));
+    assert_eq!(island.gap, Some(8.0));
+    assert_eq!(island.border, Some(true));
+    assert_eq!(island.pill_tabs, Some(true));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p settings_content test_island_layout_settings_parsing`
+Expected: FAIL with `unknown field island_layout`
+
+- [ ] **Step 3: Implement IslandLayoutSettings in `settings_content` and `workspace_settings`**
+
+In `crates/settings_content/src/workspace.rs`:
+```rust
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct IslandLayoutSettings {
+    /// Whether floating island layout mode is enabled.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+
+    /// Corner radius in pixels for floating panels and cards.
+    ///
+    /// Default: 18.0
+    pub corner_radius: Option<f32>,
+
+    /// Gap / padding around floating islands in pixels.
+    ///
+    /// Default: 6.0
+    pub gap: Option<f32>,
+
+    /// Whether to render a subtle border outline around floating panels.
+    ///
+    /// Default: true
+    pub border: Option<bool>,
+
+    /// Whether to display editor tabs as rounded pills inside the pane header.
+    ///
+    /// Default: true
+    pub pill_tabs: Option<bool>,
+}
+```
+
+Add `pub island_layout: Option<IslandLayoutSettings>` to `WorkspaceSettingsContent`.
+
+In `crates/workspace/src/workspace_settings.rs`:
+```rust
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct IslandLayoutSettings {
+    pub enabled: bool,
+    pub corner_radius: f32,
+    pub gap: f32,
+    pub border: bool,
+    pub pill_tabs: bool,
+}
+
+impl Default for IslandLayoutSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            corner_radius: 18.0,
+            gap: 6.0,
+            border: true,
+            pill_tabs: true,
+        }
+    }
+}
+```
+Add `pub island_layout: IslandLayoutSettings` to `WorkspaceSettings` and map it in `impl Settings for WorkspaceSettings`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p settings_content -p workspace`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/settings_content/src/workspace.rs crates/workspace/src/workspace_settings.rs
+git commit -m "feat(settings): add island_layout configuration options
+
+- Define IslandLayoutSettings in WorkspaceSettingsContent
+- Add runtime IslandLayoutSettings to WorkspaceSettings with default values"
+```
+
+---
+
+### Task 2: Floating Pill Tabs Styling
+
+**Files:**
+- Modify: `crates/ui/src/components/tab.rs`
+- Modify: `crates/ui/src/components/tab_bar.rs`
+- Test: `crates/ui/src/components/tab.rs`
+
+**Interfaces:**
+- Produces: `Tab::pill_style(mut self, pill: bool) -> Self` and `TabBar::pill_style(mut self, pill: bool) -> Self`.
+- Consumes: `TabPosition`, `ThemeColors`.
+
+- [ ] **Step 1: Write test for Tab component pill styling**
+
+In `crates/ui/src/components/tab.rs`:
+```rust
+#[gpui::test]
+async fn test_tab_pill_style(cx: &mut gpui::TestAppContext) {
+    let window = cx.add_window(|_| {
+        Tab::new("test_tab")
+            .pill_style(true)
+            .selected(true)
+            .child("test.rs")
+    });
+    assert!(window.is_ok());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ui test_tab_pill_style`
+Expected: FAIL with `no method named pill_style`
+
+- [ ] **Step 3: Implement pill style in Tab and TabBar**
+
+In `crates/ui/src/components/tab.rs`:
+Add `pill_style: bool` field to `Tab` with builder method:
+```rust
+pub fn pill_style(mut self, pill: bool) -> Self {
+    self.pill_style = pill;
+    self
+}
+```
+In `impl RenderOnce for Tab`:
+When `self.pill_style` is true:
+- Apply `.rounded_md().mx_0p5().my_1().px_2()`
+- If `self.selected`: `.bg(tab_bg).border_1().border_color(cx.theme().colors().border_variant)`
+- If not `selected`: `.bg(gpui::transparent_black()).hover(|s| s.bg(tab_hover_bg))` without bottom/side border attachments.
+
+In `crates/ui/src/components/tab_bar.rs`:
+Add `pill_style: bool` and pass it down or adjust tab bar container padding (`py_0p5 px_1`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ui test_tab_pill_style`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ui/src/components/tab.rs crates/ui/src/components/tab_bar.rs
+git commit -m "feat(ui): add pill style support to Tab and TabBar components
+
+- Add pill_style option to Tab and TabBar
+- Render rounded pill chips with proper active/inactive contrast in pill mode"
+```
+
+---
+
+### Task 3: Floating Dock Panels & Resize Handles
+
+**Files:**
+- Modify: `crates/workspace/src/dock.rs`
+- Test: `crates/workspace/src/dock.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceSettings::get_global(cx).island_layout`.
+- Produces: Rounded dock card rendering and adjusted resize handle placement.
+
+- [ ] **Step 1: Write test for Dock island mode rendering**
+
+In `crates/workspace/src/dock.rs`:
+```rust
+#[gpui::test]
+async fn test_dock_island_rendering(cx: &mut gpui::TestAppContext) {
+    // Verify dock renders properly with island settings active
+}
+```
+
+- [ ] **Step 2: Run test to verify initial state**
+
+Run: `cargo test -p workspace test_dock_island_rendering`
+
+- [ ] **Step 3: Update `Dock::render` for Island Mode**
+
+In `crates/workspace/src/dock.rs`:
+Read `let island_layout = WorkspaceSettings::get_global(cx).island_layout;`
+When `island_layout.enabled`:
+```rust
+.when(island_layout.enabled, |this| {
+    this.rounded(px(island_layout.corner_radius))
+        .overflow_hidden()
+        .shadow_sm()
+        .when(island_layout.border, |this| {
+            this.border_1().border_color(cx.theme().colors().border)
+        })
+})
+```
+Adjust resize handle margins and padding so handles lie within the inter-card gap.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p workspace`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/workspace/src/dock.rs
+git commit -m "feat(workspace): style dock panels as floating cards in island layout
+
+- Apply corner radius, overflow clipping, and borders to dock cards
+- Position resize handles within layout gap"
+```
+
+---
+
+### Task 4: Floating Editor Panes & Split Views
+
+**Files:**
+- Modify: `crates/workspace/src/pane.rs`
+- Modify: `crates/workspace/src/pane_group.rs`
+- Test: `crates/workspace/src/pane.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceSettings::get_global(cx).island_layout`.
+- Produces: Rounded pane containers, clipped buffers/gutters, and rounded drag-and-drop target overlays.
+
+- [ ] **Step 1: Write test for Pane island mode rendering**
+
+In `crates/workspace/src/pane.rs`:
+```rust
+#[gpui::test]
+async fn test_pane_island_rendering(cx: &mut gpui::TestAppContext) {
+    // Verify pane renders with rounded container and pill tabs
+}
+```
+
+- [ ] **Step 2: Run test to verify initial state**
+
+Run: `cargo test -p workspace test_pane_island_rendering`
+
+- [ ] **Step 3: Implement Pane and PaneGroup island card styling**
+
+In `crates/workspace/src/pane_group.rs` (`Member::render`):
+When `island_layout.enabled`:
+- Add `p(px(island_layout.gap / 2.0))` around pane members in split axes so splits have clean gap spacing.
+
+In `crates/workspace/src/pane.rs` (`Pane::render`):
+- Read `let island_layout = WorkspaceSettings::get_global(cx).island_layout;`
+- Apply `.when(island_layout.enabled, |this| this.rounded(px(island_layout.corner_radius)).overflow_hidden().when(island_layout.border, |t| t.border_1().border_color(cx.theme().colors().border)))` to pane card container.
+- Pass `island_layout.pill_tabs` to `render_tab_bar`.
+- In drag target overlay: apply `.rounded(px(island_layout.corner_radius))` so the drop indicator follows the rounded boundary.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p workspace`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/workspace/src/pane.rs crates/workspace/src/pane_group.rs
+git commit -m "feat(workspace): add floating card styling and split gaps to editor panes
+
+- Apply corner radius and overflow clipping to editor panes
+- Add split pane gap spacing in pane_group
+- Render rounded drag and drop indicators"
+```
+
+---
+
+### Task 5: Workspace Canvas Backdrop & Floating Status Bar
+
+**Files:**
+- Modify: `crates/workspace/src/workspace.rs`
+- Test: `crates/workspace/src/workspace.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceSettings::get_global(cx).island_layout`.
+- Produces: Complete floating island workspace layout with canvas backdrop, uniform gap grid, and floating status bar pill.
+
+- [ ] **Step 1: Write test for Workspace island layout rendering**
+
+In `crates/workspace/src/workspace.rs`:
+```rust
+#[gpui::test]
+async fn test_workspace_island_layout(cx: &mut gpui::TestAppContext) {
+    // Verify workspace layout builds with island layout enabled
+}
+```
+
+- [ ] **Step 2: Run test to verify initial state**
+
+Run: `cargo test -p workspace test_workspace_island_layout`
+
+- [ ] **Step 3: Implement canvas backdrop, grid gaps, and floating status bar**
+
+In `crates/workspace/src/workspace.rs` (`Workspace::render`):
+- Read `let island_layout = WorkspaceSettings::get_global(cx).island_layout;`
+- When `island_layout.enabled`:
+  - Set `#workspace` background to canvas / window background: `.bg(colors.window_background.unwrap_or(colors.background))` and outer padding `.p(px(island_layout.gap))`.
+  - Add gap spacing (`gap(px(island_layout.gap))`) between `left_dock`, center editor group, `right_dock`, and `bottom_dock`.
+  - Style status bar as floating pill: `.rounded(px(island_layout.corner_radius * 0.75)).mx_2().mb_1().border_1().border_color(colors.border).shadow_sm()`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p workspace`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/workspace/src/workspace.rs
+git commit -m "feat(workspace): implement canvas backdrop, panel gaps, and floating status bar
+
+- Add canvas backdrop and perimeter gaps to workspace grid
+- Render status bar as floating pill card
+- Complete end-to-end floating island layout"
+```
+
+---
+
+### Task 6: End-to-End Verification & Formatting
+
+**Files:**
+- All touched crates
+
+- [ ] **Step 1: Run full test suite for workspace, ui, and settings**
+
+Run: `cargo test -p workspace -p ui -p settings_content -p settings`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run clippy and format check**
+
+Run: `./script/clippy`
+Expected: Zero errors / warnings on touched files.
+
+- [ ] **Step 3: Final verification commit if needed**
+
+```bash
+git commit -m "chore(ui): finalize floating island layout verification"
+```

--- a/.agents/specs/2026-08-16-floating-island-rounded-layout-design.md
+++ b/.agents/specs/2026-08-16-floating-island-rounded-layout-design.md
@@ -1,0 +1,163 @@
+# Floating Island Layout & Rounded Corners Design Specification
+
+## Overview
+
+This specification details the design and architecture for implementing a **Floating Island Layout** with configurable rounded corners in Zed Code Editor. The feature transforms docked panels (editor panes, sidebars/project panel, terminal, and status bar) into cohesive, floating cards separated by customizable gaps over a textured background canvas, accompanied by rounded pill-style editor tabs.
+
+The entire system is configurable via `settings.json`, allowing users to toggle floating island mode on/off and adjust corner radii, gaps, and borders dynamically.
+
+---
+
+## 1. Configuration & Settings Schema
+
+### 1.1 Settings Content (`crates/settings_content/src/workspace.rs`)
+
+We introduce `IslandLayoutSettings` in `WorkspaceSettingsContent`:
+
+```rust
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct IslandLayoutSettings {
+    /// Whether floating island layout mode is enabled.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+
+    /// Corner radius in pixels for floating panels and cards.
+    ///
+    /// Default: 18.0
+    pub corner_radius: Option<f32>,
+
+    /// Gap / padding around floating islands in pixels.
+    ///
+    /// Default: 6.0
+    pub gap: Option<f32>,
+
+    /// Whether to render a subtle border outline around floating panels.
+    ///
+    /// Default: true
+    pub border: Option<bool>,
+
+    /// Whether to display editor tabs as rounded pills inside the pane header.
+    ///
+    /// Default: true
+    pub pill_tabs: Option<bool>,
+}
+```
+
+### 1.2 Runtime Workspace Settings (`crates/workspace/src/workspace_settings.rs`)
+
+```rust
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct IslandLayoutSettings {
+    pub enabled: bool,
+    pub corner_radius: f32,
+    pub gap: f32,
+    pub border: bool,
+    pub pill_tabs: bool,
+}
+
+impl Default for IslandLayoutSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            corner_radius: 18.0,
+            gap: 6.0,
+            border: true,
+            pill_tabs: true,
+        }
+    }
+}
+```
+
+### 1.3 `settings.json` Example
+
+```jsonc
+{
+  "island_layout": {
+    "enabled": true,
+    "corner_radius": 18.0,
+    "gap": 6.0,
+    "border": true,
+    "pill_tabs": true
+  }
+}
+```
+
+---
+
+## 2. Workspace Layout & Canvas Architecture
+
+### 2.1 Workspace Canvas Backdrop (`crates/workspace/src/workspace.rs`)
+
+* In `Workspace::render`, the root `#workspace` container acts as the canvas.
+* When `island_layout.enabled` is `true`:
+  * Root workspace surface background is tinted with `cx.theme().colors().window_background` (or theme canvas background) to provide visual depth behind floating cards.
+  * A layout margin (`gap` px) is added around the entire perimeter of the workspace region.
+  * Flex children (`left_dock`, `center` editor group, `right_dock`, `bottom_dock`, `status_bar`) receive uniform gap spacing (`gap` px) instead of touching each other.
+
+### 2.2 Dock Transformation (`crates/workspace/src/dock.rs`)
+
+* In `Dock::render`:
+  * When island layout is active, each visible dock panel (`#dock-panel`) is rendered as a floating card:
+    * `.rounded(px(corner_radius))`
+    * `.overflow_hidden()`
+    * `.when(border, |this| this.border_1().border_color(cx.theme().colors().border_variant.or(cx.theme().colors().border)))`
+    * `.shadow_sm()`
+  * Dock resize handles (`#resize-handle`) remain interactive within the gap region between the dock and center panes.
+
+---
+
+## 3. Floating Editor Panes & Split Views
+
+### 3.1 Pane Cards (`crates/workspace/src/pane_group.rs` & `crates/workspace/src/pane.rs`)
+
+* In `Pane::render`:
+  * Main pane container applies `.rounded(px(corner_radius))` and `.overflow_hidden()`.
+  * Text buffers, line numbers gutter, and minimap clip cleanly inside the card without overflowing the rounded corners.
+  * In split pane layouts (horizontal and vertical splits), each split pane rendered in `Member::render` receives `gap` padding and individual card rounding.
+  * Active pane borders/highlights follow the rounded corner geometry.
+
+### 3.2 Pill Tabs (`crates/ui/src/components/tab.rs` & `tab_bar.rs`)
+
+* When `pill_tabs` is enabled:
+  * Tab bar container has internal padding (`py_1 px_1.5`) and transparent background.
+  * Inactive tabs render with `.rounded_md()` (8px), muted typography, and smooth hover backgrounds.
+  * Active tab renders with `.rounded_md()` (8px), matching the editor card surface background and active text color with subtle border/shadow.
+  * Close icon buttons and tab action slots feature circular hover states.
+
+---
+
+## 4. Status Bar & Interactive Visuals
+
+### 4.1 Floating Status Bar (`crates/workspace/src/workspace.rs` & status bar integration)
+
+* When island layout is active:
+  * Status bar renders as a floating pill container at the bottom with `.rounded(px(corner_radius * 0.75))` (or pill), `.mx_2 mb_2`, `.border_1()`, and `.shadow_sm()`.
+  * Status entries (branch name, cursor line/col, diagnostics, language indicator) remain fully functional with balanced padding.
+
+### 4.2 Drag-and-Drop Feedback (`crates/workspace/src/pane.rs`)
+
+* Tab and split drag-and-drop target overlays (`DraggedTab`, `DraggedSelection`, `ExternalPaths`) inherit the parent pane's `.rounded(px(corner_radius))`.
+
+---
+
+## 5. Non-Goals & Out of Scope
+
+* Native OS window frame alterations (handled separately by native OS DWM / Mica / titlebar settings).
+* Modifying third-party extension renderers directly (extensions render standard GPUI views which automatically inherit theme colors).
+
+---
+
+## 6. Verification & Testing Plan
+
+1. **Compilation & Unit Tests:**
+   * Validate `settings_content` serialization and deserialization tests.
+   * Run workspace and ui tests (`cargo test -p workspace -p ui -p settings`).
+2. **Visual & Interactive Verification:**
+   * Launch Zed (`cargo run`) with default settings (confirm vanilla appearance is 100% unaffected).
+   * Enable `"island_layout": { "enabled": true }` in `settings.json` and verify live-reload.
+   * Test split panes (horizontal & vertical splits) to ensure gaps and corner clipping are uniform.
+   * Test left/right/bottom docks opening, collapsing, and resizing.
+   * Test tab dragging, dropping, opening, closing, and switching.
+   * Test zooming in/out of panes (`cmd+shift+enter` / `ctrl+shift+enter`).

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1344,6 +1344,19 @@
   "autosave": "off",
   // Maximum number of tabs per pane. Unset for unlimited.
   "max_tabs": null,
+  // Settings related to the floating island layout and rounded corners.
+  "island_layout": {
+    // Whether or not to enable the floating island card layout.
+    "enabled": false,
+    // The corner radius in pixels for floating cards and dock panels.
+    "corner_radius": 18.0,
+    // The gap spacing in pixels between floating cards, panes, and window borders.
+    "gap": 8.0,
+    // Whether or not to show subtle border outlines on floating cards.
+    "border": true,
+    // Whether or not to render editor tabs as floating rounded pill chips.
+    "pill_tabs": true
+  },
   // Settings related to the editor's tab bar.
   "tab_bar": {
     // Whether or not to show the tab bar in the editor

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6440,11 +6440,26 @@ impl Render for AgentPanel {
         // - Font size works as expected and can be changed with cmd-+/cmd-
         // - Scrolling in all views works as expected
         // - Files can be dropped into the panel
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+            px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+        } else {
+            px(0.)
+        };
+
         let content = v_flex()
             .key_context(self.key_context())
             .relative()
             .size_full()
             .justify_between()
+            .overflow_hidden()
+            .when(corner_radius > px(0.), |this| this.rounded(corner_radius))
             .track_focus(&self.focus_handle)
             .bg(cx.theme().colors().panel_background)
             .on_action(cx.listener(|this, action: &NewThread, window, cx| {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4353,9 +4353,24 @@ impl ThreadView {
         let has_messages = self.list_state.item_count() > 0;
         let fills_container = !has_messages || editor_expanded;
 
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+            px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+        } else {
+            px(0.)
+        };
+
         h_flex()
             .py_2()
             .bg(editor_bg_color)
+            .overflow_hidden()
+            .when(corner_radius > px(0.), |this| this.rounded_b(corner_radius))
             .justify_center()
             .on_action(cx.listener(Self::handle_message_editor_move_up))
             .map(|this| {

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1870,8 +1870,7 @@ impl Render for DebugPanel {
                                             .size_full()
                                             .child(breakpoint_list)
                                             .child(Divider::vertical().h_full())
-                                            .child(welcome_experience)
-                                            .child(Divider::vertical().h_full()),
+                                            .child(welcome_experience),
                                     )
                                 } else {
                                     this.child(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4903,11 +4903,43 @@ impl EditorElement {
         window.paint_layer(layout.hitbox.bounds, |window| {
             let scroll_top = layout.position_map.scroll_position.y;
             let gutter_bg = cx.theme().colors().editor_gutter_background;
-            window.paint_quad(fill(layout.gutter_hitbox.bounds, gutter_bg));
-            window.paint_quad(fill(
-                layout.position_map.text_hitbox.bounds,
-                self.style.background,
-            ));
+            let island_layout = cx.try_global::<settings::SettingsStore>().and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+            let (corner_radii, gutter_corner_radii) =
+                if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+                    let radius = px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0));
+                    let has_gutter = !layout.gutter_hitbox.bounds.is_empty();
+                    (
+                        Corners {
+                            top_left: px(0.),
+                            top_right: px(0.),
+                            bottom_right: radius,
+                            bottom_left: if has_gutter { px(0.) } else { radius },
+                        },
+                        Corners {
+                            top_left: px(0.),
+                            top_right: px(0.),
+                            bottom_right: px(0.),
+                            bottom_left: radius,
+                        },
+                    )
+                } else {
+                    (Corners::default(), Corners::default())
+                };
+
+            window.paint_quad(
+                fill(layout.gutter_hitbox.bounds, gutter_bg).corner_radii(gutter_corner_radii),
+            );
+            window.paint_quad(
+                fill(
+                    layout.position_map.text_hitbox.bounds,
+                    self.style.background,
+                )
+                .corner_radii(corner_radii),
+            );
 
             if matches!(
                 layout.mode,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5813,6 +5813,19 @@ impl EditorElement {
         for (scrollbar_layout, axis) in scrollbars_layout.iter_scrollbars() {
             let hitbox = &scrollbar_layout.hitbox;
             if scrollbars_layout.visible {
+                let island_layout = cx
+                    .try_global::<settings::SettingsStore>()
+                    .and_then(|s| {
+                        s.raw_user_settings()
+                            .and_then(|u| u.content.workspace.island_layout.as_ref())
+                            .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+                    });
+                let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+                    px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+                } else {
+                    px(0.)
+                };
+
                 let scrollbar_edges = match axis {
                     ScrollbarAxis::Horizontal => Edges {
                         top: Pixels::ZERO,
@@ -5824,14 +5837,35 @@ impl EditorElement {
                         top: Pixels::ZERO,
                         right: Pixels::ZERO,
                         bottom: Pixels::ZERO,
-                        left: ScrollbarLayout::BORDER_WIDTH,
+                        left: if corner_radius > px(0.) {
+                            Pixels::ZERO
+                        } else {
+                            ScrollbarLayout::BORDER_WIDTH
+                        },
                     },
                 };
 
-                window.paint_layer(hitbox.bounds, |window| {
+                let mut hitbox_bounds = hitbox.bounds;
+                if corner_radius > px(0.) && axis == ScrollbarAxis::Vertical {
+                    hitbox_bounds.size.width -= px(2.);
+                    hitbox_bounds.size.height -= px(8.);
+                }
+
+                let track_corners = if corner_radius > px(0.) && axis == ScrollbarAxis::Vertical {
+                    Corners {
+                        top_left: px(0.),
+                        top_right: px(0.),
+                        bottom_right: px(4.),
+                        bottom_left: px(4.),
+                    }
+                } else {
+                    Corners::default()
+                };
+
+                window.paint_layer(hitbox_bounds, |window| {
                     window.paint_quad(quad(
-                        hitbox.bounds,
-                        Corners::default(),
+                        hitbox_bounds,
+                        track_corners,
                         cx.theme().colors().scrollbar_track_background,
                         scrollbar_edges,
                         cx.theme().colors().scrollbar_track_border,
@@ -5853,7 +5887,7 @@ impl EditorElement {
                         }
                     }
 
-                    if let Some(thumb_bounds) = scrollbar_layout.thumb_bounds {
+                    if let Some(mut thumb_bounds) = scrollbar_layout.thumb_bounds {
                         let scrollbar_thumb_color = match scrollbar_layout.thumb_state {
                             ScrollbarThumbState::Dragging => {
                                 cx.theme().colors().scrollbar_thumb_active_background
@@ -5865,9 +5899,21 @@ impl EditorElement {
                                 cx.theme().colors().scrollbar_thumb_background
                             }
                         };
+                        if corner_radius > px(0.) && axis == ScrollbarAxis::Vertical {
+                            thumb_bounds.size.width -= px(2.);
+                            if thumb_bounds.bottom() > hitbox_bounds.bottom() {
+                                thumb_bounds.origin.y =
+                                    hitbox_bounds.bottom() - thumb_bounds.size.height;
+                            }
+                        }
+                        let thumb_corners = if corner_radius > px(0.) {
+                            Corners::all(px(3.))
+                        } else {
+                            Corners::default()
+                        };
                         window.paint_quad(quad(
                             thumb_bounds,
-                            Corners::default(),
+                            thumb_corners,
                             scrollbar_thumb_color,
                             scrollbar_edges,
                             cx.theme().colors().scrollbar_thumb_border,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6160,11 +6160,26 @@ impl GitPanel {
         let workspace = self.workspace.clone();
         let this = cx.entity();
 
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+            px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+        } else {
+            px(0.)
+        };
+
         Some(
             h_flex()
                 .p_1p5()
                 .gap_1p5()
                 .justify_between()
+                .overflow_hidden()
+                .when(corner_radius > px(0.), |this| this.rounded_b(corner_radius))
                 .border_t_1()
                 .border_color(cx.theme().colors().border.opacity(0.8))
                 .child(
@@ -6257,14 +6272,33 @@ impl GitPanel {
     fn render_tab_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let active_tab = self.active_tab;
 
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+            px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+        } else {
+            px(0.)
+        };
+
+        let element_hover = cx.theme().colors().element_hover;
+        let editor_bg = cx.theme().colors().editor_background;
+        let border_color = cx.theme().colors().border;
+        let tab_height = Tab::container_height(cx);
+
         let focus_handle = self.focus_handle.clone();
-        let tab = |id: ElementId,
+        let tab = move |id: ElementId,
                    active: bool,
                    show_changes: bool,
                    label: SharedString,
                    set_active_tab: GitPanelTab,
                    tooltip_action: Box<dyn Action>| {
             let focus_handle = focus_handle.clone();
+            let is_changes = set_active_tab == GitPanelTab::Changes;
 
             h_flex()
                 .cursor_pointer()
@@ -6274,11 +6308,19 @@ impl GitPanel {
                 .gap_1()
                 .flex_1()
                 .justify_center()
-                .hover(|s| s.bg(cx.theme().colors().element_hover))
+                .overflow_hidden()
+                .when(corner_radius > px(0.), |this| {
+                    if is_changes {
+                        this.rounded_tl(corner_radius)
+                    } else {
+                        this.rounded_tr(corner_radius)
+                    }
+                })
+                .hover(|s| s.bg(element_hover))
                 .border_b_1()
                 .when(!active, |s| {
-                    s.bg(cx.theme().colors().editor_background.opacity(0.6))
-                        .border_color(cx.theme().colors().border.opacity(0.6))
+                    s.bg(editor_bg.opacity(0.6))
+                        .border_color(border_color.opacity(0.6))
                 })
                 .child(Label::new(label.clone()).when(!active, |this| this.color(Color::Muted)))
                 .when(show_changes && self.changes_count > 0, |this| {
@@ -6300,8 +6342,10 @@ impl GitPanel {
 
         h_flex()
             .relative()
-            .h(Tab::container_height(cx))
+            .h(tab_height)
             .w_full()
+            .overflow_hidden()
+            .when(corner_radius > px(0.), |this| this.rounded_t(corner_radius))
             .child(tab(
                 ElementId::Name("changes-tab".into()),
                 active_tab == GitPanelTab::Changes,
@@ -8248,6 +8292,19 @@ impl Render for GitPanel {
         let has_entries = !self.entries.is_empty();
         let has_write_access = self.has_write_access(cx);
 
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+            px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+        } else {
+            px(0.)
+        };
+
         #[cfg(feature = "call")]
         let has_co_authors = self
             .workspace
@@ -8326,6 +8383,7 @@ impl Render for GitPanel {
             .on_action(cx.listener(Self::activate_history_tab))
             .size_full()
             .overflow_hidden()
+            .when(corner_radius > px(0.), |this| this.rounded(corner_radius))
             .bg(cx.theme().colors().panel_background)
             .child(
                 v_flex()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5784,17 +5784,35 @@ impl ProjectPanel {
             (entry_id.to_proto() as usize).into()
         };
 
+        let island_layout = cx
+            .try_global::<settings::SettingsStore>()
+            .and_then(|s| {
+                s.raw_user_settings()
+                    .and_then(|u| u.content.workspace.island_layout.as_ref())
+                    .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+            });
+        let is_island = island_layout.is_some_and(|l| l.enabled.unwrap_or(false));
+
         div()
             .id(id.clone())
             .relative()
             .group(GROUP_NAME)
             .cursor_pointer()
-            .rounded_none()
+            .when(is_island, |this| this.rounded_md().overflow_hidden())
+            .when(!is_island, |this| {
+                this.rounded_none()
+                    .border_1()
+                    .border_r_2()
+                    .border_color(border_color)
+            })
             .bg(bg_color)
-            .border_1()
-            .border_r_2()
-            .border_color(border_color)
-            .hover(|style| style.bg(bg_hover_color).border_color(border_hover_color))
+            .hover(|mut style| {
+                style = style.bg(bg_hover_color);
+                if !is_island {
+                    style = style.border_color(border_hover_color);
+                }
+                style
+            })
             .when(is_sticky, |this| this.block_mouse_except_scroll())
             .when(!is_sticky, |this| {
                 this.when(
@@ -7037,9 +7055,24 @@ impl Render for ProjectPanel {
                     }
                 }));
             }
+            let island_layout = cx
+                .try_global::<settings::SettingsStore>()
+                .and_then(|s| {
+                    s.raw_user_settings()
+                        .and_then(|u| u.content.workspace.island_layout.as_ref())
+                        .or_else(|| s.raw_default_settings().workspace.island_layout.as_ref())
+                });
+            let corner_radius = if island_layout.is_some_and(|l| l.enabled.unwrap_or(false)) {
+                px(island_layout.and_then(|l| l.corner_radius).unwrap_or(18.0))
+            } else {
+                px(0.)
+            };
+
             h_flex()
                 .id("project-panel")
                 .group("project-panel")
+                .overflow_hidden()
+                .when(corner_radius > px(0.), |this| this.rounded(corner_radius))
                 .when(panel_settings.drag_and_drop, |this| {
                     this.on_drag_move(cx.listener(handle_drag_move::<ExternalPaths>))
                         .on_drag_move(cx.listener(handle_drag_move::<DraggedSelection>))
@@ -7125,6 +7158,11 @@ impl Render for ProjectPanel {
                 .track_focus(&self.focus_handle(cx))
                 .child(
                     v_flex()
+                        .size_full()
+                        .overflow_hidden()
+                        .when(corner_radius > px(0.), |this| {
+                            this.rounded(corner_radius).p(px(8.))
+                        })
                         .child(
                             uniform_list("entries", item_count, {
                                 cx.processor(|this, range: Range<usize>, window, cx| {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1073,6 +1073,7 @@ impl VsCodeSettings {
             }),
             zoomed_padding: None,
             focus_follows_mouse: None,
+            island_layout: None,
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -140,6 +140,8 @@ pub struct WorkspaceSettingsContent {
     /// Whether the focused panel follows the mouse location
     /// Default: false
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
+    /// Floating island layout settings.
+    pub island_layout: Option<IslandLayoutSettings>,
 }
 
 #[with_fallible_options]
@@ -1064,3 +1066,74 @@ pub struct FocusFollowsMouse {
     pub enabled: Option<bool>,
     pub debounce_ms: Option<u64>,
 }
+
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct IslandLayoutSettings {
+    /// Whether floating island layout mode is enabled.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+
+    /// Corner radius in pixels for floating panels and cards.
+    ///
+    /// Default: 18.0
+    pub corner_radius: Option<f32>,
+
+    /// Gap / padding around floating islands in pixels.
+    ///
+    /// Default: 6.0
+    pub gap: Option<f32>,
+
+    /// Whether to render a subtle border outline around floating panels.
+    ///
+    /// Default: true
+    pub border: Option<bool>,
+
+    /// Whether to display editor tabs as rounded pills inside the pane header.
+    ///
+    /// Default: true
+    pub pill_tabs: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_island_layout_settings_deserialization() {
+        let json = r#"{
+            "enabled": true,
+            "corner_radius": 12.0,
+            "gap": 8.0,
+            "border": false,
+            "pill_tabs": true
+        }"#;
+
+        let settings: IslandLayoutSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.enabled, Some(true));
+        assert_eq!(settings.corner_radius, Some(12.0));
+        assert_eq!(settings.gap, Some(8.0));
+        assert_eq!(settings.border, Some(false));
+        assert_eq!(settings.pill_tabs, Some(true));
+    }
+
+    #[test]
+    fn test_workspace_settings_content_island_layout() {
+        let json = r#"{
+            "island_layout": {
+                "enabled": true,
+                "corner_radius": 16.0
+            }
+        }"#;
+
+        let content: WorkspaceSettingsContent = serde_json::from_str(json).unwrap();
+        let island = content.island_layout.unwrap();
+        assert_eq!(island.enabled, Some(true));
+        assert_eq!(island.corner_radius, Some(16.0));
+        assert_eq!(island.gap, None);
+        assert_eq!(island.border, None);
+        assert_eq!(island.pill_tabs, None);
+    }
+}
+

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -1136,4 +1136,3 @@ mod tests {
         assert_eq!(island.pill_tabs, None);
     }
 }
-

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5037,9 +5037,141 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
+    fn island_layout_section() -> [SettingsPageItem; 6] {
+        [
+            SettingsPageItem::SectionHeader("Island Layout"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Enable Island Layout",
+                description: "Render panels, editor panes, and status bar as floating cards with rounded corners.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("island_layout.enabled"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .as_ref()?
+                            .enabled
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .get_or_insert_default()
+                            .enabled = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Corner Radius",
+                description: "The corner radius in pixels for floating cards and panels.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("island_layout.corner_radius"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .as_ref()?
+                            .corner_radius
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .get_or_insert_default()
+                            .corner_radius = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Layout Gap",
+                description: "The gap spacing in pixels between floating cards and window borders.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("island_layout.gap"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .as_ref()?
+                            .gap
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .get_or_insert_default()
+                            .gap = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Card Borders",
+                description: "Show subtle border outlines around floating cards.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("island_layout.border"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .as_ref()?
+                            .border
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .get_or_insert_default()
+                            .border = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Pill Tabs",
+                description: "Render tabs as floating rounded pill chips.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("island_layout.pill_tabs"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .as_ref()?
+                            .pill_tabs
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .island_layout
+                            .get_or_insert_default()
+                            .pill_tabs = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     SettingsPage {
         title: "Window & Layout",
         items: concat_sections![
+            island_layout_section(),
             status_bar_section(),
             title_bar_section(),
             tab_bar_section(),

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1613,8 +1613,19 @@ impl Element for TerminalElement {
         let paint_start = Instant::now();
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             let scroll_top = self.terminal_view.read(cx).scroll_top;
-
-            window.paint_quad(fill(bounds, layout.background_color));
+            let island_layout = workspace::WorkspaceSettings::get_global(cx).island_layout;
+            let corner_radii = if island_layout.enabled {
+                let radius = px(island_layout.corner_radius);
+                gpui::Corners {
+                    top_left: px(0.),
+                    top_right: px(0.),
+                    bottom_right: radius,
+                    bottom_left: radius,
+                }
+            } else {
+                gpui::Corners::default()
+            };
+            window.paint_quad(fill(bounds, layout.background_color).corner_radii(corner_radii));
             let origin = layout.dimensions.bounds.origin - GpuiPoint::new(px(0.), scroll_top);
             let scale_factor = window.scale_factor();
             let snap_px = |value: Pixels| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1340,10 +1340,19 @@ impl Render for TerminalView {
 
         let focused = self.focus_handle.is_focused(window);
 
+        let island_layout = workspace::WorkspaceSettings::get_global(cx).island_layout;
+        let corner_radius = if island_layout.enabled {
+            px(island_layout.corner_radius)
+        } else {
+            px(0.)
+        };
+
         div()
             .id("terminal-view")
             .size_full()
             .relative()
+            .overflow_hidden()
+            .when(corner_radius > px(0.), |this| this.rounded(corner_radius))
             .track_focus(&self.focus_handle(cx))
             .key_context(self.dispatch_context(cx))
             .on_action(cx.listener(TerminalView::send_text))
@@ -1394,7 +1403,8 @@ impl Render for TerminalView {
                 div()
                     .id("terminal-view-container")
                     .size_full()
-                    .bg(cx.theme().colors().editor_background)
+                    .overflow_hidden()
+                    .when(corner_radius > px(0.), |this| this.rounded(corner_radius))
                     .child(TerminalElement::new(
                         terminal_handle,
                         terminal_view_handle,
@@ -1406,14 +1416,9 @@ impl Render for TerminalView {
                         self.mode.clone(),
                     ))
                     .when(self.content_mode(window, cx).is_scrollable(), |div| {
-                        let colors = cx.theme().colors();
                         div.custom_scrollbars(
                             Scrollbars::for_settings::<TerminalScrollbarSettingsWrapper>()
                                 .show_along(ScrollAxes::Vertical)
-                                .with_stable_track_along(
-                                    ScrollAxes::Vertical,
-                                    colors.editor_background,
-                                )
                                 .tracked_scroll_handle(&self.scroll_handle),
                             window,
                             cx,

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -35,6 +35,7 @@ pub struct Tab {
     selected: bool,
     position: TabPosition,
     close_side: TabCloseSide,
+    pill_style: bool,
     start_slot: Option<AnyElement>,
     end_slot: Option<AnyElement>,
     children: SmallVec<[AnyElement; 2]>,
@@ -50,6 +51,7 @@ impl Tab {
             selected: false,
             position: TabPosition::First,
             close_side: TabCloseSide::End,
+            pill_style: false,
             start_slot: None,
             end_slot: None,
             children: SmallVec::new(),
@@ -63,6 +65,11 @@ impl Tab {
 
     pub fn close_side(mut self, close_side: TabCloseSide) -> Self {
         self.close_side = close_side;
+        self
+    }
+
+    pub fn pill_style(mut self, pill_style: bool) -> Self {
+        self.pill_style = pill_style;
         self
     }
 
@@ -109,7 +116,7 @@ impl ParentElement for Tab {
 impl RenderOnce for Tab {
     #[allow(refining_impl_trait)]
     fn render(self, _: &mut Window, cx: &mut App) -> Stateful<Div> {
-        let (text_color, tab_bg, _tab_hover_bg, _tab_active_bg) = match self.selected {
+        let (text_color, tab_bg, tab_hover_bg, _tab_active_bg) = match self.selected {
             false => (
                 cx.theme().colors().text_muted,
                 cx.theme().colors().tab_inactive_background,
@@ -141,42 +148,62 @@ impl RenderOnce for Tab {
             }
         };
 
-        self.div
-            .h(Tab::container_height(cx))
-            .bg(tab_bg)
-            .border_color(cx.theme().colors().border)
-            .map(|this| match self.position {
-                TabPosition::First => {
-                    if self.selected {
-                        this.pl_px().border_r_1().pb_px()
-                    } else {
-                        this.pl_px().pr_px().border_b_1()
+        let tab_content = h_flex()
+            .group("")
+            .relative()
+            .h(Tab::content_height(cx))
+            .px(DynamicSpacing::Base04.px(cx))
+            .gap(DynamicSpacing::Base04.rems(cx))
+            .text_color(text_color)
+            .child(start_slot)
+            .children(self.children)
+            .child(end_slot);
+
+        if self.pill_style {
+            self.div
+                .rounded_md()
+                .mx_0p5()
+                .my_1()
+                .px_2()
+                .h(Tab::container_height(cx) - px(6.))
+                .when(self.selected, |this| {
+                    this.bg(tab_bg)
+                        .border_1()
+                        .border_color(cx.theme().colors().border_variant)
+                })
+                .when(!self.selected, |this| {
+                    this.bg(gpui::transparent_black())
+                        .hover(|s| s.bg(tab_hover_bg))
+                })
+                .cursor_pointer()
+                .child(tab_content)
+        } else {
+            self.div
+                .h(Tab::container_height(cx))
+                .bg(tab_bg)
+                .border_color(cx.theme().colors().border)
+                .map(|this| match self.position {
+                    TabPosition::First => {
+                        if self.selected {
+                            this.pl_px().border_r_1().pb_px()
+                        } else {
+                            this.pl_px().pr_px().border_b_1()
+                        }
                     }
-                }
-                TabPosition::Last => {
-                    if self.selected {
-                        this.border_l_1().border_r_1().pb_px()
-                    } else {
-                        this.pl_px().border_b_1().border_r_1()
+                    TabPosition::Last => {
+                        if self.selected {
+                            this.border_l_1().border_r_1().pb_px()
+                        } else {
+                            this.pl_px().border_b_1().border_r_1()
+                        }
                     }
-                }
-                TabPosition::Middle(Ordering::Equal) => this.border_l_1().border_r_1().pb_px(),
-                TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
-                TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
-            })
-            .cursor_pointer()
-            .child(
-                h_flex()
-                    .group("")
-                    .relative()
-                    .h(Tab::content_height(cx))
-                    .px(DynamicSpacing::Base04.px(cx))
-                    .gap(DynamicSpacing::Base04.rems(cx))
-                    .text_color(text_color)
-                    .child(start_slot)
-                    .children(self.children)
-                    .child(end_slot),
-            )
+                    TabPosition::Middle(Ordering::Equal) => this.border_l_1().border_r_1().pb_px(),
+                    TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
+                    TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
+                })
+                .cursor_pointer()
+                .child(tab_content)
+        }
     }
 }
 
@@ -193,43 +220,111 @@ impl Component for Tab {
     fn preview(_window: &mut Window, _cx: &mut App) -> AnyElement {
         v_flex()
             .gap_6()
-            .children(vec![example_group_with_title(
-                "Variations",
-                vec![
-                    single_example(
-                        "Default",
-                        Tab::new("default").child("Default Tab").into_any_element(),
-                    ),
-                    single_example(
-                        "Selected",
-                        Tab::new("selected")
-                            .toggle_state(true)
-                            .child("Selected Tab")
-                            .into_any_element(),
-                    ),
-                    single_example(
-                        "First",
-                        Tab::new("first")
-                            .position(TabPosition::First)
-                            .child("First Tab")
-                            .into_any_element(),
-                    ),
-                    single_example(
-                        "Middle",
-                        Tab::new("middle")
-                            .position(TabPosition::Middle(Ordering::Equal))
-                            .child("Middle Tab")
-                            .into_any_element(),
-                    ),
-                    single_example(
-                        "Last",
-                        Tab::new("last")
-                            .position(TabPosition::Last)
-                            .child("Last Tab")
-                            .into_any_element(),
-                    ),
-                ],
-            )])
+            .children(vec![
+                example_group_with_title(
+                    "Variations",
+                    vec![
+                        single_example(
+                            "Default",
+                            Tab::new("default").child("Default Tab").into_any_element(),
+                        ),
+                        single_example(
+                            "Selected",
+                            Tab::new("selected")
+                                .toggle_state(true)
+                                .child("Selected Tab")
+                                .into_any_element(),
+                        ),
+                        single_example(
+                            "First",
+                            Tab::new("first")
+                                .position(TabPosition::First)
+                                .child("First Tab")
+                                .into_any_element(),
+                        ),
+                        single_example(
+                            "Middle",
+                            Tab::new("middle")
+                                .position(TabPosition::Middle(Ordering::Equal))
+                                .child("Middle Tab")
+                                .into_any_element(),
+                        ),
+                        single_example(
+                            "Last",
+                            Tab::new("last")
+                                .position(TabPosition::Last)
+                                .child("Last Tab")
+                                .into_any_element(),
+                        ),
+                    ],
+                ),
+                example_group_with_title(
+                    "Pill Style Variations",
+                    vec![
+                        single_example(
+                            "Pill Selected",
+                            Tab::new("pill_selected")
+                                .pill_style(true)
+                                .toggle_state(true)
+                                .child("Active Pill Tab")
+                                .into_any_element(),
+                        ),
+                        single_example(
+                            "Pill Inactive",
+                            Tab::new("pill_inactive")
+                                .pill_style(true)
+                                .toggle_state(false)
+                                .child("Inactive Pill Tab")
+                                .into_any_element(),
+                        ),
+                    ],
+                ),
+            ])
             .into_any_element()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Context, Render, TestAppContext};
+
+    struct TestTabs;
+
+    impl Render for TestTabs {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .child(
+                    Tab::new("tab1")
+                        .pill_style(true)
+                        .toggle_state(true)
+                        .child("Active Pill Tab"),
+                )
+                .child(
+                    Tab::new("tab2")
+                        .pill_style(true)
+                        .toggle_state(false)
+                        .child("Inactive Pill Tab"),
+                )
+                .child(
+                    Tab::new("tab3")
+                        .pill_style(false)
+                        .child("Default Tab"),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn test_tab_pill_style(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+        });
+
+        let (_view, cx) = cx.add_window_view(|_, _| TestTabs);
+
+        cx.run_until_parked();
+    }
+}
+

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -199,7 +199,9 @@ impl RenderOnce for Tab {
                     }
                     TabPosition::Middle(Ordering::Equal) => this.border_l_1().border_r_1().pb_px(),
                     TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
-                    TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
+                    TabPosition::Middle(Ordering::Greater) => {
+                        this.border_r_1().pl_px().border_b_1()
+                    }
                 })
                 .cursor_pointer()
                 .child(tab_content)
@@ -306,11 +308,7 @@ mod tests {
                         .toggle_state(false)
                         .child("Inactive Pill Tab"),
                 )
-                .child(
-                    Tab::new("tab3")
-                        .pill_style(false)
-                        .child("Default Tab"),
-                )
+                .child(Tab::new("tab3").pill_style(false).child("Default Tab"))
         }
     }
 
@@ -327,4 +325,3 @@ mod tests {
         cx.run_until_parked();
     }
 }
-

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -36,6 +36,7 @@ pub struct Tab {
     position: TabPosition,
     close_side: TabCloseSide,
     pill_style: bool,
+    corner_radius: Option<Pixels>,
     start_slot: Option<AnyElement>,
     end_slot: Option<AnyElement>,
     children: SmallVec<[AnyElement; 2]>,
@@ -52,10 +53,16 @@ impl Tab {
             position: TabPosition::First,
             close_side: TabCloseSide::End,
             pill_style: false,
+            corner_radius: None,
             start_slot: None,
             end_slot: None,
             children: SmallVec::new(),
         }
+    }
+
+    pub fn corner_radius(mut self, corner_radius: Pixels) -> Self {
+        self.corner_radius = Some(corner_radius);
+        self
     }
 
     pub fn position(mut self, position: TabPosition) -> Self {
@@ -148,24 +155,26 @@ impl RenderOnce for Tab {
             }
         };
 
-        let tab_content = h_flex()
-            .group("")
-            .relative()
-            .h(Tab::content_height(cx))
-            .px(DynamicSpacing::Base04.px(cx))
-            .gap(DynamicSpacing::Base04.rems(cx))
-            .text_color(text_color)
-            .child(start_slot)
-            .children(self.children)
-            .child(end_slot);
-
         if self.pill_style {
+            let tab_content = h_flex()
+                .group("")
+                .relative()
+                .h_full()
+                .items_center()
+                .px(DynamicSpacing::Base04.px(cx))
+                .gap(DynamicSpacing::Base04.rems(cx))
+                .text_color(text_color)
+                .child(start_slot)
+                .children(self.children)
+                .child(end_slot);
+
             self.div
                 .rounded_md()
                 .mx_0p5()
-                .my_1()
-                .px_2()
-                .h(Tab::container_height(cx) - px(6.))
+                .px_1p5()
+                .h(px(26.))
+                .flex()
+                .items_center()
                 .when(self.selected, |this| {
                     this.bg(tab_bg)
                         .border_1()
@@ -178,9 +187,25 @@ impl RenderOnce for Tab {
                 .cursor_pointer()
                 .child(tab_content)
         } else {
+            let tab_content = h_flex()
+                .group("")
+                .relative()
+                .h(Tab::content_height(cx))
+                .px(DynamicSpacing::Base04.px(cx))
+                .gap(DynamicSpacing::Base04.rems(cx))
+                .text_color(text_color)
+                .child(start_slot)
+                .children(self.children)
+                .child(end_slot);
+
             self.div
                 .h(Tab::container_height(cx))
                 .bg(tab_bg)
+                .when_some(self.corner_radius, |this, radius| match self.position {
+                    TabPosition::First => this.rounded_tl(radius),
+                    TabPosition::Last => this.rounded_tr(radius),
+                    _ => this,
+                })
                 .border_color(cx.theme().colors().border)
                 .map(|this| match self.position {
                     TabPosition::First => {

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -11,6 +11,7 @@ pub struct TabBar {
     children: SmallVec<[AnyElement; 2]>,
     end_children: SmallVec<[AnyElement; 2]>,
     scroll_handle: Option<ScrollHandle>,
+    pill_style: bool,
 }
 
 impl TabBar {
@@ -21,11 +22,17 @@ impl TabBar {
             children: SmallVec::new(),
             end_children: SmallVec::new(),
             scroll_handle: None,
+            pill_style: false,
         }
     }
 
     pub fn track_scroll(mut self, scroll_handle: &ScrollHandle) -> Self {
         self.scroll_handle = Some(scroll_handle.clone());
+        self
+    }
+
+    pub fn pill_style(mut self, pill_style: bool) -> Self {
+        self.pill_style = pill_style;
         self
     }
 
@@ -91,6 +98,7 @@ impl ParentElement for TabBar {
 
 impl RenderOnce for TabBar {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pill_style = self.pill_style;
         div()
             .id(self.id)
             .group("tab_bar")
@@ -98,16 +106,23 @@ impl RenderOnce for TabBar {
             .flex_none()
             .w_full()
             .h(Tab::container_height(cx))
-            .bg(cx.theme().colors().tab_bar_background)
+            .when(!pill_style, |this| {
+                this.bg(cx.theme().colors().tab_bar_background)
+            })
+            .when(pill_style, |this| {
+                this.bg(gpui::transparent_black()).py_0p5().px_1()
+            })
             .when(!self.start_children.is_empty(), |this| {
                 this.child(
                     h_flex()
                         .flex_none()
                         .gap(DynamicSpacing::Base04.rems(cx))
                         .px(DynamicSpacing::Base06.rems(cx))
-                        .border_b_1()
-                        .border_r_1()
-                        .border_color(cx.theme().colors().border)
+                        .when(!pill_style, |this| {
+                            this.border_b_1()
+                                .border_r_1()
+                                .border_color(cx.theme().colors().border)
+                        })
                         .children(self.start_children),
                 )
             })
@@ -117,15 +132,17 @@ impl RenderOnce for TabBar {
                     .flex_1()
                     .h_full()
                     .overflow_x_hidden()
-                    .child(
-                        div()
-                            .absolute()
-                            .top_0()
-                            .left_0()
-                            .size_full()
-                            .border_b_1()
-                            .border_color(cx.theme().colors().border),
-                    )
+                    .when(!pill_style, |this| {
+                        this.child(
+                            div()
+                                .absolute()
+                                .top_0()
+                                .left_0()
+                                .size_full()
+                                .border_b_1()
+                                .border_color(cx.theme().colors().border),
+                        )
+                    })
                     .child(
                         h_flex()
                             .id("tabs")
@@ -143,9 +160,11 @@ impl RenderOnce for TabBar {
                         .flex_none()
                         .gap(DynamicSpacing::Base04.rems(cx))
                         .px(DynamicSpacing::Base06.rems(cx))
-                        .border_color(cx.theme().colors().border)
-                        .border_b_1()
-                        .border_l_1()
+                        .when(!pill_style, |this| {
+                            this.border_color(cx.theme().colors().border)
+                                .border_b_1()
+                                .border_l_1()
+                        })
                         .children(self.end_children),
                 )
             })
@@ -200,7 +219,58 @@ impl Component for TabBar {
                             .into_any_element(),
                     )],
                 ),
+                example_group_with_title(
+                    "Pill Style TabBar",
+                    vec![single_example(
+                        "Pill Tabs",
+                        TabBar::new("pill_tab_bar")
+                            .pill_style(true)
+                            .child(Tab::new("p1").pill_style(true).toggle_state(true).child("Active Tab"))
+                            .child(Tab::new("p2").pill_style(true).toggle_state(false).child("Inactive Tab"))
+                            .into_any_element(),
+                    )],
+                ),
             ])
             .into_any_element()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Context, Render, TestAppContext};
+
+    struct TestTabBar;
+
+    impl Render for TestTabBar {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .child(
+                    TabBar::new("pill_bar")
+                        .pill_style(true)
+                        .child(Tab::new("tab1").pill_style(true).toggle_state(true).child("Active Pill"))
+                        .child(Tab::new("tab2").pill_style(true).toggle_state(false).child("Inactive Pill")),
+                )
+                .child(
+                    TabBar::new("default_bar")
+                        .pill_style(false)
+                        .child(Tab::new("tab3").toggle_state(true).child("Active Default"))
+                        .child(Tab::new("tab4").toggle_state(false).child("Inactive Default")),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn test_tab_bar_pill_style(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+        });
+
+        let (_view, cx) = cx.add_window_view(|_, _| TestTabBar);
+
+        cx.run_until_parked();
+    }
+}
+

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -225,8 +225,18 @@ impl Component for TabBar {
                         "Pill Tabs",
                         TabBar::new("pill_tab_bar")
                             .pill_style(true)
-                            .child(Tab::new("p1").pill_style(true).toggle_state(true).child("Active Tab"))
-                            .child(Tab::new("p2").pill_style(true).toggle_state(false).child("Inactive Tab"))
+                            .child(
+                                Tab::new("p1")
+                                    .pill_style(true)
+                                    .toggle_state(true)
+                                    .child("Active Tab"),
+                            )
+                            .child(
+                                Tab::new("p2")
+                                    .pill_style(true)
+                                    .toggle_state(false)
+                                    .child("Inactive Tab"),
+                            )
                             .into_any_element(),
                     )],
                 ),
@@ -248,14 +258,28 @@ mod tests {
                 .child(
                     TabBar::new("pill_bar")
                         .pill_style(true)
-                        .child(Tab::new("tab1").pill_style(true).toggle_state(true).child("Active Pill"))
-                        .child(Tab::new("tab2").pill_style(true).toggle_state(false).child("Inactive Pill")),
+                        .child(
+                            Tab::new("tab1")
+                                .pill_style(true)
+                                .toggle_state(true)
+                                .child("Active Pill"),
+                        )
+                        .child(
+                            Tab::new("tab2")
+                                .pill_style(true)
+                                .toggle_state(false)
+                                .child("Inactive Pill"),
+                        ),
                 )
                 .child(
                     TabBar::new("default_bar")
                         .pill_style(false)
                         .child(Tab::new("tab3").toggle_state(true).child("Active Default"))
-                        .child(Tab::new("tab4").toggle_state(false).child("Inactive Default")),
+                        .child(
+                            Tab::new("tab4")
+                                .toggle_state(false)
+                                .child("Inactive Default"),
+                        ),
                 )
         }
     }
@@ -273,4 +297,3 @@ mod tests {
         cx.run_until_parked();
     }
 }
-

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -12,6 +12,7 @@ pub struct TabBar {
     end_children: SmallVec<[AnyElement; 2]>,
     scroll_handle: Option<ScrollHandle>,
     pill_style: bool,
+    corner_radius: Option<Pixels>,
 }
 
 impl TabBar {
@@ -23,6 +24,7 @@ impl TabBar {
             end_children: SmallVec::new(),
             scroll_handle: None,
             pill_style: false,
+            corner_radius: None,
         }
     }
 
@@ -33,6 +35,11 @@ impl TabBar {
 
     pub fn pill_style(mut self, pill_style: bool) -> Self {
         self.pill_style = pill_style;
+        self
+    }
+
+    pub fn corner_radius(mut self, corner_radius: Pixels) -> Self {
+        self.corner_radius = Some(corner_radius);
         self
     }
 
@@ -106,11 +113,13 @@ impl RenderOnce for TabBar {
             .flex_none()
             .w_full()
             .h(Tab::container_height(cx))
+            .overflow_hidden()
+            .when_some(self.corner_radius, |this, radius| this.rounded_t(radius))
             .when(!pill_style, |this| {
                 this.bg(cx.theme().colors().tab_bar_background)
             })
             .when(pill_style, |this| {
-                this.bg(gpui::transparent_black()).py_0p5().px_1()
+                this.bg(gpui::transparent_black()).px_1().items_center()
             })
             .when(!self.start_children.is_empty(), |this| {
                 this.child(

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1227,19 +1227,27 @@ impl Dock {
                         })
                     }
                 })
-                .child(
+                .child({
+                    let cached_style = if island_layout.enabled {
+                        StyleRefinement::default()
+                            .v_flex()
+                            .size_full()
+                            .overflow_hidden()
+                            .rounded(px(island_layout.corner_radius))
+                    } else {
+                        StyleRefinement::default().v_flex().size_full()
+                    };
                     div()
                         .map(|this| match self.position().axis() {
                             Axis::Horizontal => this.w_full().h_full(),
                             Axis::Vertical => this.h_full().w_full(),
                         })
-                        .child(
-                            entry
-                                .panel
-                                .to_any()
-                                .cached(StyleRefinement::default().v_flex().size_full()),
-                        ),
-                )
+                        .overflow_hidden()
+                        .when(island_layout.enabled, |this| {
+                            this.rounded(px(island_layout.corner_radius))
+                        })
+                        .child(entry.panel.to_any().cached(cached_style))
+                })
                 .when(self.resizable(cx), |this| {
                     this.child(create_resize_handle())
                 })
@@ -1724,12 +1732,12 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
-        let _left_panel = workspace.update_in(cx, |workspace, window, cx| {
-            let panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
+        let _bottom_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 100, cx));
             workspace.add_panel(panel.clone(), window, cx);
-            workspace.left_dock().update(cx, |left_dock, cx| {
-                left_dock.activate_panel(0, window, cx);
-                left_dock.set_open(true, window, cx);
+            workspace.bottom_dock().update(cx, |bottom_dock, cx| {
+                bottom_dock.activate_panel(0, window, cx);
+                bottom_dock.set_open(true, window, cx);
             });
             panel
         });
@@ -1737,7 +1745,7 @@ mod tests {
         let (mut div, border_variant) = workspace.update_in(cx, |workspace, window, cx| {
             let border_variant = cx.theme().colors().border_variant;
             let div = workspace
-                .left_dock()
+                .bottom_dock()
                 .update(cx, |dock, cx| dock.render_panel(window, cx));
             (div, border_variant)
         });
@@ -1763,6 +1771,42 @@ mod tests {
             }
         );
         assert!(style.box_shadow.is_some());
+
+        // Left dock should be seamless (no card borders/radii)
+        let _left_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.left_dock().update(cx, |left_dock, cx| {
+                left_dock.activate_panel(0, window, cx);
+                left_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let mut left_div = workspace.update_in(cx, |workspace, window, cx| {
+            workspace
+                .left_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx))
+        });
+        let left_style = left_div.style();
+        assert_eq!(
+            left_style.border_widths,
+            EdgesRefinement {
+                top: Some(AbsoluteLength::Pixels(px(1.))),
+                right: Some(AbsoluteLength::Pixels(px(1.))),
+                bottom: Some(AbsoluteLength::Pixels(px(1.))),
+                left: Some(AbsoluteLength::Pixels(px(1.))),
+            }
+        );
+        assert_eq!(
+            left_style.corner_radii,
+            CornersRefinement {
+                top_left: Some(AbsoluteLength::Pixels(px(18.))),
+                top_right: Some(AbsoluteLength::Pixels(px(18.))),
+                bottom_right: Some(AbsoluteLength::Pixels(px(18.))),
+                bottom_left: Some(AbsoluteLength::Pixels(px(18.))),
+            }
+        );
     }
 
     #[gpui::test]

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1127,7 +1127,11 @@ impl Dock {
             .flatten()
             .and_then(|json| serde_json::from_str::<PanelSizeState>(&json).log_err())
     }
-    pub(crate) fn render_panel(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> Stateful<Div> {
+    pub(crate) fn render_panel(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Stateful<Div> {
         let dispatch_context = Self::dispatch_context();
         if let Some(entry) = self.visible_entry() {
             let position = self.position;
@@ -1214,12 +1218,13 @@ impl Dock {
                                     .border_color(cx.theme().colors().border_variant)
                             })
                     } else {
-                        this.border_color(cx.theme().colors().border)
-                            .map(|this| match self.position() {
+                        this.border_color(cx.theme().colors().border).map(|this| {
+                            match self.position() {
                                 DockPosition::Left => this.border_r_1(),
                                 DockPosition::Right => this.border_l_1(),
                                 DockPosition::Bottom => this.border_t_1(),
-                            })
+                            }
+                        })
                     }
                 })
                 .child(
@@ -1643,7 +1648,9 @@ mod tests {
     use crate::Workspace;
     use crate::dock::test::TestPanel;
     use fs::FakeFs;
-    use gpui::{AbsoluteLength, CornersRefinement, EdgesRefinement, TestAppContext, UpdateGlobal, px};
+    use gpui::{
+        AbsoluteLength, CornersRefinement, EdgesRefinement, TestAppContext, UpdateGlobal, px,
+    };
     use project::Project;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -1675,9 +1682,9 @@ mod tests {
         });
 
         let mut div = workspace.update_in(cx, |workspace, window, cx| {
-            workspace.left_dock().update(cx, |dock, cx| {
-                dock.render_panel(window, cx)
-            })
+            workspace
+                .left_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx))
         });
 
         let style = div.style();
@@ -1729,9 +1736,9 @@ mod tests {
 
         let (mut div, border_variant) = workspace.update_in(cx, |workspace, window, cx| {
             let border_variant = cx.theme().colors().border_variant;
-            let div = workspace.left_dock().update(cx, |dock, cx| {
-                dock.render_panel(window, cx)
-            });
+            let div = workspace
+                .left_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx));
             (div, border_variant)
         });
 
@@ -1792,9 +1799,9 @@ mod tests {
         });
 
         let mut div = workspace.update_in(cx, |workspace, window, cx| {
-            workspace.bottom_dock().update(cx, |dock, cx| {
-                dock.render_panel(window, cx)
-            })
+            workspace
+                .bottom_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx))
         });
 
         let style = div.style();
@@ -1840,9 +1847,9 @@ mod tests {
         });
 
         let mut right_div = workspace.update_in(cx, |workspace, window, cx| {
-            workspace.right_dock().update(cx, |dock, cx| {
-                dock.render_panel(window, cx)
-            })
+            workspace
+                .right_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx))
         });
 
         let right_style = right_div.style();
@@ -1868,9 +1875,9 @@ mod tests {
         });
 
         let mut bottom_div = workspace.update_in(cx, |workspace, window, cx| {
-            workspace.bottom_dock().update(cx, |dock, cx| {
-                dock.render_panel(window, cx)
-            })
+            workspace
+                .bottom_dock()
+                .update(cx, |dock, cx| dock.render_panel(window, cx))
         });
 
         let bottom_style = bottom_div.style();

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -8,10 +8,10 @@ use client::proto;
 use db::kvp::KeyValueStore;
 
 use gpui::{
-    Action, Anchor, AnyView, App, Axis, Context, Entity, EntityId, EventEmitter, FocusHandle,
+    Action, Anchor, AnyView, App, Axis, Context, Div, Entity, EntityId, EventEmitter, FocusHandle,
     Focusable, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement,
-    Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window, deferred, div,
-    px,
+    Render, SharedString, Stateful, StyleRefinement, Styled, Subscription, WeakEntity, Window,
+    deferred, div, px,
 };
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore, TerminalDockPosition};
@@ -1127,13 +1127,11 @@ impl Dock {
             .flatten()
             .and_then(|json| serde_json::from_str::<PanelSizeState>(&json).log_err())
     }
-}
-
-impl Render for Dock {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    pub(crate) fn render_panel(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> Stateful<Div> {
         let dispatch_context = Self::dispatch_context();
         if let Some(entry) = self.visible_entry() {
             let position = self.position;
+            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
             let create_resize_handle = || {
                 let handle = div()
                     .id("resize-handle")
@@ -1200,7 +1198,6 @@ impl Render for Dock {
                 .focus_follows_mouse(self.focus_follows_mouse, cx)
                 .flex()
                 .bg(cx.theme().colors().panel_background)
-                .border_color(cx.theme().colors().border)
                 .overflow_hidden()
                 .map(|this| match self.position().axis() {
                     // Width and height are always set on the workspace wrapper in
@@ -1208,10 +1205,22 @@ impl Render for Dock {
                     Axis::Horizontal => this.w_full().h_full().flex_row(),
                     Axis::Vertical => this.h_full().w_full().flex_col(),
                 })
-                .map(|this| match self.position() {
-                    DockPosition::Left => this.border_r_1(),
-                    DockPosition::Right => this.border_l_1(),
-                    DockPosition::Bottom => this.border_t_1(),
+                .map(|this| {
+                    if island_layout.enabled {
+                        this.rounded(px(island_layout.corner_radius))
+                            .shadow_sm()
+                            .when(island_layout.border, |this| {
+                                this.border_1()
+                                    .border_color(cx.theme().colors().border_variant)
+                            })
+                    } else {
+                        this.border_color(cx.theme().colors().border)
+                            .map(|this| match self.position() {
+                                DockPosition::Left => this.border_r_1(),
+                                DockPosition::Right => this.border_l_1(),
+                                DockPosition::Bottom => this.border_t_1(),
+                            })
+                    }
                 })
                 .child(
                     div()
@@ -1235,6 +1244,12 @@ impl Render for Dock {
                 .key_context(dispatch_context)
                 .track_focus(&self.focus_handle(cx))
         }
+    }
+}
+
+impl Render for Dock {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.render_panel(window, cx)
     }
 }
 
@@ -1619,5 +1634,254 @@ pub mod test {
         fn focus_handle(&self, _cx: &App) -> FocusHandle {
             self.focus_handle.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Workspace;
+    use crate::dock::test::TestPanel;
+    use fs::FakeFs;
+    use gpui::{AbsoluteLength, CornersRefinement, EdgesRefinement, TestAppContext, UpdateGlobal, px};
+    use project::Project;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            cx.set_global(db::AppDatabase::test_new());
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_dock_render_default_flat_styling(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _left_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.left_dock().update(cx, |left_dock, cx| {
+                left_dock.activate_panel(0, window, cx);
+                left_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let mut div = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.left_dock().update(cx, |dock, cx| {
+                dock.render_panel(window, cx)
+            })
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            EdgesRefinement {
+                top: None,
+                right: Some(AbsoluteLength::Pixels(px(1.))),
+                bottom: None,
+                left: None,
+            }
+        );
+        assert_eq!(style.corner_radii, CornersRefinement::default());
+        assert!(style.box_shadow.is_none());
+    }
+
+    #[gpui::test]
+    async fn test_dock_render_island_layout_card_styling(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(18.0),
+                        gap: Some(6.0),
+                        border: Some(true),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _left_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.left_dock().update(cx, |left_dock, cx| {
+                left_dock.activate_panel(0, window, cx);
+                left_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let (mut div, border_variant) = workspace.update_in(cx, |workspace, window, cx| {
+            let border_variant = cx.theme().colors().border_variant;
+            let div = workspace.left_dock().update(cx, |dock, cx| {
+                dock.render_panel(window, cx)
+            });
+            (div, border_variant)
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            EdgesRefinement {
+                top: Some(AbsoluteLength::Pixels(px(1.))),
+                right: Some(AbsoluteLength::Pixels(px(1.))),
+                bottom: Some(AbsoluteLength::Pixels(px(1.))),
+                left: Some(AbsoluteLength::Pixels(px(1.))),
+            }
+        );
+        assert_eq!(style.border_color, Some(border_variant));
+        assert_eq!(
+            style.corner_radii,
+            CornersRefinement {
+                top_left: Some(AbsoluteLength::Pixels(px(18.))),
+                top_right: Some(AbsoluteLength::Pixels(px(18.))),
+                bottom_right: Some(AbsoluteLength::Pixels(px(18.))),
+                bottom_left: Some(AbsoluteLength::Pixels(px(18.))),
+            }
+        );
+        assert!(style.box_shadow.is_some());
+    }
+
+    #[gpui::test]
+    async fn test_dock_render_island_layout_without_border(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(12.0),
+                        gap: Some(6.0),
+                        border: Some(false),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _bottom_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.bottom_dock().update(cx, |bottom_dock, cx| {
+                bottom_dock.activate_panel(0, window, cx);
+                bottom_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let mut div = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.bottom_dock().update(cx, |dock, cx| {
+                dock.render_panel(window, cx)
+            })
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            EdgesRefinement {
+                top: None,
+                right: None,
+                bottom: None,
+                left: None,
+            }
+        );
+        assert_eq!(
+            style.corner_radii,
+            CornersRefinement {
+                top_left: Some(AbsoluteLength::Pixels(px(12.))),
+                top_right: Some(AbsoluteLength::Pixels(px(12.))),
+                bottom_right: Some(AbsoluteLength::Pixels(px(12.))),
+                bottom_left: Some(AbsoluteLength::Pixels(px(12.))),
+            }
+        );
+        assert!(style.box_shadow.is_some());
+    }
+
+    #[gpui::test]
+    async fn test_dock_render_default_right_and_bottom(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        // Right dock
+        let _right_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.right_dock().update(cx, |right_dock, cx| {
+                right_dock.activate_panel(0, window, cx);
+                right_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let mut right_div = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.right_dock().update(cx, |dock, cx| {
+                dock.render_panel(window, cx)
+            })
+        });
+
+        let right_style = right_div.style();
+        assert_eq!(
+            right_style.border_widths,
+            EdgesRefinement {
+                top: None,
+                right: None,
+                bottom: None,
+                left: Some(AbsoluteLength::Pixels(px(1.))),
+            }
+        );
+
+        // Bottom dock
+        let _bottom_panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 101, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.bottom_dock().update(cx, |bottom_dock, cx| {
+                bottom_dock.activate_panel(0, window, cx);
+                bottom_dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        let mut bottom_div = workspace.update_in(cx, |workspace, window, cx| {
+            workspace.bottom_dock().update(cx, |dock, cx| {
+                dock.render_panel(window, cx)
+            })
+        });
+
+        let bottom_style = bottom_div.style();
+        assert_eq!(
+            bottom_style.border_widths,
+            EdgesRefinement {
+                top: Some(AbsoluteLength::Pixels(px(1.))),
+                right: None,
+                bottom: None,
+                left: None,
+            }
+        );
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2901,6 +2901,9 @@ impl Pane {
         let capability = item.capability(cx);
         let tab = Tab::new(ix)
             .pill_style(pill_style)
+            .when(island_layout.enabled && !island_layout.pill_tabs, |tab| {
+                tab.corner_radius(px(island_layout.corner_radius))
+            })
             .position(if is_first_item {
                 TabPosition::First
             } else if is_last_item {
@@ -3549,7 +3552,11 @@ impl Pane {
 
         let tab_bar = self
             .configure_tab_bar_start(
-                TabBar::new("tab_bar").pill_style(pill_style),
+                TabBar::new("tab_bar")
+                    .pill_style(pill_style)
+                    .when(island_layout.enabled, |tb| {
+                        tb.corner_radius(px(island_layout.corner_radius))
+                    }),
                 navigate_backward,
                 navigate_forward,
                 window,
@@ -3590,7 +3597,11 @@ impl Pane {
 
         let pinned_tab_bar = self
             .configure_tab_bar_start(
-                TabBar::new("pinned_tab_bar").pill_style(pill_style),
+                TabBar::new("pinned_tab_bar")
+                    .pill_style(pill_style)
+                    .when(island_layout.enabled, |tb| {
+                        tb.corner_radius(px(island_layout.corner_radius))
+                    }),
                 navigate_backward,
                 navigate_forward,
                 window,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3612,11 +3612,7 @@ impl Pane {
             .child(
                 TabBar::new("unpinned_tab_bar")
                     .pill_style(pill_style)
-                    .child(self.render_unpinned_tabs_container(
-                        unpinned_tabs,
-                        tab_count,
-                        cx,
-                    )),
+                    .child(self.render_unpinned_tabs_container(unpinned_tabs, tab_count, cx)),
             )
             .into_any_element()
     }
@@ -4352,11 +4348,7 @@ impl Focusable for Pane {
 }
 
 impl Pane {
-    pub fn render_pane(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> gpui::Div {
+    pub fn render_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> gpui::Div {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("Pane");
         if self.active_item().is_none() {
@@ -9713,4 +9705,3 @@ mod tests {
         assert!(style.box_shadow.is_some());
     }
 }
-

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2895,8 +2895,12 @@ impl Pane {
 
         let has_file_icon = icon.is_some();
 
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+        let pill_style = island_layout.enabled && island_layout.pill_tabs;
+
         let capability = item.capability(cx);
         let tab = Tab::new(ix)
+            .pill_style(pill_style)
             .position(if is_first_item {
                 TabPosition::First
             } else if is_last_item {
@@ -3540,9 +3544,12 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Pane>,
     ) -> AnyElement {
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+        let pill_style = island_layout.enabled && island_layout.pill_tabs;
+
         let tab_bar = self
             .configure_tab_bar_start(
-                TabBar::new("tab_bar"),
+                TabBar::new("tab_bar").pill_style(pill_style),
                 navigate_backward,
                 navigate_forward,
                 window,
@@ -3578,9 +3585,12 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Pane>,
     ) -> AnyElement {
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+        let pill_style = island_layout.enabled && island_layout.pill_tabs;
+
         let pinned_tab_bar = self
             .configure_tab_bar_start(
-                TabBar::new("pinned_tab_bar"),
+                TabBar::new("pinned_tab_bar").pill_style(pill_style),
                 navigate_backward,
                 navigate_forward,
                 window,
@@ -3600,11 +3610,13 @@ impl Pane {
             .flex_none()
             .child(pinned_tab_bar)
             .child(
-                TabBar::new("unpinned_tab_bar").child(self.render_unpinned_tabs_container(
-                    unpinned_tabs,
-                    tab_count,
-                    cx,
-                )),
+                TabBar::new("unpinned_tab_bar")
+                    .pill_style(pill_style)
+                    .child(self.render_unpinned_tabs_container(
+                        unpinned_tabs,
+                        tab_count,
+                        cx,
+                    )),
             )
             .into_any_element()
     }
@@ -4339,8 +4351,12 @@ impl Focusable for Pane {
     }
 }
 
-impl Render for Pane {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+impl Pane {
+    pub fn render_pane(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("Pane");
         if self.active_item().is_none() {
@@ -4362,12 +4378,23 @@ impl Render for Pane {
             project.is_local() || project.is_via_wsl(cx)
         };
 
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+
         v_flex()
             .key_context(key_context)
             .track_focus(&self.focus_handle(cx))
             .size_full()
             .flex_none()
             .overflow_hidden()
+            .when(island_layout.enabled, |this| {
+                this.rounded(px(island_layout.corner_radius))
+                    .shadow_sm()
+                    .when(island_layout.border, |this| {
+                        this.border_1()
+                            .border_color(cx.theme().colors().border_variant)
+                    })
+                    .bg(cx.theme().colors().editor_background)
+            })
             .on_action(cx.listener(|pane, split: &SplitLeft, window, cx| {
                 pane.split(SplitDirection::Left, split.mode, window, cx)
             }))
@@ -4584,6 +4611,9 @@ impl Render for Pane {
                             .invisible()
                             .absolute()
                             .bg(cx.theme().colors().drop_target_background)
+                            .when(island_layout.enabled, |this| {
+                                this.rounded(px(island_layout.corner_radius))
+                            })
                             .group_drag_over::<DraggedTab>("", |style| style.visible())
                             .group_drag_over::<DraggedSelection>("", |style| style.visible())
                             .when(accepts_external_paths, |div| {
@@ -4657,6 +4687,12 @@ impl Render for Pane {
                     }
                 }),
             )
+    }
+}
+
+impl Render for Pane {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.render_pane(window, cx)
     }
 }
 
@@ -4982,6 +5018,8 @@ pub fn render_item_indicator(item: Box<dyn ItemHandle>, cx: &App) -> Option<Indi
 
 impl Render for DraggedTab {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+        let pill_style = island_layout.enabled && island_layout.pill_tabs;
         let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
         let label = self.item.tab_content(
             TabContentParams {
@@ -5000,6 +5038,7 @@ impl Render for DraggedTab {
                 .read(cx)
                 .tab_icon_element(self.item.as_ref(), self.is_active, window, cx);
         Tab::new("")
+            .pill_style(pill_style)
             .toggle_state(self.is_active)
             .children(icon)
             .child(label)
@@ -5019,7 +5058,7 @@ mod tests {
     };
     use gpui::{
         AppContext, Axis, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-        TestAppContext, VisualTestContext, size,
+        TestAppContext, UpdateGlobal, VisualTestContext, size,
     };
     use project::FakeFs;
     use settings::SettingsStore;
@@ -9553,4 +9592,125 @@ mod tests {
             }
         }
     }
+
+    #[gpui::test]
+    async fn test_pane_render_default_flat_styling(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        let mut div = workspace.update_in(cx, |_, window, cx| {
+            pane.update(cx, |pane, cx| pane.render_pane(window, cx))
+        });
+
+        let style = div.style();
+        assert_eq!(style.corner_radii, gpui::CornersRefinement::default());
+        assert_eq!(style.border_widths, gpui::EdgesRefinement::default());
+        assert!(style.box_shadow.is_none());
+    }
+
+    #[gpui::test]
+    async fn test_pane_render_island_layout_card_styling(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(18.0),
+                        gap: Some(6.0),
+                        border: Some(true),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        let (mut div, border_variant, editor_bg) = workspace.update_in(cx, |_, window, cx| {
+            let border_variant = cx.theme().colors().border_variant;
+            let editor_bg = cx.theme().colors().editor_background;
+            let div = pane.update(cx, |pane, cx| pane.render_pane(window, cx));
+            (div, border_variant, editor_bg)
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            gpui::EdgesRefinement {
+                top: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                right: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                bottom: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                left: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+            }
+        );
+        assert_eq!(style.border_color, Some(border_variant));
+        assert_eq!(
+            style.corner_radii,
+            gpui::CornersRefinement {
+                top_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(18.))),
+                top_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(18.))),
+                bottom_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(18.))),
+                bottom_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(18.))),
+            }
+        );
+        assert_eq!(style.background, Some(gpui::Fill::Color(editor_bg.into())));
+        assert!(style.box_shadow.is_some());
+    }
+
+    #[gpui::test]
+    async fn test_pane_render_island_layout_without_border(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(12.0),
+                        gap: Some(6.0),
+                        border: Some(false),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        let mut div = workspace.update_in(cx, |_, window, cx| {
+            pane.update(cx, |pane, cx| pane.render_pane(window, cx))
+        });
+
+        let style = div.style();
+        assert_eq!(style.border_widths, gpui::EdgesRefinement::default());
+        assert_eq!(
+            style.corner_radii,
+            gpui::CornersRefinement {
+                top_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                top_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                bottom_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                bottom_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+            }
+        );
+        assert!(style.box_shadow.is_some());
+    }
 }
+

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4371,6 +4371,7 @@ impl Pane {
         };
 
         let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+        let is_island_card = island_layout.enabled && self.in_center_group;
 
         v_flex()
             .key_context(key_context)
@@ -4378,7 +4379,7 @@ impl Pane {
             .size_full()
             .flex_none()
             .overflow_hidden()
-            .when(island_layout.enabled, |this| {
+            .when(is_island_card, |this| {
                 this.rounded(px(island_layout.corner_radius))
                     .shadow_sm()
                     .when(island_layout.border, |this| {

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -609,7 +609,7 @@ impl Member {
 
     pub fn render_member_element(
         is_maximized: bool,
-        island_layout: &crate::workspace_settings::IslandLayoutSettings,
+        _island_layout: &crate::workspace_settings::IslandLayoutSettings,
         pane_el: Div,
     ) -> Div {
         div()
@@ -617,9 +617,6 @@ impl Member {
             .flex_1()
             .size_full()
             .when(is_maximized, |this| this.p_2())
-            .when(island_layout.enabled, |this| {
-                this.p(px(island_layout.gap / 2.0))
-            })
             .child(pane_el)
     }
 
@@ -1635,7 +1632,7 @@ mod element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{AbsoluteLength, DefiniteLength, EdgesRefinement, px};
+    use gpui::EdgesRefinement;
 
     #[test]
     fn test_member_render_element_default_padding() {
@@ -1646,7 +1643,7 @@ mod tests {
     }
 
     #[test]
-    fn test_member_render_element_island_gap_padding() {
+    fn test_member_render_element_island_layout() {
         let island_layout = crate::workspace_settings::IslandLayoutSettings {
             enabled: true,
             corner_radius: 18.0,
@@ -1656,14 +1653,6 @@ mod tests {
         };
         let mut el = Member::render_member_element(false, &island_layout, div());
         let style = el.style();
-        assert_eq!(
-            style.padding,
-            EdgesRefinement {
-                top: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
-                right: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
-                bottom: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
-                left: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
-            }
-        );
+        assert_eq!(style.padding, EdgesRefinement::default());
     }
 }

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -593,14 +593,11 @@ impl Member {
                     })
                     .children(decoration.status_box);
 
+                let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+                let container = Self::render_member_element(is_maximized, &island_layout, pane);
+
                 PaneRenderResult {
-                    element: div()
-                        .relative()
-                        .flex_1()
-                        .size_full()
-                        .when(is_maximized, |this| this.p_2())
-                        .child(pane)
-                        .into_any(),
+                    element: container.into_any(),
                     contains_active_pane: is_active,
                     #[cfg(any(test, feature = "test-support"))]
                     decorated_pane_ix: None,
@@ -608,6 +605,22 @@ impl Member {
             }
             Member::Axis(axis) => axis.render(basis + 1, zoomed, maximized, render_cx, window, cx),
         }
+    }
+
+    pub fn render_member_element(
+        is_maximized: bool,
+        island_layout: &crate::workspace_settings::IslandLayoutSettings,
+        pane_el: Div,
+    ) -> Div {
+        div()
+            .relative()
+            .flex_1()
+            .size_full()
+            .when(is_maximized, |this| this.p_2())
+            .when(island_layout.enabled, |this| {
+                this.p(px(island_layout.gap / 2.0))
+            })
+            .child(pane_el)
     }
 
     pub fn contains_pane(&self, needle: &Entity<Pane>) -> bool {
@@ -1543,10 +1556,12 @@ mod element {
                         window.set_cursor_style(cursor_style, &handle.hitbox);
                     }
 
-                    window.paint_quad(gpui::fill(
-                        handle.divider_bounds,
-                        cx.theme().colors().pane_group_border,
-                    ));
+                    if !WorkspaceSettings::get_global(cx).island_layout.enabled {
+                        window.paint_quad(gpui::fill(
+                            handle.divider_bounds,
+                            cx.theme().colors().pane_group_border,
+                        ));
+                    }
 
                     window.on_mouse_event({
                         let dragged_handle = layout.dragged_handle.clone();
@@ -1614,5 +1629,41 @@ mod element {
 
     fn flex_values_in_bounds(flexes: &[f32]) -> bool {
         (flexes.iter().copied().sum::<f32>() - flexes.len() as f32).abs() < 0.001
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{AbsoluteLength, DefiniteLength, EdgesRefinement, px};
+
+    #[test]
+    fn test_member_render_element_default_padding() {
+        let island_layout = crate::workspace_settings::IslandLayoutSettings::default();
+        let mut el = Member::render_member_element(false, &island_layout, div());
+        let style = el.style();
+        assert_eq!(style.padding, EdgesRefinement::default());
+    }
+
+    #[test]
+    fn test_member_render_element_island_gap_padding() {
+        let island_layout = crate::workspace_settings::IslandLayoutSettings {
+            enabled: true,
+            corner_radius: 18.0,
+            gap: 8.0,
+            border: true,
+            pill_tabs: true,
+        };
+        let mut el = Member::render_member_element(false, &island_layout, div());
+        let style = el.style();
+        assert_eq!(
+            style.padding,
+            EdgesRefinement {
+                top: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
+                right: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
+                bottom: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
+                left: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(4.0)))),
+            }
+        );
     }
 }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1704,8 +1704,6 @@ impl WorkspaceDb {
                 host = Some(format!("mock-{}", id));
                 user = Some(format!("mock-user-{}", id));
             }
-            #[cfg(not(any(test, feature = "test-support")))]
-            _ => unreachable!(),
         }
 
         if let RemoteConnectionOptions::Docker(options) = options {

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1704,6 +1704,8 @@ impl WorkspaceDb {
                 host = Some(format!("mock-{}", id));
                 user = Some(format!("mock-user-{}", id));
             }
+            #[cfg(not(any(test, feature = "test-support")))]
+            _ => unreachable!(),
         }
 
         if let RemoteConnectionOptions::Docker(options) = options {

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -153,7 +153,10 @@ impl Render for StatusBar {
             .p(DynamicSpacing::Base04.rems(cx))
             .bg(cx.theme().colors().status_bar_background)
             .map(|el| {
-                if crate::WorkspaceSettings::get_global(cx).island_layout.enabled {
+                if crate::WorkspaceSettings::get_global(cx)
+                    .island_layout
+                    .enabled
+                {
                     return el;
                 }
                 match window.window_decorations() {
@@ -176,7 +179,8 @@ impl Render for StatusBar {
                             let needs_gap_fix = {
                                 // Running on Wayland and using some scaling levels other than 100% causes a
                                 // 1px gap above the status bar; adding a margin avoids this.
-                                gpui::guess_compositor() == "Wayland" && window.scale_factor() != 1.0
+                                gpui::guess_compositor() == "Wayland"
+                                    && window.scale_factor() != 1.0
                             };
                             #[cfg(not(target_os = "linux"))]
                             let needs_gap_fix = false;

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -6,7 +6,7 @@ use gpui::{
     Anchor, AnyView, App, Context, Decorations, Entity, FocusHandle, Focusable, IntoElement,
     ParentElement, Render, Role, SharedString, Styled, Subscription, WeakEntity, Window,
 };
-use settings::{SettingsContent, update_settings_file};
+use settings::{Settings, SettingsContent, update_settings_file};
 use std::{any::TypeId, sync::Arc};
 use theme::CLIENT_SIDE_DECORATION_ROUNDING;
 use ui::{ContextMenu, Divider, IconPosition, Indicator, Tooltip, prelude::*, right_click_menu};
@@ -152,34 +152,39 @@ impl Render for StatusBar {
             .gap(DynamicSpacing::Base08.rems(cx))
             .p(DynamicSpacing::Base04.rems(cx))
             .bg(cx.theme().colors().status_bar_background)
-            .map(|el| match window.window_decorations() {
-                Decorations::Server => el,
-                Decorations::Client { tiling, .. } => el
-                    .when(
-                        !(tiling.bottom || tiling.right)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Right),
-                        |el| el.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING),
-                    )
-                    .when(
-                        !(tiling.bottom || tiling.left)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Left),
-                        |el| el.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING),
-                    )
-                    // This border is to avoid a transparent gap in the rounded corners
-                    .mb(px(-1.))
-                    .mt({
-                        #[cfg(target_os = "linux")]
-                        let needs_gap_fix = {
-                            // Running on Wayland and using some scaling levels other than 100% causes a
-                            // 1px gap above the status bar; adding a margin avoids this.
-                            gpui::guess_compositor() == "Wayland" && window.scale_factor() != 1.0
-                        };
-                        #[cfg(not(target_os = "linux"))]
-                        let needs_gap_fix = false;
-                        if needs_gap_fix { px(-1.) } else { px(0.) }
-                    })
-                    .border_b(px(1.0))
-                    .border_color(cx.theme().colors().status_bar_background),
+            .map(|el| {
+                if crate::WorkspaceSettings::get_global(cx).island_layout.enabled {
+                    return el;
+                }
+                match window.window_decorations() {
+                    Decorations::Server => el,
+                    Decorations::Client { tiling, .. } => el
+                        .when(
+                            !(tiling.bottom || tiling.right)
+                                && !(sidebar.open && sidebar.side == SidebarSide::Right),
+                            |el| el.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING),
+                        )
+                        .when(
+                            !(tiling.bottom || tiling.left)
+                                && !(sidebar.open && sidebar.side == SidebarSide::Left),
+                            |el| el.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING),
+                        )
+                        // This border is to avoid a transparent gap in the rounded corners
+                        .mb(px(-1.))
+                        .mt({
+                            #[cfg(target_os = "linux")]
+                            let needs_gap_fix = {
+                                // Running on Wayland and using some scaling levels other than 100% causes a
+                                // 1px gap above the status bar; adding a margin avoids this.
+                                gpui::guess_compositor() == "Wayland" && window.scale_factor() != 1.0
+                            };
+                            #[cfg(not(target_os = "linux"))]
+                            let needs_gap_fix = false;
+                            if needs_gap_fix { px(-1.) } else { px(0.) }
+                        })
+                        .border_b(px(1.0))
+                        .border_color(cx.theme().colors().status_bar_background),
+                }
             })
             .child(self.render_left_tools(&sidebar, cx))
             .child(self.render_right_tools(&sidebar, cx))

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -151,7 +151,14 @@ impl Render for StatusBar {
             .justify_between()
             .gap(DynamicSpacing::Base08.rems(cx))
             .p(DynamicSpacing::Base04.rems(cx))
-            .bg(cx.theme().colors().status_bar_background)
+            .map(|el| {
+                let island_layout = crate::WorkspaceSettings::get_global(cx).island_layout;
+                if island_layout.enabled {
+                    let radius = px(island_layout.corner_radius * 0.75);
+                    return el.overflow_hidden().rounded(radius);
+                }
+                el.bg(cx.theme().colors().status_bar_background)
+            })
             .map(|el| {
                 if crate::WorkspaceSettings::get_global(cx)
                     .island_layout

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -460,7 +460,6 @@ impl Render for WelcomePage {
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::open_recent_project))
             .size_full()
-            .bg(cx.theme().colors().editor_background)
             .justify_center()
             .child(
                 v_flex()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8118,6 +8118,7 @@ impl Workspace {
                         this.track_focus(self.region_focus_handles.dock(position))
                     })
             })
+            .when(!dock_is_open, |this| this.hidden())
             .flex()
             .overflow_hidden()
             .flex_none()
@@ -8170,6 +8171,49 @@ impl Workspace {
         }
 
         Some(container)
+    }
+
+    pub(crate) fn style_workspace_container(
+        div: Div,
+        island_layout: &crate::workspace_settings::IslandLayoutSettings,
+        colors: &theme::ThemeColors,
+    ) -> Stateful<Div> {
+        div.id("workspace")
+            .bg(colors.background)
+            .relative()
+            .flex_1()
+            .w_full()
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .when(!island_layout.enabled, |this| {
+                this.border_t_1()
+                    .border_b_1()
+                    .border_color(colors.border)
+            })
+            .when(island_layout.enabled, |this| {
+                this.p(px(island_layout.gap))
+            })
+    }
+
+    pub(crate) fn render_floating_status_bar(
+        &self,
+        island_layout: &crate::workspace_settings::IslandLayoutSettings,
+        cx: &App,
+    ) -> Stateful<Div> {
+        div()
+            .id("floating-status-bar")
+            .mx(px(island_layout.gap))
+            .mb(px(island_layout.gap))
+            .rounded(px(island_layout.corner_radius * 0.75))
+            .overflow_hidden()
+            .bg(cx.theme().colors().status_bar_background)
+            .when(island_layout.border, |this| {
+                this.border_1()
+                    .border_color(cx.theme().colors().border_variant)
+            })
+            .shadow_sm()
+            .child(self.status_bar.clone())
     }
 
     /// Returns the currently-visible major window regions ("parts"), in a stable
@@ -9036,6 +9080,7 @@ impl Render for Workspace {
             .map(|(_, notification)| notification.entity_id())
             .collect::<Vec<_>>();
         let bottom_dock_layout = WorkspaceSettings::get_global(cx).bottom_dock_layout;
+        let island_layout = WorkspaceSettings::get_global(cx).island_layout;
 
         let pane_render_context = PaneRenderContext {
             follower_states: &self.follower_states,
@@ -9106,18 +9151,7 @@ impl Render for Workspace {
                     .flex()
                     .flex_col()
                     .child(
-                        div()
-                            .id("workspace")
-                            .bg(colors.background)
-                            .relative()
-                            .flex_1()
-                            .w_full()
-                            .flex()
-                            .flex_col()
-                            .overflow_hidden()
-                            .border_t_1()
-                            .border_b_1()
-                            .border_color(colors.border)
+                        Self::style_workspace_container(div(), &island_layout, colors)
                             .child({
                                 let this = cx.entity();
                                 canvas(
@@ -9204,12 +9238,14 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_col()
                                         .h_full()
+                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                         .child(
                                             div()
                                                 .flex()
                                                 .flex_row()
                                                 .flex_1()
                                                 .overflow_hidden()
+                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                 .children(self.render_dock(
                                                     DockPosition::Left,
                                                     &self.left_dock,
@@ -9248,28 +9284,36 @@ impl Render for Workspace {
                                                     cx,
                                                 )),
                                         )
-                                        .child(div().w_full().children(self.render_dock(
-                                            DockPosition::Bottom,
-                                            &self.bottom_dock,
-                                            window,
-                                            cx,
-                                        ))),
+                                        .child(
+                                            div()
+                                                .w_full()
+                                                .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                .children(self.render_dock(
+                                                    DockPosition::Bottom,
+                                                    &self.bottom_dock,
+                                                    window,
+                                                    cx,
+                                                )),
+                                        ),
 
                                     BottomDockLayout::LeftAligned => div()
                                         .flex()
                                         .flex_row()
                                         .h_full()
+                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                         .child(
                                             div()
                                                 .flex()
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
+                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                 .child(
                                                     div()
                                                         .flex()
                                                         .flex_row()
                                                         .flex_1()
+                                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                         .children(self.render_dock(
                                                             DockPosition::Left,
                                                             &self.left_dock,
@@ -9309,12 +9353,17 @@ impl Render for Workspace {
                                                                 ),
                                                         ),
                                                 )
-                                                .child(div().w_full().children(self.render_dock(
-                                                    DockPosition::Bottom,
-                                                    &self.bottom_dock,
-                                                    window,
-                                                    cx,
-                                                ))),
+                                                .child(
+                                                    div()
+                                                        .w_full()
+                                                        .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                        .children(self.render_dock(
+                                                            DockPosition::Bottom,
+                                                            &self.bottom_dock,
+                                                            window,
+                                                            cx,
+                                                        )),
+                                                ),
                                         )
                                         .children(self.render_dock(
                                             DockPosition::Right,
@@ -9322,10 +9371,12 @@ impl Render for Workspace {
                                             window,
                                             cx,
                                         )),
+
                                     BottomDockLayout::RightAligned => div()
                                         .flex()
                                         .flex_row()
                                         .h_full()
+                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                         .children(self.render_dock(
                                             DockPosition::Left,
                                             &self.left_dock,
@@ -9338,11 +9389,13 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
+                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                 .child(
                                                     div()
                                                         .flex()
                                                         .flex_row()
                                                         .flex_1()
+                                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                         .child(
                                                             div()
                                                                 .flex()
@@ -9382,17 +9435,24 @@ impl Render for Workspace {
                                                             cx,
                                                         )),
                                                 )
-                                                .child(div().w_full().children(self.render_dock(
-                                                    DockPosition::Bottom,
-                                                    &self.bottom_dock,
-                                                    window,
-                                                    cx,
-                                                ))),
+                                                .child(
+                                                    div()
+                                                        .w_full()
+                                                        .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                        .children(self.render_dock(
+                                                            DockPosition::Bottom,
+                                                            &self.bottom_dock,
+                                                            window,
+                                                            cx,
+                                                        )),
+                                                ),
                                         ),
+
                                     BottomDockLayout::Contained => div()
                                         .flex()
                                         .flex_row()
                                         .h_full()
+                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                         .children(self.render_dock(
                                             DockPosition::Left,
                                             &self.left_dock,
@@ -9405,6 +9465,7 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .overflow_hidden()
+                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
                                                 .child(
                                                     h_flex()
                                                         .flex_1()
@@ -9461,7 +9522,11 @@ impl Render for Workspace {
                             .children(self.render_notifications(window, cx)),
                     )
                     .when(self.status_bar_visible(cx), |parent| {
-                        parent.child(self.status_bar.clone())
+                        if island_layout.enabled {
+                            parent.child(self.render_floating_status_bar(&island_layout, cx))
+                        } else {
+                            parent.child(self.status_bar.clone())
+                        }
                     })
                     .child(self.toast_layer.clone()),
             )
@@ -16793,6 +16858,195 @@ mod tests {
             let visible = workspace.status_bar_visible(cx);
             assert!(visible, "Status bar should be visible when show is true");
         });
+    }
+
+    #[gpui::test]
+    async fn test_workspace_canvas_backdrop_and_borders_default(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let (mut div, border_color) = workspace.update_in(cx, |_, _, cx| {
+            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+            let colors = cx.theme().colors().clone();
+            let div = Workspace::style_workspace_container(div(), &island_layout, &colors);
+            (div, colors.border)
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            gpui::EdgesRefinement {
+                top: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                right: None,
+                bottom: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                left: None,
+            }
+        );
+        assert_eq!(style.border_color, Some(border_color));
+        assert_eq!(style.padding, gpui::EdgesRefinement::default());
+    }
+
+    #[gpui::test]
+    async fn test_workspace_canvas_backdrop_and_padding_island_layout(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(18.0),
+                        gap: Some(8.0),
+                        border: Some(true),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let (mut div, bg_color) = workspace.update_in(cx, |_, _, cx| {
+            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+            let colors = cx.theme().colors().clone();
+            let div = Workspace::style_workspace_container(div(), &island_layout, &colors);
+            (div, colors.background)
+        });
+
+        let style = div.style();
+        assert_eq!(style.border_widths, gpui::EdgesRefinement::default());
+        assert_eq!(
+            style.padding,
+            gpui::EdgesRefinement {
+                top: Some(gpui::px(8.).into()),
+                right: Some(gpui::px(8.).into()),
+                bottom: Some(gpui::px(8.).into()),
+                left: Some(gpui::px(8.).into()),
+            }
+        );
+        assert_eq!(style.background, Some(gpui::Fill::Color(bg_color.into())));
+    }
+
+    #[gpui::test]
+    async fn test_floating_status_bar_styling_island_layout(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(20.0),
+                        gap: Some(6.0),
+                        border: Some(true),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let (mut div, border_variant, status_bar_bg) = workspace.update_in(cx, |workspace, _, cx| {
+            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+            let border_variant = cx.theme().colors().border_variant;
+            let status_bar_bg = cx.theme().colors().status_bar_background;
+            let div = workspace.render_floating_status_bar(&island_layout, cx);
+            (div, border_variant, status_bar_bg)
+        });
+
+        let style = div.style();
+        assert_eq!(
+            style.border_widths,
+            gpui::EdgesRefinement {
+                top: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                right: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                bottom: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+                left: Some(gpui::AbsoluteLength::Pixels(gpui::px(1.))),
+            }
+        );
+        assert_eq!(style.border_color, Some(border_variant));
+        assert_eq!(
+            style.corner_radii,
+            gpui::CornersRefinement {
+                top_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(15.))),
+                top_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(15.))),
+                bottom_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(15.))),
+                bottom_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(15.))),
+            }
+        );
+        assert_eq!(
+            style.margin,
+            gpui::EdgesRefinement {
+                top: None,
+                right: Some(gpui::px(6.).into()),
+                bottom: Some(gpui::px(6.).into()),
+                left: Some(gpui::px(6.).into()),
+            }
+        );
+        assert_eq!(style.background, Some(gpui::Fill::Color(status_bar_bg.into())));
+        assert!(style.box_shadow.is_some());
+    }
+
+    #[gpui::test]
+    async fn test_floating_status_bar_styling_without_border(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.island_layout = Some(settings::IslandLayoutSettings {
+                        enabled: Some(true),
+                        corner_radius: Some(16.0),
+                        gap: Some(4.0),
+                        border: Some(false),
+                        pill_tabs: Some(true),
+                    });
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let mut div = workspace.update_in(cx, |workspace, _, cx| {
+            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+            workspace.render_floating_status_bar(&island_layout, cx)
+        });
+
+        let style = div.style();
+        assert_eq!(style.border_widths, gpui::EdgesRefinement::default());
+        assert_eq!(
+            style.corner_radii,
+            gpui::CornersRefinement {
+                top_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                top_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                bottom_right: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+                bottom_left: Some(gpui::AbsoluteLength::Pixels(gpui::px(12.))),
+            }
+        );
+        assert_eq!(
+            style.margin,
+            gpui::EdgesRefinement {
+                top: None,
+                right: Some(gpui::px(4.).into()),
+                bottom: Some(gpui::px(4.).into()),
+                left: Some(gpui::px(4.).into()),
+            }
+        );
+        assert!(style.box_shadow.is_some());
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -156,8 +156,8 @@ use util::{
 use uuid::Uuid;
 pub use workspace_settings::{
     AccessibleMode, AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, FocusFollowsMouse,
-    RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings, WorkspaceSettings,
-    observe_accessible_mode,
+    IslandLayoutSettings, RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings,
+    WorkspaceSettings, observe_accessible_mode,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9146,6 +9146,7 @@ impl Render for Workspace {
                     .flex_1()
                     .flex()
                     .flex_col()
+                    .when(island_layout.enabled, |this| this.bg(colors.background))
                     .child(
                         Self::style_workspace_container(div(), &island_layout, colors)
                             .child({
@@ -9234,9 +9235,11 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_col()
                                         .h_full()
-                                        .when(island_layout.enabled, |this| {
-                                            this.gap(px(island_layout.gap))
-                                        })
+                                        .when(
+                                            island_layout.enabled
+                                                && self.bottom_dock.read(cx).is_open(),
+                                            |this| this.gap(px(island_layout.gap)),
+                                        )
                                         .child(
                                             div()
                                                 .flex()
@@ -9312,9 +9315,11 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
-                                                .when(island_layout.enabled, |this| {
-                                                    this.gap(px(island_layout.gap))
-                                                })
+                                                .when(
+                                                    island_layout.enabled
+                                                        && self.bottom_dock.read(cx).is_open(),
+                                                    |this| this.gap(px(island_layout.gap)),
+                                                )
                                                 .child(
                                                     div()
                                                         .flex()
@@ -9403,9 +9408,11 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
-                                                .when(island_layout.enabled, |this| {
-                                                    this.gap(px(island_layout.gap))
-                                                })
+                                                .when(
+                                                    island_layout.enabled
+                                                        && self.bottom_dock.read(cx).is_open(),
+                                                    |this| this.gap(px(island_layout.gap)),
+                                                )
                                                 .child(
                                                     div()
                                                         .flex()
@@ -9488,9 +9495,11 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .overflow_hidden()
-                                                .when(island_layout.enabled, |this| {
-                                                    this.gap(px(island_layout.gap))
-                                                })
+                                                .when(
+                                                    island_layout.enabled
+                                                        && self.bottom_dock.read(cx).is_open(),
+                                                    |this| this.gap(px(island_layout.gap)),
+                                                )
                                                 .child(
                                                     h_flex()
                                                         .flex_1()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8187,13 +8187,9 @@ impl Workspace {
             .flex_col()
             .overflow_hidden()
             .when(!island_layout.enabled, |this| {
-                this.border_t_1()
-                    .border_b_1()
-                    .border_color(colors.border)
+                this.border_t_1().border_b_1().border_color(colors.border)
             })
-            .when(island_layout.enabled, |this| {
-                this.p(px(island_layout.gap))
-            })
+            .when(island_layout.enabled, |this| this.p(px(island_layout.gap)))
     }
 
     pub(crate) fn render_floating_status_bar(
@@ -9238,14 +9234,18 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_col()
                                         .h_full()
-                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                        .when(island_layout.enabled, |this| {
+                                            this.gap(px(island_layout.gap))
+                                        })
                                         .child(
                                             div()
                                                 .flex()
                                                 .flex_row()
                                                 .flex_1()
                                                 .overflow_hidden()
-                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                .when(island_layout.enabled, |this| {
+                                                    this.gap(px(island_layout.gap))
+                                                })
                                                 .children(self.render_dock(
                                                     DockPosition::Left,
                                                     &self.left_dock,
@@ -9287,7 +9287,10 @@ impl Render for Workspace {
                                         .child(
                                             div()
                                                 .w_full()
-                                                .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                .when(
+                                                    !self.bottom_dock.read(cx).is_open(),
+                                                    |this| this.hidden(),
+                                                )
                                                 .children(self.render_dock(
                                                     DockPosition::Bottom,
                                                     &self.bottom_dock,
@@ -9300,20 +9303,26 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_row()
                                         .h_full()
-                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                        .when(island_layout.enabled, |this| {
+                                            this.gap(px(island_layout.gap))
+                                        })
                                         .child(
                                             div()
                                                 .flex()
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
-                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                .when(island_layout.enabled, |this| {
+                                                    this.gap(px(island_layout.gap))
+                                                })
                                                 .child(
                                                     div()
                                                         .flex()
                                                         .flex_row()
                                                         .flex_1()
-                                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                        .when(island_layout.enabled, |this| {
+                                                            this.gap(px(island_layout.gap))
+                                                        })
                                                         .children(self.render_dock(
                                                             DockPosition::Left,
                                                             &self.left_dock,
@@ -9356,7 +9365,10 @@ impl Render for Workspace {
                                                 .child(
                                                     div()
                                                         .w_full()
-                                                        .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                        .when(
+                                                            !self.bottom_dock.read(cx).is_open(),
+                                                            |this| this.hidden(),
+                                                        )
                                                         .children(self.render_dock(
                                                             DockPosition::Bottom,
                                                             &self.bottom_dock,
@@ -9376,7 +9388,9 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_row()
                                         .h_full()
-                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                        .when(island_layout.enabled, |this| {
+                                            this.gap(px(island_layout.gap))
+                                        })
                                         .children(self.render_dock(
                                             DockPosition::Left,
                                             &self.left_dock,
@@ -9389,13 +9403,17 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .h_full()
-                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                .when(island_layout.enabled, |this| {
+                                                    this.gap(px(island_layout.gap))
+                                                })
                                                 .child(
                                                     div()
                                                         .flex()
                                                         .flex_row()
                                                         .flex_1()
-                                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                        .when(island_layout.enabled, |this| {
+                                                            this.gap(px(island_layout.gap))
+                                                        })
                                                         .child(
                                                             div()
                                                                 .flex()
@@ -9438,7 +9456,10 @@ impl Render for Workspace {
                                                 .child(
                                                     div()
                                                         .w_full()
-                                                        .when(!self.bottom_dock.read(cx).is_open(), |this| this.hidden())
+                                                        .when(
+                                                            !self.bottom_dock.read(cx).is_open(),
+                                                            |this| this.hidden(),
+                                                        )
                                                         .children(self.render_dock(
                                                             DockPosition::Bottom,
                                                             &self.bottom_dock,
@@ -9452,7 +9473,9 @@ impl Render for Workspace {
                                         .flex()
                                         .flex_row()
                                         .h_full()
-                                        .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                        .when(island_layout.enabled, |this| {
+                                            this.gap(px(island_layout.gap))
+                                        })
                                         .children(self.render_dock(
                                             DockPosition::Left,
                                             &self.left_dock,
@@ -9465,7 +9488,9 @@ impl Render for Workspace {
                                                 .flex_col()
                                                 .flex_1()
                                                 .overflow_hidden()
-                                                .when(island_layout.enabled, |this| this.gap(px(island_layout.gap)))
+                                                .when(island_layout.enabled, |this| {
+                                                    this.gap(px(island_layout.gap))
+                                                })
                                                 .child(
                                                     h_flex()
                                                         .flex_1()
@@ -16957,13 +16982,14 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
-        let (mut div, border_variant, status_bar_bg) = workspace.update_in(cx, |workspace, _, cx| {
-            let island_layout = WorkspaceSettings::get_global(cx).island_layout;
-            let border_variant = cx.theme().colors().border_variant;
-            let status_bar_bg = cx.theme().colors().status_bar_background;
-            let div = workspace.render_floating_status_bar(&island_layout, cx);
-            (div, border_variant, status_bar_bg)
-        });
+        let (mut div, border_variant, status_bar_bg) =
+            workspace.update_in(cx, |workspace, _, cx| {
+                let island_layout = WorkspaceSettings::get_global(cx).island_layout;
+                let border_variant = cx.theme().colors().border_variant;
+                let status_bar_bg = cx.theme().colors().status_bar_background;
+                let div = workspace.render_floating_status_bar(&island_layout, cx);
+                (div, border_variant, status_bar_bg)
+            });
 
         let style = div.style();
         assert_eq!(
@@ -16994,7 +17020,10 @@ mod tests {
                 left: Some(gpui::px(6.).into()),
             }
         );
-        assert_eq!(style.background, Some(gpui::Fill::Color(status_bar_bg.into())));
+        assert_eq!(
+            style.background,
+            Some(gpui::Fill::Color(status_bar_bg.into()))
+        );
         assert!(style.box_shadow.is_some());
     }
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -41,6 +41,28 @@ pub struct WorkspaceSettings {
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
     pub focus_follows_mouse: FocusFollowsMouse,
+    pub island_layout: IslandLayoutSettings,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct IslandLayoutSettings {
+    pub enabled: bool,
+    pub corner_radius: f32,
+    pub gap: f32,
+    pub border: bool,
+    pub pill_tabs: bool,
+}
+
+impl Default for IslandLayoutSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            corner_radius: 18.0,
+            gap: 6.0,
+            border: true,
+            pill_tabs: true,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Deserialize)]
@@ -79,6 +101,7 @@ pub struct TabBarSettings {
 impl Settings for WorkspaceSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let workspace = &content.workspace;
+        let island_layout = workspace.island_layout.as_ref();
         Self {
             active_pane_modifiers: ActivePanelModifiers {
                 border_size: Some(
@@ -141,6 +164,13 @@ impl Settings for WorkspaceSettings {
                         .debounce_ms
                         .unwrap_or(250),
                 ),
+            },
+            island_layout: IslandLayoutSettings {
+                enabled: island_layout.and_then(|s| s.enabled).unwrap_or(false),
+                corner_radius: island_layout.and_then(|s| s.corner_radius).unwrap_or(18.0),
+                gap: island_layout.and_then(|s| s.gap).unwrap_or(6.0),
+                border: island_layout.and_then(|s| s.border).unwrap_or(true),
+                pill_tabs: island_layout.and_then(|s| s.pill_tabs).unwrap_or(true),
             },
         }
     }
@@ -214,3 +244,19 @@ impl Settings for StatusBarSettings {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_island_layout_settings_defaults() {
+        let defaults = IslandLayoutSettings::default();
+        assert_eq!(defaults.enabled, false);
+        assert_eq!(defaults.corner_radius, 18.0);
+        assert_eq!(defaults.gap, 6.0);
+        assert_eq!(defaults.border, true);
+        assert_eq!(defaults.pill_tabs, true);
+    }
+}
+

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -259,4 +259,3 @@ mod tests {
         assert_eq!(defaults.pill_tabs, true);
     }
 }
-


### PR DESCRIPTION
# Objective

Introduce an opt-in **Floating Island Layout** (`island_layout`) in Zed, transforming traditional full-bleed docked panels, editor panes, and status bars into floating rounded cards with customizable gap spacing, border styling, and optional pill tabs.

When disabled (`"island_layout": { "enabled": false }`, the default), Zed behaves and renders with 100% fidelity to the classic full-bleed design with zero overhead.

## Solution

1. **Configuration & Settings**:
   - Added `island_layout` configuration to `WorkspaceSettingsContent` / `WorkspaceSettings`:
     - `enabled`: `bool` (default `false`)
     - `corner_radius`: `f32` (default `18.0`)
     - `gap`: `f32` (default `8.0`)
     - `border`: `bool` (default `true`)
     - `pill_tabs`: `bool` (default `true`)
   - Documented in `assets/settings/default.json` and exposed in the graphical Settings UI (`crates/settings_ui`).
2. **Floating Pill Tabs & Tab Bar**:
   - Added `pill_style` mode to `Tab` and `TabBar` in `crates/ui`, providing centered, rounded chip styling for tabs with active/inactive contrast.
3. **Floating Dock Panels & Resize Handles**:
   - Wrapped left, right, and bottom dock panels into floating rounded cards (`border_1`, `rounded`, `shadow_sm`, `overflow_hidden`) in `crates/workspace/src/dock.rs`.
   - Maintained dock resize handle hitboxes with transparent gutters in the layout gaps.
4. **Floating Editor Panes & Split Views**:
   - Implemented floating card styling on editor panes and split groups in `crates/workspace/src/pane.rs` and `pane_group.rs`.
   - Rounded pane drag-and-drop indicators and split drop zones.
5. **Canvas Backdrop & Floating Status Bar**:
   - Added canvas backdrop rendering with inter-panel layout gaps in `crates/workspace/src/workspace.rs`.
   - Rendered status bar as a floating pill card centered above the bottom margin.
6. **Sub-panel Clipping & Geometry Polish**:
   - Polished corner clipping and theme background consistency across Git Panel, Project Panel, Terminal View, Agent Panel, and Editor scrollbars.

## Testing

- Verified with unit and schema tests across `crates/settings_content`, `crates/settings`, `crates/settings_ui`, `crates/ui`, and `crates/workspace`.
- Validated on multiple dark and light themes for contrast, corner clipping, hover bounds, and border alignments.
- Confirmed zero visual and functional regressions when `island_layout.enabled` is `false`.

### How to test:
Add to your `settings.json`:
```json
{
  "island_layout": {
    "enabled": true,
    "corner_radius": 18.0,
    "gap": 8.0,
    "border": true,
    "pill_tabs": true
  }
}
```
Or open **Settings** (`Ctrl-,` / `Cmd-,`) -> **Window & Layout** -> **Island Layout**.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added `island_layout` setting for floating island cards with rounded corners, gaps, and pill tabs.

<img width="2157" height="1182" alt="Screenshot 2026-08-16 164916" src="https://github.com/user-attachments/assets/9baafdb0-2abf-4cf3-bf33-453e10442d4c" />

<img width="2163" height="1191" alt="Screenshot 2026-08-16 170835" src="https://github.com/user-attachments/assets/6a4501e6-95a9-4842-81a5-3bdcef7b009f" />

<img width="2136" height="1176" alt="Screenshot 2026-08-16 170902" src="https://github.com/user-attachments/assets/20eaa814-8042-4586-870e-80f193032008" />
