### PR TITLE
openai_subscribed: Request ungated account model catalog

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -9,7 +9,6 @@ use language_model::{
     LanguageModelProviderState, ProviderSettingsView,
 };
 use openai_subscribed::{PROVIDER_ID, PROVIDER_NAME, State, create_language_model};
-use release_channel::AppVersion;
 use std::sync::Arc;
 use ui::{ConfiguredApiCard, prelude::*};
 
@@ -26,15 +25,7 @@ impl OpenAiSubscribedProvider {
         credentials_provider: Arc<dyn CredentialsProvider>,
         cx: &mut App,
     ) -> Self {
-        let app_version = AppVersion::global(cx);
-        let client_version = format!(
-            "{}.{}.{}",
-            app_version.major, app_version.minor, app_version.patch
-        )
-        .into();
-        let state = cx.new(|cx| {
-            State::new_with_client_version(http_client, credentials_provider, client_version, cx)
-        });
+        let state = cx.new(|cx| State::new(http_client, credentials_provider, cx));
         Self { state }
     }
 }

--- a/crates/openai_subscribed/src/openai_subscribed.rs
+++ b/crates/openai_subscribed/src/openai_subscribed.rs
@@ -38,6 +38,11 @@ const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 const CREDENTIALS_KEY: &str = "https://chatgpt.com/backend-api/codex";
 const TOKEN_REFRESH_BUFFER_MS: u64 = 5 * 60 * 1000;
+/// Requests the complete account catalog without Codex CLI version filtering.
+///
+/// The backend treats this exact version as an ungated sentinel. Other versions
+/// are compared with each model's `minimal_client_version`.
+const UNGATED_MODEL_CATALOG_CLIENT_VERSION: &str = "0.0.0";
 // Codex applies the same bound because model discovery is a startup-critical request.
 const MODEL_CATALOG_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -88,21 +93,15 @@ impl std::fmt::Display for RefreshError {
 }
 
 impl State {
-    /// Creates the state and starts loading any persisted credentials.
+    /// Creates state and starts loading persisted credentials.
+    ///
+    /// Model discovery requests the ungated account catalog because host
+    /// application versions are unrelated to Codex CLI compatibility versions.
+    ///
     /// [`State::load_task`] resolves once the load finishes.
     pub fn new(
         http_client: Arc<dyn HttpClient>,
         credentials_provider: Arc<dyn CredentialsProvider>,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        Self::new_with_client_version(http_client, credentials_provider, "0.0.0".into(), cx)
-    }
-
-    /// Creates the state with the client version reported during model discovery.
-    pub fn new_with_client_version(
-        http_client: Arc<dyn HttpClient>,
-        credentials_provider: Arc<dyn CredentialsProvider>,
-        client_version: SharedString,
         cx: &mut Context<Self>,
     ) -> Self {
         let load_task = cx
@@ -160,7 +159,7 @@ impl State {
             load_task: Some(load_task),
             credentials_provider,
             http_client,
-            client_version,
+            client_version: UNGATED_MODEL_CATALOG_CLIENT_VERSION.into(),
             available_models: ChatGptModel::all(),
             auth_generation: 0,
             model_catalog_generation: 0,


### PR DESCRIPTION
The ChatGPT Codex models endpoint interprets `client_version` as a Codex CLI compatibility version and filters models whose `minimal_client_version` is newer. Zed was passing its unrelated application version, so catalog contents depended accidentally on how Zed's release number compared with Codex's version sequence.

A read-only sweep against the authenticated endpoint showed that omitting the parameter returns HTTP 400, ordinary versions receive the expected compatibility-filtered subsets, and `0.0.0` is a special ungated sentinel. The `0.0.0` response had the same model set, ETag, and canonical body hash as current and higher Codex versions, while `0.0.1` returned no models.

This moves ownership of that behavior into `openai_subscribed::State`. The normal constructor now always requests the ungated account catalog, and the public constructor that accepted arbitrary host versions is removed so applications cannot accidentally couple model visibility to their own version scheme. The existing initial-load test pins the resulting `client_version=0.0.0` request.

Testing performed:

- `cargo nextest run -p openai_subscribed`
- `cargo nextest run -p language_models openai_subscribed`
- `./script/clippy -p openai_subscribed -p language_models`
- `cargo fmt --all -- --check`
- `git diff --check`

Release Notes:

- Fixed ChatGPT subscription model discovery to avoid filtering models by Zed's application version.
