### PR TITLE
workspace: Restore user-added toolchains when reopening remote projects

### DIFF
--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -142,10 +142,12 @@ impl ToolchainStore {
     ) {
         let mut did_remove = false;
         self.user_toolchains
-            .entry(scope)
+            .entry(scope.clone())
             .and_modify(|toolchains| did_remove = toolchains.shift_remove(&toolchain));
         if did_remove {
-            cx.emit(ToolchainStoreEvent::CustomToolchainsModified);
+            cx.emit(ToolchainStoreEvent::CustomToolchainRemoved(
+                scope, toolchain,
+            ));
         }
     }
 
@@ -473,6 +475,9 @@ struct RemoteStore(WeakEntity<RemoteToolchainStore>);
 pub enum ToolchainStoreEvent {
     ToolchainActivated,
     CustomToolchainsModified,
+    /// Serializing the workspace only rewrites the rows it owns, so globally-scoped
+    /// toolchains have to be deleted from the database explicitly.
+    CustomToolchainRemoved(ToolchainScope, Toolchain),
 }
 
 impl EventEmitter<ToolchainStoreEvent> for LocalToolchainStore {}

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -1,12 +1,16 @@
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use super::*;
 use crate::item::test::TestItem;
+use crate::persistence::model::{SerializedPane, SerializedPaneGroup};
 use agent_settings::AgentSettings;
 use client::proto;
+use collections::IndexSet;
 use fs::{FakeFs, Fs};
 use gpui::{TestAppContext, VisualTestContext};
+use language::{LanguageName, Toolchain, ToolchainScope};
 use project::DisableAiSettings;
+use remote::{MockConnectionOptions, RemoteConnectionOptions};
 use serde_json::json;
 use settings::{Settings, SettingsStore};
 use util::path;
@@ -1160,6 +1164,95 @@ async fn test_remote_project_root_dir_changes_update_groups(cx: &mut TestAppCont
             "project groups should no longer contain the stale initial key; got {keys:?}"
         );
     });
+}
+
+#[gpui::test]
+async fn test_open_remote_project_restores_user_toolchains(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let app_state = cx.update(AppState::test);
+    let fs = app_state.fs.as_fake();
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            "main.py": "",
+            ".venv": { "bin": { "python": "" } },
+        }),
+    )
+    .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/project").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace_id = cx
+        .update(|cx| WorkspaceDb::global(cx))
+        .next_id()
+        .await
+        .unwrap();
+
+    let global_toolchain = Toolchain {
+        language_name: LanguageName::new_static("Python"),
+        name: "Global Venv".into(),
+        path: path!("/home/user/global-venv/bin/python").into(),
+        as_json: json!({ "kind": "venv" }),
+    };
+    let project_toolchain = Toolchain {
+        language_name: LanguageName::new_static("Python"),
+        name: "Project Venv".into(),
+        path: path!("/project/.venv/bin/python").into(),
+        as_json: json!({ "kind": "venv" }),
+    };
+    let user_toolchains = BTreeMap::from_iter([
+        (
+            ToolchainScope::Global,
+            IndexSet::from_iter([global_toolchain.clone()]),
+        ),
+        (
+            ToolchainScope::Project,
+            IndexSet::from_iter([project_toolchain.clone()]),
+        ),
+    ]);
+
+    let serialized_workspace = SerializedWorkspace {
+        id: workspace_id,
+        location: SerializedWorkspaceLocation::Remote(RemoteConnectionOptions::Mock(
+            MockConnectionOptions { id: 1 },
+        )),
+        paths: PathList::new(&[path!("/project")]),
+        identity_paths: None,
+        center_group: SerializedPaneGroup::Pane(SerializedPane::default()),
+        window_bounds: None,
+        centered_layout: false,
+        display: None,
+        docks: DockStructure::default(),
+        session_id: None,
+        bookmarks: BTreeMap::new(),
+        breakpoints: BTreeMap::new(),
+        user_toolchains: user_toolchains.clone(),
+        window_id: None,
+    };
+
+    cx.update(|cx| {
+        let project = project.clone();
+        cx.spawn(async move |cx| {
+            open_remote_project_inner(
+                project,
+                vec![PathBuf::from(path!("/project"))],
+                workspace_id,
+                Some(serialized_workspace),
+                app_state,
+                window,
+                None,
+                None,
+                cx,
+            )
+            .await
+        })
+    })
+    .await
+    .unwrap();
+
+    let restored = project.read_with(cx, |project, cx| project.user_toolchains(cx));
+    assert_eq!(restored, Some(user_toolchains));
 }
 
 #[gpui::test]

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1465,6 +1465,57 @@ impl WorkspaceDb {
         ret
     }
 
