### PR TITLE
docs: correct WSL command to `projects: open folder in wsl`

### DIFF
--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -111,7 +111,7 @@ Zed supports opening folders inside of WSL natively on Windows.
 
 ### Opening a local folder in WSL
 
-To open a local folder inside a WSL container, use the `projects: open in wsl` action and select the folder you want to open. You will be presented with a list of available WSL distributions to open the folder in.
+To open a local folder inside a WSL container, use the `projects: open folder in wsl` action and select the folder you want to open. You will be presented with a list of available WSL distributions to open the folder in.
 
 ### Opening a folder already in WSL
 


### PR DESCRIPTION
# Objective

I'd like to start getting more involved in Zed, so i thought some routine docs hygiene would be a good first step. 

Fixes #60922.

The WSL section of the remote development docs tells users to run the `projects: open in wsl` action to open a local folder in WSL. That command doesn't exist — the action is `OpenFolderInWsl` in the `projects` namespace (`crates/zed_actions/src/lib.rs`), which surfaces in the command palette as `projects: open folder in wsl`. Following the docs as written leaves users unable to find the command.

## Solution

Update `docs/src/remote-development.md` to reference the correct command, `projects: open folder in wsl`. This also keeps it consistent with the sibling `projects: open wsl` action documented in the next section.

## Testing

Docs-only change. Verified the command name against the action definition (`#[action(namespace = projects)] OpenFolderInWsl`) in `crates/zed_actions/src/lib.rs`; no build or runtime behavior changes.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability

_(Remaining checklist items — unsafe blocks, tests, performance — are N/A for a one-line docs correction.)_
