### PR TITLE
Agent prompt history navigation

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -235,6 +235,16 @@
     },
   },
   {
+    "context": "AgentPromptHistory",
+    "bindings": {
+      "up": "menu::SelectPrevious",
+      "down": "menu::SelectNext",
+      "enter": "menu::Confirm",
+      "tab": "menu::Confirm",
+      "escape": "menu::Cancel",
+    },
+  },
+  {
     "context": "AgentFeedbackMessageEditor > Editor",
     "bindings": {
       "escape": "menu::Cancel",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -272,6 +272,16 @@
     },
   },
   {
+    "context": "AgentPromptHistory",
+    "bindings": {
+      "up": "menu::SelectPrevious",
+      "down": "menu::SelectNext",
+      "enter": "menu::Confirm",
+      "tab": "menu::Confirm",
+      "escape": "menu::Cancel",
+    },
+  },
+  {
     "context": "AgentFeedbackMessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -236,6 +236,16 @@
     },
   },
   {
+    "context": "AgentPromptHistory",
+    "bindings": {
+      "up": "menu::SelectPrevious",
+      "down": "menu::SelectNext",
+      "enter": "menu::Confirm",
+      "tab": "menu::Confirm",
+      "escape": "menu::Cancel",
+    },
+  },
+  {
     "context": "AgentFeedbackMessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1290,6 +1290,10 @@
     //
     // Default: false
     "use_modifier_to_send": false,
+    // Whether pressing the up arrow in an empty agent message editor opens prompt history.
+    //
+    // Default: true
+    "message_history_navigation": true,
     // Minimum number of lines to display in the agent message editor.
     //
     // Default: 4

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -237,6 +237,7 @@ pub struct AgentSettings {
     pub thinking_display: ThinkingBlockDisplay,
     pub cancel_generation_on_terminal_stop: bool,
     pub use_modifier_to_send: bool,
+    pub message_history_navigation: bool,
     pub message_editor_min_lines: usize,
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
@@ -813,6 +814,7 @@ impl Settings for AgentSettings {
             thinking_display: agent.thinking_display.unwrap(),
             cancel_generation_on_terminal_stop: agent.cancel_generation_on_terminal_stop.unwrap(),
             use_modifier_to_send: agent.use_modifier_to_send.unwrap(),
+            message_history_navigation: agent.message_history_navigation.unwrap(),
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
@@ -1060,6 +1062,27 @@ mod tests {
     fn test_invalid_regex_returns_none() {
         let result = CompiledRegex::new("[invalid(regex", false);
         assert!(result.is_none());
+    }
+
+    #[gpui::test]
+    fn test_message_history_navigation_setting(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+        project::DisableAiSettings::register(cx);
+        AgentSettings::register(cx);
+
+        assert!(AgentSettings::get_global(cx).message_history_navigation);
+
+        SettingsStore::update_global(cx, |store, cx| {
+            store
+                .set_user_settings(
+                    r#"{ "agent": { "message_history_navigation": false } }"#,
+                    cx,
+                )
+                .unwrap();
+        });
+
+        assert!(!AgentSettings::get_global(cx).message_history_navigation);
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -1007,6 +1007,7 @@ mod tests {
             terminal_init_command: None,
             cancel_generation_on_terminal_stop: true,
             use_modifier_to_send: true,
+            message_history_navigation: true,
             message_editor_min_lines: 1,
             tool_permissions: Default::default(),
             sandbox_permissions: Default::default(),

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6803,6 +6803,57 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_enter_and_tab_restore_without_sending(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Recall this prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let entry_count = active_thread(&conversation_view, cx)
+            .read_with(cx, |view, cx| view.thread.read(cx).entries().len());
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+
+        for confirm_key in ["enter", "tab"] {
+            cx.update(|window, cx| editor_focus.focus(window, cx));
+            cx.simulate_keystrokes("up");
+            cx.run_until_parked();
+            assert_eq!(
+                selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+                Some("Recall this prompt")
+            );
+
+            cx.simulate_keystrokes(confirm_key);
+            cx.run_until_parked();
+
+            assert_eq!(
+                message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+                "Recall this prompt"
+            );
+            assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+            active_thread(&conversation_view, cx).read_with(cx, |view, cx| {
+                assert_eq!(view.thread.read(cx).entries().len(), entry_count);
+                assert_eq!(view.thread.read(cx).status(), ThreadStatus::Idle);
+            });
+
+            message_editor.update_in(cx, |editor, window, cx| {
+                editor.clear(window, cx);
+            });
+            cx.run_until_parked();
+        }
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7093,6 +7093,56 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_move_up_prefers_last_queued_prompt(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("History prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            for prompt in ["First queued", "Second queued"] {
+                view.add_to_queue(
+                    vec![acp::ContentBlock::Text(acp::TextContent::new(prompt))],
+                    vec![],
+                    window,
+                    cx,
+                );
+            }
+        });
+        cx.run_until_parked();
+
+        assert!(
+            active_thread(&conversation_view, cx)
+                .read_with(cx, |view, cx| { view.prompt_history(cx).is_some() })
+        );
+        cx.update(|window, cx| message_editor.focus_handle(cx).focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert_eq!(
+            message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+            "Second queued"
+        );
+        assert_eq!(
+            active_thread(&conversation_view, cx)
+                .read_with(cx, |view, _cx| view.message_queue.len()),
+            1
+        );
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6865,6 +6865,49 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_escape_dismisses_without_restoring(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Do not restore this prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let entry_count = active_thread(&conversation_view, cx)
+            .read_with(cx, |view, cx| view.thread.read(cx).entries().len());
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| editor_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Do not restore this prompt")
+        );
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+        cx.update(|window, cx| {
+            assert!(message_editor.read(cx).focus_handle(cx).is_focused(window));
+        });
+        active_thread(&conversation_view, cx).read_with(cx, |view, cx| {
+            assert_eq!(view.thread.read(cx).entries().len(), entry_count);
+            assert_eq!(view.thread.read(cx).status(), ThreadStatus::Idle);
+        });
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7240,6 +7240,71 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_restores_supported_structured_content(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let image_uri = acp_thread::MentionUri::PastedImage {
+            name: "History image".to_string(),
+        }
+        .to_uri()
+        .to_string();
+        let expected_blocks = vec![
+            acp::ContentBlock::Text(acp::TextContent::new("Before:")),
+            acp::ContentBlock::ResourceLink(acp::ResourceLink::new(
+                "link.rs",
+                "file:///project/link.rs",
+            )),
+            acp::ContentBlock::Text(acp::TextContent::new(":Between:")),
+            acp::ContentBlock::Resource(acp::EmbeddedResource::new(
+                acp::EmbeddedResourceResource::TextResourceContents(
+                    acp::TextResourceContents::new(
+                        "fn restored() {}",
+                        "file:///project/context.rs",
+                    ),
+                ),
+            )),
+            acp::ContentBlock::Text(acp::TextContent::new(":After:")),
+            acp::ContentBlock::Image(
+                acp::ImageContent::new(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+                    "image/png",
+                )
+                .uri(Some(image_uri)),
+            ),
+            acp::ContentBlock::Text(acp::TextContent::new(":Done")),
+        ];
+
+        let thread =
+            active_thread(&conversation_view, cx).read_with(cx, |view, _cx| view.thread.clone());
+        thread.update(cx, |thread, cx| {
+            for block in expected_blocks.iter().cloned() {
+                thread
+                    .handle_session_update(
+                        acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(block)),
+                        cx,
+                    )
+                    .expect("restored structured ACP prompt should be applied");
+            }
+        });
+        cx.run_until_parked();
+
+        let message_editor = message_editor(&conversation_view, cx);
+        cx.update(|window, cx| message_editor.focus_handle(cx).focus(window, cx));
+        cx.simulate_keystrokes("up enter");
+        cx.run_until_parked();
+
+        let restored_blocks =
+            message_editor.read_with(cx, |editor, cx| editor.draft_content_blocks_snapshot(cx));
+        assert_eq!(restored_blocks, expected_blocks);
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_prompt_history_only_opens_for_root_thread_input(cx: &mut TestAppContext) {
         init_test(cx);
         bind_default_linux_keymap(cx);

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6971,6 +6971,48 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_non_empty_draft_preserves_move_up(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("History prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let draft = "First line\nOther line";
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text(draft, window, cx);
+            editor.set_cursor_offset(draft.len(), window, cx);
+            editor.focus_handle(cx).focus(window, cx);
+        });
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert_eq!(
+            message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+            draft
+        );
+        message_editor.read_with(cx, |message_editor, cx| {
+            let editor = message_editor.editor().read(cx);
+            let selection = editor.selections.newest_anchor();
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let expected_offset = MultiBufferOffset("First line".len());
+            assert_eq!(selection.start.to_offset(&snapshot), expected_offset);
+            assert_eq!(selection.end.to_offset(&snapshot), expected_offset);
+        });
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7186,6 +7186,60 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_restores_resumed_acp_entry_without_client_id(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let thread_view = active_thread(&conversation_view, cx);
+        thread_view.update(cx, |view, cx| {
+            view.thread.update(cx, |thread, cx| {
+                thread
+                    .handle_session_update(
+                        acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(
+                            "Restored ACP prompt".into(),
+                        )),
+                        cx,
+                    )
+                    .expect("restored ACP prompt should be applied");
+            });
+        });
+        cx.run_until_parked();
+
+        thread_view.read_with(cx, |view, cx| {
+            let Some(AgentThreadEntry::UserMessage(message)) =
+                view.thread.read(cx).entries().last()
+            else {
+                panic!("restored entry should be a user message");
+            };
+            assert!(message.client_id.is_none());
+        });
+
+        let message_editor = message_editor(&conversation_view, cx);
+        cx.update(|window, cx| message_editor.focus_handle(cx).focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Restored ACP prompt")
+        );
+
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+
+        assert_eq!(
+            message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+            "Restored ACP prompt"
+        );
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_prompt_history_only_opens_for_root_thread_input(cx: &mut TestAppContext) {
         init_test(cx);
         bind_default_linux_keymap(cx);

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7143,6 +7143,49 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_thread_focus_preserves_line_scrolling(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("History prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let thread_view = active_thread(&conversation_view, cx);
+        draw_thread_list_at(
+            &thread_view,
+            ListOffset {
+                item_ix: 1,
+                offset_in_item: px(0.0),
+            },
+            cx,
+        );
+        let scroll_top_before =
+            thread_view.read_with(cx, |view, _cx| view.list_state.logical_scroll_top());
+        assert_eq!(scroll_top_before.item_ix, 1);
+
+        let thread_focus = thread_view.read_with(cx, |view, _cx| view.focus_handle.clone());
+        cx.update(|window, cx| thread_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        let scroll_top_after =
+            thread_view.read_with(cx, |view, _cx| view.list_state.logical_scroll_top());
+        assert!(scroll_top_after.item_ix < scroll_top_before.item_ix);
+        assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7043,6 +7043,56 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_move_up_propagates_when_disabled(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let move_up_propagated = Rc::new(Cell::new(false));
+        cx.update({
+            let move_up_propagated = move_up_propagated.clone();
+            move |cx| {
+                cx.on_action(move |_: &zed_actions::editor::MoveUp, _cx| {
+                    move_up_propagated.set(true)
+                });
+            }
+        });
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Available history", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            active_thread(&conversation_view, cx)
+                .read_with(cx, |view, cx| { view.prompt_history(cx).is_some() })
+        );
+        cx.update(|window, cx| {
+            AgentSettings::override_global(
+                AgentSettings {
+                    message_history_navigation: false,
+                    ..AgentSettings::get_global(cx).clone()
+                },
+                cx,
+            );
+            message_editor.focus_handle(cx).focus(window, cx);
+        });
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert!(move_up_propagated.get());
+        assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -3704,6 +3704,7 @@ pub(crate) mod tests {
     use serde_json::json;
     use settings::SettingsStore;
     use std::any::Any;
+    use std::cell::Cell;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::sync::Arc;
@@ -7009,6 +7010,35 @@ pub(crate) mod tests {
             assert_eq!(selection.start.to_offset(&snapshot), expected_offset);
             assert_eq!(selection.end.to_offset(&snapshot), expected_offset);
         });
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+    }
+
+    #[gpui::test]
+    async fn test_prompt_history_move_up_propagates_without_history(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let move_up_propagated = Rc::new(Cell::new(false));
+        cx.update({
+            let move_up_propagated = move_up_propagated.clone();
+            move |cx| {
+                cx.on_action(move |_: &zed_actions::editor::MoveUp, _cx| {
+                    move_up_propagated.set(true)
+                });
+            }
+        });
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        cx.update(|window, cx| message_editor.focus_handle(cx).focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert!(move_up_propagated.get());
+        assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
         assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
     }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6681,6 +6681,15 @@ pub(crate) mod tests {
             .read_with(cx, |view, cx| view.selected_prompt_history_preview(cx))
     }
 
+    fn prompt_history_horizontal_scroll_state(
+        conversation_view: &Entity<ConversationView>,
+        cx: &TestAppContext,
+    ) -> Option<(Pixels, Pixels)> {
+        active_thread(conversation_view, cx).read_with(cx, |view, cx| {
+            view.prompt_history_horizontal_scroll_state(cx)
+        })
+    }
+
     fn bind_default_linux_keymap(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let mut bindings = settings::KeymapFile::load_asset_allow_partial_failure(
@@ -6969,6 +6978,85 @@ pub(crate) mod tests {
             assert_eq!(view.thread.read(cx).entries().len(), entry_count);
             assert_eq!(view.thread.read(cx).status(), ThreadStatus::Idle);
         });
+    }
+
+    #[gpui::test]
+    async fn test_prompt_history_long_preview_stays_within_popup_width(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+        cx.simulate_resize(size(px(500.), px(600.)));
+        cx.run_until_parked();
+
+        let long_prompt = (0..100)
+            .map(|index| format!("prompt-word-{index}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text(&long_prompt, window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| editor_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        let assert_popup_is_width_constrained = |cx: &mut VisualTestContext| {
+            let window_bounds = cx.update(|window, _cx| window.bounds());
+            let popup_bounds = cx
+                .debug_bounds("agent-prompt-history-popover")
+                .expect("prompt history popup should be rendered");
+            let entry_bounds = cx
+                .debug_bounds("agent-prompt-history-entry-0")
+                .expect("prompt history entry should be rendered");
+            let preview_bounds = cx
+                .debug_bounds("agent-prompt-history-preview-0")
+                .expect("prompt history preview should be rendered");
+
+            assert!(
+                popup_bounds.left() >= window_bounds.left(),
+                "popup {popup_bounds:?} extends left of window {window_bounds:?}"
+            );
+            assert!(
+                popup_bounds.right() <= window_bounds.right(),
+                "popup {popup_bounds:?} extends right of window {window_bounds:?}"
+            );
+            assert!(entry_bounds.left() >= popup_bounds.left());
+            assert!(entry_bounds.right() <= popup_bounds.right());
+            assert!(preview_bounds.left() >= entry_bounds.left());
+            assert!(preview_bounds.right() <= entry_bounds.right());
+        };
+
+        assert_popup_is_width_constrained(cx);
+        let (horizontal_offset, horizontal_overflow) =
+            prompt_history_horizontal_scroll_state(&conversation_view, cx)
+                .expect("prompt history should be open");
+        assert_eq!(horizontal_offset, px(0.));
+        assert_eq!(horizontal_overflow, px(0.));
+
+        cx.simulate_resize(size(px(360.), px(600.)));
+        cx.run_until_parked();
+        assert_popup_is_width_constrained(cx);
+        let (horizontal_offset, horizontal_overflow) =
+            prompt_history_horizontal_scroll_state(&conversation_view, cx)
+                .expect("prompt history should remain open after resizing");
+        assert_eq!(horizontal_offset, px(0.));
+        assert_eq!(horizontal_overflow, px(0.));
+
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        assert_eq!(
+            message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+            long_prompt
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6704,6 +6704,23 @@ pub(crate) mod tests {
         cx.run_until_parked();
         assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
 
+        let history =
+            active_thread(&conversation_view, cx).read_with(cx, |view, cx| view.prompt_history(cx));
+        assert!(matches!(
+            history
+                .as_ref()
+                .and_then(|history| history.selected_chunks())
+                .and_then(|chunks| chunks.first()),
+            Some(acp::ContentBlock::Text(text)) if text.text == "Remember this prompt"
+        ));
+        assert_eq!(
+            history
+                .as_ref()
+                .and_then(|history| history.selected_preview())
+                .map(SharedString::as_ref),
+            Some("Remember this prompt")
+        );
+
         cx.simulate_keystrokes("up");
         cx.run_until_parked();
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6672,9 +6672,15 @@ pub(crate) mod tests {
         cx.read(|cx| thread.read(cx).message_editor.clone())
     }
 
-    #[gpui::test]
-    async fn test_prompt_history_opens_from_empty_editor(cx: &mut TestAppContext) {
-        init_test(cx);
+    fn selected_prompt_history_preview(
+        conversation_view: &Entity<ConversationView>,
+        cx: &TestAppContext,
+    ) -> Option<String> {
+        active_thread(conversation_view, cx)
+            .read_with(cx, |view, cx| view.selected_prompt_history_preview(cx))
+    }
+
+    fn bind_default_linux_keymap(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let mut bindings = settings::KeymapFile::load_asset_allow_partial_failure(
                 "keymaps/default-linux.json",
@@ -6686,6 +6692,12 @@ pub(crate) mod tests {
             }
             cx.bind_keys(bindings);
         });
+    }
+
+    #[gpui::test]
+    async fn test_prompt_history_opens_from_empty_editor(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
 
         let (conversation_view, cx) =
             setup_conversation_view(StubAgentServer::default_response(), cx).await;
@@ -6732,6 +6744,62 @@ pub(crate) mod tests {
                     .is_some_and(|entry| entry.key.as_ref() == "AgentPromptHistory")
             }));
         });
+    }
+
+    #[gpui::test]
+    async fn test_prompt_history_keyboard_navigation_clamps_at_boundaries(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let connection = StubAgentConnection::new();
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        for prompt in ["First", "Second", "Third"] {
+            connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+                acp::ContentChunk::new("Response".into()),
+            )]);
+            message_editor.update_in(cx, |editor, window, cx| {
+                editor.set_text(prompt, window, cx);
+            });
+            active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+                view.send(window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| editor_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Third")
+        );
+
+        cx.simulate_keystrokes("up up up");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("First")
+        );
+
+        cx.simulate_keystrokes("down");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Second")
+        );
+
+        cx.simulate_keystrokes("down down");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Third")
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -3694,8 +3694,8 @@ pub(crate) mod tests {
     use action_log::ActionLog;
     use agent::{AgentTool, EditFileTool, FetchTool, TerminalTool, ToolPermissionContext};
     use agent_servers::FakeAcpAgentServer;
-    use editor::MultiBufferOffset;
     use editor::actions::Paste;
+    use editor::{MultiBufferOffset, ToOffset};
     use feature_flags::{AcpBetaFeatureFlag, FeatureFlag as _, FeatureFlagAppExt as _};
     use fs::FakeFs;
     use gpui::{ClipboardItem, EventEmitter, TestAppContext, VisualTestContext, point, size};
@@ -6840,6 +6840,17 @@ pub(crate) mod tests {
                 message_editor.read_with(cx, |editor, cx| editor.text(cx)),
                 "Recall this prompt"
             );
+            message_editor.read_with(cx, |message_editor, cx| {
+                let editor = message_editor.editor().read(cx);
+                let selection = editor.selections.newest_anchor();
+                let snapshot = editor.buffer().read(cx).snapshot(cx);
+                let expected_offset = MultiBufferOffset("Recall this prompt".len());
+                assert_eq!(selection.start.to_offset(&snapshot), expected_offset);
+                assert_eq!(selection.end.to_offset(&snapshot), expected_offset);
+            });
+            cx.update(|window, cx| {
+                assert!(message_editor.read(cx).focus_handle(cx).is_focused(window));
+            });
             assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
             active_thread(&conversation_view, cx).read_with(cx, |view, cx| {
                 assert_eq!(view.thread.read(cx).entries().len(), entry_count);

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6672,6 +6672,51 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_opens_from_empty_editor(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            let mut bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+                "keymaps/default-linux.json",
+                cx,
+            )
+            .unwrap();
+            for binding in &mut bindings {
+                binding.set_meta(settings::KeybindSource::Default.meta());
+            }
+            cx.bind_keys(bindings);
+        });
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Remember this prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| editor_focus.focus(window, cx));
+        cx.run_until_parked();
+        assert!(message_editor.read_with(cx, |editor, cx| editor.is_empty(cx)));
+
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        cx.update(|window, _cx| {
+            assert!(window.context_stack().iter().any(|context| {
+                context
+                    .primary()
+                    .is_some_and(|entry| entry.key.as_ref() == "AgentPromptHistory")
+            }));
+        });
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -6908,6 +6908,69 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_click_accepts_clicked_entry(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let connection = StubAgentConnection::new();
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let message_editor = message_editor(&conversation_view, cx);
+        for prompt in ["First", "Second", "Third"] {
+            connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+                acp::ContentChunk::new("Response".into()),
+            )]);
+            message_editor.update_in(cx, |editor, window, cx| {
+                editor.set_text(prompt, window, cx);
+            });
+            active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+                view.send(window, cx);
+            });
+            cx.run_until_parked();
+        }
+
+        let entry_count = active_thread(&conversation_view, cx)
+            .read_with(cx, |view, cx| view.thread.read(cx).entries().len());
+        let editor_focus = message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| editor_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Third")
+        );
+
+        let first_entry_bounds = cx
+            .debug_bounds("agent-prompt-history-entry-0")
+            .expect("first prompt history entry should be rendered");
+        cx.simulate_click(first_entry_bounds.center(), gpui::Modifiers::none());
+        cx.run_until_parked();
+
+        assert_eq!(
+            message_editor.read_with(cx, |editor, cx| editor.text(cx)),
+            "First"
+        );
+        message_editor.read_with(cx, |message_editor, cx| {
+            let editor = message_editor.editor().read(cx);
+            let selection = editor.selections.newest_anchor();
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let expected_offset = MultiBufferOffset("First".len());
+            assert_eq!(selection.start.to_offset(&snapshot), expected_offset);
+            assert_eq!(selection.end.to_offset(&snapshot), expected_offset);
+        });
+        assert!(selected_prompt_history_preview(&conversation_view, cx).is_none());
+        cx.update(|window, cx| {
+            assert!(message_editor.read(cx).focus_handle(cx).is_focused(window));
+        });
+        active_thread(&conversation_view, cx).read_with(cx, |view, cx| {
+            assert_eq!(view.thread.read(cx).entries().len(), entry_count);
+            assert_eq!(view.thread.read(cx).status(), ThreadStatus::Idle);
+        });
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -109,6 +109,7 @@ pub(crate) const DRAFT_PROMPT_PERSIST_DEBOUNCE: Duration = Duration::from_millis
 
 pub(crate) mod elicitation;
 mod message_queue;
+mod prompt_history;
 mod thread_search_bar;
 mod thread_view;
 pub use message_queue::*;

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7186,6 +7186,90 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_prompt_history_only_opens_for_root_thread_input(cx: &mut TestAppContext) {
+        init_test(cx);
+        bind_default_linux_keymap(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let root_message_editor = message_editor(&conversation_view, cx);
+        root_message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Root history prompt", window, cx);
+        });
+        active_thread(&conversation_view, cx).update_in(cx, |view, window, cx| {
+            view.send(window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.update(|window, cx| root_message_editor.focus_handle(cx).focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+        assert_eq!(
+            selected_prompt_history_preview(&conversation_view, cx).as_deref(),
+            Some("Root history prompt")
+        );
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        let root_thread = active_thread(&conversation_view, cx);
+        let (parent_session_id, connection, project, conversation) =
+            root_thread.read_with(cx, |view, cx| {
+                let thread = view.thread.read(cx);
+                (
+                    thread.session_id().clone(),
+                    thread.connection().clone(),
+                    thread.project().clone(),
+                    view.conversation.clone(),
+                )
+            });
+        let subagent_session_id = acp::SessionId::new("subagent-history");
+        let subagent_thread = cx.update(|_window, cx| {
+            create_test_acp_thread(
+                Some(parent_session_id),
+                "subagent-history",
+                connection,
+                project,
+                cx,
+            )
+        });
+        subagent_thread.update(cx, |thread, cx| {
+            thread.push_user_content_block(
+                None,
+                acp::ContentBlock::Text(acp::TextContent::new("Subagent history prompt")),
+                cx,
+            );
+        });
+        conversation.update(cx, |conversation, cx| {
+            conversation.register_thread(subagent_thread.clone(), cx);
+        });
+        let subagent_view = conversation_view.update_in(cx, |view, window, cx| {
+            let subagent_view =
+                view.new_thread_view(subagent_thread, conversation, false, None, window, cx);
+            if let Some(connected) = view.as_connected_mut() {
+                connected
+                    .threads
+                    .insert(subagent_session_id.clone(), subagent_view.clone());
+            }
+            view.navigate_to_thread(subagent_session_id, window, cx);
+            subagent_view
+        });
+        cx.run_until_parked();
+
+        assert!(subagent_view.read_with(cx, |view, cx| view.prompt_history(cx).is_some()));
+        let subagent_focus = subagent_view.read_with(cx, |view, _cx| view.focus_handle.clone());
+        cx.update(|window, cx| subagent_focus.focus(window, cx));
+        cx.simulate_keystrokes("up");
+        cx.run_until_parked();
+
+        assert!(subagent_view.read_with(cx, |view, cx| {
+            view.message_editor.read(cx).is_empty(cx)
+                && view.selected_prompt_history_preview(cx).is_none()
+        }));
+    }
+
+    #[gpui::test]
     async fn test_rewind_views(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -48,6 +48,10 @@ impl PromptHistoryPopover {
     }
 
     fn confirm(&mut self, _: &menu::Confirm, _window: &mut Window, cx: &mut Context<Self>) {
+        self.accept_selected(cx);
+    }
+
+    fn accept_selected(&self, cx: &mut Context<Self>) {
         if let Some(chunks) = self.history.selected_chunks() {
             cx.emit(PromptHistoryPopoverEvent::Accepted(chunks.to_vec()));
         }
@@ -99,15 +103,28 @@ impl Render for PromptHistoryPopover {
                             .iter()
                             .enumerate()
                             .map(|(index, entry)| {
-                                ListItem::new(("agent-prompt-history-entry", index))
-                                    .inset(true)
-                                    .toggle_state(index == selected_index)
+                                div()
+                                    .w_full()
+                                    .debug_selector(|| {
+                                        format!("agent-prompt-history-entry-{index}")
+                                    })
                                     .child(
-                                        h_flex().w_full().min_w_0().child(
-                                            Label::new(entry.preview().clone())
-                                                .size(LabelSize::Small)
-                                                .truncate(),
-                                        ),
+                                        ListItem::new(("agent-prompt-history-entry", index))
+                                            .inset(true)
+                                            .toggle_state(index == selected_index)
+                                            .on_click(cx.listener(
+                                                move |this, _event, _window, cx| {
+                                                    this.history.select(index);
+                                                    this.accept_selected(cx);
+                                                },
+                                            ))
+                                            .child(
+                                                h_flex().w_full().min_w_0().child(
+                                                    Label::new(entry.preview().clone())
+                                                        .size(LabelSize::Small)
+                                                        .truncate(),
+                                                ),
+                                            ),
                                     )
                             }),
                     ),

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -1,4 +1,5 @@
-use gpui::{App, FocusHandle, Focusable, IntoElement, Render, ScrollHandle, Window};
+use agent_client_protocol::schema::v1 as acp;
+use gpui::{App, EventEmitter, FocusHandle, Focusable, IntoElement, Render, ScrollHandle, Window};
 use ui::{ListItem, WithScrollbar, prelude::*};
 
 use super::PromptHistory;
@@ -8,6 +9,12 @@ pub(super) struct PromptHistoryPopover {
     focus_handle: FocusHandle,
     scroll_handle: ScrollHandle,
 }
+
+pub(super) enum PromptHistoryPopoverEvent {
+    Accepted(Vec<acp::ContentBlock>),
+}
+
+impl EventEmitter<PromptHistoryPopoverEvent> for PromptHistoryPopover {}
 
 impl PromptHistoryPopover {
     pub(super) fn new(history: PromptHistory, cx: &mut Context<Self>) -> Self {
@@ -39,6 +46,12 @@ impl PromptHistoryPopover {
         cx.notify();
     }
 
+    fn confirm(&mut self, _: &menu::Confirm, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(chunks) = self.history.selected_chunks() {
+            cx.emit(PromptHistoryPopoverEvent::Accepted(chunks.to_vec()));
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn selected_preview(&self) -> Option<&str> {
         self.history
@@ -62,6 +75,7 @@ impl Render for PromptHistoryPopover {
             .key_context("AgentPromptHistory")
             .on_action(cx.listener(Self::select_previous))
             .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::confirm))
             .w_full()
             .flex_shrink_1()
             .elevation_2(cx)

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -12,6 +12,7 @@ pub(super) struct PromptHistoryPopover {
 
 pub(super) enum PromptHistoryPopoverEvent {
     Accepted(Vec<acp::ContentBlock>),
+    Dismissed,
 }
 
 impl EventEmitter<PromptHistoryPopoverEvent> for PromptHistoryPopover {}
@@ -52,6 +53,10 @@ impl PromptHistoryPopover {
         }
     }
 
+    fn cancel(&mut self, _: &menu::Cancel, _window: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(PromptHistoryPopoverEvent::Dismissed);
+    }
+
     #[cfg(test)]
     pub(super) fn selected_preview(&self) -> Option<&str> {
         self.history
@@ -76,6 +81,7 @@ impl Render for PromptHistoryPopover {
             .on_action(cx.listener(Self::select_previous))
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::confirm))
+            .on_action(cx.listener(Self::cancel))
             .w_full()
             .flex_shrink_1()
             .elevation_2(cx)

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -15,6 +15,28 @@ impl PromptHistoryPopover {
             focus_handle: cx.focus_handle(),
         }
     }
+
+    fn select_previous(
+        &mut self,
+        _: &menu::SelectPrevious,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.history.select_previous();
+        cx.notify();
+    }
+
+    fn select_next(&mut self, _: &menu::SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+        self.history.select_next();
+        cx.notify();
+    }
+
+    #[cfg(test)]
+    pub(super) fn selected_preview(&self) -> Option<&str> {
+        self.history
+            .selected_preview()
+            .map(|preview| preview.as_ref())
+    }
 }
 
 impl Focusable for PromptHistoryPopover {
@@ -24,9 +46,11 @@ impl Focusable for PromptHistoryPopover {
 }
 
 impl Render for PromptHistoryPopover {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .track_focus(&self.focus_handle)
             .key_context("AgentPromptHistory")
+            .on_action(cx.listener(Self::select_previous))
+            .on_action(cx.listener(Self::select_next))
     }
 }

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -1,0 +1,32 @@
+use gpui::{App, FocusHandle, Focusable, IntoElement, Render, Window};
+use ui::prelude::*;
+
+use super::PromptHistory;
+
+pub(super) struct PromptHistoryPopover {
+    history: PromptHistory,
+    focus_handle: FocusHandle,
+}
+
+impl PromptHistoryPopover {
+    pub(super) fn new(history: PromptHistory, cx: &mut Context<Self>) -> Self {
+        Self {
+            history,
+            focus_handle: cx.focus_handle(),
+        }
+    }
+}
+
+impl Focusable for PromptHistoryPopover {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for PromptHistoryPopover {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("AgentPromptHistory")
+    }
+}

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -1,18 +1,22 @@
-use gpui::{App, FocusHandle, Focusable, IntoElement, Render, Window};
-use ui::prelude::*;
+use gpui::{App, FocusHandle, Focusable, IntoElement, Render, ScrollHandle, Window};
+use ui::{ListItem, WithScrollbar, prelude::*};
 
 use super::PromptHistory;
 
 pub(super) struct PromptHistoryPopover {
     history: PromptHistory,
     focus_handle: FocusHandle,
+    scroll_handle: ScrollHandle,
 }
 
 impl PromptHistoryPopover {
     pub(super) fn new(history: PromptHistory, cx: &mut Context<Self>) -> Self {
+        let scroll_handle = ScrollHandle::new();
+        scroll_handle.scroll_to_item(history.selected_index());
         Self {
             history,
             focus_handle: cx.focus_handle(),
+            scroll_handle,
         }
     }
 
@@ -23,11 +27,15 @@ impl PromptHistoryPopover {
         cx: &mut Context<Self>,
     ) {
         self.history.select_previous();
+        self.scroll_handle
+            .scroll_to_item(self.history.selected_index());
         cx.notify();
     }
 
     fn select_next(&mut self, _: &menu::SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
         self.history.select_next();
+        self.scroll_handle
+            .scroll_to_item(self.history.selected_index());
         cx.notify();
     }
 
@@ -46,11 +54,44 @@ impl Focusable for PromptHistoryPopover {
 }
 
 impl Render for PromptHistoryPopover {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        div()
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let selected_index = self.history.selected_index();
+
+        v_flex()
             .track_focus(&self.focus_handle)
             .key_context("AgentPromptHistory")
             .on_action(cx.listener(Self::select_previous))
             .on_action(cx.listener(Self::select_next))
+            .w_full()
+            .flex_shrink_1()
+            .elevation_2(cx)
+            .child(
+                v_flex()
+                    .id("agent-prompt-history-list")
+                    .w_full()
+                    .max_h_40()
+                    .p_1()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.scroll_handle)
+                    .children(
+                        self.history
+                            .entries()
+                            .iter()
+                            .enumerate()
+                            .map(|(index, entry)| {
+                                ListItem::new(("agent-prompt-history-entry", index))
+                                    .inset(true)
+                                    .toggle_state(index == selected_index)
+                                    .child(
+                                        h_flex().w_full().min_w_0().child(
+                                            Label::new(entry.preview().clone())
+                                                .size(LabelSize::Small)
+                                                .truncate(),
+                                        ),
+                                    )
+                            }),
+                    ),
+            )
+            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
     }
 }

--- a/crates/agent_ui/src/conversation_view/prompt_history.rs
+++ b/crates/agent_ui/src/conversation_view/prompt_history.rs
@@ -67,6 +67,14 @@ impl PromptHistoryPopover {
             .selected_preview()
             .map(|preview| preview.as_ref())
     }
+
+    #[cfg(test)]
+    pub(super) fn horizontal_scroll_state(&self) -> (gpui::Pixels, gpui::Pixels) {
+        (
+            self.scroll_handle.offset().x,
+            self.scroll_handle.max_offset().x,
+        )
+    }
 }
 
 impl Focusable for PromptHistoryPopover {
@@ -80,6 +88,7 @@ impl Render for PromptHistoryPopover {
         let selected_index = self.history.selected_index();
 
         v_flex()
+            .debug_selector(|| "agent-prompt-history-popover".to_string())
             .track_focus(&self.focus_handle)
             .key_context("AgentPromptHistory")
             .on_action(cx.listener(Self::select_previous))
@@ -87,14 +96,18 @@ impl Render for PromptHistoryPopover {
             .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::cancel))
             .w_full()
+            .min_w_0()
             .flex_shrink_1()
+            .overflow_x_hidden()
             .elevation_2(cx)
             .child(
                 v_flex()
                     .id("agent-prompt-history-list")
                     .w_full()
+                    .min_w_0()
                     .max_h_40()
                     .p_1()
+                    .overflow_x_hidden()
                     .overflow_y_scroll()
                     .track_scroll(&self.scroll_handle)
                     .children(
@@ -105,6 +118,8 @@ impl Render for PromptHistoryPopover {
                             .map(|(index, entry)| {
                                 div()
                                     .w_full()
+                                    .min_w_0()
+                                    .overflow_x_hidden()
                                     .debug_selector(|| {
                                         format!("agent-prompt-history-entry-{index}")
                                     })
@@ -119,11 +134,21 @@ impl Render for PromptHistoryPopover {
                                                 },
                                             ))
                                             .child(
-                                                h_flex().w_full().min_w_0().child(
-                                                    Label::new(entry.preview().clone())
-                                                        .size(LabelSize::Small)
-                                                        .truncate(),
-                                                ),
+                                                h_flex()
+                                                    .w_full()
+                                                    .min_w_0()
+                                                    .overflow_x_hidden()
+                                                    .debug_selector(move || {
+                                                        format!(
+                                                            "agent-prompt-history-preview-{index}"
+                                                        )
+                                                    })
+                                                    .child(
+                                                        Label::new(entry.preview().clone())
+                                                            .size(LabelSize::Small)
+                                                            .flex_1()
+                                                            .truncate(),
+                                                    ),
                                             ),
                                     )
                             }),

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -12960,6 +12960,79 @@ mod tests {
     }
 
     #[test]
+    fn test_prompt_history_deduplicates_complete_structured_content_by_latest_occurrence() {
+        let resource_link = |uri| {
+            vec![
+                acp::ContentBlock::Text(acp::TextContent::new("Review:")),
+                acp::ContentBlock::ResourceLink(acp::ResourceLink::new("same.rs", uri)),
+            ]
+        };
+        let embedded_resource = |content| {
+            vec![
+                acp::ContentBlock::Text(acp::TextContent::new("Review:")),
+                acp::ContentBlock::Resource(acp::EmbeddedResource::new(
+                    acp::EmbeddedResourceResource::TextResourceContents(
+                        acp::TextResourceContents::new(content, "file:///project/same.rs"),
+                    ),
+                )),
+            ]
+        };
+        let image = |data| {
+            vec![
+                acp::ContentBlock::Text(acp::TextContent::new("Review:")),
+                acp::ContentBlock::Image(
+                    acp::ImageContent::new(data, "image/png")
+                        .uri(Some("zed:///agent/pasted-image?name=Same".to_string())),
+                ),
+            ]
+        };
+
+        let link_a = resource_link("file:///project/a/same.rs");
+        let link_b = resource_link("file:///project/b/same.rs");
+        let resource_a = embedded_resource("first contents");
+        let resource_b = embedded_resource("second contents");
+        let image_a = image("first-image-data");
+        let image_b = image("second-image-data");
+
+        assert_eq!(
+            prompt_history_preview(&link_a),
+            prompt_history_preview(&link_b)
+        );
+        assert_eq!(
+            prompt_history_preview(&resource_a),
+            prompt_history_preview(&resource_b)
+        );
+        assert_eq!(
+            prompt_history_preview(&image_a),
+            prompt_history_preview(&image_b)
+        );
+
+        let history = PromptHistory::from_prompts([
+            link_a.clone(),
+            resource_a.clone(),
+            image_a.clone(),
+            link_b.clone(),
+            resource_b.clone(),
+            image_b.clone(),
+            link_a.clone(),
+            resource_a.clone(),
+            image_a.clone(),
+        ])
+        .expect("history should contain structured prompts");
+
+        let prompts = history
+            .entries()
+            .iter()
+            .map(|entry| entry.chunks.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            prompts,
+            vec![link_b, resource_b, image_b, link_a, resource_a, image_a]
+        );
+        assert_eq!(history.selected_index(), prompts.len() - 1);
+    }
+
+    #[test]
     fn test_prompt_history_navigation_clamps_at_boundaries() {
         fn selected_text(history: &PromptHistory) -> Option<&str> {
             let acp::ContentBlock::Text(text) = history.selected_chunks()?.first()? else {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -860,6 +860,16 @@ impl PromptHistory {
             .get(self.selected_index)
             .map(PromptHistoryEntry::preview)
     }
+
+    pub(super) fn select_previous(&mut self) {
+        self.selected_index = self.selected_index.saturating_sub(1);
+    }
+
+    pub(super) fn select_next(&mut self) {
+        if let Some(last_index) = self.entries.len().checked_sub(1) {
+            self.selected_index = self.selected_index.saturating_add(1).min(last_index);
+        }
+    }
 }
 
 impl ThreadView {
@@ -12860,6 +12870,37 @@ mod tests {
             Some("First prompt")
         );
         assert!(PromptHistory::from_prompts([]).is_none());
+    }
+
+    #[test]
+    fn test_prompt_history_navigation_clamps_at_boundaries() {
+        fn selected_text(history: &PromptHistory) -> Option<&str> {
+            let acp::ContentBlock::Text(text) = history.selected_chunks()?.first()? else {
+                return None;
+            };
+            Some(text.text.as_str())
+        }
+
+        let prompt = |text| vec![acp::ContentBlock::Text(acp::TextContent::new(text))];
+        let mut history =
+            PromptHistory::from_prompts([prompt("First"), prompt("Second"), prompt("Third")])
+                .expect("history should contain prompts");
+
+        assert_eq!(selected_text(&history), Some("Third"));
+
+        history.select_previous();
+        assert_eq!(selected_text(&history), Some("Second"));
+        history.select_previous();
+        assert_eq!(selected_text(&history), Some("First"));
+        history.select_previous();
+        assert_eq!(selected_text(&history), Some("First"));
+
+        history.select_next();
+        assert_eq!(selected_text(&history), Some("Second"));
+        history.select_next();
+        assert_eq!(selected_text(&history), Some("Third"));
+        history.select_next();
+        assert_eq!(selected_text(&history), Some("Third"));
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -772,6 +772,96 @@ pub fn open_markdown_in_workspace(
     })
 }
 
+pub(super) struct PromptHistoryEntry {
+    chunks: Vec<acp::ContentBlock>,
+    preview: SharedString,
+}
+
+impl PromptHistoryEntry {
+    fn new(chunks: Vec<acp::ContentBlock>) -> Self {
+        let preview = prompt_history_preview(&chunks);
+        Self { chunks, preview }
+    }
+
+    pub(super) fn preview(&self) -> &SharedString {
+        &self.preview
+    }
+}
+
+fn prompt_history_preview(chunks: &[acp::ContentBlock]) -> SharedString {
+    let mut preview = String::new();
+    let mut append = |text: &str| {
+        for word in text.split_whitespace() {
+            if !preview.is_empty() {
+                preview.push(' ');
+            }
+            preview.push_str(word);
+        }
+    };
+
+    for chunk in chunks {
+        match chunk {
+            acp::ContentBlock::Text(text) => append(&text.text),
+            acp::ContentBlock::ResourceLink(resource) => append(&resource.name),
+            acp::ContentBlock::Resource(resource) => match &resource.resource {
+                acp::EmbeddedResourceResource::TextResourceContents(resource) => {
+                    append(&resource.uri)
+                }
+                acp::EmbeddedResourceResource::BlobResourceContents(resource) => {
+                    append(&resource.uri)
+                }
+                _ => {}
+            },
+            acp::ContentBlock::Image(_) => append("Image"),
+            acp::ContentBlock::Audio(_) => append("Audio"),
+            _ => {}
+        }
+    }
+
+    preview.into()
+}
+
+pub(super) struct PromptHistory {
+    entries: Vec<PromptHistoryEntry>,
+    selected_index: usize,
+}
+
+impl PromptHistory {
+    fn from_prompts(prompts: impl IntoIterator<Item = Vec<acp::ContentBlock>>) -> Option<Self> {
+        let mut entries: Vec<PromptHistoryEntry> = Vec::new();
+        for chunks in prompts {
+            entries.retain(|entry| entry.chunks != chunks);
+            entries.push(PromptHistoryEntry::new(chunks));
+        }
+        let selected_index = entries.len().checked_sub(1)?;
+        Some(Self {
+            entries,
+            selected_index,
+        })
+    }
+
+    fn from_thread_entries(entries: &[AgentThreadEntry]) -> Option<Self> {
+        Self::from_prompts(entries.iter().filter_map(|entry| {
+            let AgentThreadEntry::UserMessage(message) = entry else {
+                return None;
+            };
+            (!message.indented).then(|| message.chunks.clone())
+        }))
+    }
+
+    pub(super) fn selected_chunks(&self) -> Option<&[acp::ContentBlock]> {
+        self.entries
+            .get(self.selected_index)
+            .map(|entry| entry.chunks.as_slice())
+    }
+
+    pub(super) fn selected_preview(&self) -> Option<&SharedString> {
+        self.entries
+            .get(self.selected_index)
+            .map(PromptHistoryEntry::preview)
+    }
+}
+
 impl ThreadView {
     pub(crate) fn new(
         root_thread_id: ThreadId,
@@ -1253,6 +1343,10 @@ impl ThreadView {
 
     pub fn has_queued_messages(&self) -> bool {
         !self.message_queue.is_empty()
+    }
+
+    pub(super) fn prompt_history(&self, cx: &App) -> Option<PromptHistory> {
+        PromptHistory::from_thread_entries(self.thread.read(cx).entries())
     }
 
     // events
@@ -12730,6 +12824,42 @@ mod tests {
         );
         // No matching prefix: returns the trimmed input unchanged.
         assert_eq!(strip_leading_command("hello", "compact"), "hello");
+    }
+
+    #[test]
+    fn test_prompt_history_keeps_latest_occurrence_selected() {
+        fn prompt_text(chunks: &[acp::ContentBlock]) -> Option<&str> {
+            let acp::ContentBlock::Text(text) = chunks.first()? else {
+                return None;
+            };
+            Some(text.text.as_str())
+        }
+
+        let prompt = |text| vec![acp::ContentBlock::Text(acp::TextContent::new(text))];
+
+        let history = PromptHistory::from_prompts([
+            prompt("First\n prompt"),
+            prompt("Second"),
+            prompt("First\n prompt"),
+        ])
+        .expect("history should contain unique prompts");
+
+        let prompt_texts = history
+            .entries
+            .iter()
+            .filter_map(|entry| prompt_text(&entry.chunks))
+            .collect::<Vec<_>>();
+
+        assert_eq!(prompt_texts, vec!["Second", "First\n prompt"]);
+        assert_eq!(
+            history.selected_chunks().and_then(prompt_text),
+            Some("First\n prompt")
+        );
+        assert_eq!(
+            history.selected_preview().map(SharedString::as_ref),
+            Some("First prompt")
+        );
+        assert!(PromptHistory::from_prompts([]).is_none());
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1362,6 +1362,15 @@ impl ThreadView {
         PromptHistory::from_thread_entries(self.thread.read(cx).entries())
     }
 
+    #[cfg(test)]
+    pub(super) fn selected_prompt_history_preview(&self, cx: &App) -> Option<String> {
+        self.prompt_history_popover
+            .as_ref()?
+            .read(cx)
+            .selected_preview()
+            .map(str::to_owned)
+    }
+
     // events
 
     pub fn handle_entry_view_event(

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -51,6 +51,7 @@ use workspace::{OpenOptions, SERIALIZATION_THROTTLE_TIME};
 use super::elicitation::{
     ElicitationCard, ElicitationCardHandlers, ElicitationFormState, should_render_elicitation,
 };
+use super::prompt_history::PromptHistoryPopover;
 use super::*;
 
 const DATA_RETENTION_LEARN_MORE_URL: &str = "https://support.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models";
@@ -621,6 +622,7 @@ pub struct ThreadView {
     pub in_flight_prompt: Option<Vec<acp::ContentBlock>>,
     pub _subscriptions: Vec<Subscription>,
     pub message_editor: Entity<MessageEditor>,
+    prompt_history_popover: Option<Entity<PromptHistoryPopover>>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub fast_mode_menu_handle: PopoverMenuHandle<ContextMenu>,
@@ -1134,6 +1136,7 @@ impl ThreadView {
             hovered_edited_file_buttons: None,
             in_flight_prompt: None,
             message_editor,
+            prompt_history_popover: None,
             add_context_menu_handle: PopoverMenuHandle::default(),
             thinking_effort_menu_handle: PopoverMenuHandle::default(),
             fast_mode_menu_handle: PopoverMenuHandle::default(),
@@ -2467,11 +2470,35 @@ impl ThreadView {
             cx.propagate();
             return;
         }
-        let Some(last_id) = self.message_queue.last_id() else {
-            cx.propagate();
+
+        if let Some(last_id) = self.message_queue.last_id() {
+            self.move_queued_message_to_main_editor(last_id, None, None, window, cx);
             return;
+        }
+
+        if !self.open_prompt_history(window, cx) {
+            cx.propagate();
+        }
+    }
+
+    fn open_prompt_history(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.is_subagent()
+            || !AgentSettings::get_global(cx).message_history_navigation
+            || !self.message_editor.focus_handle(cx).is_focused(window)
+            || !self.message_editor.read(cx).is_empty(cx)
+        {
+            return false;
+        }
+
+        let Some(history) = self.prompt_history(cx) else {
+            return false;
         };
-        self.move_queued_message_to_main_editor(last_id, None, None, window, cx);
+        let popover = cx.new(|cx| PromptHistoryPopover::new(history, cx));
+        let focus_handle = popover.focus_handle(cx);
+        self.prompt_history_popover = Some(popover);
+        focus_handle.focus(window, cx);
+        cx.notify();
+        true
     }
 
     // editor methods
@@ -4489,6 +4516,7 @@ impl ThreadView {
                             .when(fills_container, |this| this.flex_1())
                             .pt_1()
                             .pr_2p5()
+                            .children(self.prompt_history_popover.clone())
                             .child(self.message_editor.clone())
                             .when(has_messages, |this| {
                                 this.child(

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2520,6 +2520,9 @@ impl ThreadView {
                 PromptHistoryPopoverEvent::Accepted(chunks) => {
                     this.accept_prompt_history(chunks.clone(), window, cx);
                 }
+                PromptHistoryPopoverEvent::Dismissed => {
+                    this.dismiss_prompt_history(window, cx);
+                }
             },
         );
         let focus_handle = popover.focus_handle(cx);
@@ -2536,14 +2539,18 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.prompt_history_popover = None;
-        self._prompt_history_subscription = None;
         self.message_editor.update(cx, |editor, cx| {
             editor.set_message(chunks, window, cx);
             let cursor_offset = editor.text(cx).len();
             editor.set_cursor_offset(cursor_offset, window, cx);
-            editor.focus_handle(cx).focus(window, cx);
         });
+        self.dismiss_prompt_history(window, cx);
+    }
+
+    fn dismiss_prompt_history(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.prompt_history_popover = None;
+        self._prompt_history_subscription = None;
+        self.message_editor.focus_handle(cx).focus(window, cx);
         cx.notify();
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -51,7 +51,7 @@ use workspace::{OpenOptions, SERIALIZATION_THROTTLE_TIME};
 use super::elicitation::{
     ElicitationCard, ElicitationCardHandlers, ElicitationFormState, should_render_elicitation,
 };
-use super::prompt_history::PromptHistoryPopover;
+use super::prompt_history::{PromptHistoryPopover, PromptHistoryPopoverEvent};
 use super::*;
 
 const DATA_RETENTION_LEARN_MORE_URL: &str = "https://support.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models";
@@ -623,6 +623,7 @@ pub struct ThreadView {
     pub _subscriptions: Vec<Subscription>,
     pub message_editor: Entity<MessageEditor>,
     prompt_history_popover: Option<Entity<PromptHistoryPopover>>,
+    _prompt_history_subscription: Option<Subscription>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub fast_mode_menu_handle: PopoverMenuHandle<ContextMenu>,
@@ -1145,6 +1146,7 @@ impl ThreadView {
             in_flight_prompt: None,
             message_editor,
             prompt_history_popover: None,
+            _prompt_history_subscription: None,
             add_context_menu_handle: PopoverMenuHandle::default(),
             thinking_effort_menu_handle: PopoverMenuHandle::default(),
             fast_mode_menu_handle: PopoverMenuHandle::default(),
@@ -2511,11 +2513,35 @@ impl ThreadView {
             return false;
         };
         let popover = cx.new(|cx| PromptHistoryPopover::new(history, cx));
+        let subscription = cx.subscribe_in(
+            &popover,
+            window,
+            |this, _popover, event, window, cx| match event {
+                PromptHistoryPopoverEvent::Accepted(chunks) => {
+                    this.accept_prompt_history(chunks.clone(), window, cx);
+                }
+            },
+        );
         let focus_handle = popover.focus_handle(cx);
         self.prompt_history_popover = Some(popover);
+        self._prompt_history_subscription = Some(subscription);
         focus_handle.focus(window, cx);
         cx.notify();
         true
+    }
+
+    fn accept_prompt_history(
+        &mut self,
+        chunks: Vec<acp::ContentBlock>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.prompt_history_popover = None;
+        self._prompt_history_subscription = None;
+        self.message_editor.update(cx, |editor, cx| {
+            editor.set_message(chunks, window, cx);
+        });
+        cx.notify();
     }
 
     // editor methods

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -881,6 +881,12 @@ impl PromptHistory {
             self.selected_index = self.selected_index.saturating_add(1).min(last_index);
         }
     }
+
+    pub(super) fn select(&mut self, index: usize) {
+        if self.entries.get(index).is_some() {
+            self.selected_index = index;
+        }
+    }
 }
 
 impl ThreadView {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2540,6 +2540,9 @@ impl ThreadView {
         self._prompt_history_subscription = None;
         self.message_editor.update(cx, |editor, cx| {
             editor.set_message(chunks, window, cx);
+            let cursor_offset = editor.text(cx).len();
+            editor.set_cursor_offset(cursor_offset, window, cx);
+            editor.focus_handle(cx).focus(window, cx);
         });
         cx.notify();
     }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -851,6 +851,14 @@ impl PromptHistory {
         }))
     }
 
+    pub(super) fn entries(&self) -> &[PromptHistoryEntry] {
+        &self.entries
+    }
+
+    pub(super) fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
     pub(super) fn selected_chunks(&self) -> Option<&[acp::ContentBlock]> {
         self.entries
             .get(self.selected_index)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1388,6 +1388,19 @@ impl ThreadView {
             .map(str::to_owned)
     }
 
+    #[cfg(test)]
+    pub(super) fn prompt_history_horizontal_scroll_state(
+        &self,
+        cx: &App,
+    ) -> Option<(Pixels, Pixels)> {
+        Some(
+            self.prompt_history_popover
+                .as_ref()?
+                .read(cx)
+                .horizontal_scroll_state(),
+        )
+    }
+
     // events
 
     pub fn handle_entry_view_event(
@@ -4543,6 +4556,8 @@ impl ThreadView {
         let fills_container = !has_messages || editor_expanded;
 
         h_flex()
+            .w_full()
+            .min_w_0()
             .py_2()
             .bg(editor_bg_color)
             .justify_center()
@@ -4559,6 +4574,7 @@ impl ThreadView {
             })
             .child(
                 v_flex()
+                    .min_w_0()
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
                     .when(max_content_width.is_none(), |this| this.w_full())
                     .min_w_0()
@@ -4572,6 +4588,7 @@ impl ThreadView {
                         v_flex()
                             .relative()
                             .w_full()
+                            .min_w_0()
                             .min_h_0()
                             .when(fills_container, |this| this.flex_1())
                             .pt_1()

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -866,6 +866,7 @@ impl PromptHistory {
             .map(|entry| entry.chunks.as_slice())
     }
 
+    #[cfg(test)]
     pub(super) fn selected_preview(&self) -> Option<&SharedString> {
         self.entries
             .get(self.selected_index)

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -328,6 +328,10 @@ pub struct AgentSettingsContent {
     ///
     /// Default: false
     pub use_modifier_to_send: Option<bool>,
+    /// Whether pressing the up arrow in an empty agent message editor opens prompt history.
+    ///
+    /// Default: true
+    pub message_history_navigation: Option<bool>,
     /// Minimum number of lines of height the agent message editor should have.
     ///
     /// Default: 4

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8653,6 +8653,29 @@ fn ai_page(cx: &App) -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Message History Navigation",
+                description: "Whether pressing the up arrow in an empty agent message editor opens prompt history.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("agent.message_history_navigation"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()?
+                            .message_history_navigation
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .message_history_navigation = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Message Editor Min Lines",
                 description: "Minimum number of lines to display in the agent message editor.",
                 field: Box::new(SettingField {

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -90,6 +90,31 @@ In long conversations, use the scroll arrow buttons at the bottom of the panel t
 
 When focus is in the message editor, you can also use {#kb agent::ScrollOutputPageUp}, {#kb agent::ScrollOutputPageDown}, {#kb agent::ScrollOutputToTop}, {#kb agent::ScrollOutputToBottom}, {#kb agent::ScrollOutputLineUp}, and {#kb agent::ScrollOutputLineDown} to navigate the thread, or {#kb agent::ScrollOutputToPreviousMessage} and {#kb agent::ScrollOutputToNextMessage} to jump between your prompts.
 
+#### Reusing Previous Prompts {#prompt-history-navigation}
+
+In a top-level agent thread, focus the empty message editor and press
+{#kb editor::MoveUp} to open prompts that you previously submitted in that
+thread. Use {#kb menu::SelectPrevious} and {#kb menu::SelectNext} to move through
+the list. Press {#kb menu::Confirm} to restore the selected prompt without
+sending it, or {#kb menu::Cancel} to close the list and leave the editor empty.
+You can also click a prompt to restore it.
+
+Prompt history preserves supported context in the original prompt, including
+resource links, embedded text resources, and images. Repeated prompts appear at
+the position of their latest occurrence.
+
+Arrow behavior depends on focus and editor state:
+
+- When the message editor contains a draft, arrow keys move the cursor normally.
+- When a queued prompt is available, {#kb editor::MoveUp} restores the most
+  recently queued prompt before opening history.
+- When the thread pane is focused, arrow keys scroll the conversation.
+- Subagent views do not open prompt history.
+
+Prompt history navigation is enabled by default. You can change it with the
+[`agent.message_history_navigation`](./agent-settings.md#prompt-history-navigation)
+setting.
+
 ### Thread titles {#thread-titles}
 
 Thread titles are auto-generated based on the content of the conversation.

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -107,6 +107,27 @@ By default, context compaction (both `/compact` and auto-compaction) uses the th
 
 - The configured model should have a context window at least as large as the thread's primary model for predictable behavior.
 
+## Prompt History Navigation {#prompt-history-navigation}
+
+Message history navigation is enabled by default. When the top-level Agent
+Panel message editor is focused and empty, {#kb editor::MoveUp} opens prompts
+previously submitted in that thread. See
+[Reusing Previous Prompts](./agent-panel.md#prompt-history-navigation) for the
+full focus and arrow-key behavior.
+
+To disable prompt history navigation, turn off **Message History Navigation** in
+the AI settings page.
+
+Or add this to your settings.json:
+
+```json [settings]
+{
+  "agent": {
+    "message_history_navigation": false
+  }
+}
+```
+
 ## External Agents {#external-agents}
 
 The External Agents section configures ACP-integrated agents.


### PR DESCRIPTION
# Objective

- Add shell-style prompt history navigation to the Agent Panel, making it faster to reuse or modify prompts previously submitted in the current thread.
- Implements the feature proposed in [Discussion #62611](https://github.com/zed-industries/zed/discussions/62611).

## Solution

- Pressing <kbd>↑</kbd> in an empty, focused message editor opens a prompt history popover.
- The popover supports:
  - <kbd>↑</kbd>/<kbd>↓</kbd> navigation
  - <kbd>Enter</kbd> or <kbd>Tab</kbd> to restore the selected prompt without submitting it
  - Mouse selection
  - <kbd>Esc</kbd> to dismiss
- Restored prompts remain editable before submission.
- History is reconstructed from user messages in the current thread, so it persists when the thread is reopened.
- Structured prompt content—including text, images, resource links, and embedded resources—is preserved.
- Duplicate prompts are collapsed based on their complete structured content, with the latest occurrence determining their position.
- Existing behavior is preserved when:
  - The editor contains a draft
  - A queued prompt can be restored
  - The conversation pane has focus
  - The current view belongs to a subagent
- Adds the `agent.message_history_navigation` setting, enabled by default and exposed in the AI settings UI.
- Adds documentation and default keybindings for macOS, Linux, and Windows.

## Testing

- Added unit and GPUI coverage for:
  - Opening history from an empty editor
  - Keyboard navigation and boundary handling
  - Restoring prompts with <kbd>Enter</kbd> and <kbd>Tab</kbd>
  - Mouse selection and <kbd>Esc</kbd> dismissal
  - Preserving normal arrow-key behavior for drafts and the conversation pane
  - Prioritizing queued prompts
  - Disabled history navigation
  - Root-thread versus subagent behavior
  - Restored ACP threads
  - Structured content round-tripping and deduplication
  - Constraining long previews to the popup width
- The focused tests can be run with:

  ```sh
  cargo test -p agent_ui prompt_history
  ```
  
- Reviewers can also test manually:
  1. Submit several prompts in a top-level Agent Panel thread.
  2. Focus the empty message editor and press <kbd>↑</kbd>.
  3. Navigate the history and restore an entry using the keyboard or mouse.
  4. Confirm the prompt is restored without being submitted and can still be edited.
  5. Reopen the thread and confirm its prompt history remains available.
  6. Disable Message History Navigation in AI settings and confirm <kbd>↑</kbd> resumes its previous behavior.
- The keybindings are defined for macOS, Linux, and Windows. Platform-specific manual verification is still welcome.
Self-Review Checklist:
- I've reviewed my own diff for quality, security, and reliability
- Unsafe blocks (if any) have justifying comments
- The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- Tests cover the new/changed behavior
- Performance impact has been considered and is acceptable

## Showcase

See the video in [Discussion #62611](https://github.com/zed-industries/zed/discussions/62611).