### PR TITLE
docs: Fix some links

### DIFF
--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2966,10 +2966,10 @@ At this point, the server may or may not return hints depending on its implement
 
 The following languages have inlay hints preconfigured by Zed:
 
-- [Go](../languages/go)
-- [Rust](../languages/rust)
-- [Svelte](../languages/svelte)
-- [TypeScript](../languages/typescript)
+- [Go](../languages/go.md)
+- [Rust](../languages/rust.md)
+- [Svelte](../languages/svelte.md)
+- [TypeScript](../languages/typescript.md)
 
 Use the `lsp` section for the server configuration. Examples are provided in the corresponding language documentation.
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2966,10 +2966,10 @@ At this point, the server may or may not return hints depending on its implement
 
 The following languages have inlay hints preconfigured by Zed:
 
-- [Go](https://docs.zed.dev/languages/go)
-- [Rust](https://docs.zed.dev/languages/rust)
-- [Svelte](https://docs.zed.dev/languages/svelte)
-- [TypeScript](https://docs.zed.dev/languages/typescript)
+- [Go](../languages/go)
+- [Rust](../languages/rust)
+- [Svelte](../languages/svelte)
+- [TypeScript](../languages/typescript)
 
 Use the `lsp` section for the server configuration. Examples are provided in the corresponding language documentation.
 


### PR DESCRIPTION
This PR fixes some links in the docs to use relative links instead of pointing to `docs.zed.dev` (which isn't where the docs actually live).

Release Notes:

- N/A
