### PR TITLE
Use Unicode ellipses in interface copy

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -543,7 +543,7 @@ impl ActivityIndicator {
             return Some(Content {
                 icon: ActivityIcon::Icon(IconName::Download),
                 message: format!(
-                    "Downloading {}...",
+                    "Downloading {}…",
                     downloading.iter().map(|name| name.as_ref()).fold(
                         String::new(),
                         |mut acc, s| {
@@ -568,7 +568,7 @@ impl ActivityIndicator {
             return Some(Content {
                 icon: ActivityIcon::Icon(IconName::Download),
                 message: format!(
-                    "Checking for updates to {}...",
+                    "Checking for updates to {}…",
                     checking_for_update.iter().map(|name| name.as_ref()).fold(
                         String::new(),
                         |mut acc, s| {

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -94,7 +94,7 @@ impl AgentRegistryPage {
             let registry_store = AgentRegistryStore::global(cx);
             let query_editor = cx.new(|cx| {
                 let mut input = Editor::single_line(window, cx);
-                input.set_placeholder_text("Search agents...", window, cx);
+                input.set_placeholder_text("Search agents…", window, cx);
                 input
             });
             cx.subscribe(&query_editor, Self::on_query_change).detach();
@@ -292,7 +292,7 @@ impl AgentRegistryPage {
         let fetch_error = registry_store.fetch_error();
 
         let message = if is_fetching {
-            "Loading registry..."
+            "Loading registry…"
         } else if fetch_error.is_some() {
             "Failed to load the agent registry. Please check your connection and try again."
         } else {

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -596,7 +596,7 @@ impl<T: 'static> PromptEditor<T> {
     fn thumbs_up(&mut self, _: &ThumbsUpResult, _window: &mut Window, cx: &mut Context<Self>) {
         match &self.session_state.completion {
             CompletionState::Pending => {
-                self.toast("Can't rate, still generating...", None, cx);
+                self.toast("Can't rate, still generating…", None, cx);
                 return;
             }
             CompletionState::Rated => {
@@ -659,7 +659,7 @@ impl<T: 'static> PromptEditor<T> {
     fn thumbs_down(&mut self, _: &ThumbsDownResult, _window: &mut Window, cx: &mut Context<Self>) {
         match &self.session_state.completion {
             CompletionState::Pending => {
-                self.toast("Can't rate, still generating...", None, cx);
+                self.toast("Can't rate, still generating…", None, cx);
                 return;
             }
             CompletionState::Rated => {

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1293,7 +1293,7 @@ impl PickerDelegate for ProjectPickerDelegate {
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
         format!(
-            "Associate the \"{}\" thread with...",
+            "Associate the \"{}\" thread with…",
             self.thread
                 .title
                 .as_ref()

--- a/crates/auto_update_helper/src/auto_update_helper.rs
+++ b/crates/auto_update_helper/src/auto_update_helper.rs
@@ -109,7 +109,7 @@ mod windows_impl {
     pub(crate) fn show_error(mut content: String) {
         if content.len() > 600 {
             content.truncate(600);
-            content.push_str("...\n");
+            content.push_str("…\n");
         }
         let _ = unsafe {
             MessageBoxW(

--- a/crates/auto_update_helper/src/dialog.rs
+++ b/crates/auto_update_helper/src/dialog.rs
@@ -171,7 +171,7 @@ unsafe extern "system" fn wnd_proc(
                 &HSTRING::from(font_name),
             );
             let temp = SelectObject(hdc, font.into());
-            let string = HSTRING::from("Updating Zed...");
+            let string = HSTRING::from("Updating Zed…");
             return_if_failed!(TextOutW(hdc, 20, 15, &string).ok());
             return_if_failed!(DeleteObject(temp).ok());
 

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -5405,7 +5405,7 @@ async fn test_references(
         assert_eq!(status.name.0, "my-fake-lsp-adapter");
         assert_eq!(
             status.pending_work.values().next().unwrap().message,
-            Some("Finding references...".into())
+            Some("Finding references…".into())
         );
     });
 
@@ -5463,7 +5463,7 @@ async fn test_references(
         assert_eq!(status.name.0, "my-fake-lsp-adapter");
         assert_eq!(
             status.pending_work.values().next().unwrap().message,
-            Some("Finding references...".into())
+            Some("Finding references…".into())
         );
     });
 

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -262,7 +262,7 @@ impl PickerDelegate for ChannelModalDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Search collaborator by username...".into()
+        "Search collaborator by username…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/collab_ui/src/collab_panel/contact_finder.rs
+++ b/crates/collab_ui/src/collab_panel/contact_finder.rs
@@ -86,7 +86,7 @@ impl PickerDelegate for ContactFinderDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Search collaborator by username...".into()
+        "Search collaborator by username…".into()
     }
 
     fn update_matches(

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -392,7 +392,7 @@ impl PickerDelegate for CommandPaletteDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Execute a command...".into()
+        "Execute a command…".into()
     }
 
     fn select_history(

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -296,7 +296,7 @@ pub async fn download_adapter_from_github(
         adapter_name,
         github_version.url,
     );
-    delegate.output_to_console(format!("Downloading from {}...", github_version.url));
+    delegate.output_to_console(format!("Downloading from {}…", github_version.url));
 
     let mut response = delegate
         .http_client()

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -338,7 +338,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
             .or(self.path_to_codelldb.get().cloned());
 
         if command.is_none() {
-            delegate.output_to_console(format!("Checking latest version of {}...", self.name()));
+            delegate.output_to_console(format!("Checking latest version of {}…", self.name()));
             let adapter_path = paths::debug_adapters_dir().join(&Self::ADAPTER_NAME);
             let version_path = match self.fetch_latest_adapter_version(delegate).await {
                 Ok(version) => {

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -509,7 +509,7 @@ impl DebugAdapter for JsDebugAdapter {
         cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
         if self.checked.set(()).is_ok() {
-            delegate.output_to_console(format!("Checking latest version of {}...", self.name()));
+            delegate.output_to_console(format!("Checking latest version of {}…", self.name()));
             if let Some(version) = self.fetch_latest_adapter_version(delegate).await.log_err() {
                 adapters::download_adapter_from_github(
                     self.name(),

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1177,8 +1177,9 @@ impl VariableList {
     }
 
     fn center_truncate_string(s: &str, mut max_chars: usize) -> String {
-        const ELLIPSIS: &str = "...";
+        const ELLIPSIS: &str = "…";
         const MIN_LENGTH: usize = 3;
+        let ellipsis_length = ELLIPSIS.chars().count();
 
         max_chars = max_chars.max(MIN_LENGTH);
 
@@ -1187,11 +1188,11 @@ impl VariableList {
             return s.to_string();
         }
 
-        if ELLIPSIS.len() + MIN_LENGTH > max_chars {
+        if ellipsis_length + MIN_LENGTH > max_chars {
             return s.chars().take(MIN_LENGTH).collect();
         }
 
-        let available_chars = max_chars - ELLIPSIS.len();
+        let available_chars = max_chars - ellipsis_length;
 
         let start_chars = available_chars / 2;
         let end_chars = available_chars - start_chars;
@@ -1633,7 +1634,7 @@ mod tests {
         // Test simple truncation
         assert_eq!(
             VariableList::center_truncate_string("value->value2->value3->value4", 20),
-            "value->v...3->value4"
+            "value->va…e3->value4"
         );
 
         // Test with very long expression
@@ -1642,25 +1643,25 @@ mod tests {
                 "object->property1->property2->property3->property4->property5",
                 30
             ),
-            "object->prope...ty4->property5"
+            "object->proper…rty4->property5"
         );
 
-        // Test edge case with limit equal to ellipsis length
+        // Test edge case with limit equal to the minimum length
         assert_eq!(VariableList::center_truncate_string("anything", 3), "any");
 
-        // Test edge case with limit less than ellipsis length
+        // Test edge case with limit less than the minimum length
         assert_eq!(VariableList::center_truncate_string("anything", 2), "any");
 
         // Test with UTF-8 characters
         assert_eq!(
             VariableList::center_truncate_string("café->résumé->naïve->voilà", 15),
-            "café->...>voilà"
+            "café->r…->voilà"
         );
 
         // Test with emoji (multi-byte UTF-8)
         assert_eq!(
             VariableList::center_truncate_string("😀->happy->face->😎->cool", 15),
-            "😀->hap...->cool"
+            "😀->happ…😎->cool"
         );
     }
 }

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -195,7 +195,7 @@ async fn test_escape_code_processing(executor: BackgroundExecutor, cx: &mut Test
     client
         .fake_event(dap::messages::Events::Output(dap::OutputEvent {
             category: None,
-            output: "Checking latest version of JavaScript...".to_string(),
+            output: "Checking latest version of JavaScript…".to_string(),
             data: None,
             variables_reference: None,
             source: None,
@@ -319,7 +319,7 @@ async fn test_escape_code_processing(executor: BackgroundExecutor, cx: &mut Test
                     .editor().clone();
 
             assert_eq!(
-                "Checking latest version of JavaScript...\n   ▲ Next.js 15.1.5\n   - Local:        http://localhost:3000\n   - Network:      http://192.168.1.144:3000\n\n ✓ Starting...\nSomething else...\n ✓ Ready in 1009ms\nBoth background and foreground!\nEven more...\n",
+                "Checking latest version of JavaScript…\n   ▲ Next.js 15.1.5\n   - Local:        http://localhost:3000\n   - Network:      http://192.168.1.144:3000\n\n ✓ Starting...\nSomething else...\n ✓ Ready in 1009ms\nBoth background and foreground!\nEven more...\n",
                 editor
                     .read(cx)
                     .text(cx)

--- a/crates/dev_container/src/lib.rs
+++ b/crates/dev_container/src/lib.rs
@@ -976,7 +976,7 @@ impl DevContainerModal {
                                     .color(Color::Muted)
                                     .with_rotate_animation(2),
                             )
-                            .child(Label::new("Querying template registry...")),
+                            .child(Label::new("Querying template registry…")),
                     ),
                 )
                 .child(ListSeparator)
@@ -1028,7 +1028,7 @@ impl DevContainerModal {
                                     .color(Color::Muted)
                                     .with_rotate_animation(2),
                             )
-                            .child(Label::new("Querying features...")),
+                            .child(Label::new("Querying features…")),
                     ),
                 )
                 .child(ListSeparator)

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -1324,11 +1324,11 @@ impl Editor {
                 )?,
 
                 None => pending_completion_container(icons.base)
-                    .child(Label::new("...").size(LabelSize::Small)),
+                    .child(Label::new("…").size(LabelSize::Small)),
             },
 
             None => pending_completion_container(icons.base)
-                .child(Label::new("...").size(LabelSize::Small)),
+                .child(Label::new("…").size(LabelSize::Small)),
         };
 
         let completion = if is_refreshing || self.active_edit_prediction.is_none() {

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -769,7 +769,7 @@ impl Editor {
         // Create the prompt editor for the review input
         let prompt_editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
-            editor.set_placeholder_text("Add a review comment...", window, cx);
+            editor.set_placeholder_text("Add a review comment…", window, cx);
             editor
         });
 

--- a/crates/encoding_selector/src/encoding_selector.rs
+++ b/crates/encoding_selector/src/encoding_selector.rs
@@ -225,7 +225,7 @@ impl PickerDelegate for EncodingSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Reopen with encoding...".into()
+        "Reopen with encoding…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/etw_tracing/etw_tracing.rs
+++ b/crates/etw_tracing/etw_tracing.rs
@@ -137,7 +137,7 @@ pub fn init(cx: &mut App) {
         };
         match send_json(&mut session.writer, &Command::Save) {
             Ok(()) => {
-                show_etw_notification(cx, "Stopping ETW recording...");
+                show_etw_notification(cx, "Stopping ETW recording…");
             }
             Err(error) => {
                 show_etw_notification(cx, format!("Failed to stop ETW recording: {error:#}"));
@@ -153,7 +153,7 @@ pub fn init(cx: &mut App) {
         };
         match send_json(&mut session.writer, &Command::Cancel) {
             Ok(()) => {
-                show_etw_notification(cx, "Cancelling ETW recording...");
+                show_etw_notification(cx, "Cancelling ETW recording…");
             }
             Err(error) => {
                 show_etw_notification(cx, format!("Failed to cancel ETW recording: {error:#}"));

--- a/crates/extensions_ui/src/extension_version_selector.rs
+++ b/crates/extensions_ui/src/extension_version_selector.rs
@@ -97,7 +97,7 @@ impl PickerDelegate for ExtensionVersionSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select extension version...".into()
+        "Select extension version…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -430,7 +430,7 @@ impl ExtensionsPage {
 
             let query_editor = cx.new(|cx| {
                 let mut input = Editor::single_line(window, cx);
-                input.set_placeholder_text("Search extensions...", window, cx);
+                input.set_placeholder_text("Search extensions…", window, cx);
                 if let Some(id) = focus_extension_id {
                     input.set_text(format!("id:{id}"), window, cx);
                 }
@@ -709,7 +709,7 @@ impl ExtensionsPage {
             Some(ContextMenu::build(window, cx, |context_menu, window, _| {
                 context_menu
                     .entry(
-                        "Install Another Version...",
+                        "Install Another Version…",
                         None,
                         window.handler_for(&this, {
                             let extension_id = extension_id.clone();

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1799,7 +1799,7 @@ impl PickerDelegate for FileFinderDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Search project files...".into()
+        "Search project files…".into()
     }
 
     fn searchbar_trailer(

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5630,7 +5630,7 @@ impl GitPanel {
 
     pub fn configure_commit_button(&self, cx: &mut Context<Self>) -> (bool, &'static str) {
         if self.generate_commit_message_task.is_some() {
-            (false, "Generating commit message...")
+            (false, "Generating commit message…")
         } else if self.has_unstaged_conflicts() {
             (false, "You must resolve conflicts before committing")
         } else if !self.has_staged_changes() && !self.has_tracked_changes() && !self.amend_pending {

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -571,7 +571,7 @@ impl RefPickerModal {
     ) -> Self {
         let editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
-            editor.set_placeholder_text("Enter git ref...", window, cx);
+            editor.set_placeholder_text("Enter git ref…", window, cx);
             editor
         });
 

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -171,7 +171,7 @@ impl PickerDelegate for RepositorySelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select a repository...".into()
+        "Select a repository…".into()
     }
 
     fn editor_position(&self) -> PickerEditorPosition {

--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -102,7 +102,7 @@ impl DivInspector {
 
                             // Initialize editors immediately instead of waiting for
                             // `update_inspected_element`. This avoids continuing to show
-                            // "Loading..." until the user moves the mouse to a different element.
+                            // "Loading…" until the user moves the mouse to a different element.
                             if let Some(id) = this.inspector_id.take() {
                                 let inspector_state =
                                     window.with_inspector_state(Some(&id), cx, |state, _window| {
@@ -520,9 +520,7 @@ impl Render for DivInspector {
                 )
             })
             .map(|this| match &self.state {
-                State::Loading | State::BuffersLoaded { .. } => {
-                    this.child(Label::new("Loading..."))
-                }
+                State::Loading | State::BuffersLoaded { .. } => this.child(Label::new("Loading…")),
                 State::LoadError { message } => this.child(
                     div()
                         .w_full()

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -2665,7 +2665,7 @@ impl Render for ConfigurationView {
             .and_then(|s| s.authentication_method.clone());
 
         if self.load_credentials_task.is_some() {
-            return div().child(Label::new("Loading credentials...")).into_any();
+            return div().child(Label::new("Loading credentials…")).into_any();
         }
 
         let configured_label = match &auth {

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -714,7 +714,7 @@ pub(crate) fn render_mermaid_diagram(
                     .child(render_mermaid_code_view(&parsed.contents.contents))
                     .child(
                         div().absolute().top_1().right_2().child(
-                            Label::new("Rendering...")
+                            Label::new("Rendering…")
                                 .size(LabelSize::XSmall)
                                 .color(Color::Muted)
                                 .with_animation(

--- a/crates/onboarding/src/base_keymap_picker.rs
+++ b/crates/onboarding/src/base_keymap_picker.rs
@@ -107,7 +107,7 @@ impl PickerDelegate for BaseKeymapSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select a base keymap...".into()
+        "Select a base keymap…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -276,7 +276,7 @@ impl PickerDelegate for OutlineViewDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Search buffer symbols...".into()
+        "Search buffer symbols…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1658,7 +1658,7 @@ impl LspCommand for GetReferences {
     }
 
     fn status(&self) -> Option<String> {
-        Some("Finding references...".to_owned())
+        Some("Finding references…".to_owned())
     }
 
     fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1175,7 +1175,7 @@ impl ProjectPanel {
                             })
                             .when(is_remote, |menu| {
                                 menu.separator()
-                                    .action("Download...", Box::new(DownloadFromRemote))
+                                    .action("Download…", Box::new(DownloadFromRemote))
                             })
                             .separator()
                             .action("Copy Path", Box::new(zed_actions::workspace::CopyPath))
@@ -3651,7 +3651,7 @@ impl ProjectPanel {
                             workspace.show_toast(
                                 workspace::Toast::new(
                                     notification_id.clone(),
-                                    format!("Downloading 0/{} files...", total_files),
+                                    format!("Downloading 0/{} files…", total_files),
                                 ),
                                 cx,
                             );
@@ -3667,11 +3667,7 @@ impl ProjectPanel {
                                 workspace.show_toast(
                                     workspace::Toast::new(
                                         notification_id.clone(),
-                                        format!(
-                                            "Downloading {}/{} files...",
-                                            index + 1,
-                                            total_files
-                                        ),
+                                        format!("Downloading {}/{} files…", index + 1, total_files),
                                     ),
                                     cx,
                                 );

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -114,7 +114,7 @@ impl PickerDelegate for ProjectSymbolsDelegate {
         "project symbols"
     }
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Search project symbols...".into()
+        "Search project symbols…".into()
     }
 
     fn confirm(&mut self, secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -242,7 +242,7 @@ impl PickerDelegate for KernelPickerDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select a kernel...".into()
+        "Select a kernel…".into()
     }
 
     fn update_matches(

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -1176,7 +1176,7 @@ impl Render for CodeCell {
                                                                 .text_color(
                                                                     cx.theme().colors().text_muted,
                                                                 )
-                                                                .child("Running..."),
+                                                                .child("Running…"),
                                                         )
                                                         .into_any_element()
                                                 } else if let Some(duration_text) =

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -753,7 +753,7 @@ impl ExecutionView {
 impl Render for ExecutionView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let status = match &self.status {
-            ExecutionStatus::ConnectingToKernel => Label::new("Connecting to kernel...")
+            ExecutionStatus::ConnectingToKernel => Label::new("Connecting to kernel…")
                 .color(Color::Muted)
                 .into_any_element(),
             ExecutionStatus::Executing => h_flex()
@@ -764,7 +764,7 @@ impl Render for ExecutionView {
                         .color(Color::Muted)
                         .with_rotate_animation(3),
                 )
-                .child(Label::new("Executing...").color(Color::Muted))
+                .child(Label::new("Executing…").color(Color::Muted))
                 .into_any_element(),
             ExecutionStatus::Finished => Icon::new(IconName::Check)
                 .size(IconSize::Small)
@@ -772,18 +772,16 @@ impl Render for ExecutionView {
             ExecutionStatus::Unknown => Label::new("Unknown status")
                 .color(Color::Muted)
                 .into_any_element(),
-            ExecutionStatus::ShuttingDown => Label::new("Kernel shutting down...")
+            ExecutionStatus::ShuttingDown => Label::new("Kernel shutting down…")
                 .color(Color::Muted)
                 .into_any_element(),
-            ExecutionStatus::Restarting => Label::new("Kernel restarting...")
+            ExecutionStatus::Restarting => Label::new("Kernel restarting…")
                 .color(Color::Muted)
                 .into_any_element(),
             ExecutionStatus::Shutdown => Label::new("Kernel shutdown")
                 .color(Color::Muted)
                 .into_any_element(),
-            ExecutionStatus::Queued => Label::new("Queued...")
-                .color(Color::Muted)
-                .into_any_element(),
+            ExecutionStatus::Queued => Label::new("Queued…").color(Color::Muted).into_any_element(),
             ExecutionStatus::KernelErrored(error) => Label::new(format!("Kernel error: {}", error))
                 .color(Color::Error)
                 .into_any_element(),

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -99,7 +99,7 @@ pub fn install_ipykernel_and_assign(
             workspace.show_toast(
                 workspace::Toast::new(
                     notification_id.clone(),
-                    format!("Installing ipykernel in {}...", env_name),
+                    format!("Installing ipykernel in {}…", env_name),
                 ),
                 cx,
             );

--- a/crates/settings_profile_selector/src/settings_profile_selector.rs
+++ b/crates/settings_profile_selector/src/settings_profile_selector.rs
@@ -155,7 +155,7 @@ impl PickerDelegate for SettingsProfileSelectorDelegate {
     }
 
     fn placeholder_text(&self, _: &mut Window, _: &mut App) -> std::sync::Arc<str> {
-        "Select a settings profile...".into()
+        "Select a settings profile…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -204,7 +204,7 @@ impl PickerDelegate for ScopeSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _: &mut App) -> Arc<str> {
-        "Select snippet scope...".into()
+        "Select snippet scope…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -167,7 +167,7 @@ impl PickerDelegate for IconThemeSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select Icon Theme...".into()
+        "Select Icon Theme…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -383,7 +383,7 @@ impl PickerDelegate for ThemeSelectorDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select Theme...".into()
+        "Select Theme…".into()
     }
 
     fn match_count(&self) -> usize {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -618,11 +618,11 @@ impl TitleBar {
             remote::ConnectionState::Connected => (Color::Success, format!("Connected to: {host}")),
             remote::ConnectionState::HeartbeatMissed => (
                 Color::Warning,
-                format!("Connection attempt to {host} missed. Retrying..."),
+                format!("Connection attempt to {host} missed. Retrying…"),
             ),
             remote::ConnectionState::Reconnecting => (
                 Color::Warning,
-                format!("Lost connection to {host}. Reconnecting..."),
+                format!("Lost connection to {host}. Reconnecting…"),
             ),
             remote::ConnectionState::Disconnected => {
                 (Color::Error, format!("Disconnected from {host}"))
@@ -1153,7 +1153,7 @@ impl TitleBar {
                     Some(AutoUpdateStatus::Updated { .. }) => "Please restart Zed to Collaborate",
                     Some(AutoUpdateStatus::Installing { .. })
                     | Some(AutoUpdateStatus::Downloading { .. })
-                    | Some(AutoUpdateStatus::Checking) => "Updating...",
+                    | Some(AutoUpdateStatus::Checking) => "Updating…",
                     Some(AutoUpdateStatus::Idle)
                     | Some(AutoUpdateStatus::Errored { .. })
                     | None => "Please update Zed to Collaborate",

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -78,11 +78,11 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                     MenuItem::action("Open Default Key Bindings", zed_actions::OpenDefaultKeymap),
                     MenuItem::separator(),
                     MenuItem::action(
-                        "Select Theme...",
+                        "Select Theme…",
                         zed_actions::theme_selector::Toggle::default(),
                     ),
                     MenuItem::action(
-                        "Select Icon Theme...",
+                        "Select Icon Theme…",
                         zed_actions::icon_theme_selector::Toggle::default(),
                     ),
                 ])),
@@ -112,10 +112,10 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::action("New Window", workspace::NewWindow),
                 MenuItem::separator(),
                 #[cfg(not(target_os = "macos"))]
-                MenuItem::action("Open File...", workspace::OpenFiles),
+                MenuItem::action("Open File…", workspace::OpenFiles),
                 MenuItem::action(
                     if cfg!(not(target_os = "macos")) {
-                        "Open Folder..."
+                        "Open Folder…"
                     } else {
                         "Open…"
                     },
@@ -222,15 +222,15 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::action("Back", workspace::GoBack),
                 MenuItem::action("Forward", workspace::GoForward),
                 MenuItem::separator(),
-                MenuItem::action("Command Palette...", zed_actions::command_palette::Toggle),
+                MenuItem::action("Command Palette…", zed_actions::command_palette::Toggle),
                 MenuItem::separator(),
-                MenuItem::action("Go to File...", workspace::ToggleFileFinder::default()),
+                MenuItem::action("Go to File…", workspace::ToggleFileFinder::default()),
                 // MenuItem::action("Go to Symbol in Project", project_symbols::Toggle),
                 MenuItem::action(
-                    "Go to Symbol in Editor...",
+                    "Go to Symbol in Editor…",
                     zed_actions::outline::ToggleOutline,
                 ),
-                MenuItem::action("Go to Line/Column...", editor::actions::ToggleGoToLine),
+                MenuItem::action("Go to Line/Column…", editor::actions::ToggleGoToLine),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Go to Definition",
@@ -296,9 +296,9 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::action("View Dependency Licenses", zed_actions::OpenLicenses),
                 MenuItem::action("Show Welcome", onboarding::ShowWelcome),
                 MenuItem::separator(),
-                MenuItem::action("File Bug Report...", zed_actions::feedback::FileBugReport),
-                MenuItem::action("Request Feature...", zed_actions::feedback::RequestFeature),
-                MenuItem::action("Email Us...", zed_actions::feedback::EmailZed),
+                MenuItem::action("File Bug Report…", zed_actions::feedback::FileBugReport),
+                MenuItem::action("Request Feature…", zed_actions::feedback::RequestFeature),
+                MenuItem::action("Email Us…", zed_actions::feedback::EmailZed),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Documentation",

--- a/crates/zed/src/zed/quick_action_bar/repl_menu.rs
+++ b/crates/zed/src/zed/quick_action_bar/repl_menu.rs
@@ -123,7 +123,7 @@ impl QuickActionBar {
                             menu.custom_row(move |_window, _cx| {
                                 h_flex()
                                     .child(
-                                        Label::new(format!("{}...", status.to_string()))
+                                        Label::new(format!("{}…", status.to_string()))
                                             .size(LabelSize::Small)
                                             .color(Color::Muted),
                                     )

--- a/crates/zed/src/zed/telemetry_log.rs
+++ b/crates/zed/src/zed/telemetry_log.rs
@@ -539,7 +539,7 @@ impl TelemetryLogToolbarItemView {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let search_editor = cx.new(|cx| {
             let mut editor = editor::Editor::single_line(window, cx);
-            editor.set_placeholder_text("Filter events...", window, cx);
+            editor.set_placeholder_text("Filter events…", window, cx);
             editor
         });
 


### PR DESCRIPTION
It’s a silly little thing, and it would have likely gone unnoticed for the longest time, but I think it’s important to be consistent (in anything you do or say, really). Our interface generally uses a single Unicode [ellipsis](https://en.wikipedia.org/wiki/Ellipsis), but several menus, placeholders, progress messages, and diagnostic surfaces still used three ASCII periods.

Make those remaining strings consistent and keep character-based truncation limits correct when the replacement occupies multiple UTF-8 bytes.

---

Release Notes:

- Use the right punctuation mark (ellipsis) throughout Zed