### PR TITLE
workspace: Reopen the most recent linked worktree when opening a project group

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1215,26 +1215,49 @@ impl MultiWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Workspace>>> {
-        if let Some(workspace) = self.workspace_for_paths(&path_list, None, cx) {
+        // A project group's `path_list` is the group's *identity* paths, which
+        // for a linked git worktree is the main checkout of the repo. When
+        // opening such a group with no workspace currently loaded, resolve the
+        // paths to the most recently used workspace for that identity so the
+        // user gets the worktree they actually last worked in, rather than
+        // always falling back to the main checkout.
+        let identity_path_list = match project_group.as_ref() {
+            Some(project_group) if project_group.path_list() == &path_list => {
+                Some(path_list.clone())
+            }
+            _ => None,
+        };
+        let effective_path_list = match identity_path_list {
+            Some(identity) => {
+                let db = crate::persistence::WorkspaceDb::global(cx);
+                db.most_recent_workspace_paths_for_identity(&identity)
+                    .filter(|paths| !paths.is_empty() && paths != &identity)
+                    .unwrap_or(identity)
+            }
+            None => path_list.clone(),
+        };
+
+        if let Some(workspace) = self.workspace_for_paths(&effective_path_list, None, cx) {
             self.activate(workspace.clone(), source_workspace, window, cx);
             return Task::ready(Ok(workspace));
         }
 
         let paths = path_list.paths().to_vec();
+        let effective_paths = effective_path_list.paths().to_vec();
         let app_state = self.workspace().read(cx).app_state().clone();
         let requesting_window = window.window_handle().downcast::<MultiWorkspace>();
         let fs = <dyn Fs>::global(cx);
 
         cx.spawn(async move |_this, cx| {
             let effective_path_list = if let Some(project_group) = project_group {
-                let metadata_tasks: Vec<_> = paths
+                let metadata_tasks: Vec<_> = effective_paths
                     .iter()
                     .map(|path| fs.metadata(path.as_path()))
                     .collect();
                 let metadata_results = futures::future::join_all(metadata_tasks).await;
                 // Only fall back when every path is definitely absent; real
                 // filesystem errors should not be treated as "missing".
-                let all_paths_missing = !paths.is_empty()
+                let all_paths_missing = !effective_paths.is_empty()
                     && metadata_results
                         .into_iter()
                         // Ok(None) means the path is definitely absent
@@ -1243,7 +1266,7 @@ impl MultiWorkspace {
                 if all_paths_missing {
                     project_group.path_list().clone()
                 } else {
-                    PathList::new(&paths)
+                    PathList::new(&effective_paths)
                 }
             } else {
                 PathList::new(&paths)
@@ -1354,6 +1377,17 @@ impl MultiWorkspace {
         self.held[displayed].activated_at = Some(stamp);
 
         if !should_retain_workspaces && !old_active_was_retained {
+            // Persist the workspace we're leaving so its row reflects the
+            // moment it was last used. Without this the pending throttled
+            // serialization is dropped on detach, leaving a stale timestamp
+            // that makes the recent-projects dedup pick a different workspace
+            // of the same git identity (e.g. the main checkout) when the user
+            // switches back to the worktree they just left.
+            old_active_workspace
+                .update(cx, |workspace, cx| {
+                    workspace.flush_serialization(window, cx)
+                })
+                .detach();
             self.detach_workspace(&old_active_workspace, cx);
         }
 
@@ -1395,6 +1429,11 @@ impl MultiWorkspace {
         let displayed_workspace = self.workspace().clone();
         for workspace in self.workspaces().cloned().collect::<Vec<_>>() {
             if workspace != displayed_workspace {
+                workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.flush_serialization(window, cx)
+                    })
+                    .detach();
                 self.detach_workspace(&workspace, cx);
             }
         }

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 
 use super::*;
+use super::persistence::{
+    WorkspaceDb,
+    model::{SerializedPane, SerializedPaneGroup, SerializedWorkspace},
+};
 use crate::item::test::TestItem;
 use agent_settings::AgentSettings;
 use client::proto;
@@ -578,6 +582,120 @@ async fn test_find_or_create_workspace_uses_project_group_key_when_paths_are_mis
             mw.workspaces().count(),
             1,
             "falling back to the project group key should not create a second workspace"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_find_or_create_local_workspace_reopens_most_recent_worktree_for_group(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    // Main repo with a linked worktree.
+    fs.insert_tree(
+        "/the-project",
+        json!({
+            ".git": "gitdir: ./.bare\n",
+            ".bare": {
+                "worktrees": {
+                    "feature-a": {
+                        "commondir": "../../",
+                        "HEAD": "ref: refs/heads/feature-a"
+                    }
+                }
+            },
+            "src": { "main.rs": "" }
+        }),
+    )
+    .await;
+    fs.insert_tree(
+        "/the-project/feature-a",
+        json!({
+            ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+            "src": { "lib.rs": "" }
+        }),
+    )
+    .await;
+    // A different project is what's currently open in the window.
+    fs.insert_tree("/other-project", json!({ "file.txt": "" })).await;
+
+    cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+    // Seed the database with two workspaces for the same repo identity: the
+    // main checkout (older) and the linked worktree (most recent).
+    let identity = PathList::new(&["/the-project"]);
+    let db = cx.update(|cx| WorkspaceDb::global(cx));
+    db.save_workspace(SerializedWorkspace {
+        identity_paths: Some(identity.clone()),
+        id: WorkspaceId(1),
+        paths: identity.clone(),
+        center_group: SerializedPaneGroup::Pane(SerializedPane::default()),
+        window_bounds: Default::default(),
+        display: Default::default(),
+        docks: Default::default(),
+        bookmarks: Default::default(),
+        breakpoints: Default::default(),
+        centered_layout: false,
+        session_id: None,
+        window_id: Some(1),
+        user_toolchains: Default::default(),
+        location: SerializedWorkspaceLocation::Local,
+    })
+    .await;
+    db.save_workspace(SerializedWorkspace {
+        identity_paths: Some(identity.clone()),
+        id: WorkspaceId(2),
+        paths: PathList::new(&["/the-project/feature-a"]),
+        center_group: SerializedPaneGroup::Pane(SerializedPane::default()),
+        window_bounds: Default::default(),
+        display: Default::default(),
+        docks: Default::default(),
+        bookmarks: Default::default(),
+        breakpoints: Default::default(),
+        centered_layout: false,
+        session_id: None,
+        window_id: Some(2),
+        user_toolchains: Default::default(),
+        location: SerializedWorkspaceLocation::Local,
+    })
+    .await;
+    db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+        .await
+        .unwrap();
+    db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+        .await
+        .unwrap();
+
+    let project = Project::test(fs.clone(), ["/other-project".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+    let group_key = ProjectGroupKey::new(None, identity.clone());
+    let workspace = multi_workspace
+        .update_in(cx, |mw, window, cx| {
+            mw.find_or_create_local_workspace(
+                identity.clone(),
+                Some(group_key),
+                None,
+                OpenMode::Activate,
+                None,
+                window,
+                cx,
+            )
+        })
+        .await
+        .expect("opening a project group should create a workspace");
+
+    multi_workspace.read_with(cx, |_, cx| {
+        assert_eq!(
+            PathList::new(&workspace.read(cx).root_paths(cx)),
+            PathList::new(&["/the-project/feature-a"]),
+            "opening a project group should reopen the most recent linked worktree workspace, not the main checkout"
         );
     });
 }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1839,6 +1839,40 @@ impl WorkspaceDb {
             .collect())
     }
 
+    /// Returns the paths of the most recently used local workspace whose
+    /// `identity_paths` match the given list. Project groups are keyed by the
+    /// identity paths of a repo (its main checkout), so opening a group with
+    /// no workspace currently loaded needs this to find the workspace the user
+    /// actually last worked in — a linked git worktree — instead of always
+    /// falling back to the main checkout.
+    pub(crate) fn most_recent_workspace_paths_for_identity(
+        &self,
+        identity_paths: &PathList,
+    ) -> Option<PathList> {
+        let serialized = identity_paths.serialize();
+        self.most_recent_local_workspace_paths_for_identity_query(serialized.paths)
+            .log_err()
+            .flatten()
+            .map(|(paths, paths_order)| {
+                PathList::deserialize(&SerializedPathList {
+                    paths,
+                    order: paths_order,
+                })
+            })
+    }
+
+    query! {
+        pub(crate) fn most_recent_local_workspace_paths_for_identity_query(identity_paths: String) -> Result<Option<(String, String)>> {
+            SELECT paths, paths_order
+            FROM workspaces
+            WHERE
+                identity_paths IS ?1 AND
+                remote_connection_id IS NULL
+            ORDER BY timestamp DESC
+            LIMIT 1
+        }
+    }
+
     query! {
         fn recent_workspaces_query() -> Result<Vec<(WorkspaceId, String, String, Option<String>, Option<String>, Option<u64>, Option<String>, String)>> {
             SELECT workspace_id, paths, paths_order, identity_paths, identity_paths_order, remote_connection_id, session_id, timestamp
@@ -5391,6 +5425,84 @@ mod tests {
         );
         assert_eq!(result[0].workspace_id, WorkspaceId(2));
         assert_eq!(result[0].timestamp, t1);
+    }
+
+    #[gpui::test]
+    async fn test_most_recent_workspace_paths_for_identity(cx: &mut gpui::TestAppContext) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db = WorkspaceDb::open_test_db("test_most_recent_workspace_paths_for_identity").await;
+
+        fs.insert_tree(
+            "/the-project",
+            json!({
+                ".git": "gitdir: ./.bare\n",
+                ".bare": {
+                    "worktrees": {
+                        "feature-a": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature-a"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/the-project/feature-a",
+            json!({
+                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        let identity = PathList::new(&["/the-project"]);
+        db.save_workspace(SerializedWorkspace {
+            identity_paths: Some(identity.clone()),
+            ..workspace_with(1, &[Path::new("/the-project")], empty_pane_group(), None)
+        })
+        .await;
+        db.save_workspace(SerializedWorkspace {
+            identity_paths: Some(identity.clone()),
+            ..workspace_with(
+                2,
+                &[Path::new("/the-project/feature-a")],
+                empty_pane_group(),
+                None,
+            )
+        })
+        .await;
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+
+        // The linked worktree workspace is the most recent for the identity,
+        // so it should be the one resolved.
+        assert_eq!(
+            db.most_recent_workspace_paths_for_identity(&identity)
+                .unwrap()
+                .paths(),
+            &[PathBuf::from("/the-project/feature-a")]
+        );
+
+        // Flip the timestamps: the main checkout is now most recent.
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:02".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+        assert_eq!(
+            db.most_recent_workspace_paths_for_identity(&identity)
+                .unwrap()
+                .paths(),
+            &[PathBuf::from("/the-project")]
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
### Summary

When a project group has no workspace currently loaded, opening it in the Recent Projects picker (or sidebar) falls back to the group's *identity* paths. For a linked git worktree, the identity paths are the **main checkout** of the repo, so switching away and back restored the main checkout instead of the worktree the user was last working in.

This PR fixes that by:

1. **Resolving the group's identity paths to the most recently used local workspace** before creating/reopening a workspace (`MultiWorkspace::find_or_create_local_workspace`). A new `WorkspaceDb::most_recent_workspace_paths_for_identity` query returns the newest row for the identity, so a linked worktree's paths win over the main checkout.
2. **Flushing pending workspace serialization before detaching** on project switch (`activate` and `collapse_to_single_workspace`). The throttled serialize task was dropped on detach, leaving a stale timestamp that made the recent-projects dedup (`dedupe_recent_workspaces`) pick the wrong workspace of the same git identity.

### Test Plan

- New `persistence::test_most_recent_workspace_paths_for_identity` verifies the newest workspace for an identity is resolved, in both timestamp orders.
- New `multi_workspace_tests::test_find_or_create_local_workspace_reopens_most_recent_worktree_for_group` reproduces the bug: seeding a main checkout + linked worktree row for the same identity and opening the group restores the worktree.
- Existing `test_find_or_create_workspace_uses_project_group_key_when_paths_are_missing` still passes (no regression).
- `cargo test -p workspace` (45 persistence + 27 multi_workspace tests) and `cargo clippy -p workspace` are clean.