### PR TITLE
Prevent long ACP permission labels from overflowing

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -9828,6 +9828,8 @@ impl ThreadView {
                 let option_id = SharedString::from(option.option_id.0.clone());
                 let option_name = permission_option_button_label(&option.name);
                 Button::new((option_id, entry_ix), option_name)
+                    .aria_label(option.name.clone())
+                    .truncate(true)
                     .map(|this| {
                         // The sandbox-fallback prompt offers a "Retry" option
                         // that re-attempts creating the sandbox; it isn't an

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6043,6 +6043,10 @@ fn network_grants_nothing(network: &SandboxNetPolicy) -> bool {
     }
 }
 
+fn permission_option_button_label(option_name: &str) -> SharedString {
+    option_name.replace('\n', "⏎").into()
+}
+
 /// Rows for the write-access group: a message for the "all"/"none" cases, or one
 /// row per granted path.
 fn sandbox_fs_rows(fs: &SandboxFsDisplay) -> Vec<SandboxRow> {
@@ -9822,7 +9826,8 @@ impl ThreadView {
             .gap_0p5()
             .children(options.iter().map(move |option| {
                 let option_id = SharedString::from(option.option_id.0.clone());
-                Button::new((option_id, entry_ix), option.name.clone())
+                let option_name = permission_option_button_label(&option.name);
+                Button::new((option_id, entry_ix), option_name)
                     .map(|this| {
                         // The sandbox-fallback prompt offers a "Retry" option
                         // that re-attempts creating the sandbox; it isn't an
@@ -12690,6 +12695,14 @@ mod tests {
         acp::AvailableCommand::new(name, "").meta(acp_thread::meta_with_command_category(
             acp_thread::CommandCategory::Mcp,
         ))
+    }
+
+    #[test]
+    fn test_permission_option_button_label_is_single_line() {
+        assert_eq!(
+            permission_option_button_label("Always allow\nthis command\nfor this conversation"),
+            "Always allow⏎this command⏎for this conversation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes #62858.

ACP agents can return permission option names containing embedded newlines or extremely long descriptions. Those labels could paint beyond fixed-height buttons and overlap the surrounding confirmation controls.

## Solution

- Replace embedded newlines with visible `⏎` markers for single-row display.
- Truncate overflowing visual labels while preserving the original text for accessibility.
- Add regression coverage for multiline option labels.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check main..HEAD`
- [ ] `cargo test -p agent_ui test_permission_option_button_label_is_single_line -- --nocapture`
  - Blocked locally before test execution because `wasmtime-c-api-impl` could not spawn `cmake`; `cmake` is not installed.

To manually verify, use an external ACP agent that returns a permission option with a long, multiline name and confirm that each button stays on one truncated row without overlapping the surrounding controls.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed long ACP permission option labels overflowing the agent panel.
