### PR TITLE
cloud_api_client: Move spawn native websocket to the background

### DIFF
--- a/crates/cloud_api_client/src/websocket/native.rs
+++ b/crates/cloud_api_client/src/websocket/native.rs
@@ -31,7 +31,7 @@ impl Connection {
         let rx = self.rx.fuse();
         let (message_tx, message_rx) = unbounded();
         let executor = cx.background_executor().clone();
-        let task = cx.spawn(async move |_cx| {
+        let task = cx.background_executor().spawn(async move {
             let keepalive_timer = executor.timer(KEEPALIVE_INTERVAL).fuse();
             futures::pin_mut!(keepalive_timer, rx);
 

--- a/crates/cloud_api_client/src/websocket/native.rs
+++ b/crates/cloud_api_client/src/websocket/native.rs
@@ -31,7 +31,7 @@ impl Connection {
         let rx = self.rx.fuse();
         let (message_tx, message_rx) = unbounded();
         let executor = cx.background_executor().clone();
-        let task = cx.background_executor().spawn(async move {
+        let task = cx.background_spawn(async move {
             let keepalive_timer = executor.timer(KEEPALIVE_INTERVAL).fuse();
             futures::pin_mut!(keepalive_timer, rx);
 

--- a/crates/cloud_api_client/src/websocket/native.rs
+++ b/crates/cloud_api_client/src/websocket/native.rs
@@ -5,7 +5,7 @@ use cloud_api_types::websocket_protocol::{PROTOCOL_VERSION, PROTOCOL_VERSION_HEA
 use futures::channel::mpsc::unbounded;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{FutureExt as _, SinkExt as _, StreamExt as _, TryStreamExt as _};
-use gpui::{App, Task};
+use gpui::{App, AppContext, Task};
 use http_client::http::request;
 use yawc::frame::Frame;
 use yawc::{TcpWebSocket, WebSocket};


### PR DESCRIPTION
# Objective

While working on something else, I noticed that I sometimes get this warning about a foreground hang:

```
2026-08-19T11:25:45+02:00 INFO [zed::reliability::hang_detection::logging] New foreground hang detected: Tasks(s) that ran too long 215.24375ms          - crates/cloud_api_client/src/websocket/native.rs:34:23
```

That I believe can just be safely moved to the background, unless I'm missing something here.

## Solution

Spawn the websocket task on the background instead of on the foreground, so that we can't hang the foreground thread anymore for **~200ms**.

## Testing

I have tested that I can still connect to the websocket, not sure what else to test.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
