### PR TITLE
agent: Support non-blocking tool calls

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -817,6 +817,7 @@ impl NativeAgent {
         let subscriptions = vec![
             cx.subscribe(&thread_handle, Self::handle_thread_title_updated),
             cx.subscribe(&thread_handle, Self::handle_thread_token_usage_updated),
+            cx.subscribe(&thread_handle, Self::handle_thread_continuation_requested),
             cx.observe(&thread_handle, move |this, thread, cx| {
                 this.save_thread(thread, cx)
             }),
@@ -1334,6 +1335,37 @@ impl NativeAgent {
         session.acp_thread.update(cx, |acp_thread, cx| {
             acp_thread.update_token_usage(usage.0.clone(), cx);
         });
+    }
+
+    /// A non-blocking tool call finished while the thread was idle: start a
+    /// continuation turn so its queued result is delivered to the model, and
+    /// forward the turn's events to the session's ACP thread so the activity
+    /// is visible (mirrors how MCP prompts drive thread turns).
+    fn handle_thread_continuation_requested(
+        &mut self,
+        thread: Entity<Thread>,
+        _: &ContinuationRequested,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(session) = self.sessions.get(thread.read(cx).id()) else {
+            return;
+        };
+        let acp_thread = session.acp_thread.clone();
+        let response_stream = match thread.update(cx, |thread, cx| thread.send_existing(cx)) {
+            Ok(response_stream) => response_stream,
+            Err(error) => {
+                log::error!("Failed to start continuation turn: {error:?}");
+                return;
+            }
+        };
+        let connection = Some(NativeAgentConnection(cx.entity()));
+        NativeAgentConnection::handle_thread_events(
+            response_stream,
+            acp_thread.downgrade(),
+            connection,
+            cx,
+        )
+        .detach_and_log_err(cx);
     }
 
     fn handle_project_event(

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -3327,6 +3327,38 @@ impl ThreadEnvironment for NativeThreadEnvironment {
         self.resume_subagent_thread(session_id, cx)
     }
 
+    fn steer_subagent(
+        &self,
+        session_id: acp::SessionId,
+        message: String,
+        cx: &mut App,
+    ) -> Result<Option<usize>> {
+        let Some(parent_thread_entity) = self.thread.upgrade() else {
+            anyhow::bail!("Parent thread no longer exists".to_string());
+        };
+        let (subagent_thread, entry_count) = self.agent.update(cx, |agent, cx| {
+            let session = agent
+                .sessions
+                .get(&session_id)
+                .ok_or_else(|| anyhow!("No subagent session found with id {session_id}"))?;
+            let entry_count = session.acp_thread.read(cx).entries().len();
+            anyhow::Ok((session.thread.clone(), entry_count))
+        })??;
+
+        // Only direct children may be steered, so a session's behavior stays
+        // predictable for the thread that spawned it.
+        let is_direct_child = subagent_thread.read(cx).parent_thread_id().as_ref()
+            == Some(parent_thread_entity.read(cx).id());
+        if !is_direct_child {
+            anyhow::bail!("Session {session_id} is not a subagent of this thread");
+        }
+
+        let steered = subagent_thread.update(cx, |thread, cx| {
+            thread.steer(ClientUserMessageId::new(), [message], cx)
+        });
+        Ok(steered.then_some(entry_count))
+    }
+
     fn create_sibling_thread(
         &self,
         request: SiblingThreadRequest,
@@ -3471,26 +3503,49 @@ impl SubagentHandle for NativeSubagentHandle {
             });
 
             let result = match task.await {
-                SubagentPromptResult::Completed => thread.read_with(cx, |thread, _cx| {
-                    thread
-                        .last_message()
-                        .and_then(|message| {
-                            let content = message.as_agent_message()?
-                                .content
-                                .iter()
-                                .filter_map(|c| match c {
-                                    AgentMessageContent::Text(text) => Some(text.as_str()),
-                                    _ => None,
-                                })
-                                .join("\n\n");
-                            if content.is_empty() {
-                                None
-                            } else {
-                                Some( content)
-                            }
+                SubagentPromptResult::Completed => {
+                    // Non-blocking tool calls may still be executing when the
+                    // turn ends; their results steer continuation turns
+                    // (driven by the agent's ContinuationRequested handler).
+                    // Wait for the subagent to become quiescent so the parent
+                    // receives its truly final output rather than a summary
+                    // that predates those results.
+                    let (quiet_tx, mut quiet_rx) = mpsc::unbounded();
+                    let _subscription = cx.update(|cx| {
+                        cx.observe(&thread, move |_, _| {
+                            quiet_tx.unbounded_send(()).ok();
                         })
-                        .context("No response from subagent")
-                }),
+                    });
+                    loop {
+                        let quiescent = thread.read_with(cx, |thread, _| thread.is_quiescent());
+                        if quiescent {
+                            break;
+                        }
+                        if quiet_rx.next().await.is_none() {
+                            break;
+                        }
+                    }
+                    thread.read_with(cx, |thread, _cx| {
+                        thread
+                            .last_message()
+                            .and_then(|message| {
+                                let content = message.as_agent_message()?
+                                    .content
+                                    .iter()
+                                    .filter_map(|c| match c {
+                                        AgentMessageContent::Text(text) => Some(text.as_str()),
+                                        _ => None,
+                                    })
+                                    .join("\n\n");
+                                if content.is_empty() {
+                                    None
+                                } else {
+                                    Some( content)
+                                }
+                            })
+                            .context("No response from subagent")
+                    })
+                }
                 SubagentPromptResult::Cancelled => Err(anyhow!("User canceled")),
                 SubagentPromptResult::Error(message) => Err(anyhow!("{message}")),
                 SubagentPromptResult::ContextWindowWarning => {

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1408,6 +1408,603 @@ async fn test_non_blocking_tool_call_requests_continuation_when_idle(cx: &mut Te
     );
 }
 
+/// A user message appended mid-turn via `Thread::steer` ends the turn at
+/// the next reasoning boundary and is processed as a continuation on the
+/// same event stream; steering an idle thread refuses.
+#[gpui::test]
+async fn test_steer_running_turn(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(EchoTool);
+    });
+
+    let events = thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Run the tools"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "first"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "first"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let steered = thread.update(cx, |thread, cx| {
+        thread.steer(ClientUserMessageId::new(), ["steer this"], cx)
+    });
+    assert!(steered, "steer should succeed while a turn is running");
+
+    // The boundary is reached once the in-flight tool batch completes.
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_2".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "second"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "second"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The continuation's request ends with the steered user message (merged
+    // with the preceding tool results into one user message).
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("a continuation completion should have been requested");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    assert_eq!(last_message.content.last(), Some(&"steer this".into()));
+
+    fake_model.send_last_completion_stream_text_chunk("done");
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+
+    let steered = thread.update(cx, |thread, cx| {
+        thread.steer(ClientUserMessageId::new(), ["too late"], cx)
+    });
+    assert!(!steered, "steer should refuse when no turn is running");
+}
+
+/// A non-blocking tool call inside a subagent session is delivered via a
+/// continuation turn on the subagent, and the parent's spawn_agent call
+/// keeps waiting until the subagent is quiescent, so the parent receives
+/// the subagent's truly final output.
+#[gpui::test]
+async fn test_subagent_can_use_non_blocking_tool_calls(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+    });
+    cx.update(|cx| {
+        cx.update_flags(true, vec!["subagents".to_string()]);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.create_dir(paths::settings_file().parent().unwrap())
+        .await
+        .unwrap();
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "default_profile": "test-profile",
+                "profiles": {
+                    "test-profile": {
+                        "name": "Test Profile",
+                        "tools": {
+                            SpawnAgentTool::NAME: true,
+                            ListDirectoryTool::NAME: true,
+                            GatedEchoTool::NAME: true,
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.update(|cx| {
+        settings::init(cx);
+        watch_settings(fs.clone(), cx);
+    });
+
+    fs.insert_tree(
+        "/",
+        json!({
+            "a": {
+                "b.md": "Lorem"
+            }
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/a").as_ref()], cx).await;
+    let thread_store = cx.new(|cx| ThreadStore::new(cx));
+    let agent =
+        cx.update(|cx| NativeAgent::new(thread_store.clone(), Templates::new(), fs.clone(), cx));
+    let connection = Rc::new(NativeAgentConnection(agent.clone()));
+
+    let acp_thread = cx
+        .update(|cx| {
+            connection
+                .clone()
+                .new_session(project.clone(), PathList::new(&[Path::new("")]), cx)
+        })
+        .await
+        .unwrap();
+    let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+    let thread = agent.read_with(cx, |agent, _| {
+        agent.sessions.get(&session_id).unwrap().thread.clone()
+    });
+    let model = Arc::new(FakeLanguageModel::default());
+    thread.update(cx, |thread, cx| {
+        thread.set_model(model.clone(), cx);
+    });
+    cx.run_until_parked();
+
+    let send = acp_thread.update(cx, |thread, cx| thread.send_raw("Prompt", cx));
+    cx.run_until_parked();
+    model.send_last_completion_stream_text_chunk("spawning subagent");
+    let subagent_tool_input = SpawnAgentToolInput {
+        label: "label".to_string(),
+        message: "subagent task prompt".to_string(),
+        session_id: None,
+    };
+    model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "subagent_1".into(),
+            name: SpawnAgentTool::NAME.into(),
+            raw_input: serde_json::to_string(&subagent_tool_input).unwrap(),
+            input: language_model::LanguageModelToolUseInput::Json(
+                serde_json::to_value(&subagent_tool_input).unwrap(),
+            ),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let subagent_session_id = thread.read_with(cx, |thread, cx| {
+        thread
+            .running_subagent_ids(cx)
+            .get(0)
+            .expect("subagent thread should be running")
+            .clone()
+    });
+    let subagent_thread = agent.read_with(cx, |agent, _cx| {
+        agent
+            .sessions
+            .get(&subagent_session_id)
+            .expect("subagent session should exist")
+            .thread
+            .clone()
+    });
+
+    // The gated tool is added mid-turn; the subagent's first tool call keeps
+    // the turn alive so the tool refresh at the next iteration picks it up.
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    subagent_thread.update(cx, |thread, _cx| {
+        thread.add_tool(GatedEchoTool::new(release_rx));
+    });
+
+    model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "list_1".into(),
+            name: ListDirectoryTool::NAME.into(),
+            raw_input: json!({"path": "/a"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"path": "/a"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The subagent calls the gated tool non-blockingly and ends its turn
+    // while the tool is still running.
+    model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "gated_1".into(),
+            name: GatedEchoTool::NAME.into(),
+            raw_input: json!({"text": "slow", "blocking": false}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(
+                json!({"text": "slow", "blocking": false}),
+            ),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("the subagent should continue after the placeholder");
+    let placeholder_text = completion
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|content| match content {
+            MessageContent::ToolResult(result) if result.tool_use_id.to_string() == "gated_1" => {
+                result.content.iter().find_map(|content| match content {
+                    language_model::LanguageModelToolResultContent::Text(text) => {
+                        Some(text.to_string())
+                    }
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("placeholder result for the non-blocking call");
+    let placeholder: serde_json::Value = serde_json::from_str(&placeholder_text).unwrap();
+    assert_eq!(placeholder["status"], json!("running"));
+    let async_id = placeholder["async_tool_call_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    model.send_last_completion_stream_text_chunk("started background work");
+    model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The subagent's turn ended, but the parent's spawn_agent call must
+    // still be waiting for the gated tool's result: no completion may be
+    // requested until the subagent is quiescent.
+    assert!(
+        subagent_thread.read_with(cx, |thread, _| thread.is_turn_complete()),
+        "the subagent's turn should have ended"
+    );
+    assert!(
+        model.pending_completions().is_empty(),
+        "no completion may run while the subagent's non-blocking tool is still executing"
+    );
+
+    release_tx.send(()).unwrap();
+    cx.run_until_parked();
+
+    // The finished result drives a continuation turn on the subagent.
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("a continuation completion should have been requested on the subagent");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    let MessageContent::Text(text) = &last_message.content[0] else {
+        panic!(
+            "expected a text user message, got {:?}",
+            last_message.content
+        );
+    };
+    let delivery: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(delivery["async_tool_call_id"], json!(async_id));
+    assert_eq!(delivery["status"], json!("completed"));
+
+    model.send_last_completion_stream_text_chunk("final answer");
+    model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // Only now does the parent's spawn_agent call resolve, with the
+    // subagent's truly final output.
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("the parent should continue once the subagent is quiescent");
+    let spawn_result_text = completion
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|content| match content {
+            MessageContent::ToolResult(result)
+                if result.tool_use_id.to_string() == "subagent_1" =>
+            {
+                result.content.iter().find_map(|content| match content {
+                    language_model::LanguageModelToolResultContent::Text(text) => {
+                        Some(text.to_string())
+                    }
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("spawn_agent result for the parent");
+    assert!(
+        spawn_result_text.contains("final answer"),
+        "parent should receive the subagent's final output, got: {spawn_result_text}"
+    );
+
+    model.send_last_completion_stream_text_chunk("parent done");
+    model.end_last_completion_stream();
+    send.await.unwrap();
+}
+
+/// Resuming a running subagent session via spawn_agent steers it: the
+/// message joins the running turn at its next boundary and the call returns
+/// an acknowledgment instead of the session's output. A non-blocking
+/// spawn_agent call's placeholder carries the new session_id, so the parent
+/// can reference the session before it finishes.
+#[gpui::test]
+async fn test_spawn_agent_steers_running_subagent(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+    });
+    cx.update(|cx| {
+        cx.update_flags(true, vec!["subagents".to_string()]);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.create_dir(paths::settings_file().parent().unwrap())
+        .await
+        .unwrap();
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "default_profile": "test-profile",
+                "profiles": {
+                    "test-profile": {
+                        "name": "Test Profile",
+                        "tools": {
+                            SpawnAgentTool::NAME: true,
+                            ListDirectoryTool::NAME: true,
+                        }
+                    }
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.update(|cx| {
+        settings::init(cx);
+        watch_settings(fs.clone(), cx);
+    });
+
+    fs.insert_tree(
+        "/",
+        json!({
+            "a": {
+                "b.md": "Lorem"
+            }
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/a").as_ref()], cx).await;
+    let thread_store = cx.new(|cx| ThreadStore::new(cx));
+    let agent =
+        cx.update(|cx| NativeAgent::new(thread_store.clone(), Templates::new(), fs.clone(), cx));
+    let connection = Rc::new(NativeAgentConnection(agent.clone()));
+
+    let acp_thread = cx
+        .update(|cx| {
+            connection
+                .clone()
+                .new_session(project.clone(), PathList::new(&[Path::new("")]), cx)
+        })
+        .await
+        .unwrap();
+    let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
+    let thread = agent.read_with(cx, |agent, _| {
+        agent.sessions.get(&session_id).unwrap().thread.clone()
+    });
+    let model = Arc::new(FakeLanguageModel::default());
+    thread.update(cx, |thread, cx| {
+        thread.set_model(model.clone(), cx);
+    });
+    cx.run_until_parked();
+
+    let send = acp_thread.update(cx, |thread, cx| thread.send_raw("Prompt", cx));
+    cx.run_until_parked();
+
+    // Spawn the subagent non-blockingly so the parent keeps reasoning while
+    // it runs.
+    let subagent_tool_input = json!({
+        "label": "label",
+        "message": "subagent task prompt",
+        "blocking": false,
+    });
+    model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "subagent_1".into(),
+            name: SpawnAgentTool::NAME.into(),
+            raw_input: subagent_tool_input.to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(subagent_tool_input.clone()),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let subagent_session_id = thread.read_with(cx, |thread, cx| {
+        thread
+            .running_subagent_ids(cx)
+            .get(0)
+            .expect("subagent thread should be running")
+            .clone()
+    });
+
+    // The placeholder result carries the new session id up front. (The
+    // parent's continuation and the subagent's first request race, so search
+    // all pending completions rather than relying on request order.)
+    let completions = model.pending_completions();
+    let (parent_completion, placeholder_text) = completions
+        .iter()
+        .find_map(|completion| {
+            completion
+                .messages
+                .iter()
+                .flat_map(|message| &message.content)
+                .find_map(|content| match content {
+                    MessageContent::ToolResult(result)
+                        if result.tool_use_id.to_string() == "subagent_1" =>
+                    {
+                        result.content.iter().find_map(|content| match content {
+                            language_model::LanguageModelToolResultContent::Text(text) => {
+                                Some(text.to_string())
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .map(|text| (completion.clone(), text))
+        })
+        .expect("placeholder result for the non-blocking spawn");
+    let placeholder: serde_json::Value = serde_json::from_str(&placeholder_text).unwrap();
+    assert_eq!(placeholder["status"], json!("running"));
+    assert!(
+        placeholder["async_tool_call_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("a~"),
+        "placeholder should carry an async tool call id: {placeholder}"
+    );
+    assert_eq!(
+        placeholder["session_id"],
+        json!(subagent_session_id.to_string()),
+        "placeholder should carry the subagent session id"
+    );
+
+    // The parent steers the running subagent by resuming its session. The
+    // subagent's own request is still pending, so drive the parent's
+    // completion directly.
+    let steer_input = SpawnAgentToolInput {
+        label: "steer".to_string(),
+        message: "course correct".to_string(),
+        session_id: Some(subagent_session_id.clone()),
+    };
+    model.send_completion_stream_event(
+        &parent_completion,
+        LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
+            id: "steer_1".into(),
+            name: SpawnAgentTool::NAME.into(),
+            raw_input: serde_json::to_string(&steer_input).unwrap(),
+            input: language_model::LanguageModelToolUseInput::Json(
+                serde_json::to_value(&steer_input).unwrap(),
+            ),
+            is_input_complete: true,
+            thought_signature: None,
+        }),
+    );
+    model.end_completion_stream(&parent_completion);
+    cx.run_until_parked();
+
+    // The steer call returns an acknowledgment immediately rather than
+    // awaiting the subagent's output.
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("the parent should continue after the steer acknowledgment");
+    let steer_result_text = completion
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|content| match content {
+            MessageContent::ToolResult(result) if result.tool_use_id.to_string() == "steer_1" => {
+                result.content.iter().find_map(|content| match content {
+                    language_model::LanguageModelToolResultContent::Text(text) => {
+                        Some(text.to_string())
+                    }
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("steer acknowledgment result");
+    assert!(
+        steer_result_text.contains("Steered the running agent session"),
+        "expected a steer acknowledgment, got: {steer_result_text}"
+    );
+
+    // Let the parent finish its turn; the subagent is still running.
+    model.send_last_completion_stream_text_chunk("waiting for the subagent");
+    model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The steered message ends the subagent's turn at its next boundary: one
+    // blocking tool call later, a continuation processes it.
+    model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "list_1".into(),
+            name: ListDirectoryTool::NAME.into(),
+            raw_input: json!({"path": "/a"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"path": "/a"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("the steered message should drive a continuation on the subagent");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    assert_eq!(last_message.content, vec!["course correct".into()]);
+
+    // The subagent's final output still arrives at the original spawn_agent
+    // call, whose non-blocking result is delivered to the now-idle parent as
+    // a continuation.
+    model.send_last_completion_stream_text_chunk("steered final answer");
+    model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let completion = model
+        .pending_completions()
+        .pop()
+        .expect("the spawn result should drive a continuation on the parent");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    let MessageContent::Text(text) = &last_message.content[0] else {
+        panic!(
+            "expected a text user message, got {:?}",
+            last_message.content
+        );
+    };
+    let delivery: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(delivery["tool_name"], json!(SpawnAgentTool::NAME));
+    assert_eq!(delivery["status"], json!("completed"));
+    assert!(
+        delivery["result"]
+            .as_str()
+            .unwrap()
+            .contains("steered final answer"),
+        "the spawn result should carry the subagent's final output: {delivery}"
+    );
+
+    model.send_last_completion_stream_text_chunk("parent done");
+    model.end_last_completion_stream();
+    send.await.unwrap();
+}
+
 /// Same bug as `test_tool_call_id_scoped_per_completion_request`, but
 /// exercised through persistence and `Thread::replay()` instead of live
 /// streaming.

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -28,8 +28,8 @@ use language_model::{
     CompletionIntent, LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
     LanguageModelId, LanguageModelImageExt, LanguageModelProviderId, LanguageModelProviderName,
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage,
-    LanguageModelToolResult, LanguageModelToolSchemaFormat, LanguageModelToolUse, MessageContent,
-    Role, StopReason, TokenUsage,
+    LanguageModelRequestToolInput, LanguageModelToolResult, LanguageModelToolSchemaFormat,
+    LanguageModelToolUse, MessageContent, Role, StopReason, TokenUsage,
     fake_provider::{FakeLanguageModel, FakeLanguageModelProvider},
 };
 use pretty_assertions::assert_eq;
@@ -1137,6 +1137,274 @@ async fn test_tool_call_id_scoped_per_completion_request(cx: &mut TestAppContext
         "raw tool_use ids that recur across separate completion requests within the same turn \
          must map to distinct ACP tool call ids, otherwise the second tool call would overwrite \
          the first instead of appearing as a new entry"
+    );
+}
+
+/// A tool call with `"blocking": false` must not hold up the turn: the
+/// model immediately receives a placeholder result carrying an
+/// `async_tool_call_id`, and the real result is delivered later as a new
+/// user message with the same id.
+#[gpui::test]
+async fn test_non_blocking_tool_call(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(EchoTool);
+        thread.add_tool(GatedEchoTool::new(release_rx));
+    });
+
+    let events = thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Run the tools"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // The runtime offers an optional `blocking` property on every tool
+    // schema, defaulting to blocking.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let echo_tool = completion
+        .tools
+        .iter()
+        .find(|tool| tool.name == EchoTool::NAME)
+        .unwrap();
+    let LanguageModelRequestToolInput::Function { input_schema, .. } = &echo_tool.input else {
+        panic!("expected a function tool");
+    };
+    assert_eq!(
+        input_schema["properties"]["blocking"]["default"],
+        json!(true),
+        "tools should offer the blocking property"
+    );
+
+    // The model calls one tool non-blockingly and one blockingly.
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_slow".into(),
+            name: GatedEchoTool::NAME.into(),
+            raw_input: json!({"text": "slow", "blocking": false}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(
+                json!({"text": "slow", "blocking": false}),
+            ),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_fast".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "fast"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "fast"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The turn did not wait for the gated tool: the model immediately
+    // received a placeholder result carrying an async_tool_call_id, plus the
+    // blocking call's real result.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result_text = |tool_use_id: &str| {
+        completion
+            .messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .find_map(|content| match content {
+                MessageContent::ToolResult(result)
+                    if result.tool_use_id.to_string() == tool_use_id =>
+                {
+                    result.content.iter().find_map(|content| match content {
+                        language_model::LanguageModelToolResultContent::Text(text) => {
+                            Some(text.to_string())
+                        }
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected a tool result for {tool_use_id}"))
+    };
+    let placeholder: serde_json::Value = serde_json::from_str(&tool_result_text("call_slow"))
+        .unwrap_or_else(|_| panic!("not json: {:?}", tool_result_text("call_slow")));
+    assert_eq!(placeholder["status"], json!("running"));
+    let async_id = placeholder["async_tool_call_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        async_id.starts_with("a~"),
+        "async tool call id should carry the fixed prefix: {async_id}"
+    );
+    assert_eq!(tool_result_text("call_fast"), "fast");
+
+    // Let the gated tool finish while the model is still responding; its
+    // result is delivered at the next reasoning boundary.
+    release_tx.send(()).unwrap();
+    cx.run_until_parked();
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The finished result steered the thread into a continuation whose
+    // request ends with a new user message carrying the same id.
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("a continuation completion should have been requested");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    let MessageContent::Text(text) = &last_message.content[0] else {
+        panic!(
+            "expected a text user message, got {:?}",
+            last_message.content
+        );
+    };
+    let delivery: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(delivery["async_tool_call_id"], json!(async_id));
+    assert_eq!(delivery["tool_name"], json!(GatedEchoTool::NAME));
+    assert_eq!(delivery["status"], json!("completed"));
+    let result: serde_json::Value =
+        serde_json::from_str(delivery["result"].as_str().unwrap()).unwrap();
+    assert_eq!(result["text"], json!("slow"));
+    assert_eq!(
+        result["received_blocking_key"],
+        json!(false),
+        "the runtime must strip the blocking property before the tool runs"
+    );
+
+    // End the continuation turn; the original event stream completes after
+    // reporting the delivered user message.
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    let remaining = events.collect::<Vec<_>>().await;
+    assert!(remaining.iter().any(|event| matches!(
+        event,
+        Ok(ThreadEvent::UserMessage(message))
+            if matches!(&*message.content, [UserMessageContent::Text(text)] if text.contains(&async_id))
+    )));
+    assert!(
+        remaining
+            .iter()
+            .any(|event| matches!(event, Ok(ThreadEvent::Stop(_))))
+    );
+}
+
+/// A non-blocking tool call that finishes after the turn ended requests a
+/// continuation turn so its result still reaches the model.
+#[gpui::test]
+async fn test_non_blocking_tool_call_requests_continuation_when_idle(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(GatedEchoTool::new(release_rx));
+    });
+
+    let events = thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Run the tool"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_slow".into(),
+            name: GatedEchoTool::NAME.into(),
+            raw_input: json!({"text": "slow", "blocking": false}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(
+                json!({"text": "slow", "blocking": false}),
+            ),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // The model gets the placeholder and ends its turn while the tool is
+    // still running.
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let placeholder_text = completion
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|content| match content {
+            MessageContent::ToolResult(result) if result.tool_use_id.to_string() == "call_slow" => {
+                result.content.iter().find_map(|content| match content {
+                    language_model::LanguageModelToolResultContent::Text(text) => {
+                        Some(text.to_string())
+                    }
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("placeholder result for the non-blocking call");
+    let placeholder: serde_json::Value = serde_json::from_str(&placeholder_text).unwrap();
+    let async_id = placeholder["async_tool_call_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+    assert!(fake_model.pending_completions().is_empty());
+
+    // When the tool finishes with no turn running, a continuation is
+    // requested instead of the result being delivered mid-turn.
+    let continuation_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let _subscription = cx.update(|cx| {
+        cx.subscribe(&thread, {
+            let continuation_requested = continuation_requested.clone();
+            move |_, _: &ContinuationRequested, _| {
+                continuation_requested.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        })
+    });
+    release_tx.send(()).unwrap();
+    cx.run_until_parked();
+    assert!(continuation_requested.load(std::sync::atomic::Ordering::SeqCst));
+
+    // Driving the continuation (as NativeAgent does) delivers the result.
+    let events = thread
+        .update(cx, |thread, cx| thread.send_existing(cx))
+        .unwrap();
+    cx.run_until_parked();
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("a continuation completion should have been requested");
+    let last_message = completion.messages.last().unwrap();
+    assert_eq!(last_message.role, Role::User);
+    let MessageContent::Text(text) = &last_message.content[0] else {
+        panic!(
+            "expected a text user message, got {:?}",
+            last_message.content
+        );
+    };
+    let delivery: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(delivery["async_tool_call_id"], json!(async_id));
+    assert_eq!(delivery["status"], json!("completed"));
+
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    let remaining = events.collect::<Vec<_>>().await;
+    assert!(
+        remaining
+            .iter()
+            .any(|event| matches!(event, Ok(ThreadEvent::Stop(_))))
     );
 }
 
@@ -4884,6 +5152,7 @@ async fn setup(cx: &mut TestAppContext, model: TestModel) -> ThreadTest {
                         "name": "Test Profile",
                         "tools": {
                             EchoTool::NAME: true,
+                            GatedEchoTool::NAME: true,
                             DelayTool::NAME: true,
                             WordListTool::NAME: true,
                             ToolRequiringPermission::NAME: true,

--- a/crates/agent/src/tests/test_tools.rs
+++ b/crates/agent/src/tests/test_tools.rs
@@ -183,6 +183,61 @@ impl AgentTool for StreamingFailingEchoTool {
     }
 }
 
+/// A tool that echoes its input only after being released via a oneshot,
+/// used to test non-blocking tool calls. Its input is raw JSON so tests can
+/// also verify that the runtime-level `blocking` property never reaches the
+/// tool.
+pub struct GatedEchoTool {
+    release_rx: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl GatedEchoTool {
+    pub fn new(release_rx: oneshot::Receiver<()>) -> Self {
+        Self {
+            release_rx: Mutex::new(Some(release_rx)),
+        }
+    }
+}
+
+impl AgentTool for GatedEchoTool {
+    type Input = serde_json::Value;
+    type Output = String;
+
+    const NAME: &'static str = "gated_echo";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "Gated Echo".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<String, String>> {
+        let release_rx = self.release_rx.lock().unwrap().take();
+        cx.spawn(async move |_cx| {
+            let input = input.recv().await.map_err(|e| e.to_string())?;
+            if let Some(release_rx) = release_rx {
+                release_rx.await.map_err(|e| e.to_string())?;
+            }
+            Ok(json!({
+                "text": input.get("text"),
+                "received_blocking_key": input.get("blocking").is_some(),
+            })
+            .to_string())
+        })
+    }
+}
+
 /// A tool that echoes its input
 #[derive(JsonSchema, Serialize, Deserialize)]
 pub struct EchoToolInput {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -72,6 +72,10 @@ use uuid::Uuid;
 const TOOL_CANCELED_MESSAGE: &str = "Tool canceled by user";
 const TOOL_CALL_INTERRUPTED_BY_FOLLOW_UP_MESSAGE: &str =
     "Permission denied: user sent a follow-up message instead of approving the tool call.";
+/// Tool input property the runtime injects into every tool schema so the
+/// model can run a call non-blockingly. Handled entirely by the agent
+/// runtime — tools (built-in, MCP, or future) never see it and never opt in.
+const BLOCKING_INPUT_PROPERTY: &str = "blocking";
 pub(crate) const FOLLOW_UP_PERMISSION_DENIED_OPTION_ID: &str = "follow_up_permission_denied";
 pub const MAX_TOOL_NAME_LENGTH: usize = 64;
 pub const MAX_SUBAGENT_DEPTH: u8 = 1;
@@ -1259,6 +1263,15 @@ pub struct Thread {
     /// running to completion. The UI sets this to deliver a "steering" queued
     /// message mid-task; by default queued messages wait for the turn to finish.
     end_turn_at_next_boundary: bool,
+    /// Tool calls the model chose to run non-blockingly (`"blocking": false`
+    /// in the tool input) that are still executing independently of any turn,
+    /// keyed by tool use id.
+    non_blocking_tool_calls: HashMap<LanguageModelToolUseId, NonBlockingToolCall>,
+    /// Results of non-blocking tool calls that finished but haven't been
+    /// delivered to the model. Drained into new user messages at the next
+    /// reasoning boundary; appended rather than patched in place so long
+    /// contexts stay friendly to prompt caching.
+    queued_non_blocking_results: Vec<FinishedNonBlockingToolCall>,
     pending_message: Option<AgentMessage>,
     pub(crate) tools: BTreeMap<SharedString, Arc<dyn AnyAgentTool>>,
     request_token_usage: HashMap<ClientUserMessageId, language_model::TokenUsage>,
@@ -1403,6 +1416,8 @@ impl Thread {
             user_store: project.read(cx).user_store(),
             running_turn: None,
             end_turn_at_next_boundary: false,
+            non_blocking_tool_calls: HashMap::default(),
+            queued_non_blocking_results: Vec::new(),
             pending_message: None,
             tools: BTreeMap::default(),
             request_token_usage: HashMap::default(),
@@ -1786,6 +1801,8 @@ impl Thread {
             user_store: project.read(cx).user_store(),
             running_turn: None,
             end_turn_at_next_boundary: false,
+            non_blocking_tool_calls: HashMap::default(),
+            queued_non_blocking_results: Vec::new(),
             pending_message: None,
             tools: BTreeMap::default(),
             request_token_usage: db_thread.request_token_usage.clone(),
@@ -2689,16 +2706,46 @@ impl Thread {
             async move |this, cx| {
                 log::debug!("Starting agent turn execution");
 
-                let turn_result =
+                let mut turn_result =
                     Self::run_turn_internal(&this, &event_stream, cancellation_rx.clone(), cx)
                         .await;
 
-                // Check if we were cancelled - if so, cancel() already took running_turn
-                // and we shouldn't touch it (it might be a NEW turn now)
-                let was_cancelled = *cancellation_rx.borrow();
-                if was_cancelled {
-                    log::debug!("Turn was cancelled, skipping cleanup");
-                    return;
+                // Non-blocking tool results that arrive as a turn winds down
+                // steer the conversation into a continuation on this same
+                // event stream, so the client observes one uninterrupted
+                // prompt.
+                loop {
+                    // Check if we were cancelled - if so, cancel() already took running_turn
+                    // and we shouldn't touch it (it might be a NEW turn now)
+                    let was_cancelled = *cancellation_rx.borrow();
+                    if was_cancelled {
+                        log::debug!("Turn was cancelled, skipping cleanup");
+                        return;
+                    }
+                    if turn_result.is_err() {
+                        break;
+                    }
+                    let continue_with_results = this
+                        .update(cx, |this, cx| {
+                            this.flush_pending_message(cx);
+                            if this.drain_finished_non_blocking_tool_calls(&event_stream, cx) {
+                                true
+                            } else {
+                                // Mark the thread idle in the same update that
+                                // finds the queue empty, so a result arriving
+                                // right now takes the continuation-request path
+                                // instead of being stranded in the queue.
+                                this.running_turn.take();
+                                false
+                            }
+                        })
+                        .unwrap_or(false);
+                    if !continue_with_results {
+                        break;
+                    }
+                    turn_result =
+                        Self::run_turn_internal(&this, &event_stream, cancellation_rx.clone(), cx)
+                            .await;
                 }
 
                 _ = this.update(cx, |this, cx| this.flush_pending_message(cx));
@@ -2743,6 +2790,14 @@ impl Thread {
         // Set when a refusal fallback occurs so subsequent iterations use the fallback model.
         let mut refusal_fallback_model: Option<Arc<dyn LanguageModel>> = None;
         loop {
+            // Non-blocking tool results that finished since the previous
+            // iteration are delivered here, at a reasoning boundary.
+            let delivered = this.update(cx, |this, cx| {
+                this.drain_finished_non_blocking_tool_calls(event_stream, cx)
+            })?;
+            if delivered {
+                intent = CompletionIntent::UserPrompt;
+            }
             match Self::perform_compaction_if_needed(
                 this,
                 event_stream,
@@ -3265,17 +3320,28 @@ impl Thread {
     ) -> Result<(), anyhow::Error> {
         log::debug!("Tool finished {:?}", tool_result);
 
-        event_stream.update_tool_call_fields(
-            &scoped_tool_call_id(owning_message_ix, &tool_result.tool_use_id),
-            acp::ToolCallUpdateFields::new()
-                .status(if tool_result.is_error {
-                    acp::ToolCallStatus::Failed
-                } else {
-                    acp::ToolCallStatus::Completed
-                })
-                .raw_output(tool_result.output.clone()),
-            None,
-        );
+        // A non-blocking call's placeholder result flows through this same
+        // path; its UI entry stays in progress until the real result is
+        // delivered (see `drain_finished_non_blocking_tool_calls`).
+        let is_non_blocking_placeholder = this
+            .read_with(cx, |this, _| {
+                this.non_blocking_tool_calls
+                    .contains_key(&tool_result.tool_use_id)
+            })
+            .unwrap_or(false);
+        if !is_non_blocking_placeholder {
+            event_stream.update_tool_call_fields(
+                &scoped_tool_call_id(owning_message_ix, &tool_result.tool_use_id),
+                acp::ToolCallUpdateFields::new()
+                    .status(if tool_result.is_error {
+                        acp::ToolCallStatus::Failed
+                    } else {
+                        acp::ToolCallStatus::Completed
+                    })
+                    .raw_output(tool_result.output.clone()),
+                None,
+            );
+        }
         this.update(cx, |this, _cx| {
             this.pending_message()
                 .tool_results
@@ -3522,6 +3588,10 @@ impl Thread {
                 )));
             }
         };
+        // `blocking` is a runtime-level concern (see
+        // `build_completion_request`); strip it so tools never have to know
+        // it exists. Absent or malformed values default to blocking.
+        let (input, blocking) = split_blocking_flag(input);
 
         if !tool_use.is_input_complete {
             if tool.supports_input_streaming() {
@@ -3562,6 +3632,19 @@ impl Thread {
         {
             sender.send_full(input);
             return None;
+        }
+
+        if !blocking && !self.is_subagent() {
+            log::debug!("Running tool {} non-blockingly", tool_use.name);
+            return Some(self.run_tool_non_blocking(
+                tool,
+                input,
+                tool_use.id,
+                tool_use.name,
+                owning_message_ix,
+                event_stream,
+                cx,
+            ));
         }
 
         log::debug!("Running tool {}", tool_use.name);
@@ -3683,6 +3766,167 @@ impl Thread {
                 },
             )
         })
+    }
+
+    /// Runs a tool without blocking the reasoning loop: the tool executes
+    /// independently of the turn, the model immediately receives a
+    /// placeholder result carrying an `async_tool_call_id`, and the real
+    /// result is delivered later as a new user message (see
+    /// [`Thread::drain_finished_non_blocking_tool_calls`]).
+    fn run_tool_non_blocking(
+        &mut self,
+        tool: Arc<dyn AnyAgentTool>,
+        input: serde_json::Value,
+        tool_use_id: LanguageModelToolUseId,
+        tool_name: Arc<str>,
+        owning_message_ix: usize,
+        event_stream: &ThreadEventStream,
+        cx: &mut Context<Self>,
+    ) -> Task<(usize, LanguageModelToolResult)> {
+        let async_id = self.fresh_async_tool_call_id();
+        // A dedicated cancellation channel keeps the tool running across
+        // turn cancellations: the model was told the call runs independently.
+        let (cancellation_tx, cancellation_rx) = watch::channel(false);
+        let tool_task = self.run_tool(
+            tool,
+            ToolInput::ready(input),
+            tool_use_id.clone(),
+            tool_name.clone(),
+            owning_message_ix,
+            event_stream,
+            cancellation_rx,
+            cx,
+        );
+        self.non_blocking_tool_calls.insert(
+            tool_use_id.clone(),
+            NonBlockingToolCall {
+                async_id: async_id.clone(),
+                owning_message_ix,
+                _cancellation_tx: cancellation_tx,
+            },
+        );
+        cx.spawn({
+            let tool_use_id = tool_use_id.clone();
+            async move |this, cx| {
+                let (_, result) = tool_task.await;
+                this.update(cx, |this, cx| {
+                    this.complete_non_blocking_tool_call(tool_use_id, result, cx)
+                })
+                .log_err();
+            }
+        })
+        .detach();
+
+        Task::ready((
+            owning_message_ix,
+            LanguageModelToolResult {
+                tool_use_id,
+                tool_name,
+                is_error: false,
+                content: vec![LanguageModelToolResultContent::Text(Arc::from(
+                    serde_json::json!({
+                        "async_tool_call_id": async_id.as_ref(),
+                        "status": "running",
+                        "note": concat!(
+                            "This tool call is running non-blockingly. Its result will ",
+                            "arrive later as a user message with the same async_tool_call_id. ",
+                            "Do not wait for it; continue with other work."
+                        ),
+                    })
+                    .to_string(),
+                ))],
+                output: None,
+            },
+        ))
+    }
+
+    /// Short, distinctive id for a non-blocking tool call (e.g. "a~K4u"): a
+    /// fixed prefix and a random-looking suffix, so it stands out in the
+    /// model's context and is unlikely to collide with anything else in it.
+    fn fresh_async_tool_call_id(&self) -> SharedString {
+        const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        loop {
+            let bytes = Uuid::new_v4().into_bytes();
+            let suffix: String = bytes[..3]
+                .iter()
+                .map(|byte| CHARSET[*byte as usize % CHARSET.len()] as char)
+                .collect();
+            let id = SharedString::from(format!("a~{suffix}"));
+            let in_flight = self
+                .non_blocking_tool_calls
+                .values()
+                .any(|call| call.async_id == id);
+            let queued = self
+                .queued_non_blocking_results
+                .iter()
+                .any(|result| result.async_id == id);
+            if !in_flight && !queued {
+                return id;
+            }
+        }
+    }
+
+    /// Called when a non-blocking tool call finishes. The result is queued
+    /// for delivery at the next reasoning boundary; if no turn is running, a
+    /// continuation turn is requested so the result still reaches the model.
+    fn complete_non_blocking_tool_call(
+        &mut self,
+        tool_use_id: LanguageModelToolUseId,
+        result: LanguageModelToolResult,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(call) = self.non_blocking_tool_calls.remove(&tool_use_id) else {
+            return;
+        };
+        self.queued_non_blocking_results
+            .push(FinishedNonBlockingToolCall {
+                async_id: call.async_id,
+                tool_call_id: scoped_tool_call_id(call.owning_message_ix, &tool_use_id),
+                result,
+            });
+        if self.running_turn.is_none() {
+            cx.emit(ContinuationRequested);
+        }
+        cx.notify();
+    }
+
+    /// Delivers finished non-blocking tool results as new user messages at a
+    /// reasoning boundary, and reports their final status to the UI. Results
+    /// are appended as new messages rather than patched into the originating
+    /// assistant message so long contexts stay friendly to prompt caching.
+    /// Returns whether anything was delivered.
+    fn drain_finished_non_blocking_tool_calls(
+        &mut self,
+        event_stream: &ThreadEventStream,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.queued_non_blocking_results.is_empty() {
+            return false;
+        }
+        for finished in self.queued_non_blocking_results.drain(..) {
+            event_stream.update_tool_call_fields(
+                &finished.tool_call_id,
+                acp::ToolCallUpdateFields::new()
+                    .status(if finished.result.is_error {
+                        acp::ToolCallStatus::Failed
+                    } else {
+                        acp::ToolCallStatus::Completed
+                    })
+                    .raw_output(finished.result.output.clone()),
+                None,
+            );
+            let message = UserMessage {
+                id: ClientUserMessageId::new(),
+                content: non_blocking_result_message_content(&finished.async_id, &finished.result)
+                    .into(),
+            };
+            event_stream.send_user_message(&message);
+            self.messages.push(Arc::new(Message::User(message)));
+        }
+        self.updated_at = Utc::now();
+        self.clear_summary();
+        cx.notify();
+        true
     }
 
     fn handle_tool_use_json_parse_error_event(
@@ -4073,6 +4317,36 @@ impl Thread {
                             {
                                 properties.remove("reason");
                             }
+                        }
+                    }
+                    // The `blocking` property is offered on every tool
+                    // without tool authors opting in; the runtime strips it
+                    // from the input before the tool runs (see
+                    // `handle_tool_use_event`). Subagent threads are excluded
+                    // because nothing would deliver a late result once their
+                    // turn has ended.
+                    if !self.is_subagent() {
+                        if let Some(properties) = schema
+                            .get_mut("properties")
+                            .and_then(|value| value.as_object_mut())
+                        {
+                            properties
+                                .entry(BLOCKING_INPUT_PROPERTY.to_string())
+                                .or_insert_with(|| {
+                                    serde_json::json!({
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": concat!(
+                                            "Whether the agent waits for this tool call's result ",
+                                            "before continuing (default true). Set to false for ",
+                                            "long-running work whose result is not needed for the ",
+                                            "current reasoning step: the tool keeps running ",
+                                            "independently, the call immediately returns an ",
+                                            "async_tool_call_id, and the real result is delivered ",
+                                            "later as a user message carrying the same id."
+                                        ),
+                                    })
+                                });
                         }
                     }
                     Some(LanguageModelRequestTool::function(
@@ -4771,6 +5045,67 @@ enum CompactionInsertion {
     Manual { marker_id: ClientUserMessageId },
 }
 
+/// Splits the runtime-managed `blocking` flag out of a tool call's input.
+/// Tools never see the property; absent or malformed values mean blocking.
+fn split_blocking_flag(mut input: serde_json::Value) -> (serde_json::Value, bool) {
+    let blocking = input
+        .as_object_mut()
+        .and_then(|object| object.remove(BLOCKING_INPUT_PROPERTY))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true);
+    (input, blocking)
+}
+
+/// Builds the user message content carrying a finished non-blocking tool
+/// call's result: a JSON envelope tagged with the call's
+/// `async_tool_call_id`, followed by any images the tool produced.
+fn non_blocking_result_message_content(
+    async_id: &str,
+    result: &LanguageModelToolResult,
+) -> Vec<UserMessageContent> {
+    let mut text = String::new();
+    let mut images = Vec::new();
+    for part in &result.content {
+        match part {
+            LanguageModelToolResultContent::Text(part_text) => {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(part_text);
+            }
+            LanguageModelToolResultContent::Image(image) => images.push(image.clone()),
+        }
+    }
+    let envelope = serde_json::json!({
+        "async_tool_call_id": async_id,
+        "tool_name": result.tool_name,
+        "status": if result.is_error { "failed" } else { "completed" },
+        "result": text,
+    });
+    let mut content = vec![UserMessageContent::Text(envelope.to_string())];
+    content.extend(images.into_iter().map(UserMessageContent::Image));
+    content
+}
+
+/// A tool call the model chose to run non-blockingly (see
+/// [`Thread::run_tool_non_blocking`]). Held until the call finishes so the
+/// result can be matched back to its model-facing async id and ACP tool call.
+struct NonBlockingToolCall {
+    async_id: SharedString,
+    owning_message_ix: usize,
+    /// Kept so the tool's cancellation channel stays open for the life of the
+    /// call — non-blocking calls outlive individual turns.
+    _cancellation_tx: watch::Sender<bool>,
+}
+
+/// A non-blocking tool call that finished and is waiting to be delivered to
+/// the model at the next reasoning boundary.
+struct FinishedNonBlockingToolCall {
+    async_id: SharedString,
+    tool_call_id: acp::ToolCallId,
+    result: LanguageModelToolResult,
+}
+
 struct RunningTurn {
     /// Holds the task that handles agent interaction until the end of the turn.
     /// Survives across multiple requests as the model performs tool calls and
@@ -4941,6 +5276,13 @@ pub async fn stream_thread_title(
 pub struct TokenUsageUpdated(pub Option<acp_thread::TokenUsage>);
 
 impl EventEmitter<TokenUsageUpdated> for Thread {}
+
+/// Emitted when a non-blocking tool call finished while no turn was running.
+/// Whoever drives this thread (e.g. `NativeAgent`) should start a
+/// continuation turn so the queued result reaches the model.
+pub struct ContinuationRequested;
+
+impl EventEmitter<ContinuationRequested> for Thread {}
 
 pub struct TitleUpdated;
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -780,6 +780,20 @@ pub trait ThreadEnvironment {
         ))
     }
 
+    /// Steers a running subagent session with a follow-up message: the
+    /// message is incorporated at the session's next reasoning boundary and
+    /// no direct response is returned. Returns `Ok(Some(entry_count))` when
+    /// the session was running and thus steered, `Ok(None)` when it is idle
+    /// and should be resumed with a new turn instead.
+    fn steer_subagent(
+        &self,
+        _session_id: acp::SessionId,
+        _message: String,
+        _cx: &mut App,
+    ) -> Result<Option<usize>> {
+        Ok(None)
+    }
+
     /// Creates an independent sibling thread visible in the agent sidebar.
     /// Unlike subagents, sibling threads are first-class threads that persist
     /// and run in parallel without reporting results back to the parent.
@@ -1263,6 +1277,12 @@ pub struct Thread {
     /// running to completion. The UI sets this to deliver a "steering" queued
     /// message mid-task; by default queued messages wait for the turn to finish.
     end_turn_at_next_boundary: bool,
+    /// User messages appended mid-turn via [`Thread::steer`]. Held back until
+    /// the turn ends at the next reasoning boundary so they land after the
+    /// in-flight assistant message (with its tool uses and results) in the
+    /// conversation; the turn's outer loop then delivers them as a
+    /// continuation on the same event stream.
+    steered_messages: Vec<UserMessage>,
     /// Tool calls the model chose to run non-blockingly (`"blocking": false`
     /// in the tool input) that are still executing independently of any turn,
     /// keyed by tool use id.
@@ -1416,6 +1436,7 @@ impl Thread {
             user_store: project.read(cx).user_store(),
             running_turn: None,
             end_turn_at_next_boundary: false,
+            steered_messages: Vec::new(),
             non_blocking_tool_calls: HashMap::default(),
             queued_non_blocking_results: Vec::new(),
             pending_message: None,
@@ -1801,6 +1822,7 @@ impl Thread {
             user_store: project.read(cx).user_store(),
             running_turn: None,
             end_turn_at_next_boundary: false,
+            steered_messages: Vec::new(),
             non_blocking_tool_calls: HashMap::default(),
             queued_non_blocking_results: Vec::new(),
             pending_message: None,
@@ -2554,6 +2576,43 @@ impl Thread {
         self.run_turn(cx)
     }
 
+    /// Appends a user message that steers the currently running turn: the
+    /// turn ends at the next reasoning boundary and the message is processed
+    /// as a continuation on the same event stream, mirroring the UI's
+    /// steering flow. The message is held back from the conversation until
+    /// the boundary so it lands after the in-flight assistant message.
+    /// Returns `false` when no turn is running — callers should start a new
+    /// turn instead (e.g. resuming an idle subagent session).
+    pub fn steer<T>(
+        &mut self,
+        id: ClientUserMessageId,
+        content: impl IntoIterator<Item = T>,
+        cx: &mut Context<Self>,
+    ) -> bool
+    where
+        T: Into<UserMessageContent>,
+    {
+        if self.running_turn.is_none() {
+            return false;
+        }
+        self.steered_messages.push(UserMessage {
+            id,
+            content: content.into_iter().map(Into::into).collect::<Arc<_>>(),
+        });
+        self.end_turn_at_next_boundary = true;
+        cx.notify();
+        true
+    }
+
+    /// Whether the thread has no running turn and no non-blocking tool calls
+    /// still executing or awaiting delivery. Subagent drivers use this to
+    /// wait for a subagent's truly final output.
+    pub(crate) fn is_quiescent(&self) -> bool {
+        self.running_turn.is_none()
+            && self.non_blocking_tool_calls.is_empty()
+            && self.queued_non_blocking_results.is_empty()
+    }
+
     /// Force a manual context compaction using the summary strategy,
     /// regardless of the current token usage or context window size.
     pub fn compact(
@@ -2728,7 +2787,23 @@ impl Thread {
                     let continue_with_results = this
                         .update(cx, |this, cx| {
                             this.flush_pending_message(cx);
-                            if this.drain_finished_non_blocking_tool_calls(&event_stream, cx) {
+                            let delivered_results =
+                                this.drain_finished_non_blocking_tool_calls(&event_stream, cx);
+                            let has_steered_messages = !this.steered_messages.is_empty();
+                            if delivered_results || has_steered_messages {
+                                if has_steered_messages {
+                                    // The steer flag ended the previous turn
+                                    // at this boundary; consume it so the
+                                    // continuation runs to completion.
+                                    this.end_turn_at_next_boundary = false;
+                                    for message in this.steered_messages.drain(..) {
+                                        event_stream.send_user_message(&message);
+                                        this.messages.push(Arc::new(Message::User(message)));
+                                    }
+                                    this.updated_at = Utc::now();
+                                    this.clear_summary();
+                                    cx.notify();
+                                }
                                 true
                             } else {
                                 // Mark the thread idle in the same update that
@@ -2736,6 +2811,7 @@ impl Thread {
                                 // right now takes the continuation-request path
                                 // instead of being stranded in the queue.
                                 this.running_turn.take();
+                                cx.notify();
                                 false
                             }
                         })
@@ -3617,6 +3693,7 @@ impl Thread {
                     owning_message_ix,
                     event_stream,
                     cancellation_rx,
+                    None,
                     cx,
                 ));
             } else {
@@ -3634,7 +3711,7 @@ impl Thread {
             return None;
         }
 
-        if !blocking && !self.is_subagent() {
+        if !blocking {
             log::debug!("Running tool {} non-blockingly", tool_use.name);
             return Some(self.run_tool_non_blocking(
                 tool,
@@ -3657,6 +3734,7 @@ impl Thread {
             owning_message_ix,
             event_stream,
             cancellation_rx,
+            None,
             cx,
         ))
     }
@@ -3670,6 +3748,7 @@ impl Thread {
         owning_message_ix: usize,
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
+        non_blocking_identity_tx: Option<oneshot::Sender<serde_json::Value>>,
         cx: &mut Context<Self>,
     ) -> Task<(usize, LanguageModelToolResult)> {
         // A workspace can become restricted after a thread has already started.
@@ -3706,6 +3785,7 @@ impl Thread {
             self.sandbox_grants.clone(),
             Some(cx.weak_entity()),
         );
+        *tool_event_stream.non_blocking_identity_tx.borrow_mut() = non_blocking_identity_tx;
         tool_event_stream.update_fields(
             acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress),
         );
@@ -3772,7 +3852,9 @@ impl Thread {
     /// independently of the turn, the model immediately receives a
     /// placeholder result carrying an `async_tool_call_id`, and the real
     /// result is delivered later as a new user message (see
-    /// [`Thread::drain_finished_non_blocking_tool_calls`]).
+    /// [`Thread::drain_finished_non_blocking_tool_calls`]). Tools that opt in
+    /// via [`AgentTool::provides_non_blocking_identity`] can additionally
+    /// patch identity metadata (e.g. a new session id) into the placeholder.
     fn run_tool_non_blocking(
         &mut self,
         tool: Arc<dyn AnyAgentTool>,
@@ -3787,6 +3869,12 @@ impl Thread {
         // A dedicated cancellation channel keeps the tool running across
         // turn cancellations: the model was told the call runs independently.
         let (cancellation_tx, cancellation_rx) = watch::channel(false);
+        let (identity_tx, identity_rx) = if tool.provides_non_blocking_identity() {
+            let (identity_tx, identity_rx) = oneshot::channel();
+            (Some(identity_tx), Some(identity_rx))
+        } else {
+            (None, None)
+        };
         let tool_task = self.run_tool(
             tool,
             ToolInput::ready(input),
@@ -3795,6 +3883,7 @@ impl Thread {
             owning_message_ix,
             event_stream,
             cancellation_rx,
+            identity_tx,
             cx,
         );
         self.non_blocking_tool_calls.insert(
@@ -3817,27 +3906,41 @@ impl Thread {
         })
         .detach();
 
-        Task::ready((
-            owning_message_ix,
-            LanguageModelToolResult {
-                tool_use_id,
-                tool_name,
-                is_error: false,
-                content: vec![LanguageModelToolResultContent::Text(Arc::from(
-                    serde_json::json!({
-                        "async_tool_call_id": async_id.as_ref(),
-                        "status": "running",
-                        "note": concat!(
-                            "This tool call is running non-blockingly. Its result will ",
-                            "arrive later as a user message with the same async_tool_call_id. ",
-                            "Do not wait for it; continue with other work."
-                        ),
-                    })
-                    .to_string(),
-                ))],
-                output: None,
-            },
-        ))
+        cx.foreground_executor().spawn(async move {
+            // When the tool reports identity metadata it arrives right after
+            // startup; a dropped sender (tool finished or failed before
+            // reporting) falls back to the generic placeholder.
+            let identity = match identity_rx {
+                Some(identity_rx) => identity_rx.await.ok(),
+                None => None,
+            };
+            let mut envelope = serde_json::json!({
+                "async_tool_call_id": async_id.as_ref(),
+                "status": "running",
+                "note": concat!(
+                    "This tool call is running non-blockingly. Its result will ",
+                    "arrive later as a user message with the same async_tool_call_id. ",
+                    "Do not wait for it; continue with other work."
+                ),
+            });
+            if let (Some(envelope_object), Some(serde_json::Value::Object(identity))) =
+                (envelope.as_object_mut(), identity)
+            {
+                envelope_object.extend(identity);
+            }
+            (
+                owning_message_ix,
+                LanguageModelToolResult {
+                    tool_use_id,
+                    tool_name,
+                    is_error: false,
+                    content: vec![LanguageModelToolResultContent::Text(Arc::from(
+                        envelope.to_string(),
+                    ))],
+                    output: None,
+                },
+            )
+        })
     }
 
     /// Short, distinctive id for a non-blocking tool call (e.g. "a~K4u"): a
@@ -3995,6 +4098,7 @@ impl Thread {
             owning_message_ix,
             event_stream,
             cancellation_rx,
+            None,
             cx,
         ))
     }
@@ -4322,32 +4426,28 @@ impl Thread {
                     // The `blocking` property is offered on every tool
                     // without tool authors opting in; the runtime strips it
                     // from the input before the tool runs (see
-                    // `handle_tool_use_event`). Subagent threads are excluded
-                    // because nothing would deliver a late result once their
-                    // turn has ended.
-                    if !self.is_subagent() {
-                        if let Some(properties) = schema
-                            .get_mut("properties")
-                            .and_then(|value| value.as_object_mut())
-                        {
-                            properties
-                                .entry(BLOCKING_INPUT_PROPERTY.to_string())
-                                .or_insert_with(|| {
-                                    serde_json::json!({
-                                        "type": "boolean",
-                                        "default": true,
-                                        "description": concat!(
-                                            "Whether the agent waits for this tool call's result ",
-                                            "before continuing (default true). Set to false for ",
-                                            "long-running work whose result is not needed for the ",
-                                            "current reasoning step: the tool keeps running ",
-                                            "independently, the call immediately returns an ",
-                                            "async_tool_call_id, and the real result is delivered ",
-                                            "later as a user message carrying the same id."
-                                        ),
-                                    })
-                                });
-                        }
+                    // `handle_tool_use_event`).
+                    if let Some(properties) = schema
+                        .get_mut("properties")
+                        .and_then(|value| value.as_object_mut())
+                    {
+                        properties
+                            .entry(BLOCKING_INPUT_PROPERTY.to_string())
+                            .or_insert_with(|| {
+                                serde_json::json!({
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": concat!(
+                                        "Whether the agent waits for this tool call's result ",
+                                        "before continuing (default true). Set to false for ",
+                                        "long-running work whose result is not needed for the ",
+                                        "current reasoning step: the tool keeps running ",
+                                        "independently, the call immediately returns an ",
+                                        "async_tool_call_id, and the real result is delivered ",
+                                        "later as a user message carrying the same id."
+                                    ),
+                                })
+                            });
                     }
                     Some(LanguageModelRequestTool::function(
                         tool_name.to_string(),
@@ -5461,6 +5561,14 @@ where
         false
     }
 
+    /// Whether the tool reports identity metadata for a non-blocking call's
+    /// immediate response (via
+    /// [`ToolCallEventStream::report_non_blocking_identity`]). Runtime-only
+    /// opt-in; tools that don't override it get the generic placeholder.
+    fn provides_non_blocking_identity() -> bool {
+        false
+    }
+
     /// Some tools rely on a provider for the underlying billing or other reasons.
     /// Allow the tool to check if they are compatible, or should be filtered out.
     fn supports_provider(_provider: &LanguageModelProviderId) -> bool {
@@ -5535,6 +5643,10 @@ pub trait AnyAgentTool {
     fn supports_input_streaming(&self) -> bool {
         false
     }
+    /// See [`AgentTool::provides_non_blocking_identity`].
+    fn provides_non_blocking_identity(&self) -> bool {
+        false
+    }
     fn supports_provider(&self, _provider: &LanguageModelProviderId) -> bool {
         true
     }
@@ -5575,6 +5687,10 @@ where
 
     fn supports_input_streaming(&self) -> bool {
         T::supports_input_streaming()
+    }
+
+    fn provides_non_blocking_identity(&self) -> bool {
+        T::provides_non_blocking_identity()
     }
 
     fn initial_title(&self, input: serde_json::Value, _cx: &mut App) -> SharedString {
@@ -5837,6 +5953,10 @@ pub struct ToolCallEventStream {
     /// sandbox grant is recorded so it survives reopening. `None` in tests and
     /// for streams not tied to a live thread.
     thread: Option<WeakEntity<Thread>>,
+    /// Channel for a tool to contribute identity metadata to a non-blocking
+    /// call's immediate response (see [`AgentTool::provides_non_blocking_identity`]).
+    /// `None` when the call is blocking.
+    non_blocking_identity_tx: Rc<RefCell<Option<oneshot::Sender<serde_json::Value>>>>,
 }
 
 impl ToolCallEventStream {
@@ -5921,6 +6041,17 @@ impl ToolCallEventStream {
             cancellation_rx,
             sandbox_grants,
             thread,
+            non_blocking_identity_tx: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    /// Reports identity metadata for a non-blocking call's immediate response
+    /// (e.g. `spawn_agent` reports the new session id so the parent can
+    /// reference the session before it finishes). No-op when the call is
+    /// blocking — the final result already carries everything the model needs.
+    pub fn report_non_blocking_identity(&self, metadata: serde_json::Value) {
+        if let Some(sender) = self.non_blocking_identity_tx.borrow_mut().take() {
+            sender.send(metadata).ok();
         }
     }
 

--- a/crates/agent/src/tools/spawn_agent_tool.rs
+++ b/crates/agent/src/tools/spawn_agent_tool.rs
@@ -34,6 +34,7 @@ use crate::{AgentTool, ThreadEnvironment, ToolCallEventStream, ToolInput};
 /// - You will receive only the agent's final message as output.
 /// - Successful calls return a session_id that you can use for follow-up messages.
 /// - Error results may also include a session_id if a session was already created.
+/// - Resuming (via `session_id`) a session that is still running steers it instead: your message is incorporated at that agent's next reasoning boundary, and this call returns immediately with an acknowledgment rather than the agent's output. The running call that is driving the session (a spawn_agent call, yours or a previous one) still receives its final output.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct SpawnAgentToolInput {
@@ -130,6 +131,10 @@ impl AgentTool for SpawnAgentTool {
         acp::ToolKind::Other
     }
 
+    fn provides_non_blocking_identity() -> bool {
+        true
+    }
+
     fn initial_title(
         &self,
         input: Result<Self::Input, serde_json::Value>,
@@ -161,6 +166,51 @@ impl AgentTool for SpawnAgentTool {
                     session_info: None,
                 })?;
 
+            // Resuming a session that is still running steers it: the
+            // message joins the running turn at its next reasoning boundary
+            // and this call returns an acknowledgment instead of awaiting
+            // the session's output.
+            if let Some(session_id) = input.session_id.clone() {
+                let steered = cx
+                    .update(|cx| {
+                        self.environment.steer_subagent(
+                            session_id.clone(),
+                            input.message.clone(),
+                            cx,
+                        )
+                    })
+                    .map_err(|error| SpawnAgentToolOutput::Error {
+                        session_id: Some(session_id.clone()),
+                        error: error.to_string(),
+                        session_info: None,
+                    })?;
+                if let Some(message_start_index) = steered {
+                    let session_info = SubagentSessionInfo {
+                        session_id: session_id.clone(),
+                        message_start_index,
+                        message_end_index: None,
+                    };
+                    let output = format!(
+                        "Steered the running agent session {session_id}: the message will be \
+                         incorporated at its next reasoning boundary. No direct response is \
+                         returned; the session's output arrives as the result of the spawn_agent \
+                         call that is driving it."
+                    );
+                    event_stream.update_fields_with_meta(
+                        acp::ToolCallUpdateFields::new().content(vec![output.clone().into()]),
+                        Some(acp::Meta::from_iter([(
+                            SUBAGENT_SESSION_INFO_META_KEY.into(),
+                            serde_json::json!(&session_info),
+                        )])),
+                    );
+                    return Ok(SpawnAgentToolOutput::Success {
+                        session_id,
+                        output,
+                        session_info,
+                    });
+                }
+            }
+
             let (subagent, mut session_info) = cx.update(|cx| {
                 let subagent = if let Some(session_id) = input.session_id {
                     self.environment.resume_subagent(session_id, cx)
@@ -189,6 +239,10 @@ impl AgentTool for SpawnAgentTool {
 
                 Ok((subagent, session_info))
             })?;
+
+            event_stream.report_non_blocking_identity(serde_json::json!({
+                "session_id": session_info.session_id,
+            }));
 
             let send_result = subagent.send(input.message, cx).await;
 


### PR DESCRIPTION
## What

Lets the model mark any tool call as non-blocking via an optional `blocking` boolean (default `true`) that the agent runtime injects into every tool schema and strips from the input before the tool runs. No tool — built-in, MCP, or future — opts in or even sees the property.

With conventional parallel tool execution the agent still waits for all tool calls in a batch before its next reasoning step. A call with `"blocking": false` removes that synchronization point for long-running work (tests, sub-agents, MCP calls) whose result is useful but not needed for the current step.

## How it works

- The call executes independently of the turn. The model immediately receives a placeholder result carrying a short `async_tool_call_id` (e.g. `a~K4u`) instead of a canceled-sentinel, so the reasoning loop continues without waiting.
- When the tool finishes, its result is delivered as a new, appended user message tagged with the same id — never patched in place, to stay friendly to prompt caching:
  - turn active → delivered at the next reasoning boundary,
  - turn winding down → steered into a continuation on the same event stream,
  - thread idle → a `ContinuationRequested` event lets `NativeAgent` start a continuation turn (mirrors the MCP-prompt flow, so the activity stays visible in the UI).
- The runtime owns the lifecycle and races; the tool never knows whether the agent is generating, waiting, or done. This is orthogonal to execution concurrency: a tool can run concurrently and still be blocking.

Subagent threads and streaming-input tools are excluded (forced blocking): nothing would deliver a late result after a subagent's turn ends, and streaming tools begin executing on partial input.

## Suggested .rules additions

When adding a test tool in `crates/agent/src/tests`, its `NAME` must also be added to the `tools` map of `test-profile` in `setup()` (`tests/mod.rs`); otherwise calls to it fail at runtime with `No tool named X exists`.

## Related discussion
[Discussion#62908](https://github.com/zed-industries/zed/discussions/62908)

Release Notes:

- Added support for non-blocking tool calls in the agent
