### PR TITLE
editor: Make soft_wrap none truly unwrapped

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1528,9 +1528,8 @@
   // How to soft-wrap long lines of text.
   // Possible values:
   //
-  // 1. Prefer a single line generally, unless an overly long line is encountered.
+  // 1. Do not soft-wrap.
   //      "soft_wrap": "none",
-  //      "soft_wrap": "prefer_line", // (deprecated, same as "none")
   // 2. Soft wrap lines that overflow the editor.
   //      "soft_wrap": "editor_width",
   // 3. Soft wrap lines at the preferred line length or the editor width (whichever is smaller).

--- a/crates/benchmarks/benches/display_map.rs
+++ b/crates/benchmarks/benches/display_map.rs
@@ -191,14 +191,14 @@ fn create_highlight_endpoints_benchmark(c: &mut Criterion) {
         &snapshot,
         |bench, snapshot| {
             bench.iter(|| {
-                black_box(snapshot.chunks(
+                drop(black_box(snapshot.chunks(
                     DisplayRow(400)..DisplayRow(400 + LINE_VIEW_PORT_COUNT as u32),
                     language::LanguageAwareStyling {
                         tree_sitter: false,
                         diagnostics: false,
                     },
                     Default::default(),
-                ));
+                )));
             });
         },
     );

--- a/crates/editor/src/config.rs
+++ b/crates/editor/src/config.rs
@@ -249,7 +249,7 @@ impl Editor {
                 SoftWrap::Bounded(soft_wrap) => {
                     wrap_guides.push((soft_wrap as usize, true));
                 }
-                SoftWrap::GitDiff | SoftWrap::None | SoftWrap::EditorWidth => {}
+                SoftWrap::None | SoftWrap::EditorWidth => {}
             }
             wrap_guides.extend(settings.wrap_guides.iter().map(|guide| (*guide, false)))
         }
