### PR TITLE
markdown: Respect buffer_line_height in code blocks

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -6414,50 +6414,6 @@ mod tests {
         });
     }
 
-    /// Renders a paragraph followed by a fenced code block at the given
-    /// `buffer_line_height`, returning the rendered line heights of the
-    /// paragraph and of the first code block row.
-    ///
-    /// Note that this does not reproduce the `WithRemSize` wrapper the real
-    /// preview renders inside, so rem-derived lengths (such as the `rems(1.3)`
-    /// prose leading) resolve against the default rem size rather than
-    /// `markdown_preview_font_size`. Code block metrics are unaffected, since
-    /// the code font size is set as absolute pixels.
-    fn rendered_prose_and_code_line_heights(
-        cx: &mut TestAppContext,
-        font_size: f32,
-        buffer_line_height: f32,
-    ) -> (Pixels, Pixels) {
-        ensure_theme_initialized(cx);
-        cx.update(|cx| {
-            settings::SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |settings| {
-                    settings.theme.markdown_preview_font_size = Some(font_size.into());
-                    settings.theme.buffer_line_height =
-                        Some(settings::BufferLineHeight::Custom(buffer_line_height));
-                });
-            });
-        });
-        cx.run_until_parked();
-
-        let style = {
-            let window = cx.add_empty_window();
-            window.update(|window, cx| MarkdownStyle::themed(MarkdownFont::Preview, window, cx))
-        };
-
-        let markdown =
-            cx.new(|cx| Markdown::new("Body text\n\n```\nfoo\nbar\n```\n".into(), None, None, cx));
-        let rendered = render_markdown_entity_in_view(markdown, style, None, None, cx);
-
-        let [prose, code] = &rendered.lines[..] else {
-            panic!(
-                "expected a prose line and a code block line, got {} lines",
-                rendered.lines.len()
-            )
-        };
-        (prose.layout.line_height(), code.layout.line_height())
-    }
-
     #[gpui::test]
     fn test_code_block_line_height_follows_buffer_line_height_setting(cx: &mut TestAppContext) {
         let font_size = 14.0;
@@ -6504,10 +6460,6 @@ mod tests {
             window.update(|window, cx| MarkdownStyle::themed(MarkdownFont::Preview, window, cx))
         };
 
-        // Callers such as the agent panel override the code font size after
-        // building the style. The line height is stored as a fraction so it
-        // follows that override; an absolute value computed from the theme's
-        // font size would stay at 14 * 1.5 instead.
         let overridden_font_size = 28.0;
         style.code_block.text.font_size = Some(px(overridden_font_size).into());
 
@@ -6691,5 +6643,49 @@ mod tests {
         assert!(quad_bounds.left() < px(0.));
         assert!(visible_bounds.left() >= px(0.));
         assert!(visible_bounds.right() <= window_width);
+    }
+
+    /// Renders a paragraph followed by a fenced code block at the given
+    /// `buffer_line_height`, returning the rendered line heights of the
+    /// paragraph and of the first code block row.
+    ///
+    /// Note that this does not reproduce the `WithRemSize` wrapper the real
+    /// preview renders inside, so rem-derived lengths (such as the `rems(1.3)`
+    /// prose leading) resolve against the default rem size rather than
+    /// `markdown_preview_font_size`. Code block metrics are unaffected, since
+    /// the code font size is set as absolute pixels.
+    fn rendered_prose_and_code_line_heights(
+        cx: &mut TestAppContext,
+        font_size: f32,
+        buffer_line_height: f32,
+    ) -> (Pixels, Pixels) {
+        ensure_theme_initialized(cx);
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme.markdown_preview_font_size = Some(font_size.into());
+                    settings.theme.buffer_line_height =
+                        Some(settings::BufferLineHeight::Custom(buffer_line_height));
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        let style = {
+            let window = cx.add_empty_window();
+            window.update(|window, cx| MarkdownStyle::themed(MarkdownFont::Preview, window, cx))
+        };
+
+        let markdown =
+            cx.new(|cx| Markdown::new("Body text\n\n```\nfoo\nbar\n```\n".into(), None, None, cx));
+        let rendered = render_markdown_entity_in_view(markdown, style, None, None, cx);
+
+        let [prose, code] = &rendered.lines[..] else {
+            panic!(
+                "expected a prose line and a code block line, got {} lines",
+                rendered.lines.len()
+            )
+        };
+        (prose.layout.line_height(), code.layout.line_height())
     }
 }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -38,7 +38,7 @@ use gpui::{
     ImageFormat, ImageSource, KeyContext, Length, MouseButton, MouseDownEvent, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Point, ScrollHandle, Stateful, StrikethroughStyle,
     StyleRefinement, StyledImage, StyledText, Subscription, Task, TextAlign, TextLayout, TextRun,
-    TextStyle, TextStyleRefinement, WrappedLineLayout, actions, canvas, img, point, quad,
+    TextStyle, TextStyleRefinement, WrappedLineLayout, actions, canvas, img, point, quad, relative,
 };
 use language::{CharClassifier, Language, LanguageRegistry, Rope};
 use parser::CodeBlockMetadata;
