### PR TITLE
project: Keep related diagnostic locations in sync

### DIFF
--- a/crates/language/src/diagnostic.rs
+++ b/crates/language/src/diagnostic.rs
@@ -2,10 +2,11 @@ use gpui::SharedString;
 use lsp::{DiagnosticRelatedInformation, DiagnosticSeverity, NumberOrString};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::sync::Arc;
+use std::{ops::Range, sync::Arc};
+use text::Anchor;
 
 /// A diagnostic associated with a certain range of a buffer.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Diagnostic {
     /// The name of the service that produced this diagnostic.
     pub source: Option<String>,
@@ -50,6 +51,12 @@ pub struct Diagnostic {
     ///
     /// Kept as sent, since flattening it into non-primary entries is lossy.
     pub related_information: Option<Arc<[DiagnosticRelatedInformation]>>,
+    /// Anchored ranges for related information that points into this buffer.
+    ///
+    /// This is intentionally not serialized. The anchors are local to the buffer that owns the
+    /// diagnostic, while the original LSP locations are retained above for protocol round trips.
+    #[serde(skip)]
+    pub related_information_anchors: Option<Arc<[Option<Range<Anchor>>]>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +84,29 @@ impl Default for Diagnostic {
             data: None,
             registration_id: None,
             related_information: None,
+            related_information_anchors: None,
         }
     }
 }
+
+impl PartialEq for Diagnostic {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source
+            && self.registration_id == other.registration_id
+            && self.code == other.code
+            && self.code_description == other.code_description
+            && self.severity == other.severity
+            && self.message == other.message
+            && self.markdown == other.markdown
+            && self.group_id == other.group_id
+            && self.is_primary == other.is_primary
+            && self.is_disk_based == other.is_disk_based
+            && self.is_unnecessary == other.is_unnecessary
+            && self.source_kind == other.source_kind
+            && self.data == other.data
+            && self.underline == other.underline
+            && self.related_information == other.related_information
+    }
+}
+
+impl Eq for Diagnostic {}

--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -9,7 +9,7 @@ use std::{
     ops::Range,
 };
 use sum_tree::{self, Bias, SumTree};
-use text::{Anchor, FromAnchor, PointUtf16, ToOffset};
+use text::{Anchor, FromAnchor, OffsetRangeExt, PointUtf16, ToOffset};
 
 /// A set of diagnostics associated with a given buffer, provided
 /// by a single language server.
@@ -143,6 +143,50 @@ impl DiagnosticEntryRef<'_, PointUtf16> {
                 .related_information
                 .as_ref()
                 .map(|related_information| related_information.to_vec()),
