### PR TITLE
agent_ui: Reap idle ACP agent connections

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -1,4 +1,5 @@
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 use acp_thread::{AgentConnection, LoadError};
 use agent_servers::AcpConnection;
@@ -6,12 +7,28 @@ use agent_servers::{AgentServer, AgentServerDelegate};
 use anyhow::Result;
 use collections::HashMap;
 use futures::{FutureExt, future::Shared};
-use gpui::{App, AppContext, Context, Entity, EventEmitter, SharedString, Subscription, Task};
+use gpui::{
+    App, AppContext, Context, Entity, EventEmitter, Global, SharedString, Subscription, Task,
+};
 
 use project::{AgentServerStore, AgentServersUpdated, Project};
 use watch::Receiver;
 
 use crate::Agent;
+
+const DEFAULT_UNUSED_CONNECTION_GRACE: Duration = Duration::from_secs(30);
+
+const REAP_INTERVAL: Duration = Duration::from_secs(10);
+
+pub struct UnusedConnectionGrace(pub Duration);
+impl Global for UnusedConnectionGrace {}
+
+impl UnusedConnectionGrace {
+    pub fn global(cx: &App) -> Duration {
+        cx.try_global::<Self>()
+            .map_or(DEFAULT_UNUSED_CONNECTION_GRACE, |grace| grace.0)
+    }
+}
 
 pub enum AgentConnectionEntry {
     Connecting {
@@ -66,9 +83,46 @@ pub struct ActiveAcpConnection {
     pub connection: Rc<AcpConnection>,
 }
 
+/// Dropping a lease is deliberately inert — it holds a token instead of calling
+/// back into the store — so one that outlives the store, or the entry it was
+/// taken against, cannot corrupt the count.
+#[derive(Clone)]
+pub struct AgentConnectionLease {
+    key: Agent,
+    _token: Rc<()>,
+}
+
+impl AgentConnectionLease {
+    pub fn key(&self) -> &Agent {
+        &self.key
+    }
+}
+
+struct CachedConnection {
+    entry: Entity<AgentConnectionEntry>,
+    /// Strong count of 1 means the store is the only holder.
+    token: Rc<()>,
+    unused_since: Option<Instant>,
+    stale: bool,
+}
+
+impl CachedConnection {
+    fn lease_count(&self) -> usize {
+        Rc::strong_count(&self.token) - 1
+    }
+
+    fn lease(&self, key: Agent) -> AgentConnectionLease {
+        AgentConnectionLease {
+            key,
+            _token: self.token.clone(),
+        }
+    }
+}
+
 pub struct AgentConnectionStore {
     project: Entity<Project>,
-    entries: HashMap<Agent, Entity<AgentConnectionEntry>>,
+    entries: HashMap<Agent, CachedConnection>,
+    _reaper: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -76,9 +130,23 @@ impl AgentConnectionStore {
     pub fn new(project: Entity<Project>, cx: &mut Context<Self>) -> Self {
         let agent_server_store = project.read(cx).agent_server_store().clone();
         let subscription = cx.subscribe(&agent_server_store, Self::handle_agent_servers_updated);
+        let reaper = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor().timer(REAP_INTERVAL).await;
+                if this
+                    .update(cx, |this, cx| {
+                        this.reap_unused_connections(Instant::now(), cx)
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
         Self {
             project,
             entries: HashMap::default(),
+            _reaper: reaper,
             _subscriptions: vec![subscription],
         }
     }
@@ -88,18 +156,18 @@ impl AgentConnectionStore {
     }
 
     pub fn entry(&self, key: &Agent) -> Option<&Entity<AgentConnectionEntry>> {
-        self.entries.get(key)
+        self.entries.get(key).map(|cached| &cached.entry)
     }
 
     pub fn connection_status(&self, key: &Agent, cx: &App) -> AgentConnectionStatus {
         self.entries
             .get(key)
-            .map(|entry| entry.read(cx).status())
+            .map(|cached| cached.entry.read(cx).status())
             .unwrap_or(AgentConnectionStatus::Disconnected)
     }
 
     pub fn agent_version(&self, key: &Agent, cx: &App) -> Option<SharedString> {
-        match self.entries.get(key)?.read(cx) {
+        match self.entries.get(key)?.entry.read(cx) {
             AgentConnectionEntry::Connected(state) => state.connection.agent_version(),
             AgentConnectionEntry::Connecting { .. } | AgentConnectionEntry::Error { .. } => None,
         }
@@ -108,7 +176,7 @@ impl AgentConnectionStore {
     pub fn active_acp_connections(&self, cx: &App) -> Vec<ActiveAcpConnection> {
         self.entries
             .values()
-            .filter_map(|entry| match entry.read(cx) {
+            .filter_map(|cached| match cached.entry.read(cx) {
                 AgentConnectionEntry::Connected(state) => state
                     .connection
                     .clone()
@@ -124,32 +192,58 @@ impl AgentConnectionStore {
             .collect()
     }
 
+    pub fn lease_count(&self, key: &Agent) -> usize {
+        self.entries
+            .get(key)
+            .map_or(0, |cached| cached.lease_count())
+    }
+
     pub fn restart_connection(
         &mut self,
         key: Agent,
         server: Rc<dyn AgentServer>,
         cx: &mut Context<Self>,
     ) -> Entity<AgentConnectionEntry> {
-        if let Some(entry) = self.entries.get(&key) {
-            if matches!(entry.read(cx), AgentConnectionEntry::Connecting { .. }) {
-                return entry.clone();
+        if let Some(cached) = self.entries.get(&key) {
+            if matches!(
+                cached.entry.read(cx),
+                AgentConnectionEntry::Connecting { .. }
+            ) {
+                return cached.entry.clone();
             }
         }
 
-        self.entries.remove(&key);
-        self.request_connection(key, server, cx)
+        self.connect(key, server, cx).0
     }
 
+    /// Hold the returned lease for as long as the connection is needed,
+    /// including across a task that is only awaiting an RPC.
     pub fn request_connection(
         &mut self,
         key: Agent,
         server: Rc<dyn AgentServer>,
         cx: &mut Context<Self>,
-    ) -> Entity<AgentConnectionEntry> {
-        if let Some(entry) = self.entries.get(&key) {
-            return entry.clone();
+    ) -> (Entity<AgentConnectionEntry>, AgentConnectionLease) {
+        if let Some(cached) = self.entries.get_mut(&key) {
+            let reusable = !cached.stale
+                && !matches!(cached.entry.read(cx), AgentConnectionEntry::Error { .. });
+            if reusable {
+                cached.unused_since = None;
+                return (cached.entry.clone(), cached.lease(key));
+            }
         }
 
+        self.connect(key, server, cx)
+    }
+
+    /// The replaced entry's token is carried over: its leases belong to holders
+    /// still using this agent, and a fresh token would look unused.
+    fn connect(
+        &mut self,
+        key: Agent,
+        server: Rc<dyn AgentServer>,
+        cx: &mut Context<Self>,
+    ) -> (Entity<AgentConnectionEntry>, AgentConnectionLease) {
         let (mut new_version_rx, mut loading_status_rx, connect_task) =
             self.start_connection(server, cx);
         let connect_task = connect_task.shared();
@@ -158,7 +252,18 @@ impl AgentConnectionStore {
             connect_task: connect_task.clone(),
         });
 
-        self.entries.insert(key.clone(), entry.clone());
+        let token = self
+            .entries
+            .remove(&key)
+            .map_or_else(|| Rc::new(()), |cached| cached.token);
+        let cached = CachedConnection {
+            entry: entry.clone(),
+            token,
+            unused_since: None,
+            stale: false,
+        };
+        let lease = cached.lease(key.clone());
+        self.entries.insert(key.clone(), cached);
         cx.notify();
 
         cx.spawn({
@@ -167,7 +272,7 @@ impl AgentConnectionStore {
             async move |this, cx| match connect_task.await {
                 Ok(connected_state) => {
                     this.update(cx, move |this, cx| {
-                        if this.entries.get(&key) != entry.upgrade().as_ref() {
+                        if !this.is_current_entry(&key, &entry) {
                             return;
                         }
 
@@ -185,7 +290,7 @@ impl AgentConnectionStore {
                 }
                 Err(error) => {
                     this.update(cx, move |this, cx| {
-                        if this.entries.get(&key) != entry.upgrade().as_ref() {
+                        if !this.is_current_entry(&key, &entry) {
                             return;
                         }
 
@@ -197,7 +302,6 @@ impl AgentConnectionStore {
                                 }
                             })
                             .ok();
-                        this.entries.remove(&key);
                         cx.notify();
                     })
                     .ok();
@@ -216,7 +320,7 @@ impl AgentConnectionStore {
                     };
 
                     this.update(cx, move |this, cx| {
-                        if this.entries.get(&key) != entry.upgrade().as_ref() {
+                        if !this.is_current_entry(&key, &entry) {
                             return;
                         }
 
@@ -227,7 +331,9 @@ impl AgentConnectionStore {
                                 ));
                             })
                             .ok();
-                        this.entries.remove(&key);
+                        if let Some(cached) = this.entries.get_mut(&key) {
+                            cached.stale = true;
+                        }
                         cx.notify();
                     })
                     .ok();
@@ -245,7 +351,7 @@ impl AgentConnectionStore {
                     let key = key.clone();
                     let entry = entry.clone();
                     this.update(cx, move |this, cx| {
-                        if this.entries.get(&key) != entry.upgrade().as_ref() {
+                        if !this.is_current_entry(&key, &entry) {
                             return;
                         }
 
@@ -262,7 +368,58 @@ impl AgentConnectionStore {
         })
         .detach();
 
-        entry
+        (entry, lease)
+    }
+
+    fn is_current_entry(
+        &self,
+        key: &Agent,
+        entry: &gpui::WeakEntity<AgentConnectionEntry>,
+    ) -> bool {
+        self.entries
+            .get(key)
+            .zip(entry.upgrade())
+            .is_some_and(|(cached, entry)| cached.entry == entry)
+    }
+
+    /// Unused is observed on one pass and reaped on a later one, so a
+    /// connection outlives its last holder by the grace period plus up to one
+    /// sweep: a lease has no drop hook, and respawning costs more than waiting.
+    pub fn reap_unused_connections(&mut self, now: Instant, cx: &mut Context<Self>) {
+        let grace = UnusedConnectionGrace::global(cx);
+        let mut reaped = false;
+
+        self.entries.retain(|key, cached| {
+            // Runs in-process, so there is no process to reclaim.
+            if key.is_native() {
+                return true;
+            }
+            if cached.lease_count() > 0 {
+                cached.unused_since = None;
+                return true;
+            }
+            // Leave it until it settles, so a connection requested a moment
+            // ago is not reaped from under the caller awaiting it.
+            if matches!(
+                cached.entry.read(cx),
+                AgentConnectionEntry::Connecting { .. }
+            ) {
+                return true;
+            }
+
+            let unused_since = *cached.unused_since.get_or_insert(now);
+            if now.saturating_duration_since(unused_since) < grace {
+                return true;
+            }
+
+            log::debug!("reaping unused agent connection for {key:?}");
+            reaped = true;
+            false
+        });
+
+        if reaped {
+            cx.notify();
+        }
     }
 
     fn handle_agent_servers_updated(
@@ -272,13 +429,30 @@ impl AgentConnectionStore {
         cx: &mut Context<Self>,
     ) {
         let store = store.read(cx);
-        self.entries.retain(|key, _| match key {
+        self.retain_configured_agents(|key| match key {
             Agent::NativeAgent => true,
             Agent::Custom { id } => store.external_agents.contains_key(id),
             #[cfg(any(test, feature = "test-support"))]
             Agent::Stub => true,
         });
         cx.notify();
+    }
+
+    /// An agent that has been unconfigured keeps its entry until its last lease
+    /// is released, so that holders stay counted and the connection is reaped
+    /// once rather than orphaned here and replaced by a fresh, uncounted one.
+    /// Marking it stale keeps it from being handed to any new caller.
+    pub(crate) fn retain_configured_agents(&mut self, is_configured: impl Fn(&Agent) -> bool) {
+        self.entries.retain(|key, cached| {
+            if is_configured(key) {
+                return true;
+            }
+            if cached.lease_count() > 0 {
+                cached.stale = true;
+                return true;
+            }
+            false
+        });
     }
 
     fn start_connection(

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -7,7 +7,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use acp_thread::{AcpThread, AcpThreadEvent, MentionUri, ThreadStatus, line_range_suffix};
@@ -158,6 +158,21 @@ impl MaxIdleRetainedThreads {
         cx.try_global::<Self>().map_or(5, |g| g.0)
     }
 }
+
+/// A retained thread holds its agent connection open, and an external agent
+/// server is a live process, so a few stale background threads keep several of
+/// them resident for the lifetime of the window. Defaults to 10 minutes.
+pub struct IdleRetainedThreadTimeout(pub Duration);
+impl gpui::Global for IdleRetainedThreadTimeout {}
+
+impl IdleRetainedThreadTimeout {
+    pub fn global(cx: &App) -> Duration {
+        cx.try_global::<Self>()
+            .map_or(Duration::from_secs(10 * 60), |timeout| timeout.0)
+    }
+}
+
+const IDLE_RETAINED_THREAD_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct TerminalId(uuid::Uuid);
@@ -1151,6 +1166,7 @@ impl BaseView {
 }
 
 pub struct AgentPanel {
+    _idle_thread_sweep: Task<()>,
     workspace: WeakEntity<Workspace>,
     /// Workspace id is used as a database key
     workspace_id: Option<WorkspaceId>,
@@ -1554,6 +1570,20 @@ impl AgentPanel {
         })
         .detach();
 
+        let idle_thread_sweep = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(IDLE_RETAINED_THREAD_SWEEP_INTERVAL)
+                    .await;
+                if this
+                    .update(cx, |this, cx| this.cleanup_retained_threads(cx))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
+
         let panel = Self {
             workspace_id,
             base_view,
@@ -1589,6 +1619,7 @@ impl AgentPanel {
             _thread_metadata_store_subscription,
             last_context_source: None,
             is_active: false,
+            _idle_thread_sweep: idle_thread_sweep,
         };
 
         panel.ensure_native_agent_connection(cx);
@@ -4176,6 +4207,10 @@ impl AgentPanel {
     }
 
     fn cleanup_retained_threads(&mut self, cx: &App) {
+        self.cleanup_retained_threads_at(Instant::now(), cx);
+    }
+
+    fn cleanup_retained_threads_at(&mut self, now: Instant, cx: &App) {
         let mut potential_removals = self
             .retained_threads
             .iter()
@@ -4189,14 +4224,24 @@ impl AgentPanel {
             .collect::<Vec<_>>();
 
         let max_idle = MaxIdleRetainedThreads::global(cx);
+        let idle_timeout = IdleRetainedThreadTimeout::global(cx);
+
+        // Idle past the timeout goes regardless of how few are retained: each
+        // one holds an agent server process open, and the filter above already
+        // limited this to threads `session/load` can restore.
+        let mut to_remove = potential_removals
+            .iter()
+            .filter(|(_, view)| {
+                view.read(cx).updated_at(cx).is_some_and(|updated_at| {
+                    now.saturating_duration_since(updated_at) >= idle_timeout
+                })
+            })
+            .map(|(id, _)| **id)
+            .collect::<Vec<_>>();
 
         potential_removals.sort_unstable_by_key(|(_, view)| view.read(cx).updated_at(cx));
         let n = potential_removals.len().saturating_sub(max_idle);
-        let to_remove = potential_removals
-            .into_iter()
-            .map(|(id, _)| *id)
-            .take(n)
-            .collect::<Vec<_>>();
+        to_remove.extend(potential_removals.into_iter().map(|(id, _)| *id).take(n));
         for id in to_remove {
             self.retained_threads.remove(&id);
         }
@@ -11038,6 +11083,66 @@ mod tests {
             missing.is_none(),
             "unknown session ids should not produce initial content"
         );
+    }
+
+    #[gpui::test]
+    async fn test_cleanup_retained_threads_drops_threads_idle_past_timeout(
+        cx: &mut TestAppContext,
+    ) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let connection = StubAgentConnection::new()
+            .with_supports_load_session(true)
+            .with_agent_id("loadable-stub".into())
+            .with_telemetry_id("loadable-stub".into());
+        let mut session_ids = Vec::new();
+        let mut thread_ids = Vec::new();
+
+        for _ in 0..3 {
+            let (session_id, thread_id) =
+                open_generating_thread_with_loadable_connection(&panel, &connection, &mut cx);
+            session_ids.push(session_id);
+            thread_ids.push(thread_id);
+        }
+
+        let base_time = Instant::now();
+
+        for session_id in session_ids.iter().take(2) {
+            connection.end_turn(session_id.clone(), acp::StopReason::EndTurn);
+        }
+        cx.run_until_parked();
+
+        let timeout = cx.update(|_window, cx| IdleRetainedThreadTimeout::global(cx));
+
+        panel.update(&mut cx, |panel, cx| {
+            let stale = panel
+                .retained_threads
+                .get(&thread_ids[0])
+                .expect("retained thread should exist")
+                .clone();
+            stale.update(cx, |view, cx| view.set_updated_at(base_time, cx));
+
+            let fresh = panel
+                .retained_threads
+                .get(&thread_ids[1])
+                .expect("retained thread should exist")
+                .clone();
+            fresh.update(cx, |view, cx| {
+                view.set_updated_at(base_time + timeout + Duration::from_secs(60), cx)
+            });
+
+            panel.cleanup_retained_threads_at(base_time + timeout, cx);
+        });
+
+        panel.read_with(&cx, |panel, _cx| {
+            assert!(
+                !panel.retained_threads.contains_key(&thread_ids[0]),
+                "a thread idle past the timeout should be dropped so its agent server can exit"
+            );
+            assert!(
+                panel.retained_threads.contains_key(&thread_ids[1]),
+                "a recently active thread should be retained"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -80,7 +80,7 @@ use super::entry_view_state::EntryViewState;
 use crate::ModeSelector;
 use crate::ModelSelectorPopover;
 use crate::agent_connection_store::{
-    AgentConnectedState, AgentConnectionEntryEvent, AgentConnectionStore,
+    AgentConnectedState, AgentConnectionEntryEvent, AgentConnectionLease, AgentConnectionStore,
 };
 use crate::agent_diff::AgentDiff;
 use crate::completion_provider::{AgentContextSelection, AvailableSkill};
@@ -273,6 +273,9 @@ pub(crate) struct Conversation {
 
 impl Conversation {
     pub fn register_thread(&mut self, thread: Entity<AcpThread>, cx: &mut Context<Self>) {
+        // Registration counts as activity, otherwise a thread that is opened
+        // and left alone reads as idle since the beginning of time.
+        self.updated_at = Some(Instant::now());
         let session_id = thread.read(cx).session_id().clone();
         let subscription = cx.subscribe(&thread, {
             let session_id = session_id.clone();
@@ -727,6 +730,7 @@ enum ServerState {
         _loading: Entity<LoadingView>,
         connection: Option<Rc<dyn AgentConnection>>,
         _request_elicitation_subscription: Option<Subscription>,
+        _lease: AgentConnectionLease,
     },
     LoadError {
         error: LoadError,
@@ -744,6 +748,7 @@ pub struct ConnectedServerState {
     conversation: Entity<Conversation>,
     _connection_entry_subscription: Subscription,
     _request_elicitation_subscription: Option<Subscription>,
+    _lease: AgentConnectionLease,
 }
 
 enum AuthState {
@@ -1044,9 +1049,10 @@ impl ConversationView {
         }
         let session_work_dirs = work_dirs.unwrap_or_else(|| project.read(cx).default_path_list(cx));
 
-        let connection_entry = connection_store.update(cx, |store, cx| {
+        let (connection_entry, lease) = connection_store.update(cx, |store, cx| {
             store.request_connection(connection_key, agent.clone(), cx)
         });
+        let connected_lease = lease.clone();
 
         let connection_entry_subscription =
             cx.subscribe(&connection_entry, |this, _entry, event, cx| match event {
@@ -1195,6 +1201,7 @@ impl ConversationView {
                         this.set_server_state(
                             ServerState::Connected(ConnectedServerState {
                                 connection,
+                                _lease: connected_lease,
                                 auth_state: AuthState::Ok,
                                 active_id: Some(root_session_id.clone()),
                                 threads: HashMap::from_iter([(root_session_id, current)]),
@@ -1225,6 +1232,7 @@ impl ConversationView {
             _loading: loading_view,
             connection: None,
             _request_elicitation_subscription: None,
+            _lease: lease,
         }
     }
 
@@ -1459,6 +1467,12 @@ impl ConversationView {
             } else {
                 let request_elicitation_subscription =
                     Self::request_elicitation_subscription(&connection, cx);
+                let connection_store = this.connection_store.clone();
+                let connection_key = this.connection_key.clone();
+                let agent = this.agent.clone();
+                let lease = connection_store.update(cx, |store, cx| {
+                    store.request_connection(connection_key, agent, cx).1
+                });
                 this.set_server_state(
                     ServerState::Connected(ConnectedServerState {
                         auth_state,
@@ -1468,6 +1482,7 @@ impl ConversationView {
                         conversation: cx.new(|_cx| Conversation::default()),
                         _connection_entry_subscription: Subscription::new(|| {}),
                         _request_elicitation_subscription: request_elicitation_subscription,
+                        _lease: lease,
                     }),
                     cx,
                 );
@@ -11054,6 +11069,208 @@ pub(crate) mod tests {
             closed_count > 0,
             "close_session should have been called for each thread"
         );
+    }
+
+    #[gpui::test]
+    async fn test_reaps_connection_after_last_conversation_drops(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(CloseCapableConnection::new()), cx).await;
+        cx.run_until_parked();
+
+        let connection_store =
+            conversation_view.read_with(cx, |view, _cx| view.connection_store.clone());
+        let connection_key = conversation_view.read_with(cx, |view, _cx| view.agent_key().clone());
+
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+            );
+            assert_eq!(store.lease_count(&connection_key), 1);
+        });
+
+        drop(conversation_view);
+        // Entity release is deferred to the end of the effect cycle, so the
+        // lease is not gone until one has run.
+        cx.update(|_window, _cx| {});
+        cx.run_until_parked();
+
+        connection_store.read_with(cx, |store, _cx| {
+            assert_eq!(
+                store.lease_count(&connection_key),
+                0,
+                "dropping the view should release its lease",
+            );
+        });
+
+        let now = Instant::now();
+        let long_enough = Duration::from_secs(60 * 60);
+        connection_store.update(cx, |store, cx| store.reap_unused_connections(now, cx));
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+                "the first pass only observes that the connection is unused",
+            );
+        });
+
+        connection_store.update(cx, |store, cx| {
+            store.reap_unused_connections(now + long_enough, cx)
+        });
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Disconnected,
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_keeps_connection_while_another_holder_has_a_lease(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(CloseCapableConnection::new()), cx).await;
+        cx.run_until_parked();
+
+        let connection_store =
+            conversation_view.read_with(cx, |view, _cx| view.connection_store.clone());
+        let connection_key = conversation_view.read_with(cx, |view, _cx| view.agent_key().clone());
+
+        let server: Rc<dyn AgentServer> =
+            Rc::new(StubAgentServer::new(CloseCapableConnection::new()));
+        let lease = connection_store.update(cx, |store, cx| {
+            store
+                .request_connection(connection_key.clone(), server, cx)
+                .1
+        });
+
+        drop(conversation_view);
+        cx.run_until_parked();
+
+        let now = Instant::now();
+        let long_enough = Duration::from_secs(60 * 60);
+        connection_store.update(cx, |store, cx| store.reap_unused_connections(now, cx));
+        connection_store.update(cx, |store, cx| {
+            store.reap_unused_connections(now + long_enough, cx)
+        });
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.lease_count(&connection_key),
+                1,
+                "the outstanding lease should still be counted",
+            );
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+                "a connection with an outstanding lease must not be reaped",
+            );
+        });
+
+        drop(lease);
+        connection_store.update(cx, |store, cx| store.reap_unused_connections(now, cx));
+        connection_store.update(cx, |store, cx| {
+            store.reap_unused_connections(now + long_enough, cx)
+        });
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Disconnected,
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_unconfigured_agent_keeps_its_entry_until_leases_are_released(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(CloseCapableConnection::new()), cx).await;
+        cx.run_until_parked();
+
+        let connection_store =
+            conversation_view.read_with(cx, |view, _cx| view.connection_store.clone());
+        let connection_key = conversation_view.read_with(cx, |view, _cx| view.agent_key().clone());
+
+        // The agent is removed from settings while a view is still using it.
+        connection_store.update(cx, |store, _cx| store.retain_configured_agents(|_| false));
+
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.lease_count(&connection_key),
+                1,
+                "the live view's lease should still be counted",
+            );
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+                "an entry with outstanding leases must not be dropped from the map",
+            );
+        });
+
+        drop(conversation_view);
+        cx.update(|_window, _cx| {});
+        cx.run_until_parked();
+
+        let now = Instant::now();
+        let long_enough = Duration::from_secs(60 * 60);
+        connection_store.update(cx, |store, cx| store.reap_unused_connections(now, cx));
+        connection_store.update(cx, |store, cx| {
+            store.reap_unused_connections(now + long_enough, cx)
+        });
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Disconnected,
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_lease_survives_reconnect(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(CloseCapableConnection::new()), cx).await;
+        cx.run_until_parked();
+
+        let connection_store =
+            conversation_view.read_with(cx, |view, _cx| view.connection_store.clone());
+        let connection_key = conversation_view.read_with(cx, |view, _cx| view.agent_key().clone());
+
+        // The view is still using the agent, so its lease has to carry over to
+        // the replacement entry.
+        let server: Rc<dyn AgentServer> =
+            Rc::new(StubAgentServer::new(CloseCapableConnection::new()));
+        connection_store.update(cx, |store, cx| {
+            store.restart_connection(connection_key.clone(), server, cx)
+        });
+        cx.run_until_parked();
+
+        let now = Instant::now();
+        let long_enough = Duration::from_secs(60 * 60);
+        connection_store.update(cx, |store, cx| store.reap_unused_connections(now, cx));
+        connection_store.update(cx, |store, cx| {
+            store.reap_unused_connections(now + long_enough, cx)
+        });
+
+        connection_store.read_with(cx, |store, cx| {
+            assert_eq!(
+                store.lease_count(&connection_key),
+                1,
+                "the live view's lease should carry over to the new connection",
+            );
+            assert_eq!(
+                store.connection_status(&connection_key, cx),
+                crate::agent_connection_store::AgentConnectionStatus::Connected,
+            );
+        });
+
+        drop(conversation_view);
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -693,6 +693,7 @@ fn fetch_sessions_for_agent(
     cx: &mut App,
 ) -> Task<AgentSessionFetchResult> {
     let mut wait_for_connection_tasks = Vec::new();
+    let mut leases = Vec::new();
 
     for store in stores {
         let remote_connection = store
@@ -702,7 +703,9 @@ fn fetch_sessions_for_agent(
             .remote_connection_options(cx);
         let agent = Agent::from(agent_id.clone());
         let server = agent.server(<dyn Fs>::global(cx), ThreadStore::global(cx));
-        let entry = store.update(cx, |store, cx| store.request_connection(agent, server, cx));
+        let (entry, lease) =
+            store.update(cx, |store, cx| store.request_connection(agent, server, cx));
+        leases.push(lease);
 
         wait_for_connection_tasks.push(entry.read(cx).wait_for_connection().map({
             let agent_id = agent_id.clone();
@@ -712,6 +715,8 @@ fn fetch_sessions_for_agent(
     }
 
     cx.spawn(async move |cx| {
+        // Held so the connections survive until every page is listed.
+        let _leases = leases;
         let mut stats = AgentSessionFetchStats::default();
         let results = futures::future::join_all(wait_for_connection_tasks).await;
 

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -820,13 +820,17 @@ impl ThreadsArchiveView {
         };
         let fs = <dyn Fs>::global(cx);
 
-        let task = agent_connection_store.update(cx, |store, cx| {
-            store
-                .request_connection(agent.clone(), agent.server(fs, ThreadStore::global(cx)), cx)
-                .read(cx)
-                .wait_for_connection()
+        let (task, lease) = agent_connection_store.update(cx, |store, cx| {
+            let (entry, lease) = store.request_connection(
+                agent.clone(),
+                agent.server(fs, ThreadStore::global(cx)),
+                cx,
+            );
+            (entry.read(cx).wait_for_connection(), lease)
         });
         cx.spawn(async move |_this, cx| {
+            // Held so the connection survives until the session is deleted.
+            let _lease = lease;
             crate::thread_worktree_archive::cleanup_thread_archived_worktrees(thread_id, cx).await;
 
             let state = task.await?;


### PR DESCRIPTION
Fixes #56747.

## The leak

`session/close` is session-scoped and does not terminate an ACP agent server.
The process only exits when the last `Rc<dyn AgentConnection>` is dropped and
`AcpConnection::drop` kills its process group — which works correctly today:
`util::process::Child::kill` calls `killpg`, and the child is spawned through
`set_pre_exec_to_start_new_session`, so pid == pgid and the whole subtree goes
with it.

The problem is that nothing tracked who was still using a cached connection, so
`AgentConnectionStore` held its `Rc` for the lifetime of the window. Every
external agent that had ever been used stayed resident. On my machine that was
7 `claude-code-acp` bridges and 13 `claude` children, several idle for more than
24 hours, holding roughly 1.25 GB.

## Reference-counted connections

`request_connection` now returns an `AgentConnectionLease` alongside the entry,
and a connection is dropped once its last lease is released.

The lease holds an `Rc<()>` token rather than calling back into the store on
drop. A lease that outlives the store — or the entry it was taken against —
is inert, so it cannot corrupt the count.

Two cases needed care:

- **Reconnects.** A restart or an error retry replaces the entry underneath
  holders that are still using that agent. The token is carried across to the
  replacement, otherwise the new entry looks unused and is reaped while views
  are live. For the same reason a new-version notification now marks the entry
  stale instead of removing it.
- **Non-view callers.** `threads_archive_view`, `thread_import` and
  `ensure_native_agent_connection` also open connections. They hold leases for
  the duration of their work now, so there is no way to spawn a connection that
  nothing counts.

Reaping is deferred and two-phase — an entry is first observed to be unused and
only dropped on a later pass — because a lease has no drop hook to make it
exact. Erring towards keeping a connection is much cheaper than tearing down one
that is about to be used again. The native agent is exempt: it runs in-process,
so there is no process to reclaim.

## Idle retained threads

Reference counting alone does not fix the reported case. A retained
`ConversationView` holds a lease, and the panel keeps up to
`MaxIdleRetainedThreads` of them plus the active thread and any drafts. They
share one connection per agent, so a handful of stale background threads keeps
several agent servers resident even though nothing is using them.

`cleanup_retained_threads` now also evicts on age, not only when the retained
list is over the cap. Its existing predicate already requires an idle thread
whose agent supports `session/load`, so a thread dropped this way is restored in
full when reopened. Registering a thread stamps `updated_at`, so a thread that
is opened and then left alone has an age rather than reading as idle since the
beginning of time.

Both timeouts are GPUI globals following the existing `MaxIdleRetainedThreads`
pattern — 30s grace on an unused connection, 10 minutes on an idle retained
thread — so they can be overridden in tests and promoted to settings later if
that is wanted.

## Credit

The first commit builds on #61493 by @ton618to, which diagnosed the connection
lifetime problem correctly and is credited as co-author. This version replaces
the manual `HashMap<Agent, usize>` with leases to close the reconnect and
error-path desyncs, covers the non-view callers, and keeps `reset` from tearing
down and respawning the connection.

## Tests

`cargo test -p agent_ui --lib` — 409 passed, 0 failed. Four new tests: reap after
the last view drops, a connection survives while another holder has a lease, a
lease survives a reconnect, and an idle retained thread is evicted past its
timeout.

Release Notes:

- Fixed external agent server processes staying alive after their threads were closed or left idle
