### PR TITLE
git_ui: Improve discard tracked changes context menu option

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -300,6 +300,7 @@ impl Render for StashMessageModal {
 
 fn git_panel_context_menu(
     has_tracked_changes: bool,
+    has_staged_tracked_changes: bool,
     has_staged_changes: bool,
     has_unstaged_changes: bool,
     has_new_changes: bool,
@@ -316,7 +317,7 @@ fn git_panel_context_menu(
             .action_disabled_when(!has_unstaged_changes, "Stage All", StageAll.boxed_clone())
             .action_disabled_when(!has_staged_changes, "Unstage All", UnstageAll.boxed_clone())
             .action_disabled_when(
-                !has_tracked_changes,
+                !has_staged_tracked_changes,
                 "Restore All Changes",
                 RestoreTrackedFiles.boxed_clone(),
             )
@@ -352,7 +353,7 @@ fn git_panel_context_menu(
             })
             .separator()
             .action_disabled_when(
-                !has_tracked_changes,
+                !has_staged_tracked_changes,
                 "Discard Tracked Changes",
                 RestoreTrackedFiles.boxed_clone(),
             )
@@ -2014,6 +2015,49 @@ impl GitPanel {
             .unique_by(|entry| entry.repo_path.clone())
     }
 
+    fn directory_descendants(&self, entry_index: usize) -> Option<&[GitStatusEntry]> {
+        let GitListEntry::Directory(directory) = self.entries.get(entry_index)? else {
+            return None;
+        };
+
+        self.view_mode
+            .tree_state()?
+            .directory_descendants
+            .get(&directory.key)
+            .map(Vec::as_slice)
+    }
+
+    /// Returns the list of entries that are children of the directory where the
+    /// context menu is deployed, if deployed.
+    fn directory_context_descendants(&self) -> Option<&[GitStatusEntry]> {
+        let entry_index = self.context_menu.as_ref()?.target_entry_index?;
+        self.directory_descendants(entry_index)
+    }
+
+    fn is_staged_tracked(entry: &GitStatusEntry) -> bool {
+        !entry.status.is_created() && entry.staging.has_staged()
+    }
+
+    fn change_flags_for_entries(entries: &[GitStatusEntry]) -> (bool, bool, bool, bool, bool) {
+        (
+            entries.iter().any(|entry| !entry.status.is_created()),
+            entries.iter().any(Self::is_staged_tracked),
+            entries.iter().any(|entry| entry.staging.has_staged()),
+            entries.iter().any(|entry| entry.staging.has_unstaged()),
+            entries.iter().any(|entry| entry.status.is_created()),
+        )
+    }
+
+    fn staged_tracked_entries<'a>(
+        entries: impl IntoIterator<Item = &'a GitStatusEntry>,
+    ) -> Vec<GitStatusEntry> {
+        entries
+            .into_iter()
+            .filter(|entry| Self::is_staged_tracked(entry))
+            .cloned()
+            .collect()
+    }
+
     fn open_diff(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
         if self.active_tab == GitPanelTab::History {
             self.open_selected_history_commit(window, cx);
@@ -2431,12 +2475,9 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         let entries = self
-            .change_entries_by_path()
-            .filter(|status_entry| {
-                !status_entry.status.is_created() && status_entry.status.staging().has_staged()
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+            .directory_context_descendants()
+            .map(Self::staged_tracked_entries)
+            .unwrap_or_else(|| Self::staged_tracked_entries(self.change_entries_by_path()));
 
         match entries.len() {
             0 => return,
@@ -5292,6 +5333,10 @@ impl GitPanel {
         self.tracked_count > 0
     }
 
+    fn has_staged_tracked_changes(&self) -> bool {
+        self.change_entries_by_path().any(Self::is_staged_tracked)
+    }
+
     pub fn has_unstaged_conflicts(&self) -> bool {
         self.change_entries_by_path()
             .any(|entry| entry.status.is_conflicted() && entry.staging.has_unstaged())
@@ -5831,6 +5876,7 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let has_tracked_changes = self.has_tracked_changes();
+        let has_staged_tracked_changes = self.has_staged_tracked_changes();
         let has_staged_changes = self.has_staged_changes();
         let has_unstaged_changes = self.has_unstaged_changes();
         let has_new_changes = self.new_count > 0;
@@ -5849,6 +5895,7 @@ impl GitPanel {
             .menu(move |window, cx| {
                 Some(git_panel_context_menu(
                     has_tracked_changes,
+                    has_staged_tracked_changes,
                     has_staged_changes,
                     has_unstaged_changes,
                     has_new_changes,
@@ -7365,7 +7412,7 @@ impl GitPanel {
                     .on_mouse_down(
                         MouseButton::Right,
                         cx.listener(move |this, event: &MouseDownEvent, window, cx| {
-                            this.deploy_panel_context_menu(event.position, false, window, cx)
+                            this.deploy_panel_context_menu(event.position, None, false, window, cx)
                         }),
                     )
                     .custom_scrollbars(
@@ -7540,7 +7587,7 @@ impl GitPanel {
     ) {
         if matches!(self.entries.get(ix), Some(GitListEntry::Directory(_))) {
             self.selected_entry = Some(ix);
-            self.deploy_panel_context_menu(position, true, window, cx);
+            self.deploy_panel_context_menu(position, Some(ix), true, window, cx);
             return;
         }
 
@@ -7606,18 +7653,36 @@ impl GitPanel {
     fn deploy_panel_context_menu(
         &mut self,
         position: Point<Pixels>,
+        target_entry_index: Option<usize>,
         include_copy_paths: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let has_tracked_changes = self.has_tracked_changes();
-        let has_staged_changes = self.has_staged_changes();
-        let has_unstaged_changes = self.has_unstaged_changes();
-        let has_new_changes = self.new_count > 0;
         let has_stash_items = self.stash_entries.entries.len() > 0;
+        let (
+            has_tracked_changes,
+            has_staged_tracked_changes,
+            has_staged_changes,
+            has_unstaged_changes,
+            has_new_changes,
+        ) = target_entry_index
+            .and_then(|entry_index| self.directory_descendants(entry_index))
+            .map_or_else(
+                || {
+                    (
+                        self.has_tracked_changes(),
+                        self.has_staged_tracked_changes(),
+                        self.has_staged_changes(),
+                        self.has_unstaged_changes(),
+                        self.new_count > 0,
+                    )
+                },
+                Self::change_flags_for_entries,
+            );
 
         let context_menu = git_panel_context_menu(
             has_tracked_changes,
+            has_staged_tracked_changes,
             has_staged_changes,
             has_unstaged_changes,
             has_new_changes,
@@ -7628,7 +7693,8 @@ impl GitPanel {
             window,
             cx,
         );
-        self.set_context_menu(context_menu, position, None, window, cx);
+
+        self.set_context_menu(context_menu, position, target_entry_index, window, cx);
     }
 
     fn set_context_menu(
@@ -12922,6 +12988,70 @@ mod tests {
             history_panel_was_focused && center_item_is_focused,
             "pane navigation should focus the History panel after moving right and restore the center item after moving left; History panel focused after moving right: {history_panel_was_focused}, center item focused after moving left: {center_item_is_focused}"
         );
+    }
+
+    #[test]
+    fn test_directory_discard_tracked_changes() {
+        let entry = |path, status: FileStatus| GitStatusEntry {
+            repo_path: repo_path(path),
+            staging: status.staging(),
+            status,
+            diff_stat: None,
+        };
+
+        // 1. Single tracked file that is staged.
+        let entries = vec![entry(
+            "directory/tracked.rs",
+            FileStatus::index(StatusCode::Modified),
+        )];
+        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        assert!(has_staged_tracked_changes);
+        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
+
+        // 2. Single untracked file that is staged.
+        let entries = vec![entry(
+            "directory/new.rs",
+            FileStatus::index(StatusCode::Added),
+        )];
+        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        assert!(!has_staged_tracked_changes);
+        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+
+        // 3. Single tracked file that is unstaged.
+        let entries = vec![entry(
+            "directory/tracked.rs",
+            StatusCode::Modified.worktree(),
+        )];
+        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        assert!(!has_staged_tracked_changes);
+        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+
+        // 4. Single untracked file that is unstaged.
+        let entries = vec![entry("directory/new.rs", FileStatus::Untracked)];
+        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        assert!(!has_staged_tracked_changes);
+        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+
+        // 5. Mixed tracked and untracked files that are both staged and
+        // unstaged.
+        let entries = vec![
+            entry(
+                "directory/staged_tracked.rs",
+                FileStatus::index(StatusCode::Modified),
+            ),
+            entry(
+                "directory/staged_new.rs",
+                FileStatus::index(StatusCode::Added),
+            ),
+            entry(
+                "directory/unstaged_tracked.rs",
+                StatusCode::Modified.worktree(),
+            ),
+            entry("directory/unstaged_new.rs", FileStatus::Untracked),
+        ];
+        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        assert!(has_staged_tracked_changes);
+        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2038,14 +2038,10 @@ impl GitPanel {
         !entry.status.is_created() && entry.staging.has_staged()
     }
 
-    fn change_flags_for_entries(entries: &[GitStatusEntry]) -> (bool, bool, bool, bool, bool) {
-        (
-            entries.iter().any(|entry| !entry.status.is_created()),
-            entries.iter().any(Self::is_staged_tracked),
-            entries.iter().any(|entry| entry.staging.has_staged()),
-            entries.iter().any(|entry| entry.staging.has_unstaged()),
-            entries.iter().any(|entry| entry.status.is_created()),
-        )
+    fn contains_staged_tracked_entry<'a>(
+        entries: impl IntoIterator<Item = &'a GitStatusEntry>,
+    ) -> bool {
+        entries.into_iter().any(Self::is_staged_tracked)
     }
 
     fn staged_tracked_entries<'a>(
@@ -5334,7 +5330,7 @@ impl GitPanel {
     }
 
     fn has_staged_tracked_changes(&self) -> bool {
-        self.change_entries_by_path().any(Self::is_staged_tracked)
+        Self::contains_staged_tracked_entry(self.change_entries_by_path())
     }
 
     pub fn has_unstaged_conflicts(&self) -> bool {
@@ -7659,25 +7655,15 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         let has_stash_items = self.stash_entries.entries.len() > 0;
-        let (
-            has_tracked_changes,
-            has_staged_tracked_changes,
-            has_staged_changes,
-            has_unstaged_changes,
-            has_new_changes,
-        ) = target_entry_index
+        let has_tracked_changes = self.has_tracked_changes();
+        let has_staged_changes = self.has_staged_changes();
+        let has_unstaged_changes = self.has_unstaged_changes();
+        let has_new_changes = self.new_count > 0;
+        let has_staged_tracked_changes = target_entry_index
             .and_then(|entry_index| self.directory_descendants(entry_index))
             .map_or_else(
-                || {
-                    (
-                        self.has_tracked_changes(),
-                        self.has_staged_tracked_changes(),
-                        self.has_staged_changes(),
-                        self.has_unstaged_changes(),
-                        self.new_count > 0,
-                    )
-                },
-                Self::change_flags_for_entries,
+                || self.has_staged_tracked_changes(),
+                |entries| Self::contains_staged_tracked_entry(entries),
             );
 
         let context_menu = git_panel_context_menu(
@@ -13004,7 +12990,7 @@ mod tests {
             "directory/tracked.rs",
             FileStatus::index(StatusCode::Modified),
         )];
-        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
         assert!(has_staged_tracked_changes);
         assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
 
@@ -13013,7 +12999,7 @@ mod tests {
             "directory/new.rs",
             FileStatus::index(StatusCode::Added),
         )];
-        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
         assert!(!has_staged_tracked_changes);
         assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
 
@@ -13022,13 +13008,13 @@ mod tests {
             "directory/tracked.rs",
             StatusCode::Modified.worktree(),
         )];
-        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
         assert!(!has_staged_tracked_changes);
         assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
 
         // 4. Single untracked file that is unstaged.
         let entries = vec![entry("directory/new.rs", FileStatus::Untracked)];
-        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
         assert!(!has_staged_tracked_changes);
         assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
 
@@ -13049,7 +13035,7 @@ mod tests {
             ),
             entry("directory/unstaged_new.rs", FileStatus::Untracked),
         ];
-        let (_, has_staged_tracked_changes, _, _, _) = GitPanel::change_flags_for_entries(&entries);
+        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
         assert!(has_staged_tracked_changes);
         assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
     }


### PR DESCRIPTION
# Objective

Ensure that the "Discard Tracked Changes" option shown in the context menu that can be opened in the Git Panel's "Changes" tab is only displayed when it can actually be used. Currently, it is also shown when the "Unstaged" section has tracked files, even though clicking will not actually do anything.

Besides fixing that, the changes in this Pull Request also update how the "Discard Tracked Changes" action works when picked from a subfolder, with only changes in that subfolder being discarded.

Closes #62535

## Solution

- Update `git_ui::git_panel::git_panel_context_menu` to now accept a `has_staged_tracked_changes` boolean, in order to be able to differentiate between the panel having tracked changes, be it unstaged or staged, and specifically staged tracked changes, as we only want the "Discard Tracked Changes" to be enabled and affect staged changes.
- Add `git_ui::git_panel::GitPanel::directory_context_descendants` in order to be able to obtain the list of entries under the directory where the context menu was deployed, if any.
- Update `git_ui::git_panel::GitPanel::restored_tracked_files` to leverage the new `directory_context_descendants` method, ensuring that only the entries under the context menu's directory are restored, instead of all staged tracked files

## Testing

Tested both manually, as shown in the "Showcase" section, as well as introduced a new test for these changes – `git_ui::git_panel::tests::test_directory_discard_tracked_changes`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>

  https://github.com/user-attachments/assets/24bbb23c-78fb-4fe3-82da-d8bcaec0d79c
</details>

<details>
  <summary>After</summary>
  
  https://github.com/user-attachments/assets/70db9189-9122-4ee4-b03f-648935c4f0a4
</details>

---

Release Notes:

- Fixed the "Discard Tracked Changes" option being enabled for files in the "Unstaged" section in the Git Panel
- Updated the "Discard Tracked Changes" option to only affects files in the directory where the context menu was deployed
