### PR TITLE
gpui: Add destructive PromptButton for native alerts

### DIFF
--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -306,6 +306,26 @@ impl Render for WindowDemo {
                 })
                 .detach();
             }))
+            .child(button("Prompt (destructive)", |window, cx| {
+                let answer = window.prompt(
+                    PromptLevel::Warning,
+                    "Save changes to 1 request?",
+                    Some("Unsaved changes will be lost if you discard them."),
+                    &[
+                        PromptButton::ok("Save"),
+                        PromptButton::destructive("Discard"),
+                        PromptButton::cancel("Cancel"),
+                    ],
+                    cx,
+                );
+
+                cx.spawn(async move |_| match answer.await.unwrap() {
+                    0 => println!("You have clicked Save"),
+                    1 => println!("You have clicked Discard"),
+                    _ => println!("You have clicked Cancel"),
+                })
+                .detach();
+            }))
     }
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -2383,6 +2383,8 @@ pub enum PromptButton {
     Ok(SharedString),
     /// Cancel button
     Cancel(SharedString),
+    /// Destructive button
+    Destructive(SharedString),
     /// Other button
     Other(SharedString),
 }
@@ -2403,10 +2405,20 @@ impl PromptButton {
         PromptButton::Cancel(label.into())
     }
 
+    /// Create a Destructive button
+    pub fn destructive(label: impl Into<SharedString>) -> Self {
+        PromptButton::Destructive(label.into())
+    }
+
     /// Returns true if this button is a cancel button.
     #[allow(dead_code)]
     pub fn is_cancel(&self) -> bool {
         matches!(self, PromptButton::Cancel(_))
+    }
+
+    /// Returns true if this button is a destructive button.
+    pub fn is_destructive(&self) -> bool {
+        matches!(self, PromptButton::Destructive(_))
     }
 
     /// Returns the label of the button
@@ -2414,8 +2426,28 @@ impl PromptButton {
         match self {
             PromptButton::Ok(label) => label,
             PromptButton::Cancel(label) => label,
+            PromptButton::Destructive(label) => label,
             PromptButton::Other(label) => label,
         }
+    }
+}
+
+#[cfg(test)]
+mod prompt_button_tests {
+    use super::PromptButton;
+
+    #[test]
+    fn destructive_button_is_marked_destructive() {
+        let button = PromptButton::destructive("Discard");
+        assert!(button.is_destructive());
+        assert_eq!(button.label().as_ref(), "Discard");
+    }
+
+    #[test]
+    fn non_destructive_buttons_are_not_destructive() {
+        assert!(!PromptButton::ok("Save").is_destructive());
+        assert!(!PromptButton::cancel("Cancel").is_destructive());
+        assert!(!PromptButton::new("Other").is_destructive());
     }
 }
 

--- a/crates/gpui/src/window/prompts.rs
+++ b/crates/gpui/src/window/prompts.rs
@@ -5,7 +5,7 @@ use futures::channel::oneshot;
 use crate::{
     AnyView, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle, Focusable,
     InteractiveElement, IntoElement, ParentElement, PromptButton, PromptLevel, Render,
-    StatefulInteractiveElement, Styled, div, opaque_grey, white,
+    StatefulInteractiveElement, Styled, div, opaque_grey, red, util::FluentBuilder, white,
 };
 
 use super::Window;
