### PR TITLE
Preserve typed errors when listing Anthropic models

### DIFF
--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -28,3 +28,6 @@ serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+http_client = { workspace = true, features = ["test-support"] }

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -333,7 +333,7 @@ pub async fn list_models(
     api_url: &str,
     api_key: &str,
     extra_headers: &CustomHeaders,
-) -> Result<Vec<Model>> {
+) -> Result<Vec<Model>, AnthropicError> {
     let uri = format!("{api_url}/v1/models?limit=1000");
 
     let request = HttpRequest::builder()
@@ -344,29 +344,27 @@ pub async fn list_models(
         .header("Accept", "application/json")
         .extra_headers(extra_headers)
         .body(AsyncBody::default())
-        .context("failed to build Anthropic models list request")?;
+        .map_err(AnthropicError::BuildRequestBody)?;
 
     let mut response = client
         .send(request)
         .await
-        .context("failed to send Anthropic models list request")?;
+        .map_err(AnthropicError::HttpSend)?;
+
+    if !response.status().is_success() {
+        let rate_limits = RateLimitInfo::from_headers(response.headers());
+        return Err(handle_error_response(response, rate_limits).await);
+    }
 
     let mut body = String::new();
     response
         .body_mut()
         .read_to_string(&mut body)
         .await
-        .context("failed to read Anthropic models list response")?;
-
-    anyhow::ensure!(
-        response.status().is_success(),
-        "failed to list Anthropic models: {} {}",
-        response.status(),
-        body,
-    );
+        .map_err(AnthropicError::ReadResponse)?;
 
     let parsed: ListModelsResponse =
-        serde_json::from_str(&body).context("failed to parse Anthropic models list response")?;
+        serde_json::from_str(&body).map_err(AnthropicError::DeserializeResponse)?;
 
     let models = parsed
         .data
@@ -1265,6 +1263,35 @@ pub fn completion_error_from_anthropic_api(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_client::FakeHttpClient;
+
+    #[test]
+    fn list_models_preserves_anthropic_api_errors() {
+        let client = FakeHttpClient::create(|_| async move {
+            Ok(http::Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(AsyncBody::from(
+                    r#"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"},"request_id":"request-id"}"#,
+                ))
+                .expect("valid response"))
+        });
+
+        let error = futures::executor::block_on(list_models(
+            client.as_ref(),
+            ANTHROPIC_API_URL,
+            "invalid-key",
+            &CustomHeaders::default(),
+        ))
+        .expect_err("authentication should fail");
+
+        assert!(matches!(
+            error,
+            AnthropicError::ApiError(ApiError {
+                error_type,
+                message,
+            }) if error_type == "authentication_error" && message == "invalid x-api-key"
+        ));
+    }
 
     fn listed_entry(id: &str, capabilities: ModelCapabilities) -> ListModelEntry {
         ListModelEntry {

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -120,7 +120,8 @@ impl State {
                 api_key.as_ref(),
                 &extra_headers,
             )
-            .await?;
+            .await
+            .map_err(LanguageModelCompletionError::from)?;
 
             this.update(cx, |this, cx| {
                 this.fetched_models = models;


### PR DESCRIPTION
Anthropic model-list requests currently flatten request, transport, response, and API failures into `anyhow` strings. Callers therefore cannot distinguish an invalid API key from connectivity or provider failures, even though Anthropic returns a structured error payload.

This changes `list_models` to return `AnthropicError`, maps each request stage to its existing typed variant, and routes unsuccessful responses through the same structured response handler used by completion requests. The language model provider converts that error at its existing `LanguageModelCompletionError` boundary. A regression test verifies that an authentication response retains both its error category and Anthropic's human-readable message.

Testing performed:

- `cargo fmt --check`
- `cargo nextest run -p anthropic -p language_models`
- `./script/clippy -p anthropic -p language_models`

Release Notes:

- Fixed Anthropic API key errors being reported as generic model-list failures.
