### PR TITLE
Preserve folder order when reopening multi-folder projects

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -151,7 +151,7 @@ pub async fn get_recent_projects(
     let entries: Vec<RecentProjectEntry> = filtered
         .into_iter()
         .map(|workspace| {
-            let paths: Vec<PathBuf> = workspace.paths.paths().to_vec();
+            let paths: Vec<PathBuf> = workspace.paths.ordered_paths().cloned().collect();
             let ordered_paths: Vec<&PathBuf> = workspace.identity_paths.ordered_paths().collect();
 
             let name = ordered_paths
@@ -814,7 +814,7 @@ impl RecentProjects {
             {
                 if let Some(workspace) = picker.delegate.workspaces.get(hit.candidate_id) {
                     if matches!(workspace.location, SerializedWorkspaceLocation::Local) {
-                        let paths_to_add = workspace.paths.paths().to_vec();
+                        let paths_to_add = workspace.paths.ordered_paths().cloned().collect();
                         picker
                             .delegate
                             .add_paths_to_project(paths_to_add, window, cx);
@@ -1474,7 +1474,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let raw_paths = &workspace.paths;
                 let identity_paths = &workspace.identity_paths;
                 let is_local = matches!(location, SerializedWorkspaceLocation::Local);
-                let paths_to_add = raw_paths.paths().to_vec();
+                let paths_to_add: Vec<PathBuf> = raw_paths.ordered_paths().cloned().collect();
                 let ordered_paths: Vec<_> = identity_paths
                     .ordered_paths()
                     .map(|p| p.compact().to_string_lossy().to_string())
@@ -2151,7 +2151,8 @@ impl RecentProjectsDelegate {
             }
             match candidate_workspace_location {
                 SerializedWorkspaceLocation::Local => {
-                    let paths = candidate_workspace_paths.paths().to_vec();
+                    let paths: Vec<PathBuf> =
+                        candidate_workspace_paths.ordered_paths().cloned().collect();
                     if replace_current_window {
                         if let Some(handle) = window.window_handle().downcast::<MultiWorkspace>() {
                             cx.defer(move |cx| {
@@ -2197,7 +2198,7 @@ impl RecentProjectsDelegate {
                         RemoteSettings::get_global(cx)
                             .fill_connection_options_from_settings(connection);
                     };
-                    let paths = candidate_workspace_paths.paths().to_vec();
+                    let paths = candidate_workspace_paths.ordered_paths().cloned().collect();
                     cx.spawn_in(window, async move |_, cx| {
                         open_remote_project(connection.clone(), paths, app_state, open_options, cx)
                             .await

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -236,7 +236,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
         match &recent_workspace.location {
             SerializedWorkspaceLocation::Local => {
                 if let Some(handle) = window.window_handle().downcast::<MultiWorkspace>() {
-                    let paths = recent_workspace.paths.paths().to_vec();
+                    let paths = recent_workspace.paths.ordered_paths().cloned().collect();
                     cx.defer(move |cx| {
                         if let Some(task) = handle
                             .update(cx, |multi_workspace, window, cx| {
@@ -262,7 +262,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                         crate::RemoteSettings::get_global(cx)
                             .fill_connection_options_from_settings(connection);
                     };
-                    let paths = recent_workspace.paths.paths().to_vec();
+                    let paths = recent_workspace.paths.ordered_paths().cloned().collect();
                     cx.spawn_in(window, async move |_, cx| {
                         open_remote_project(connection.clone(), paths, app_state, open_options, cx)
                             .await

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1132,7 +1132,7 @@ impl MultiWorkspace {
         let app_state = self.workspace().read(cx).app_state().clone();
         let window_handle = window.window_handle().downcast::<MultiWorkspace>();
         let connect_task = connect_remote(connection_options.clone(), window, cx);
-        let paths_vec = paths.paths().to_vec();
+        let paths_vec: Vec<PathBuf> = paths.ordered_paths().cloned().collect();
 
         cx.spawn(async move |_this, cx| {
             let session = connect_task
@@ -1171,7 +1171,7 @@ impl MultiWorkspace {
                         !paths_vec.is_empty() && resolved.iter().all(|resolved| resolved.is_none());
 
                     if all_paths_missing {
-                        project_group.path_list().paths().to_vec()
+                        project_group.path_list().ordered_paths().cloned().collect()
                     } else {
                         paths_vec
                     }
@@ -1220,7 +1220,7 @@ impl MultiWorkspace {
             return Task::ready(Ok(workspace));
         }
 
-        let paths = path_list.paths().to_vec();
+        let paths: Vec<PathBuf> = path_list.ordered_paths().cloned().collect();
         let app_state = self.workspace().read(cx).app_state().clone();
         let requesting_window = window.window_handle().downcast::<MultiWorkspace>();
         let fs = <dyn Fs>::global(cx);
@@ -1272,7 +1272,7 @@ impl MultiWorkspace {
             let result = cx
                 .update(|cx| {
                     Workspace::new_local(
-                        effective_path_list.paths().to_vec(),
+                        effective_path_list.ordered_paths().cloned().collect(),
                         app_state,
                         requesting_window,
                         None,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -3473,6 +3473,59 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_workspace_roundtrip_preserves_folder_order() {
+        let db = WorkspaceDb::open_test_db("test_workspace_roundtrip_preserves_folder_order").await;
+
+        // Folders in the order the user arranged them, which is not lexicographic.
+        let paths = PathList::new(&["/zed", "/api", "/mono"]);
+        let workspace = SerializedWorkspace {
+            id: WorkspaceId(1),
+            paths: paths.clone(),
+            identity_paths: Some(paths),
+            location: SerializedWorkspaceLocation::Local,
+            center_group: Default::default(),
+            window_bounds: Default::default(),
+            bookmarks: Default::default(),
+            breakpoints: Default::default(),
+            display: Default::default(),
+            docks: Default::default(),
+            centered_layout: false,
+            session_id: None,
+            window_id: Some(1),
+            user_toolchains: Default::default(),
+        };
+
+        db.save_workspace(workspace).await;
+
+        // A workspace is looked up by its path set, in any order...
+        let restored = db.workspace_for_roots(&["/api", "/mono", "/zed"]).unwrap();
+
+        // ...but reopening it has to restore the folders in the user's order,
+        // since that is the order the worktrees are created in.
+        assert_eq!(
+            restored.paths.ordered_paths().collect::<Vec<_>>(),
+            [
+                &PathBuf::from("/zed"),
+                &PathBuf::from("/api"),
+                &PathBuf::from("/mono"),
+            ]
+        );
+        assert_eq!(
+            restored
+                .identity_paths
+                .as_ref()
+                .unwrap()
+                .ordered_paths()
+                .collect::<Vec<_>>(),
+            [
+                &PathBuf::from("/zed"),
+                &PathBuf::from("/api"),
+                &PathBuf::from("/mono"),
+            ]
+        );
+    }
+
+    #[gpui::test]
     async fn test_session_workspaces() {
         zlog::init_test();
 

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -306,7 +306,7 @@ impl WelcomePage {
                 let is_local = matches!(workspace.location, SerializedWorkspaceLocation::Local);
 
                 if is_local {
-                    let paths = workspace.paths.paths().to_vec();
+                    let paths = workspace.paths.ordered_paths().cloned().collect();
                     let open_mode = match WorkspaceSettings::get_global(cx).default_open_behavior {
                         DefaultOpenBehavior::ExistingWindow => OpenMode::Activate,
                         DefaultOpenBehavior::NewWindow => OpenMode::NewWindow,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1441,8 +1441,7 @@ pub(crate) async fn restore_or_create_workspace(
                     let paths = multi_workspace
                         .active_workspace
                         .paths
-                        .paths()
-                        .iter()
+                        .ordered_paths()
                         .map(PathBuf::from)
                         .collect::<Vec<_>>();
                     let state = multi_workspace.state.clone();

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -899,8 +899,7 @@ async fn open_workspaces(
         match location {
             SerializedWorkspaceLocation::Local => {
                 let workspace_paths = workspace_paths
-                    .paths()
-                    .iter()
+                    .ordered_paths()
                     .map(|path| path.to_string_lossy().into_owned())
                     .collect();
 
@@ -931,7 +930,7 @@ async fn open_workspaces(
                 cx.spawn(async move |cx| {
                     open_remote_project(
                         connection,
-                        workspace_paths.paths().to_vec(),
+                        workspace_paths.ordered_paths().cloned().collect(),
                         app_state,
                         open_options,
                         cx,


### PR DESCRIPTION
# Objective

Multi-folder projects reopen with their folders in lexicographic order rather than the order the user arranged them in.

`PathList` deliberately stores its paths sorted, so that a workspace is identified by its path *set* regardless of order, and keeps the user's original order alongside it, retrievable via `ordered_paths()`. The recent projects picker already renders entries with `ordered_paths()`, but the code paths that actually **open** a workspace read `paths()` — the sorted list. Worktrees are created in the order the paths are handed over, so the project panel comes back alphabetized, and the next serialization then persists that alphabetized order as though the user had chosen it.

The picker shows the inconsistency clearly: an entry's label is built from `ordered_paths()` and displays the user's order, but activating that same entry opens the folders sorted.

Remote projects are hit hardest. `Workspace::new_local` already re-derives its paths from the stored workspace with `ordered_paths()` before creating worktrees, which masks the problem for most local projects. `open_remote_project_inner` has no equivalent step — it creates worktrees straight from the paths it is handed — so a remote project comes back alphabetized every time it is reopened, and the reordering is then written back to the database on the next save.

Affected entry points:

- Recent projects picker (modal and sidebar), both local and remote
- "Add folder(s) to this project" from the picker
- `MultiWorkspace::find_or_create_workspace` / `find_or_create_local_workspace`
- The welcome page's recent project list
- Session restore at startup (remote projects)
- The `zed` CLI

## Solution

Use `ordered_paths()` at the call sites that open a workspace or add folders to one. `MultiWorkspace::open_project_group_in_new_window` and `Workspace::new_local` already did this; this change brings the remaining call sites in line.

`paths()` is deliberately left in place where the sorted list is the correct thing to read — identity and dedup comparisons, and set-membership checks such as `RecentProjectsDelegate::is_open_folder` and `dedupe_recent_workspaces`.

## Testing

- Added `test_workspace_roundtrip_preserves_folder_order` to the `workspace` persistence tests: it saves a workspace whose folders are in non-lexicographic order, looks it back up by an arbitrarily ordered path set, and asserts that both `paths` and `identity_paths` come back in the user's order. This covers the data every one of these call sites reads.
- `cargo test -p workspace --lib` passes (240 tests), as does `cargo check -p workspace -p recent_projects` and a `rustfmt --check` over every touched file (Windows).
- The remaining changes are a mechanical `paths()` → `ordered_paths()` swap. Both spellings yield `Iterator<Item = &PathBuf>`, so the surrounding expressions are unchanged. These call sites sit in UI and session-restore machinery with no unit-test harness, and were verified by reading them rather than by an automated test.
- My Windows box is missing the Spectre-mitigated MSVC libs that `python-environment-tools` needs, which blocks any build that pulls in the `languages` crate. That covers the `zed` binary crate and `recent_projects`' test profile, so the two one-line changes in `crates/zed` and the existing `recent_projects` tests are covered by CI rather than by a local run.
- Hands-on testing by someone who reopens a multi-folder remote project would be welcome.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed multi-folder projects reopening with their folders in alphabetical order instead of the order they were arranged in.