+    /// Removes a single user-added toolchain. `save_workspace` only rewrites the rows
+    /// belonging to a given workspace, and globally-scoped toolchains are stored under a
+    /// sentinel workspace id shared by every workspace, so they would otherwise survive
+    /// their removal and reappear on the next launch.
+    pub(crate) async fn delete_user_toolchain(
+        &self,
+        workspace_id: WorkspaceId,
+        location: SerializedWorkspaceLocation,
+        scope: ToolchainScope,
+        toolchain: Toolchain,
+    ) -> Result<()> {
+        self.write(move |conn| {
+            let remote_connection_id = match location {
+                SerializedWorkspaceLocation::Local => None,
+                SerializedWorkspaceLocation::Remote(connection_options) => Some(
+                    Self::get_or_create_remote_connection_internal(conn, connection_options)?.0,
+                ),
+            };
+            let (workspace_id, worktree_root_path, relative_worktree_path) = match scope {
+                ToolchainScope::Subproject(worktree_root_path, relative_worktree_path) => (
+                    workspace_id,
+                    worktree_root_path.to_string_lossy().into_owned(),
+                    relative_worktree_path.as_unix_str().to_owned(),
+                ),
+                ToolchainScope::Project => (workspace_id, String::default(), String::default()),
+                ToolchainScope::Global => (WorkspaceId(0), String::default(), String::default()),
+            };
+            // `raw_json` is deliberately not matched on, mirroring `Toolchain`'s own notion of
+            // equality: two entries that look identical in the UI are the same toolchain.
+            conn.exec_bound(sql!(
+                DELETE FROM user_toolchains
+                WHERE remote_connection_id IS ?1
+                    AND workspace_id = ?2
+                    AND worktree_root_path = ?3
+                    AND relative_worktree_path = ?4
+                    AND language_name = ?5
+                    AND name = ?6
+                    AND path = ?7
+            ))?((
+                remote_connection_id,
+                workspace_id,
+                worktree_root_path,
+                relative_worktree_path,
+                toolchain.language_name.as_ref().to_owned(),
+                toolchain.name.to_string(),
+                toolchain.path.to_string(),
+            ))
+        })
+        .await
+    }
+
     pub(crate) async fn save_workspace(&self, workspace: SerializedWorkspace) {
         let paths = workspace.paths.serialize();
         let identity_paths = workspace.identity_paths.map(|paths| paths.serialize());
@@ -3293,6 +3344,74 @@ mod tests {
             flexes: None,
             children,
         }
+    }
+
+    #[gpui::test]
+    async fn test_deleting_globally_scoped_user_toolchain() {
+        zlog::init_test();
+
+        let db = WorkspaceDb::open_test_db("test_deleting_globally_scoped_user_toolchain").await;
+
+        let toolchain = Toolchain {
+            language_name: LanguageName::new_static("Python"),
+            name: "Global Venv".into(),
+            path: "/home/user/global-venv/bin/python".into(),
+            as_json: json!({ "kind": "venv" }),
+        };
+        let user_toolchains = BTreeMap::from_iter([(
+            ToolchainScope::Global,
+            IndexSet::from_iter([toolchain.clone()]),
+        )]);
+        let workspace = SerializedWorkspace {
+            id: WorkspaceId(7),
+            paths: PathList::new(&["/tmp"]),
+            identity_paths: None,
+            location: SerializedWorkspaceLocation::Local,
+            center_group: SerializedPaneGroup::Pane(SerializedPane::new(vec![], false, 0)),
+            window_bounds: Default::default(),
+            display: Default::default(),
+            docks: Default::default(),
+            bookmarks: Default::default(),
+            breakpoints: Default::default(),
+            centered_layout: false,
+            session_id: None,
+            window_id: None,
+            user_toolchains: user_toolchains.clone(),
+        };
+
+        db.save_workspace(workspace.clone()).await;
+        assert_eq!(
+            db.workspace_for_roots(&["/tmp"]).unwrap().user_toolchains,
+            user_toolchains
+        );
+
+        // Globally scoped toolchains are shared between workspaces, so rewriting a workspace
+        // that no longer knows about one must not be what removes it.
+        db.save_workspace(SerializedWorkspace {
+            user_toolchains: Default::default(),
+            ..workspace.clone()
+        })
+        .await;
+        assert_eq!(
+            db.workspace_for_roots(&["/tmp"]).unwrap().user_toolchains,
+            user_toolchains
+        );
+
+        db.delete_user_toolchain(
+            workspace.id,
+            SerializedWorkspaceLocation::Local,
+            ToolchainScope::Global,
+            toolchain,
+        )
+        .await
+        .unwrap();
+        assert!(
+            db.workspace_for_roots(&["/tmp"])
+                .unwrap()
+                .user_toolchains
+                .values()
+                .all(IndexSet::is_empty)
+        );
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -73,7 +73,10 @@ pub use item::{
     ProjectItem, SerializableItem, SerializableItemHandle, WeakItemHandle,
 };
 use itertools::Itertools;
-use language::{Buffer, LanguageRegistry, Rope, language_settings::all_language_settings};
+use language::{
+    Buffer, LanguageRegistry, Rope, Toolchain, ToolchainScope,
+    language_settings::all_language_settings,
+};
 pub use modal_layer::*;
 use node_runtime::NodeRuntime;
 use notifications::{
@@ -1658,7 +1661,11 @@ impl Workspace {
                     ToolchainStoreEvent::CustomToolchainsModified => {
                         workspace.serialize_workspace(window, cx);
                     }
-                    _ => {}
+                    ToolchainStoreEvent::CustomToolchainRemoved(scope, toolchain) => {
+                        workspace.delete_user_toolchain(scope.clone(), toolchain.clone(), cx);
+                        workspace.serialize_workspace(window, cx);
+                    }
+                    ToolchainStoreEvent::ToolchainActivated => {}
                 },
             )
             .detach();
@@ -7095,6 +7102,27 @@ impl Workspace {
         }
     }
 
