### PR TITLE
markdown: Fix search and selection highlights that hide the preview text

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -4081,8 +4081,8 @@ impl Element for HighlightedLine {
         window: &mut Window,
         cx: &mut App,
     ) {
-        self.text.paint(window, cx);
         self.line.paint_highlights(window);
+        self.text.paint(window, cx);
     }
 }
 


### PR DESCRIPTION
# Objective

This PR fixes a bug in the markdown preview. The preview paints the search highlights and the selection highlights on top of the text. The editor paints the same highlights below the text.

The bug is old:

- The selection paint order comes from the first version of the `markdown` crate (zed-industries/zed#11556, May 2024).
- The search highlights kept the same order when search came to the preview (zed-industries/zed#52502, April 2026).
- The bug is in stable (`v1.16.1`), in preview (`v1.17.0-pre`), and on `main`.

The effect depends on the alpha value of the theme color:

- If `search.match_background` is opaque, the highlight fully covers the matched text. The user cannot see the text.
- If the color is translucent, the highlight changes the color of the text.

The bug is important, for two reasons:

1. **Opaque highlight colors are common.** We examined the 50 most-downloaded theme extensions on the marketplace (438 theme variants). In 14 of the 50 extensions (28%), one or more variants set an opaque `search.match_background`. These 14 extensions have 24% of the downloads in this group. Examples: Tokyo Night, Dracula, Material Dark, Fleet, New Darcula, Zedokai, Everforest, and Base16. All 11 stock themes use alpha `0x66`; this is why the defect is not visible with them.

2. **Opaque highlight colors are valid.** The [theme JSON schema](https://zed.dev/schema/themes/v0.2.0.json) does not put a limit on the alpha value of `search.match_background`. The [theme extension docs](https://zed.dev/docs/extensions/themes) also do not have this requirement. The editor shows the same opaque colors correctly.

Because opaque colors are common and valid, the paint order must keep the text visible: highlights below, text on top.

## Solution

zed-industries/zed#62714 recently moved the highlight paint step into the paint function of each line. That refactor made a minimal fix possible: paint the highlight quads of a line before you paint the text of that line. The change is one line in `HighlightedLine::paint`.

This fix does not change the highlight geometry. This fix does not change the clip behavior that zed-industries/zed#62714 corrected.

## Testing

- Run `cargo test -p markdown`. All 152 tests pass. This includes the highlight-geometry tests from zed-industries/zed#62714.
- Run `cargo fmt --all -- --check` and `cargo clippy -p markdown --all-targets --all-features -- -D warnings`. There are no errors.
- Do a manual A/B test with the same file and the same theme. The theme has an opaque `search.match_background`. A build without the fix does not show the matched text. Stable `v1.16.1` also does not show it. A build with the fix shows the text on top of the highlight. This is equal to the editor.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before my fix (`main` branch, `Monokai reversed` theme from marketplace):
<img width="600"  alt="before" src="https://github.com/user-attachments/assets/1973e6af-2ff8-46b3-a3b0-37a823d83cde" />

After my fix:
<img width="600" alt="after" src="https://github.com/user-attachments/assets/45e140d0-d80f-4326-b095-3d0df2cad2ae" />

Release Notes:

- Fixed a bug where the search and selection highlights covered the text in the markdown preview




