### PR TITLE
repl: Render SVG cell outputs

### DIFF
--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AssetSource, DevicePixels, IsZero, RenderImage, Result, SharedString, Size,
+    AssetSource, DevicePixels, IsZero, Pixels, RenderImage, Result, SharedString, Size, px,
     swap_rgba_pa_to_bgra,
 };
 use image::Frame;
@@ -101,6 +101,14 @@ pub struct SvgRenderer {
 /// to paths, so callers that need to rasterize the same SVG at multiple
 /// scales should retain this value to avoid re-paying the parse cost.
 pub struct ParsedSvg(usvg::Tree);
+
+impl ParsedSvg {
+    /// The intrinsic size of the document, in logical pixels.
+    pub fn size(&self) -> Size<Pixels> {
+        let size = self.0.size();
+        crate::size(px(size.width()), px(size.height()))
+    }
+}
 
 /// The size in which to rasterize the SVG.
 #[derive(Clone, Copy)]

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -67,9 +67,12 @@ use settings::Settings;
 /// When deciding what to render from a collection of mediatypes, we need to rank them in order of importance
 fn rank_mime_type(mimetype: &MimeType) -> usize {
     match mimetype {
-        MimeType::DataTable(_) => 7,
-        MimeType::Html(_) => 6,
-        MimeType::Json(_) => 5,
+        MimeType::DataTable(_) => 8,
+        MimeType::Html(_) => 7,
+        MimeType::Json(_) => 6,
+        // Rank SVG above raster images so a kernel that offers both is shown
+        // as the scalable version.
+        MimeType::Svg(_) => 5,
         MimeType::Png(_) => 4,
         MimeType::Jpeg(_) => 3,
         MimeType::Markdown(_) => 2,
@@ -422,6 +425,10 @@ impl Output {
                     display_id,
                 },
                 Err(error) => Output::Message(format!("Failed to load image: {}", error)),
+            },
+            Some(MimeType::Svg(data)) => Output::Image {
+                content: cx.new(|cx| ImageView::from_svg(data, cx)),
+                display_id,
             },
             Some(MimeType::DataTable(data)) => Output::Table {
                 content: cx.new(|cx| TableView::new(data, window, cx)),
@@ -859,14 +866,16 @@ mod tests {
         let data_table = MimeType::DataTable(Box::default());
         let html = MimeType::Html(String::new());
         let json = MimeType::Json(serde_json::json!({}));
+        let svg = MimeType::Svg(String::new());
         let png = MimeType::Png(String::new());
         let jpeg = MimeType::Jpeg(String::new());
         let markdown = MimeType::Markdown(String::new());
         let plain = MimeType::Plain(String::new());
 
-        assert_eq!(rank_mime_type(&data_table), 7);
-        assert_eq!(rank_mime_type(&html), 6);
-        assert_eq!(rank_mime_type(&json), 5);
+        assert_eq!(rank_mime_type(&data_table), 8);
+        assert_eq!(rank_mime_type(&html), 7);
+        assert_eq!(rank_mime_type(&json), 6);
+        assert_eq!(rank_mime_type(&svg), 5);
         assert_eq!(rank_mime_type(&png), 4);
         assert_eq!(rank_mime_type(&jpeg), 3);
         assert_eq!(rank_mime_type(&markdown), 2);
@@ -874,7 +883,8 @@ mod tests {
 
         assert!(rank_mime_type(&data_table) > rank_mime_type(&html));
         assert!(rank_mime_type(&html) > rank_mime_type(&json));
-        assert!(rank_mime_type(&json) > rank_mime_type(&png));
+        assert!(rank_mime_type(&json) > rank_mime_type(&svg));
+        assert!(rank_mime_type(&svg) > rank_mime_type(&png));
         assert!(rank_mime_type(&png) > rank_mime_type(&jpeg));
         assert!(rank_mime_type(&jpeg) > rank_mime_type(&markdown));
         assert!(rank_mime_type(&markdown) > rank_mime_type(&plain));
@@ -882,10 +892,8 @@ mod tests {
 
     #[test]
     fn test_rank_mime_type_unsupported_returns_zero() {
-        let svg = MimeType::Svg(String::new());
         let latex = MimeType::Latex(String::new());
 
-        assert_eq!(rank_mime_type(&svg), 0);
         assert_eq!(rank_mime_type(&latex), 0);
     }
 

--- a/crates/repl/src/outputs/image.rs
+++ b/crates/repl/src/outputs/image.rs
@@ -3,9 +3,14 @@ use base64::{
     Engine as _, alphabet,
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
 };
-use gpui::{App, ClipboardItem, Image, ImageFormat, Pixels, RenderImage, Window, img};
+use futures::{FutureExt as _, select_biased};
+use gpui::{
+    App, ClipboardItem, DevicePixels, Empty, Image, ImageFormat, ParsedSvg, Pixels, RenderImage,
+    SharedString, Size, SvgSize, Task, Window, img, size,
+};
 use settings::Settings as _;
 use std::sync::Arc;
+use std::time::Duration;
 use ui::{IntoElement, Styled, prelude::*};
 
 use crate::outputs::{OutputContent, plain};
@@ -14,10 +19,39 @@ use crate::repl_settings::ReplSettings;
 /// ImageView renders an image inline in an editor, adapting to the line height to fit the image.
 pub struct ImageView {
     clipboard_image: Arc<Image>,
-    height: u32,
-    width: u32,
-    image: Arc<RenderImage>,
+    source: ImageSource,
+    task: Option<Task<()>>,
 }
+
+enum ImageSource {
+    Raster {
+        image: Arc<RenderImage>,
+        size: Size<Pixels>,
+    },
+    Svg(SvgImage),
+}
+
+enum SvgImage {
+    Parsing {
+        /// Set once parsing has run long enough to be worth telling the user about.
+        slow: bool,
+    },
+    Ready {
+        parsed: Arc<ParsedSvg>,
+        /// The raster being displayed, and the device size it was made at.
+        raster: Option<(Size<DevicePixels>, Arc<RenderImage>)>,
+        /// The device size of a rasterization that is currently running.
+        rendering: Option<Size<DevicePixels>>,
+    },
+    Failed(SharedString),
+}
+
+/// Rasters are capped so that a large document cannot ask for a huge texture.
+const MAX_RASTER_SIZE: f32 = 2000.;
+
+/// How long to let an SVG parse before showing a loading state, so that the
+/// common case of a small document does not flash one.
+const SLOW_PARSE_THRESHOLD: Duration = Duration::from_millis(2);
 
 pub const STANDARD_INDIFFERENT: GeneralPurpose = GeneralPurpose::new(
     &alphabet::STANDARD,
@@ -64,10 +98,131 @@ impl ImageView {
 
         Ok(ImageView {
             clipboard_image,
-            height,
-            width,
-            image: Arc::new(gpui_image_data),
+            source: ImageSource::Raster {
+                image: Arc::new(gpui_image_data),
+                size: size(px(width as f32), px(height as f32)),
+            },
+            task: None,
         })
+    }
+
+    pub fn from_svg(svg: &str, cx: &mut Context<Self>) -> Self {
+        let clipboard_image =
+            Arc::new(Image::from_bytes(ImageFormat::Svg, svg.as_bytes().to_vec()));
+        let svg_renderer = cx.svg_renderer();
+
+        let task = cx.spawn({
+            let clipboard_image = clipboard_image.clone();
+            async move |this, cx| {
+                let mut parse = cx
+                    .background_spawn(
+                        async move { svg_renderer.parse_svg(clipboard_image.bytes()) },
+                    )
+                    .fuse();
+                let mut slow = cx.background_executor().timer(SLOW_PARSE_THRESHOLD).fuse();
+
+                let parsed = select_biased! {
+                    parsed = parse => parsed,
+                    _ = slow => {
+                        this.update(cx, |this, cx| {
+                            if let ImageSource::Svg(SvgImage::Parsing { slow }) = &mut this.source {
+                                *slow = true;
+                                cx.notify();
+                            }
+                        })
+                        .ok();
+                        parse.await
+                    }
+                };
+
+                this.update(cx, |this, cx| {
+                    this.source = ImageSource::Svg(match parsed {
+                        Ok(parsed) => SvgImage::Ready {
+                            parsed: Arc::new(parsed),
+                            raster: None,
+                            rendering: None,
+                        },
+                        Err(error) => SvgImage::Failed(error.to_string().into()),
+                    });
+                    cx.notify();
+                })
+                .ok();
+            }
+        });
+
+        ImageView {
+            clipboard_image,
+            source: ImageSource::Svg(SvgImage::Parsing { slow: false }),
+            task: Some(task),
+        }
+    }
+
+    /// Rasterizes the SVG at the size it is laid out at, so that it stays sharp
+    /// instead of being scaled from a raster made at some other size.
+    fn rasterize_svg(
+        &mut self,
+        display_size: Size<Pixels>,
+        scale_factor: f32,
+        cx: &mut Context<Self>,
+    ) {
+        let ImageSource::Svg(SvgImage::Ready {
+            parsed,
+            raster,
+            rendering,
+        }) = &mut self.source
+        else {
+            return;
+        };
+
+        let target = raster_size(display_size, scale_factor);
+        if target.width.0 <= 0
+            || target.height.0 <= 0
+            || raster.as_ref().map(|(size, _)| *size) == Some(target)
+            || *rendering == Some(target)
+        {
+            return;
+        }
+
+        *rendering = Some(target);
+        let parsed = parsed.clone();
+        let svg_renderer = cx.svg_renderer();
+
+        self.task = Some(cx.spawn(async move |this, cx| {
+            let rendered = cx
+                .background_spawn(async move {
+                    svg_renderer.render_parsed(&parsed, SvgSize::ExactSize(target))
+                })
+                .await;
+
+            this.update(cx, |this, cx| {
+                let ImageSource::Svg(svg) = &mut this.source else {
+                    return;
+                };
+                match rendered {
+                    Ok(image) => {
+                        if let SvgImage::Ready {
+                            raster, rendering, ..
+                        } = svg
+                        {
+                            *rendering = None;
+                            if let Some((_, previous)) = raster.replace((target, image)) {
+                                cx.drop_image(previous, None);
+                            }
+                        }
+                    }
+                    Err(error) => *svg = SvgImage::Failed(error.to_string().into()),
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn render_pending(&self) -> AnyElement {
+        match &self.source {
+            ImageSource::Svg(SvgImage::Parsing { slow: false }) => Empty.into_any_element(),
+            _ => div().child("Rendering SVG...").into_any_element(),
+        }
     }
 
     fn scaled_size(
@@ -75,16 +230,17 @@ impl ImageView {
         line_height: Pixels,
         max_width: Option<Pixels>,
         max_height: Option<Pixels>,
-    ) -> (Pixels, Pixels) {
-        let (mut height, mut width) = if self.height as f32 / f32::from(line_height)
-            == u8::MAX as f32
-        {
-            let height = u8::MAX as f32 * line_height;
-            let width = Pixels::from(self.width as f32 * f32::from(height) / self.height as f32);
-            (height, width)
-        } else {
-            (self.height.into(), self.width.into())
-        };
+    ) -> Option<Size<Pixels>> {
+        let intrinsic_size = self.source.size()?;
+
+        let (mut height, mut width) =
+            if f32::from(intrinsic_size.height) / f32::from(line_height) == u8::MAX as f32 {
+                let height = u8::MAX as f32 * line_height;
+                let width = intrinsic_size.width * (height / intrinsic_size.height);
+                (height, width)
+            } else {
+                (intrinsic_size.height, intrinsic_size.width)
+            };
 
         let mut scale: f32 = 1.0;
         if let Some(max_width) = max_width {
@@ -104,8 +260,41 @@ impl ImageView {
             height *= scale;
         }
 
-        (height, width)
+        Some(size(width, height))
     }
+}
+
+impl ImageSource {
+    /// The intrinsic size of the image, once it is known.
+    fn size(&self) -> Option<Size<Pixels>> {
+        match self {
+            ImageSource::Raster { size, .. } => Some(*size),
+            ImageSource::Svg(SvgImage::Ready { parsed, .. }) => Some(parsed.size()),
+            ImageSource::Svg(_) => None,
+        }
+    }
+
+    fn image(&self) -> Option<&Arc<RenderImage>> {
+        match self {
+            ImageSource::Raster { image, .. } => Some(image),
+            ImageSource::Svg(SvgImage::Ready { raster, .. }) => {
+                raster.as_ref().map(|(_, image)| image)
+            }
+            ImageSource::Svg(_) => None,
+        }
+    }
+}
+
+/// The device size to rasterize at, capped so that a large document cannot ask
+/// for a huge texture.
+fn raster_size(display_size: Size<Pixels>, scale_factor: f32) -> Size<DevicePixels> {
+    let longest_side = f32::from(display_size.width).max(f32::from(display_size.height));
+    let mut scale = scale_factor;
+    if longest_side * scale > MAX_RASTER_SIZE {
+        scale = MAX_RASTER_SIZE / longest_side;
+    }
+
+    display_size.map(|side| DevicePixels((f32::from(side) * scale).round() as i32))
 }
 
 impl Render for ImageView {
@@ -121,11 +310,25 @@ impl Render for ImageView {
             None
         };
 
-        let (height, width) = self.scaled_size(line_height, max_width, max_height);
+        if let ImageSource::Svg(SvgImage::Failed(error)) = &self.source {
+            return div()
+                .child(format!("Failed to render SVG: {error}"))
+                .into_any_element();
+        }
 
-        let image = self.image.clone();
+        let Some(display_size) = self.scaled_size(line_height, max_width, max_height) else {
+            return self.render_pending();
+        };
 
-        img(image).w(width).h(height)
+        self.rasterize_svg(display_size, window.scale_factor(), cx);
+
+        match self.source.image() {
+            Some(image) => img(image.clone())
+                .w(display_size.width)
+                .h(display_size.height)
+                .into_any_element(),
+            None => self.render_pending(),
+        }
     }
 }
 
@@ -157,6 +360,87 @@ mod tests {
         base64::engine::general_purpose::STANDARD.encode(bytes)
     }
 
+    const TEST_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80"><rect width="120" height="80" fill="red"/></svg>"#;
+
+    #[gpui::test]
+    async fn test_image_view_parses_svg_in_the_background(cx: &mut gpui::TestAppContext) {
+        let view = cx.new(|cx| ImageView::from_svg(TEST_SVG, cx));
+
+        view.read_with(cx, |view, _| {
+            assert!(matches!(
+                view.source,
+                ImageSource::Svg(SvgImage::Parsing { .. })
+            ));
+        });
+
+        cx.run_until_parked();
+
+        view.read_with(cx, |view, _| {
+            assert_eq!(view.source.size(), Some(size(px(120.0), px(80.0))));
+            assert!(view.source.image().is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_image_view_reports_invalid_svg(cx: &mut gpui::TestAppContext) {
+        let view = cx.new(|cx| ImageView::from_svg("not an svg", cx));
+        cx.run_until_parked();
+
+        view.read_with(cx, |view, _| {
+            assert!(matches!(view.source, ImageSource::Svg(SvgImage::Failed(_))));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_image_view_rasterizes_svg_at_display_size(cx: &mut gpui::TestAppContext) {
+        let view = cx.new(|cx| ImageView::from_svg(TEST_SVG, cx));
+        cx.run_until_parked();
+
+        view.update(cx, |view, cx| {
+            view.rasterize_svg(size(px(60.0), px(40.0)), 2.0, cx)
+        });
+        cx.run_until_parked();
+
+        let image = view
+            .read_with(cx, |view, _| view.source.image().cloned())
+            .expect("SVG should have been rasterized");
+        assert_eq!(image.size(0), size(DevicePixels(120), DevicePixels(80)));
+
+        // Laying out at the same size again reuses the raster.
+        view.update(cx, |view, cx| {
+            view.rasterize_svg(size(px(60.0), px(40.0)), 2.0, cx)
+        });
+        cx.run_until_parked();
+        view.read_with(cx, |view, _| {
+            assert!(Arc::ptr_eq(
+                &image,
+                view.source.image().expect("raster should be kept")
+            ));
+        });
+
+        view.update(cx, |view, cx| {
+            view.rasterize_svg(size(px(30.0), px(20.0)), 1.0, cx)
+        });
+        cx.run_until_parked();
+        view.read_with(cx, |view, _| {
+            assert_eq!(
+                view.source
+                    .image()
+                    .expect("SVG should have been rasterized")
+                    .size(0),
+                size(DevicePixels(30), DevicePixels(20))
+            );
+        });
+    }
+
+    #[test]
+    fn test_raster_size_is_capped() {
+        let capped = raster_size(size(px(4000.0), px(2000.0)), 2.0);
+
+        assert_eq!(capped.width, DevicePixels(MAX_RASTER_SIZE as i32));
+        assert_eq!(capped.height, DevicePixels(MAX_RASTER_SIZE as i32 / 2));
+    }
+
     #[test]
     fn test_image_view_scaled_size_respects_limits() {
         let encoded = encode_test_image(200, 120);
@@ -168,11 +452,11 @@ mod tests {
         let line_height = Pixels::from(10.0);
         let max_width = Pixels::from(50.0);
         let max_height = Pixels::from(40.0);
-        let (height, width) =
-            image_view.scaled_size(line_height, Some(max_width), Some(max_height));
+        let display_size = image_view
+            .scaled_size(line_height, Some(max_width), Some(max_height))
+            .expect("raster images have a known size");
 
-        assert_eq!(f32::from(width), 50.0);
-        assert_eq!(f32::from(height), 30.0);
+        assert_eq!(display_size, size(px(50.0), px(30.0)));
     }
 
     #[test]
@@ -184,9 +468,10 @@ mod tests {
         };
 
         let line_height = Pixels::from(10.0);
-        let (height, width) = image_view.scaled_size(line_height, None, None);
+        let display_size = image_view
+            .scaled_size(line_height, None, None)
+            .expect("raster images have a known size");
 
-        assert_eq!(f32::from(width), 200.0);
-        assert_eq!(f32::from(height), 120.0);
+        assert_eq!(display_size, size(px(200.0), px(120.0)));
     }
 }


### PR DESCRIPTION
Closes #61717

Reopened from #61718, which could not be reopened after being closed. Also supersedes #44512, which was closed as abandoned.

SVG outputs from kernels (image/svg+xml) were showing "Unsupported media type" instead of the image. matplotlib, plotly, and other libraries commonly emit SVG, so this was a visible gap for data science users. This came up in discussion #25936.

Note: this does not close #60203. That case sends `text/html` alongside SVG and PNG, and the HTML still wins the ranking, so it needs separate work.

This renders SVG outputs through GPUI's SVG renderer, reusing the existing ImageView with a from_svg constructor. It also ranks SVG above raster images, so a kernel that offers both shows the scalable version. If you would rather keep PNG first, that is a one line change and I am happy to flip it.

The old jupyter_protocol issue that blocked #44512 (image/svg+xml being parsed as a generic image and dropped) is fixed in the version Zed uses now, so no cargo patch is needed.

I added a unit test that checks an SVG renders at its intrinsic size. This caught a scale factor bug where SVGs were rendering at twice their size. The two existing rank_mime_type tests are updated for the new ordering. Tested locally on macOS, and a cell producing image/svg+xml now renders the vector image inline.

![SVG output rendered inline](https://raw.githubusercontent.com/ArneshBanerjee/zed-jupyter/pr-assets/61717-svg-after.png)

Release Notes:

- Added rendering of SVG outputs in the REPL and notebook editor