@@ -138,6 +138,7 @@ impl Render for FallbackPromptRenderer {
                     .rounded_xs()
                     .cursor_pointer()
                     .text_sm()
+                    .when(action.is_destructive(), |this| this.text_color(red()))
                     .child(action.label().clone())
                     .id(ix)
                     .on_click(cx.listener(move |_, _, _, cx| {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1737,6 +1737,10 @@ impl PlatformWindow for MacWindow {
             let button = alert.addButtonWithTitle(&title);
             button.setTag(ix as NSInteger);
 
+            if answer.is_destructive() {
+                button.setHasDestructiveAction(true);
+            }
+
             if answer.is_cancel() {
                 if let Some(key) = core::char::from_u32(crate::events::ESCAPE_KEY as u32) {
                     let key = NSString::from_str(&key.to_string());

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -764,7 +764,9 @@ impl PlatformWindow for WindowsWindow {
                             PromptButton::Cancel(_) => IDCANCEL.0,
                             // the first few low integer values are reserved for known buttons
                             // so for simplicity we just go backwards from -1
-                            PromptButton::Other(_) => -(index as i32) - 1,
+                            PromptButton::Other(_) | PromptButton::Destructive(_) => {
+                                -(index as i32) - 1
+                            }
                         };
                         button_id_map.push(button_id);
                         buttons.push(TASKDIALOG_BUTTON {

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -41,7 +41,7 @@ fn zed_prompt_renderer(
         |cx| ZedPromptRenderer {
             _level: level,
             message: cx.new(|cx| Markdown::new(SharedString::new(message), None, None, cx)),
-            actions: actions.iter().map(|a| a.label().to_string()).collect(),
+            actions: actions.to_vec(),
             focus: cx.focus_handle(),
             active_action_id: 0,
             detail: detail
@@ -56,7 +56,7 @@ fn zed_prompt_renderer(
 pub struct ZedPromptRenderer {
     _level: PromptLevel,
     message: Entity<Markdown>,
-    actions: Vec<String>,
+    actions: Vec<PromptButton>,
     focus: FocusHandle,
     active_action_id: usize,
     detail: Option<Entity<Markdown>>,
@@ -68,7 +68,7 @@ impl ZedPromptRenderer {
     }
 
     fn cancel(&mut self, _: &menu::Cancel, _window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(ix) = self.actions.iter().position(|a| a == "Cancel") {
+        if let Some(ix) = self.actions.iter().position(|action| action.is_cancel()) {
             cx.emit(PromptResponse(ix));
         }
     }
@@ -142,12 +142,18 @@ impl Render for ZedPromptRenderer {
                 v_flex()
                     .gap_1()
                     .children(self.actions.iter().enumerate().map(|(ix, action)| {
-                        Button::new(ix, action.clone())
+                        let style = if action.is_destructive() {
+                            ButtonStyle::Tinted(TintColor::Error)
+                        } else {
+                            ButtonStyle::Outlined
+                        };
+                        Button::new(ix, action.label().to_string())
                             .full_width()
-                            .style(ButtonStyle::Outlined)
-                            .when(ix == self.active_action_id, |s| {
-                                s.style(ButtonStyle::Tinted(TintColor::Accent))
-                            })
+                            .style(style)
+                            .when(
+                                ix == self.active_action_id && !action.is_destructive(),
+                                |button| button.style(ButtonStyle::Tinted(TintColor::Accent)),
+                            )
                             .tab_index(ix as isize)
                             .on_click(cx.listener(move |_, _, _window, cx| {
                                 cx.emit(PromptResponse(ix));


### PR DESCRIPTION
# Objective

- Add first-class support for destructive prompt buttons in GPUI, so actions like "Discard" can use native destructive styling instead of rendering as normal `PromptButton::Other` buttons.
- Builds on the existing `PromptButton` API introduced in #29538.

## Solution

- Add `PromptButton::Destructive`, `PromptButton::destructive(label)`, and `is_destructive()` to GPUI.
- On macOS, call `NSButton.setHasDestructiveAction` after adding destructive alert buttons.
- In GPUI's fallback prompt renderer, render destructive buttons with red text.
- On Windows, treat `Destructive` like `Other` for now since TaskDialog has no clean per-button danger styling in v1.
- In `ui_prompt`, preserve `Vec<PromptButton>` instead of flattening to strings so destructive actions can use `ButtonStyle::Tinted(TintColor::Error)` and cancel handling can use `is_cancel()` instead of matching the literal `"Cancel"` label.
- Add a destructive prompt demo to the `window` example.

Example usage:

```rust
window.prompt(
    PromptLevel::Warning,
    "Save changes to 1 request?",
    Some("Unsaved changes will be lost if you discard them."),
    &[
        PromptButton::ok("Save"),
        PromptButton::destructive("Discard"),
        PromptButton::cancel("Cancel"),
    ],
    cx,
);
```

On macOS, destructive styling is suppressed on the first/default button, so destructive actions should not be listed first.

## Testing

- Ran `cargo test -p gpui prompt_button_tests`
- Ran `./script/clippy -p gpui -p gpui_macos -p ui_prompt`
- Ran `cargo run -p gpui --example window` and clicked **Prompt (destructive)**; confirmed **Discard** uses destructive styling on macOS
- Reviewers can verify with the same commands above
- macOS is the main platform for native destructive alert styling; Linux/fallback and Zed's `ui_prompt` renderer show visually distinct destructive buttons. Windows behaves like `Other` for now (no dedicated danger styling in v1)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

Run the GPUI `window` example and click **Prompt (destructive)** to see a Save / Discard / Cancel prompt where **Discard** uses destructive styling.

Before: `"Discard"` passed as `Other` rendered like a normal button.
After: `PromptButton::destructive("Discard")` renders with native destructive styling on macOS and visually distinct styling in fallback/Zed prompt UIs.

</details>

---

Release Notes:

- Added `PromptButton::destructive` for native destructive prompt button styling on supported platforms.