### PR TITLE
Switch to `async-tar` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,8 +1239,7 @@ dependencies = [
 [[package]]
 name = "async-tar"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6affe71e5b6180fb5eaf9e8127a243694baf6ae1120c199227167302f56c14b"
+source = "git+https://github.com/zed-industries/async-tar?rev=bd3ad6f89df9a9da7a8535958756d6bf465936a0#bd3ad6f89df9a9da7a8535958756d6bf465936a0"
 dependencies = [
  "async-std",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -540,7 +540,7 @@ async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "8
 async-process = "2.5.0"
 async-recursion = "1.0.0"
 async-std = { version = "1.12", features = ["unstable"] }
-async-tar = "0.6"
+async-tar = { git = "https://github.com/zed-industries/async-tar", rev = "bd3ad6f89df9a9da7a8535958756d6bf465936a0" }
 async-task = "4.7"
 async-trait = "0.1"
 async-tungstenite = "0.31.0"


### PR DESCRIPTION
This switches to `async-tar` to point to our fork, which has a fix for a bug that is causing the Cursor ACP agent fail to download in Zed, due to Pax attributes.

We will switch back as soon as https://github.com/dignifiedquire/async-tar/pull/73 is merged.

Closes #62655

Release Notes:

- Fixed an issue where the Cursor ACP agent would fail to start