+            ..Default::default()
+        })
+    }
+
+    /// Returns a raw LSP diagnostic, resolving any same-buffer related information against the
+    /// current snapshot so edits made after the diagnostic was published are reflected.
+    pub fn to_lsp_diagnostic_stub_with_snapshot(
+        &self,
+        buffer: &text::BufferSnapshot,
+    ) -> Result<lsp::Diagnostic> {
+        let range = range_to_lsp(self.range.clone())?;
+        let related_information = self
+            .diagnostic
+            .related_information
+            .as_ref()
+            .map(|related_information| {
+                related_information
+                    .iter()
+                    .enumerate()
+                    .map(|(index, information)| {
+                        let mut information = information.clone();
+                        if let Some(Some(range)) = self
+                            .diagnostic
+                            .related_information_anchors
+                            .as_ref()
+                            .and_then(|anchors| anchors.get(index))
+                        {
+                            information.location.range =
+                                range_to_lsp(range.to_point_utf16(buffer))?;
+                        }
+                        Ok(information)
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+
+        Ok(lsp::Diagnostic {
+            range,
+            code: self.diagnostic.code.clone(),
+            severity: Some(self.diagnostic.severity),
+            source: self.diagnostic.source.clone(),
+            message: self.diagnostic.message.clone(),
+            data: self.diagnostic.data.clone(),
+            related_information,
             ..Default::default()
         })
     }

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -475,6 +475,7 @@ pub fn deserialize_diagnostics(
                     data,
                     // Not serialized: only the peer talking to the language server sends these back.
                     related_information: None,
+                    related_information_anchors: None,
                 },
             })
         })

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2950,11 +2950,11 @@ impl LspCommand for GetCodeActions {
         _: &App,
     ) -> Result<lsp::CodeActionParams> {
         let mut relevant_diagnostics = Vec::new();
-        for entry in buffer
-            .snapshot()
-            .diagnostics_in_range::<_, language::PointUtf16>(self.range.clone(), false)
+        let snapshot = buffer.snapshot();
+        for entry in
+            snapshot.diagnostics_in_range::<_, language::PointUtf16>(self.range.clone(), false)
         {
-            relevant_diagnostics.push(entry.to_lsp_diagnostic_stub()?);
+            relevant_diagnostics.push(entry.to_lsp_diagnostic_stub_with_snapshot(&snapshot)?);
         }
 
         let only = if let Some(requested) = &self.kinds {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2790,6 +2790,12 @@ impl LocalLspStore {
 
         let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
 
+        let document_uri = {
+            let buffer = buffer.read(cx);
+            File::from_dyn(buffer.file())
+                .and_then(|file| Uri::from_file_path(file.abs_path(cx)).ok())
+        };
+
         let edits_since_save = std::cell::LazyCell::new(|| {
             let saved_version = buffer.read(cx).saved_version();
             Patch::new(snapshot.edits_since::<PointUtf16>(saved_version).collect())
@@ -2798,9 +2804,43 @@ impl LocalLspStore {
         let mut sanitized_diagnostics = Vec::with_capacity(diagnostics.len());
 
         for (new_diagnostic, entry) in diagnostics {
+            let mut diagnostic = entry.diagnostic;
+            if new_diagnostic {
+                diagnostic.related_information_anchors = diagnostic
+                    .related_information
+                    .as_ref()
+                    .map(|related_information| {
+                        Arc::from(
+                            related_information
+                                .iter()
+                                .map(|information| {
+                                    let Some(document_uri) = document_uri.as_ref() else {
+                                        return None;
+                                    };
+                                    if information.location.uri != *document_uri {
+                                        return None;
+                                    }
+
+                                    let range = range_from_lsp(information.location.range);
+                                    let range = if diagnostic.is_disk_based {
+                                        Unclipped((*edits_since_save).old_to_new(range.start.0))
+                                            ..Unclipped((*edits_since_save).old_to_new(range.end.0))
+                                    } else {
+                                        range
+                                    };
+                                    Some(
+                                        snapshot.anchor_before(range.start)
+                                            ..snapshot.anchor_after(range.end),
+                                    )
+                                })
+                                .collect::<Vec<_>>(),
+                        )
+                    });
+            }
+
             let start;
             let end;
-            if new_diagnostic && entry.diagnostic.is_disk_based {
+            if new_diagnostic && diagnostic.is_disk_based {
                 // Some diagnostics are based on files on disk instead of buffers'
                 // current contents. Adjust these diagnostics' ranges to reflect
                 // any unsaved edits.
@@ -2827,10 +2867,7 @@ impl LocalLspStore {
                 }
             }
 
-            sanitized_diagnostics.push(DiagnosticEntry {
-                range,
-                diagnostic: entry.diagnostic,
-            });
+            sanitized_diagnostics.push(DiagnosticEntry { range, diagnostic });
         }
         drop(edits_since_save);
 
@@ -12232,6 +12269,7 @@ impl LspStore {
                             .related_information
                             .as_ref()
                             .map(|infos| Arc::from(infos.as_slice())),
+                        related_information_anchors: None,
                     },
                 });
                 if let Some(infos) = &diagnostic.related_information {
@@ -12261,6 +12299,7 @@ impl LspStore {
                                     data: diagnostic.data.clone(),
                                     registration_id: registration_id.clone(),
                                     related_information: None,
+                                    related_information_anchors: None,
                                 },
                             });
                         }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -9836,6 +9836,86 @@ async fn test_code_actions_include_related_information(cx: &mut gpui::TestAppCon
 }
 
 #[gpui::test]
+async fn test_code_actions_update_related_information_after_buffer_edit(
+    cx: &mut gpui::TestAppContext,
+) {
+    let (project, buffer, _handle, fake_servers) =
+        code_action_project(&["test-language-server"], cx).await;
+    let fake_server = &fake_servers[0];
+
+    let uri = Uri::from_file_path(path!("/dir/a.ts")).unwrap();
+    let related_information = vec![
+        lsp::DiagnosticRelatedInformation {
+            location: lsp::Location {
+                uri: uri.clone(),
+                range: lsp::Range::new(lsp::Position::new(0, 2), lsp::Position::new(0, 3)),
+            },
+            message: String::new(),
+        },
+        lsp::DiagnosticRelatedInformation {
+            location: lsp::Location {
+                uri: Uri::from_file_path(path!("/dir/b.ts")).unwrap(),
+                range: lsp::Range::new(lsp::Position::new(4, 0), lsp::Position::new(4, 1)),
+            },
+            message: String::new(),
+        },
+    ];
+    fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
+        uri,
+        version: None,
+        diagnostics: vec![lsp::Diagnostic {
+            range: lsp::Range::new(lsp::Position::new(0, 2), lsp::Position::new(0, 3)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("test-language-server".to_string()),
+            message: "primary diagnostic".to_string(),
+            related_information: Some(related_information),
+            ..Default::default()
+        }],
+    });
+    cx.executor().run_until_parked();
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "inserted\n")], None, cx)
+    });
+
+    let mut request_handled = fake_server
+        .set_request_handler::<lsp::request::CodeActionRequest, _, _>(|params, _| async move {
+            let diagnostic = params
+                .context
+                .diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.message == "primary diagnostic")
+                .expect("the primary diagnostic should be sent");
+            assert_eq!(
+                diagnostic.range,
+                lsp::Range::new(lsp::Position::new(1, 2), lsp::Position::new(1, 3))
+            );
+            let related_information = diagnostic
+                .related_information
+                .as_ref()
+                .expect("related information should be preserved");
+            assert_eq!(
+                related_information[0].location.range,
+                lsp::Range::new(lsp::Position::new(1, 2), lsp::Position::new(1, 3))
+            );
+            assert_eq!(
+                related_information[1].location.range,
+                lsp::Range::new(lsp::Position::new(4, 0), lsp::Position::new(4, 1))
+            );
+            Ok(Some(Vec::new()))
+        });
+
+    let code_actions_task = project.update(cx, |project, cx| {
+        project.code_actions(&buffer, 0..buffer.read(cx).len(), None, cx)
+    });
+    request_handled
+        .next()
+        .await
+        .expect("The code action request should have been triggered");
+    assert!(code_actions_task.await.unwrap().unwrap().is_empty());
+}
+
+#[gpui::test]
 async fn test_code_actions_without_related_information(cx: &mut gpui::TestAppContext) {
     let (project, buffer, _handle, fake_servers) =
         code_action_project(&["test-language-server"], cx).await;


### PR DESCRIPTION
Closes #62796

Keep same-file diagnostic related-information ranges anchored to the buffer so code-action requests follow edits. Locations in other files remain unchanged.

Release Notes:

- Fixed stale related diagnostic locations after buffer edits