### PR TITLE
sidebar: Wrap import onboarding title when the panel is narrow

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -7635,9 +7635,14 @@ fn render_import_onboarding_banner(
                 .min_w_0()
                 .w_full()
                 .gap_1()
+                .items_start()
                 .justify_between()
-                .flex_wrap()
-                .child(Label::new(title).size(LabelSize::Small))
+                .child(
+                    div()
+                        .min_w_0()
+                        .flex_1()
+                        .child(Label::new(title).size(LabelSize::Small)),
+                )
                 .child(
                     IconButton::new(
                         SharedString::from(format!("close-{id}-onboarding")),


### PR DESCRIPTION
Narrowing the agent sidebar clips the import-threads banner title mid-word. The title now wraps instead of overflowing the close button.

<img width="212" height="279" alt="Screenshot 2026-08-16 at 11 25 26 PM" src="https://github.com/user-attachments/assets/03e20b9d-ea29-4872-a4c1-f364509ddacb" />

Release Notes:

- Fixed the agent sidebar import-threads banner clipping its title when the panel is narrow