### PR TITLE
gpui: Fix `TestWindow` panicking on `window_handle`

### DIFF
--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -48,11 +48,13 @@ pub(crate) struct TestWindowState {
 #[derive(Clone)]
 pub struct TestWindow(pub(crate) Rc<Mutex<TestWindowState>>);
 
+// Test windows are not backed by a real platform window, so there is no raw
+// handle to report; `NotSupported` is `raw_window_handle`'s variant for exactly this.
 impl HasWindowHandle for TestWindow {
     fn window_handle(
         &self,
     ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
-        unimplemented!("Test Windows are not backed by a real platform window")
+        Err(raw_window_handle::HandleError::NotSupported)
     }
 }
 
@@ -60,7 +62,7 @@ impl HasDisplayHandle for TestWindow {
     fn display_handle(
         &self,
     ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
-        unimplemented!("Test Windows are not backed by a real platform window")
+        Err(raw_window_handle::HandleError::NotSupported)
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6950,6 +6950,25 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_window_reports_no_raw_handle_instead_of_panicking(cx: &mut TestAppContext) {
+        use raw_window_handle::{HandleError, HasDisplayHandle as _, HasWindowHandle as _};
+
+        let window = cx.add_window(|_, _| EmptyView);
+        window
+            .update(cx, |_, window, _| {
+                assert!(matches!(
+                    window.window_handle(),
+                    Err(HandleError::NotSupported)
+                ));
+                assert!(matches!(
+                    window.display_handle(),
+                    Err(HandleError::NotSupported)
+                ));
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
     fn test_appearance_change_runs_after_app_update(cx: &mut TestAppContext) {
         let window = cx.add_window(|_, _| EmptyView);
         let observed_appearance = Rc::new(Cell::new(None));


### PR DESCRIPTION
> **AI disclosure:** I used Claude (Anthropic) to diagnose this, write the fix and its test, and draft this PR description, after every headless test in my own app started panicking during a gpui upgrade. I reviewed the diff and the reasoning below, ran the tests myself, and understand and take responsibility for the change, per Zed's [AI Policy](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#ai-policy).

# Objective

- `TestWindow` panics instead of returning an error when asked for its raw window handle. `HasWindowHandle` and `HasDisplayHandle` both return `Result<_, HandleError>`, so a window with no C-typed handle can report that — but `TestWindow` calls `unimplemented!()`. Callers who correctly write `window_handle().ok()?` still crash, and any headless test whose window reaches code that asks for the platform handle dies on boot.
- This has two halves, and only the second made it reachable:
  - `a54eaaece` ("Add raw window handle implementations to GPUI", #7101, 2024-01-30) added both impls for `TestWindow` as `unimplemented!()` placeholders while the real platforms got real ones. `TestWindow` was `pub(crate)` then, so nothing outside gpui could hit it.
  - `4270f8995` ("gpui: Implement `HasWindowHandle` on `Window`", #24327, 2025-02-06) made `Window` implement both traits by forwarding to `platform_window`. From then on, any consumer asking a `Window` for its raw handle reaches `TestWindow` under `TestAppContext`.
- I hit this through [gpui-component](https://github.com/longbridge/gpui-component), whose macOS accessibility code calls `HasWindowHandle::window_handle(window).ok()?` on every window it roots — correct defensive code that still panics, taking every one of my headless `#[gpui::test]` tests down at boot.


## Solution

- `TestWindow::window_handle` and `TestWindow::display_handle` now return `Err(HandleError::NotSupported)` instead of calling `unimplemented!()`. That variant's documentation describes exactly this case — "the underlying handle cannot be represented using the types in this crate".
- Real platform windows are untouched: this only changes what the test platform reports, so `Ok(...)` on macOS, Linux and Windows is unaffected. Callers that already handle the error path now get the error they were written for.

## Testing

- Added `test_window_reports_no_raw_handle_instead_of_panicking` in `crates/gpui/src/window.rs`, asserting both calls return `Err(HandleError::NotSupported)`.
- Reverting the fix while keeping the test reproduces the original panic, so the test pins the behaviour rather than passing vacuously.
- `cargo test -p gpui --lib` from a clean target directory — 220 passed, 0 failed:

```
   Compiling gpui v0.2.2 (/…/zed/crates/gpui)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5m 25s
     Running unittests src/gpui.rs (target/debug/deps/gpui-463768d254ca0c08)

running 220 tests
...
test window::tests::test_window_reports_no_raw_handle_instead_of_panicking ... ok
...
test result: ok. 220 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
```
- Tested on macOS. The change is confined to `crates/gpui/src/platform/test/`, which is platform independent, but I have not built the Linux or Windows platform crates.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before — the new test against the current `unimplemented!()`:

```
thread 'window::tests::test_window_reports_no_raw_handle_instead_of_panicking' panicked at
crates/gpui/src/platform/test/window.rs:57:9:
not implemented: Test Windows are not backed by a real platform window

test result: FAILED. 0 passed; 1 failed
```

After — see the full run above.

Release Notes:

- N/A
