### PR TITLE
file_finder: Keep filenames visible for long paths

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -2199,8 +2199,8 @@ impl FileFinderDelegate {
                         .w_full()
                         .min_w_0()
                         .gap_1p5()
-                        .child(file_name_label.truncate_middle())
-                        .child(full_path_label.truncate_start()),
+                        .child(file_name_label.flex_none().truncate_middle())
+                        .child(full_path_label.flex_1().truncate_start()),
                 )
                 .end_slot::<AnyElement>(end_slot),
         )


### PR DESCRIPTION
# Objective

Prevent long worktree and directory paths from shrinking filenames until they become difficult to read in file finder results.

## Solution

Give the filename label non-shrinking flex sizing, and let the path label use the remaining space. When the path does not fit, it truncates from the beginning so the directories nearest the file remain visible.

## Testing

- Ran `cargo fmt --all --check`.
- Ran `cargo test -p file_finder --lib` — 79 tests passed.
- Ran `./script/clippy -p file_finder`.
- To verify manually, open a project with a long root name, search for files, and resize the file finder. Confirm that filenames remain visible while paths truncate from the beginning.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed long project paths obscuring file names in the file finder.
