### PR TITLE
Show Git history for editor selection

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -220,6 +220,7 @@ pub fn deploy_context_menu(
         let evaluate_selection = window.is_action_available(&EvaluateSelectedText, cx);
         let run_to_cursor = window.is_action_available(&RunToCursor, cx);
         let format_selections = window.is_action_available(&FormatSelections, cx);
+        let selection_history = window.is_action_available(&git::FileHistoryForSelection, cx);
         let disable_ai = DisableAiSettings::is_ai_disabled_for_buffer(
             editor.buffer.read(cx).as_singleton().as_ref(),
             cx,
@@ -325,6 +326,11 @@ pub fn deploy_context_menu(
                     !has_git_repo,
                     "View File History",
                     Box::new(git::FileHistory),
+                )
+                .action_disabled_when(
+                    !has_git_repo || !selection_history,
+                    "View History for Selection",
+                    Box::new(git::FileHistoryForSelection),
                 );
             match focus {
                 Some(focus) => builder.context(focus),

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -61,6 +61,9 @@ actions!(
         Blame,
         /// Shows the git history for the selected file, folder, or project.
         FileHistory,
+        /// Shows the git history for the selected line range in the active editor.
+        /// If no selection is active, falls back to the current line.
+        FileHistoryForSelection,
         /// Opens a permalink for the selected file on its Git hosting provider.
         OpenFilePermalink,
         /// Copies a permalink for the selected file on its Git hosting provider.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -734,9 +734,28 @@ pub enum LogSource {
     Branch(SharedString),
     Sha(Oid),
     Path(RepoPath),
+    /// History for a line range within a file. Uses
+    /// `git log -L <start>,<end>:<path> --no-patch`. Git tracks the selected
+    /// lines across commit history.
+    Selection {
+        path: RepoPath,
+        start_line: u32,
+        end_line: u32,
+    },
 }
 
 impl LogSource {
+    pub fn is_path_history(&self) -> bool {
+        self.path().is_some()
+    }
+
+    pub fn path(&self) -> Option<&RepoPath> {
+        match self {
+            LogSource::Path(path) | LogSource::Selection { path, .. } => Some(path),
+            LogSource::All | LogSource::Branch(_) | LogSource::Sha(_) => None,
+        }
+    }
+
     fn get_args(&self) -> Vec<Cow<'_, str>> {
         let mut args = match self {
             LogSource::All => vec![
@@ -753,11 +772,25 @@ impl LogSource {
                 Cow::Borrowed("--"),
                 Cow::Borrowed(path.as_unix_str()),
             ],
+            LogSource::Selection {
+                path,
+                start_line,
+                end_line,
+            } => vec![
+                Cow::Owned(format!(
+                    "-L {},{}:{}",
+                    start_line,
+                    end_line,
+                    path.as_unix_str()
+                )),
+                Cow::Borrowed("--no-patch"),
+            ],
         };
         // Without a terminator git cannot tell a branch named `docs/rewrite` from a
         // `docs/rewrite` directory in the working tree, and refuses the argument as
-        // ambiguous. `Path` states its own separator before the path it passes.
-        if !matches!(self, LogSource::Path(_)) {
+        // ambiguous. `Path` states its own separator before the path it passes; `Selection`
+        // embeds its path in `-L` and has no revision argument.
+        if !matches!(self, LogSource::Path(_) | LogSource::Selection { .. }) {
             args.push(Cow::Borrowed("--"));
         }
         args
@@ -5468,6 +5501,124 @@ mod tests {
             path_args.iter().filter(|arg| arg.as_ref() == "--").count(),
             1,
             "Path states the separator itself and must not gain a second one"
+        );
+    }
+
+    #[test]
+    fn test_log_source_selection_get_args() {
+        let path = RepoPath::new("src/main.rs").unwrap();
+        let source = LogSource::Selection {
+            path: path.clone(),
+            start_line: 3,
+            end_line: 5,
+        };
+        let args: Vec<String> = source.get_args().iter().map(|s| s.to_string()).collect();
+        assert_eq!(args, vec!["-L 3,5:src/main.rs", "--no-patch"]);
+        assert!(source.is_path_history());
+        assert_eq!(source.path(), Some(&path));
+        assert!(!LogSource::All.is_path_history());
+        assert_eq!(LogSource::All.path(), None);
+    }
+
+    #[gpui::test]
+    async fn test_initial_graph_data_accepts_selection_log_source(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git_init_repo(repo_dir.path());
+
+        // Commit 1: add file with 5 lines.
+        fs::write(
+            repo_dir.path().join("file.txt"),
+            "line1\nline2\nline3\nline4\nline5\n",
+        )
+        .unwrap();
+        git_command(repo_dir.path(), ["add", "file.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "add file"]);
+
+        // Commit 2: modify line 3.
+        fs::write(
+            repo_dir.path().join("file.txt"),
+            "line1\nline2\nline3 changed\nline4\nline5\n",
+        )
+        .unwrap();
+        git_command(repo_dir.path(), ["commit", "-am", "edit line 3"]);
+
+        // Commit 3: modify line 1 (does not touch lines 2-4).
+        fs::write(
+            repo_dir.path().join("file.txt"),
+            "line1 changed\nline2\nline3 changed\nline4\nline5\n",
+        )
+        .unwrap();
+        git_command(repo_dir.path(), ["commit", "-am", "edit line 1"]);
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let (request_tx, request_rx) = async_channel::unbounded();
+
+        repo.initial_graph_data(
+            LogSource::Selection {
+                path: RepoPath::new("file.txt").unwrap(),
+                start_line: 3,
+                end_line: 3,
+            },
+            LogOrder::DateOrder,
+            request_tx,
+        )
+        .await
+        .unwrap();
+
+        let graph_data = request_rx.recv().await.unwrap();
+        // Line 3 was touched by commit 1 (added) and commit 2 (edited). Commit 3
+        // only touched line 1, so it must be filtered out by `git log -L`.
+        assert_eq!(graph_data.len(), 2);
+    }
+
+    #[gpui::test]
+    async fn test_initial_graph_data_selection_preserves_git_error(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git_init_repo(repo_dir.path());
+        fs::write(repo_dir.path().join("file.txt"), "line1\nline2\n").unwrap();
+        git_command(repo_dir.path(), ["add", "file.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "add"]);
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let (request_tx, _request_rx) = async_channel::unbounded();
+
+        let err = repo
+            .initial_graph_data(
+                LogSource::Selection {
+                    path: RepoPath::new("file.txt").unwrap(),
+                    start_line: 99,
+                    end_line: 100,
+                },
+                LogOrder::DateOrder,
+                request_tx,
+            )
+            .await
+            .expect_err("should error on untouched range");
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("has only 2 lines"),
+            "expected git's line range error, got: {msg}"
         );
     }
 

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -5,6 +5,7 @@ use crate::{
     commit_view::CommitView,
     git_status_icon,
 };
+use buffer_diff::BufferDiffSnapshot;
 use collections::{BTreeMap, HashMap, IndexSet};
 use editor::Editor;
 use file_icons::FileIcons;
@@ -22,7 +23,7 @@ use gpui::{
     UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred, point, prelude::*,
     px, uniform_list,
 };
-use language::line_diff;
+use language::{ToPoint, line_diff};
 use markdown::{Markdown, MarkdownElement};
 use menu::{Cancel, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use picker::{Picker, PickerDelegate};
@@ -58,8 +59,9 @@ use ui::{
 };
 use util::{ResultExt, debug_panic};
 use workspace::{
-    ItemNavHistory, ModalView, Workspace,
+    ItemNavHistory, ModalView, Toast, Workspace,
     item::{Item, ItemEvent, TabTooltipContent},
+    notifications::NotificationId,
 };
 
 const COMMIT_CIRCLE_RADIUS: Pixels = px(3.5);
@@ -73,6 +75,178 @@ const COMMIT_TAG_LIST_WIDTH_IN_REMS: Rems = rems(10.);
 const TREE_INDENT: f32 = 20.0;
 const TABLE_COLUMN_COUNT: usize = 4;
 const ROW_VERTICAL_PADDING: Pixels = px(4.0);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SelectionHistoryProjection {
+    Mapped { start_line: u32, end_line: u32 },
+    NoCommittedLines,
+}
+
+#[derive(Clone)]
+enum PendingSelectionHistoryTarget {
+    Ready {
+        repo_id: RepositoryId,
+        repo_path: RepoPath,
+        buffer: Entity<language::Buffer>,
+        source_range: Range<language::Anchor>,
+    },
+    UnsupportedDeletedSelection,
+}
+
+enum SelectionHistoryError {
+    NoCommittedLines,
+    UnsupportedDeletedSelection,
+    DiffLoad(String),
+}
+
+impl SelectionHistoryError {
+    fn notification_id(&self) -> NotificationId {
+        let id = match self {
+            Self::NoCommittedLines => "selection-history-no-committed-lines",
+            Self::UnsupportedDeletedSelection => "selection-history-deleted-lines",
+            Self::DiffLoad(_) => "selection-history-diff-load-failed",
+        };
+        NotificationId::named(id.into())
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::NoCommittedLines => "Selected lines have no commit history".to_string(),
+            Self::UnsupportedDeletedSelection => {
+                "Selection endpoints inside deleted lines are not supported".to_string()
+            }
+            Self::DiffLoad(error) => format!("Failed to load selection history: {error}"),
+        }
+    }
+}
+
+fn show_selection_history_error(
+    workspace: &mut Workspace,
+    error: SelectionHistoryError,
+    cx: &mut Context<Workspace>,
+) {
+    workspace.show_toast(Toast::new(error.notification_id(), error.message()), cx);
+}
+
+fn validate_selection_history_projection(
+    start_line: u32,
+    end_line: u32,
+    base_text: &language::BufferSnapshot,
+) -> SelectionHistoryProjection {
+    let max_point = base_text.max_point();
+    let committed_line_count = if base_text.is_empty() {
+        0
+    } else if max_point.column == 0 {
+        max_point.row
+    } else {
+        max_point.row + 1
+    };
+
+    if start_line > committed_line_count {
+        SelectionHistoryProjection::NoCommittedLines
+    } else {
+        SelectionHistoryProjection::Mapped {
+            start_line,
+            end_line,
+        }
+    }
+}
+
+fn project_selection_history_to_head(
+    source_range: Range<language::Anchor>,
+    buffer: &language::BufferSnapshot,
+    diff: &BufferDiffSnapshot,
+) -> SelectionHistoryProjection {
+    let start = source_range.start.to_point(buffer);
+    let end = source_range.end.to_point(buffer);
+    let start_row = start.row;
+    let end_row = if end.column == 0 && end.row > start_row {
+        end.row - 1
+    } else {
+        end.row
+    };
+
+    let normalized_start = language::Point::new(start_row, 0);
+    let normalized_end = language::Point::new(end_row, buffer.line_len(end_row));
+    let normalized_range =
+        buffer.anchor_before(normalized_start)..buffer.anchor_after(normalized_end);
+
+    let hunks = diff
+        .raw_hunks_intersecting_range(normalized_range, buffer)
+        .collect::<Vec<_>>();
+    let mut fully_added_rows = hunks
+        .iter()
+        .filter(|hunk| hunk.diff_base_byte_range.is_empty() && !hunk.range.is_empty())
+        .filter_map(|hunk| {
+            let start_row = if hunk.range.start.column == 0 {
+                hunk.range.start.row
+            } else {
+                hunk.range.start.row + 1
+            };
+            let end_row = if hunk.range.end.column == 0 {
+                hunk.range.end.row
+            } else if hunk.range.end.column >= buffer.line_len(hunk.range.end.row) {
+                hunk.range.end.row + 1
+            } else {
+                hunk.range.end.row
+            };
+            (start_row < end_row).then_some(start_row..end_row)
+        })
+        .collect::<Vec<_>>();
+    fully_added_rows.sort_by_key(|range| range.start);
+
+    let mut first_committed_row = start_row;
+    for added_rows in &fully_added_rows {
+        if added_rows.end <= first_committed_row {
+            continue;
+        }
+        if added_rows.start > first_committed_row {
+            break;
+        }
+        first_committed_row = added_rows.end;
+    }
+    if first_committed_row > end_row {
+        return SelectionHistoryProjection::NoCommittedLines;
+    }
+
+    let base_text = diff.base_text();
+    let mut base_start = diff.buffer_point_to_base_text_point(normalized_start, buffer);
+    let mut base_end = diff.buffer_point_to_base_text_point(normalized_end, buffer);
+    if base_end < base_start {
+        std::mem::swap(&mut base_start, &mut base_end);
+    }
+
+    for hunk in hunks {
+        if hunk.range.is_empty() || hunk.diff_base_byte_range.is_empty() {
+            continue;
+        }
+        let intersects = if normalized_start == normalized_end {
+            hunk.range.start <= normalized_start && hunk.range.end >= normalized_end
+        } else {
+            hunk.range.start < normalized_end && hunk.range.end > normalized_start
+        };
+        if !intersects {
+            continue;
+        }
+        base_start = base_start.min(base_text.offset_to_point(hunk.diff_base_byte_range.start));
+        base_end = base_end.max(base_text.offset_to_point(hunk.diff_base_byte_range.end));
+    }
+
+    if base_start == base_end {
+        let point = diff
+            .buffer_point_to_base_text_point(language::Point::new(first_committed_row, 0), buffer);
+        let line = point.row + 1;
+        return validate_selection_history_projection(line, line, base_text);
+    }
+
+    let start_line = base_start.row + 1;
+    let end_line = if base_end.column == 0 && base_end.row > base_start.row {
+        base_end.row
+    } else {
+        base_end.row + 1
+    };
+    validate_selection_history_projection(start_line, end_line, base_text)
+}
 
 struct CopiedState {
     copied_at: Option<Instant>,
@@ -1076,6 +1250,98 @@ pub fn init(cx: &mut App) {
                     })
                 },
             )
+            .when_some(
+                resolve_selection_history_target(workspace, window, cx),
+                |div, target| {
+                    let git_store = workspace.project().read(cx).git_store().clone();
+                    let project = workspace.project().clone();
+                    let workspace = workspace.weak_handle();
+
+                    div.on_action(move |_: &git::FileHistoryForSelection, window, cx| {
+                        let PendingSelectionHistoryTarget::Ready {
+                            repo_id,
+                            repo_path,
+                            buffer,
+                            source_range,
+                        } = target.clone()
+                        else {
+                            workspace
+                                .update(cx, |workspace, cx| {
+                                    show_selection_history_error(
+                                        workspace,
+                                        SelectionHistoryError::UnsupportedDeletedSelection,
+                                        cx,
+                                    );
+                                })
+                                .ok();
+                            return;
+                        };
+
+                        let load_diff = project.update(cx, |project, cx| {
+                            project.open_uncommitted_diff(buffer.clone(), cx)
+                        });
+                        let workspace = workspace.clone();
+                        let git_store = git_store.clone();
+                        window
+                            .spawn(cx, async move |cx| -> anyhow::Result<()> {
+                                let diff = match load_diff.await {
+                                    Ok(diff) => diff,
+                                    Err(error) => {
+                                        workspace.update(cx, |workspace, cx| {
+                                            show_selection_history_error(
+                                                workspace,
+                                                SelectionHistoryError::DiffLoad(error.to_string()),
+                                                cx,
+                                            );
+                                        })?;
+                                        return Ok(());
+                                    }
+                                };
+
+                                let buffer_snapshot =
+                                    buffer.read_with(cx, |buffer, _| buffer.snapshot());
+                                let diff_snapshot =
+                                    diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                                let projection = project_selection_history_to_head(
+                                    source_range,
+                                    &buffer_snapshot,
+                                    &diff_snapshot,
+                                );
+
+                                workspace.update_in(
+                                    cx,
+                                    |workspace, window, cx| match projection {
+                                        SelectionHistoryProjection::Mapped {
+                                            start_line,
+                                            end_line,
+                                        } => open_or_reuse_graph(
+                                            workspace,
+                                            repo_id,
+                                            git_store,
+                                            LogSource::Selection {
+                                                path: repo_path,
+                                                start_line,
+                                                end_line,
+                                            },
+                                            None,
+                                            window,
+                                            cx,
+                                        ),
+                                        SelectionHistoryProjection::NoCommittedLines => {
+                                            show_selection_history_error(
+                                                workspace,
+                                                SelectionHistoryError::NoCommittedLines,
+                                                cx,
+                                            );
+                                        }
+                                    },
+                                )?;
+                                Ok(())
+                            })
+                            .detach();
+                    })
+                },
+            )
             .when(
                 workspace.project().read(cx).active_repository(cx).is_some(),
                 |div| {
@@ -1185,6 +1451,45 @@ fn resolve_file_history_target(
         .read(cx)
         .repository_and_path_for_project_path(&project_path, cx)?;
     Some((repo.read(cx).id, LogSource::Path(repo_path)))
+}
+
+/// Resolves a `git::FileHistoryForSelection` target from the active editor's
+/// current selection. If no non-empty selection exists, falls back to the
+/// current line as a single-line range (matches PyCharm behavior).
+fn resolve_selection_history_target(
+    workspace: &Workspace,
+    _window: &Window,
+    cx: &App,
+) -> Option<PendingSelectionHistoryTarget> {
+    let editor = workspace.active_item_as::<Editor>(cx)?;
+    let editor_ref = editor.read(cx);
+
+    let selection = editor_ref.selections.newest_anchor();
+    if selection.start.diff_base_anchor().is_some() || selection.end.diff_base_anchor().is_some() {
+        return Some(PendingSelectionHistoryTarget::UnsupportedDeletedSelection);
+    }
+
+    let multibuffer = editor_ref.buffer().read(cx);
+    let snapshot = multibuffer.snapshot(cx);
+    let (buffer, source_range) =
+        snapshot.anchor_range_to_buffer_anchor_range(selection.start..selection.end)?;
+    let source_buffer = multibuffer.buffer(buffer.remote_id())?;
+    let file = buffer.file()?;
+    let project_path = ProjectPath {
+        worktree_id: file.worktree_id(cx),
+        path: file.path().clone(),
+    };
+
+    let git_store = workspace.project().read(cx).git_store();
+    let (repo, repo_path) = git_store
+        .read(cx)
+        .repository_and_path_for_project_path(&project_path, cx)?;
+    Some(PendingSelectionHistoryTarget::Ready {
+        repo_id: repo.read(cx).id,
+        repo_path,
+        buffer: source_buffer,
+        source_range,
+    })
 }
 
 pub fn open_or_reuse_graph(
@@ -1393,7 +1698,7 @@ impl GitGraph {
             }
         };
 
-        let is_path_history = matches!(self.log_source, LogSource::Path(_));
+        let is_path_history = self.log_source.is_path_history();
         let graph_fraction = if is_path_history { 0.0 } else { value(0) };
         let offset = if is_path_history { 0 } else { 1 };
 
@@ -1480,7 +1785,7 @@ impl GitGraph {
             state
         });
 
-        let column_widths = if matches!(log_source, LogSource::Path(_)) {
+        let column_widths = if log_source.is_path_history() {
             cx.new(|_cx| {
                 RedistributableColumnsState::new(
                     4,
@@ -1521,7 +1826,7 @@ impl GitGraph {
         };
         let column_visibility = TableRow::from_element(
             false,
-            if matches!(log_source, LogSource::Path(_)) {
+            if log_source.is_path_history() {
                 TABLE_COLUMN_COUNT
             } else {
                 TABLE_COLUMN_COUNT + 1
@@ -2496,7 +2801,7 @@ impl GitGraph {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let is_path_history = matches!(self.log_source, LogSource::Path(_));
+        let is_path_history = self.log_source.is_path_history();
         let columns: &[&str] = if is_path_history {
             &["Description", "Date", "Author", "Commit"]
         } else {
@@ -3739,7 +4044,7 @@ impl Render for GitGraph {
                     this.child(self.render_loading_spinner(cx))
                 })
         } else {
-            let is_path_history = matches!(self.log_source, LogSource::Path(_));
+            let is_path_history = self.log_source.is_path_history();
             let header_resize_info =
                 HeaderResizeInfo::from_redistributable(&self.column_widths, cx);
 
@@ -4119,10 +4424,10 @@ impl Item for GitGraph {
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
         });
-        let path_history_path = match &self.log_source {
-            LogSource::Path(path) => Some(path.as_unix_str().to_string()),
-            _ => None,
-        };
+        let path_history_path = self
+            .log_source
+            .path()
+            .map(|path| path.as_unix_str().to_string());
 
         Some(TabTooltipContent::Custom(Box::new(Tooltip::element({
             move |_, _| {
@@ -4144,7 +4449,7 @@ impl Item for GitGraph {
     }
 
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
-        if let LogSource::Path(path) = &self.log_source {
+        if let Some(path) = self.log_source.path() {
             return path
                 .as_ref()
                 .file_name()
@@ -4436,6 +4741,10 @@ mod persistence {
             LogSource::Branch(_) => LOG_SOURCE_BRANCH,
             LogSource::Sha(_) => LOG_SOURCE_SHA,
             LogSource::Path(_) => LOG_SOURCE_PATH,
+            // Selection is a transient view opened from an editor selection
+            // and does not roundtrip through the DB: persist it as Path history
+            // so the reopened graph still shows file history.
+            LogSource::Selection { .. } => LOG_SOURCE_PATH,
         }
     }
 
@@ -4445,6 +4754,7 @@ mod persistence {
             LogSource::Branch(branch) => Some(branch.to_string()),
             LogSource::Sha(oid) => Some(oid.to_string()),
             LogSource::Path(path) => Some(path.as_unix_str().to_string()),
+            LogSource::Selection { path, .. } => Some(path.as_unix_str().to_string()),
         }
     }
 
@@ -4716,6 +5026,7 @@ fn generate_parents_from_oids(
 mod tests {
     use super::*;
     use anyhow::{Context, Result, bail};
+    use buffer_diff::BufferDiff;
     use collections::{HashMap, HashSet};
     use fs::FakeFs;
     use git::Oid;
@@ -4740,6 +5051,241 @@ mod tests {
             language_model::init(cx);
             crate::init(cx);
         });
+    }
+
+    fn selection_history_projection(
+        cx: &mut TestAppContext,
+        head_text: &str,
+        current_text: &str,
+        range: Range<language::Point>,
+    ) -> SelectionHistoryProjection {
+        let buffer = cx.new(|cx| language::Buffer::local(current_text, cx));
+        let diff = cx.new(|cx| {
+            BufferDiff::new_with_base_text(head_text, &buffer.read(cx).text_snapshot(), cx)
+        });
+        cx.run_until_parked();
+
+        let buffer_snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+        let anchor_range =
+            buffer_snapshot.anchor_before(range.start)..buffer_snapshot.anchor_before(range.end);
+        project_selection_history_to_head(anchor_range, &buffer_snapshot, &diff_snapshot)
+    }
+
+    #[gpui::test]
+    fn test_selection_history_projection(cx: &mut TestAppContext) {
+        use SelectionHistoryProjection::{Mapped, NoCommittedLines};
+
+        let cases = [
+            (
+                "unchanged middle line",
+                "a\nb\nc\n",
+                "a\nb\nc\n",
+                language::Point::new(1, 0)..language::Point::new(2, 0),
+                Mapped {
+                    start_line: 2,
+                    end_line: 2,
+                },
+            ),
+            (
+                "leading insertion",
+                "a\nb\nc\n",
+                "new\na\nb\nc\n",
+                language::Point::new(0, 0)..language::Point::new(2, 0),
+                Mapped {
+                    start_line: 1,
+                    end_line: 1,
+                },
+            ),
+            (
+                "selection shifted by leading insertion",
+                "fn main() {\n    let x = 1;\n    let y = 2;\n    let z = x + y;\n}\n",
+                "// uncommitted\nfn main() {\n    let x = 1;\n    let y = 2;\n    let z = x + y;\n}\n",
+                language::Point::new(3, 0)..language::Point::new(5, 0),
+                Mapped {
+                    start_line: 3,
+                    end_line: 4,
+                },
+            ),
+            (
+                "trailing insertion",
+                "a\nb\n",
+                "a\nnew\nb\n",
+                language::Point::new(0, 0)..language::Point::new(2, 0),
+                Mapped {
+                    start_line: 1,
+                    end_line: 1,
+                },
+            ),
+            (
+                "interior insertion",
+                "a\nb\n",
+                "a\nnew\nb\n",
+                language::Point::new(0, 0)..language::Point::new(3, 0),
+                Mapped {
+                    start_line: 1,
+                    end_line: 2,
+                },
+            ),
+            (
+                "all-added line",
+                "a\nb\n",
+                "a\nnew\nb\n",
+                language::Point::new(1, 0)..language::Point::new(2, 0),
+                NoCommittedLines,
+            ),
+            (
+                "unequal replacement",
+                "a\nb\nc\nd\n",
+                "a\nB\nC\nX\nd\n",
+                language::Point::new(2, 0)..language::Point::new(3, 0),
+                Mapped {
+                    start_line: 2,
+                    end_line: 3,
+                },
+            ),
+            (
+                "half-open endpoint",
+                "a\nb\n",
+                "a\nb\n",
+                language::Point::new(0, 0)..language::Point::new(1, 0),
+                Mapped {
+                    start_line: 1,
+                    end_line: 1,
+                },
+            ),
+            (
+                "committed blank line",
+                "a\n\nb\n",
+                "a\n\nb\n",
+                language::Point::new(1, 0)..language::Point::new(2, 0),
+                Mapped {
+                    start_line: 2,
+                    end_line: 2,
+                },
+            ),
+            (
+                "all-added blank line",
+                "a\nb\n",
+                "a\n\nb\n",
+                language::Point::new(1, 0)..language::Point::new(2, 0),
+                NoCommittedLines,
+            ),
+            (
+                "live line adjacent to deletion",
+                "a\ngone\nb\n",
+                "a\nb\n",
+                language::Point::new(1, 0)..language::Point::new(2, 0),
+                Mapped {
+                    start_line: 3,
+                    end_line: 3,
+                },
+            ),
+            (
+                "empty committed file",
+                "",
+                "",
+                language::Point::zero()..language::Point::zero(),
+                NoCommittedLines,
+            ),
+            (
+                "caret on virtual eof row",
+                "a\n",
+                "a\n",
+                language::Point::new(1, 0)..language::Point::new(1, 0),
+                NoCommittedLines,
+            ),
+            (
+                "half-open range ending at virtual eof",
+                "a\n",
+                "a\n",
+                language::Point::zero()..language::Point::new(1, 0),
+                Mapped {
+                    start_line: 1,
+                    end_line: 1,
+                },
+            ),
+            (
+                "caret at eof without trailing newline",
+                "a",
+                "a",
+                language::Point::new(0, 1)..language::Point::new(0, 1),
+                Mapped {
+                    start_line: 1,
+                    end_line: 1,
+                },
+            ),
+        ];
+
+        for (name, head_text, current_text, range, expected) in cases {
+            assert_eq!(
+                selection_history_projection(cx, head_text, current_text, range),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[gpui::test]
+    fn test_selection_history_crosses_expanded_deleted_hunk(cx: &mut TestAppContext) {
+        let buffer = cx.new(|cx| language::Buffer::local("a\nb\n", cx));
+        let diff = cx.new(|cx| {
+            BufferDiff::new_with_base_text("a\ngone\nb\n", &buffer.read(cx).text_snapshot(), cx)
+        });
+        cx.run_until_parked();
+
+        let multibuffer = cx.new(|cx| {
+            let mut multibuffer = editor::MultiBuffer::new(language::Capability::ReadWrite);
+            multibuffer.set_excerpts_for_buffer(
+                buffer.clone(),
+                [language::Point::zero()..language::Point::new(2, 0)],
+                0,
+                cx,
+            );
+            multibuffer.add_diff(diff, cx);
+            multibuffer.set_all_diff_hunks_expanded(cx);
+            multibuffer
+        });
+        cx.run_until_parked();
+
+        let snapshot = multibuffer.read_with(cx, |multibuffer, cx| multibuffer.snapshot(cx));
+        let deleted_anchor = snapshot.anchor_before(language::Point::new(1, 1));
+        assert!(deleted_anchor.diff_base_anchor().is_some());
+
+        let live_start = snapshot.anchor_before(language::Point::zero());
+        let live_end = snapshot.anchor_before(snapshot.max_point());
+        assert!(
+            snapshot
+                .anchor_range_to_buffer_anchor_range(live_start..live_end)
+                .is_some(),
+            "live endpoints surrounding a deleted hunk should resolve"
+        );
+    }
+
+    #[test]
+    fn test_selection_history_error_messages() {
+        let no_history = SelectionHistoryError::NoCommittedLines;
+        assert_eq!(
+            no_history.notification_id(),
+            NotificationId::named("selection-history-no-committed-lines".into())
+        );
+        assert_eq!(
+            no_history.message(),
+            "Selected lines have no commit history"
+        );
+
+        let deleted = SelectionHistoryError::UnsupportedDeletedSelection;
+        assert_eq!(
+            deleted.notification_id(),
+            NotificationId::named("selection-history-deleted-lines".into())
+        );
+
+        let load = SelectionHistoryError::DiffLoad("backend failed".to_string());
+        assert_eq!(
+            load.notification_id(),
+            NotificationId::named("selection-history-diff-load-failed".into())
+        );
+        assert!(load.message().contains("backend failed"));
     }
 
     fn build_oid_to_row_map(graph: &GraphData) -> HashMap<Oid, usize> {
@@ -5907,6 +6453,183 @@ mod tests {
                 graphs[0].read(cx).log_source,
                 LogSource::Path(tracked_repo_path)
             );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_file_history_for_selection_opens_graph(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new(util::path!("/project")),
+            json!({
+                ".git": {},
+                "main.rs": "// uncommitted\nfn main() {\n    let x = 1;\n    let y = 2;\n    let z = x + y;\n}\n",
+            }),
+        )
+        .await;
+        fs.set_head_for_repo(
+            Path::new(util::path!("/project/.git")),
+            &[(
+                "main.rs",
+                "fn main() {\n    let x = 1;\n    let y = 2;\n    let z = x + y;\n}\n".to_string(),
+            )],
+            "head",
+        );
+        let commits = vec![Arc::new(InitialGraphCommitData {
+            sha: Oid::from_bytes(&[1; 20]).unwrap(),
+            parents: smallvec![],
+            ref_names: vec!["HEAD".into(), "refs/heads/main".into()],
+        })];
+        fs.set_graph_commits(Path::new(util::path!("/project/.git")), commits);
+
+        let project = Project::test(fs.clone(), [Path::new(util::path!("/project"))], cx).await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have active repository")
+        });
+        let file_repo_path = RepoPath::new(&"main.rs").unwrap();
+        let file_project_path = repository
+            .read_with(cx, |repository, cx| {
+                repository.repo_path_to_project_path(&file_repo_path, cx)
+            })
+            .expect("file should resolve to project path");
+
+        let workspace_window = cx.add_window(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace = workspace_window
+            .read_with(cx, |multi, _| multi.workspace().clone())
+            .expect("workspace should exist");
+
+        cx.background_executor.allow_parking();
+
+        // Open the file in an editor and select current rows 3-4. The
+        // uncommitted first line means they map to HEAD lines 3-4.
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer(file_project_path.clone(), cx)
+            })
+            .await
+            .expect("buffer should open");
+        let diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(buffer.clone(), cx)
+            })
+            .await
+            .expect("uncommitted diff should open");
+        let buffer_snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+        assert_eq!(
+            project_selection_history_to_head(
+                buffer_snapshot.anchor_before(language::Point::new(3, 0))
+                    ..buffer_snapshot.anchor_before(language::Point::new(5, 0)),
+                &buffer_snapshot,
+                &diff_snapshot,
+            ),
+            SelectionHistoryProjection::Mapped {
+                start_line: 3,
+                end_line: 4,
+            }
+        );
+        workspace_window
+            .update(cx, |multi, window, cx| {
+                let workspace = multi.workspace();
+                let multibuffer = cx.new(|cx| {
+                    let mut mb = editor::MultiBuffer::new(language::Capability::ReadWrite);
+                    mb.set_excerpts_for_buffer(
+                        buffer.clone(),
+                        [language::Point::new(3, 0)..language::Point::new(6, 0)],
+                        0,
+                        cx,
+                    );
+                    mb
+                });
+                let editor = cx.new(|cx| {
+                    Editor::for_multibuffer(multibuffer, Some(project.clone()), window, cx)
+                });
+                workspace.update(cx, |workspace, cx| {
+                    workspace.add_item_to_active_pane(
+                        Box::new(editor.clone()),
+                        None,
+                        true,
+                        window,
+                        cx,
+                    );
+                });
+                editor.update(cx, |editor, cx| {
+                    let snapshot = editor.buffer().read(cx).snapshot(cx);
+                    // The endpoint at excerpt row 2 is excluded.
+                    let start = snapshot.anchor_before(language::Point::new(0, 0));
+                    let end = snapshot.anchor_before(language::Point::new(2, 0));
+                    editor.change_selections(
+                        editor::SelectionEffects::no_scroll(),
+                        window,
+                        cx,
+                        |selections| {
+                            selections.select_anchor_ranges([start..end]);
+                        },
+                    );
+                    window.focus(&editor.focus_handle(cx), cx);
+                });
+            })
+            .expect("workspace window should be available");
+        cx.run_until_parked();
+
+        // Dispatch the new action.
+        workspace_window
+            .update(cx, |_, window, cx| {
+                window.dispatch_action(Box::new(git::FileHistoryForSelection), cx);
+            })
+            .expect("workspace window should be available");
+        cx.run_until_parked();
+
+        // The opened GitGraph should be filtered with LogSource::Selection on
+        // src/main.rs, lines 3..=4 (1-based inclusive).
+        workspace.read_with(cx, |workspace, cx| {
+            let graphs = workspace.items_of_type::<GitGraph>(cx).collect::<Vec<_>>();
+            assert_eq!(graphs.len(), 1, "expected exactly one GitGraph to open");
+            let graph = graphs[0].read(cx);
+            assert_eq!(graph.column_visibility.as_slice().len(), TABLE_COLUMN_COUNT);
+            assert_eq!(graph.tab_content_text(0, cx), "main.rs");
+            let log_source = graph.log_source.clone();
+            match log_source {
+                LogSource::Selection {
+                    path,
+                    start_line,
+                    end_line,
+                } => {
+                    assert_eq!(path, file_repo_path);
+                    assert_eq!(start_line, 3);
+                    assert_eq!(end_line, 4);
+                }
+                other => panic!("expected LogSource::Selection, got {other:?}"),
+            }
+        });
+
+        let selection_source = LogSource::Selection {
+            path: file_repo_path,
+            start_line: 3,
+            end_line: 4,
+        };
+        repository.update(cx, |repository, _| {
+            repository.prune_selection_graph_data_for_test(0, None);
+            assert!(
+                repository
+                    .get_graph_data(selection_source.clone(), LogOrder::DateOrder)
+                    .is_none()
+            );
+        });
+        workspace.read_with(cx, |workspace, cx| {
+            let graph = workspace
+                .items_of_type::<GitGraph>(cx)
+                .next()
+                .expect("git graph should remain open");
+            assert_eq!(graph.read(cx).graph_data.commits.len(), 1);
         });
     }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -656,12 +656,15 @@ enum NextCommitDataRequest {
 }
 
 pub struct InitialGitGraphData {
-    fetch_task: Task<()>,
+    _fetch_task: Task<()>,
+    is_loading: bool,
     pub error: Option<SharedString>,
     pub commit_data: Vec<Arc<InitialGraphCommitData>>,
     pub commit_oid_to_index: HashMap<Oid, usize>,
     subscribers: Vec<async_channel::Sender<Result<Vec<Arc<InitialGraphCommitData>>, SharedString>>>,
 }
+
+const MAX_COMPLETED_SELECTION_GRAPH_DATA: usize = 32;
 
 pub struct GraphDataResponse<'a> {
     pub commits: &'a [Arc<InitialGraphCommitData>],
@@ -7320,6 +7323,48 @@ impl Repository {
         .detach();
     }
 
+    fn prune_completed_selection_graph_data(
+        &mut self,
+        max_completed: usize,
+        excluded_key: Option<&(LogSource, LogOrder)>,
+    ) {
+        let completed_count = self
+            .initial_graph_data
+            .iter()
+            .filter(|((source, _), data)| {
+                matches!(source, LogSource::Selection { .. }) && !data.is_loading
+            })
+            .count();
+        let remove_count = completed_count.saturating_sub(max_completed);
+        if remove_count == 0 {
+            return;
+        }
+
+        let keys = self
+            .initial_graph_data
+            .iter()
+            .filter(|(key, data)| {
+                matches!(key.0, LogSource::Selection { .. })
+                    && !data.is_loading
+                    && excluded_key != Some(key)
+            })
+            .take(remove_count)
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        for key in keys {
+            self.initial_graph_data.remove(&key);
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn prune_selection_graph_data_for_test(
+        &mut self,
+        max_completed: usize,
+        excluded_key: Option<&(LogSource, LogOrder)>,
+    ) {
+        self.prune_completed_selection_graph_data(max_completed, excluded_key);
+    }
+
     pub fn graph_data(
         &mut self,
         log_source: LogSource,
@@ -7327,9 +7372,15 @@ impl Repository {
         range: Range<usize>,
         cx: &mut Context<Self>,
     ) -> GraphDataResponse<'_> {
+        let graph_data_key = (log_source.clone(), log_order);
+        if matches!(log_source, LogSource::Selection { .. })
+            && !self.initial_graph_data.contains_key(&graph_data_key)
+        {
+            self.prune_completed_selection_graph_data(MAX_COMPLETED_SELECTION_GRAPH_DATA - 1, None);
+        }
         let initial_commit_data = self
             .initial_graph_data
-            .entry((log_source.clone(), log_order))
+            .entry(graph_data_key)
             .or_insert_with(|| {
                 let state = self.repository_state.clone();
                 let log_source = log_source.clone();
@@ -7362,32 +7413,37 @@ impl Repository {
 
                     repository
                         .update(cx, |repository, cx| {
-                            if let Some(data) = repository
-                                .initial_graph_data
-                                .get_mut(&(log_source.clone(), log_order))
+                            let graph_data_key = (log_source.clone(), log_order);
+                            let event = if let Some(data) =
+                                repository.initial_graph_data.get_mut(&graph_data_key)
                             {
-                                match &result {
-                                    Ok(()) => {
-                                        cx.emit(RepositoryEvent::GraphEvent(
-                                            (log_source.clone(), log_order),
-                                            GitGraphEvent::FullyLoaded,
-                                        ));
-                                    }
+                                let event = match &result {
+                                    Ok(()) => GitGraphEvent::FullyLoaded,
                                     Err(fetch_task_error) => {
                                         data.subscribers.retain(|sender| {
                                             sender.try_send(Err(fetch_task_error.clone())).is_ok()
                                         });
                                         data.error = Some(fetch_task_error.clone());
-                                        cx.emit(RepositoryEvent::GraphEvent(
-                                            (log_source.clone(), log_order),
-                                            GitGraphEvent::LoadingError,
-                                        ));
+                                        GitGraphEvent::LoadingError
                                     }
-                                }
+                                };
                                 data.subscribers.clear();
+                                data.is_loading = false;
+                                Some(event)
                             } else {
                                 debug_panic!(
                                     "This task would be dropped if this entry doesn't exist"
+                                );
+                                None
+                            };
+
+                            if let Some(event) = event {
+                                cx.emit(RepositoryEvent::GraphEvent(graph_data_key.clone(), event));
+                            }
+                            if matches!(log_source, LogSource::Selection { .. }) {
+                                repository.prune_completed_selection_graph_data(
+                                    MAX_COMPLETED_SELECTION_GRAPH_DATA,
+                                    Some(&graph_data_key),
                                 );
                             }
                         })
@@ -7395,7 +7451,8 @@ impl Repository {
                 });
 
                 InitialGitGraphData {
-                    fetch_task,
+                    _fetch_task: fetch_task,
+                    is_loading: true,
                     error: None,
                     commit_data: Vec::new(),
                     commit_oid_to_index: HashMap::default(),
@@ -7409,7 +7466,7 @@ impl Repository {
         GraphDataResponse {
             commits: &initial_commit_data.commit_data
                 [range.start.min(max_start)..range.end.min(max_end)],
-            is_loading: !initial_commit_data.fetch_task.is_ready(),
+            is_loading: initial_commit_data.is_loading,
             error: initial_commit_data.error.clone(),
         }
     }
@@ -11083,6 +11140,15 @@ fn log_source_to_proto(log_source: &LogSource) -> proto::GitLogSource {
             LogSource::Path(path) => {
                 proto::git_log_source::Source::Path(path.as_unix_str().to_owned())
             }
+            LogSource::Selection {
+                path,
+                start_line,
+                end_line,
+            } => proto::git_log_source::Source::Selection(proto::GitLogSourceSelection {
+                path: path.as_unix_str().to_owned(),
+                start_line: *start_line,
+                end_line: *end_line,
+            }),
         }),
     }
 }
@@ -11098,6 +11164,11 @@ fn log_source_from_proto(log_source: proto::GitLogSource) -> Result<LogSource> {
         proto::git_log_source::Source::Path(path) => {
             Ok(LogSource::Path(RepoPath::from_proto(&path)?))
         }
+        proto::git_log_source::Source::Selection(selection) => Ok(LogSource::Selection {
+            path: RepoPath::from_proto(&selection.path)?,
+            start_line: selection.start_line,
+            end_line: selection.end_line,
+        }),
     }
 }
 
@@ -12288,6 +12359,150 @@ mod tests {
             coalesced,
             repo_paths(&["submodule/a.txt", "submodule/nested/b.txt", "top_level.rs"])
         );
+    }
+
+    #[gpui::test]
+    async fn test_selection_graph_cache_is_bounded(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                "file.rs": "fn main() {}\n",
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [Path::new("/project")], cx).await;
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have a repository")
+        });
+        let path = RepoPath::new("file.rs").unwrap();
+
+        repository.update(cx, |repository, cx| {
+            repository.graph_data(LogSource::All, LogOrder::DateOrder, 0..usize::MAX, cx);
+            for start_line in 1..=33 {
+                repository.graph_data(
+                    LogSource::Selection {
+                        path: path.clone(),
+                        start_line,
+                        end_line: start_line,
+                    },
+                    LogOrder::DateOrder,
+                    0..usize::MAX,
+                    cx,
+                );
+            }
+
+            let selection_entries = repository
+                .initial_graph_data
+                .iter()
+                .filter(|((source, _), _)| matches!(source, LogSource::Selection { .. }))
+                .collect::<Vec<_>>();
+            assert_eq!(selection_entries.len(), 33);
+            assert!(selection_entries.iter().all(|(_, data)| data.is_loading));
+        });
+
+        cx.run_until_parked();
+
+        let evicted_line = repository.read_with(cx, |repository, _| {
+            assert!(
+                repository
+                    .initial_graph_data
+                    .contains_key(&(LogSource::All, LogOrder::DateOrder))
+            );
+            let selection_entries = repository
+                .initial_graph_data
+                .iter()
+                .filter(|((source, _), _)| matches!(source, LogSource::Selection { .. }))
+                .collect::<Vec<_>>();
+            assert_eq!(selection_entries.len(), 32);
+            assert!(selection_entries.iter().all(|(_, data)| !data.is_loading));
+
+            (1..=33)
+                .find(|line| {
+                    !repository.initial_graph_data.contains_key(&(
+                        LogSource::Selection {
+                            path: path.clone(),
+                            start_line: *line,
+                            end_line: *line,
+                        },
+                        LogOrder::DateOrder,
+                    ))
+                })
+                .expect("one completed selection entry should be evicted")
+        });
+
+        repository.update(cx, |repository, cx| {
+            repository.graph_data(
+                LogSource::Selection {
+                    path: path.clone(),
+                    start_line: evicted_line,
+                    end_line: evicted_line,
+                },
+                LogOrder::DateOrder,
+                0..usize::MAX,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        repository.read_with(cx, |repository, _| {
+            assert_eq!(
+                repository
+                    .initial_graph_data
+                    .keys()
+                    .filter(|(source, _)| matches!(source, LogSource::Selection { .. }))
+                    .count(),
+                32
+            );
+            assert!(repository.initial_graph_data.contains_key(&(
+                LogSource::Selection {
+                    path,
+                    start_line: evicted_line,
+                    end_line: evicted_line,
+                },
+                LogOrder::DateOrder,
+            )));
+        });
+    }
+
+    #[test]
+    fn test_log_source_selection_proto_roundtrip() {
+        let original = LogSource::Selection {
+            path: RepoPath::new("src/main.rs").unwrap(),
+            start_line: 2,
+            end_line: 4,
+        };
+
+        // LogSource -> proto
+        let proto = log_source_to_proto(&original);
+
+        // proto -> LogSource
+        let roundtrip = log_source_from_proto(proto).unwrap();
+
+        match (original, roundtrip) {
+            (
+                LogSource::Selection {
+                    path: p1,
+                    start_line: s1,
+                    end_line: e1,
+                },
+                LogSource::Selection {
+                    path: p2,
+                    start_line: s2,
+                    end_line: e2,
+                },
+            ) => {
+                assert_eq!(p1, p2);
+                assert_eq!(s1, s2);
+                assert_eq!(e1, e2);
+            }
+            _ => panic!("roundtrip did not preserve LogSource::Selection variant"),
+        }
     }
 }
 

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -789,12 +789,19 @@ message GetCommitDataResponse {
 
 message GitLogSourceAll {}
 
+message GitLogSourceSelection {
+  string path = 1;
+  uint32 start_line = 2;
+  uint32 end_line = 3;
+}
+
 message GitLogSource {
   oneof source {
     GitLogSourceAll all = 1;
     string branch = 2;
     string sha = 3;
     string path = 4;
+    GitLogSourceSelection selection = 5;
   }
 }
 


### PR DESCRIPTION
# Objective
Add a **View History for Selection** action that shows the commit history for the selected editor lines.

This implements the workflow discussed in [Discussion #54672](https://github.com/zed-industries/zed/discussions/54672). Unlike the revision-aware inline blame work in #60039, this change opens the existing GitGraph for the current editor selection.

## Solution

- Add **View History for Selection** to the editor context menu for single-buffer selections.
- Project selections in a dirty buffer back to committed `HEAD`, handling leading insertions, replacements, line shifts caused by deletions, half-open row boundaries, and virtual EOF.
- Use `git log -L` to retrieve the commit history for the selected committed line range and display it in GitGraph.
- Show a notification when the selected lines are entirely uncommitted and therefore have no commit history.
- Limit completed selection-history entries to 32 while preserving non-selection history and active selection requests.

## Testing

Automated checks completed on macOS arm64:

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- 12 focused unit tests across `git`, `project`, `git_ui`, and `editor`
- `buf lint crates/proto/proto`
- `buf format --diff --exit-code crates/proto/proto`
- `./script/clippy -p editor -p git -p git_ui -p project`
- `cargo build -p zed --bin zed`

Manual verification covered:

- Selecting committed lines in a dirty buffer containing an uncommitted leading insertion
- Opening GitGraph with the expected commit history
- Opening commit details from the history
- Selecting an entirely new line and receiving the no-history notification

The implementation was manually tested on macOS arm64. Other platforms were not tested manually.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Select one or more editor lines and choose **View History for Selection** from the context menu. Zed opens GitGraph with the commits associated with those lines, including selections made in a dirty buffer.

<details>
  <summary>View screenshots</summary>

### View History for Selection action

The action is available from the editor context menu for a single-buffer selection.

<img width="3296" height="2416" alt="View History for Selection in the editor context menu" src="https://github.com/user-attachments/assets/848e658c-751e-431e-9042-321f5d7c25e1" />

### Selection history in GitGraph

GitGraph displays the commits associated with the selected lines.

<img width="3296" height="2416" alt="GitGraph showing commits associated with the selected lines" src="https://github.com/user-attachments/assets/e841b6d5-3b33-446e-86b6-95a5de348ac3" />

### Commit details

Commit details can be opened directly from the selection history.

<img width="3296" height="2416" alt="Commit details opened from the selection history" src="https://github.com/user-attachments/assets/ddfd59d0-7aec-4cc1-a5d7-2e89d2de85e8" />

### Entirely uncommitted selection

When all selected lines are uncommitted, Zed reports that the selection has no commit history.

<img width="3296" height="2416" alt="Notification that the selected lines have no commit history" src="https://github.com/user-attachments/assets/0cc751ae-8b5b-45ee-aef0-4eca1d3d8c5c" />

</details>

---

Release Notes:

- Added a context menu action to view Git history for selected editor lines.