@@ -270,6 +270,7 @@ impl MarkdownStyle {
                     font_features: Some(theme_settings.buffer_font.features.clone()),
                     font_size: Some(buffer_font_size.into()),
                     font_weight: Some(buffer_font_weight),
+                    line_height: Some(relative(theme_settings.buffer_line_height.value())),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -6411,6 +6412,122 @@ mod tests {
                 px(24.0)
             );
         });
+    }
+
+    /// Renders a paragraph followed by a fenced code block at the given
+    /// `buffer_line_height`, returning the rendered line heights of the
+    /// paragraph and of the first code block row.
+    ///
+    /// Note that this does not reproduce the `WithRemSize` wrapper the real
+    /// preview renders inside, so rem-derived lengths (such as the `rems(1.3)`
+    /// prose leading) resolve against the default rem size rather than
+    /// `markdown_preview_font_size`. Code block metrics are unaffected, since
+    /// the code font size is set as absolute pixels.
+    fn rendered_prose_and_code_line_heights(
+        cx: &mut TestAppContext,
+        font_size: f32,
+        buffer_line_height: f32,
+    ) -> (Pixels, Pixels) {
+        ensure_theme_initialized(cx);
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme.markdown_preview_font_size = Some(font_size.into());
+                    settings.theme.buffer_line_height =
+                        Some(settings::BufferLineHeight::Custom(buffer_line_height));
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        let style = {
+            let window = cx.add_empty_window();
+            window.update(|window, cx| MarkdownStyle::themed(MarkdownFont::Preview, window, cx))
+        };
+
+        let markdown =
+            cx.new(|cx| Markdown::new("Body text\n\n```\nfoo\nbar\n```\n".into(), None, None, cx));
+        let rendered = render_markdown_entity_in_view(markdown, style, None, None, cx);
+
+        let [prose, code] = &rendered.lines[..] else {
+            panic!(
+                "expected a prose line and a code block line, got {} lines",
+                rendered.lines.len()
+            )
+        };
+        (prose.layout.line_height(), code.layout.line_height())
+    }
+
+    #[gpui::test]
+    fn test_code_block_line_height_follows_buffer_line_height_setting(cx: &mut TestAppContext) {
+        let font_size = 14.0;
+        let (tight_prose, tight_code) = rendered_prose_and_code_line_heights(cx, font_size, 1.2);
+        let (loose_prose, loose_code) = rendered_prose_and_code_line_heights(cx, font_size, 1.8);
+
+        // Left unset, code blocks fall back to the ambient default of ~1.618
+        // regardless of this setting.
+        assert!(
+            (tight_code - px(font_size * 1.2)).abs() <= px(0.5),
+            "code block line height ({tight_code:?}) should be ~{} at buffer_line_height 1.2",
+            font_size * 1.2
+        );
+        assert!(
+            (loose_code - px(font_size * 1.8)).abs() <= px(0.5),
+            "code block line height ({loose_code:?}) should be ~{} at buffer_line_height 1.8",
+            font_size * 1.8
+        );
+
+        // Prose leading is set per element as `rems(1.3)` and is a typographic
+        // choice independent of the buffer's line height, so it must not move.
+        assert_eq!(
+            tight_prose, loose_prose,
+            "prose line height should not follow buffer_line_height"
+        );
+    }
+
+    #[gpui::test]
+    fn test_code_block_line_height_tracks_overridden_code_font_size(cx: &mut TestAppContext) {
+        ensure_theme_initialized(cx);
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme.markdown_preview_font_size = Some(14.0.into());
+                    settings.theme.buffer_line_height =
+                        Some(settings::BufferLineHeight::Custom(1.5));
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        let mut style = {
+            let window = cx.add_empty_window();
+            window.update(|window, cx| MarkdownStyle::themed(MarkdownFont::Preview, window, cx))
+        };
+
+        // Callers such as the agent panel override the code font size after
+        // building the style. The line height is stored as a fraction so it
+        // follows that override; an absolute value computed from the theme's
+        // font size would stay at 14 * 1.5 instead.
+        let overridden_font_size = 28.0;
+        style.code_block.text.font_size = Some(px(overridden_font_size).into());
+
+        let markdown =
+            cx.new(|cx| Markdown::new("Body text\n\n```\nfoo\nbar\n```\n".into(), None, None, cx));
+        let rendered = render_markdown_entity_in_view(markdown, style, None, None, cx);
+        let [_, code] = &rendered.lines[..] else {
+            panic!(
+                "expected a prose line and a code block line, got {} lines",
+                rendered.lines.len()
+            )
+        };
+
+        let code_line_height = code.layout.line_height();
+        assert!(
+            (code_line_height - px(overridden_font_size * 1.5)).abs() <= px(0.5),
+            "code block line height ({code_line_height:?}) should follow the overridden \
+             font size, expected ~{}",
+            overridden_font_size * 1.5
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

- Fixes #62528
- Code blocks in rendered markdown ignored the `buffer_line_height` setting. With the line height left unset, they fell back to the ambient default of ~1.618, so the same code was spaced more loosely in markdown than it was in an editor or the terminal.
- The extra leading is most obvious with box-drawing characters — the ASCII-art box from the issue renders as disconnected stripes instead of continuous vertical rules.
- The issue also notes that the preview font "seems bigger". That part is working as intended and is not changed here: preview code blocks size from `markdown_preview_font_size`, which falls back to `ui_font_size` rather than `buffer_font_size` so that temporary UI zoom doesn't resize the preview. Users who want it to match the editor can set `markdown_preview_font_size` explicitly.

## Solution

- Set `line_height` on the code block text style in `MarkdownStyle::themed_with_overrides`, derived from `theme_settings.buffer_line_height`.
- The value is `relative(...)` rather than absolute pixels so it tracks the code font size, which some callers override after building the style (e.g. the agent panel sets `code_block.text.font_size` downstream). An absolute value computed from the theme's font size would be wrong for those callers.
- Scope: this applies to every `MarkdownFont` variant — preview, agent panel, and editor — since the code block style is shared and `with_preview_overrides` doesn't touch line height.
- Prose leading is deliberately unchanged. It stays a per-element typographic choice, independent of the buffer setting.

## Testing

- `cargo test -p markdown` — 145 passed, 0 failed.
- Added `test_code_block_line_height_follows_buffer_line_height_setting`: renders a paragraph plus a fenced code block at `buffer_line_height` 1.2 and 1.8, asserts the code block's rendered line height tracks the setting, and asserts prose leading does *not* move.
- Added `test_code_block_line_height_tracks_overridden_code_font_size`: overrides `code_block.text.font_size` after building the style and asserts the line height follows the override. This is what pins the `relative` vs. absolute choice.
- To reproduce manually, set `"buffer_line_height": { "custom": 1.2 }` and open a markdown preview containing the ASCII-art box from #62528. The vertical rules should join into continuous lines, matching how the same block renders in an editor, and should visibly separate again at `"comfortable"`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before
<img width="927" height="912" alt="Screenshot 2026-08-17 at 5 06 41 PM" src="https://github.com/user-attachments/assets/be6213bf-f3aa-42fb-8784-1985b5379d74" />

After
<img width="915" height="994" alt="Screenshot 2026-08-17 at 5 06 54 PM" src="https://github.com/user-attachments/assets/c9c7f395-50cb-437b-a423-2030da88e4f4" />



---

Release Notes:

- Fixed markdown code blocks not respecting the `buffer_line_height` setting
