### PR TITLE
vim: Dismiss diagnostic and diff overlays with Helix Esc

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -418,7 +418,7 @@
     },
   },
   {
-    "context": "VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar",
+    "context": "VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar && !diffs_expanded && !active_diagnostics",
     "bindings": {
       "j": ["vim::Down", { "display_lines": true }],
       "down": ["vim::Down", { "display_lines": true }],
@@ -445,15 +445,21 @@
     },
   },
   {
-    "context": "Editor && mode == full && VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar && os == windows",
+    "context": "Editor && mode == full && VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar && !diffs_expanded && !active_diagnostics && os == windows",
     "bindings": {
       "escape": "menu::Cancel",
     },
   },
   {
-    "context": "vim_mode == helix_select && !menu && !BufferSearchBar",
+    "context": "vim_mode == helix_select && !menu && !BufferSearchBar && !diffs_expanded && !active_diagnostics",
     "bindings": {
       "escape": "vim::SwitchToHelixNormalMode",
+    },
+  },
+  {
+    "context": "(vim_mode == helix_normal || vim_mode == helix_select) && !menu && (diffs_expanded || active_diagnostics)",
+    "bindings": {
+      "escape": "editor::Cancel",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -418,7 +418,7 @@
     },
   },
   {
-    "context": "VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar && !diffs_expanded && !active_diagnostics",
+    "context": "VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar",
     "bindings": {
       "j": ["vim::Down", { "display_lines": true }],
       "down": ["vim::Down", { "display_lines": true }],
@@ -428,11 +428,16 @@
       "g down": "vim::Down",
       "g k": "vim::Up",
       "g up": "vim::Up",
-      "escape": "vim::SwitchToHelixNormalMode",
       "i": "vim::HelixInsert",
       "a": "vim::HelixAppend",
       "shift-a": "vim::HelixInsertEndOfLine",
       "ctrl-[": "editor::Cancel",
+    },
+  },
+  {
+    "context": "VimControl && vim_mode == helix_normal && !menu && !BufferSearchBar && !diffs_expanded && !active_diagnostics",
+    "bindings": {
+      "escape": "vim::SwitchToHelixNormalMode",
     },
   },
   // Vim/Helix consume Escape before menu::Cancel can dismiss notifications. macOS (Ctrl-C) and Linux

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2787,6 +2787,10 @@ impl Editor {
             key_context.add("diffs_expanded");
         }
 
