### PR TITLE
project: Fall back to the language server when Prettier has no parser

### DIFF
--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -4913,6 +4913,7 @@ async fn test_prettier_formatting_buffer(
                 ..Default::default()
             })
             .into(),
+            prettier_parser_name: Some("typescript".into()),
             ..Default::default()
         },
         Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),

--- a/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
+++ b/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
@@ -691,6 +691,7 @@ async fn test_ssh_collaboration_formatting_with_prettier(
                 ..LanguageMatcher::default()
             })
             .into(),
+            prettier_parser_name: Some("typescript".into()),
             ..LanguageConfig::default()
         },
         Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26039,6 +26039,7 @@ async fn test_document_format_with_prettier(cx: &mut TestAppContext) {
                 ..Default::default()
             })
             .into(),
+            prettier_parser_name: Some("typescript".into()),
             ..Default::default()
         },
         Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -76,6 +76,20 @@ impl Prettier {
         ".prettierignore",
     ];
 
+    /// Whether prettier has a parser for the given language. When the `auto` formatter is used,
+    /// this decides whether to run prettier or fall back to the language server: prettier silently
+    /// produces no edits for a language it has no parser for, so without this check formatting
+    /// appears to do nothing. Languages prettier supports declare `prettier_parser_name` in their
+    /// config; an explicit `prettier.parser` override counts too. Plugins are handled by the
+    /// caller, since they can add parsers this doesn't know about.
+    pub fn has_parser_for_language(
+        buffer_language: Option<&Language>,
+        prettier_settings: &PrettierSettings,
+    ) -> bool {
+        prettier_settings.parser.is_some()
+            || buffer_language.is_some_and(|language| language.prettier_parser_name().is_some())
+    }
+
     pub async fn locate_prettier_installation(
         fs: &dyn Fs,
         installed_prettiers: &HashSet<PathBuf>,
@@ -1069,6 +1083,49 @@ mod tests {
                 assert!(message.contains("/root/work/full-stack-foundations"), "Error message should mention potential candidates without prettier node_modules contents");
             },
         };
+    }
+
+    // Regression test for https://github.com/zed-industries/zed/issues/61573. The `auto` formatter
+    // must not pick prettier for a language it has no parser for (e.g. XML), otherwise it silently
+    // formats nothing instead of falling back to the language server.
+    #[test]
+    fn test_has_parser_for_language() {
+        use language::{Language, LanguageConfig};
+
+        fn language(prettier_parser_name: Option<&str>) -> Language {
+            Language::new(
+                LanguageConfig {
+                    name: "Test".into(),
+                    prettier_parser_name: prettier_parser_name.map(Into::into),
+                    ..Default::default()
+                },
+                None,
+            )
+        }
+        fn settings(parser: Option<&str>) -> PrettierSettings {
+            PrettierSettings {
+                allowed: true,
+                parser: parser.map(Into::into),
+                plugins: HashSet::default(),
+                options: HashMap::default(),
+            }
+        }
+
+        // A language prettier supports declares a parser -> use prettier.
+        assert!(Prettier::has_parser_for_language(
+            Some(&language(Some("babel"))),
+            &settings(None)
+        ));
+        // A language prettier has no parser for (e.g. XML) -> don't use prettier.
+        assert!(!Prettier::has_parser_for_language(
+            Some(&language(None)),
+            &settings(None)
+        ));
+        // An explicit `prettier.parser` override counts even without a language parser.
+        assert!(Prettier::has_parser_for_language(
+            Some(&language(None)),
+            &settings(Some("xml"))
+        ));
     }
 
     #[gpui::test]

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1741,6 +1741,22 @@ impl LocalLspStore {
             .flatten()
             .chain(formatters);
 
+        // `auto` uses prettier when it's allowed and can actually format this buffer's language,
+        // otherwise it falls back to the primary language server. Prettier produces no edits for a
+        // language it has no parser for (e.g. XML), so picking it there would silently format
+        // nothing. Plugins can add parsers prettier doesn't know about, so any configured plugin
+        // keeps prettier in play.
+        let auto_uses_prettier = settings.prettier.allowed && {
+            let buffer_language = buffer
+                .handle
+                .read_with(cx, |buffer, _| buffer.language().cloned());
+            prettier::Prettier::has_parser_for_language(
+                buffer_language.as_deref(),
+                &settings.prettier,
+            ) || prettier_store::prettier_plugins_for_language(&settings)
+                .is_some_and(|plugins| !plugins.is_empty())
+        };
+
         // Only explicitly configured formatters surface their failures;
         // auto-resolved ones stay silent so a missing optional tool
         // (e.g. prettier) does not warn on every save.
@@ -1748,7 +1764,7 @@ impl LocalLspStore {
         for formatter in formatters {
             let is_auto = formatter == &Formatter::Auto;
             let formatter = if is_auto {
-                if settings.prettier.allowed {
+                if auto_uses_prettier {
                     zlog::trace!(logger => "Formatter set to auto: defaulting to prettier");
                     &Formatter::Prettier
                 } else {


### PR DESCRIPTION
Fixes #61573.

With `formatter: "auto"`, prettier gets picked for any allowed language, even ones it has no parser for like XML. Prettier just does nothing there, so the file never gets formatted even when a language server could do it. now `auto` only picks prettier when it has a parser for the language (or a plugin), otherwise it uses the language server

Also
- Fixed `formatter: "auto"` doing nothing for languages prettier can't format (like XML) instead of falling back to the language server.
