### PR TITLE
x_ai: Add Grok 4.5 and Grok 4.6 models

### DIFF
--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -260,23 +260,33 @@ impl XAiLanguageModel {
 }
 
 fn x_ai_reasoning_efforts(model: &x_ai::Model) -> &'static [open_ai::ReasoningEffort] {
-    if model.supports_reasoning_effort() {
-        &[
+    match model {
+        x_ai::Model::Grok43 => &[
             open_ai::ReasoningEffort::None,
             open_ai::ReasoningEffort::Low,
             open_ai::ReasoningEffort::Medium,
             open_ai::ReasoningEffort::High,
-        ]
-    } else {
-        &[]
+        ],
+        x_ai::Model::Grok45 => &[
+            open_ai::ReasoningEffort::Low,
+            open_ai::ReasoningEffort::Medium,
+            open_ai::ReasoningEffort::High,
+        ],
+        x_ai::Model::Grok46 => &[
+            open_ai::ReasoningEffort::Low,
+            open_ai::ReasoningEffort::Medium,
+            open_ai::ReasoningEffort::High,
+            open_ai::ReasoningEffort::XHigh,
+        ],
+        _ => &[],
     }
 }
 
 fn default_thinking_reasoning_effort(model: &x_ai::Model) -> Option<open_ai::ReasoningEffort> {
-    if model.supports_reasoning_effort() {
-        Some(open_ai::ReasoningEffort::Low)
-    } else {
-        None
+    match model {
+        x_ai::Model::Grok43 => Some(open_ai::ReasoningEffort::Low),
+        x_ai::Model::Grok45 | x_ai::Model::Grok46 => Some(open_ai::ReasoningEffort::High),
+        _ => None,
     }
 }
 
@@ -481,6 +491,91 @@ mod tests {
         assert_eq!(
             reasoning_effort_for_request(&request, &x_ai::Model::Grok43),
             Some(open_ai::ReasoningEffort::None)
+        );
+    }
+
+    #[test]
+    fn grok_45_supports_selectable_thinking_effort_levels() {
+        let effort_levels = supported_thinking_effort_levels(&x_ai::Model::Grok45);
+        let values = effort_levels
+            .iter()
+            .map(|level| level.value.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["low", "medium", "high"]);
+        assert_eq!(
+            effort_levels
+                .iter()
+                .find(|level| level.is_default)
+                .map(|level| level.value.as_ref()),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn grok_46_supports_selectable_thinking_effort_levels() {
+        let effort_levels = supported_thinking_effort_levels(&x_ai::Model::Grok46);
+        let values = effort_levels
+            .iter()
+            .map(|level| level.value.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["low", "medium", "high", "xhigh"]);
+        assert_eq!(
+            effort_levels
+                .iter()
+                .find(|level| level.is_default)
+                .map(|level| level.value.as_ref()),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn grok_45_request_uses_selected_reasoning_effort() {
+        let request = LanguageModelRequest {
+            thinking_allowed: true,
+            thinking_effort: Some("medium".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            reasoning_effort_for_request(&request, &x_ai::Model::Grok45),
+            Some(open_ai::ReasoningEffort::Medium)
+        );
+    }
+
+    #[test]
+    fn grok_46_request_uses_xhigh_reasoning_effort() {
+        let request = LanguageModelRequest {
+            thinking_allowed: true,
+            thinking_effort: Some("xhigh".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            reasoning_effort_for_request(&request, &x_ai::Model::Grok46),
+            Some(open_ai::ReasoningEffort::XHigh)
+        );
+        assert_eq!(
+            reasoning_effort_for_request(&request, &x_ai::Model::Grok45),
+            Some(open_ai::ReasoningEffort::High)
+        );
+    }
+
+    #[test]
+    fn grok_45_and_46_cannot_disable_reasoning() {
+        let request = LanguageModelRequest {
+            thinking_allowed: false,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            reasoning_effort_for_request(&request, &x_ai::Model::Grok45),
+            None
+        );
+        assert_eq!(
+            reasoning_effort_for_request(&request, &x_ai::Model::Grok46),
+            None
         );
     }
 }

--- a/crates/x_ai/src/x_ai.rs
+++ b/crates/x_ai/src/x_ai.rs
@@ -10,6 +10,10 @@ pub enum Model {
     #[default]
     #[serde(rename = "grok-4.3", alias = "grok-4.3-latest")]
     Grok43,
+    #[serde(rename = "grok-4.5", alias = "grok-4.5-latest")]
+    Grok45,
+    #[serde(rename = "grok-4.6", alias = "grok-4.6-latest")]
+    Grok46,
     #[serde(rename = "grok-4.20-0309-reasoning")]
     Grok420Reasoning,
     #[serde(rename = "grok-4.20-0309-non-reasoning")]
@@ -36,6 +40,8 @@ impl Model {
     pub fn from_id(id: &str) -> Result<Self> {
         match id {
             "grok-4.3" => Ok(Self::Grok43),
+            "grok-4.5" => Ok(Self::Grok45),
+            "grok-4.6" => Ok(Self::Grok46),
             "grok-4.20-0309-reasoning" => Ok(Self::Grok420Reasoning),
             "grok-4.20-0309-non-reasoning" => Ok(Self::Grok420NonReasoning),
             _ => anyhow::bail!("invalid model id '{id}'"),
@@ -45,6 +51,8 @@ impl Model {
     pub fn id(&self) -> &str {
         match self {
             Self::Grok43 => "grok-4.3",
+            Self::Grok45 => "grok-4.5",
+            Self::Grok46 => "grok-4.6",
             Self::Grok420Reasoning => "grok-4.20-0309-reasoning",
             Self::Grok420NonReasoning => "grok-4.20-0309-non-reasoning",
             Self::Custom { name, .. } => name,
@@ -54,6 +62,8 @@ impl Model {
     pub fn display_name(&self) -> &str {
         match self {
             Self::Grok43 => "Grok 4.3",
+            Self::Grok45 => "Grok 4.5",
+            Self::Grok46 => "Grok 4.6",
             Self::Grok420Reasoning => "Grok 4.20 Reasoning",
             Self::Grok420NonReasoning => "Grok 4.20 (Non-Reasoning)",
             Self::Custom {
@@ -65,6 +75,7 @@ impl Model {
     pub fn max_token_count(&self) -> u64 {
         match self {
             Self::Grok43 => 1_000_000,
+            Self::Grok45 | Self::Grok46 => 500_000,
             Self::Grok420Reasoning | Self::Grok420NonReasoning => 2_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -73,6 +84,7 @@ impl Model {
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
             Self::Grok43 | Self::Grok420Reasoning | Self::Grok420NonReasoning => Some(64_000),
+            Self::Grok45 | Self::Grok46 => None,
             Self::Custom {
                 max_output_tokens, ..
             } => *max_output_tokens,
@@ -81,7 +93,11 @@ impl Model {
 
     pub fn supports_parallel_tool_calls(&self) -> bool {
         match self {
-            Self::Grok43 | Self::Grok420Reasoning | Self::Grok420NonReasoning => true,
+            Self::Grok43
+            | Self::Grok45
+            | Self::Grok46
+            | Self::Grok420Reasoning
+            | Self::Grok420NonReasoning => true,
             Self::Custom {
                 parallel_tool_calls: Some(support),
                 ..
@@ -92,7 +108,11 @@ impl Model {
 
     pub fn requires_json_schema_subset(&self) -> bool {
         match self {
-            Self::Grok43 | Self::Grok420Reasoning | Self::Grok420NonReasoning => true,
+            Self::Grok43
+            | Self::Grok45
+            | Self::Grok46
+            | Self::Grok420Reasoning
+            | Self::Grok420NonReasoning => true,
             Self::Custom { .. } => false,
         }
     }
@@ -103,7 +123,11 @@ impl Model {
 
     pub fn supports_tool(&self) -> bool {
         match self {
-            Self::Grok43 | Self::Grok420Reasoning | Self::Grok420NonReasoning => true,
+            Self::Grok43
+            | Self::Grok45
+            | Self::Grok46
+            | Self::Grok420Reasoning
+            | Self::Grok420NonReasoning => true,
             Self::Custom {
                 supports_tools: Some(support),
                 ..
@@ -114,7 +138,11 @@ impl Model {
 
     pub fn supports_images(&self) -> bool {
         match self {
-            Self::Grok43 | Self::Grok420Reasoning | Self::Grok420NonReasoning => true,
+            Self::Grok43
+            | Self::Grok45
+            | Self::Grok46
+            | Self::Grok420Reasoning
+            | Self::Grok420NonReasoning => true,
             Self::Custom {
                 supports_images: Some(support),
                 ..
@@ -125,7 +153,7 @@ impl Model {
 
     pub fn supports_reasoning_effort(&self) -> bool {
         match self {
-            Self::Grok43 => true,
+            Self::Grok43 | Self::Grok45 | Self::Grok46 => true,
             Self::Grok420Reasoning | Self::Grok420NonReasoning | Self::Custom { .. } => false,
         }
     }


### PR DESCRIPTION
Add the latest xAI models to the bring-your-own-key provider so they call api.x.ai directly, with the published context windows and reasoning-effort levels.

# Objective

Add the native support for grok-4.5 and grok-4.6

## Solution

Add grok-4.5 and grok-4.6 as the new native xAI models

## Testing

Tested locally with compilation and tested with IDE, grok-4.5 and grok-4.6 can be selected from dropdown list in Zed IDE now.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Add native xAI model grok-4.5 and grok-4.6
