### PR TITLE
Implement `inspector` flag

### DIFF
--- a/crates/inspector_ui/Cargo.toml
+++ b/crates/inspector_ui/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 [lib]
 path = "src/inspector_ui.rs"
 
+[features]
+inspector = []
+
 [dependencies]
 anyhow.workspace = true
 command_palette_hooks.workspace = true

--- a/crates/inspector_ui/src/inspector_ui.rs
+++ b/crates/inspector_ui/src/inspector_ui.rs
@@ -1,12 +1,12 @@
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "inspector"))]
 mod div_inspector;
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "inspector"))]
 mod inspector;
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "inspector"))]
 pub use inspector::init;
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(any(debug_assertions, feature = "inspector")))]
 pub fn init(_app_state: std::sync::Arc<workspace::AppState>, cx: &mut gpui::App) {
     use std::any::TypeId;
     use workspace::notifications::NotifyResultExt as _;

--- a/crates/inspector_ui/src/inspector_ui.rs
+++ b/crates/inspector_ui/src/inspector_ui.rs
@@ -13,7 +13,7 @@ pub fn init(_app_state: std::sync::Arc<workspace::AppState>, cx: &mut gpui::App)
 
     cx.on_action(|_: &zed_actions::dev::ToggleInspector, cx| {
         Err::<(), anyhow::Error>(anyhow::anyhow!(
-            "dev::ToggleInspector is only available in debug builds"
+            "dev::ToggleInspector is only available in debug builds and Nightly"
         ))
         .notify_app_err(cx);
     });

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -45,3 +45,4 @@ ignored = ["log"]
 
 [features]
 default = []
+derive_inspector_reflection = []

--- a/crates/ui/src/traits/styled_ext.rs
+++ b/crates/ui/src/traits/styled_ext.rs
@@ -20,7 +20,10 @@ fn elevated_borderless<E: Styled>(this: E, cx: &mut App, index: ElevationIndex) 
 /// Extends [`gpui::Styled`] with Zed-specific styling methods.
 // gate on rust-analyzer so rust-analyzer never needs to expand this macro, it takes up to 10 seconds to expand due to inefficiencies in rust-analyzers proc-macro srv
 #[cfg_attr(
-    all(debug_assertions, not(rust_analyzer)),
+    all(
+        any(debug_assertions, feature = "derive_inspector_reflection"),
+        not(rust_analyzer)
+    ),
     gpui_macros::derive_inspector_reflection
 )]
 pub trait StyledExt: Styled + Sized {

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -12,6 +12,11 @@ default-run = "zed"
 workspace = true
 
 [features]
+inspector = [
+    "gpui/inspector",
+    "inspector_ui/inspector",
+    "ui/derive_inspector_reflection",
+]
 tracy = ["ztracing/tracy"]
 # LEAK_BACKTRACE=1 cargo run --features zed/track-project-leak --profile release-fast
 track-project-leak = ["gpui/leak-detection"]
@@ -117,11 +122,16 @@ fs.workspace = true
 futures.workspace = true
 git.workspace = true
 git_hosting_providers.workspace = true
-git_ui = { workspace = true, features = [ "call" ] }
+git_ui = { workspace = true, features = ["call"] }
 git_ui_core.workspace = true
 go_to_line.workspace = true
-gpui = { workspace = true, features = [ "profiler" ] }
-gpui_platform = { workspace = true, features = [ "screen-capture", "font-kit", "wayland", "x11" ] }
+gpui = { workspace = true, features = ["profiler"] }
+gpui_platform = { workspace = true, features = [
+    "screen-capture",
+    "font-kit",
+    "wayland",
+    "x11",
+] }
 gpui_tokio.workspace = true
 image = { workspace = true, optional = true }
 spin = "0.10.0"
@@ -233,20 +243,13 @@ ztracing.workspace = true
 [target.'cfg(target_os = "windows")'.dependencies]
 etw_tracing.workspace = true
 windows.workspace = true
-gpui = { workspace = true, features = [
-    "profiler",
-    "windows-manifest",
-] }
+gpui = { workspace = true, features = ["profiler", "windows-manifest"] }
 
 [build-dependencies]
 windows_resources = { path = "../windows_resources" }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
-gpui = { workspace = true, features = [
-    "profiler",
-    "wayland",
-    "x11",
-] }
+gpui = { workspace = true, features = ["profiler", "wayland", "x11"] }
 ashpd.workspace = true
 image.workspace = true
 
@@ -278,7 +281,6 @@ image.workspace = true
 agent_ui = { workspace = true, features = ["test-support"] }
 search = { workspace = true, features = ["test-support"] }
 repl = { workspace = true, features = ["test-support"] }
-
 
 
 [package.metadata.bundle-dev]


### PR DESCRIPTION
# Objective

Make it easy to conditionally enable the gpui inspector, with a goal of eventually turning it on in nightly.

## Solution

The new `zed/inspector` flag (and supporting flags in other crates) enables the relevant inspector features in `gpui`, `ui`, and `inspector_ui` to be able to display the gpui inspector.

## Testing

- Enabling the inspector adds about 5mb to the binary, and for context the zed binary is > 400mb at this time.
- Observationally, the inspector doesn't affect performance in a meaningful way, but I did not run profiling.

```
# release with inspector (inspector on)
cargo run --release --features inspector
# release without inspector (inspector off)
cargo run --release
# dev build with debug assertions (inspector on)
cargo run
```

then trigger `dev::ToggleInspector`.

- linux: `ctrl-alt-i`
- windows: `shift-alt-i`
- macos: `cmd-alt-i`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