+    fn delete_user_toolchain(
+        &self,
+        scope: ToolchainScope,
+        toolchain: Toolchain,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(database_id) = self.database_id() else {
+            return;
+        };
+        let WorkspaceLocation::Location(location, _) = self.workspace_location(cx) else {
+            return;
+        };
+        let db = WorkspaceDb::global(cx);
+        cx.background_spawn(async move {
+            db.delete_user_toolchain(database_id, location, scope, toolchain)
+                .await
+                .log_err();
+        })
+        .detach();
+    }
+
     fn serialize_workspace_internal(&self, window: &mut Window, cx: &mut App) -> Task<()> {
         let Some(database_id) = self.database_id() else {
             return Task::ready(());
@@ -10853,6 +10881,18 @@ async fn open_remote_project_inner(
     source_workspace: Option<WeakEntity<Workspace>>,
     cx: &mut AsyncApp,
 ) -> Result<(Entity<Workspace>, Vec<Option<Box<dyn ItemHandle>>>)> {
+    // Restore these before the workspace exists, as serializing a workspace whose toolchain
+    // store is still empty would delete the very rows we're about to read back.
+    if let Some(serialized_workspace) = serialized_workspace.as_ref() {
+        project.update(cx, |project, cx| {
+            for (scope, toolchains) in &serialized_workspace.user_toolchains {
+                for toolchain in toolchains {
+                    project.add_toolchain(toolchain.clone(), scope.clone(), cx);
+                }
+            }
+        });
+    }
+
     let mut project_paths_to_open = vec![];
     let mut project_path_errors = vec![];
 


### PR DESCRIPTION
User-added toolchains (`Add Toolchain` / `Add Virtual Environment` in the toolchain selector) were persisted correctly, but never read back when reopening a remote project, and globally scoped ones could not be removed at all.

## Restoring user toolchains on remote reconnect

`Workspace::local_workspace_for_paths` rehydrates `SerializedWorkspace::user_toolchains` into the project's toolchain store, but `open_remote_project_inner` only restored the *active* toolchain selection from the separate `toolchains` table. Reopening an SSH/WSL/Docker project therefore came back with an empty set of user-added toolchains, so a manually added virtual environment disappeared from the toolchain selector and from the REPL's kernel list on every reconnect.

Project- and subproject-scoped entries were then destroyed outright: with the store empty, the next `serialize_workspace` runs `DELETE FROM user_toolchains WHERE workspace_id = ?1` and rewrites nothing. Global entries survived in the database under the sentinel `workspace_id = 0` but stayed invisible.

The restore happens before the `Workspace` is constructed, matching the local path and making it impossible for a serialization to race with it.

## Removing globally scoped toolchains

`save_workspace` only rewrites the rows a workspace owns, and global toolchains are deliberately stored under `workspace_id = 0` because they are shared by every workspace on that host. Widening the `DELETE` to cover them is not viable — a second window that was opened before a global toolchain was added would wipe it on its next serialization — so removal is now an explicit, targeted delete driven by a new `ToolchainStoreEvent::CustomToolchainRemoved`. Without it, removing a global toolchain only lasted until the next launch.

## Tests

- `test_open_remote_project_restores_user_toolchains` covers the restore for both global and project scope; it fails on `main`.
- `test_deleting_globally_scoped_user_toolchain` asserts that rewriting an unrelated workspace leaves a global toolchain alone, and that the targeted delete removes it.

Closes #49761
Closes #21470

Supersedes #55967, which fixed the restore path only and has since gone stale against `main`; thanks to @anilzeybek for the original diagnosis.

Release Notes:

- Fixed manually added toolchains, such as Python virtual environments, not being restored when reopening a remote project.
- Fixed removal of a globally scoped toolchain not persisting across restarts.
