### PR TITLE
git_ui: Added support of preview tabs to Git panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1415,6 +1415,8 @@
     "enabled": true,
     // Whether to open tabs in preview mode when opened from the project panel with a single click.
     "enable_preview_from_project_panel": true,
+    // Whether to open tabs in preview mode when opened from the git panel with a single click.
+    "enable_preview_from_git_panel": true,
     // Whether to open tabs in preview mode when selected from the file finder.
     "enable_preview_from_file_finder": false,
     // Whether to open tabs in preview mode when opened from a multibuffer.

--- a/crates/git_ui/src/branch_diff.rs
+++ b/crates/git_ui/src/branch_diff.rs
@@ -104,7 +104,7 @@ impl BranchDiff {
                 workspace.update_in(cx, |workspace, window, cx| {
                     let git_store = project.read(cx).git_store().clone();
                     let Some(base_ref) = base_ref else {
-                        ProjectDiff::deploy_at(workspace, None, window, cx);
+                        ProjectDiff::deploy_at(workspace, None, false, window, cx);
                         return;
                     };
                     let branch_diff =

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2133,9 +2133,7 @@ impl GitPanel {
                         .project_path_to_repo_path(&project_path, cx)
                         .as_ref()
             {
-                if !allow_preview
-                    && let Some(pane) = workspace.read(cx).pane_for(&project_diff)
-                {
+                if !allow_preview && let Some(pane) = workspace.read(cx).pane_for(&project_diff) {
                     pane.update(cx, |pane, _| {
                         pane.unpreview_item_if_preview(project_diff.entity_id());
                     });
@@ -2213,7 +2211,7 @@ impl GitPanel {
                 window,
                 cx,
             )
-                .detach_and_notify_err(self.workspace.clone(), window, cx);
+            .detach_and_notify_err(self.workspace.clone(), window, cx);
 
             Some(())
         });

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -100,6 +100,7 @@ use workspace::SERIALIZATION_THROTTLE_TIME;
 use workspace::{
     Item, ModalView, Workspace,
     dock::{DockPosition, Panel, PanelEvent},
+    item::PreviewTabsSettings,
     notifications::{DetachAndPromptErr, NotificationId, NotifyTaskExt},
 };
 use zed_actions::{
@@ -2099,6 +2100,10 @@ impl GitPanel {
     }
 
     fn open_diff(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        self.open_diff_impl(false, window, cx);
+    }
+
+    fn open_diff_impl(&mut self, allow_preview: bool, window: &mut Window, cx: &mut Context<Self>) {
         if self.active_tab == GitPanelTab::History {
             self.open_selected_history_commit(window, cx);
             return;
@@ -2128,6 +2133,13 @@ impl GitPanel {
                         .project_path_to_repo_path(&project_path, cx)
                         .as_ref()
             {
+                if !allow_preview
+                    && let Some(pane) = workspace.read(cx).pane_for(&project_diff)
+                {
+                    pane.update(cx, |pane, _| {
+                        pane.unpreview_item_if_preview(project_diff.entity_id());
+                    });
+                }
                 project_diff.focus_handle(cx).focus(window, cx);
                 project_diff.update(cx, |project_diff, cx| project_diff.autoscroll(cx));
                 return None;
@@ -2136,13 +2148,31 @@ impl GitPanel {
             self.workspace
                 .update(cx, |workspace, cx| match target {
                     DiffTarget::Uncommitted => {
-                        ProjectDiff::deploy_at(workspace, Some(entry.clone()), window, cx);
+                        ProjectDiff::deploy_at(
+                            workspace,
+                            Some(entry.clone()),
+                            allow_preview,
+                            window,
+                            cx,
+                        );
                     }
                     DiffTarget::Staged => {
-                        StagedDiff::deploy_at(workspace, Some(entry.clone()), window, cx);
+                        StagedDiff::deploy_at(
+                            workspace,
+                            Some(entry.clone()),
+                            allow_preview,
+                            window,
+                            cx,
+                        );
                     }
                     DiffTarget::Unstaged => {
-                        UnstagedDiff::deploy_at(workspace, Some(entry.clone()), window, cx);
+                        UnstagedDiff::deploy_at(
+                            workspace,
+                            Some(entry.clone()),
+                            allow_preview,
+                            window,
+                            cx,
+                        );
                     }
                 })
                 .ok();
@@ -2158,6 +2188,15 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.open_solo_diff_impl(false, window, cx);
+    }
+
+    fn open_solo_diff_impl(
+        &mut self,
+        allow_preview: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         maybe!({
             let entry = self
                 .entries
@@ -2166,7 +2205,14 @@ impl GitPanel {
                 .clone();
             let repository = self.active_repository.clone()?;
 
-            SoloDiffView::open_or_focus(entry, repository, self.workspace.clone(), window, cx)
+            SoloDiffView::open_or_focus(
+                entry,
+                repository,
+                self.workspace.clone(),
+                allow_preview,
+                window,
+                cx,
+            )
                 .detach_and_notify_err(self.workspace.clone(), window, cx);
 
             Some(())
@@ -2174,6 +2220,10 @@ impl GitPanel {
     }
 
     fn view_file(&mut self, _: &ViewFile, window: &mut Window, cx: &mut Context<Self>) {
+        self.view_file_impl(false, window, cx);
+    }
+
+    fn view_file_impl(&mut self, allow_preview: bool, window: &mut Window, cx: &mut Context<Self>) {
         maybe!({
             let entry = self.entries.get(self.selected_entry?)?.status_entry()?;
             let project_path = self
@@ -2185,7 +2235,15 @@ impl GitPanel {
             self.workspace
                 .update(cx, |workspace, cx| {
                     workspace
-                        .open_path_preview(project_path, None, false, false, true, window, cx)
+                        .open_path_preview(
+                            project_path,
+                            None,
+                            false,
+                            allow_preview,
+                            true,
+                            window,
+                            cx,
+                        )
                         .detach_and_log_err(cx);
                 })
                 .ok()?;
@@ -2223,6 +2281,7 @@ impl GitPanel {
     fn open_selected_entry_on_click(
         &mut self,
         secondary: bool,
+        allow_preview: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -2238,14 +2297,14 @@ impl GitPanel {
         };
         match action {
             GitPanelClickBehavior::ProjectDiff => {
-                self.open_diff(&Default::default(), window, cx);
+                self.open_diff_impl(allow_preview, window, cx);
                 self.focus_handle.focus(window, cx);
             }
             GitPanelClickBehavior::FileDiff => {
-                self.open_solo_diff(&Default::default(), window, cx);
+                self.open_solo_diff_impl(allow_preview, window, cx);
             }
             GitPanelClickBehavior::ViewFile => {
-                self.view_file(&Default::default(), window, cx);
+                self.view_file_impl(allow_preview, window, cx);
             }
         }
     }
@@ -4534,7 +4593,7 @@ impl GitPanel {
             .cloned();
         if let Some(workspace) = self.workspace.upgrade() {
             workspace.update(cx, |workspace, cx| {
-                StagedDiff::deploy_at(workspace, entry, window, cx);
+                StagedDiff::deploy_at(workspace, entry, false, window, cx);
             });
         }
     }
@@ -4551,7 +4610,7 @@ impl GitPanel {
             .cloned();
         if let Some(workspace) = self.workspace.upgrade() {
             workspace.update(cx, |workspace, cx| {
-                UnstagedDiff::deploy_at(workspace, entry, window, cx);
+                UnstagedDiff::deploy_at(workspace, entry, false, window, cx);
             });
         }
     }
@@ -7998,7 +8057,15 @@ impl GitPanel {
                 cx.listener(move |this, event: &ClickEvent, window, cx| {
                     this.selected_entry = Some(ix);
                     cx.notify();
-                    this.open_selected_entry_on_click(event.modifiers().secondary(), window, cx);
+                    let allow_preview = PreviewTabsSettings::get_global(cx)
+                        .enable_preview_from_git_panel
+                        && event.click_count() == 1;
+                    this.open_selected_entry_on_click(
+                        event.modifiers().secondary(),
+                        allow_preview,
+                        window,
+                        cx,
+                    );
                 })
             })
             .on_mouse_down(

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -73,9 +73,7 @@ pub(crate) fn activate_or_add_with_preview<T: Item>(
 ) -> Entity<T> {
     if let Some(existing) = existing {
         workspace.activate_item(&existing, true, true, window, cx);
-        if !allow_preview
-            && let Some(pane) = workspace.pane_for(&existing)
-        {
+        if !allow_preview && let Some(pane) = workspace.pane_for(&existing) {
             pane.update(cx, |pane, _| {
                 pane.unpreview_item_if_preview(existing.entity_id());
             });

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -21,7 +21,7 @@ use project_diff::ProjectDiff;
 use time::OffsetDateTime;
 use ui::{ButtonLike, ContextMenu, ElevationIndex, PopoverMenuHandle, TintColor, prelude::*};
 use workspace::{
-    ModalView, OpenMode, Workspace,
+    Item, ModalView, OpenMode, Workspace,
     notifications::{DetachAndPromptErr, NotifyTaskExt},
 };
 use zed_actions;
@@ -59,6 +59,49 @@ pub mod unstaged_diff;
 
 pub use blame_ui::GitBlameStatus;
 pub use conflict_view::MergeConflictIndicator;
+
+/// Activates `existing`, or builds a new item and adds it to the active pane.
+/// With `allow_preview`, a new item takes over the pane's preview tab slot,
+/// while opening an existing item permanently promotes it out of preview.
+pub(crate) fn activate_or_add_with_preview<T: Item>(
+    workspace: &mut Workspace,
+    existing: Option<Entity<T>>,
+    allow_preview: bool,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+    build: impl FnOnce(&mut Workspace, &mut Window, &mut Context<Workspace>) -> Entity<T>,
+) -> Entity<T> {
+    if let Some(existing) = existing {
+        workspace.activate_item(&existing, true, true, window, cx);
+        if !allow_preview
+            && let Some(pane) = workspace.pane_for(&existing)
+        {
+            pane.update(cx, |pane, _| {
+                pane.unpreview_item_if_preview(existing.entity_id());
+            });
+        }
+        existing
+    } else {
+        let item = build(workspace, window, cx);
+        if allow_preview {
+            let pane = workspace.active_pane().clone();
+            pane.update(cx, |pane, cx| {
+                let destination_index = pane.replace_preview_item_id(item.entity_id(), window, cx);
+                pane.add_item(
+                    Box::new(item.clone()),
+                    false,
+                    true,
+                    destination_index,
+                    window,
+                    cx,
+                );
+            });
+        } else {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        }
+        item
+    }
+}
 
 pub fn init(cx: &mut App) {
     editor::set_blame_renderer(blame_ui::GitBlameRenderer, cx);
@@ -374,7 +417,7 @@ fn open_file_diff(
     cx: &mut App,
 ) {
     window.defer(cx, move |window, cx| {
-        SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
+        SoloDiffView::open_or_focus(entry, repository, workspace.clone(), false, window, cx)
             .detach_and_notify_err(workspace, window, cx);
     });
 }

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -75,25 +75,25 @@ impl ProjectDiff {
     pub(crate) fn register(workspace: &mut Workspace, cx: &mut Context<Workspace>) {
         workspace.register_action(Self::deploy);
         workspace.register_action(|workspace, _: &DiffHead, window, cx| {
-            Self::deploy_at(workspace, None, window, cx);
+            Self::deploy_at(workspace, None, false, window, cx);
         });
         workspace.register_action(
             |workspace, _: &git_actions::ViewUncommittedChanges, window, cx| {
-                Self::deploy_at(workspace, None, window, cx);
+                Self::deploy_at(workspace, None, false, window, cx);
             },
         );
         workspace.register_action(
             |workspace, _: &git_actions::ViewUnstagedChanges, window, cx| {
-                UnstagedDiff::deploy_at(workspace, None, window, cx);
+                UnstagedDiff::deploy_at(workspace, None, false, window, cx);
             },
         );
         workspace.register_action(
             |workspace, _: &git_actions::ViewStagedChanges, window, cx| {
-                StagedDiff::deploy_at(workspace, None, window, cx);
+                StagedDiff::deploy_at(workspace, None, false, window, cx);
             },
         );
         workspace.register_action(|workspace, _: &Add, window, cx| {
-            Self::deploy_at(workspace, None, window, cx);
+            Self::deploy_at(workspace, None, false, window, cx);
         });
         workspace::register_serializable_item::<ProjectDiff>(cx);
     }
@@ -109,12 +109,13 @@ impl ProjectDiff {
             BranchDiff::deploy_branch_diff(workspace, window, cx);
             return;
         }
-        Self::deploy_at(workspace, None, window, cx)
+        Self::deploy_at(workspace, None, false, window, cx)
     }
 
     pub fn deploy_at(
         workspace: &mut Workspace,
         entry: Option<GitStatusEntry>,
+        allow_preview: bool,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -129,26 +130,22 @@ impl ProjectDiff {
         let intended_repo = workspace.project().read(cx).active_repository(cx);
 
         let existing = workspace.items_of_type::<Self>(cx).next();
-        let project_diff = if let Some(existing) = existing {
+        if let Some(existing) = &existing {
             existing.update(cx, |project_diff, cx| {
                 project_diff.move_to_beginning(window, cx);
             });
-
-            workspace.activate_item(&existing, true, true, window, cx);
-            existing
-        } else {
-            let workspace_handle = cx.entity();
-            let project_diff =
-                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx));
-            workspace.add_item_to_active_pane(
-                Box::new(project_diff.clone()),
-                None,
-                true,
-                window,
-                cx,
-            );
-            project_diff
-        };
+        }
+        let project_diff = crate::activate_or_add_with_preview(
+            workspace,
+            existing,
+            allow_preview,
+            window,
+            cx,
+            |workspace, window, cx| {
+                let workspace_handle = cx.entity();
+                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx))
+            },
+        );
 
         if let Some(intended) = &intended_repo {
             let needs_switch = project_diff

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -54,6 +54,7 @@ impl SoloDiffView {
         entry: GitStatusEntry,
         repository: Entity<Repository>,
         workspace: WeakEntity<Workspace>,
+        allow_preview: bool,
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<Entity<Self>>> {
@@ -67,7 +68,14 @@ impl SoloDiffView {
             .find(|item| item.read(cx).matches(&repository, &entry.repo_path, cx));
         if let Some(existing) = existing {
             workspace_entity.update(cx, |workspace, cx| {
-                workspace.activate_item(&existing, true, true, window, cx);
+                crate::activate_or_add_with_preview(
+                    workspace,
+                    Some(existing.clone()),
+                    allow_preview,
+                    window,
+                    cx,
+                    |_, _, _| existing.clone(),
+                );
             });
             existing.focus_handle(cx).focus(window, cx);
             return Task::ready(Ok(existing));
@@ -112,7 +120,14 @@ impl SoloDiffView {
                     )
                 });
 
-                workspace.add_item_to_active_pane(Box::new(view.clone()), None, true, window, cx);
+                crate::activate_or_add_with_preview(
+                    workspace,
+                    None,
+                    allow_preview,
+                    window,
+                    cx,
+                    |_, _, _| view.clone(),
+                );
                 view
             })
         })

--- a/crates/git_ui/src/staged_diff.rs
+++ b/crates/git_ui/src/staged_diff.rs
@@ -150,6 +150,7 @@ impl StagedDiff {
     pub fn deploy_at(
         workspace: &mut Workspace,
         entry: Option<GitStatusEntry>,
+        allow_preview: bool,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -163,22 +164,17 @@ impl StagedDiff {
         );
         let intended_repo = workspace.project().read(cx).active_repository(cx);
         let existing = workspace.items_of_type::<Self>(cx).next();
-        let staged_diff = if let Some(existing) = existing {
-            workspace.activate_item(&existing, true, true, window, cx);
-            existing
-        } else {
-            let workspace_handle = cx.entity();
-            let staged_diff =
-                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx));
-            workspace.add_item_to_active_pane(
-                Box::new(staged_diff.clone()),
-                None,
-                true,
-                window,
-                cx,
-            );
-            staged_diff
-        };
+        let staged_diff = crate::activate_or_add_with_preview(
+            workspace,
+            existing,
+            allow_preview,
+            window,
+            cx,
+            |workspace, window, cx| {
+                let workspace_handle = cx.entity();
+                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx))
+            },
+        );
 
         if let Some(intended) = &intended_repo {
             let needs_switch = staged_diff
@@ -820,7 +816,7 @@ mod tests {
         });
 
         workspace.update_in(cx, |workspace, window, cx| {
-            StagedDiff::deploy_at(workspace, None, window, cx);
+            StagedDiff::deploy_at(workspace, None, false, window, cx);
         });
         cx.run_until_parked();
 
@@ -911,7 +907,7 @@ mod tests {
         cx.run_until_parked();
 
         workspace.update_in(cx, |workspace, window, cx| {
-            StagedDiff::deploy_at(workspace, None, window, cx);
+            StagedDiff::deploy_at(workspace, None, false, window, cx);
         });
         cx.run_until_parked();
 

--- a/crates/git_ui/src/unstaged_diff.rs
+++ b/crates/git_ui/src/unstaged_diff.rs
@@ -204,6 +204,7 @@ impl UnstagedDiff {
     pub fn deploy_at(
         workspace: &mut Workspace,
         entry: Option<GitStatusEntry>,
+        allow_preview: bool,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -217,22 +218,17 @@ impl UnstagedDiff {
         );
         let intended_repo = workspace.project().read(cx).active_repository(cx);
         let existing = workspace.items_of_type::<Self>(cx).next();
-        let unstaged_diff = if let Some(existing) = existing {
-            workspace.activate_item(&existing, true, true, window, cx);
-            existing
-        } else {
-            let workspace_handle = cx.entity();
-            let unstaged_diff =
-                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx));
-            workspace.add_item_to_active_pane(
-                Box::new(unstaged_diff.clone()),
-                None,
-                true,
-                window,
-                cx,
-            );
-            unstaged_diff
-        };
+        let unstaged_diff = crate::activate_or_add_with_preview(
+            workspace,
+            existing,
+            allow_preview,
+            window,
+            cx,
+            |workspace, window, cx| {
+                let workspace_handle = cx.entity();
+                cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx))
+            },
+        );
 
         if let Some(intended) = &intended_repo {
             let needs_switch = unstaged_diff

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -774,6 +774,7 @@ impl VsCodeSettings {
         skip_default(PreviewTabsSettingsContent {
             enabled: self.read_bool("workbench.editor.enablePreview"),
             enable_preview_from_project_panel: None,
+            enable_preview_from_git_panel: None,
             enable_preview_from_file_finder: self
                 .read_bool("workbench.editor.enablePreviewFromQuickOpen"),
             enable_preview_from_multibuffer: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -188,6 +188,10 @@ pub struct PreviewTabsSettingsContent {
     ///
     /// Default: true
     pub enable_preview_from_project_panel: Option<bool>,
+    /// Whether to open tabs in preview mode when opened from the git panel with a single click.
+    ///
+    /// Default: true
+    pub enable_preview_from_git_panel: Option<bool>,
     /// Whether to open tabs in preview mode when selected from the file finder.
     ///
     /// Default: false

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4672,7 +4672,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn preview_tabs_section() -> [SettingsPageItem; 8] {
+    fn preview_tabs_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Preview Tabs"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4712,6 +4712,29 @@ fn window_and_layout_page() -> SettingsPage {
                             .preview_tabs
                             .get_or_insert_default()
                             .enable_preview_from_project_panel = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Enable Preview From Git Panel",
+                description: "Whether to open tabs in preview mode when opened from the git panel with a single click.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("preview_tabs.enable_preview_from_git_panel"),
+                    pick: |settings_content| {
+                        settings_content
+                            .preview_tabs
+                            .as_ref()?
+                            .enable_preview_from_git_panel
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .preview_tabs
+                            .get_or_insert_default()
+                            .enable_preview_from_git_panel = value;
                     },
                 }),
                 metadata: None,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -31,7 +31,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use ui::{Color, Icon, IntoElement, Label, LabelCommon};
+use ui::{Color, FluentBuilder as _, Icon, IntoElement, Label, LabelCommon};
 use util::ResultExt;
 
 pub const LEADER_UPDATE_THROTTLE: Duration = Duration::from_millis(200);
@@ -67,6 +67,7 @@ pub struct ItemSettings {
 pub struct PreviewTabsSettings {
     pub enabled: bool,
     pub enable_preview_from_project_panel: bool,
+    pub enable_preview_from_git_panel: bool,
     pub enable_preview_from_file_finder: bool,
     pub enable_preview_from_multibuffer: bool,
     pub enable_preview_multibuffer_from_code_navigation: bool,
@@ -103,6 +104,7 @@ impl Settings for PreviewTabsSettings {
             enable_preview_from_project_panel: preview_tabs
                 .enable_preview_from_project_panel
                 .unwrap(),
+            enable_preview_from_git_panel: preview_tabs.enable_preview_from_git_panel.unwrap(),
             enable_preview_from_file_finder: preview_tabs.enable_preview_from_file_finder.unwrap(),
             enable_preview_from_multibuffer: preview_tabs.enable_preview_from_multibuffer.unwrap(),
             enable_preview_multibuffer_from_code_navigation: preview_tabs
@@ -180,6 +182,7 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
         Label::new(text)
             .single_line()
             .color(params.text_color())
+            .when(params.preview, |this| this.italic())
             .into_any_element()
     }
 

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -1594,7 +1594,7 @@ import { AiPaneTabContext } from 'context';
     // Create and add the ProjectDiff using the public deploy_at method
     workspace_window
         .update(cx, |workspace, window, cx| {
-            ProjectDiff::deploy_at(workspace, None, window, cx);
+            ProjectDiff::deploy_at(workspace, None, false, window, cx);
         })
         .log_err();
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3478,6 +3478,7 @@ Examples:
   "preview_tabs": {
     "enabled": true,
     "enable_preview_from_project_panel": true,
+    "enable_preview_from_git_panel": true,
     "enable_preview_from_file_finder": false,
     "enable_preview_from_multibuffer": true,
     "enable_preview_multibuffer_from_code_navigation": false,
@@ -3491,6 +3492,16 @@ Examples:
 
 - Description: Determines whether to open files in preview mode when opened from the project panel with a single click.
 - Setting: `enable_preview_from_project_panel`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### Enable preview from git panel
+
+- Description: Determines whether to open files and diffs in preview mode when opened from the git panel with a single click.
+- Setting: `enable_preview_from_git_panel`
 - Default: `true`
 
 **Options**


### PR DESCRIPTION
Hello Zed team, I'm thrilled to submit my first contribution since I've been using Zed _a lot_ recently and it's really close to becoming a permanent replacement of other IDEs for me and my team. 

# Objective
Reviewing large-scale code changes prior to committing those often requires switching between individual affected file diffs.
In case I don't prefer using a project-wide diff but rather a single-file diff as a primary click action of Git panel, switching between file diffs clutters opened tabs, because every Git panel click currently opens a permanent tab, unlike the project panel and file finder, which do support preview tabs.

https://github.com/zed-industries/zed/pull/43921 explicitly left the remaining preview-opening paths for future PRs; this covers the git panel.

## Solution
TL;DR Git panel now supports preview tabs.

- New setting added: `preview_tabs.enable_preview_from_git_panel` (**default on, matching the project panel**). Single click opens the file, per-file diff, or diff multibuffer as a preview tab reused by later clicks; double click or keyboard confirm opens permanently and promotes an existing preview — same semantics as `pane::open_item`. Jumping to specific file at diff multibuffer by clicking on a changed file at Git panel is preserved.
- Preview handling lives in a shared `activate_or_add_with_preview` helper threaded through `ProjectDiff`/`StagedDiff``/UnstagedDiff` `deploy_at` and `SoloDiffView`, replacing their duplicated activate-or-add blocks.
- The default `Item::tab_content` now renders italic titles for preview tabs, matching the editor's own override; this covers the diff views, whose per-view `tab_content` overrides were recently removed in zed-industries/zed#62875.


## Testing

I've tested these changes and am actively using the new setting being enabled during my day-to-day work

- `cargo test -p git_ui`
- Manually verified all three click behaviors, double-click promotion, multi-pane behavior, and preview-slot reuse.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase
Preview tab opened for of a single-file diff: 
<img width="2032" height="956" alt="image" src="https://github.com/user-attachments/assets/d3d505e5-b3c7-497e-a78b-4321dd16705a" />
---

Release Notes:

- Git panel now supports preview tabs, enabled by default.
