### PR TITLE
Enable CSV preview for all users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18449,7 +18449,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "editor",
- "feature_flags",
  "fuzzy",
  "gpui",
  "log",

--- a/crates/tabular_data_preview/Cargo.toml
+++ b/crates/tabular_data_preview/Cargo.toml
@@ -9,7 +9,6 @@ path = "src/tabular_data_preview.rs"
 
 [dependencies]
 anyhow.workspace = true
-feature_flags.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 editor.workspace = true

--- a/crates/tabular_data_preview/src/tabular_data_preview.rs
+++ b/crates/tabular_data_preview/src/tabular_data_preview.rs
@@ -1,5 +1,4 @@
 use editor::{Editor, EditorEvent};
-use feature_flags::{FeatureFlag, FeatureFlagAppExt as _, PresenceFlag, register_feature_flag};
 use gpui::{
     AppContext, Entity, EventEmitter, FocusHandle, Focusable, ListAlignment, Task, actions,
 };
@@ -24,14 +23,6 @@ mod table_data_engine;
 mod types;
 
 actions!(tabular_data, [OpenPreview, OpenPreviewToTheSide]);
-
-pub struct TabularDataPreviewFeatureFlag;
-
-impl FeatureFlag for TabularDataPreviewFeatureFlag {
-    const NAME: &'static str = "tabular-data-preview";
-    type Value = PresenceFlag;
-}
-register_feature_flag!(TabularDataPreviewFeatureFlag);
 
 pub struct TabularDataPreviewPane {
     pub(crate) engine: TableDataEngine,
@@ -91,28 +82,24 @@ impl TabularDataPreviewPane {
 
     pub fn register(workspace: &mut Workspace) {
         workspace.register_action_renderer(|div, _, _, cx| {
-            div.when(cx.has_flag::<TabularDataPreviewFeatureFlag>(), |div| {
-                div.on_action(cx.listener(|workspace, _: &OpenPreview, window, cx| {
+            div.on_action(cx.listener(|workspace, _: &OpenPreview, window, cx| {
+                if let Some(editor) =
+                    Self::resolve_active_item_as_tabular_data_editor(workspace, cx)
+                {
+                    let pane = workspace.active_pane().clone();
+                    Self::open_preview_in_pane(editor, pane, window, cx);
+                }
+            }))
+            .on_action(cx.listener(
+                |workspace, _: &OpenPreviewToTheSide, window, cx| {
                     if let Some(editor) =
                         Self::resolve_active_item_as_tabular_data_editor(workspace, cx)
                     {
                         let pane = workspace.active_pane().clone();
-                        Self::open_preview_in_pane(editor, pane, window, cx);
+                        Self::open_preview_to_the_side_of_pane(workspace, editor, pane, window, cx);
                     }
-                }))
-                .on_action(cx.listener(
-                    |workspace, _: &OpenPreviewToTheSide, window, cx| {
-                        if let Some(editor) =
-                            Self::resolve_active_item_as_tabular_data_editor(workspace, cx)
-                        {
-                            let pane = workspace.active_pane().clone();
-                            Self::open_preview_to_the_side_of_pane(
-                                workspace, editor, pane, window, cx,
-                            );
-                        }
-                    },
-                ))
-            })
+                },
+            ))
         });
     }
 

--- a/crates/zed/src/zed/quick_action_bar/preview.rs
+++ b/crates/zed/src/zed/quick_action_bar/preview.rs
@@ -1,9 +1,8 @@
 use editor::{Editor, MultiBuffer};
-use feature_flags::FeatureFlagAppExt as _;
 use gpui::{AnyElement, Entity, Modifiers};
 use markdown_preview::markdown_preview_view::MarkdownPreviewView;
 use svg_preview::svg_preview_view::SvgPreviewView;
-use tabular_data_preview::{TabularDataPreviewFeatureFlag, TabularDataPreviewPane};
+use tabular_data_preview::TabularDataPreviewPane;
 use ui::{Tooltip, prelude::*, text_for_keystroke};
 
 use super::QuickActionBar;
@@ -31,7 +30,6 @@ impl QuickActionBar {
         {
             PreviewTarget::Svg(buffer)
         } else if let Some(editor) = editor
-            && cx.has_flag::<TabularDataPreviewFeatureFlag>()
             && TabularDataPreviewPane::is_tabular_data_file(&editor, cx)
         {
             PreviewTarget::TabularData(editor)


### PR DESCRIPTION
Closes #58145

Remove the `tabular-data-preview` feature flag and register CSV preview actions and the quick action bar button for every user. Also remove the now-unused `feature_flags` dependency from the CSV preview crate.

Release Notes:

- Added CSV preview access for all users