@@ -261,9 +261,7 @@ impl Editor {
         let settings = self.buffer.read(cx).language_settings(cx);
         let mode = self.soft_wrap_mode_override.unwrap_or(settings.soft_wrap);
         match mode {
-            language_settings::SoftWrap::PreferLine | language_settings::SoftWrap::None => {
-                SoftWrap::None
-            }
+            language_settings::SoftWrap::None => SoftWrap::None,
             language_settings::SoftWrap::EditorWidth => SoftWrap::EditorWidth,
             language_settings::SoftWrap::Bounded => {
                 SoftWrap::Bounded(settings.preferred_line_length)
@@ -291,7 +289,6 @@ impl Editor {
             self.soft_wrap_mode_override.take();
         } else {
             let soft_wrap = match self.soft_wrap_mode(cx) {
-                SoftWrap::GitDiff => return,
                 SoftWrap::None => language_settings::SoftWrap::EditorWidth,
                 SoftWrap::EditorWidth | SoftWrap::Bounded(_) => language_settings::SoftWrap::None,
             };

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -80,9 +80,9 @@ mod wrap_map;
 
 pub use crate::display_map::{fold_map::FoldMap, inlay_map::InlayMap, tab_map::TabMap};
 pub use block_map::{
-    Block, BlockChunks as DisplayChunks, BlockContext, BlockId, BlockMap, BlockPlacement,
-    BlockPoint, BlockProperties, BlockRows, BlockStyle, CompanionView, CompanionViewMut,
-    CustomBlockId, EditorMargins, RenderBlock, StickyHeaderExcerpt,
+    Block, BlockContext, BlockId, BlockMap, BlockPlacement, BlockPoint, BlockProperties, BlockRows,
+    BlockStyle, CompanionView, CompanionViewMut, CustomBlockId, EditorMargins, RenderBlock,
+    StickyHeaderExcerpt,
 };
 pub use crease_map::*;
 pub use fold_map::{
@@ -132,13 +132,20 @@ use std::{
 };
 
 use crate::{
-    EditorStyle, RowExt, hover_links::InlayHighlight, inlays::Inlay, movement::TextLayoutDetails,
+    EditorStyle, MAX_LINE_LEN, RowExt, hover_links::InlayHighlight, inlays::Inlay,
+    movement::TextLayoutDetails, scroll::ScrollPixelOffset,
 };
 use block_map::{BlockPointCursor, BlockRow, BlockSnapshot};
-use fold_map::{FoldPointCursor, FoldSnapshot};
+use fold_map::{Chunk, FoldPointCursor, FoldSnapshot};
 use inlay_map::{BufferOffsetToInlayPointCursor, InlaySnapshot};
+use itertools::Either;
 use tab_map::{TabPoint, TabPointCursor, TabSnapshot};
 use wrap_map::{WrapMap, WrapPatch, WrapPointCursor};
+
+const BULLETS: &str = match std::str::from_utf8(&[b'*'; rope::Chunk::MASK_BITS]) {
+    Ok(bullets) => bullets,
+    Err(_) => panic!("BULLETS must be ASCII"),
+};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FoldStatus {
@@ -1491,6 +1498,109 @@ impl<'a> HighlightedChunk<'a> {
     }
 }
 
+fn mask_chunks<'a>(chunks: impl Iterator<Item = Chunk<'a>>) -> impl Iterator<Item = Chunk<'a>> {
+    chunks.flat_map(|chunk| {
+        let text = chunk.text;
+        text.split_inclusive('\n').flat_map(move |segment| {
+            let (content, has_newline) = match segment.strip_suffix('\n') {
+                Some(content) => (content, true),
+                None => (segment, false),
+            };
+            let content_chunks = std::iter::from_fn({
+                let chunk = chunk.clone();
+                let mut content = content;
+                move || {
+                    if content.is_empty() {
+                        return None;
+                    }
+                    let (piece_len, bullet_count) = match content.char_indices().nth(BULLETS.len())
+                    {
+                        Some((ix, _)) => (ix, BULLETS.len()),
+                        None => (content.len(), content.chars().count()),
+                    };
+                    content = &content[piece_len..];
+                    Some(Chunk {
+                        text: &BULLETS[..bullet_count],
+                        tabs: 0,
+                        chars: 1u128.unbounded_shl(bullet_count as u32).wrapping_sub(1),
+                        newlines: 0,
+                        ..chunk.clone()
+                    })
+                }
+            });
+            let newline_chunk = has_newline.then(|| Chunk {
+                text: "\n",
+                tabs: 0,
+                chars: 1,
+                newlines: 1,
+                ..chunk.clone()
+            });
+            content_chunks.chain(newline_chunk)
+        })
+    })
+}
+
+pub enum RowLayout<'a> {
+    Shaped(Arc<LineLayout>),
+    Grid {
+        snapshot: &'a DisplaySnapshot,
+        row: DisplayRow,
+        cell_width: Pixels,
+        len: u32,
+    },
+}
+
+impl RowLayout<'_> {
+    pub fn width(&self) -> ScrollPixelOffset {
+        match self {
+            Self::Shaped(layout) => ScrollPixelOffset::from(layout.width),
+            Self::Grid {
+                cell_width, len, ..
+            } => ScrollPixelOffset::from(*cell_width) * *len as ScrollPixelOffset,
+        }
+    }
+
+    pub fn x_for_index(&self, index: usize) -> ScrollPixelOffset {
+        match self {
+            Self::Shaped(layout) => ScrollPixelOffset::from(layout.x_for_index(index)),
+            Self::Grid {
+                cell_width, len, ..
+            } => {
+                ScrollPixelOffset::from(*cell_width) * index.min(*len as usize) as ScrollPixelOffset
+            }
+        }
+    }
+
+    pub fn closest_index_for_x(&self, x: ScrollPixelOffset) -> usize {
+        match self {
+            Self::Shaped(layout) => layout.closest_index_for_x(Pixels::from(x)),
+            Self::Grid {
+                snapshot,
+                row,
+                cell_width,
+                len,
+            } => {
+                if *cell_width <= Pixels::ZERO {
+                    return 0;
+                }
+                let cells = (x / ScrollPixelOffset::from(*cell_width)).max(0.);
+                let column = (cells.round() as u32).min(*len);
+                let point = DisplayPoint::new(*row, column);
+                let left = snapshot.clip_point(point, Bias::Left).column();
+                let right = snapshot.clip_point(point, Bias::Right).column();
+                let column = if cells - ScrollPixelOffset::from(left)
+                    <= ScrollPixelOffset::from(right) - cells
+                {
+                    left
+                } else {
+                    right
+                };
+                column as usize
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct DisplaySnapshot {
     pub display_map_id: EntityId,
@@ -1517,6 +1627,11 @@ impl DisplaySnapshot {
     pub fn wrap_snapshot(&self) -> &WrapSnapshot {
         &self.block_snapshot.wrap_snapshot
     }
+
+    pub fn has_soft_wraps(&self) -> bool {
+        self.wrap_snapshot().has_soft_wraps()
+    }
+
     pub fn tab_snapshot(&self) -> &TabSnapshot {
         &self.block_snapshot.wrap_snapshot.tab_snapshot
     }
@@ -1788,33 +1903,30 @@ impl DisplaySnapshot {
     /// Returns text chunks starting at the given display row until the end of the file
     #[instrument(skip_all)]
     pub fn text_chunks(&self, display_row: DisplayRow) -> impl Iterator<Item = &str> {
-        self.block_snapshot
-            .chunks(
-                BlockRow(display_row.0)..BlockRow(self.max_point().row().next_row().0),
-                LanguageAwareStyling {
-                    tree_sitter: false,
-                    diagnostics: false,
-                },
-                self.masked,
-                Highlights::default(),
-            )
-            .map(|h| h.text)
+        let chunks = self.block_snapshot.chunks(
+            BlockRow(display_row.0)..BlockRow(self.max_point().row().next_row().0),
+            LanguageAwareStyling {
+                tree_sitter: false,
+                diagnostics: false,
+            },
+            Highlights::default(),
+        );
+        self.mask_chunks_if_needed(chunks).map(|h| h.text)
     }
 
     /// Returns text chunks starting at the end of the given display row in reverse until the start of the file
     #[instrument(skip_all)]
     pub fn reverse_text_chunks(&self, display_row: DisplayRow) -> impl Iterator<Item = &str> {
         (0..=display_row.0).rev().flat_map(move |row| {
-            self.block_snapshot
-                .chunks(
-                    BlockRow(row)..BlockRow(row + 1),
-                    LanguageAwareStyling {
-                        tree_sitter: false,
-                        diagnostics: false,
-                    },
-                    self.masked,
-                    Highlights::default(),
-                )
+            let chunks = self.block_snapshot.chunks(
+                BlockRow(row)..BlockRow(row + 1),
+                LanguageAwareStyling {
+                    tree_sitter: false,
+                    diagnostics: false,
+                },
+                Highlights::default(),
+            );
+            self.mask_chunks_if_needed(chunks)
                 .map(|h| h.text)
                 .collect::<Vec<_>>()
                 .into_iter()
@@ -1828,18 +1940,29 @@ impl DisplaySnapshot {
         display_rows: Range<DisplayRow>,
         language_aware: LanguageAwareStyling,
         highlight_styles: HighlightStyles,
-    ) -> DisplayChunks<'_> {
-        self.block_snapshot.chunks(
+    ) -> impl Iterator<Item = Chunk<'_>> {
+        let chunks = self.block_snapshot.chunks(
             BlockRow(display_rows.start.0)..BlockRow(display_rows.end.0),
             language_aware,
-            self.masked,
             Highlights {
                 text_highlights: Some(&self.text_highlights),
                 inlay_highlights: Some(&self.inlay_highlights),
                 semantic_token_highlights: Some(&self.semantic_token_highlights),
                 styles: highlight_styles,
             },
-        )
+        );
+        self.mask_chunks_if_needed(chunks)
+    }
+
+    fn mask_chunks_if_needed<'a>(
+        &self,
+        chunks: impl Iterator<Item = Chunk<'a>>,
+    ) -> impl Iterator<Item = Chunk<'a>> {
+        if self.masked {
+            Either::Left(mask_chunks(chunks))
+        } else {
+            Either::Right(chunks)
+        }
     }
 
     #[instrument(skip_all)]
@@ -1849,15 +1972,60 @@ impl DisplaySnapshot {
         language_aware: LanguageAwareStyling,
         editor_style: &'a EditorStyle,
     ) -> impl Iterator<Item = HighlightedChunk<'a>> {
-        self.chunks(
+        let chunks = self.chunks(
             display_rows,
             language_aware,
             HighlightStyles {
                 inlay_hint: Some(editor_style.inlay_hints_style),
                 edit_prediction: Some(editor_style.edit_prediction_styles),
             },
-        )
-        .flat_map({
+        );
+        self.map_to_highlighted_chunks(chunks, editor_style)
+    }
+
+    pub(crate) fn highlighted_chunks_in_range<'a>(
+        &'a self,
+        range: Range<DisplayPoint>,
+        language_aware: LanguageAwareStyling,
+        editor_style: &'a EditorStyle,
+    ) -> impl Iterator<Item = HighlightedChunk<'a>> {
+        let range =
+            self.clip_point(range.start, Bias::Left)..self.clip_point(range.end, Bias::Right);
+        debug_assert!(
+            !self.has_soft_wraps() || (range.start.column() == 0 && range.end.column() == 0),
+            "column sub-ranges are unsupported with soft wraps: wrap chunks emit synthetic \
+             soft-wrap indentation whole, never clipped by column"
+        );
+        debug_assert!(
+            (range.start.row().0..=range.end.row().0)
+                .all(|row| !self.is_block_line(DisplayRow(row))),
+            "block rows are unsupported: this path reads the wrap snapshot, bypassing the block map"
+        );
+        let start = self.block_snapshot.to_wrap_point(range.start.0, Bias::Left);
+        let end = self.block_snapshot.to_wrap_point(range.end.0, Bias::Right);
+        let chunks = self.wrap_snapshot().chunks(
+            start..end,
+            language_aware,
+            Highlights {
+                text_highlights: Some(&self.text_highlights),
+                inlay_highlights: Some(&self.inlay_highlights),
+                semantic_token_highlights: Some(&self.semantic_token_highlights),
+                styles: HighlightStyles {
+                    inlay_hint: Some(editor_style.inlay_hints_style),
+                    edit_prediction: Some(editor_style.edit_prediction_styles),
+                },
+            },
+        );
+        let chunks = self.mask_chunks_if_needed(chunks);
+        self.map_to_highlighted_chunks(chunks, editor_style)
+    }
+
+    fn map_to_highlighted_chunks<'a>(
+        &'a self,
+        chunks: impl Iterator<Item = Chunk<'a>> + 'a,
+        editor_style: &'a EditorStyle,
+    ) -> impl Iterator<Item = HighlightedChunk<'a>> + 'a {
+        chunks.flat_map({
             // track the current underline style so that we can apply it to
             // inlay hints within the diagnostic's span
             let mut current_diagnostic_underline: Option<UnderlineStyle> = None;
@@ -1996,15 +2164,21 @@ impl DisplaySnapshot {
     pub fn layout_row(
         &self,
         display_row: DisplayRow,
-        TextLayoutDetails {
-            text_system,
-            editor_style,
-            rem_size,
-            scroll_anchor: _,
-            visible_rows: _,
-            vertical_scroll_margin: _,
-        }: &TextLayoutDetails,
-    ) -> Arc<LineLayout> {
+        details: &TextLayoutDetails,
+    ) -> RowLayout<'_> {
+        if display_row <= self.max_point().row() && !self.has_soft_wraps() {
+            let line_len = self.line_len(display_row);
+            if line_len as usize > MAX_LINE_LEN {
+                return RowLayout::Grid {
+                    snapshot: self,
+                    row: display_row,
+                    cell_width: self.grid_cell_width(details),
+                    len: line_len,
+                };
+            }
+        }
+
+        let editor_style = &details.editor_style;
         let mut runs = Vec::new();
         let mut line = String::new();
 
@@ -2038,15 +2212,19 @@ impl DisplaySnapshot {
             }
         }
 
-        let font_size = editor_style.text.font_size.to_pixels(*rem_size);
-        text_system.layout_line(&line, font_size, &runs, None)
+        let font_size = editor_style.text.font_size.to_pixels(details.rem_size);
+        RowLayout::Shaped(
+            details
+                .text_system
+                .layout_line(&line, font_size, &runs, None),
+        )
     }
 
     pub fn x_for_display_point(
         &self,
         display_point: DisplayPoint,
         text_layout_details: &TextLayoutDetails,
-    ) -> Pixels {
+    ) -> ScrollPixelOffset {
         let line = self.layout_row(display_point.row(), text_layout_details);
         line.x_for_index(display_point.column() as usize)
     }
@@ -2054,11 +2232,23 @@ impl DisplaySnapshot {
     pub fn display_column_for_x(
         &self,
         display_row: DisplayRow,
-        x: Pixels,
+        x: ScrollPixelOffset,
         details: &TextLayoutDetails,
     ) -> u32 {
         let layout_line = self.layout_row(display_row, details);
         layout_line.closest_index_for_x(x) as u32
+    }
+
+    pub(crate) fn grid_cell_width(&self, details: &TextLayoutDetails) -> Pixels {
+        let font_id = details
+            .text_system
+            .resolve_font(&details.editor_style.text.font());
+        let font_size = details
+            .editor_style
+            .text
+            .font_size
+            .to_pixels(details.rem_size);
+        details.text_system.em_layout_width(font_id, font_size)
     }
 
     #[instrument(skip_all)]
@@ -2902,6 +3092,56 @@ pub mod tests {
             log::info!("block text: {:?}", snapshot.block_snapshot.text());
             log::info!("display text: {:?}", snapshot.text());
 
+            let mut masked_snapshot = snapshot.clone();
+            masked_snapshot.masked = true;
+            let text = snapshot.text();
+            let masked_text = masked_snapshot.text();
+            assert_eq!(
+                masked_text.split('\n').count(),
+                text.split('\n').count(),
+                "masking must preserve display row structure"
+            );
+            for (masked_line, line) in masked_text.split('\n').zip(text.split('\n')) {
+                assert_eq!(
+                    masked_line,
+                    "*".repeat(line.chars().count()),
+                    "masking must emit one bullet per char of {line:?}"
+                );
+            }
+            let masked_chunks = masked_snapshot.chunks(
+                DisplayRow(0)..masked_snapshot.max_point().row().next_row(),
+                LanguageAwareStyling {
+                    tree_sitter: false,
+                    diagnostics: false,
+                },
+                HighlightStyles::default(),
+            );
+            for chunk in masked_chunks {
+                let mut expected_chars = 0u128;
+                let mut expected_newlines = 0u128;
+                for (ix, c) in chunk.text.char_indices() {
+                    expected_chars |= 1 << ix;
+                    if c == '\n' {
+                        expected_newlines |= 1 << ix;
+                    }
+                }
+                assert_eq!(
+                    chunk.tabs, 0,
+                    "masked chunk {:?} must have no tabs",
+                    chunk.text
+                );
+                assert_eq!(
+                    chunk.chars, expected_chars,
+                    "masked chunk {:?} has an inconsistent chars bitmask",
+                    chunk.text
+                );
+                assert_eq!(
+                    chunk.newlines, expected_newlines,
+                    "masked chunk {:?} has an inconsistent newlines bitmask",
+                    chunk.text
+                );
+            }
+
             // Line boundaries
             let buffer = snapshot.buffer_snapshot();
             for _ in 0..5 {
@@ -3057,33 +3297,33 @@ pub mod tests {
                 ),
                 (
                     DisplayPoint::new(DisplayRow(0), 7),
-                    language::SelectionGoal::HorizontalPosition(f64::from(x))
+                    language::SelectionGoal::HorizontalPosition(x)
                 )
             );
             assert_eq!(
                 movement::down(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(0), 7),
-                    language::SelectionGoal::HorizontalPosition(f64::from(x)),
+                    language::SelectionGoal::HorizontalPosition(x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(1), 10),
-                    language::SelectionGoal::HorizontalPosition(f64::from(x))
+                    language::SelectionGoal::HorizontalPosition(x)
                 )
             );
             assert_eq!(
                 movement::down(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(1), 10),
-                    language::SelectionGoal::HorizontalPosition(f64::from(x)),
+                    language::SelectionGoal::HorizontalPosition(x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(2), 4),
-                    language::SelectionGoal::HorizontalPosition(f64::from(x))
+                    language::SelectionGoal::HorizontalPosition(x)
                 )
             );
 
@@ -3336,6 +3576,352 @@ pub mod tests {
                 ("() {}\n}".to_string(), Some(Hsla::red())),
             ]
         );
+    }
+
+    #[gpui::test]
+    async fn test_highlighted_chunks_in_range_clips_to_char_boundaries(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let buffer = cx.new(|cx| Buffer::local(format!("{}\nplain", "α".repeat(16)), cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = cx.update(|cx| map.update(cx, |map, cx| map.snapshot(cx)));
+        let style = EditorStyle::default();
+        let language_aware = LanguageAwareStyling {
+            tree_sitter: false,
+            diagnostics: false,
+        };
+        let chunks_text = |range: Range<DisplayPoint>| {
+            snapshot
+                .highlighted_chunks_in_range(range, language_aware, &style)
+                .map(|chunk| chunk.text)
+                .collect::<String>()
+        };
+
+        assert_eq!(
+            chunks_text(DisplayPoint::new(DisplayRow(0), 2)..DisplayPoint::new(DisplayRow(0), 8)),
+            "ααα"
+        );
+        assert_eq!(
+            chunks_text(DisplayPoint::new(DisplayRow(0), 3)..DisplayPoint::new(DisplayRow(0), 9)),
+            "αααα"
+        );
+        assert_eq!(
+            chunks_text(DisplayPoint::new(DisplayRow(0), 31)..DisplayPoint::new(DisplayRow(1), 3)),
+            "α\npla"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_highlighted_chunks_in_range_masks_redacted_text(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let long_len = MAX_LINE_LEN * 2;
+        let buffer = cx.new(|cx| Buffer::local(format!("{}\nsecret", "x".repeat(long_len)), cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = cx.update(|cx| {
+            map.update(cx, |map, cx| {
+                map.masked = true;
+                map.snapshot(cx)
+            })
+        });
+        let style = EditorStyle::default();
+        let language_aware = LanguageAwareStyling {
+            tree_sitter: false,
+            diagnostics: false,
+        };
+        let chunks_text = |range: Range<DisplayPoint>| {
+            snapshot
+                .highlighted_chunks_in_range(range, language_aware, &style)
+                .map(|chunk| chunk.text)
+                .collect::<String>()
+        };
+
+        let window_start = long_len as u32 - 200;
+        assert_eq!(
+            chunks_text(
+                DisplayPoint::new(DisplayRow(0), window_start)
+                    ..DisplayPoint::new(DisplayRow(0), window_start + 10)
+            ),
+            "*".repeat(10)
+        );
+        assert_eq!(
+            chunks_text(
+                DisplayPoint::new(DisplayRow(0), long_len as u32 - 2)
+                    ..DisplayPoint::new(DisplayRow(1), 3)
+            ),
+            "**\n***"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_masked_text_chunks_preserve_newlines(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let buffer = cx.new(|cx| Buffer::local("secret\nwörds\nhere", cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = cx.update(|cx| {
+            map.update(cx, |map, cx| {
+                map.masked = true;
+                map.snapshot(cx)
+            })
+        });
+
+        assert_eq!(
+            snapshot.text_chunks(DisplayRow(0)).collect::<String>(),
+            "******\n*****\n****"
+        );
+        assert_eq!(
+            snapshot
+                .reverse_text_chunks(DisplayRow(2))
+                .collect::<String>(),
+            "****\n*****\n******"
+        );
+        assert_eq!(
+            snapshot
+                .chunks(
+                    DisplayRow(0)..DisplayRow(3),
+                    LanguageAwareStyling {
+                        tree_sitter: false,
+                        diagnostics: false,
+                    },
+                    HighlightStyles::default(),
+                )
+                .map(|chunk| chunk.text)
+                .collect::<String>(),
+            "******\n*****\n****"
+        );
+    }
+
+    #[test]
+    fn test_mask_chunks_splits_chunks_longer_than_bullets() {
+        let first_len = BULLETS.len() + 22;
+        let second_len = BULLETS.len() * 2 + 44;
+        let text = format!("{}\n{}", "α".repeat(first_len), "x".repeat(second_len));
+        let chunk = Chunk {
+            text: &text,
+            ..Chunk::default()
+        };
+
+        let masked = mask_chunks(std::iter::once(chunk)).collect::<Vec<_>>();
+
+        for chunk in &masked {
+            assert!(chunk.text.len() <= BULLETS.len());
+            assert_eq!(
+                chunk.chars,
+                1u128.unbounded_shl(chunk.text.len() as u32).wrapping_sub(1)
+            );
+        }
+        assert_eq!(
+            masked.iter().map(|chunk| chunk.text).collect::<String>(),
+            format!("{}\n{}", "*".repeat(first_len), "*".repeat(second_len))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_columnar_selection_on_huge_unwrapped_line_uses_monospace_grid(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let mut cx = crate::test::editor_test_context::EditorTestContext::new(cx).await;
+        let long_len = MAX_LINE_LEN * 2;
+        cx.set_state(&format!(
+            "ˇ{}\n{}",
+            "x".repeat(long_len),
+            "α".repeat(long_len)
+        ));
+
+        cx.update_editor(|editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window, cx);
+            let snapshot = editor.snapshot(window, cx);
+            let cell_width = snapshot
+                .x_for_display_point(DisplayPoint::new(DisplayRow(0), 1), &text_layout_details);
+            assert!(cell_width > 0.);
+
+            let positions = cell_width * 100.0..cell_width * 200.0;
+            let selection = editor
+                .selections
+                .build_columnar_selection(
+                    &snapshot,
+                    DisplayRow(0),
+                    &positions,
+                    false,
+                    &text_layout_details,
+                )
+                .unwrap();
+            assert_eq!(selection.start, Point::new(0, 100));
+            assert_eq!(selection.end, Point::new(0, 200));
+
+            let positions = cell_width * 101.0..cell_width * 200.0;
+            let selection = editor
+                .selections
+                .build_columnar_selection(
+                    &snapshot,
+                    DisplayRow(1),
+                    &positions,
+                    false,
+                    &text_layout_details,
+                )
+                .unwrap();
+            assert_eq!(selection.start, Point::new(1, 100));
+            assert_eq!(selection.end, Point::new(1, 200));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_navigation_on_huge_unwrapped_lines_uses_monospace_grid(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let mut cx = crate::test::editor_test_context::EditorTestContext::new(cx).await;
+        let long_len = MAX_LINE_LEN * 2;
+        cx.set_state(&format!(
+            "ˇ{}\n{}\nshort",
+            "x".repeat(long_len),
+            "α".repeat(long_len)
+        ));
+
+        cx.update_editor(|editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window, cx);
+            let snapshot = editor.snapshot(window, cx);
+
+            let column = (long_len - 10) as u32;
+            let x = snapshot.x_for_display_point(
+                DisplayPoint::new(DisplayRow(0), column),
+                &text_layout_details,
+            );
+            assert!(x > 0.);
+            assert_eq!(
+                snapshot.display_column_for_x(DisplayRow(0), x, &text_layout_details),
+                column
+            );
+
+            let odd_x = snapshot.x_for_display_point(
+                DisplayPoint::new(DisplayRow(0), (long_len - 9) as u32),
+                &text_layout_details,
+            );
+            assert_eq!(
+                snapshot.display_column_for_x(DisplayRow(1), odd_x, &text_layout_details),
+                (long_len - 10) as u32
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_layout_row_shapes_long_rows_when_soft_wrapped(cx: &mut gpui::TestAppContext) {
+        cx.background_executor
+            .set_block_on_ticks(usize::MAX..=usize::MAX);
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let mut cx = crate::test::editor_test_context::EditorTestContext::new(cx).await;
+        let editor = cx.editor.clone();
+        let window = cx.window;
+
+        cx.update_window(window, |_, window, cx| {
+            let text_layout_details =
+                editor.update(cx, |editor, cx| editor.text_layout_details(window, cx));
+
+            let buffer = MultiBuffer::build_simple(&"x".repeat(MAX_LINE_LEN * 3), cx);
+            let map = cx.new(|cx| {
+                DisplayMap::new(
+                    buffer,
+                    font("Helvetica"),
+                    px(14.0),
+                    Some(px(12_000.0)),
+                    1,
+                    1,
+                    FoldPlaceholder::test(),
+                    DiagnosticSeverity::Warning,
+                    cx,
+                )
+            });
+            let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+            assert!(snapshot.has_soft_wraps());
+            assert!(snapshot.line_len(DisplayRow(0)) as usize > MAX_LINE_LEN);
+
+            assert!(matches!(
+                snapshot.layout_row(DisplayRow(0), &text_layout_details),
+                RowLayout::Shaped(_)
+            ));
+        })
+        .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_masked_soft_wrapped_line_with_deep_indent(cx: &mut gpui::TestAppContext) {
+        cx.background_executor
+            .set_block_on_ticks(usize::MAX..=usize::MAX);
+        cx.update(|cx| init_test(cx, &|_| {}));
+
+        let text = format!("{}{}", " ".repeat(200), "x".repeat(2000));
+        let buffer = cx.new(|cx| Buffer::local(text, cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                Some(px(3000.0)),
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = cx.update(|cx| {
+            map.update(cx, |map, cx| {
+                map.masked = true;
+                map.snapshot(cx)
+            })
+        });
+        assert!(snapshot.max_point().row().0 > 0);
+
+        let masked_text = snapshot.text_chunks(DisplayRow(0)).collect::<String>();
+        let unmasked_line_count = snapshot.max_point().row().0 as usize + 1;
+        assert_eq!(masked_text.split('\n').count(), unmasked_line_count);
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -30,7 +30,6 @@ use text::{BufferId, Edit};
 use ui::{ElementId, IntoElement};
 
 const NEWLINES: &[u8; rope::Chunk::MASK_BITS] = &[b'\n'; _];
-const BULLETS: &[u8; rope::Chunk::MASK_BITS] = &[b'*'; _];
 
 /// Tracks custom blocks such as diagnostics that should be displayed within buffer.
 ///
@@ -559,7 +558,6 @@ pub struct BlockChunks<'a> {
     output_row: BlockRow,
     max_output_row: BlockRow,
     line_count_overflow: RowDelta,
-    masked: bool,
 }
 
 #[derive(Clone)]
@@ -2218,7 +2216,6 @@ impl BlockSnapshot {
                 tree_sitter: false,
                 diagnostics: false,
             },
-            false,
             Highlights::default(),
         )
         .map(|chunk| chunk.text)
@@ -2230,7 +2227,6 @@ impl BlockSnapshot {
         &'a self,
         rows: Range<BlockRow>,
         language_aware: LanguageAwareStyling,
-        masked: bool,
         highlights: Highlights<'a>,
     ) -> BlockChunks<'a> {
         let max_output_row = cmp::min(rows.end, self.transforms.summary().output_rows);
@@ -2254,7 +2250,7 @@ impl BlockSnapshot {
 
         BlockChunks {
             input_chunks: self.wrap_snapshot.chunks(
-                input_start..input_end,
+                WrapPoint::new(input_start, 0)..WrapPoint::new(input_end, 0),
                 language_aware,
                 highlights,
             ),
@@ -2263,7 +2259,6 @@ impl BlockSnapshot {
             output_row: rows.start,
             line_count_overflow: RowDelta(0),
             max_output_row,
-            masked,
         }
     }
 
@@ -2660,7 +2655,8 @@ impl BlockChunks<'_> {
                     self.transforms.end().1,
                     start_input_row + (self.max_output_row - start_output_row),
                 );
-                self.input_chunks.seek(start_input_row..end_input_row);
+                self.input_chunks
+                    .seek(WrapPoint::new(start_input_row, 0)..WrapPoint::new(end_input_row, 0));
             }
         }
     }
@@ -2737,31 +2733,20 @@ impl<'a> Iterator for BlockChunks<'a> {
             offset_for_row(self.input_chunk.text, transform_end - self.output_row);
         self.output_row += prefix_rows;
 
-        let (mut prefix, suffix) = self.input_chunk.text.split_at(prefix_bytes);
+        let (prefix, suffix) = self.input_chunk.text.split_at(prefix_bytes);
+        let mask = 1u128.unbounded_shl(prefix_bytes as u32).wrapping_sub(1);
+        let chars = self.input_chunk.chars & mask;
+        let tabs = self.input_chunk.tabs & mask;
+        let newlines = self.input_chunk.newlines & mask;
         self.input_chunk.text = suffix;
-        self.input_chunk.tabs >>= prefix_bytes.saturating_sub(1);
-        self.input_chunk.chars >>= prefix_bytes.saturating_sub(1);
-        self.input_chunk.newlines >>= prefix_bytes.saturating_sub(1);
-
-        let mut tabs = self.input_chunk.tabs;
-        let mut chars = self.input_chunk.chars;
-        let mut newlines = self.input_chunk.newlines;
-
-        if self.masked {
-            // Not great for multibyte text because to keep cursor math correct we
-            // need to have the same number of chars in the input as output.
-            let chars_count = prefix.chars().count();
-            let bullet_len = chars_count;
-            prefix = unsafe { std::str::from_utf8_unchecked(&BULLETS[..bullet_len]) };
-            chars = 1u128.unbounded_shl(bullet_len as u32).wrapping_sub(1);
-            tabs = 0;
-            newlines = 0;
-        }
+        self.input_chunk.tabs = self.input_chunk.tabs.unbounded_shr(prefix_bytes as u32);
+        self.input_chunk.chars = self.input_chunk.chars.unbounded_shr(prefix_bytes as u32);
+        self.input_chunk.newlines = self.input_chunk.newlines.unbounded_shr(prefix_bytes as u32);
 
         let chunk = Chunk {
             text: prefix,
-            tabs,
             chars,
+            tabs,
             newlines,
             ..self.input_chunk.clone()
         };
@@ -4494,7 +4479,6 @@ mod tests {
                             tree_sitter: false,
                             diagnostics: false,
                         },
-                        false,
                         Highlights::default(),
                     )
                     .map(|chunk| chunk.text)

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -145,7 +145,7 @@ pub struct WrapChunks<'a> {
     input_chunks: tab_map::TabChunks<'a>,
     input_chunk: Chunk<'a>,
     output_position: WrapPoint,
-    max_output_row: WrapRow,
+    max_output: WrapPoint,
     transforms: Cursor<'a, 'static, Transform, Dimensions<WrapPoint, TabPoint>>,
     snapshot: &'a WrapSnapshot,
 }
@@ -751,12 +751,12 @@ impl WrapSnapshot {
     #[ztracing::instrument(skip_all)]
     pub(crate) fn chunks<'a>(
         &'a self,
-        rows: Range<WrapRow>,
+        range: Range<WrapPoint>,
         language_aware: LanguageAwareStyling,
         highlights: Highlights<'a>,
     ) -> WrapChunks<'a> {
-        let output_start = WrapPoint::new(rows.start, 0);
-        let output_end = WrapPoint::new(rows.end, 0);
+        let output_start = range.start;
+        let output_end = range.end;
         let mut transforms = self
             .transforms
             .cursor::<Dimensions<WrapPoint, TabPoint>>(());
@@ -777,7 +777,7 @@ impl WrapSnapshot {
             ),
             input_chunk: Default::default(),
             output_position: output_start,
-            max_output_row: rows.end,
+            max_output: output_end,
             transforms,
             snapshot: self,
         }
@@ -786,6 +786,10 @@ impl WrapSnapshot {
     #[ztracing::instrument(skip_all)]
     pub fn max_point(&self) -> WrapPoint {
         WrapPoint(self.transforms.summary().output.lines)
+    }
+
+    pub fn has_soft_wraps(&self) -> bool {
+        self.transforms.summary().has_wraps()
     }
 
     #[ztracing::instrument(skip_all)]
@@ -1055,7 +1059,7 @@ impl WrapSnapshot {
     #[cfg(test)]
     pub fn text_chunks(&self, wrap_row: WrapRow) -> impl Iterator<Item = &str> {
         self.chunks(
-            wrap_row..self.max_point().row() + WrapRow(1),
+            WrapPoint::new(wrap_row, 0)..WrapPoint::new(self.max_point().row() + WrapRow(1), 0),
             LanguageAwareStyling {
                 tree_sitter: false,
                 diagnostics: false,
@@ -1138,9 +1142,9 @@ impl WrapPointCursor<'_> {
 
 impl WrapChunks<'_> {
     #[ztracing::instrument(skip_all)]
-    pub(crate) fn seek(&mut self, rows: Range<WrapRow>) {
-        let output_start = WrapPoint::new(rows.start, 0);
-        let output_end = WrapPoint::new(rows.end, 0);
+    pub(crate) fn seek(&mut self, range: Range<WrapPoint>) {
+        let output_start = range.start;
+        let output_end = range.end;
         self.transforms.seek(&output_start, Bias::Right);
         let mut input_start = TabPoint(self.transforms.start().1.0);
         if self.transforms.item().is_some_and(|t| t.is_isomorphic()) {
@@ -1153,7 +1157,7 @@ impl WrapChunks<'_> {
         self.input_chunks.seek(input_start..input_end);
         self.input_chunk = Chunk::default();
         self.output_position = output_start;
-        self.max_output_row = rows.end;
+        self.max_output = output_end;
     }
 }
 
@@ -1162,7 +1166,7 @@ impl<'a> Iterator for WrapChunks<'a> {
 
     #[ztracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.output_position.row() >= self.max_output_row {
+        if self.output_position >= self.max_output {
             return None;
         }
 
@@ -1176,7 +1180,8 @@ impl<'a> Iterator for WrapChunks<'a> {
                 // Exclude newline starting prior to the desired row.
                 start_ix = 1;
                 summary.row = 0;
-            } else if self.output_position.row() + WrapRow(1) >= self.max_output_row {
+            } else if WrapPoint::new(self.output_position.row() + WrapRow(1), 0) >= self.max_output
+            {
                 // Exclude soft indentation ending after the desired row.
                 end_ix = 1;
                 summary.column = 0;
@@ -1197,6 +1202,9 @@ impl<'a> Iterator for WrapChunks<'a> {
         let mut input_len = 0;
         let transform_end = self.transforms.end().0;
         for c in self.input_chunk.text.chars() {
+            if self.output_position >= self.max_output {
+                break;
+            }
             let char_len = c.len_utf8();
             input_len += char_len;
             if c == '\n' {
@@ -1931,7 +1939,7 @@ mod tests {
 
                 let actual_text = self
                     .chunks(
-                        WrapRow(start_row)..WrapRow(end_row),
+                        WrapPoint::new(WrapRow(start_row), 0)..WrapPoint::new(WrapRow(end_row), 0),
                         LanguageAwareStyling {
                             tree_sitter: true,
                             diagnostics: true,
@@ -1947,6 +1955,82 @@ mod tests {
                     start_row..end_row
                 );
             }
+
+            fn random_col(line: &str, rng: &mut impl Rng) -> u32 {
+                if line.is_empty() {
+                    return 0;
+                }
+                let mut col = rng.random_range(0..=line.len());
+                while !line.is_char_boundary(col) {
+                    col -= 1;
+                }
+                col as u32
+            }
+            let text = self.text();
+            let lines = text.split('\n').collect::<Vec<_>>();
+            for _ in 0..10 {
+                let end_row = rng.random_range(0..lines.len());
+                let start_row = rng.random_range(0..=end_row);
+                let start_col = random_col(lines[start_row], rng);
+                let end_col = random_col(lines[end_row], rng);
+                let start = WrapPoint::new(WrapRow(start_row as u32), start_col);
+                let end = WrapPoint::new(WrapRow(end_row as u32), end_col);
+                if start >= end || self.range_intersects_wrap(start..end) {
+                    continue;
+                }
+
+                let mut expected_text = String::new();
+                for row in start_row..=end_row {
+                    let line = lines[row];
+                    let s = if row == start_row {
+                        start_col as usize
+                    } else {
+                        0
+                    };
+                    let e = if row == end_row {
+                        end_col as usize
+                    } else {
+                        line.len()
+                    };
+                    expected_text.push_str(&line[s..e]);
+                    if row != end_row {
+                        expected_text.push('\n');
+                    }
+                }
+
+                let actual_text = self
+                    .chunks(
+                        start..end,
+                        LanguageAwareStyling {
+                            tree_sitter: true,
+                            diagnostics: true,
+                        },
+                        Highlights::default(),
+                    )
+                    .map(|c| c.text)
+                    .collect::<String>();
+                assert_eq!(
+                    expected_text,
+                    actual_text,
+                    "windowed chunks mismatch for range {:?}",
+                    start..end
+                );
+            }
+        }
+
+        fn range_intersects_wrap(&self, range: Range<WrapPoint>) -> bool {
+            let mut cursor = self.transforms.cursor::<WrapPoint>(());
+            cursor.seek(&range.start, Bias::Right);
+            while let Some(transform) = cursor.item() {
+                if *cursor.start() >= range.end {
+                    break;
+                }
+                if !transform.is_isomorphic() {
+                    return true;
+                }
+                cursor.next();
+            }
+            false
         }
     }
 }

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -1125,7 +1125,6 @@ impl Editor {
                         scroll_top,
                         scroll_bottom,
                         line_height,
-                        scroll_pixel_position,
                         target_display_point,
                         editor_width,
                         window,
@@ -1151,7 +1150,6 @@ impl Editor {
                     visible_row_range,
                     target_display_point,
                     line_height,
-                    scroll_pixel_position,
                     content_origin,
                     editor_width,
                     window,
@@ -1696,9 +1694,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<(AnyElement, gpui::Point<Pixels>)> {
-        let scrolled_content_origin =
-            content_origin - gpui::Point::new(scroll_pixel_position.x.into(), Pixels::ZERO);
-
         const SCROLL_PADDING_Y: Pixels = px(12.);
 
         if target_display_point.row() < visible_row_range.start {
@@ -1708,7 +1703,8 @@ impl Editor {
                 visible_row_range,
                 line_layouts,
                 newest_selection_head,
-                scrolled_content_origin,
+                content_origin,
+                scroll_pixel_position,
                 window,
                 cx,
             );
@@ -1719,7 +1715,8 @@ impl Editor {
                 visible_row_range,
                 line_layouts,
                 newest_selection_head,
-                scrolled_content_origin,
+                content_origin,
+                scroll_pixel_position,
                 window,
                 cx,
             );
@@ -1731,7 +1728,8 @@ impl Editor {
             line_layouts.get(target_display_point.row().minus(visible_row_range.start) as usize)?;
         let target_column = target_display_point.column() as usize;
 
-        let target_x = line_layout.x_for_index(target_column);
+        let target_x =
+            Pixels::from(line_layout.x_for_index(target_column) - scroll_pixel_position.x);
         let target_y = (target_display_point.row().as_f64() * f64::from(line_height))
             - scroll_pixel_position.y;
 
@@ -1761,7 +1759,7 @@ impl Editor {
 
         let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
 
-        let mut origin = scrolled_content_origin + point(target_x, target_y.into())
+        let mut origin = content_origin + point(target_x, target_y.into())
             - point(
                 if flag_on_right {
                     POLE_WIDTH
@@ -1785,7 +1783,8 @@ impl Editor {
         visible_row_range: Range<DisplayRow>,
         line_layouts: &[LineWithInvisibles],
         newest_selection_head: Option<DisplayPoint>,
-        scrolled_content_origin: gpui::Point<Pixels>,
+        content_origin: gpui::Point<Pixels>,
+        scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<(AnyElement, gpui::Point<Pixels>)> {
@@ -1800,9 +1799,10 @@ impl Editor {
             line_layouts.get(cursor.row().minus(visible_row_range.start) as usize)?;
         let cursor_column = cursor.column() as usize;
 
-        let cursor_character_x = cursor_row_layout.x_for_index(cursor_column);
+        let cursor_character_x =
+            Pixels::from(cursor_row_layout.x_for_index(cursor_column) - scroll_pixel_position.x);
 
-        let origin = scrolled_content_origin + point(cursor_character_x, to_y(size));
+        let origin = content_origin + point(cursor_character_x, to_y(size));
 
         element.prepaint_at(origin, window, cx);
         Some((element, origin))
@@ -1817,7 +1817,6 @@ impl Editor {
         scroll_top: ScrollOffset,
         scroll_bottom: ScrollOffset,
         line_height: Pixels,
-        scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
         target_display_point: DisplayPoint,
         editor_width: Pixels,
         window: &mut Window,
@@ -1868,7 +1867,6 @@ impl Editor {
                 visible_row_range,
                 target_display_point,
                 line_height,
-                scroll_pixel_position,
                 content_origin,
                 editor_width,
                 window,
@@ -1884,7 +1882,6 @@ impl Editor {
         visible_row_range: Range<DisplayRow>,
         target_display_point: DisplayPoint,
         line_height: Pixels,
-        scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
         content_origin: gpui::Point<Pixels>,
         editor_width: Pixels,
         window: &mut Window,
@@ -1904,8 +1901,7 @@ impl Editor {
         let line_origin =
             self.display_to_pixel_point(target_line_end, editor_snapshot, window, cx)?;
 
-        let start_point = content_origin - point(scroll_pixel_position.x.into(), Pixels::ZERO);
-        let mut origin = start_point
+        let mut origin = content_origin
             + line_origin
             + point(Self::EDIT_PREDICTION_POPOVER_PADDING_X, Pixels::ZERO);
         origin.x = origin.x.max(content_origin.x);
@@ -2049,6 +2045,7 @@ impl Editor {
                 editor_snapshot,
                 style,
                 editor_width,
+                None,
                 |_| false,
                 window,
                 cx,
@@ -2064,9 +2061,9 @@ impl Editor {
         let popover_right_bound = cmp::min(text_bounds.right(), viewport_bounds.right());
 
         let x_after_longest = Pixels::from(
-            ScrollPixelOffset::from(
-                text_bounds.origin.x + longest_line_width + Self::EDIT_PREDICTION_POPOVER_PADDING_X,
-            ) - scroll_pixel_position.x,
+            ScrollPixelOffset::from(text_bounds.origin.x + Self::EDIT_PREDICTION_POPOVER_PADDING_X)
+                + longest_line_width
+                - scroll_pixel_position.x,
         );
 
         let element_bounds = element.layout_as_root(AvailableSpace::min_size(), window, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -502,14 +502,9 @@ impl EditorMode {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SoftWrap {
-    /// Prefer not to wrap at all.
-    ///
-    /// Note: this is currently internal, as actually limited by [`crate::MAX_LINE_LEN`] until it wraps.
-    /// The mode is used inside git diff hunks, where it's seems currently more useful to not wrap as much as possible.
-    GitDiff,
-    /// Prefer a single line generally, unless an overly long line is encountered.
+    /// Do not soft-wrap.
     None,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
@@ -7638,9 +7633,7 @@ impl Editor {
                     *head.column_mut() += 1;
                     head = display_map.clip_point(head, Bias::Right);
                     let goal = SelectionGoal::HorizontalPosition(
-                        display_map
-                            .x_for_display_point(head, text_layout_details)
-                            .into(),
+                        display_map.x_for_display_point(head, text_layout_details),
                     );
                     selection.collapse_to(head, goal);
 
@@ -10693,10 +10686,10 @@ impl Editor {
     ) -> Option<gpui::Point<Pixels>> {
         let line_height = self.style(cx).text.line_height_in_pixels(window.rem_size());
         let text_layout_details = self.text_layout_details(window, cx);
-        let mut scroll_top = text_layout_details
+        let scroll_position = text_layout_details
             .scroll_anchor
-            .scroll_position(editor_snapshot)
-            .y;
+            .scroll_position(editor_snapshot);
+        let mut scroll_top = scroll_position.y;
         if !line_height.is_zero() {
             scroll_top =
                 window.pixel_snap_f64(scroll_top * f64::from(line_height)) / f64::from(line_height);
@@ -10705,9 +10698,18 @@ impl Editor {
         if source.row().as_f64() < scroll_top.floor() {
             return None;
         }
+        let em_width = ScrollPixelOffset::from(
+            editor_snapshot
+                .display_snapshot
+                .grid_cell_width(&text_layout_details),
+        );
+        let scroll_left = window.pixel_snap_f64(scroll_position.x * em_width);
         let source_x = editor_snapshot.x_for_display_point(source, &text_layout_details);
-        let source_y = line_height * (source.row().as_f64() - scroll_top) as f32;
-        Some(gpui::Point::new(source_x, source_y))
+        let source_y = (source.row().as_f64() - scroll_top) * f64::from(line_height);
+        Some(gpui::Point::new(
+            Pixels::from(source_x - scroll_left),
+            Pixels::from(source_y),
+        ))
     }
 
     pub fn register_addon<T: Addon>(&mut self, instance: T) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1043,13 +1043,15 @@ impl EditorElement {
                         [cursor_position.row().minus(visible_display_row_range.start) as usize];
                     let cursor_column = cursor_position.column() as usize;
 
-                    let cursor_character_x = cursor_row_layout.x_for_index(cursor_column)
-                        + cursor_row_layout
-                            .alignment_offset(self.style.text.text_align, text_hitbox.size.width);
-                    let cursor_next_x = cursor_row_layout.x_for_index(cursor_column + 1)
-                        + cursor_row_layout
-                            .alignment_offset(self.style.text.text_align, text_hitbox.size.width);
-                    let mut cell_width = cursor_next_x - cursor_character_x;
+                    let alignment_offset = ScrollPixelOffset::from(
+                        cursor_row_layout
+                            .alignment_offset(self.style.text.text_align, text_hitbox.size.width),
+                    );
+                    let cursor_character_x =
+                        cursor_row_layout.x_for_index(cursor_column) + alignment_offset;
+                    let cursor_next_x =
+                        cursor_row_layout.x_for_index(cursor_column + 1) + alignment_offset;
+                    let mut cell_width = Pixels::from(cursor_next_x - cursor_character_x);
                     if cell_width == Pixels::ZERO {
                         cell_width = em_advance;
                     }
@@ -1118,7 +1120,7 @@ impl EditorElement {
                         }
                     }
 
-                    let x = cursor_character_x - scroll_pixel_position.x.into();
+                    let x = Pixels::from(cursor_character_x - scroll_pixel_position.x);
                     let y = ((cursor_position.row().as_f64() - scroll_position.y)
                         * ScrollPixelOffset::from(line_height))
                     .into();
@@ -1260,11 +1262,11 @@ impl EditorElement {
 
         let row_index = label_row.minus(context.visible_display_row_range.start) as usize;
         let row_layout = &context.line_layouts[row_index];
-        let label_column = label_display_point.column().min(row_layout.len as u32) as usize;
-        let label_x = row_layout.x_for_index(label_column)
-            + row_layout.alignment_offset(context.text_align, context.content_width)
-            - context.scroll_pixel_position.x.into()
-            + label.x_offset;
+        let label_column = label_display_point.column().min(row_layout.full_len as u32) as usize;
+        let label_x =
+            Pixels::from(row_layout.x_for_index(label_column) - context.scroll_pixel_position.x)
+                + row_layout.alignment_offset(context.text_align, context.content_width)
+                + label.x_offset;
         let label_y = ((label_row.as_f64() - context.scroll_position.y)
             * ScrollPixelOffset::from(context.line_height))
         .into();
@@ -1632,13 +1634,13 @@ impl EditorElement {
                 let size = element.layout_as_root(available_space, window, cx);
 
                 let line = &lines[ix];
-                let padding = if line.width == Pixels::ZERO {
+                let padding = if line.width == 0. {
                     Pixels::ZERO
                 } else {
                     4. * em_width
                 };
                 let position = point(
-                    Pixels::from(scroll_pixel_position.x) + line.width + padding,
+                    Pixels::from(scroll_pixel_position.x + line.width) + padding,
                     line_height
                         * (DisplayRow(start_row.0 + ix as u32).as_f64() - scroll_position.y) as f32,
                 );
@@ -1804,7 +1806,7 @@ impl EditorElement {
                     crease_trailer.bounds.right()
                 } else {
                     Pixels::from(
-                        ScrollPixelOffset::from(content_origin.x + line_layout.width)
+                        ScrollPixelOffset::from(content_origin.x) + line_layout.width
                             - scroll_pixel_position.x,
                     )
                 };
@@ -2068,7 +2070,7 @@ impl EditorElement {
                 crease_trailer.bounds.right()
             } else {
                 Pixels::from(
-                    ScrollPixelOffset::from(content_origin.x + line_layout.width)
+                    ScrollPixelOffset::from(content_origin.x) + line_layout.width
                         - scroll_pixel_position.x,
                 )
             };
@@ -3061,11 +3063,27 @@ impl EditorElement {
         processed_ranges
     }
 
+    fn update_renderer_widths(
+        &self,
+        is_minimap: bool,
+        request_layout: &EditorRequestLayoutState,
+        line_layouts: &[LineWithInvisibles],
+        cx: &mut App,
+    ) -> bool {
+        !is_minimap
+            && request_layout.has_remaining_prepaint_depth()
+            && self.editor.update(cx, |editor, cx| {
+                editor.update_renderer_widths(renderer_widths(line_layouts), cx)
+            })
+    }
+
     fn layout_lines(
         rows: Range<DisplayRow>,
         snapshot: &EditorSnapshot,
         style: &EditorStyle,
         editor_width: Pixels,
+        cell_width: Pixels,
+        byte_columns_to_shape: Option<Range<usize>>,
         is_row_soft_wrapped: impl Copy + Fn(usize) -> bool,
         bg_segments_per_row: &[Vec<(Range<DisplayPoint>, Hsla)>],
         window: &mut Window,
@@ -3106,14 +3124,37 @@ impl EditorElement {
                         None,
                     );
                     LineWithInvisibles {
-                        width: line.width,
-                        len: line.len,
+                        width: line.width.into(),
+                        full_len: line.len,
                         fragments: smallvec![LineFragment::Text(line)],
                         invisibles: Vec::new(),
                         font_size,
+                        shaped_start_index: 0,
+                        grid_cell_width: cell_width,
                     }
                 })
                 .collect()
+        } else if let Some(byte_columns) = byte_columns_to_shape {
+            let mut layouts = Vec::with_capacity(rows.len());
+            for row in rows.start.0..rows.end.0 {
+                let display_row = DisplayRow(row);
+                let row_bg = bg_segments_per_row
+                    .get((row - rows.start.0) as usize)
+                    .map(std::slice::from_ref)
+                    .unwrap_or(&[]);
+                layouts.push(layout_windowed_row(
+                    display_row,
+                    &byte_columns,
+                    snapshot,
+                    style,
+                    editor_width,
+                    cell_width,
+                    row_bg,
+                    window,
+                    cx,
+                ));
+            }
+            layouts
         } else {
             let use_tree_sitter = !snapshot.semantic_tokens_enabled
                 || snapshot.use_tree_sitter_for_syntax(rows.start, cx);
@@ -3129,6 +3170,8 @@ impl EditorElement {
                 rows.len(),
                 &snapshot.mode,
                 editor_width,
+                cell_width,
+                None,
                 is_row_soft_wrapped,
                 bg_segments_per_row,
                 window,
@@ -3180,7 +3223,7 @@ impl EditorElement {
         em_width: Pixels,
         text_hitbox: &Hitbox,
         editor_width: Pixels,
-        scroll_width: &mut Pixels,
+        scroll_width: &mut ScrollPixelOffset,
         resized_blocks: &mut HashMap<CustomBlockId, u32>,
         row_block_types: &mut HashMap<DisplayRow, bool>,
         selections: &[Selection<Point>],
@@ -3204,8 +3247,8 @@ impl EditorElement {
                 let align_to = block_start.to_display_point(snapshot);
                 let x_and_width = |layout: &LineWithInvisibles| {
                     (
-                        text_x + layout.x_for_index(align_to.column() as usize),
-                        text_x + layout.width,
+                        text_x + Pixels::from(layout.x_for_index(align_to.column() as usize)),
+                        text_x + Pixels::from(layout.width),
                     )
                 };
                 let line_ix = align_to.row().0.checked_sub(rows.start.0);
@@ -3218,6 +3261,7 @@ impl EditorElement {
                             snapshot,
                             &self.style,
                             editor_width,
+                            None,
                             is_row_soft_wrapped,
                             window,
                             cx,
@@ -3252,7 +3296,7 @@ impl EditorElement {
                             block_id,
                             height: custom.height.unwrap_or(1),
                             selected,
-                            max_width: text_hitbox.size.width.max(*scroll_width),
+                            max_width: text_hitbox.size.width.max(Pixels::from(*scroll_width)),
                             editor_style: &self.style,
                             indent_guide_padding: indent_guides
                                 .as_ref()
@@ -3506,12 +3550,12 @@ impl EditorElement {
         hitbox: &Hitbox,
         text_hitbox: &Hitbox,
         editor_width: Pixels,
-        scroll_width: &mut Pixels,
+        scroll_width: &mut ScrollPixelOffset,
         editor_margins: &EditorMargins,
         em_width: Pixels,
         text_x: Pixels,
         line_height: Pixels,
-        line_layouts: &mut [LineWithInvisibles],
+        line_layouts: &[LineWithInvisibles],
         selections: &[Selection<Point>],
         selected_buffer_ids: &Vec<BufferId>,
         latest_selection_anchors: &HashMap<BufferId, Anchor>,
@@ -3593,14 +3637,16 @@ impl EditorElement {
                     .width
                     .max(fixed_block_max_width)
                     .max(
-                        editor_margins.gutter.width + *scroll_width + editor_margins.extended_right,
+                        editor_margins.gutter.width
+                            + Pixels::from(*scroll_width)
+                            + editor_margins.extended_right,
                     )
                     .into(),
                 (BlockStyle::Spacer, _) => hitbox
                     .size
                     .width
                     .max(fixed_block_max_width)
-                    .max(*scroll_width + editor_margins.extended_right)
+                    .max(Pixels::from(*scroll_width) + editor_margins.extended_right)
                     .into(),
                 (BlockStyle::Fixed, _) => unreachable!(),
             };
@@ -3665,7 +3711,9 @@ impl EditorElement {
                 BlockStyle::Fixed => AvailableSpace::MinContent,
                 BlockStyle::Flex => {
                     AvailableSpace::Definite(hitbox.size.width.max(fixed_block_max_width).max(
-                        editor_margins.gutter.width + *scroll_width + editor_margins.extended_right,
+                        editor_margins.gutter.width
+                            + Pixels::from(*scroll_width)
+                            + editor_margins.extended_right,
                     ))
                 }
                 BlockStyle::Spacer => AvailableSpace::Definite(
@@ -3673,7 +3721,7 @@ impl EditorElement {
                         .size
                         .width
                         .max(fixed_block_max_width)
-                        .max(*scroll_width + editor_margins.extended_right),
+                        .max(Pixels::from(*scroll_width) + editor_margins.extended_right),
                 ),
                 BlockStyle::Sticky => AvailableSpace::Definite(hitbox.size.width),
             };
@@ -3719,8 +3767,9 @@ impl EditorElement {
         }
 
         if resized_blocks.is_empty() {
-            *scroll_width =
-                (*scroll_width).max(fixed_block_max_width - editor_margins.gutter.width);
+            *scroll_width = (*scroll_width).max(ScrollPixelOffset::from(
+                fixed_block_max_width - editor_margins.gutter.width,
+            ));
         }
 
         RenderBlocksOutput {
@@ -3848,9 +3897,8 @@ impl EditorElement {
                 x: cmp::max(
                     px(0.),
                     Pixels::from(
-                        ScrollPixelOffset::from(
-                            cursor_row_layout.x_for_index(cursor.column() as usize),
-                        ) - scroll_pixel_position.x,
+                        cursor_row_layout.x_for_index(cursor.column() as usize)
+                            - scroll_pixel_position.x,
                     ),
                 ),
                 y: cmp::max(
@@ -4372,8 +4420,10 @@ impl EditorElement {
             as usize];
 
         // Compute Hovered Point
-        let x = hovered_row_layout.x_for_index(popover_position.column() as usize)
-            - Pixels::from(scroll_pixel_position.x);
+        let x = Pixels::from(
+            hovered_row_layout.x_for_index(popover_position.column() as usize)
+                - scroll_pixel_position.x,
+        );
         let y = Pixels::from(
             popover_position.row().as_f64() * ScrollPixelOffset::from(line_height)
                 - scroll_pixel_position.y,
@@ -4811,8 +4861,10 @@ impl EditorElement {
             return;
         };
 
-        let target_x = cursor_row_layout.x_for_index(newest_selection_head.column() as usize)
-            - Pixels::from(scroll_pixel_position.x);
+        let target_x = Pixels::from(
+            cursor_row_layout.x_for_index(newest_selection_head.column() as usize)
+                - scroll_pixel_position.x,
+        );
         let target_y = Pixels::from(
             selection_row.as_f64() * ScrollPixelOffset::from(line_height) - scroll_pixel_position.y,
         );
@@ -6250,10 +6302,9 @@ impl EditorElement {
                             start_x: if row == range.start.row() {
                                 layout.content_origin.x
                                     + Pixels::from(
-                                        ScrollPixelOffset::from(
-                                            line_layout.x_for_index(range.start.column() as usize)
-                                                + alignment_offset,
-                                        ) - layout.position_map.scroll_pixel_position.x,
+                                        line_layout.x_for_index(range.start.column() as usize)
+                                            + ScrollPixelOffset::from(alignment_offset)
+                                            - layout.position_map.scroll_pixel_position.x,
                                     )
                             } else {
                                 layout.content_origin.x + alignment_offset
@@ -6262,19 +6313,18 @@ impl EditorElement {
                             end_x: if row == range.end.row() {
                                 layout.content_origin.x
                                     + Pixels::from(
-                                        ScrollPixelOffset::from(
-                                            line_layout.x_for_index(range.end.column() as usize)
-                                                + alignment_offset,
-                                        ) - layout.position_map.scroll_pixel_position.x,
+                                        line_layout.x_for_index(range.end.column() as usize)
+                                            + ScrollPixelOffset::from(alignment_offset)
+                                            - layout.position_map.scroll_pixel_position.x,
                                     )
                             } else {
                                 Pixels::from(
                                     ScrollPixelOffset::from(
                                         layout.content_origin.x
-                                            + line_layout.width
                                             + alignment_offset
                                             + line_end_overshoot,
-                                    ) - layout.position_map.scroll_pixel_position.x,
+                                    ) + line_layout.width
+                                        - layout.position_map.scroll_pixel_position.x,
                                 )
                             },
                         }
@@ -7043,9 +7093,11 @@ fn render_blame_entry(
 pub(crate) struct LineWithInvisibles {
     fragments: SmallVec<[LineFragment; 1]>,
     invisibles: Vec<Invisible>,
-    len: usize,
-    pub(crate) width: Pixels,
+    full_len: usize,
+    pub(crate) width: ScrollPixelOffset,
     font_size: Pixels,
+    shaped_start_index: usize,
+    grid_cell_width: Pixels,
 }
 
 enum LineFragment {
@@ -7056,6 +7108,12 @@ enum LineFragment {
         size: Size<Pixels>,
         len: usize,
     },
+}
+
+#[derive(Copy, Clone)]
+struct RowWindow {
+    start_col: usize,
+    full_len: usize,
 }
 
 impl fmt::Debug for LineFragment {
@@ -7072,6 +7130,18 @@ impl fmt::Debug for LineFragment {
 }
 
 impl LineWithInvisibles {
+    fn grid_only(full_len: usize, font_size: Pixels, cell_width: Pixels) -> Self {
+        Self {
+            fragments: SmallVec::new(),
+            invisibles: Vec::new(),
+            full_len,
+            width: ScrollPixelOffset::from(cell_width) * full_len as ScrollPixelOffset,
+            font_size,
+            shaped_start_index: 0,
+            grid_cell_width: cell_width,
+        }
+    }
+
     fn from_chunks<'a>(
         chunks: impl Iterator<Item = HighlightedChunk<'a>>,
         editor_style: &EditorStyle,
@@ -7079,19 +7149,19 @@ impl LineWithInvisibles {
         max_line_count: usize,
         editor_mode: &EditorMode,
         text_width: Pixels,
+        cell_width: Pixels,
+        row_window: Option<RowWindow>,
         is_row_soft_wrapped: impl Copy + Fn(usize) -> bool,
         bg_segments_per_row: &[Vec<(Range<DisplayPoint>, Hsla)>],
         window: &mut Window,
         cx: &mut App,
     ) -> Vec<Self> {
         let text_style = &editor_style.text;
+        let col_base = row_window.as_ref().map_or(0, |w| w.start_col);
         let mut layouts = Vec::with_capacity(max_line_count);
         let mut fragments: SmallVec<[LineFragment; 1]> = SmallVec::new();
         let mut line = String::new();
-        // Byte offset into the logical line used to position invisible markers.
-        // Unlike `line`, this is not cleared when we flush `shape_line` for
-        // mid-line inlays/replacements, so marker offsets stay correct in that case.
-        let mut line_byte_offset: usize = 0;
+        let mut line_byte_offset: usize = col_base;
         let mut invisibles = Vec::new();
         let mut width = Pixels::ZERO;
         let mut len = 0;
@@ -7116,7 +7186,9 @@ impl LineWithInvisibles {
                     continue;
                 }
 
-                if len + line.len() + highlighted_chunk.text.len() > max_line_len {
+                if row_window.is_none()
+                    && len + line.len() + highlighted_chunk.text.len() > max_line_len
+                {
                     line_exceeded_max_len = true;
                     continue;
                 }
@@ -7126,7 +7198,12 @@ impl LineWithInvisibles {
                     let text_runs: &[TextRun] = if segments.is_empty() {
                         &styles
                     } else {
-                        &Self::split_runs_by_bg_segments(&styles, segments, min_contrast, len)
+                        &Self::split_runs_by_bg_segments(
+                            &styles,
+                            segments,
+                            min_contrast,
+                            col_base + len,
+                        )
                     };
                     let shaped_line = window.text_system().shape_line(
                         line.as_str().into(),
@@ -7215,7 +7292,12 @@ impl LineWithInvisibles {
                         let text_runs = if segments.is_empty() {
                             &styles
                         } else {
-                            &Self::split_runs_by_bg_segments(&styles, segments, min_contrast, len)
+                            &Self::split_runs_by_bg_segments(
+                                &styles,
+                                segments,
+                                min_contrast,
+                                col_base + len,
+                            )
                         };
                         let shaped_line = window.text_system().shape_line(
                             line.clone().into(),
@@ -7226,16 +7308,31 @@ impl LineWithInvisibles {
                         width += shaped_line.width;
                         len += shaped_line.len;
                         fragments.push(LineFragment::Text(shaped_line));
+                        let row_width = match row_window.as_ref() {
+                            Some(w) => {
+                                let cell = ScrollPixelOffset::from(cell_width);
+                                cell * col_base as ScrollPixelOffset
+                                    + ScrollPixelOffset::from(width)
+                                    + cell
+                                        * w.full_len.saturating_sub(col_base + len)
+                                            as ScrollPixelOffset
+                            }
+                            None => ScrollPixelOffset::from(width),
+                        };
                         layouts.push(Self {
-                            width: mem::take(&mut width),
-                            len: mem::take(&mut len),
+                            width: row_width,
+                            full_len: row_window.as_ref().map_or(len, |w| w.full_len),
                             fragments: mem::take(&mut fragments),
-                            invisibles: std::mem::take(&mut invisibles),
+                            invisibles: mem::take(&mut invisibles),
                             font_size,
+                            shaped_start_index: col_base,
+                            grid_cell_width: cell_width,
                         });
 
                         line.clear();
-                        line_byte_offset = 0;
+                        line_byte_offset = col_base;
+                        width = Pixels::ZERO;
+                        len = 0;
                         styles.clear();
                         row += 1;
                         line_exceeded_max_len = false;
@@ -7252,18 +7349,20 @@ impl LineWithInvisibles {
                             Cow::Borrowed(text_style)
                         };
 
-                        let current_line_len = len + line.len();
-                        if current_line_len + line_chunk.len() > max_line_len {
-                            let mut chunk_len = max_line_len - current_line_len;
-                            while !line_chunk.is_char_boundary(chunk_len) {
-                                chunk_len -= 1;
+                        if row_window.is_none() {
+                            let current_line_len = len + line.len();
+                            if current_line_len + line_chunk.len() > max_line_len {
+                                let mut chunk_len = max_line_len - current_line_len;
+                                while !line_chunk.is_char_boundary(chunk_len) {
+                                    chunk_len -= 1;
+                                }
+                                line_chunk = &line_chunk[..chunk_len];
+                                line_exceeded_max_len = true;
                             }
-                            line_chunk = &line_chunk[..chunk_len];
-                            line_exceeded_max_len = true;
-                        }
 
-                        if line_chunk.is_empty() {
-                            continue;
+                            if line_chunk.is_empty() {
+                                continue;
+                            }
                         }
 
                         styles.push(TextRun {
@@ -7428,7 +7527,7 @@ impl LineWithInvisibles {
         cx: &mut App,
     ) {
         let mut fragment_origin =
-            content_origin + gpui::point(Pixels::from(-scroll_pixel_position.x), line_y);
+            content_origin + gpui::point(self.scrolled_start_x(scroll_pixel_position.x), line_y);
         for fragment in &mut self.fragments {
             match fragment {
                 LineFragment::Text(line) => {
@@ -7488,7 +7587,7 @@ impl LineWithInvisibles {
         let line_height = layout.position_map.line_height;
         let mut fragment_origin = content_origin
             + gpui::point(
-                Pixels::from(-layout.position_map.scroll_pixel_position.x),
+                self.scrolled_start_x(layout.position_map.scroll_pixel_position.x),
                 line_y,
             );
 
@@ -7538,7 +7637,7 @@ impl LineWithInvisibles {
 
         let mut fragment_origin = content_origin
             + gpui::point(
-                Pixels::from(-layout.position_map.scroll_pixel_position.x),
+                self.scrolled_start_x(layout.position_map.scroll_pixel_position.x),
                 line_y,
             );
 
@@ -7594,14 +7693,14 @@ impl LineWithInvisibles {
             let token_x = self.x_for_index(token_offset);
             // Center the marker inside the actual glyph's width so it lines up with
             // proportional fonts instead of assuming a monospace `em_width` cell.
-            let glyph_width = (self.x_for_index(token_end_offset) - token_x).max(Pixels::ZERO);
-            let x_offset: ScrollPixelOffset = token_x.into();
+            let glyph_width =
+                Pixels::from(self.x_for_index(token_end_offset) - token_x).max(Pixels::ZERO);
             let invisible_offset: ScrollPixelOffset =
                 ((glyph_width - invisible_symbol.width).max(Pixels::ZERO) / 2.0).into();
             let origin = content_origin
                 + gpui::point(
                     Pixels::from(
-                        x_offset + invisible_offset - layout.position_map.scroll_pixel_position.x,
+                        token_x + invisible_offset - layout.position_map.scroll_pixel_position.x,
                     ),
                     line_y,
                 );
@@ -7633,7 +7732,7 @@ impl LineWithInvisibles {
             }),
 
             ShowWhitespaceSetting::Trailing => {
-                let mut previous_start = self.len;
+                let mut previous_start = self.full_len;
                 for ([start, end], paint) in invisible_iter.rev() {
                     if previous_start != end {
                         break;
@@ -7661,7 +7760,7 @@ impl LineWithInvisibles {
                         _ => false,
                     };
 
-                    if should_render || start == 0 || end == self.len {
+                    if should_render || start == 0 || end == self.full_len {
                         paint(window, cx);
 
                         // Since we are scanning from the left, we will skip over the first available whitespace that is part
@@ -7688,9 +7787,35 @@ impl LineWithInvisibles {
         }
     }
 
-    pub fn x_for_index(&self, index: usize) -> Pixels {
-        let mut fragment_start_x = Pixels::ZERO;
-        let mut fragment_start_index = 0;
+    fn start_x(&self) -> ScrollPixelOffset {
+        ScrollPixelOffset::from(self.grid_cell_width) * self.shaped_start_index as ScrollPixelOffset
+    }
+
+    fn scrolled_start_x(&self, scroll_x: ScrollPixelOffset) -> Pixels {
+        Pixels::from(self.start_x() - scroll_x)
+    }
+
+    fn shaped_len(&self) -> usize {
+        self.fragments
+            .iter()
+            .map(|fragment| match fragment {
+                LineFragment::Text(shaped_line) => shaped_line.len,
+                LineFragment::Element { len, .. } => *len,
+            })
+            .sum()
+    }
+
+    pub fn is_grid_positioned_index(&self, index: usize) -> bool {
+        index < self.shaped_start_index || index > self.shaped_start_index + self.shaped_len()
+    }
+
+    pub fn x_for_index(&self, index: usize) -> ScrollPixelOffset {
+        let cell_width = ScrollPixelOffset::from(self.grid_cell_width);
+        if index < self.shaped_start_index {
+            return cell_width * index as ScrollPixelOffset;
+        }
+        let mut fragment_start_x = self.start_x();
+        let mut fragment_start_index = self.shaped_start_index;
 
         for fragment in &self.fragments {
             match fragment {
@@ -7698,9 +7823,11 @@ impl LineWithInvisibles {
                     let fragment_end_index = fragment_start_index + shaped_line.len;
                     if index < fragment_end_index {
                         return fragment_start_x
-                            + shaped_line.x_for_index(index - fragment_start_index);
+                            + ScrollPixelOffset::from(
+                                shaped_line.x_for_index(index - fragment_start_index),
+                            );
                     }
-                    fragment_start_x += shaped_line.width;
+                    fragment_start_x += ScrollPixelOffset::from(shaped_line.width);
                     fragment_start_index = fragment_end_index;
                 }
                 LineFragment::Element { len, size, .. } => {
@@ -7708,35 +7835,51 @@ impl LineWithInvisibles {
                     if index < fragment_end_index {
                         return fragment_start_x;
                     }
-                    fragment_start_x += size.width;
+                    fragment_start_x += ScrollPixelOffset::from(size.width);
                     fragment_start_index = fragment_end_index;
                 }
             }
         }
 
-        fragment_start_x
+        if fragment_start_index < self.full_len {
+            fragment_start_x
+                + cell_width
+                    * (index.min(self.full_len) - fragment_start_index) as ScrollPixelOffset
+        } else {
+            fragment_start_x
+        }
     }
 
-    pub fn index_for_x(&self, x: Pixels) -> Option<usize> {
-        let mut fragment_start_x = Pixels::ZERO;
-        let mut fragment_start_index = 0;
+    pub fn index_for_x(&self, x: ScrollPixelOffset) -> Option<IndexForX> {
+        let cell_width = ScrollPixelOffset::from(self.grid_cell_width);
+        if self.shaped_start_index > 0 && x < self.start_x() {
+            if cell_width <= 0. {
+                return Some(self.classify_index(0));
+            }
+            let column = ((x / cell_width).round().max(0.) as usize).min(self.shaped_start_index);
+            return Some(self.classify_index(column));
+        }
+        let mut fragment_start_x = self.start_x();
+        let mut fragment_start_index = self.shaped_start_index;
 
         for fragment in &self.fragments {
             match fragment {
                 LineFragment::Text(shaped_line) => {
-                    let fragment_end_x = fragment_start_x + shaped_line.width;
+                    let fragment_end_x =
+                        fragment_start_x + ScrollPixelOffset::from(shaped_line.width);
                     if x < fragment_end_x {
-                        return Some(
-                            fragment_start_index + shaped_line.index_for_x(x - fragment_start_x)?,
-                        );
+                        return Some(IndexForX::Shaped(
+                            fragment_start_index
+                                + shaped_line.index_for_x(Pixels::from(x - fragment_start_x))?,
+                        ));
                     }
                     fragment_start_x = fragment_end_x;
                     fragment_start_index += shaped_line.len;
                 }
                 LineFragment::Element { len, size, .. } => {
-                    let fragment_end_x = fragment_start_x + size.width;
+                    let fragment_end_x = fragment_start_x + ScrollPixelOffset::from(size.width);
                     if x < fragment_end_x {
-                        return Some(fragment_start_index);
+                        return Some(IndexForX::Shaped(fragment_start_index));
                     }
                     fragment_start_index += len;
                     fragment_start_x = fragment_end_x;
@@ -7744,11 +7887,28 @@ impl LineWithInvisibles {
             }
         }
 
-        None
+        if fragment_start_index < self.full_len && cell_width > 0. {
+            let column = fragment_start_index
+                .saturating_add(((x - fragment_start_x) / cell_width).round().max(0.) as usize);
+            (column <= self.full_len).then(|| self.classify_index(column))
+        } else {
+            None
+        }
+    }
+
+    fn classify_index(&self, index: usize) -> IndexForX {
+        if self.is_grid_positioned_index(index) {
+            IndexForX::GridApproximation(index)
+        } else {
+            IndexForX::Shaped(index)
+        }
     }
 
     pub fn font_id_for_index(&self, index: usize) -> Option<FontId> {
-        let mut fragment_start_index = 0;
+        if index < self.shaped_start_index {
+            return None;
+        }
+        let mut fragment_start_index = self.shaped_start_index;
 
         for fragment in &self.fragments {
             match fragment {
@@ -7773,13 +7933,19 @@ impl LineWithInvisibles {
     }
 
     pub fn alignment_offset(&self, text_align: TextAlign, content_width: Pixels) -> Pixels {
-        let line_width = self.width;
+        let line_width = Pixels::from(self.width);
         match text_align {
             TextAlign::Left => px(0.0),
             TextAlign::Center => (content_width - line_width) / 2.0,
             TextAlign::Right => content_width - line_width,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexForX {
+    Shaped(usize),
+    GridApproximation(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8567,35 +8733,27 @@ impl Element for EditorElement {
                         self.style.background,
                     );
 
+                    let non_wrapping = self.editor.read(cx).soft_wrap_mode(cx) == SoftWrap::None;
+                    let visible_cols = visible_columns(editor_width, em_layout_width);
+                    let windowing_applies =
+                        non_wrapping && !snapshot.has_soft_wraps() && !em_layout_width.is_zero();
+                    let shaped_byte_columns = (windowing_applies
+                        && any_row_exceeds_shaping_limit(&snapshot, start_row..end_row))
+                    .then(|| byte_columns_to_shape(scroll_position.x, visible_cols));
+
                     let mut line_layouts = Self::layout_lines(
                         start_row..end_row,
                         &snapshot,
                         &self.style,
                         editor_width,
+                        em_layout_width,
+                        shaped_byte_columns.clone(),
                         is_row_soft_wrapped,
                         &bg_segments_per_row,
                         window,
                         cx,
                     );
-                    let new_renderer_widths = (!is_minimap).then(|| {
-                        line_layouts
-                            .iter()
-                            .flat_map(|layout| &layout.fragments)
-                            .filter_map(|fragment| {
-                                if let LineFragment::Element { id, size, .. } = fragment {
-                                    Some((*id, size.width))
-                                } else {
-                                    None
-                                }
-                            })
-                    });
-                    let renderer_widths_changed = request_layout.has_remaining_prepaint_depth()
-                        && new_renderer_widths.is_some_and(|new_renderer_widths| {
-                            self.editor.update(cx, |editor, cx| {
-                                editor.update_renderer_widths(new_renderer_widths, cx)
-                            })
-                        });
-                    if renderer_widths_changed {
+                    if self.update_renderer_widths(is_minimap, request_layout, &line_layouts, cx) {
                         return self.prepaint(
                             None,
                             _inspector_id,
@@ -8646,6 +8804,7 @@ impl Element for EditorElement {
                         &snapshot,
                         style,
                         editor_width,
+                        None,
                         is_row_soft_wrapped,
                         window,
                         cx,
@@ -8656,7 +8815,7 @@ impl Element for EditorElement {
                         text_hitbox.bounds,
                         glyph_grid_cell,
                         size(
-                            longest_line_width,
+                            Pixels::from(longest_line_width),
                             Pixels::from(max_row.as_f64() * f64::from(line_height)),
                         ),
                         longest_line_blame_width,
@@ -8664,7 +8823,8 @@ impl Element for EditorElement {
                         scroll_beyond_last_line,
                     );
 
-                    let mut scroll_width = scrollbar_layout_information.scroll_range.width;
+                    let mut scroll_width =
+                        longest_line_width + ScrollPixelOffset::from(longest_line_blame_width);
 
                     let sticky_header_excerpt = if snapshot.buffer_snapshot().show_headers() {
                         snapshot.sticky_header_excerpt(scroll_position.y)
@@ -8709,7 +8869,7 @@ impl Element for EditorElement {
                                     em_width,
                                     gutter_dimensions.full_width(),
                                     line_height,
-                                    &mut line_layouts,
+                                    &line_layouts,
                                     &local_selections,
                                     &selected_buffer_ids,
                                     &latest_selection_anchors,
@@ -8776,9 +8936,9 @@ impl Element for EditorElement {
                     };
 
                     let scroll_max: gpui::Point<ScrollPixelOffset> = point(
-                        ScrollPixelOffset::from(
-                            ((scroll_width - editor_width) / em_layout_width).max(0.0),
-                        ),
+                        ((scroll_width - ScrollPixelOffset::from(editor_width))
+                            / ScrollPixelOffset::from(em_layout_width))
+                        .max(0.0),
                         max_scroll_top,
                     );
 
@@ -8802,6 +8962,35 @@ impl Element for EditorElement {
                             scroll_position.x = new_scroll_position.x;
                         }
                     });
+
+                    if let Some(previous_byte_columns) = &shaped_byte_columns {
+                        let updated_byte_columns =
+                            byte_columns_to_shape(scroll_position.x, visible_cols);
+                        if updated_byte_columns != *previous_byte_columns {
+                            if request_layout.has_remaining_prepaint_depth() {
+                                return self.prepaint(
+                                    None,
+                                    _inspector_id,
+                                    bounds,
+                                    request_layout,
+                                    window,
+                                    cx,
+                                );
+                            }
+                            line_layouts = Self::layout_lines(
+                                start_row..end_row,
+                                &snapshot,
+                                &self.style,
+                                editor_width,
+                                em_layout_width,
+                                Some(updated_byte_columns),
+                                is_row_soft_wrapped,
+                                &bg_segments_per_row,
+                                window,
+                                cx,
+                            );
+                        }
+                    }
 
                     if !em_layout_width.is_zero() {
                         scroll_position.x = window
@@ -10182,48 +10371,14 @@ impl PositionMap {
         let scroll_position = self.scroll_position;
         let position = position - text_bounds.origin;
         let y = position.y.max(px(0.)).min(self.size.height);
-        let x = position.x + (scroll_position.x as f32 * self.em_layout_width);
+        let x = ScrollPixelOffset::from(position.x)
+            + scroll_position.x * ScrollPixelOffset::from(self.em_layout_width);
         let row = ((y / self.line_height) as f64 + scroll_position.y) as u32;
 
-        let (column, x_overshoot_after_line_end) = if let Some(line_index) =
-            row.checked_sub(self.visible_row_range.start.0)
-            && let Some(line) = self.line_layouts.get(line_index as usize)
-        {
-            let alignment_offset = line.alignment_offset(self.text_align, self.content_width);
-            let x_relative_to_text = x - alignment_offset;
-            if let Some(ix) = line.index_for_x(x_relative_to_text) {
-                (ix as u32, px(0.))
-            } else {
-                (line.len as u32, px(0.).max(x_relative_to_text - line.width))
-            }
-        } else {
-            (0, x)
-        };
-
-        let mut exact_unclipped = DisplayPoint::new(DisplayRow(row), column);
-        let previous_valid = self.snapshot.clip_point(exact_unclipped, Bias::Left);
-        let next_valid = self.snapshot.clip_point(exact_unclipped, Bias::Right);
-
-        let nearest_valid = if previous_valid == next_valid {
-            previous_valid
-        } else {
-            match self.snapshot.inlay_bias_at(exact_unclipped) {
-                Some(Bias::Left) => next_valid,
-                Some(Bias::Right) => previous_valid,
-                None => previous_valid,
-            }
-        };
-
-        let column_overshoot_after_line_end =
-            (x_overshoot_after_line_end / self.em_layout_width) as u32;
-        *exact_unclipped.column_mut() += column_overshoot_after_line_end;
-        PointForPosition {
-            previous_valid,
-            next_valid,
-            nearest_valid,
-            exact_unclipped,
-            column_overshoot_after_line_end,
-        }
+        let line = row
+            .checked_sub(self.visible_row_range.start.0)
+            .and_then(|line_index| self.line_layouts.get(line_index as usize));
+        self.resolve_point_for_position(DisplayRow(row), x, line)
     }
 
     fn point_for_position_on_line(
@@ -10235,20 +10390,63 @@ impl PositionMap {
         let text_bounds = self.text_hitbox.bounds;
         let scroll_position = self.scroll_position;
         let position = position - text_bounds.origin;
-        let x = position.x + (scroll_position.x as f32 * self.em_layout_width);
+        let x = ScrollPixelOffset::from(position.x)
+            + scroll_position.x * ScrollPixelOffset::from(self.em_layout_width);
 
-        let alignment_offset = line.alignment_offset(self.text_align, self.content_width);
-        let x_relative_to_text = x - alignment_offset;
-        let (column, x_overshoot_after_line_end) =
-            if let Some(ix) = line.index_for_x(x_relative_to_text) {
-                (ix as u32, px(0.))
+        self.resolve_point_for_position(row, x, Some(line))
+    }
+
+    fn resolve_point_for_position(
+        &self,
+        row: DisplayRow,
+        x: ScrollPixelOffset,
+        line: Option<&LineWithInvisibles>,
+    ) -> PointForPosition {
+        let line = line.map(|line| {
+            let alignment_offset = line.alignment_offset(self.text_align, self.content_width);
+            (line, x - ScrollPixelOffset::from(alignment_offset))
+        });
+        let (column, x_overshoot_after_line_end, column_may_split_char) =
+            if let Some((line, x_relative_to_text)) = line {
+                match line.index_for_x(x_relative_to_text) {
+                    Some(IndexForX::Shaped(ix)) => (ix as u32, px(0.), false),
+                    Some(IndexForX::GridApproximation(ix)) => {
+                        (ix as u32, px(0.), ix < line.full_len)
+                    }
+                    None => (
+                        line.full_len as u32,
+                        px(0.).max(Pixels::from(
+                            x_relative_to_text - line.x_for_index(line.full_len),
+                        )),
+                        false,
+                    ),
+                }
             } else {
-                (line.len as u32, px(0.).max(x_relative_to_text - line.width))
+                (0, Pixels::from(x), false)
             };
 
         let mut exact_unclipped = DisplayPoint::new(row, column);
-        let previous_valid = self.snapshot.clip_point(exact_unclipped, Bias::Left);
-        let next_valid = self.snapshot.clip_point(exact_unclipped, Bias::Right);
+        let mut previous_valid = self.snapshot.clip_point(exact_unclipped, Bias::Left);
+        let mut next_valid = self.snapshot.clip_point(exact_unclipped, Bias::Right);
+
+        if column_may_split_char
+            && previous_valid.row() == exact_unclipped.row()
+            && next_valid.row() == exact_unclipped.row()
+            && let Some((line, x_relative_to_text)) = line
+        {
+            let left = previous_valid.column();
+            let right = next_valid.column();
+            let column = if x_relative_to_text - line.x_for_index(left as usize)
+                <= line.x_for_index(right as usize) - x_relative_to_text
+            {
+                left
+            } else {
+                right
+            };
+            *exact_unclipped.column_mut() = column;
+            previous_valid = exact_unclipped;
+            next_valid = exact_unclipped;
+        }
 
         let nearest_valid = if previous_valid == next_valid {
             previous_valid
@@ -10284,11 +10482,134 @@ pub(crate) struct BlockLayout {
     pub(crate) is_buffer_header: bool,
 }
 
+fn renderer_widths(
+    line_layouts: &[LineWithInvisibles],
+) -> impl Iterator<Item = (ChunkRendererId, Pixels)> + '_ {
+    line_layouts
+        .iter()
+        .flat_map(|layout| &layout.fragments)
+        .filter_map(|fragment| match fragment {
+            LineFragment::Element { id, size, .. } => Some((*id, size.width)),
+            LineFragment::Text(_) => None,
+        })
+}
+
+fn visible_columns(editor_width: Pixels, cell_width: Pixels) -> usize {
+    if cell_width <= Pixels::ZERO {
+        return 1;
+    }
+    ((f64::from(editor_width / cell_width)).ceil() as usize).max(1)
+}
+
+fn any_row_exceeds_shaping_limit(snapshot: &EditorSnapshot, rows: Range<DisplayRow>) -> bool {
+    if rows.start >= rows.end {
+        return false;
+    }
+    let longest_visible_len =
+        snapshot.line_len(snapshot.longest_row_in_range(rows.start..rows.end)) as usize;
+    longest_visible_len > MAX_LINE_LEN
+        || (longest_visible_len > MAX_LINE_LEN / 4
+            && (rows.start.0..rows.end.0)
+                .any(|row| snapshot.line_len(DisplayRow(row)) as usize > MAX_LINE_LEN))
+}
+
+fn byte_columns_to_shape(scroll_x: ScrollOffset, visible_cols: usize) -> Range<usize> {
+    let block = (scroll_x.max(0.).floor() as usize) / visible_cols;
+    let start = block.saturating_sub(1).saturating_mul(visible_cols);
+    start..start.saturating_add(visible_cols.saturating_mul(4))
+}
+
+fn layout_windowed_row(
+    display_row: DisplayRow,
+    byte_columns: &Range<usize>,
+    snapshot: &EditorSnapshot,
+    style: &EditorStyle,
+    editor_width: Pixels,
+    cell_width: Pixels,
+    row_bg: &[Vec<(Range<DisplayPoint>, Hsla)>],
+    window: &mut Window,
+    cx: &mut App,
+) -> LineWithInvisibles {
+    let use_tree_sitter =
+        !snapshot.semantic_tokens_enabled || snapshot.use_tree_sitter_for_syntax(display_row, cx);
+    let language_aware = LanguageAwareStyling {
+        tree_sitter: use_tree_sitter,
+        diagnostics: true,
+    };
+    let mut layouts = if snapshot.is_block_line(display_row) {
+        let chunks = snapshot.highlighted_chunks(
+            display_row..display_row + DisplayRow(1),
+            language_aware,
+            style,
+        );
+        LineWithInvisibles::from_chunks(
+            chunks,
+            style,
+            MAX_LINE_LEN,
+            1,
+            &snapshot.mode,
+            editor_width,
+            cell_width,
+            None,
+            |_| false,
+            row_bg,
+            window,
+            cx,
+        )
+    } else {
+        let full_len = snapshot.line_len(display_row) as usize;
+        let start_col = snapshot
+            .clip_point(
+                DisplayPoint::new(display_row, byte_columns.start.min(full_len) as u32),
+                Bias::Left,
+            )
+            .column() as usize;
+        let end_col = snapshot
+            .clip_point(
+                DisplayPoint::new(display_row, byte_columns.end.min(full_len) as u32),
+                Bias::Right,
+            )
+            .column() as usize;
+        let chunks = snapshot.highlighted_chunks_in_range(
+            DisplayPoint::new(display_row, start_col as u32)
+                ..DisplayPoint::new(display_row, end_col as u32),
+            language_aware,
+            style,
+        );
+        LineWithInvisibles::from_chunks(
+            chunks,
+            style,
+            MAX_LINE_LEN,
+            1,
+            &snapshot.mode,
+            editor_width,
+            cell_width,
+            Some(RowWindow {
+                start_col,
+                full_len,
+            }),
+            |_| false,
+            row_bg,
+            window,
+            cx,
+        )
+    };
+    layouts.pop().unwrap_or_else(|| {
+        debug_panic!("from_chunks always yields at least one layout");
+        LineWithInvisibles::grid_only(
+            snapshot.line_len(display_row) as usize,
+            style.text.font_size.to_pixels(window.rem_size()),
+            cell_width,
+        )
+    })
+}
+
 pub fn layout_line(
     row: DisplayRow,
     snapshot: &EditorSnapshot,
     style: &EditorStyle,
     text_width: Pixels,
+    byte_columns_to_shape: Option<Range<usize>>,
     is_row_soft_wrapped: impl Copy + Fn(usize) -> bool,
     window: &mut Window,
     cx: &mut App,
@@ -10299,6 +10620,26 @@ pub fn layout_line(
         tree_sitter: use_tree_sitter,
         diagnostics: true,
     };
+    let font_id = window.text_system().resolve_font(&style.text.font());
+    let font_size = style.text.font_size.to_pixels(window.rem_size());
+    let cell_width = window.text_system().em_layout_width(font_id, font_size);
+    let full_len = snapshot.line_len(row) as usize;
+    if full_len > MAX_LINE_LEN && !snapshot.is_block_line(row) && !snapshot.has_soft_wraps() {
+        return match byte_columns_to_shape {
+            Some(byte_columns) => layout_windowed_row(
+                row,
+                &byte_columns,
+                snapshot,
+                style,
+                text_width,
+                cell_width,
+                &[],
+                window,
+                cx,
+            ),
+            None => LineWithInvisibles::grid_only(full_len, font_size, cell_width),
+        };
+    }
     let chunks = snapshot.highlighted_chunks(row..row + DisplayRow(1), language_aware, style);
     LineWithInvisibles::from_chunks(
         chunks,
@@ -10307,6 +10648,8 @@ pub fn layout_line(
         1,
         &snapshot.mode,
         text_width,
+        cell_width,
+        None,
         is_row_soft_wrapped,
         &[],
         window,
@@ -10667,8 +11010,7 @@ fn calculate_wrap_width(
     let wrap_width_for = |column: u32| (column as f32 * em_width).ceil();
 
     match soft_wrap {
-        SoftWrap::GitDiff => None,
-        SoftWrap::None => Some(wrap_width_for(MAX_LINE_LEN as u32 / 2)),
+        SoftWrap::None => None,
         SoftWrap::EditorWidth => Some(editor_width),
         SoftWrap::Bounded(column) => Some(editor_width.min(wrap_width_for(column))),
     }
@@ -10710,7 +11052,7 @@ fn compute_auto_height_layout(
     let editor_width = text_width - gutter_dimensions.margin - overscroll.width - em_width;
     let wrap_width = calculate_wrap_width(editor.soft_wrap_mode(cx), editor_width, em_width)
         .map(|width| width.min(editor_width));
-    if wrap_width.is_some() && editor.set_wrap_width(wrap_width, cx) {
+    if editor.set_wrap_width(wrap_width, cx) {
         snapshot = editor.snapshot(window, cx);
     }
 
@@ -10733,8 +11075,9 @@ fn compute_auto_height_layout(
 mod tests {
     use super::*;
     use crate::{
-        Editor, FoldPlaceholder, HighlightKey, Inlay, MultiBuffer, NavigationOverlayKey,
-        NavigationOverlayLabel, NavigationTargetOverlay, SelectionEffects,
+        Autoscroll, Editor, FoldPlaceholder, HighlightKey, Inlay, MultiBuffer,
+        NavigationOverlayKey, NavigationOverlayLabel, NavigationTargetOverlay, SelectionEffects,
+        ToggleSoftWrap,
         display_map::{BlockPlacement, BlockProperties, DisplayMap},
         editor_tests::{init_test, update_test_language_settings},
     };
@@ -11238,11 +11581,11 @@ mod tests {
         // click at the end of the second line
         let target_point = DisplayPoint::new(DisplayRow(1), 3);
         let click_x = state.content_origin.x
-            + editor.update_in(cx, |editor, window, cx| {
+            + Pixels::from(editor.update_in(cx, |editor, window, cx| {
                 editor
                     .snapshot(window, cx)
                     .x_for_display_point(target_point, &editor.text_layout_details(window, cx))
-            });
+            }));
 
         let point = state
             .position_map
@@ -11959,6 +12302,8 @@ mod tests {
                     1,
                     &editor_mode,
                     px(500.),
+                    px(10.),
+                    None,
                     |_| false,
                     &[],
                     window,
@@ -11966,10 +12311,339 @@ mod tests {
                 );
 
                 assert_eq!(layouts.len(), 1);
-                assert_eq!(layouts[0].len, max_line_len);
+                assert_eq!(layouts[0].full_len, max_line_len);
                 assert!(layouts[0].fragments.len() <= max_line_len);
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    fn test_row_window_shapes_only_visible_columns(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple("", cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+        let editor_mode = EditorMode::full();
+        let cell_width = px(10.);
+        let windowed = "a".repeat(100);
+
+        window
+            .update(cx, |_, window, cx| {
+                let chunks = std::iter::once(HighlightedChunk {
+                    text: &windowed,
+                    style: None,
+                    is_tab: false,
+                    is_inlay: false,
+                    replacement: None,
+                });
+
+                let layouts = LineWithInvisibles::from_chunks(
+                    chunks,
+                    &style,
+                    usize::MAX,
+                    1,
+                    &editor_mode,
+                    px(10_000.),
+                    cell_width,
+                    Some(RowWindow {
+                        start_col: 100,
+                        full_len: 300,
+                    }),
+                    |_| false,
+                    &[],
+                    window,
+                    cx,
+                );
+
+                assert_eq!(layouts.len(), 1);
+                let layout = &layouts[0];
+
+                assert_eq!(layout.full_len, 300);
+                assert_eq!(layout.shaped_start_index, 100);
+                assert_eq!(layout.start_x(), f64::from(cell_width * 100.));
+
+                assert_eq!(layout.shaped_len(), 100);
+
+                assert_eq!(layout.x_for_index(0), 0.);
+                assert_eq!(
+                    layout.index_for_x(0.),
+                    Some(IndexForX::GridApproximation(0))
+                );
+
+                let inside = layout.x_for_index(150);
+                let Some(IndexForX::Shaped(inside_index)) = layout.index_for_x(inside) else {
+                    panic!("expected a shaped index inside the window");
+                };
+                assert!((inside_index as isize - 150).abs() <= 1);
+
+                let window_start = layout.x_for_index(100);
+                assert_eq!(window_start, layout.start_x());
+                assert_eq!(
+                    layout.index_for_x(window_start),
+                    Some(IndexForX::Shaped(100))
+                );
+                let window_end = layout.x_for_index(200);
+                assert_eq!(layout.index_for_x(window_end), Some(IndexForX::Shaped(200)));
+                assert!(layout.is_grid_positioned_index(99));
+                assert!(layout.is_grid_positioned_index(201));
+
+                let right_of_window = layout.x_for_index(250);
+                assert_eq!(
+                    layout.index_for_x(right_of_window),
+                    Some(IndexForX::GridApproximation(250))
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn test_fully_windowed_row_keeps_shaped_width(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple("", cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+        let editor_mode = EditorMode::full();
+        let cell_width = px(10.);
+        let text = "a".repeat(100);
+
+        window
+            .update(cx, |_, window, cx| {
+                let chunks = std::iter::once(HighlightedChunk {
+                    text: &text,
+                    style: None,
+                    is_tab: false,
+                    is_inlay: false,
+                    replacement: None,
+                });
+
+                let layouts = LineWithInvisibles::from_chunks(
+                    chunks,
+                    &style,
+                    usize::MAX,
+                    1,
+                    &editor_mode,
+                    px(10_000.),
+                    cell_width,
+                    Some(RowWindow {
+                        start_col: 0,
+                        full_len: 100,
+                    }),
+                    |_| false,
+                    &[],
+                    window,
+                    cx,
+                );
+
+                assert_eq!(layouts.len(), 1);
+                let layout = &layouts[0];
+                assert_eq!(layout.full_len, 100);
+                assert_eq!(layout.shaped_start_index, 0);
+
+                let shaped_width = layout
+                    .fragments
+                    .iter()
+                    .map(|fragment| match fragment {
+                        LineFragment::Text(shaped) => shaped.width,
+                        LineFragment::Element { size, .. } => size.width,
+                    })
+                    .fold(Pixels::ZERO, |acc, width| acc + width);
+                assert_eq!(layout.width, ScrollPixelOffset::from(shaped_width));
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn test_layout_line_shapes_window_of_long_rows(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let long_len = MAX_LINE_LEN * 2;
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(&"a".repeat(long_len), cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+
+        window
+            .update(cx, |editor, window, cx| {
+                let snapshot = editor.snapshot(window, cx);
+
+                let grid_only = layout_line(
+                    DisplayRow(0),
+                    &snapshot,
+                    &style,
+                    px(500.),
+                    None,
+                    |_| false,
+                    window,
+                    cx,
+                );
+                assert_eq!(grid_only.full_len, long_len);
+                assert_eq!(grid_only.fragments.len(), 0);
+
+                let windowed = layout_line(
+                    DisplayRow(0),
+                    &snapshot,
+                    &style,
+                    px(500.),
+                    Some(100..200),
+                    |_| false,
+                    window,
+                    cx,
+                );
+                assert_eq!(windowed.full_len, long_len);
+                assert_eq!(windowed.shaped_start_index, 100);
+                assert_eq!(windowed.shaped_len(), 100);
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_soft_wrap_toggle_on_huge_line_while_scrolled(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let long_len = MAX_LINE_LEN * 100;
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(&"x".repeat(long_len), cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+        let editor_size = size(px(500.), px(500.));
+
+        let (_, state) = cx.draw(Default::default(), editor_size, |window, cx| {
+            editor.update(cx, |editor, cx| {
+                editor.change_selections(
+                    SelectionEffects::scroll(Autoscroll::fit()),
+                    window,
+                    cx,
+                    |s| {
+                        let end = Point::new(0, long_len as u32);
+                        s.select_ranges([end..end])
+                    },
+                );
+            });
+            EditorElement::new(&editor, style.clone())
+        });
+        let position_map = &state.position_map;
+        assert!(position_map.scroll_position.x > 0.);
+        let line = &position_map.line_layouts[0];
+        assert_eq!(line.full_len, long_len);
+        assert!(line.shaped_start_index > 0);
+        assert!(line.shaped_len() < long_len);
+        assert!(!line.is_grid_positioned_index(long_len));
+        let cursor_x = line.x_for_index(long_len);
+        assert!(cursor_x >= position_map.scroll_pixel_position.x);
+        assert!(
+            cursor_x <= position_map.scroll_pixel_position.x + f64::from(editor_size.width),
+            "cursor at the end of the line must be autoscrolled into view"
+        );
+
+        window
+            .update(cx, |editor, window, cx| {
+                editor.toggle_soft_wrap(&ToggleSoftWrap, window, cx);
+            })
+            .unwrap();
+
+        cx.draw(Default::default(), editor_size, |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+        cx.run_until_parked();
+        let (_, state) = cx.draw(Default::default(), editor_size, |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+        assert!(state.position_map.snapshot.has_soft_wraps());
+        assert_eq!(state.position_map.scroll_position.x, 0.);
+        assert_eq!(state.position_map.scroll_max.x, 0.);
+
+        window
+            .update(cx, |editor, window, cx| {
+                editor.toggle_soft_wrap(&ToggleSoftWrap, window, cx);
+            })
+            .unwrap();
+
+        cx.draw(Default::default(), editor_size, |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+        cx.run_until_parked();
+        let (_, state) = cx.draw(Default::default(), editor_size, |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+        let position_map = &state.position_map;
+        assert!(!position_map.snapshot.has_soft_wraps());
+        let line = &position_map.line_layouts[0];
+        assert_eq!(line.full_len, long_len);
+        assert!(line.shaped_len() < long_len);
+    }
+
+    #[gpui::test]
+    async fn test_point_for_position_snaps_grid_columns_to_char_boundaries(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx, |_| {});
+
+        let long_chars = MAX_LINE_LEN * 2;
+        let byte_len = long_chars * 2;
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(&"α".repeat(long_chars), cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+
+        let (_, state) = cx.draw(
+            Default::default(),
+            size(px(500.), px(500.)),
+            |window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(
+                        SelectionEffects::scroll(Autoscroll::fit()),
+                        window,
+                        cx,
+                        |s| {
+                            let end = Point::new(0, byte_len as u32);
+                            s.select_ranges([end..end])
+                        },
+                    );
+                });
+                EditorElement::new(&editor, style.clone())
+            },
+        );
+        let position_map = &state.position_map;
+        let line = &position_map.line_layouts[0];
+        assert!(line.shaped_start_index > 0);
+        assert_eq!(line.shaped_start_index % 2, 0);
+        let odd_column = line.shaped_start_index - 51;
+
+        let target_x = odd_column as f64 * f64::from(position_map.em_layout_width);
+        let position = gpui::point(
+            position_map.text_hitbox.bounds.origin.x
+                + Pixels::from(target_x - position_map.scroll_pixel_position.x),
+            position_map.text_hitbox.bounds.origin.y + px(1.),
+        );
+        let point_for_position = position_map.point_for_position(position);
+
+        assert_eq!(
+            point_for_position.exact_unclipped,
+            DisplayPoint::new(DisplayRow(0), odd_column as u32 - 1)
+        );
+        assert_eq!(
+            point_for_position.previous_valid,
+            DisplayPoint::new(DisplayRow(0), odd_column as u32 - 1)
+        );
     }
 
     #[gpui::test]
@@ -12492,18 +13166,23 @@ mod tests {
     }
 
     #[test]
+    fn test_byte_columns_to_shape() {
+        assert_eq!(byte_columns_to_shape(0., 100), 0..400);
+        assert_eq!(byte_columns_to_shape(99.9, 100), 0..400);
+        assert_eq!(byte_columns_to_shape(100., 100), 0..400);
+        assert_eq!(byte_columns_to_shape(200., 100), 100..500);
+        assert_eq!(byte_columns_to_shape(-5., 100), 0..400);
+        assert_eq!(byte_columns_to_shape(1_000_000., 100), 999_900..1_000_300);
+    }
+
+    #[test]
     fn test_calculate_wrap_width() {
         let editor_width = px(800.0);
         let em_width = px(8.0);
 
         assert_eq!(
-            calculate_wrap_width(SoftWrap::GitDiff, editor_width, em_width),
-            None,
-        );
-
-        assert_eq!(
             calculate_wrap_width(SoftWrap::None, editor_width, em_width),
-            Some(px((MAX_LINE_LEN as f32 / 2.0 * 8.0).ceil())),
+            None,
         );
 
         assert_eq!(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12510,6 +12510,49 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_layout_line_shapes_char_aligned_window_of_long_unicode_rows(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let text = "e\u{301} العربية क्षि ก้ 漢字 🧑🏽‍💻 ".repeat(100);
+        assert!(text.len() > MAX_LINE_LEN);
+        let requested_start = (MAX_LINE_LEN..text.len())
+            .find(|index| !text.is_char_boundary(*index))
+            .expect("the test text must contain a multibyte character after the shaping limit");
+        let requested_end = (requested_start + 400).min(text.len());
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(&text, cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+
+        window
+            .update(cx, |editor, window, cx| {
+                let snapshot = editor.snapshot(window, cx);
+                let layout = layout_line(
+                    DisplayRow(0),
+                    &snapshot,
+                    &style,
+                    px(500.),
+                    Some(requested_start..requested_end),
+                    |_| false,
+                    window,
+                    cx,
+                );
+                let shaped_end = layout.shaped_start_index + layout.shaped_len();
+
+                assert_eq!(layout.full_len, text.len());
+                assert!(layout.shaped_start_index <= requested_start);
+                assert!(shaped_end >= requested_end);
+                assert!(text.is_char_boundary(layout.shaped_start_index));
+                assert!(text.is_char_boundary(shaped_end));
+                assert!(layout.shaped_len() < text.len());
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
     async fn test_soft_wrap_toggle_on_huge_line_while_scrolled(cx: &mut TestAppContext) {
         init_test(cx, |_| {});
 

--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -27,8 +27,8 @@ use util::ResultExt;
 use workspace::{ItemHandle, ItemSettings, OpenInTerminal, OpenTerminal, RevealInProjectPanel};
 
 use super::{
-    BlockLayout, EditorElement, EditorLayout, LineWithInvisibles, layout_line,
-    render_breadcrumb_text,
+    BlockLayout, EditorElement, EditorLayout, LineWithInvisibles, byte_columns_to_shape,
+    layout_line, render_breadcrumb_text, visible_columns,
 };
 use crate::{
     BUFFER_HEADER_PADDING, DisplayRow, Editor, EditorSettings, EditorSnapshot, FILE_HEADER_HEIGHT,
@@ -249,6 +249,16 @@ impl EditorElement {
 
         let mut lines = Vec::<StickyHeaderLine>::new();
 
+        let font_id = window.text_system().resolve_font(&self.style.text.font());
+        let font_size = self.style.text.font_size.to_pixels(window.rem_size());
+        let cell_width = window.text_system().em_layout_width(font_id, font_size);
+        let byte_columns = (cell_width > Pixels::ZERO).then(|| {
+            byte_columns_to_shape(
+                scroll_pixel_position.x / f64::from(cell_width),
+                visible_columns(editor_width, cell_width),
+            )
+        });
+
         for StickyHeader {
             sticky_row,
             start_point,
@@ -260,6 +270,7 @@ impl EditorElement {
                 snapshot,
                 &self.style,
                 editor_width,
+                byte_columns.clone(),
                 is_row_soft_wrapped,
                 window,
                 cx,

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1688,8 +1688,7 @@ impl Editor {
                         let display_point = point.to_display_point(display_snapshot);
                         let goal = SelectionGoal::HorizontalPosition(
                             display_snapshot
-                                .x_for_display_point(display_point, text_layout_details)
-                                .into(),
+                                .x_for_display_point(display_point, text_layout_details),
                         );
                         (display_point, goal)
                     })
@@ -3050,10 +3049,9 @@ impl EntityInputHandler for Editor {
         let start =
             MultiBufferOffsetUtf16(OffsetUtf16(range_utf16.start)).to_display_point(&snapshot);
         let x = Pixels::from(
-            ScrollOffset::from(
-                snapshot.x_for_display_point(start, &text_layout_details)
-                    + self.gutter_dimensions.full_width(),
-            ) - scroll_left,
+            snapshot.x_for_display_point(start, &text_layout_details)
+                + ScrollOffset::from(self.gutter_dimensions.full_width())
+                - scroll_left,
         );
         let y = line_height * (start.row().as_f64() - scroll_position.y) as f32;
 

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -125,9 +125,9 @@ pub(crate) fn up_by_rows(
     text_layout_details: &TextLayoutDetails,
 ) -> (DisplayPoint, SelectionGoal) {
     let goal_x = match goal {
-        SelectionGoal::HorizontalPosition(x) => x.into(),
-        SelectionGoal::WrappedHorizontalPosition((_, x)) => x.into(),
-        SelectionGoal::HorizontalRange { end, .. } => end.into(),
+        SelectionGoal::HorizontalPosition(x) => x,
+        SelectionGoal::WrappedHorizontalPosition((_, x)) => x,
+        SelectionGoal::HorizontalRange { end, .. } => end,
         _ => map.x_for_display_point(start, text_layout_details),
     };
 
@@ -148,10 +148,7 @@ pub(crate) fn up_by_rows(
     if clipped_point.row() < point.row() {
         clipped_point = map.clip_point(point, Bias::Right);
     }
-    (
-        clipped_point,
-        SelectionGoal::HorizontalPosition(goal_x.into()),
-    )
+    (clipped_point, SelectionGoal::HorizontalPosition(goal_x))
 }
 
 pub(crate) fn down_by_rows(
@@ -163,9 +160,9 @@ pub(crate) fn down_by_rows(
     text_layout_details: &TextLayoutDetails,
 ) -> (DisplayPoint, SelectionGoal) {
     let goal_x = match goal {
-        SelectionGoal::HorizontalPosition(x) => x.into(),
-        SelectionGoal::WrappedHorizontalPosition((_, x)) => x.into(),
-        SelectionGoal::HorizontalRange { end, .. } => end.into(),
+        SelectionGoal::HorizontalPosition(x) => x,
+        SelectionGoal::WrappedHorizontalPosition((_, x)) => x,
+        SelectionGoal::HorizontalRange { end, .. } => end,
         _ => map.x_for_display_point(start, text_layout_details),
     };
 
@@ -183,10 +180,7 @@ pub(crate) fn down_by_rows(
     if clipped_point.row() > point.row() {
         clipped_point = map.clip_point(point, Bias::Left);
     }
-    (
-        clipped_point,
-        SelectionGoal::HorizontalPosition(goal_x.into()),
-    )
+    (clipped_point, SelectionGoal::HorizontalPosition(goal_x))
 }
 
 /// Returns a position of the start of line.
@@ -1441,13 +1435,13 @@ mod tests {
                 up(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(0), 2),
-                    SelectionGoal::HorizontalPosition(f64::from(col_2_x)),
+                    SelectionGoal::HorizontalPosition(col_2_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(0), 0),
-                    SelectionGoal::HorizontalPosition(f64::from(col_2_x)),
+                    SelectionGoal::HorizontalPosition(col_2_x),
                 ),
             );
             assert_eq!(
@@ -1472,26 +1466,26 @@ mod tests {
                 up(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(1), 4),
-                    SelectionGoal::HorizontalPosition(col_4_x.into()),
+                    SelectionGoal::HorizontalPosition(col_4_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(0), 3),
-                    SelectionGoal::HorizontalPosition(col_4_x.into())
+                    SelectionGoal::HorizontalPosition(col_4_x)
                 ),
             );
             assert_eq!(
                 down(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(0), 3),
-                    SelectionGoal::HorizontalPosition(col_4_x.into()),
+                    SelectionGoal::HorizontalPosition(col_4_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(1), 4),
-                    SelectionGoal::HorizontalPosition(col_4_x.into())
+                    SelectionGoal::HorizontalPosition(col_4_x)
                 ),
             );
 
@@ -1503,26 +1497,26 @@ mod tests {
                 up(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(3), 5),
-                    SelectionGoal::HorizontalPosition(col_5_x.into()),
+                    SelectionGoal::HorizontalPosition(col_5_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(1), 4),
-                    SelectionGoal::HorizontalPosition(col_5_x.into())
+                    SelectionGoal::HorizontalPosition(col_5_x)
                 ),
             );
             assert_eq!(
                 down(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(1), 4),
-                    SelectionGoal::HorizontalPosition(col_5_x.into()),
+                    SelectionGoal::HorizontalPosition(col_5_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(3), 5),
-                    SelectionGoal::HorizontalPosition(col_5_x.into())
+                    SelectionGoal::HorizontalPosition(col_5_x)
                 ),
             );
 
@@ -1547,13 +1541,13 @@ mod tests {
                 down(
                     &snapshot,
                     DisplayPoint::new(DisplayRow(4), 2),
-                    SelectionGoal::HorizontalPosition(max_point_x.into()),
+                    SelectionGoal::HorizontalPosition(max_point_x),
                     false,
                     &text_layout_details
                 ),
                 (
                     DisplayPoint::new(DisplayRow(4), 2),
-                    SelectionGoal::HorizontalPosition(max_point_x.into())
+                    SelectionGoal::HorizontalPosition(max_point_x)
                 ),
             );
         });

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -957,7 +957,10 @@ impl Editor {
                     let head_x = snapshot.x_for_display_point(newest_head, &text_layout_details);
                     let screen_left_x =
                         snapshot.x_for_display_point(screen_top, &text_layout_details);
-                    head_x <= screen_left_x + em_advance * visible_columns as f32
+                    head_x
+                        <= screen_left_x
+                            + ScrollPixelOffset::from(em_advance)
+                                * visible_columns as ScrollPixelOffset
                 }
                 None => newest_head.column() <= screen_top.column() + visible_columns as u32,
             };

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -346,7 +346,7 @@ impl Editor {
         &mut self,
         start_row: DisplayRow,
         viewport_width: Pixels,
-        scroll_width: Pixels,
+        scroll_width: ScrollOffset,
         em_advance: Pixels,
         layouts: &[LineWithInvisibles],
         autoscroll_request: Option<(Autoscroll, bool)>,
@@ -356,7 +356,6 @@ impl Editor {
         let (_, local) = autoscroll_request?;
         let em_advance = ScrollOffset::from(em_advance);
         let viewport_width = ScrollOffset::from(viewport_width);
-        let scroll_width = ScrollOffset::from(scroll_width);
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         // Horizontal autoscroll only needs selections whose head is visible.
@@ -405,16 +404,15 @@ impl Editor {
                         },
                     );
 
-                    target_left = target_left.min(ScrollOffset::from(
+                    target_left = target_left.min(
                         layouts[head.row().minus(start_row) as usize]
                             .x_for_index(start_column as usize)
-                            + self.gutter_dimensions.margin,
-                    ));
+                            + ScrollOffset::from(self.gutter_dimensions.margin),
+                    );
                     target_right = target_right.max(
-                        ScrollOffset::from(
-                            layouts[head.row().minus(start_row) as usize]
-                                .x_for_index(end_column as usize),
-                        ) + em_advance,
+                        layouts[head.row().minus(start_row) as usize]
+                            .x_for_index(end_column as usize)
+                            + em_advance,
                     );
                 }
             }

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1816,7 +1816,9 @@ impl Editor {
                     DisplayPoint::new(point.row(), line_len),
                     &text_layout_details,
                 );
-                eol_x + em_layout_width * (point.column() - line_len) as f32
+                eol_x
+                    + ScrollPixelOffset::from(em_layout_width)
+                        * (point.column() - line_len) as ScrollPixelOffset
             } else {
                 display_map.x_for_display_point(point, &text_layout_details)
             }
@@ -1844,7 +1846,7 @@ impl Editor {
 
                 let layout = display_map.layout_row(row, &text_layout_details);
                 if matches!(columnar_state, ColumnarSelectionState::FromSelection { .. })
-                    && start_x > layout.width
+                    && start_x > layout.width()
                 {
                     return None;
                 }
@@ -2004,7 +2006,7 @@ impl Editor {
                     let row = range.start.row();
                     let positions =
                         if let SelectionGoal::HorizontalRange { start, end } = selection.goal {
-                            Pixels::from(start)..Pixels::from(end)
+                            start..end
                         } else {
                             let start_x =
                                 display_map.x_for_display_point(range.start, &text_layout_details);

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use gpui::Pixels;
 use itertools::{Either, Itertools as _};
 use language::{Bias, Point, Selection, SelectionGoal};
 use multi_buffer::{MultiBufferDimension, MultiBufferOffset, MultiBufferRow, ToPoint};
@@ -14,6 +13,7 @@ use crate::{
     Anchor, DisplayPoint, DisplayRow, MultiBufferSnapshot, SelectMode, ToOffset,
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement::TextLayoutDetails,
+    scroll::ScrollPixelOffset,
 };
 
 #[derive(Debug, Clone)]
@@ -401,7 +401,7 @@ impl SelectionsCollection {
     }
 
     /// Attempts to build a selection in the provided `DisplayRow` within the
-    /// same range as the provided range of `Pixels`.
+    /// same range as the provided range of pixel positions.
     /// Returns `None` if the range is not empty but it starts past the line's
     /// length, meaning that the line isn't long enough to be contained within
     /// part of the provided range.
@@ -409,7 +409,7 @@ impl SelectionsCollection {
         &mut self,
         display_map: &DisplaySnapshot,
         row: DisplayRow,
-        positions: &Range<Pixels>,
+        positions: &Range<ScrollPixelOffset>,
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
     ) -> Option<Selection<Point>> {
@@ -437,8 +437,8 @@ impl SelectionsCollection {
             end: end.to_point(display_map),
             reversed,
             goal: SelectionGoal::HorizontalRange {
-                start: positions.start.into(),
-                end: positions.end.into(),
+                start: positions.start,
+                end: positions.end,
             },
         })
     }
@@ -485,8 +485,8 @@ impl SelectionsCollection {
             end,
             reversed,
             goal: SelectionGoal::HorizontalRange {
-                start: start_x.min(end_x).into(),
-                end: start_x.max(end_x).into(),
+                start: start_x.min(end_x),
+                end: start_x.max(end_x),
             },
         })
     }
@@ -499,7 +499,7 @@ impl SelectionsCollection {
         start_row: DisplayRow,
         end_row: DisplayRow,
         above: bool,
-        positions: &Range<Pixels>,
+        positions: &Range<ScrollPixelOffset>,
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
     ) -> Option<Selection<Point>> {

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -309,8 +309,11 @@ impl EditorTestContext {
             let y = pixel_position.y
                 + f32::from(line_height)
                     * Pixels::from(display_point.row().as_f64() - newest_point.row().as_f64());
-            let x = pixel_position.x + snapshot.x_for_display_point(display_point, &details)
-                - snapshot.x_for_display_point(newest_point, &details);
+            let x = pixel_position.x
+                + Pixels::from(
+                    snapshot.x_for_display_point(display_point, &details)
+                        - snapshot.x_for_display_point(newest_point, &details),
+                );
             Point::new(x, y)
         })
     }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -119,7 +119,6 @@ pub use tree_sitter::{Node, Parser, QueryCapture, Tree, TreeCursor};
 pub(crate) fn to_settings_soft_wrap(value: language_core::SoftWrap) -> settings::SoftWrap {
     match value {
         language_core::SoftWrap::None => settings::SoftWrap::None,
-        language_core::SoftWrap::PreferLine => settings::SoftWrap::PreferLine,
         language_core::SoftWrap::EditorWidth => settings::SoftWrap::EditorWidth,
         language_core::SoftWrap::Bounded => settings::SoftWrap::Bounded,
     }

--- a/crates/language_core/src/language_config.rs
+++ b/crates/language_core/src/language_config.rs
@@ -10,11 +10,8 @@ use std::{num::NonZeroU32, path::Path, sync::Arc};
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SoftWrap {
-    /// Prefer a single line generally, unless an overly long line is encountered.
+    /// Do not soft-wrap.
     None,
-    /// Deprecated: use None instead. Left to avoid breaking existing users' configs.
-    /// Prefer a single line generally, unless an overly long line is encountered.
-    PreferLine,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
     /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -614,7 +614,6 @@ impl VsCodeSettings {
             show_wrap_guides: None,
             soft_wrap: self.read_enum("editor.wordWrap", |s| match s {
                 "on" => Some(SoftWrap::EditorWidth),
-                "wordWrapColumn" => Some(SoftWrap::PreferLine),
                 "bounded" => Some(SoftWrap::Bounded),
                 "off" => Some(SoftWrap::None),
                 _ => None,

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -381,11 +381,8 @@ pub enum AutoIndentMode {
 )]
 #[serde(rename_all = "snake_case")]
 pub enum SoftWrap {
-    /// Prefer a single line generally, unless an overly long line is encountered.
+    /// Do not soft-wrap.
     None,
-    /// Deprecated: use None instead. Left to avoid breaking existing users' configs.
-    /// Prefer a single line generally, unless an overly long line is encountered.
-    PreferLine,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
     /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -11,7 +11,7 @@ pub enum SelectionGoal {
         start: f64,
         end: f64,
     },
-    WrappedHorizontalPosition((u32, f32)),
+    WrappedHorizontalPosition((u32, f64)),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -6,7 +6,7 @@ use editor::{
         self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary_display_point,
     },
 };
-use gpui::{Action, Context, Window, actions, px};
+use gpui::{Action, Context, Window, actions};
 use language::{CharKind, Point, Selection, SelectionGoal, TextObject, TreeSitterOptions};
 use multi_buffer::MultiBufferRow;
 use schemars::JsonSchema;
@@ -1564,12 +1564,12 @@ fn up_down_buffer_rows(
 
     let (goal_wrap, goal_x) = match goal {
         SelectionGoal::WrappedHorizontalPosition((row, x)) => (row, x),
-        SelectionGoal::HorizontalRange { end, .. } => (select_nth_wrapped_row, end as f32),
-        SelectionGoal::HorizontalPosition(x) => (select_nth_wrapped_row, x as f32),
+        SelectionGoal::HorizontalRange { end, .. } => (select_nth_wrapped_row, end),
+        SelectionGoal::HorizontalPosition(x) => (select_nth_wrapped_row, x),
         _ => {
             let x = map.x_for_display_point(point, text_layout_details);
-            goal = SelectionGoal::WrappedHorizontalPosition((select_nth_wrapped_row, x.into()));
-            (select_nth_wrapped_row, x.into())
+            goal = SelectionGoal::WrappedHorizontalPosition((select_nth_wrapped_row, x));
+            (select_nth_wrapped_row, x)
         }
     };
 
@@ -1597,7 +1597,7 @@ fn up_down_buffer_rows(
     }
 
     let new_col = if i == goal_wrap {
-        map.display_column_for_x(begin_folded_line.row(), px(goal_x), text_layout_details)
+        map.display_column_for_x(begin_folded_line.row(), goal_x, text_layout_details)
     } else {
         map.line_len(begin_folded_line.row())
     };

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -312,7 +312,7 @@ impl Vim {
             let (start, end) = match s.newest_anchor().goal {
                 SelectionGoal::HorizontalRange { start, end } if preserve_goal => (start, end),
                 SelectionGoal::HorizontalPosition(start) if preserve_goal => (start, start),
-                _ => (tail_x.into(), head_x.into()),
+                _ => (tail_x, head_x),
             };
             let mut goal = SelectionGoal::HorizontalRange { start, end };
 
@@ -357,8 +357,8 @@ impl Vim {
 
             if !preserve_goal {
                 goal = SelectionGoal::HorizontalRange {
-                    start: f64::from(positions.start),
-                    end: f64::from(positions.end),
+                    start: positions.start,
+                    end: positions.end,
                 };
             }
 
@@ -383,7 +383,7 @@ impl Vim {
                     }
                 }
 
-                if positions.start <= laid_out_line.width {
+                if positions.start <= laid_out_line.width() {
                     let selection = Selection {
                         id: s.new_selection_id(),
                         start: start.to_point(map),

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4152,10 +4152,9 @@ Positive integer values
 
 **Options**
 
-1. `none` to avoid wrapping generally, unless the line is too long
-2. `prefer_line` (deprecated, same as `none`)
-3. `editor_width` to wrap lines that overflow the editor width
-4. `bounded` to wrap lines at the minimum of `editor_width` and `preferred_line_length`
+1. `none` to never wrap; long lines extend horizontally and scroll
+2. `editor_width` to wrap lines that overflow the editor width
+3. `bounded` to wrap lines at the minimum of `editor_width` and `preferred_line_length`
 
 ## Show Wrap Guides
 


### PR DESCRIPTION
## Summary

- make `soft_wrap: "none"` genuinely disable soft wrapping
- keep macOS text shaping bounded by shaping only a horizontal viewport window for very long rows
- use an approximate monospace grid for offscreen geometry and `f64` scroll coordinates for large horizontal extents
- update editor navigation, selections, autoscroll, settings, documentation, and tests for the new no-wrap behavior

This rebases Kirill Bulatov's unpublished [`kb/no-forced-wrap`](https://github.com/zed-industries/zed/commit/b1dfe1bd30c2175c5b293facbfdf2f887ec8e368) work onto current `main`, preserving his authorship. The only additional code change fixes a current-main integration error in `Editor::newest_selection_on_screen` after horizontal positions became `f64`.

I am opening this as a draft so Kirill and the Zed team can decide whether to continue here or replace it with a PR from the original upstream branch.

Addresses #4573 and #13286.

## Why

The current `none` setting still forces wrapping at roughly 512 em. That workaround was added after unbounded whole-line layout caused crashes, and simply removing it would still hand pathological lines to CoreText. This implementation preserves bounded shaping work while allowing the logical display row to remain unwrapped.

## Validation

- `cargo fmt --all -- --check`
- all 15 focused long-line/windowing tests, including complex Unicode and deliberately unaligned UTF-8 window bounds
- `cargo test -p editor` (912 passed, 1 ignored)
- `./script/clippy -p editor`
- manual macOS rendering and interaction validation remains before marking ready

Release Notes:

- Fixed `soft_wrap: "none"` to keep long lines unwrapped without shaping the entire line.