+        if self.has_active_diagnostic_group() {
+            key_context.add("active_diagnostics");
+        }
+
         key_context
     }
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1879,13 +1879,14 @@ mod test {
     use futures::StreamExt;
     use std::{fmt::Write, time::Duration};
 
-    use editor::{HighlightKey, MultiBufferOffset};
+    use editor::{Anchor, HighlightKey, MultiBufferOffset};
     use gpui::{
         Bounds, DispatchEventResult, ElementInputHandler, KeyBinding, KeyDownEvent, Keystroke,
         PlatformInput, PlatformInputHandler, UpdateGlobal, VisualTestContext,
     };
     use indoc::indoc;
-    use language::{CursorShape, Point};
+    use language::{CursorShape, DiagnosticSourceKind, Point};
+    use lsp::LanguageServerId;
     use project::FakeFs;
     use search::{ProjectSearchView, project_search};
     use serde_json::json;
@@ -4685,6 +4686,133 @@ mod test {
             Mode::HelixNormal,
         );
         assert_eq!(cx.active_operator(), None);
+    }
+
+    #[gpui::test]
+    async fn test_helix_escape_dismisses_diagnostics(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state(
+            indoc! {"
+            fn func(abc dˇef: i32) -> u32 {
+            }"},
+            Mode::HelixNormal,
+        );
+
+        let lsp_store =
+            cx.update_editor(|editor, _, cx| editor.project().unwrap().read(cx).lsp_store());
+        let uri = cx.buffer_lsp_url.clone();
+        let message = "something is wrong";
+        cx.update(|_, cx| {
+            lsp_store.update(cx, |lsp_store, cx| {
+                lsp_store
+                    .update_diagnostics(
+                        LanguageServerId(0),
+                        lsp::PublishDiagnosticsParams {
+                            uri,
+                            version: None,
+                            diagnostics: vec![lsp::Diagnostic {
+                                range: lsp::Range::new(
+                                    lsp::Position::new(0, 12),
+                                    lsp::Position::new(0, 15),
+                                ),
+                                severity: Some(lsp::DiagnosticSeverity::ERROR),
+                                message: message.to_string(),
+                                ..Default::default()
+                            }],
+                        },
+                        None,
+                        DiagnosticSourceKind::Pushed,
+                        &[],
+                        cx,
+                    )
+                    .unwrap()
+            });
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("] d");
+        cx.update_editor(|editor, _, _| {
+            assert_eq!(
+                editor.active_diagnostic_message(),
+                Some(message),
+                "Helix ] d should activate the diagnostic overlay"
+            );
+        });
+
+        cx.simulate_keystrokes("escape");
+        cx.update_editor(|editor, _, _| {
+            assert_eq!(
+                editor.active_diagnostic_message(),
+                None,
+                "Helix Esc should dismiss the diagnostic overlay"
+            );
+        });
+        assert_eq!(cx.mode(), Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_helix_escape_collapses_expanded_diff_hunks(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state(
+            indoc! {"
+            one
+            ˇtwo
+            three"},
+            Mode::HelixNormal,
+        );
+        cx.set_head_text(indoc! {"
+            one
+            CHANGED
+            three"});
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("g o");
+        cx.update_editor(|editor, _, cx| {
+            assert!(
+                editor
+                    .buffer()
+                    .read(cx)
+                    .has_expanded_diff_hunks_in_ranges(&[Anchor::Min..Anchor::Max], cx),
+                "Helix g o should expand the diff hunk"
+            );
+        });
+
+        cx.simulate_keystrokes("escape");
+        cx.update_editor(|editor, _, cx| {
+            assert!(
+                !editor
+                    .buffer()
+                    .read(cx)
+                    .has_expanded_diff_hunks_in_ranges(&[Anchor::Min..Anchor::Max], cx),
+                "Helix Esc should collapse expanded diff hunks"
+            );
+        });
+        cx.assert_state(
+            indoc! {"
+            one
+            ˇtwo
+            three"},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_escape_without_overlay_keeps_selections(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state("hello «worlˇ»d", Mode::HelixNormal);
+        cx.simulate_keystrokes("escape");
+        cx.assert_state("hello «worlˇ»d", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("v e");
+        cx.assert_state("hello «worldˇ»", Mode::HelixSelect);
+        cx.simulate_keystrokes("escape");
+        cx.assert_state("hello «worldˇ»", Mode::HelixNormal);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixes #55197

## Problem

In Helix mode, `Esc` is bound to `vim::SwitchToHelixNormalMode`, which only calls `switch_mode(HelixNormal, true)` and never runs `editor::Cancel`. That leaves the `] d` diagnostic overlay and `g o` expanded diff hunks open. Vim mode closes both because its `Esc` binding is `editor::Cancel`.

Calling full `editor::Cancel` when no overlay is open would also collapse Helix selections, which must be preserved.

## Solution

Follow the existing `!BufferSearchBar` pattern, scoped only to Escape:

1. Add an `active_diagnostics` Editor key context when `has_active_diagnostic_group()` is true (`diffs_expanded` already exists).
2. Bind Helix `Esc` → `SwitchToHelixNormalMode` only when no overlay is open (`&& !diffs_expanded && !active_diagnostics`) in helix_normal and helix_select. The helix_normal `j`/`k`/`i`/`a` block keeps its original context so those keys still work while an overlay is open.
3. Bind Helix `Esc` → `editor::Cancel` when `diffs_expanded || active_diagnostics`.

## Testing

- `test_helix_escape_dismisses_diagnostics`: Helix `] d` then `Esc` dismisses the diagnostic overlay.
- `test_helix_escape_collapses_expanded_diff_hunks`: Helix `g o` then `Esc` collapses expanded hunks.
- `test_helix_escape_without_overlay_keeps_selections`: `Esc` with no overlay keeps Helix selections in both helix_normal and helix_select.

Release Notes:

- Fixed Helix `Esc` not closing the diagnostic overlay or expanded diff hunks