### PR TITLE
Stop retrying exhausted usage limits as transient rate limits

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4602,6 +4602,9 @@ impl Thread {
             }
             // Retrying won't help for Payment Required errors.
             PaymentRequired => None,
+            // Retrying won't help until the usage window resets or the user
+            // purchases more usage.
+            UsageLimitReached { .. } => None,
             // Retrying won't help until the user consents to data retention
             // or switches models.
             DataRetentionConsentRequired { .. } => None,

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -129,6 +129,11 @@ pub(crate) enum ThreadError {
     RateLimitExceeded {
         provider: SharedString,
     },
+    UsageLimitReached {
+        provider: SharedString,
+        message: SharedString,
+        retry_after: Option<Duration>,
+    },
     ServerOverloaded {
         provider: SharedString,
     },
@@ -173,6 +178,15 @@ impl From<anyhow::Error> for ThreadError {
             match lm_error {
                 RateLimitExceeded { provider, .. } => Self::RateLimitExceeded {
                     provider: provider.to_string().into(),
+                },
+                UsageLimitReached {
+                    provider,
+                    message,
+                    retry_after,
+                } => Self::UsageLimitReached {
+                    provider: provider.to_string().into(),
+                    message: message.clone().into(),
+                    retry_after: *retry_after,
                 },
                 ServerOverloaded { provider, .. } | ApiInternalServerError { provider, .. } => {
                     Self::ServerOverloaded {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -709,6 +709,34 @@ fn full_path_for_empty_project_path(file: &dyn language::File, cx: &App) -> Opti
     (!full_path.is_empty()).then_some(full_path)
 }
 
+/// Formats a usage-limit reset delay as a coarse human-readable duration.
+/// Reset windows are hours or days long, so minute precision is enough.
+fn format_reset_delay(delay: Duration) -> String {
+    let total_minutes = delay.as_secs() / 60;
+    let days = total_minutes / (60 * 24);
+    let hours = (total_minutes / 60) % 24;
+    let minutes = total_minutes % 60;
+
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days} day{}", if days == 1 { "" } else { "s" }));
+    }
+    if hours > 0 {
+        parts.push(format!("{hours} hour{}", if hours == 1 { "" } else { "s" }));
+    }
+    if days == 0 && minutes > 0 {
+        parts.push(format!(
+            "{minutes} minute{}",
+            if minutes == 1 { "" } else { "s" }
+        ));
+    }
+    if parts.is_empty() {
+        "less than a minute".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
 fn skill_issue_file_label(path: &std::path::Path) -> String {
     let file_name = path.file_name().and_then(|name| name.to_str());
     let parent_name = path
@@ -1892,6 +1920,11 @@ impl ThreadView {
                     "rate_limit_exceeded",
                     None,
                     format!("{provider}'s rate limit was reached.").into(),
+                ),
+                ThreadError::UsageLimitReached { provider, .. } => (
+                    "usage_limit_reached",
+                    None,
+                    format!("{provider}'s usage limit was reached.").into(),
                 ),
                 ThreadError::ServerOverloaded { provider } => (
                     "server_overloaded",
@@ -11044,6 +11077,28 @@ impl ThreadView {
                 true,
                 cx,
             ),
+            ThreadError::UsageLimitReached {
+                provider,
+                message,
+                retry_after,
+            } => {
+                let reset_hint = retry_after
+                    .map(|retry_after| {
+                        format!(" Your usage resets in {}.", format_reset_delay(retry_after))
+                    })
+                    .unwrap_or_default();
+                self.render_error_callout(
+                    "Usage Limit Reached",
+                    format!(
+                        "{provider} reported: {message}{reset_hint} \
+                        Wait for your usage to reset or switch to a different model."
+                    )
+                    .into(),
+                    false,
+                    true,
+                    cx,
+                )
+            }
             ThreadError::ServerOverloaded { provider } => self.render_error_callout(
                 "Provider Unavailable",
                 format!(

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -121,6 +121,17 @@ pub enum LanguageModelCompletionError {
         provider: LanguageModelProviderName,
         retry_after: Option<Duration>,
     },
+    /// The account's usage allowance is exhausted (e.g. a ChatGPT subscription
+    /// ran out of Codex credits, or an OpenAI API account exceeded its quota).
+    /// Unlike [`Self::RateLimitExceeded`], retrying cannot succeed until the
+    /// usage window resets or the user purchases more usage.
+    #[error("{provider} usage limit reached: {message}")]
+    UsageLimitReached {
+        provider: LanguageModelProviderName,
+        message: String,
+        /// Time until the usage window resets, when the provider reports one.
+        retry_after: Option<Duration>,
+    },
     #[error("{provider}'s API servers are overloaded right now")]
     ServerOverloaded {
         provider: LanguageModelProviderName,
@@ -278,9 +289,16 @@ impl LanguageModelCompletionError {
             StatusCode::PAYLOAD_TOO_LARGE => Self::PromptTooLarge {
                 tokens: parse_prompt_too_long(&message),
             },
-            StatusCode::TOO_MANY_REQUESTS => Self::RateLimitExceeded {
-                provider,
-                retry_after,
+            StatusCode::TOO_MANY_REQUESTS => match parse_usage_limit_message(&message) {
+                Some(usage_limit) => Self::UsageLimitReached {
+                    provider,
+                    message: usage_limit.message,
+                    retry_after: usage_limit.retry_after.or(retry_after),
+                },
+                None => Self::RateLimitExceeded {
+                    provider,
+                    retry_after,
+                },
             },
             StatusCode::INTERNAL_SERVER_ERROR => Self::ApiInternalServerError { provider, message },
             StatusCode::SERVICE_UNAVAILABLE => Self::ServerOverloaded {
@@ -298,6 +316,46 @@ impl LanguageModelCompletionError {
             },
         }
     }
+}
+
+struct UsageLimitMessage {
+    message: String,
+    retry_after: Option<Duration>,
+}
+
+/// Distinguishes a 429 that means "this account's usage allowance is
+/// exhausted" from an ordinary short-lived rate limit, since retrying the
+/// former is pointless until the usage window resets. The ChatGPT Codex
+/// backend reports `usage_limit_reached` (with the reset time) or
+/// `usage_not_included`, and the OpenAI API reports `insufficient_quota`.
+fn parse_usage_limit_message(message: &str) -> Option<UsageLimitMessage> {
+    let response = serde_json::from_str::<serde_json::Value>(message).ok()?;
+    let error = response.get("error").unwrap_or(&response);
+    let error_type = error
+        .get("type")
+        .or_else(|| error.get("code"))
+        .and_then(serde_json::Value::as_str)?;
+    if !matches!(
+        error_type,
+        "usage_limit_reached" | "usage_not_included" | "insufficient_quota"
+    ) {
+        return None;
+    }
+
+    let provider_message = error
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .filter(|message| !message.is_empty())
+        .unwrap_or("The usage limit has been reached");
+    let retry_after = error
+        .get("resets_in_seconds")
+        .and_then(serde_json::Value::as_u64)
+        .map(Duration::from_secs);
+
+    Some(UsageLimitMessage {
+        message: provider_message.to_owned(),
+        retry_after,
+    })
 }
 
 fn is_invalid_encrypted_content_message(message: &str) -> bool {
@@ -713,6 +771,90 @@ mod tests {
         assert!(matches!(
             error,
             LanguageModelCompletionError::BadRequestFormat { .. }
+        ));
+    }
+
+    #[test]
+    fn test_from_http_status_maps_codex_usage_limit_to_usage_limit_reached() {
+        let message = r#"{"type":"error","error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"plus","resets_at":1777936568,"resets_in_seconds":13872},"status_code":429}"#;
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("ChatGPT Subscription").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            message.to_string(),
+            None,
+        );
+
+        match error {
+            LanguageModelCompletionError::UsageLimitReached {
+                provider,
+                message,
+                retry_after,
+            } => {
+                assert_eq!(provider.0, "ChatGPT Subscription");
+                assert_eq!(message, "The usage limit has been reached");
+                assert_eq!(retry_after, Some(Duration::from_secs(13872)));
+            }
+            _ => panic!("Expected UsageLimitReached, got: {error:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_http_status_maps_openai_insufficient_quota_to_usage_limit_reached() {
+        let message = r#"{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","param":null,"code":"insufficient_quota"}}"#;
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("OpenAI").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            message.to_string(),
+            None,
+        );
+
+        match error {
+            LanguageModelCompletionError::UsageLimitReached {
+                provider,
+                message,
+                retry_after,
+            } => {
+                assert_eq!(provider.0, "OpenAI");
+                assert_eq!(
+                    message,
+                    "You exceeded your current quota, please check your plan and billing details."
+                );
+                assert_eq!(retry_after, None);
+            }
+            _ => panic!("Expected UsageLimitReached, got: {error:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_http_status_keeps_ordinary_429_as_rate_limit_exceeded() {
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("OpenAI").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"message":"Rate limit reached for gpt-4 in organization org-x on tokens per min.","type":"tokens","param":null,"code":"rate_limit_exceeded"}}"#.to_string(),
+            Some(Duration::from_secs(2)),
+        );
+
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::RateLimitExceeded {
+                retry_after: Some(retry_after),
+                ..
+            } if retry_after == Duration::from_secs(2)
+        ));
+
+        let error = LanguageModelCompletionError::from_http_status(
+            String::from("OpenAI").into(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too Many Requests".to_string(),
+            None,
+        );
+
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::RateLimitExceeded {
+                retry_after: None,
+                ..
+            }
         ));
     }
 


### PR DESCRIPTION
When a ChatGPT subscription runs out of Codex usage (or an OpenAI API account exceeds its quota), the backend responds with HTTP 429 and a body that distinguishes an exhausted usage allowance from an ordinary short-lived rate limit: `usage_limit_reached` / `usage_not_included` from the Codex backend, and `insufficient_quota` from the OpenAI API. `from_http_status` mapped every 429 to `RateLimitExceeded`, so the agent panel retried requests that could not succeed until the usage window reset (often hours away), then showed a generic "Rate Limit Reached" message with no hint about what was actually wrong.

This adds a `UsageLimitReached` completion error that carries the provider's message and the reset delay parsed from the response body (`resets_in_seconds`). The agent no longer auto-retries it, and the agent panel renders a dedicated callout that includes the provider's message and when usage resets, e.g.: "ChatGPT Subscription reported: The usage limit has been reached. Your usage resets in 3 hours 51 minutes. Wait for your usage to reset or switch to a different model."

Ordinary 429s (including bodies with `rate_limit_exceeded`) still map to `RateLimitExceeded` and retry as before.

Release Notes:

- Fixed the agent panel repeatedly retrying requests after a ChatGPT subscription or OpenAI account ran out of usage; it now surfaces the provider's usage-limit message and the reset time instead.
