### PR TITLE
Fix close tab hotkey closing side panel

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -728,7 +728,7 @@
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
       "f5": "debugger::Rerun",
       "ctrl-f4": "workspace::CloseActiveDock",
-      "ctrl-w": "workspace::CloseActiveDock",
+      "ctrl-w": ["pane::CloseActiveItem", { "close_pinned": false }],
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -766,7 +766,7 @@
       "cmd-k shift-down": "workspace::SwapPaneDown",
       "cmd-shift-x": "zed::Extensions",
       "f5": "debugger::Rerun",
-      "cmd-w": "workspace::CloseActiveDock",
+      "cmd-w": ["pane::CloseActiveItem", { "close_pinned": false }],
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -715,7 +715,7 @@
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
       "f5": "debugger::Rerun",
       "ctrl-f4": "workspace::CloseActiveDock",
-      "ctrl-w": "workspace::CloseActiveDock",
+      "ctrl-w": ["pane::CloseActiveItem", { "close_pinned": false }],
     },
   },
   {


### PR DESCRIPTION
Fixes #34865.

User story:
- I click on a file in the "Explorer" pane.
- This causes a new tab to be opened with the new file.
- I press "Ctrl+w", assuming that the new file tab will be closed. (This is what would happen in Visual Studio Code and is what I expect as a new Zed user.)
- Instead, the "Explorer" pane closes, because the mouse click does not properly send the "focus" to the new tab.

Personally, I would argue that after clicking on a new file, full editor focus should shift to the new file, so that I can start to navigate it with the keyboard arrows, the keyboard page up / page down keys and so on. But this is a bit debatable, so this PR is more conservative - I just leverage the already-coded "close_pinned" feature.

You can let me know if you want another PR to fix the focus behavior itself.

## Testing

I tested the changes by using a custom keybind, which worked great.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed "Ctrl + w" closing the side panel.