### PR TITLE
git: Fix branch diff with multiple merge bases

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -74,6 +74,7 @@ pub struct FakeGitRepositoryState {
     pub simulated_index_write_error_message: Option<String>,
     pub simulated_create_worktree_error: Option<String>,
     pub simulated_graph_error: Option<String>,
+    pub simulated_diff_tree_error: Option<String>,
     pub branches_requiring_force_delete: HashSet<String>,
     pub worktrees_requiring_force_delete: HashSet<PathBuf>,
     pub refs: HashMap<String, String>,
@@ -97,6 +98,7 @@ impl FakeGitRepositoryState {
             simulated_index_write_error_message: Default::default(),
             simulated_create_worktree_error: Default::default(),
             simulated_graph_error: None,
+            simulated_diff_tree_error: None,
             branches_requiring_force_delete: Default::default(),
             worktrees_requiring_force_delete: Default::default(),
             refs: HashMap::from_iter([("HEAD".into(), "abc".into())]),
@@ -232,6 +234,9 @@ impl GitRepository for FakeGitRepository {
                     .collect::<HashMap<_, _>>()
             });
         self.with_state_async(false, move |state| {
+            if let Some(message) = &state.simulated_diff_tree_error {
+                bail!("{message}");
+            }
             let contents = worktree_contents.as_ref().unwrap_or(&state.head_contents);
             let tracked_paths = state
                 .merge_base_contents

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1921,54 +1921,68 @@ impl GitRepository for RealGitRepository {
     fn diff_tree(&self, request: DiffTreeType) -> BoxFuture<'_, Result<TreeDiff>> {
         let git = self.git_binary_in_worktree();
         let working_directory = self.working_directory.clone();
-        let merge_base_ref = match &request {
-            DiffTreeType::MergeBaseWithWorktree { base } => Some(base.clone()),
-            DiffTreeType::MergeBase { .. } | DiffTreeType::Since { .. } => None,
-        };
-
-        let args = match request {
-            DiffTreeType::MergeBase { base, head } => [
-                "diff-tree",
-                "-r",
-                "-z",
-                "--abbrev=64",
-                "--no-renames",
-                "--merge-base",
-                base.as_str(),
-                head.as_str(),
-                "--",
-            ]
-            .map(OsString::from)
-            .to_vec(),
-            DiffTreeType::MergeBaseWithWorktree { base } => [
-                "diff",
-                "--raw",
-                "-z",
-                "--abbrev=64",
-                "--no-renames",
-                "--merge-base",
-                base.as_str(),
-                "--",
-            ]
-            .map(OsString::from)
-            .to_vec(),
-            DiffTreeType::Since { base, head } => [
-                "diff-tree",
-                "-r",
-                "-z",
-                "--abbrev=64",
-                "--no-renames",
-                base.as_str(),
-                head.as_str(),
-                "--",
-            ]
-            .map(OsString::from)
-            .to_vec(),
-        };
 
         self.executor
             .spawn(async move {
                 let git = git?;
+                // `git diff --merge-base` refuses to run when the base and head
+                // share more than one merge base (criss-cross history), exiting
+                // with "fatal: multiple merge bases found". Resolve the base
+                // explicitly instead, which still picks a single candidate and
+                // matches the semantics of `git diff A...B`.
+                let (args, merge_base_oid) = match &request {
+                    DiffTreeType::MergeBase { base, head } => {
+                        let merge_base = resolve_merge_base(&git, base, head).await?;
+                        (
+                            [
+                                "diff-tree",
+                                "-r",
+                                "-z",
+                                "--abbrev=64",
+                                "--no-renames",
+                                merge_base.as_str(),
+                                head.as_str(),
+                                "--",
+                            ]
+                            .map(OsString::from)
+                            .to_vec(),
+                            None,
+                        )
+                    }
+                    DiffTreeType::MergeBaseWithWorktree { base } => {
+                        let merge_base = resolve_merge_base(&git, base, "HEAD").await?;
+                        (
+                            [
+                                "diff",
+                                "--raw",
+                                "-z",
+                                "--abbrev=64",
+                                "--no-renames",
+                                merge_base.as_str(),
+                                "--",
+                            ]
+                            .map(OsString::from)
+                            .to_vec(),
+                            Some(merge_base),
+                        )
+                    }
+                    DiffTreeType::Since { base, head } => (
+                        [
+                            "diff-tree",
+                            "-r",
+                            "-z",
+                            "--abbrev=64",
+                            "--no-renames",
+                            base.as_str(),
+                            head.as_str(),
+                            "--",
+                        ]
+                        .map(OsString::from)
+                        .to_vec(),
+                        None,
+                    ),
+                };
+
                 let output = git.build_command(&args).output().await?;
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1977,7 +1991,11 @@ impl GitRepository for RealGitRepository {
 
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let mut tree_diff = stdout.parse::<TreeDiff>()?;
-                let Some(merge_base_ref) = merge_base_ref else {
+                // Files the worktree diff reports as deleted but that exist on
+                // disk (deleted from the index or from a commit, then recreated).
+                // `git diff` compares them against the index, so compare their
+                // disk contents against the merge base ourselves.
+                let Some(merge_base) = merge_base_oid else {
                     return Ok(tree_diff);
                 };
                 let Some(working_directory) = working_directory else {
@@ -1997,10 +2015,6 @@ impl GitRepository for RealGitRepository {
                     anyhow::bail!("git status failed: {stderr}");
                 }
                 let status = String::from_utf8_lossy(&status_output.stdout).parse::<GitStatus>()?;
-                // Files the diff reports as deleted but that exist on disk
-                // (deleted from the index or from a commit, then recreated).
-                // `git diff` compares them against the index, so compare their
-                // disk contents against the merge base ourselves.
                 let recreated: Vec<(RepoPath, Oid)> = status
                     .entries
                     .iter()
@@ -2023,17 +2037,6 @@ impl GitRepository for RealGitRepository {
                     return Ok(tree_diff);
                 }
 
-                let merge_base_output = git
-                    .build_command(&["merge-base", merge_base_ref.as_ref(), "HEAD"])
-                    .output()
-                    .await?;
-                if !merge_base_output.status.success() {
-                    let stderr = String::from_utf8_lossy(&merge_base_output.stderr);
-                    anyhow::bail!("git merge-base failed: {stderr}");
-                }
-                let merge_base = String::from_utf8_lossy(&merge_base_output.stdout);
-                let merge_base = merge_base.trim();
-
                 for (path, old) in recreated {
                     let full_path = working_directory.join(path.as_std_path());
                     let metadata = match smol::fs::symlink_metadata(&full_path).await {
@@ -2042,7 +2045,8 @@ impl GitRepository for RealGitRepository {
                     };
                     let base_entry = git
                         .build_command(
-                            &["ls-tree", merge_base, "--", path.as_unix_str()].map(OsString::from),
+                            &["ls-tree", merge_base.as_str(), "--", path.as_unix_str()]
+                                .map(OsString::from),
                         )
                         .output()
                         .await?;
@@ -2508,9 +2512,12 @@ impl GitRepository for RealGitRepository {
                     }
                     DiffType::HeadToWorktree => git.build_command(&["diff"]).output().await?,
                     DiffType::MergeBase { base_ref } => {
-                        git.build_command(&["diff", "--merge-base", base_ref.as_ref(), "--"])
-                            .output()
-                            .await?
+						// See `resolve_merge_base` for why the base is resolved
+						// explicitly instead of using `--merge-base`.
+						let merge_base = resolve_merge_base(&git, &base_ref, "HEAD").await?;
+						git.build_command(&["diff", merge_base.as_str(), "--"])
+							.output()
+							.await?
                     }
                 };
 
@@ -3750,6 +3757,16 @@ fn parse_initial_graph_output<'a>(
         .collect()
 }
 
+/// Resolves the merge base of `base` and `head` to a single commit.
+///
+/// `git diff --merge-base` refuses to run when the two commits share more than
+/// one merge base (criss-cross history), exiting with "fatal: multiple merge
+/// bases found". `git merge-base` itself still picks a single candidate in that
+/// situation, matching the semantics of `git diff A...B`.
+async fn resolve_merge_base(git: &GitBinary, base: &str, head: &str) -> Result<String> {
+    git.run(&["merge-base", base, head]).await
+}
+
 fn git_status_args(path_prefixes: &[RepoPath]) -> Vec<OsString> {
     let mut args = vec![
         OsString::from("status"),
@@ -4631,6 +4648,90 @@ mod tests {
                 )]),
             }
         );
+    }
+
+    #[gpui::test]
+    async fn test_merge_base_diff_with_multiple_merge_bases(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        // Build a criss-cross topology in which the base and HEAD share two
+        // merge bases. `git diff --merge-base` refuses to run here ("fatal:
+        // multiple merge bases found"), but resolving the base explicitly with
+        // `git merge-base` still picks a single candidate.
+        let repo_dir = tempfile::tempdir().unwrap();
+        git_init_repo(repo_dir.path());
+        fs::write(repo_dir.path().join("base.txt"), "base\n").unwrap();
+        git_command(repo_dir.path(), ["add", "base.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "M"]);
+        git_command(repo_dir.path(), ["checkout", "-b", "feature"]);
+        fs::write(repo_dir.path().join("b1.txt"), "b1\n").unwrap();
+        git_command(repo_dir.path(), ["add", "b1.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "B1"]);
+        git_command(repo_dir.path(), ["checkout", "main"]);
+        fs::write(repo_dir.path().join("a1.txt"), "a1\n").unwrap();
+        git_command(repo_dir.path(), ["add", "a1.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "A1"]);
+        git_command(repo_dir.path(), ["merge", "feature", "--no-edit"]);
+        git_command(repo_dir.path(), ["checkout", "feature"]);
+        git_command(repo_dir.path(), ["merge", "main@{1}", "--no-edit"]);
+        git_command(repo_dir.path(), ["checkout", "main"]);
+        fs::write(repo_dir.path().join("a2.txt"), "a2\n").unwrap();
+        git_command(repo_dir.path(), ["add", "a2.txt"]);
+        git_command(repo_dir.path(), ["commit", "-m", "A3"]);
+
+        // Sanity check that the topology really has multiple merge bases.
+        let merge_base_count = git_command_output(
+            repo_dir.path(),
+            ["merge-base", "--all", "feature", "main"],
+        )
+        .lines()
+        .count();
+        assert!(merge_base_count > 1);
+
+        let repository = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let expected = HashSet::from_iter([
+            RepoPath::new("a2.txt").unwrap(),
+            RepoPath::new("b1.txt").unwrap(),
+        ]);
+        let committed = repository
+            .diff_tree(DiffTreeType::MergeBase {
+                base: "feature".into(),
+                head: "HEAD".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            committed.entries.keys().cloned().collect::<HashSet<_>>(),
+            expected
+        );
+
+        let worktree = repository
+            .diff_tree(DiffTreeType::MergeBaseWithWorktree {
+                base: "feature".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            worktree.entries.keys().cloned().collect::<HashSet<_>>(),
+            expected.clone()
+        );
+
+        let diff = repository
+            .diff(DiffType::MergeBase {
+                base_ref: "feature".into(),
+            })
+            .await
+            .unwrap();
+        assert!(diff.contains("a2.txt"));
+        assert!(diff.contains("b1.txt"));
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/branch_diff.rs
+++ b/crates/git_ui/src/branch_diff.rs
@@ -1196,6 +1196,48 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_branch_diff_surfaces_tree_diff_errors(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": "contents\n",
+            }),
+        )
+        .await;
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.simulated_diff_tree_error = Some("simulated git failure".into());
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let diff = cx
+            .update(|window, cx| {
+                BranchDiff::new_with_default_branch(project.clone(), workspace, window, cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let error = cx.read(|cx| {
+            diff.read(cx)
+                .diff
+                .read(cx)
+                .branch_diff()
+                .read(cx)
+                .tree_diff_error()
+                .map(SharedString::to_string)
+        });
+        assert_eq!(error.as_deref(), Some("simulated git failure"));
+    }
+
+    #[gpui::test]
     async fn test_branch_diff_action_matches_existing_item_by_base_ref(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/git_ui/src/diff_multibuffer.rs
+++ b/crates/git_ui/src/diff_multibuffer.rs
@@ -903,28 +903,43 @@ impl Render for DiffMultibuffer {
                 )
             })
             .when(is_empty && !is_loading, |el| {
-                let remote_button = if let Some(panel) = self
-                    .workspace
-                    .upgrade()
-                    .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
-                {
-                    panel.update(cx, |panel, cx| panel.render_remote_button(cx))
-                } else {
-                    None
-                };
+                let error = self.branch_diff.read(cx).tree_diff_error().cloned();
                 let keybinding_focus_handle = self.focus_handle(cx);
+                let message = match error {
+                    Some(error) => v_flex()
+                        .gap_1()
+                        .child(h_flex().justify_around().child(
+                            Label::new(error).color(Color::Error),
+                        ))
+                        .into_any_element(),
+                    None => {
+                        let remote_button = if let Some(panel) = self
+                            .workspace
+                            .upgrade()
+                            .and_then(|workspace| workspace.read(cx).panel::<GitPanel>(cx))
+                        {
+                            panel.update(cx, |panel, cx| panel.render_remote_button(cx))
+                        } else {
+                            None
+                        };
+                        v_flex()
+                            .gap_1()
+                            .child(h_flex().justify_around().child(Label::new(empty_label)))
+                            .map(|el| match remote_button {
+                                Some(button) => el.child(h_flex().justify_around().child(button)),
+                                None => el.child(
+                                    h_flex()
+                                        .justify_around()
+                                        .child(Label::new("Remote up to date")),
+                                ),
+                            })
+                            .into_any_element()
+                    }
+                };
                 el.child(
                     v_flex()
                         .gap_1()
-                        .child(h_flex().justify_around().child(Label::new(empty_label)))
-                        .map(|el| match remote_button {
-                            Some(button) => el.child(h_flex().justify_around().child(button)),
-                            None => el.child(
-                                h_flex()
-                                    .justify_around()
-                                    .child(Label::new("Remote up to date")),
-                            ),
-                        })
+                        .child(message)
                         .child(
                             h_flex().justify_around().mt_1().child(
                                 Button::new("project-diff-close-button", "Close")

--- a/crates/project/src/git_store/diff_buffer_list.rs
+++ b/crates/project/src/git_store/diff_buffer_list.rs
@@ -45,6 +45,7 @@ pub struct DiffBufferList {
     tree_diff: Option<TreeDiff>,
     statuses_by_path: Option<SumTree<StatusEntry>>,
     tree_diff_base_task: Option<Task<()>>,
+    tree_diff_error: Option<SharedString>,
     _subscription: Subscription,
     update_needed: postage::watch::Sender<()>,
     _task: Task<()>,
@@ -105,6 +106,7 @@ impl DiffBufferList {
             tree_diff: None,
             statuses_by_path: None,
             tree_diff_base_task: None,
+            tree_diff_error: None,
             _subscription: git_store_subscription,
             _task: worker,
             update_needed: send,
@@ -130,6 +132,7 @@ impl DiffBufferList {
         self.tree_diff = None;
         self.statuses_by_path = None;
         self.tree_diff_base_task = None;
+        self.tree_diff_error = None;
         cx.emit(BranchDiffEvent::FileListChanged);
         *self.update_needed.borrow_mut() = ();
     }
@@ -144,6 +147,7 @@ impl DiffBufferList {
         self.tree_diff = None;
         self.statuses_by_path = None;
         self.tree_diff_base_task = None;
+        self.tree_diff_error = None;
         self.diff_base = diff_base;
 
         cx.emit(BranchDiffEvent::DiffBaseChanged);
@@ -230,7 +234,17 @@ impl DiffBufferList {
         }
 
         let task = cx.spawn(async move |this, cx| {
-            Self::reload_tree_diff(this, cx).await.log_err();
+            if let Err(error) = Self::reload_tree_diff(this.clone(), cx).await {
+                // Keep the error visible in the diff view instead of silently
+                // presenting a failed computation as "No changes".
+                this.update(cx, |this, cx| {
+                    this.tree_diff_error = Some(error.to_string().into());
+                    cx.emit(BranchDiffEvent::FileListChanged);
+                    cx.notify();
+                })
+                .log_err();
+                log::error!("failed to load branch diff: {error:#}");
+            }
         });
 
         self.tree_diff_base_task = Some(task);
@@ -278,6 +292,7 @@ impl DiffBufferList {
             let statuses_by_path = this.repo.as_ref().map(|repo| {
                 build_statuses(&repo.read(cx).snapshot, &committed_tree_diff, &tree_diff)
             });
+            this.tree_diff_error = None;
             this.committed_tree_diff = Some(committed_tree_diff);
             this.tree_diff = Some(tree_diff);
             this.statuses_by_path = statuses_by_path;
@@ -288,6 +303,12 @@ impl DiffBufferList {
 
     pub fn repo(&self) -> Option<&Entity<Repository>> {
         self.repo.as_ref()
+    }
+
+    /// The error from the last tree diff reload, if it failed. An empty diff
+    /// and a failed one look identical otherwise.
+    pub fn tree_diff_error(&self) -> Option<&SharedString> {
+        self.tree_diff_error.as_ref()
     }
 
     #[instrument(skip_all)]


### PR DESCRIPTION
Closes #62863, #61186.

## Summary

`git: compare with branch` / `git: branch diff` showed "No changes" when the selected base branch and HEAD had more than one merge base (criss-cross merge history). `git diff --merge-base <base>` fails with `fatal: multiple merge bases found` in that situation, and the failure was silently swallowed by `log_err()` in `DiffBufferList`, so the failed computation was presented as an empty diff.

## Changes

1. **Root cause (`crates/git`)**: stop passing `--merge-base` to git. Instead resolve the base explicitly with `git merge-base <base> HEAD`, then diff against the resolved commit. `git merge-base` without `--all` still returns a single deterministic candidate on criss-cross history, matching the semantics of `git diff A...B` and GitHub's compare view. This fixes all three call sites: `diff_tree` for committed (`MergeBase`) and worktree (`MergeBaseWithWorktree`) tree diffs, and `diff` for the "Review" action. As a side effect this also drops the dependency on `git diff --merge-base`, which is unavailable on git < 2.30 (see #61186).

2. **Error surfacing (`crates/project`, `crates/git_ui`)**: a failed tree diff reload is no longer swallowed. `DiffBufferList` records the error, and the branch diff view renders it (in error color) instead of the "No changes" placeholder, so a failed computation can never look like an empty diff again. The error clears automatically on a successful reload.

## Showcase

With this PR: correctly displays diff:

https://github.com/user-attachments/assets/99264b18-9cc3-410e-9a17-adf6dfa09b0f

Without this PR: displays neither diff nor error message:

https://github.com/user-attachments/assets/dd6ac5c3-757a-4e42-8366-542f94baec60

## Tests

- `crates/git`: regression test `test_merge_base_diff_with_multiple_merge_bases` builds a real criss-cross topology (verified to produce two merge bases and the git-level failure) and asserts `diff_tree` (committed + worktree) and `diff` return the expected non-empty diff.
- `crates/fs`: added `simulated_diff_tree_error` hook to the fake repository (pattern matches the existing simulated error hooks).
- `crates/git_ui`: `test_branch_diff_surfaces_tree_diff_errors` verifies a failed tree diff reload is surfaced via `DiffBufferList::tree_diff_error`.

Release Notes:

- Fixed `git: compare with branch` showing "No changes" when the repository has multiple merge bases (criss-cross history)
