### PR TITLE
Recognize .brushrc files as shell scripts

### DIFF
--- a/crates/grammars/src/bash/config.toml
+++ b/crates/grammars/src/bash/config.toml
@@ -1,7 +1,7 @@
 name = "Shell Script"
 code_fence_block_name = "bash"
 grammar = "bash"
-path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "bats", "envrc", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD", "APKBUILD", "ebuild"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "brushrc", "bats", "envrc", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD", "APKBUILD", "ebuild"]
 modeline_aliases = ["sh", "shell", "shell-script", "zsh"]
 line_comments = ["# "]
 first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh|zsh)\b'

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -264,6 +264,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
             "bash_logout",
             "bash_profile",
             "bashrc",
+            "brushrc",
             "fish",
             "nu",
             "profile",


### PR DESCRIPTION
Add `.brushrc` to the Shell Script language configuration so [Brush](https://github.com/reubeno/brush) shell configuration files receive shell syntax highlighting.

Release Notes:
- Added Shell Script language detection for `.brushrc` files.
