### PR TITLE
copilot_chat: Fix Copilot Chat sign-in on GitHub Enterprise

### DIFF
--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -38,6 +38,18 @@ impl CopilotChatConfiguration {
         }
     }
 
+    /// The OAuth client ID to use for the device-code flow.
+    ///
+    /// Switches to the default GitHub Copilot client ID if an enterprise URI is configured, 
+    /// since GitHub federates that ID to enterprise instances.
+    pub fn oauth_client_id(&self) -> &'static str {
+        if self.enterprise_uri.is_some() {
+            copilot_oauth::GITHUB_COPILOT_CLIENT_ID
+        } else {
+            copilot_oauth::ZED_COPILOT_CLIENT_ID
+        }
+    }
+
     pub fn graphql_url(&self) -> String {
         if let Some(enterprise_uri) = &self.enterprise_uri {
             let domain = Self::parse_domain(enterprise_uri);

--- a/crates/copilot_chat/src/copilot_oauth.rs
+++ b/crates/copilot_chat/src/copilot_oauth.rs
@@ -18,7 +18,13 @@ use serde::Deserialize;
 use crate::CopilotChatConfiguration;
 
 /// The public OAuth application client ID of Zed
-pub const GITHUB_COPILOT_CLIENT_ID: &str = "6e3a0413e62d19d75ff1";
+pub const ZED_COPILOT_CLIENT_ID: &str = "6e3a0413e62d19d75ff1";
+
+/// GitHub Copilot's first-party GitHub App client ID. This is the default client
+/// the official `@github/copilot-language-server` uses for its device-code flow
+/// (its `findAppIdToAuthenticate()` returns this ID when no override is set), and
+/// GitHub federates it to GitHub Enterprise instances. 
+pub const GITHUB_COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
 
 const DEVICE_CODE_SCOPE: &str = "read:user";
 const DEVICE_CODE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
@@ -58,7 +64,7 @@ pub async fn request_device_code(
     configuration: &CopilotChatConfiguration,
 ) -> Result<DeviceFlow> {
     let body = form_encode(&[
-        ("client_id", GITHUB_COPILOT_CLIENT_ID),
+        ("client_id", configuration.oauth_client_id()),
         ("scope", DEVICE_CODE_SCOPE),
     ]);
 
@@ -99,7 +105,7 @@ pub async fn poll_for_access_token(
 ) -> Result<String> {
     let mut interval = device_flow.interval;
     let body = form_encode(&[
-        ("client_id", GITHUB_COPILOT_CLIENT_ID),
+        ("client_id", configuration.oauth_client_id()),
         ("device_code", device_flow.device_code.as_str()),
         ("grant_type", DEVICE_CODE_GRANT_TYPE),
     ]);


### PR DESCRIPTION
# Objective

- Fixes newly surfaced issue where copilot chat doesn't sign in with github enterprise, specifically after version 1.15.0
- Problem introduced after PR #60535 
- Symptom: when `edit_predictions.copilot.enterprise_uri` is present in `settings.json`, copilot sign in as LLM provider fails to show device code and start the auth process.

## Investigation
Since 1.15.0 (PR #60535), Copilot Chat authentication flow was separated from the edit predictions. For OAuth, it used the public OAuth application client ID of Zed - `6e3a0413e62d19d75ff1`. That app doesn't exist on GitHub Enterprise instances, so `POST https://<host>/login/device/code` returns `404 Not Found` before any user code is issued — no code, no chat models. Edit prediction is unaffected because it delegates auth to the `@github/copilot-language-server` binary, which uses GitHub Copilot's first-party client and is enterprise-aware.

To follow the guidance from `@github/copilot-language-server`, I extracted the npm package tarball and asked Claude to find out how they authenticate. I found the following statement `E0n = "Iv1.b507a08c87ecfe98"` in `main.js` which is used as the global first-party GitHub App ID. Another app ID was found, specifically `lle = "Ov23liV9UpD7Rnfnskm3"`, but it was mentioned that this is the browser OAuth app, not the device-flow app.

## Solution
- Use GitHub Copilot's first-party device-flow client ID (`Iv1.b507a08c87ecfe98`) for the enterprise case

## Testing

- Verified against a real `*.ghe.com` host: device-code request returns `200`, polling yields a token, and Copilot Chat models load and respond.
- To test, simply put the following entry in settings:
```json
"edit_predictions": {
    "provider": "copilot",
    "copilot": {
      "enterprise_uri": "[A VALID GHE DOMAIN]",
    },
  },
```
  and see that it redirects properly. You would need to access a github enterprise instance

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
  - There were no tests for this feature to begin with
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixed github enterprise for copilot chat
