### PR TITLE
markdown: Highlight fenced code blocks with trailing info text

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -43,8 +43,8 @@ use gpui::{
 use language::{CharClassifier, Language, LanguageRegistry, Rope};
 use parser::CodeBlockMetadata;
 use parser::{
-    MarkdownEvent, MarkdownTag, MarkdownTagEnd, ParsedMetadataBlock, parse_links_only,
-    parse_markdown_with_options,
+    MarkdownEvent, MarkdownTag, MarkdownTagEnd, ParsedMetadataBlock, fenced_language_name,
+    parse_links_only, parse_markdown_with_options,
 };
 use pulldown_cmark::{Alignment, BlockQuoteKind};
 use sum_tree::TreeMap;
@@ -1247,7 +1247,9 @@ impl Markdown {
             if let Some(registry) = language_registry.as_ref() {
                 for name in language_names {
                     let language = if !name.is_empty() {
-                        registry.language_for_name_or_extension(&name).left_future()
+                        registry
+                            .language_for_name_or_extension(fenced_language_name(&name))
+                            .left_future()
                     } else if let Some(fallback) = &fallback {
                         registry.language_for_name(fallback.as_ref()).right_future()
                     } else {

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -168,6 +168,12 @@ fn build_heading_slugs(
     slugs
 }
 
+/// The language name of a fenced code block is the first word of its info string;
+/// anything after it is metadata (per CommonMark).
+pub(crate) fn fenced_language_name(info: &str) -> &str {
+    info.split_whitespace().next().unwrap_or(info)
+}
+
 fn parse_metadata_table_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
     let mut rows = Vec::new();
     let mut line_start = source_range.start;
@@ -1352,6 +1358,13 @@ mod tests {
                 Some(false)
             );
         }
+    }
+
+    #[test]
+    fn test_fenced_language_name_uses_first_word() {
+        assert_eq!(fenced_language_name("ts import.meta.vitest"), "ts");
+        assert_eq!(fenced_language_name("rust"), "rust");
+        assert_eq!(fenced_language_name("  python  extra "), "python");
     }
 
     fn assert_code_block_does_not_emit_links(markdown: &str) {


### PR DESCRIPTION
Fixes #62765.

Fenced code blocks lost highlighting when the info string had anything after the language name, like ```ts import.meta.vitest. The whole string was used as the language, so the grammar lookup missed.

CommonMark says only the first word is the language. I resolve from that word now, keeping the full string so mermaid's scale suffix (```mermaid 150) still works.

Release Notes:

- Fixed fenced code blocks not highlighting when the info string had extra text after the language name.
