### PR TITLE
project_panel: Make the window deactivation test actually deactivate

### DIFF
--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4577,15 +4577,26 @@ async fn test_rename_survives_window_deactivation(cx: &mut gpui::TestAppContext)
         .read_with(cx, |mw, _| mw.workspace().clone())
         .unwrap();
     let cx = &mut VisualTestContext::from_window(window.into(), cx);
-    let panel = workspace.update_in(cx, ProjectPanel::new);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
     cx.run_until_parked();
 
     select_path(&panel, "root/file1.txt", cx);
     panel.update_in(cx, |panel, window, cx| panel.rename(&Rename, window, cx));
+    cx.run_until_parked();
     assert!(
         panel.read_with(cx, |panel, _| panel.state.edit_state.is_some()),
         "Rename should have started"
     );
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            panel.filename_editor.read(cx).is_focused(window),
+            "The filename editor must be focused, otherwise deactivating the window blurs nothing"
+        );
+    });
 
     cx.deactivate_window();
 


### PR DESCRIPTION
Follow-up to #61852. The regression test I added there passes with or without the fix.

The test creates the panel with `ProjectPanel::new` but never calls `workspace.add_panel(...)`, so the panel is never rendered and its filename editor never holds window focus. Deactivating the window then blurs nothing, the project panel's `Blurred` handler never runs, and the assertion holds trivially.

Add the panel to the workspace so it renders and its filename editor takes focus, and assert that the editor is focused before deactivating, so the test fails at an explanatory precondition rather than silently going vacuous again.

Verified by running the new precondition without `add_panel`: it fails, because the workspace's `on_focus_lost` fallback (`crates/workspace/src/workspace.rs:1667`) reclaims focus from an editor that was never rendered into the dispatch tree.

## Suggested .rules additions

> A GPUI test that depends on focus must put the view somewhere it can actually be focused. Constructing a panel with `ProjectPanel::new` and friends does not render it, so its editors never hold window focus and every focus or blur assertion passes vacuously. Add it with `workspace.add_panel(...)`, and assert the intended editor `is_focused` before exercising blur.

Release Notes:

- N/A
