### PR TITLE
gpui_macos: Fix fullscreen behavior on non-macOS and after restart

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -505,6 +505,7 @@ const NS_APPLICATION_PRESENTATION_AUTO_HIDE_MENU_BAR: NSUInteger = 1 << 2;
 // the window on exit.
 struct SimpleFullscreenState {
     frame: NSRect,
+    bounds: Bounds<Pixels>,
     style_mask: NSWindowStyleMask,
 }
 
@@ -818,9 +819,11 @@ impl MacWindowState {
                 return None;
             }
             let screen_frame = unsafe { NSScreen::frame(screen) };
+            let bounds = self.bounds();
 
             self.simple_fullscreen_state = Some(SimpleFullscreenState {
                 frame: unsafe { NSWindow::frame(self.native_window) },
+                bounds,
                 style_mask: unsafe { self.native_window.styleMask() },
             });
 
@@ -865,6 +868,8 @@ impl MacWindowState {
     fn window_bounds(&self) -> WindowBounds {
         if self.is_fullscreen() {
             WindowBounds::Fullscreen(self.fullscreen_restore_bounds)
+        } else if let Some(state) = &self.simple_fullscreen_state {
+            WindowBounds::Windowed(state.bounds)
         } else {
             WindowBounds::Windowed(self.bounds())
         }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1026,10 +1026,11 @@ fn register_actions(
             window.zoom_window();
         })
         .register_action(|_, _: &ToggleFullScreen, window, cx| {
-            let use_simple_fullscreen = window.is_simple_fullscreen()
-                || (!window.is_fullscreen()
-                    && WorkspaceSettings::get_global(cx).fullscreen_mode
-                        == settings::FullscreenMode::Simple);
+            let use_simple_fullscreen = PlatformStyle::platform() == PlatformStyle::Mac
+                && (window.is_simple_fullscreen()
+                    || (!window.is_fullscreen()
+                        && WorkspaceSettings::get_global(cx).fullscreen_mode
+                            == settings::FullscreenMode::Simple));
             if use_simple_fullscreen {
                 window.toggle_simple_fullscreen();
             } else {


### PR DESCRIPTION
Follow-up to #60020.

- Fixes simple fullscreen preventing fullscreen from working on Linux and Windows (since I use shared dotfiles).
- Fixes quitting Zed in simple fullscreen not correctly restoring the previous window bounds, causing it to reopen maximized. We are not handling opening it back in simple fullscreen yet.

Release Notes:

- N/A