### PR TITLE
anthropic: Preserve request context during explicit compaction

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -912,11 +912,29 @@ pub struct Request {
 impl Request {
     /// Configures this request to stop after native compaction.
     ///
-    /// Tools are removed because Anthropic's internal summarizer may otherwise
-    /// invoke one instead of producing replacement context.
+    /// Tool definitions remain in the request so the trigger observes the same
+    /// context and prompt-cache prefix as normal generation. Tool choice is
+    /// disabled because explicit compaction must only produce replacement
+    /// context.
+    ///
+    /// Claude 4.6 and later reject requests ending in an assistant message as
+    /// unsupported prefill, so completed conversations receive a final user
+    /// turn that requests compaction.
     pub fn into_compact_request(mut self) -> Self {
-        self.tools.clear();
-        self.tool_choice = None;
+        self.tool_choice = (!self.tools.is_empty()).then_some(ToolChoice::None);
+        if self
+            .messages
+            .last()
+            .is_some_and(|message| message.role == Role::Assistant)
+        {
+            self.messages.push(Message {
+                role: Role::User,
+                content: vec![RequestContent::Text {
+                    text: "Compact the conversation so far.".to_string(),
+                    cache_control: None,
+                }],
+            });
+        }
         self.context_management = Some(ContextManagement {
             edits: vec![ContextManagementEdit::Compact {
                 trigger: Some(CompactionTrigger::InputTokens {

--- a/crates/anthropic/src/completion.rs
+++ b/crates/anthropic/src/completion.rs
@@ -1361,10 +1361,47 @@ mod tests {
 
     #[test]
     fn test_compact_request_pauses_at_minimum_trigger() {
-        let request =
-            request_with_assistant_content(vec![MessageContent::Text("Response".to_string())])
-                .into_compact_request();
+        let mut request =
+            request_with_assistant_content(vec![MessageContent::Text("Response".to_string())]);
+        request.tools.push(crate::Tool {
+            name: "search".to_string(),
+            description: "Search the project.".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            eager_input_streaming: false,
+            cache_control: None,
+        });
+        request.tool_choice = Some(crate::ToolChoice::Auto);
+        let request = request.into_compact_request();
 
+        assert_eq!(
+            serde_json::to_value(
+                request
+                    .messages
+                    .last()
+                    .expect("compact request should contain a final message")
+            )
+            .expect("compact request message should serialize"),
+            serde_json::json!({
+                "role": "user",
+                "content": [{
+                    "type": "text",
+                    "text": "Compact the conversation so far."
+                }]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(&request.tools).expect("compact request tools should serialize"),
+            serde_json::json!([{
+                "name": "search",
+                "description": "Search the project.",
+                "input_schema": {"type": "object"}
+            }])
+        );
+        assert_eq!(
+            serde_json::to_value(&request.tool_choice)
+                .expect("compact request tool choice should serialize"),
+            serde_json::json!({"type": "none"})
+        );
         assert_eq!(
             serde_json::to_value(&request.context_management).unwrap(),
             serde_json::json!({


### PR DESCRIPTION
Explicit compaction currently removes tool definitions before sending the request. That changes the prompt-cache prefix and can lower the effective input size below Anthropic's minimum compaction trigger, causing the request to complete without producing replacement context.

Keep tool definitions in explicit compaction requests while setting `tool_choice` to `none`, preserving the input context without allowing tool calls. Also append a user turn when the conversation ends with an assistant message, since current Anthropic models reject that shape as unsupported assistant prefill.

Testing:

- `cargo test -p anthropic`
- `cargo fmt --check`
- `./script/clippy -p anthropic`

Release Notes:

- N/A
