### PR TITLE
project_panel: Fix focus when opening entries

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2181,6 +2181,18 @@ impl ProjectPanel {
         });
     }
 
+    fn open_entry_from_click(
+        &mut self,
+        entry_id: ProjectEntryId,
+        click_count: usize,
+        cx: &mut Context<Self>,
+    ) {
+        let preview_tabs_enabled =
+            PreviewTabsSettings::get_global(cx).enable_preview_from_project_panel;
+        let allow_preview = preview_tabs_enabled && click_count == 1;
+        self.open_entry(entry_id, true, allow_preview, cx);
+    }
+
     fn split_entry(
         &mut self,
         entry_id: ProjectEntryId,
@@ -6129,12 +6141,7 @@ impl ProjectPanel {
                             project_panel.toggle_expanded(entry_id, window, cx);
                         }
                     } else {
-                        let preview_tabs_enabled =
-                            PreviewTabsSettings::get_global(cx).enable_preview_from_project_panel;
-                        let click_count = event.click_count();
-                        let focus_opened_item = click_count > 1;
-                        let allow_preview = preview_tabs_enabled && click_count == 1;
-                        project_panel.open_entry(entry_id, focus_opened_item, allow_preview, cx);
+                        project_panel.open_entry_from_click(entry_id, event.click_count(), cx);
                     }
                 }),
             )

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -173,6 +173,68 @@ async fn test_opening_file(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_clicking_file_focuses_opened_item(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/src"),
+        json!({
+            "test.rs": "// Rust file",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/src").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        workspace.open_panel::<ProjectPanel>(window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    select_path(&panel, "src/test.rs", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        window.focus(&panel.focus_handle, cx);
+        assert!(
+            panel.focus_handle.contains_focused(window, cx),
+            "Project Panel should be focused before clicking a file"
+        );
+
+        let entry_id = panel
+            .selected_entry(cx)
+            .expect("test file should be selected")
+            .1
+            .id;
+        panel.open_entry_from_click(entry_id, 1, cx);
+    });
+    cx.run_until_parked();
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        let active_item = workspace
+            .active_item(cx)
+            .expect("clicked file should be open");
+        assert!(
+            active_item
+                .item_focus_handle(cx)
+                .contains_focused(window, cx),
+            "Clicking a file should focus the opened item"
+        );
+        assert_eq!(
+            workspace.active_pane().read(cx).preview_item_id(),
+            Some(active_item.item_id()),
+            "A single click should still open the item as a preview"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_file_history_action_uses_focused_project_panel_selection(
     cx: &mut gpui::TestAppContext,
 ) {


### PR DESCRIPTION
# Objective

Fixes #34865.

This PR is a follow-up to the closed PR of #62942.

Hopefully, this should be a pretty straightforward PR to review. : )

## Solution

When a new tab is opened via clicking on a file in the "Explorer" pane, the focus should go to the new file.

## Testing

- Tested by compiling the new Zed version and then manually confirmed that the focused correctly changed after clicking.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed keyboard focus not going to a new file after opening.
