### PR TITLE
Show transient "is not bound" message in status bar for unbound

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -10,6 +10,7 @@ mod open_url_modal;
 mod quick_action_bar;
 pub mod remote_debug;
 pub mod telemetry_log;
+mod unbound_key_indicator;
 #[cfg(all(target_os = "macos", feature = "visual-tests"))]
 pub mod visual_tests;
 #[cfg(target_os = "windows")]
@@ -617,6 +618,8 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         let active_toolchain_language =
             cx.new(|cx| toolchain_selector::ActiveToolchain::new(workspace, window, cx));
         let vim_mode_indicator = cx.new(|cx| vim::ModeIndicator::new(window, cx));
+        let unbound_key_indicator =
+            cx.new(|cx| unbound_key_indicator::UnboundKeyIndicator::new(window, cx));
         let image_info = cx.new(|_cx| ImageInfo::new(workspace));
 
         let lsp_button_menu_handle = PopoverMenuHandle::default();
@@ -643,6 +646,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_left_item(git_blame_status, window, cx);
             status_bar.add_left_item(merge_conflict_indicator, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
+            status_bar.add_left_item(unbound_key_indicator, window, cx);
             status_bar.add_right_item(edit_prediction_ui, window, cx);
             status_bar.add_right_item(active_buffer_encoding, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);

--- a/crates/zed/src/zed/unbound_key_indicator.rs
+++ b/crates/zed/src/zed/unbound_key_indicator.rs
@@ -1,0 +1,520 @@
+use gpui::{App, Context, IntoElement, Keystroke, Render, SharedString, Subscription, Window};
+use ui::text_for_keystrokes;
+use workspace::{HideStatusItem, StatusItemView, item::ItemHandle, ui::prelude::*};
+
+pub struct UnboundKeyIndicator {
+    message: Option<SharedString>,
+    pending_keystrokes: Option<Vec<Keystroke>>,
+    saw_keystroke_since_pending: bool,
+    breaking_keystroke: Option<Keystroke>,
+    replay_remaining: usize,
+    _keystroke_subscription: Subscription,
+    _pending_input_subscription: Subscription,
+}
+
+impl UnboundKeyIndicator {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let keystroke_subscription = cx.observe_keystrokes(|this, event, _window, cx| {
+            if event.action.is_some() {
+                this.pending_keystrokes = None;
+                this.breaking_keystroke = None;
+                this.replay_remaining = 0;
+                this.message = None;
+                cx.notify();
+            } else if this.replay_remaining > 0 {
+                this.replay_remaining -= 1;
+            } else if this.pending_keystrokes.is_some() {
+                this.saw_keystroke_since_pending = true;
+                this.breaking_keystroke = Some(event.keystroke.clone());
+            } else if should_show_unbound(&event.keystroke) {
+                let text = text_for_keystrokes(std::slice::from_ref(&event.keystroke), cx);
+                this.message = Some(format!("{text} is not bound").into());
+                cx.notify();
+            } else if this.message.is_some() {
+                this.message = None;
+                cx.notify();
+            }
+        });
+
+        let pending_input_subscription = cx.observe_pending_input(window, |this, window, cx| {
+            if let Some(keystrokes) = window.pending_input_keystrokes() {
+                this.pending_keystrokes = Some(keystrokes.to_vec());
+                this.saw_keystroke_since_pending = false;
+                this.breaking_keystroke = None;
+                if this.message.is_some() {
+                    this.message = None;
+                    cx.notify();
+                }
+            } else if let Some(mut keystrokes) = this.pending_keystrokes.take() {
+                // In the timeout path, replay fires AFTER this observer, so
+                // we must skip those replayed keystroke events to prevent them
+                // from clearing the message. In the normal (immediate) path,
+                // replay already fired before this observer, so skip is zero.
+                if !this.saw_keystroke_since_pending {
+                    this.replay_remaining = keystrokes.len();
+                }
+                if let Some(breaking) = this.breaking_keystroke.take() {
+                    keystrokes.push(breaking);
+                }
+                let text = text_for_keystrokes(&keystrokes, cx);
+                this.message = Some(format!("{text} is not bound").into());
+                cx.notify();
+            }
+        });
+
+        Self {
+            message: None,
+            pending_keystrokes: None,
+            saw_keystroke_since_pending: false,
+            breaking_keystroke: None,
+            replay_remaining: 0,
+            _keystroke_subscription: keystroke_subscription,
+            _pending_input_subscription: pending_input_subscription,
+        }
+    }
+}
+
+fn should_show_unbound(keystroke: &Keystroke) -> bool {
+    const MODIFIER_KEYS: &[&str] = &["shift", "control", "alt", "platform", "function"];
+    if MODIFIER_KEYS.contains(&keystroke.key.as_str()) {
+        return false;
+    }
+
+    const NOISY_KEYS: &[&str] = &["escape", "backspace", "delete", "tab", "enter"];
+    if NOISY_KEYS.contains(&keystroke.key.as_str()) && !keystroke.modifiers.control && !keystroke.modifiers.alt && !keystroke.modifiers.platform {
+        return false;
+    }
+
+    let has_command_modifiers =
+        keystroke.modifiers.control || keystroke.modifiers.alt || keystroke.modifiers.platform;
+
+    has_command_modifiers || keystroke.key_char.is_none()
+}
+
+impl Render for UnboundKeyIndicator {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(message) = self.message.clone() else {
+            return div().hidden().into_any_element();
+        };
+
+        Label::new(message)
+            .size(LabelSize::Small)
+            .color(Color::Muted)
+            .into_any_element()
+    }
+}
+
+impl StatusItemView for UnboundKeyIndicator {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn hide_setting(&self, _cx: &App) -> Option<HideStatusItem> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{
+        self as gpui, Entity, FocusHandle, InteractiveElement, KeyBinding, Modifiers,
+        ParentElement, TestAppContext, actions, div,
+    };
+
+    fn keystroke(key: &str, modifiers: Modifiers, key_char: Option<&str>) -> Keystroke {
+        Keystroke {
+            key: key.to_string(),
+            modifiers,
+            key_char: key_char.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_modifier_only_keystrokes_are_hidden() {
+        for key in &["shift", "control", "alt", "platform", "function"] {
+            let ks = keystroke(key, Modifiers::default(), None);
+            assert!(
+                !should_show_unbound(&ks),
+                "modifier-only key '{key}' should not trigger the indicator"
+            );
+        }
+    }
+
+    #[test]
+    fn test_plain_character_input_is_hidden() {
+        let ks = keystroke("a", Modifiers::default(), Some("a"));
+        assert!(
+            !should_show_unbound(&ks),
+            "plain 'a' with key_char should not trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_shift_only_character_is_hidden() {
+        let ks = keystroke(
+            "a",
+            Modifiers {
+                shift: true,
+                ..Modifiers::default()
+            },
+            Some("A"),
+        );
+        assert!(
+            !should_show_unbound(&ks),
+            "shift-a should not trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_ctrl_modified_keystroke_is_shown() {
+        let ks = keystroke(
+            "k",
+            Modifiers {
+                control: true,
+                ..Modifiers::default()
+            },
+            None,
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "ctrl-k should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_alt_modified_keystroke_is_shown() {
+        let ks = keystroke(
+            "f",
+            Modifiers {
+                alt: true,
+                ..Modifiers::default()
+            },
+            None,
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "alt-f should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_platform_modified_keystroke_is_shown() {
+        let ks = keystroke(
+            "s",
+            Modifiers {
+                platform: true,
+                ..Modifiers::default()
+            },
+            None,
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "cmd/super-s should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_ctrl_shift_modified_keystroke_is_shown() {
+        let ks = keystroke(
+            "k",
+            Modifiers {
+                control: true,
+                shift: true,
+                ..Modifiers::default()
+            },
+            None,
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "ctrl-shift-k should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_function_key_without_modifiers_is_shown() {
+        let ks = keystroke("f5", Modifiers::default(), None);
+        assert!(
+            should_show_unbound(&ks),
+            "F5 (no key_char) should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_arrow_key_without_modifiers_is_shown() {
+        let ks = keystroke("left", Modifiers::default(), None);
+        assert!(
+            should_show_unbound(&ks),
+            "arrow keys (no key_char) should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_ctrl_with_key_char_is_shown() {
+        let ks = keystroke(
+            "c",
+            Modifiers {
+                control: true,
+                ..Modifiers::default()
+            },
+            Some("c"),
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "ctrl-c with key_char should still trigger (command modifier takes priority)"
+        );
+    }
+
+    struct TestView {
+        focus_handle: FocusHandle,
+    }
+
+    actions!(unbound_key_indicator_test, [TestAction]);
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .key_context("test")
+                .track_focus(&self.focus_handle)
+                .on_action(cx.listener(|_: &mut Self, _: &TestAction, _, _| {}))
+                .child(div())
+        }
+    }
+
+    fn setup_indicator(
+        cx: &mut TestAppContext,
+    ) -> (gpui::AnyWindowHandle, Entity<UnboundKeyIndicator>) {
+        let window = cx.update(|cx| {
+            cx.open_window(Default::default(), |_, cx| {
+                cx.new(|cx| TestView {
+                    focus_handle: cx.focus_handle(),
+                })
+            })
+            .unwrap()
+        });
+
+        let indicator = window
+            .update(cx, |view, window, cx| {
+                window.focus(&view.focus_handle, cx);
+                cx.new(|cx| UnboundKeyIndicator::new(window, cx))
+            })
+            .unwrap();
+
+        (*window, indicator)
+    }
+
+    #[gpui::test]
+    fn test_indicator_initially_empty(cx: &mut TestAppContext) {
+        let (_, indicator) = setup_indicator(cx);
+
+        indicator.read_with(cx, |indicator, _| {
+            assert!(indicator.message.is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_shows_unbound_keystroke(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-shift-k").unwrap());
+
+        indicator.read_with(cx, |indicator, _| {
+            let message = indicator
+                .message
+                .as_ref()
+                .expect("should show unbound message");
+            assert!(
+                message.contains("is not bound"),
+                "expected 'is not bound' in message, got: {message}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_hidden_for_plain_typing(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.dispatch_keystroke(window, Keystroke::parse("a").unwrap());
+
+        indicator.read_with(cx, |indicator, _| {
+            assert!(
+                indicator.message.is_none(),
+                "plain typing should not show unbound message"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_cleared_by_next_plain_keystroke(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-shift-k").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            assert!(indicator.message.is_some());
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("a").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            assert!(
+                indicator.message.is_none(),
+                "message should be cleared after plain keystroke"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_cleared_by_bound_action(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new("ctrl-g", TestAction, Some("test"))]);
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-shift-k").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            assert!(indicator.message.is_some());
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-g").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            assert!(
+                indicator.message.is_none(),
+                "message should be cleared when a bound action fires"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_shows_pending_sequence_when_unmatched(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new(
+                "ctrl-k ctrl-c",
+                TestAction,
+                Some("test"),
+            )]);
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-k").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            assert!(
+                indicator.message.is_none(),
+                "no message while input is pending"
+            );
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-z").unwrap());
+        indicator.read_with(cx, |indicator, _| {
+            let message = indicator
+                .message
+                .as_ref()
+                .expect("should show unbound message for failed multi-key sequence");
+            assert!(
+                message.contains("is not bound"),
+                "expected 'is not bound' in message, got: {message}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_no_duplicates_in_pending_sequence(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new(
+                "ctrl-k ctrl-c",
+                TestAction,
+                Some("test"),
+            )]);
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-k").unwrap());
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-z").unwrap());
+
+        indicator.read_with(cx, |indicator, _| {
+            let message = indicator
+                .message
+                .as_ref()
+                .expect("should show unbound message");
+            let text = message.as_ref();
+            let parts: Vec<&str> = text.split(" is not bound").collect();
+            let keystroke_text = parts[0];
+            let keystroke_parts: Vec<&str> = keystroke_text.split_whitespace().collect();
+            assert!(
+                keystroke_parts.len() <= 2,
+                "expected at most 2 keystrokes in message, got: {message}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn test_indicator_pending_cleared_by_bound_chord(cx: &mut TestAppContext) {
+        let (window, indicator) = setup_indicator(cx);
+
+        cx.update(|cx| {
+            cx.bind_keys(vec![KeyBinding::new(
+                "ctrl-k ctrl-c",
+                TestAction,
+                Some("test"),
+            )]);
+        });
+
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-k").unwrap());
+        cx.dispatch_keystroke(window, Keystroke::parse("ctrl-c").unwrap());
+
+        indicator.read_with(cx, |indicator, _| {
+            assert!(
+                indicator.message.is_none(),
+                "message should not appear when a multi-key binding matches"
+            );
+        });
+    }
+
+    #[test]
+    fn test_escape_without_modifiers_is_hidden() {
+        let ks = keystroke("escape", Modifiers::default(), None);
+        assert!(
+            !should_show_unbound(&ks),
+            "bare escape should not trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_ctrl_escape_is_shown() {
+        let ks = keystroke(
+            "escape",
+            Modifiers {
+                control: true,
+                ..Modifiers::default()
+            },
+            None,
+        );
+        assert!(
+            should_show_unbound(&ks),
+            "ctrl-escape should trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_backspace_without_modifiers_is_hidden() {
+        let ks = keystroke("backspace", Modifiers::default(), None);
+        assert!(
+            !should_show_unbound(&ks),
+            "bare backspace should not trigger the indicator"
+        );
+    }
+
+    #[test]
+    fn test_tab_without_modifiers_is_hidden() {
+        let ks = keystroke("tab", Modifiers::default(), None);
+        assert!(
+            !should_show_unbound(&ks),
+            "bare tab should not trigger the indicator"
+        );
+    }
+}


### PR DESCRIPTION
Show transient "is not bound" message in status bar for unbound keystrokes

When a key combination has no action bound to it, a message like "Ctrl-Shift-K is not bound" now appears in the status bar. The message stays until the next keystroke. Only intentional key combos trigger it (modified keys or non-character keys like F-keys), not plain text input or modifier-only taps.

Multi-key sequences (leader keys) are also handled: the indicator tracks pending input via observe_pending_input, and when a sequence like "space g k" resolves without matching any binding, the full sequence is shown as "space g k is not bound". The keystroke observer appends the final unmatched key to the tracked pending sequence so the complete chord is displayed.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Show unbound key binding message in the status bar.

<img width="680" height="352" alt="Screenshot From 2026-05-27 23-38-26" src="https://github.com/user-attachments/assets/90fbb104-0334-4c0f-be58-46c688f0773c" />

