### PR TITLE
dont show UI for a nullable f32 value whose null value is an intentio…

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2342,24 +2342,28 @@ fn editor_page() -> SettingsPage {
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Git Gutter Width",
                 description: "Width, in pixels, of the git diff indicators in the gutter. When unset, the width scales with the buffer font size.",
-                field: Box::new(SettingField {
-                    organization_override: None,
-                    json_path: Some("gutter.git_gutter_width"),
-                    pick: |settings_content| {
-                        settings_content
-                            .editor
-                            .gutter
-                            .as_ref()
-                            .and_then(|gutter| gutter.git_gutter_width.as_ref())
-                    },
-                    write: |settings_content, value, _| {
-                        settings_content
-                            .editor
-                            .gutter
-                            .get_or_insert_default()
-                            .git_gutter_width = value;
-                    },
-                }),
+                field: Box::new(
+                    // todo(settings_ui): We don't currently render custom enums with data, so this is an Option that is actually nullable
+                    SettingField {
+                        organization_override: None,
+                        json_path: Some("gutter.git_gutter_width"),
+                        pick: |settings_content| {
+                            settings_content
+                                .editor
+                                .gutter
+                                .as_ref()
+                                .and_then(|gutter| gutter.git_gutter_width.as_ref())
+                        },
+                        write: |settings_content, value, _| {
+                            settings_content
+                                .editor
+                                .gutter
+                                .get_or_insert_default()
+                                .git_gutter_width = value;
+                        },
+                    }
+                    .unimplemented(),
+                ),
                 metadata: None,
                 files: USER,
             }),


### PR DESCRIPTION
…nal value that indicates the "default" setting

# Objective

The settings UI will set `f32::min` when rendering UI for an `Option<f32>` without a default value. `git_gutter_width` is an intentionally nullable value, where `None`/null represents the "default behavior" that calculates the size automatically. The alternative is setting a fixed value.

<img width="1142" height="208" alt="CleanShot 2026-08-16 at 16 21 00@2x" src="https://github.com/user-attachments/assets/b576c990-0218-4fe4-b1c5-27b7a7c99cfb" />

## Solution

Re-using a pattern from other settings, we can take advantage of `unimplemented` to force this setting to be handled in the JSON file rather than the UI. This sidesteps the issue (since the awkward `f32::min` value is *only* caused by settings UI rendering) in the same way we do so in the rest of the settings and leaves space to build a better UI for data-holding settings in the future.

<img width="1142" height="208" alt="CleanShot 2026-08-16 at 16 20 41@2x" src="https://github.com/user-attachments/assets/ce0ecaee-739e-4405-8d05-37a689afb59a" />

## Testing

Check the value under `Editor -> Gutter -> Git Gutter Width`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="1142" height="208" alt="CleanShot 2026-08-16 at 16 20 41@2x" src="https://github.com/user-attachments/assets/ce0ecaee-739e-4405-8d05-37a689afb59a" />

---

Release Notes:

- Don't write `f32::min` `git_gutter_width` values from the settings UI
