### PR TITLE
project: Limit project search match collection

### DIFF
--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -605,16 +605,29 @@ impl Search {
                     continue;
                 };
 
-                if matched_buffers > Search::MAX_SEARCH_RESULT_FILES
-                    || matches > Search::MAX_SEARCH_RESULT_RANGES
-                {
-                    _ = tx.send(SearchResult::LimitReached).await;
+                if matched_buffers >= Search::MAX_SEARCH_RESULT_FILES {
+                    tx.send(SearchResult::LimitReached).await?;
                     break;
                 }
+
+                let remaining_matches = Search::MAX_SEARCH_RESULT_RANGES.saturating_sub(matches);
+                let mut ranges = ranges;
+                let limit_reached = ranges.len() >= remaining_matches;
+                ranges.truncate(remaining_matches);
+
+                if ranges.is_empty() && limit_reached {
+                    tx.send(SearchResult::LimitReached).await?;
+                    break;
+                }
+
                 matched_buffers += 1;
                 matches += ranges.len();
 
-                _ = tx.send(SearchResult::Buffer { buffer, ranges }).await?;
+                tx.send(SearchResult::Buffer { buffer, ranges }).await?;
+                if limit_reached {
+                    tx.send(SearchResult::LimitReached).await?;
+                    break;
+                }
             }
             anyhow::Ok(())
         })

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -512,6 +512,7 @@ impl SearchQuery {
         subrange: Option<Range<usize>>,
     ) -> Vec<Range<usize>> {
         const YIELD_INTERVAL: usize = 20000;
+        let maximum_results = crate::project_search::Search::MAX_SEARCH_RESULT_RANGES;
 
         if self.as_str().is_empty() {
             return Default::default();
@@ -556,7 +557,10 @@ impl SearchQuery {
                             continue;
                         }
                     }
-                    matches.push(mat.start()..mat.end())
+                    matches.push(mat.start()..mat.end());
+                    if matches.len() >= maximum_results {
+                        break;
+                    }
                 }
             }
 
@@ -582,6 +586,9 @@ impl SearchQuery {
                         };
                         if should_push {
                             matches.push(mat.start()..mat.end());
+                            if matches.len() >= maximum_results {
+                                break;
+                            }
                         }
                     }
                 }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8323,6 +8323,76 @@ async fn test_search(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_project_search_caps_matches_from_one_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let maximum_results = project::project_search::Search::MAX_SEARCH_RESULT_RANGES;
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "many_matches.rs": "needle ".repeat(maximum_results + 100),
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let query = SearchQuery::text(
+        "needle",
+        false,
+        true,
+        false,
+        Default::default(),
+        Default::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (range_counts, limit_reached) = search_range_counts(&project, query, cx).await;
+
+    assert_eq!(range_counts, vec![maximum_results]);
+    assert!(limit_reached);
+}
+
+#[gpui::test]
+async fn test_project_search_caps_matches_across_files(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let maximum_results = project::project_search::Search::MAX_SEARCH_RESULT_RANGES;
+    let matches_per_file = maximum_results / 2 + 100;
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "a.rs": "needle ".repeat(matches_per_file),
+            "b.rs": "needle ".repeat(matches_per_file),
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let query = SearchQuery::text(
+        "needle",
+        false,
+        true,
+        false,
+        Default::default(),
+        Default::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (range_counts, limit_reached) = search_range_counts(&project, query, cx).await;
+
+    assert_eq!(
+        range_counts,
+        vec![matches_per_file, maximum_results - matches_per_file]
+    );
+    assert_eq!(range_counts.into_iter().sum::<usize>(), maximum_results);
+    assert!(limit_reached);
+}
+
+#[gpui::test]
 async fn test_search_multiline_crlf(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
@@ -16075,6 +16145,24 @@ async fn search(
             })
         })
         .collect())
+}
+
+async fn search_range_counts(
+    project: &Entity<Project>,
+    query: SearchQuery,
+    cx: &mut gpui::TestAppContext,
+) -> (Vec<usize>, bool) {
+    let search_results = project.update(cx, |project, cx| project.search(query, cx));
+    let mut range_counts = Vec::new();
+    let mut limit_reached = false;
+    while let Ok(search_result) = search_results.rx.recv().await {
+        match search_result {
+            SearchResult::Buffer { ranges, .. } => range_counts.push(ranges.len()),
+            SearchResult::LimitReached => limit_reached = true,
+            SearchResult::WaitingForScan | SearchResult::Searching => {}
+        }
+    }
+    (range_counts, limit_reached)
 }
 
 #[gpui::test]


### PR DESCRIPTION
# Objective

Prevent project search from allocating unbounded match-range data.

## Solution

Stop searching after reaching `Search::MAX_SEARCH_RESULT_RANGES` occurrences, enforce the same global limit across files.

## Testing

- `cargo test -p project --test integration --features test-support test_project_search_caps_matches`.


Release Notes:

- Improved project search memory usage for queries with many matches.
