### PR TITLE
feat: experimental in-panel agent thread search improvements

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -451,7 +451,7 @@
   // Embedded thread-search editor navigation lives in
   // keymaps/specific-overrides-macos.json so it wins over base Editor bindings.
   {
-    "context": "CodexThreadsArchiveView",
+    "context": "AgentPanelThreadsSearch",
     "bindings": {
       "escape": "menu::Cancel"
     },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -267,6 +267,13 @@
     },
   },
   {
+    "context": "AgentPanel && SearchWithinAgentPanel",
+    "use_key_equivalents": true,
+    "bindings": {
+      "alt-f": "agent::SearchThreads",
+    },
+  },
+  {
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
@@ -439,6 +446,14 @@
     "context": "ThreadsArchiveView",
     "bindings": {
       "backspace": "agent::ArchiveSelectedThread",
+    },
+  },
+  // Embedded thread-search editor navigation lives in
+  // keymaps/specific-overrides-macos.json so it wins over base Editor bindings.
+  {
+    "context": "CodexThreadsArchiveView",
+    "bindings": {
+      "escape": "menu::Cancel"
     },
   },
   {

--- a/assets/keymaps/specific-overrides-macos.json
+++ b/assets/keymaps/specific-overrides-macos.json
@@ -7,7 +7,7 @@
 // keymaps, giving it the highest precedence of all the bindings set by us.
 [
   {
-    "context": "CodexThreadsArchiveView > Editor",
+    "context": "AgentPanelThreadsSearch > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "down": "menu::SelectNext",

--- a/assets/keymaps/specific-overrides-macos.json
+++ b/assets/keymaps/specific-overrides-macos.json
@@ -7,6 +7,17 @@
 // keymaps, giving it the highest precedence of all the bindings set by us.
 [
   {
+    "context": "CodexThreadsArchiveView > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "down": "menu::SelectNext",
+      "enter": "menu::Confirm",
+      "shift-tab": "menu::SelectPrevious",
+      "tab": "menu::SelectNext",
+      "up": "menu::SelectPrevious",
+    },
+  },
+  {
     "context": "Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -607,6 +607,7 @@ mod tests {
             sandbox_permissions: Default::default(),
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
+            search_within_agent_panel: false,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
         }

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -240,6 +240,7 @@ pub struct AgentSettings {
     pub message_editor_min_lines: usize,
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
+    pub search_within_agent_panel: bool,
     pub tool_permissions: ToolPermissions,
     pub sandbox_permissions: SandboxPermissions,
 }
@@ -816,6 +817,7 @@ impl Settings for AgentSettings {
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
+            search_within_agent_panel: agent.search_within_agent_panel.unwrap_or(false),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             sandbox_permissions: compile_sandbox_permissions(agent.sandbox_permissions),
         }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -43,6 +43,7 @@ use crate::terminal_thread_metadata_store::{
     terminal_title_without_prefix,
 };
 use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore, ThreadMetadataStoreEvent};
+use crate::threads_archive_view::{ThreadsArchiveView, ThreadsArchiveViewEvent};
 use crate::{
     Agent, AgentInitialContent, AgentThreadSource, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
@@ -50,8 +51,8 @@ use crate::{
 use crate::{
     AgentDiffPane, ConversationView, CopyThreadToClipboard, Follow, LoadThreadFromClipboard,
     NewTerminalThread, NewThread, OpenActiveThreadAsMarkdown, OpenAgentDiff, ResetFastModeWarnings,
-    ResetTrialEndUpsell, ResetTrialUpsell, ShowAllSidebarThreadMetadata, ShowThreadMetadata,
-    ToggleNewThreadMenu, ToggleOptionsMenu,
+    ResetTrialEndUpsell, ResetTrialUpsell, SearchThreads, ShowAllSidebarThreadMetadata,
+    ShowThreadMetadata, ToggleNewThreadMenu, ToggleOptionsMenu,
     conversation_view::{
         AcpThreadViewEvent, RootThreadUpdated, ThreadView, reset_fast_mode_warnings,
     },
@@ -1170,6 +1171,9 @@ pub struct AgentPanel {
     pending_terminal_spawn: Option<TerminalId>,
     new_thread_menu_handle: PopoverMenuHandle<ContextMenu>,
     agent_panel_menu_handle: PopoverMenuHandle<ContextMenu>,
+    thread_search_view: Option<Entity<ThreadsArchiveView>>,
+    thread_search_previous_focus: Option<FocusHandle>,
+    _thread_search_subscription: Option<Subscription>,
     _extension_subscription: Option<Subscription>,
     _project_subscription: Subscription,
     zoomed: bool,
@@ -1572,6 +1576,9 @@ impl AgentPanel {
             pending_terminal_spawn: None,
             new_thread_menu_handle: PopoverMenuHandle::default(),
             agent_panel_menu_handle: PopoverMenuHandle::default(),
+            thread_search_view: None,
+            thread_search_previous_focus: None,
+            _thread_search_subscription: None,
 
             _extension_subscription: extension_subscription,
             _project_subscription,
@@ -1746,6 +1753,7 @@ impl AgentPanel {
     }
 
     pub fn new_thread(&mut self, _action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
+        self.close_thread_search(window, cx);
         if !self.has_open_project(cx) {
             return;
         }
@@ -1773,6 +1781,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.close_thread_search(window, cx);
         if !self.has_open_project(cx) {
             return;
         }
@@ -4015,6 +4024,99 @@ impl AgentPanel {
         }
     }
 
+    fn focus_or_open_thread_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !AgentSettings::get_global(cx).search_within_agent_panel {
+            cx.propagate();
+            return;
+        }
+
+        if let Some(thread_search_view) = self.thread_search_view.clone() {
+            thread_search_view.update(cx, |view, cx| {
+                view.focus_filter_editor(window, cx);
+            });
+            return;
+        }
+
+        self.thread_search_previous_focus = Some(self.activation_focus_handle(cx));
+
+        let workspace = self.workspace.clone();
+        let agent_connection_store = self.connection_store.downgrade();
+        let agent_server_store = self.project.read(cx).agent_server_store().downgrade();
+        let thread_search_view = cx.new(|cx| {
+            ThreadsArchiveView::new_embedded(
+                workspace,
+                agent_connection_store,
+                agent_server_store,
+                window,
+                cx,
+            )
+        });
+        let subscription = cx.subscribe_in(
+            &thread_search_view,
+            window,
+            |this, _view, event: &ThreadsArchiveViewEvent, window, cx| {
+                this.handle_thread_search_event(event, window, cx);
+            },
+        );
+
+        self.thread_search_view = Some(thread_search_view.clone());
+        self._thread_search_subscription = Some(subscription);
+        thread_search_view.update(cx, |view, cx| {
+            view.focus_filter_editor(window, cx);
+        });
+        cx.notify();
+    }
+
+    fn close_thread_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.thread_search_view.is_none() {
+            return;
+        }
+        let previous_focus = self.thread_search_previous_focus.take();
+        self.thread_search_view = None;
+        self._thread_search_subscription = None;
+        previous_focus
+            .unwrap_or_else(|| self.activation_focus_handle(cx))
+            .focus(window, cx);
+        cx.notify();
+    }
+
+    fn search_threads(&mut self, _: &SearchThreads, window: &mut Window, cx: &mut Context<Self>) {
+        self.focus_or_open_thread_search(window, cx);
+    }
+
+    fn handle_thread_search_event(
+        &mut self,
+        event: &ThreadsArchiveViewEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            ThreadsArchiveViewEvent::Close => self.close_thread_search(window, cx),
+            ThreadsArchiveViewEvent::Activate { thread } => {
+                let agent = Agent::from(thread.agent_id.clone());
+                let thread_id = thread.thread_id;
+                let work_dirs = Some(thread.folder_paths().clone());
+                let title = thread.title();
+                self.close_thread_search(window, cx);
+                self.load_agent_thread(
+                    agent,
+                    thread_id,
+                    work_dirs,
+                    title,
+                    true,
+                    AgentThreadSource::AgentPanel,
+                    window,
+                    cx,
+                );
+            }
+            ThreadsArchiveViewEvent::NewThread => {
+                self.close_thread_search(window, cx);
+                self.new_thread(&NewThread, window, cx);
+            }
+            ThreadsArchiveViewEvent::CancelRestore { .. } | ThreadsArchiveViewEvent::Import => {}
+        }
+    }
+
     pub fn conversation_view_for_id(
         &self,
         thread_id: &ThreadId,
@@ -4379,6 +4481,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.close_thread_search(window, cx);
         if let Some(store) = ThreadMetadataStore::try_global(cx) {
             store.update(cx, |store, cx| {
                 store.unarchive(thread_id, cx);
@@ -4953,6 +5056,12 @@ impl Panel for AgentPanel {
     }
 
     fn activation_focus_handle(&self, cx: &App) -> FocusHandle {
+        if AgentSettings::get_global(cx).search_within_agent_panel
+            && let Some(thread_search_view) = &self.thread_search_view
+        {
+            return thread_search_view.focus_handle(cx);
+        }
+
         match self.visible_surface() {
             VisibleSurface::Uninitialized => self.focus_handle.clone(),
             VisibleSurface::AgentThread(conversation_view) => {
@@ -5779,10 +5888,12 @@ impl AgentPanel {
         let agent_server_store = self.project.read(cx).agent_server_store().clone();
 
         let focus_handle = self.focus_handle(cx);
+        let search_focus_handle = focus_handle.clone();
 
         let can_create_entries = self.has_open_project(cx);
         let supports_terminal = self.supports_terminal(cx);
         let showing_terminal = matches!(self.visible_surface(), VisibleSurface::Terminal(_));
+        let search_within_agent_panel = AgentSettings::get_global(cx).search_within_agent_panel;
 
         let (selected_agent_custom_icon, selected_agent_label) = if showing_terminal {
             (None, SharedString::from("Terminal"))
@@ -6132,6 +6243,29 @@ impl AgentPanel {
                         .flex_none()
                         .gap_1()
                         .children(sandbox_status)
+                        .when(
+                            search_within_agent_panel && can_create_entries && !showing_terminal,
+                            |this| {
+                                this.child(
+                                    IconButton::new("search-threads", IconName::MagnifyingGlass)
+                                        .icon_size(IconSize::Small)
+                                        .toggle_state(self.thread_search_view.is_some())
+                                        .tooltip({
+                                            move |_window, cx| {
+                                                Tooltip::for_action_in(
+                                                    "Search Threads",
+                                                    &SearchThreads,
+                                                    &search_focus_handle,
+                                                    cx,
+                                                )
+                                            }
+                                        })
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.focus_or_open_thread_search(window, cx);
+                                        })),
+                                )
+                            },
+                        )
                         .when(can_create_entries, |this| this.child(new_thread_menu))
                         .child(full_screen_button)
                         .child(self.render_panel_options_menu(window, cx)),
@@ -6422,9 +6556,12 @@ impl AgentPanel {
         }
     }
 
-    fn key_context(&self) -> KeyContext {
+    fn key_context(&self, cx: &App) -> KeyContext {
         let mut key_context = KeyContext::new_with_defaults();
         key_context.add("AgentPanel");
+        if AgentSettings::get_global(cx).search_within_agent_panel {
+            key_context.add("SearchWithinAgentPanel");
+        }
         key_context
     }
 }
@@ -6441,7 +6578,7 @@ impl Render for AgentPanel {
         // - Scrolling in all views works as expected
         // - Files can be dropped into the panel
         let content = v_flex()
-            .key_context(self.key_context())
+            .key_context(self.key_context(cx))
             .relative()
             .size_full()
             .justify_between()
@@ -6460,6 +6597,7 @@ impl Render for AgentPanel {
             .on_action(cx.listener(Self::open_active_thread_as_markdown))
             .on_action(cx.listener(Self::manage_skills))
             .on_action(cx.listener(Self::toggle_options_menu))
+            .on_action(cx.listener(Self::search_threads))
             .on_action(cx.listener(Self::increase_font_size))
             .on_action(cx.listener(Self::decrease_font_size))
             .on_action(cx.listener(Self::reset_font_size))
@@ -6481,41 +6619,49 @@ impl Render for AgentPanel {
             }))
             .child(self.render_toolbar(window, cx))
             .children(self.render_new_user_onboarding(window, cx))
-            .map(|parent| match self.visible_surface() {
-                VisibleSurface::Uninitialized if !self.has_open_project(cx) => {
-                    parent.child(self.render_no_project_state(cx))
-                }
-                VisibleSurface::Uninitialized => parent,
-                VisibleSurface::AgentThread(conversation_view) => parent
-                    .child(conversation_view.clone())
-                    .child(self.render_drag_target(cx)),
-                VisibleSurface::Terminal(terminal_view) => {
-                    let search_bar = self
-                        .active_terminal_id()
-                        .and_then(|terminal_id| self.terminals.get(&terminal_id))
-                        .and_then(|terminal| terminal.search_bar.clone());
-                    let terminal_content = v_flex()
-                        .size_full()
-                        .when_some(search_bar, |this, search_bar| {
-                            this.when(!search_bar.read(cx).is_dismissed(), |this| {
-                                this.child(
-                                    v_flex()
-                                        .group("toolbar")
-                                        .relative()
-                                        .py(DynamicSpacing::Base06.rems(cx))
-                                        .px(DynamicSpacing::Base08.rems(cx))
-                                        .border_b_1()
-                                        .border_color(cx.theme().colors().border_variant)
-                                        .bg(cx.theme().colors().toolbar_background)
-                                        .child(search_bar),
-                                )
-                            })
-                        })
-                        .child(terminal_view.clone());
+            .map(|parent| {
+                if AgentSettings::get_global(cx).search_within_agent_panel
+                    && let Some(thread_search_view) = self.thread_search_view.clone()
+                {
+                    parent.child(thread_search_view)
+                } else {
+                    match self.visible_surface() {
+                        VisibleSurface::Uninitialized if !self.has_open_project(cx) => {
+                            parent.child(self.render_no_project_state(cx))
+                        }
+                        VisibleSurface::Uninitialized => parent,
+                        VisibleSurface::AgentThread(conversation_view) => parent
+                            .child(conversation_view.clone())
+                            .child(self.render_drag_target(cx)),
+                        VisibleSurface::Terminal(terminal_view) => {
+                            let search_bar = self
+                                .active_terminal_id()
+                                .and_then(|terminal_id| self.terminals.get(&terminal_id))
+                                .and_then(|terminal| terminal.search_bar.clone());
+                            let terminal_content = v_flex()
+                                .size_full()
+                                .when_some(search_bar, |this, search_bar| {
+                                    this.when(!search_bar.read(cx).is_dismissed(), |this| {
+                                        this.child(
+                                            v_flex()
+                                                .group("toolbar")
+                                                .relative()
+                                                .py(DynamicSpacing::Base06.rems(cx))
+                                                .px(DynamicSpacing::Base08.rems(cx))
+                                                .border_b_1()
+                                                .border_color(cx.theme().colors().border_variant)
+                                                .bg(cx.theme().colors().toolbar_background)
+                                                .child(search_bar),
+                                        )
+                                    })
+                                })
+                                .child(terminal_view.clone());
 
-                    parent
-                        .child(terminal_content)
-                        .child(self.render_drag_target(cx))
+                            parent
+                                .child(terminal_content)
+                                .child(self.render_drag_target(cx))
+                        }
+                    }
                 }
             })
             .children(self.render_trial_end_upsell(window, cx));
@@ -7489,6 +7635,45 @@ mod tests {
                 "the single initial terminal should become active"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_thread_search_is_gated_by_setting(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_visible_panel(cx).await;
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.focus_or_open_thread_search(window, cx);
+        });
+        assert!(
+            panel.read_with(&cx, |panel, _cx| panel.thread_search_view.is_none()),
+            "thread search should remain unavailable when the setting is disabled"
+        );
+
+        cx.update(|_, cx| {
+            AgentSettings::override_global(
+                AgentSettings {
+                    search_within_agent_panel: true,
+                    ..AgentSettings::get_global(cx).clone()
+                },
+                cx,
+            );
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.focus_or_open_thread_search(window, cx);
+        });
+        assert!(
+            panel.read_with(&cx, |panel, _cx| panel.thread_search_view.is_some()),
+            "thread search should open when the setting is enabled"
+        );
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.close_thread_search(window, cx);
+        });
+        assert!(
+            panel.read_with(&cx, |panel, _cx| panel.thread_search_view.is_none()),
+            "closing thread search should remove the embedded view"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -322,6 +322,8 @@ actions!(
         ScrollOutputToNextMessage,
         /// Toggles in-thread search over the current agent thread's contents.
         ToggleSearch,
+        /// Opens or focuses search across agent threads.
+        SearchThreads,
         /// Import agent threads from other Zed release channels (e.g. Preview, Nightly).
         ImportThreadsFromOtherChannels,
         /// Starts a new terminal thread.
@@ -1012,6 +1014,7 @@ mod tests {
             sandbox_permissions: Default::default(),
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
+            search_within_agent_panel: false,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
         };

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1190,7 +1190,7 @@ impl Render for ThreadsArchiveView {
 
         v_flex()
             .key_context(if self.embedded {
-                "CodexThreadsArchiveView"
+                "AgentPanelThreadsSearch"
             } else {
                 "ThreadsArchiveView"
             })

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -23,7 +23,7 @@ use gpui::{
     list, prelude::*, px,
 };
 use itertools::Itertools as _;
-use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
+use menu::{Cancel, Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use picker::{
     Picker, PickerDelegate,
     highlighted_match_with_paths::{HighlightedMatch, HighlightedMatchWithPaths},
@@ -156,6 +156,7 @@ pub struct ThreadsArchiveView {
     archived_branch_names: HashMap<ThreadId, HashMap<PathBuf, String>>,
     _load_branch_names_task: Task<()>,
     thread_filter: ThreadFilter,
+    embedded: bool,
 }
 
 impl ThreadsArchiveView {
@@ -230,10 +231,30 @@ impl ThreadsArchiveView {
             archived_branch_names: HashMap::default(),
             _load_branch_names_task: Task::ready(()),
             thread_filter: ThreadFilter::All,
+            embedded: false,
         };
 
         this.update_items(cx);
         this.reload_branch_names_if_threads_changed(cx);
+        this
+    }
+
+    pub(crate) fn new_embedded(
+        workspace: WeakEntity<Workspace>,
+        agent_connection_store: WeakEntity<AgentConnectionStore>,
+        agent_server_store: WeakEntity<AgentServerStore>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut this = Self::new(
+            workspace,
+            agent_connection_store,
+            agent_server_store,
+            window,
+            cx,
+        );
+        this.embedded = true;
+        this.update_items(cx);
         this
     }
 
@@ -282,9 +303,15 @@ impl ThreadsArchiveView {
         let thread_filter = self.thread_filter;
         let sessions = store
             .entries()
-            .filter(|t| match thread_filter {
-                ThreadFilter::All => true,
-                ThreadFilter::ArchivedOnly => t.archived,
+            .filter(|t| {
+                if self.embedded {
+                    !t.archived
+                } else {
+                    match thread_filter {
+                        ThreadFilter::All => true,
+                        ThreadFilter::ArchivedOnly => t.archived,
+                    }
+                }
             })
             .sorted_by_cached_key(|t| t.created_at.unwrap_or(t.updated_at))
             .rev()
@@ -527,7 +554,7 @@ impl ThreadsArchiveView {
         }
     }
 
-    fn select_next(&mut self, _: &SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+    fn select_next(&mut self, _: &SelectNext, window: &mut Window, cx: &mut Context<Self>) {
         let next = match self.selection {
             Some(ix) => self.find_next_selectable(ix + 1),
             None => self.find_next_selectable(0),
@@ -535,6 +562,9 @@ impl ThreadsArchiveView {
         if let Some(next) = next {
             self.selection = Some(next);
             self.list_state.scroll_to_reveal_item(next);
+            if self.embedded {
+                self.focus_handle.focus(window, cx);
+            }
             cx.notify();
         }
     }
@@ -548,6 +578,9 @@ impl ThreadsArchiveView {
                 {
                     self.selection = Some(prev);
                     self.list_state.scroll_to_reveal_item(prev);
+                    if self.embedded {
+                        self.focus_handle.focus(window, cx);
+                    }
                 } else {
                     self.selection = None;
                     self.focus_filter_editor(window, cx);
@@ -559,6 +592,9 @@ impl ThreadsArchiveView {
                 if let Some(prev) = self.find_previous_selectable(last) {
                     self.selection = Some(prev);
                     self.list_state.scroll_to_reveal_item(prev);
+                    if self.embedded {
+                        self.focus_handle.focus(window, cx);
+                    }
                     cx.notify();
                 }
             }
@@ -583,12 +619,32 @@ impl ThreadsArchiveView {
     }
 
     fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(ix) = self.selection else { return };
+        let Some(ix) = self.selection.or_else(|| {
+            self.embedded
+                .then(|| self.find_next_selectable(0))
+                .flatten()
+        }) else {
+            return;
+        };
         let Some(ArchiveListItem::Entry { thread, .. }) = self.items.get(ix) else {
             return;
         };
 
-        self.unarchive_thread(thread.clone(), window, cx);
+        if self.embedded {
+            cx.emit(ThreadsArchiveViewEvent::Activate {
+                thread: thread.clone(),
+            });
+        } else {
+            self.unarchive_thread(thread.clone(), window, cx);
+        }
+    }
+
+    fn cancel(&mut self, _: &Cancel, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.embedded {
+            cx.emit(ThreadsArchiveViewEvent::Close);
+        } else {
+            cx.propagate();
+        }
     }
 
     fn render_list_entry(
@@ -673,6 +729,7 @@ impl ThreadsArchiveView {
                     .highlight_positions(highlight_positions.clone())
                     .project_paths(thread.folder_paths().paths_owned())
                     .worktrees(worktrees)
+                    .selected(self.embedded && is_focused)
                     .focused(is_focused)
                     .hovered(is_hovered)
                     .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
@@ -850,7 +907,50 @@ impl ThreadsArchiveView {
         .detach_and_log_err(cx);
     }
 
-    fn render_header(&self, window: &Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_header(&self, window: &Window, cx: &mut Context<Self>) -> AnyElement {
+        if self.embedded {
+            let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
+
+            return h_flex()
+                .h(Tab::container_height(cx))
+                .px_2()
+                .gap_1()
+                .border_b_1()
+                .border_color(cx.theme().colors().border)
+                .child(
+                    h_flex()
+                        .min_w_0()
+                        .flex_1()
+                        .gap_1()
+                        .child(
+                            Icon::new(IconName::MagnifyingGlass)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .child(self.filter_editor.clone()),
+                )
+                .when(has_query, |this| {
+                    this.child(
+                        IconButton::new("clear-filter", IconName::Close)
+                            .icon_size(IconSize::Small)
+                            .tooltip(Tooltip::text("Clear Search"))
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.reset_filter_editor_text(window, cx);
+                                this.update_items(cx);
+                            })),
+                    )
+                })
+                .child(
+                    IconButton::new("close-thread-search", IconName::Close)
+                        .icon_size(IconSize::Small)
+                        .tooltip(Tooltip::text("Close Thread Search"))
+                        .on_click(cx.listener(|_this, _, _, cx| {
+                            cx.emit(ThreadsArchiveViewEvent::Close);
+                        })),
+                )
+                .into_any_element();
+        }
+
         let has_query = !self.filter_editor.read(cx).text(cx).is_empty();
         let sidebar_on_left = matches!(
             AgentSettings::get_global(cx).sidebar_side(),
@@ -922,6 +1022,7 @@ impl ThreadsArchiveView {
             .when(right_window_controls, |this| {
                 this.children(Self::render_right_window_controls(window, cx))
             })
+            .into_any_element()
     }
 
     fn render_left_window_controls(window: &Window, cx: &mut App) -> Option<AnyElement> {
@@ -1088,7 +1189,11 @@ impl Render for ThreadsArchiveView {
         };
 
         v_flex()
-            .key_context("ThreadsArchiveView")
+            .key_context(if self.embedded {
+                "CodexThreadsArchiveView"
+            } else {
+                "ThreadsArchiveView"
+            })
             .track_focus(&self.focus_handle)
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::select_previous))
@@ -1097,11 +1202,16 @@ impl Render for ThreadsArchiveView {
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::confirm))
+            .when(self.embedded, |this| {
+                this.on_action(cx.listener(Self::cancel))
+            })
             .on_action(cx.listener(Self::remove_selected_thread))
             .on_action(cx.listener(Self::archive_selected_thread))
             .size_full()
             .child(self.render_header(window, cx))
-            .when(!has_query, |this| this.child(self.render_toolbar(cx)))
+            .when(!has_query && !self.embedded, |this| {
+                this.child(self.render_toolbar(cx))
+            })
             .child(content)
     }
 }

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -344,7 +344,7 @@ pub struct AgentSettingsContent {
     ///
     /// Default: true
     pub show_merge_conflict_indicator: Option<bool>,
-    /// Whether to enable the local experimental Codex-oriented agent UI additions.
+    /// Whether to enable experimental agent panel thread search.
     ///
     /// Default: false
     pub search_within_agent_panel: Option<bool>,

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -344,6 +344,10 @@ pub struct AgentSettingsContent {
     ///
     /// Default: true
     pub show_merge_conflict_indicator: Option<bool>,
+    /// Whether to enable the local experimental Codex-oriented agent UI additions.
+    ///
+    /// Default: false
+    pub search_within_agent_panel: Option<bool>,
     /// Per-tool permission rules for granular control over which tool actions
     /// require confirmation.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8614,6 +8614,29 @@ fn ai_page(cx: &App) -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Search Within Agent Panel",
+                description: "Enable experimental thread search keyboard controls and horizontally scrollable terminal commands in the agent panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("agent.search_within_agent_panel"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()?
+                            .search_within_agent_panel
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .search_within_agent_panel = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
         ]);
 
         items.extend([


### PR DESCRIPTION
# Objective

Make it faster to switch agent threads without giving up space to the separate threads dock.

The current agent workflow requires opening a separate dock to search threads, which moves attention away from the active conversation. For users working with many long-running agent threads, an in-panel search is more direct and keeps the conversation and its thread navigation colocated.

## Solution

Added an opt-in `agent.experimental_codex_agent_ui` setting, disabled by default.

When enabled, the agent panel provides:

- A thread-search button in the agent panel header.
- `Option+F` to open thread search.
- `Escape` to close search and restore focus to the prior view.
- Arrow keys and `Tab`/`Shift+Tab` to move through results.
- `Enter` to open the selected thread.
- A visible selected-row state for keyboard navigation.

Existing agent archive/dock behavior remains unchanged.

## Testing

Tested manually on macOS:

- Enabled **Experimental Codex Agent UI** in Settings.
- Opened inline search from the header icon and with `Option+F`.
- Verified filtering, `Escape`, arrow navigation, `Tab`/`Shift+Tab`, and `Enter`.
- Confirmed the existing agent archive/dock behavior remains unchanged.

Automated checks run:

- `cargo check -p agent_ui`
- `cargo test -p agent_ui test_fuzzy_match_positions -- --nocapture`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

| Enabled | Search tooltip | Searching | Filtered | Disabled
:--|:--|:--|:--|:--
<img width="1504" height="903" alt="enabled" src="https://github.com/user-attachments/assets/58fe3e0b-8360-4704-ae2a-bb864e66e7e8" />|<img width="1523" height="918" alt="search" src="https://github.com/user-attachments/assets/3a98aee7-4868-4e7c-80e0-5706a2a97ea7" />|<img width="1538" height="917" alt="searching" src="https://github.com/user-attachments/assets/f85b2dd5-caf2-4096-a298-af862ffd74c0" />|<img width="1515" height="921" alt="filtered" src="https://github.com/user-attachments/assets/5e336c74-a0af-4048-bcc4-6a86e8831445" />|<img width="1301" height="463" alt="disabled" src="https://github.com/user-attachments/assets/121e6207-a600-401a-9ebb-34d1a91c410c" />

Release Notes:

- Added experimental in-panel agent thread search.
