### PR TITLE
Add terminal context: read_terminal and list_terminals tools with @terminal mentions

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -63,6 +63,13 @@ pub enum MentionUri {
     TerminalSelection {
         line_count: u32,
     },
+    /// References a whole terminal (by its stable internal id) so its current
+    /// buffer can be attached as agent context. `title` is the human-facing
+    /// label shown in the UI; `id` is an opaque UUID the user never sees.
+    Terminal {
+        id: String,
+        title: String,
+    },
     GitDiff {
         base_ref: String,
     },
@@ -232,6 +239,15 @@ impl MentionUri {
                         .parse::<u32>()
                         .unwrap_or(0);
                     Ok(Self::TerminalSelection { line_count })
+                } else if let Some(terminal_id) = path.strip_prefix("/agent/terminal/") {
+                    let title = single_query_param(&url, "name")?.unwrap_or_default();
+                    if terminal_id.is_empty() {
+                        bail!("invalid terminal mention: missing id");
+                    }
+                    Ok(Self::Terminal {
+                        id: terminal_id.to_string(),
+                        title,
+                    })
                 } else if path.starts_with("/agent/git-diff") {
                     let base_ref =
                         single_query_param(&url, "base")?.unwrap_or_else(|| "main".to_string());
@@ -327,6 +343,7 @@ impl MentionUri {
             | MentionUri::Diagnostics { .. }
             | MentionUri::Fetch { .. }
             | MentionUri::TerminalSelection { .. }
+            | MentionUri::Terminal { .. }
             | MentionUri::GitDiff { .. }
             | MentionUri::MergeConflict { .. } => None,
         }
@@ -351,6 +368,7 @@ impl MentionUri {
                     format!("Terminal ({} lines)", line_count)
                 }
             }
+            MentionUri::Terminal { title, .. } => title.clone(),
             MentionUri::GitDiff { base_ref } => format!("Branch Diff ({})", base_ref),
             MentionUri::MergeConflict { file_path } => {
                 let name = Path::new(file_path)
@@ -429,6 +447,7 @@ impl MentionUri {
             MentionUri::Skill {
                 skill_file_path, ..
             } => Some(skill_file_path.to_string_lossy().into_owned().into()),
+            MentionUri::Terminal { title, .. } => Some(title.clone().into()),
             _ => None,
         }
     }
@@ -446,6 +465,7 @@ impl MentionUri {
             MentionUri::Rule { .. } => IconName::Reader.path().into(),
             MentionUri::Diagnostics { .. } => IconName::Warning.path().into(),
             MentionUri::TerminalSelection { .. } => IconName::Terminal.path().into(),
+            MentionUri::Terminal { .. } => IconName::Terminal.path().into(),
             MentionUri::Selection { .. } => IconName::Reader.path().into(),
             MentionUri::Fetch { .. } => IconName::ToolWeb.path().into(),
             MentionUri::GitDiff { .. } => IconName::GitBranch.path().into(),
@@ -557,6 +577,12 @@ impl MentionUri {
                 let mut url = Url::parse("zed:///agent/terminal-selection").unwrap();
                 url.query_pairs_mut()
                     .append_pair("lines", &line_count.to_string());
+                url
+            }
+            MentionUri::Terminal { id, title } => {
+                let mut url = Url::parse("zed:///").unwrap();
+                url.set_path(&format!("/agent/terminal/{id}"));
+                url.query_pairs_mut().append_pair("name", title);
                 url
             }
             MentionUri::GitDiff { base_ref } => {
@@ -888,6 +914,27 @@ mod tests {
             _ => panic!("Expected Directory variant"),
         }
         assert_eq!(parsed.to_uri().to_string(), file_uri);
+    }
+
+    #[test]
+    fn test_parse_terminal_uri() {
+        let terminal_uri = "zed:///agent/terminal/abc-123?name=my%20terminal";
+        let parsed = MentionUri::parse(terminal_uri, PathStyle::local()).unwrap();
+        match &parsed {
+            MentionUri::Terminal { id, title } => {
+                assert_eq!(id, "abc-123");
+                assert_eq!(title, "my terminal");
+            }
+            other => panic!("Expected Terminal variant, got {other:?}"),
+        }
+        let reparsed = MentionUri::parse(&parsed.to_uri().to_string(), PathStyle::local()).unwrap();
+        match &reparsed {
+            MentionUri::Terminal { id, title } => {
+                assert_eq!(id, "abc-123");
+                assert_eq!(title, "my terminal");
+            }
+            other => panic!("Expected Terminal variant on reparse, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -5,6 +5,7 @@ pub mod outline;
 mod pattern_extraction;
 mod sandboxing;
 mod templates;
+pub mod terminal_provider;
 #[cfg(test)]
 mod tests;
 mod thread;
@@ -3327,6 +3328,28 @@ impl ThreadEnvironment for NativeThreadEnvironment {
                 )
             })?;
         host.list_available_agents(cx)
+    }
+
+    fn read_terminal(
+        &self,
+        id: &str,
+        head: Option<u32>,
+        tail: Option<u32>,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<String>> {
+        let content = cx.update(|app| terminal_provider::read_terminal(app, id, head, tail));
+        match content {
+            Some(content) => Task::ready(Ok(content)),
+            None => Task::ready(Err(anyhow!("No open terminal with id {id}"))),
+        }
+    }
+
+    fn list_terminals(
+        &self,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<Vec<terminal_provider::TerminalSummary>>> {
+        let terminals = cx.update(|app| terminal_provider::list_terminals(app));
+        Task::ready(Ok(terminals))
     }
 }
 

--- a/crates/agent/src/terminal_provider.rs
+++ b/crates/agent/src/terminal_provider.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use gpui::{App, AppContext, Global};
+use serde::{Deserialize, Serialize};
+
+/// A terminal the agent can reference, returned by
+/// [`TerminalContentProvider::list_terminals`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalSummary {
+    /// Opaque, stable terminal id (a UUID string). Internal-only; never shown
+    /// to the user.
+    pub id: String,
+    /// Human-facing label (the terminal's title), shown in the UI.
+    pub title: String,
+    /// Current working directory of the terminal, if known.
+    pub cwd: Option<String>,
+}
+
+/// Provides access to the user's open terminals so the agent can read their
+/// contents. Implemented in `agent_ui` (which has workspace access) and
+/// registered as a gpui global; the `agent` crate consumes it without taking a
+/// dependency on the UI.
+pub trait TerminalContentProvider: Send + Sync {
+    /// Returns the current buffer of the terminal with the given id, optionally
+    /// limited to the first `head` / last `tail` lines. Returns `None` when no
+    /// terminal with that id is open.
+    fn read_terminal(&self, id: &str, head: Option<u32>, tail: Option<u32>, cx: &App)
+    -> Option<String>;
+
+    /// Lists the terminals currently open in the workspace.
+    fn list_terminals(&self, cx: &App) -> Vec<TerminalSummary>;
+}
+
+struct GlobalTerminalContentProvider(Arc<dyn TerminalContentProvider>);
+
+impl Global for GlobalTerminalContentProvider {}
+
+/// Registers the workspace-backed implementation of [`TerminalContentProvider`].
+pub fn set_terminal_content_provider(provider: Arc<dyn TerminalContentProvider>, cx: &mut App) {
+    cx.set_global(GlobalTerminalContentProvider(provider));
+}
+
+/// Returns the current buffer of the terminal with the given id, if a provider
+/// is registered and such a terminal is open.
+pub fn read_terminal(
+    cx: &App,
+    id: &str,
+    head: Option<u32>,
+    tail: Option<u32>,
+) -> Option<String> {
+    if !cx.has_global::<GlobalTerminalContentProvider>() {
+        return None;
+    }
+    cx.read_global::<GlobalTerminalContentProvider, _>(|global, app| {
+        global.0.read_terminal(id, head, tail, app)
+    })
+}
+
+/// Lists the terminals currently open in the workspace.
+pub fn list_terminals(cx: &App) -> Vec<TerminalSummary> {
+    if !cx.has_global::<GlobalTerminalContentProvider>() {
+        return Vec::new();
+    }
+    cx.read_global::<GlobalTerminalContentProvider, _>(|global, app| global.0.list_terminals(app))
+}

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -5,7 +5,7 @@ use crate::{
     GoToDefinitionTool, GrepTool, ListAgentsAndModelsTool, ListDirectoryTool, MovePathTool,
     ProjectSnapshot, ReadFileTool, RenameTool, SandboxedTerminalTool, SpawnAgentTool,
     SystemPromptTemplate, Template, Templates, TerminalTool, ToolPermissionDecision, WebSearchTool,
-    WriteFileTool, decide_permission_from_settings,
+    WriteFileTool, decide_permission_from_settings, ListTerminalsTool, ReadTerminalTool,
 };
 use acp_thread::{ClientUserMessageId, MentionUri};
 use action_log::ActionLog;
@@ -325,6 +325,7 @@ impl UserMessage {
             "<rules>\nThe user has specified the following rules that should be applied:\n";
         const OPEN_DIAGNOSTICS_TAG: &str = "<diagnostics>";
         const OPEN_DIFFS_TAG: &str = "<diffs>";
+        const OPEN_TERMINALS_TAG: &str = "<terminals>";
         const MERGE_CONFLICT_TAG: &str = "<merge_conflicts>";
         const OPEN_SKILLS_TAG: &str =
             "<skills>\nThe user has attached the following agent skills:\n";
@@ -340,6 +341,7 @@ impl UserMessage {
         let mut diffs_context = OPEN_DIFFS_TAG.to_string();
         let mut merge_conflict_context = MERGE_CONFLICT_TAG.to_string();
         let mut skills_context = OPEN_SKILLS_TAG.to_string();
+        let mut terminal_context = OPEN_TERMINALS_TAG.to_string();
 
         for chunk in &*self.content {
             let chunk = match chunk {
@@ -461,6 +463,17 @@ impl UserMessage {
                             let label = format!("{} ({})", name, source);
                             write!(&mut skills_context, "\nSkill: {}\n{}\n", label, content).ok();
                         }
+                        MentionUri::Terminal { .. } => {
+                            write!(
+                                &mut terminal_context,
+                                "\n{}",
+                                MarkdownCodeBlock {
+                                    tag: "console",
+                                    text: content
+                                }
+                            )
+                            .ok();
+                        }
                     }
 
                     language_model::MessageContent::Text(uri.as_link().to_string())
@@ -547,6 +560,13 @@ impl UserMessage {
             message
                 .content
                 .push(language_model::MessageContent::Text(merge_conflict_context));
+        }
+
+        if terminal_context.len() > OPEN_TERMINALS_TAG.len() {
+            terminal_context.push_str("</terminals>\n");
+            message
+                .content
+                .push(language_model::MessageContent::Text(terminal_context));
         }
 
         if message.content.len() > len_before_context {
@@ -797,6 +817,30 @@ pub trait ThreadEnvironment {
         Err(anyhow::anyhow!(
             "Listing available agents is not supported in this environment"
         ))
+    }
+
+    /// Reads the current buffer of the terminal with the given id, optionally
+    /// limited to the first `head` / last `tail` lines.
+    fn read_terminal(
+        &self,
+        _id: &str,
+        _head: Option<u32>,
+        _tail: Option<u32>,
+        _cx: &mut AsyncApp,
+    ) -> Task<Result<String>> {
+        Task::ready(Err(anyhow::anyhow!(
+            "Reading terminals is not supported in this environment"
+        )))
+    }
+
+    /// Lists the terminals currently open in the workspace.
+    fn list_terminals(
+        &self,
+        _cx: &mut AsyncApp,
+    ) -> Task<Result<Vec<crate::terminal_provider::TerminalSummary>>> {
+        Task::ready(Err(anyhow::anyhow!(
+            "Listing terminals is not supported in this environment"
+        )))
     }
 }
 
@@ -2163,6 +2207,8 @@ impl Thread {
             self.project.clone(),
             environment.clone(),
         ));
+        self.add_tool(ReadTerminalTool::new(environment.clone()));
+        self.add_tool(ListTerminalsTool::new(environment.clone()));
         self.add_tool(WebSearchTool);
 
         self.add_tool(AskUserTool);

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -24,6 +24,7 @@ mod rename_tool;
 mod skill_tool;
 mod spawn_agent_tool;
 mod symbol_locator;
+mod read_terminal_tool;
 mod terminal_tool;
 mod tool_permissions;
 mod web_search_tool;
@@ -94,6 +95,7 @@ pub use skill_tool::*;
 pub use spawn_agent_tool::*;
 pub use symbol_locator::*;
 
+pub use read_terminal_tool::*;
 pub use terminal_tool::*;
 pub use tool_permissions::*;
 pub use web_search_tool::*;

--- a/crates/agent/src/tools/read_terminal_tool.rs
+++ b/crates/agent/src/tools/read_terminal_tool.rs
@@ -1,0 +1,143 @@
+use agent_client_protocol::schema::v1 as acp;
+use anyhow::Result;
+use gpui::{App, SharedString, Task};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::{AgentTool, ThreadEnvironment, ToolCallEventStream, ToolInput};
+
+/// Reads the current contents of a terminal pane by its id, so the agent can
+/// act on command output or errors the user is looking at without re-running
+/// anything.
+///
+/// This is read-only: it does not execute commands or modify the terminal.
+///
+/// To discover which terminals are available, use the `list_terminals` tool,
+/// which returns each terminal's id and title.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ReadTerminalToolInput {
+    /// The id of the terminal to read. Obtain it from `list_terminals`.
+    pub terminal_id: String,
+    /// Return only the first N lines of the terminal buffer. Avoid requesting
+    /// too many lines, or the response may waste tokens or exceed the context window.
+    #[serde(default)]
+    pub head_lines: Option<u32>,
+    /// Return only the last N lines of the terminal buffer. Avoid requesting
+    /// too many lines, or the response may waste tokens or exceed the context window.
+    #[serde(default)]
+    pub tail_lines: Option<u32>,
+}
+
+/// Reads the current contents of a terminal pane.
+pub struct ReadTerminalTool {
+    environment: Rc<dyn ThreadEnvironment>,
+}
+
+impl ReadTerminalTool {
+    pub fn new(environment: Rc<dyn ThreadEnvironment>) -> Self {
+        Self { environment }
+    }
+}
+
+impl AgentTool for ReadTerminalTool {
+    type Input = ReadTerminalToolInput;
+    type Output = String;
+
+    const NAME: &'static str = "read_terminal";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Read
+    }
+
+    fn allow_in_restricted_mode() -> bool {
+        true
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "Read Terminal".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        cx.spawn(async move |cx| {
+            let input = input.recv().await.map_err(|e| e.to_string())?;
+            let content = self
+                .environment
+                .read_terminal(&input.terminal_id, input.head_lines, input.tail_lines, cx)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(content)
+        })
+    }
+}
+
+/// Returns the terminals currently open in the workspace, so the agent can
+/// reference them with `read_terminal`.
+///
+/// Each terminal is identified by a stable id and shown to the user by its
+/// title; pass the id to `read_terminal` to read its contents.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ListTerminalsToolInput {}
+
+/// Lists the terminals currently open in the workspace.
+pub struct ListTerminalsTool {
+    environment: Rc<dyn ThreadEnvironment>,
+}
+
+impl ListTerminalsTool {
+    pub fn new(environment: Rc<dyn ThreadEnvironment>) -> Self {
+        Self { environment }
+    }
+}
+
+impl AgentTool for ListTerminalsTool {
+    type Input = ListTerminalsToolInput;
+    type Output = String;
+
+    const NAME: &'static str = "list_terminals";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Read
+    }
+
+    fn allow_in_restricted_mode() -> bool {
+        true
+    }
+
+    fn initial_title(
+        &self,
+        _input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        "List Terminals".into()
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        cx.spawn(async move |cx| {
+            let _ = input.recv().await.map_err(|e| e.to_string())?;
+            let terminals = self
+                .environment
+                .list_terminals(cx)
+                .await
+                .map_err(|e| e.to_string())?;
+            let serialized = serde_json::to_string_pretty(&terminals)
+                .map_err(|e| e.to_string())?;
+            Ok(serialized)
+        })
+    }
+}

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -11,7 +11,9 @@ use std::{
 };
 
 use acp_thread::{AcpThread, AcpThreadEvent, MentionUri, ThreadStatus, line_range_suffix};
-use agent::{ContextServerRegistry, SharedThread, ThreadStore};
+use agent::{
+    ContextServerRegistry, SharedThread, ThreadStore, terminal_provider::TerminalContentProvider,
+};
 use agent_client_protocol::schema::v1 as acp;
 use agent_servers::AgentServer;
 use agent_settings::UserAgentsMd;
@@ -1188,6 +1190,78 @@ pub struct AgentPanel {
     is_active: bool,
 }
 
+/// Provides the agent with read access to the terminals open in this panel.
+struct AgentPanelTerminalContentProvider {
+    panel: WeakEntity<AgentPanel>,
+}
+
+impl TerminalContentProvider for AgentPanelTerminalContentProvider {
+    fn read_terminal(
+        &self,
+        id: &str,
+        head: Option<u32>,
+        tail: Option<u32>,
+        cx: &App,
+    ) -> Option<String> {
+            let terminal_id = TerminalId::from_key_string(id).ok()?;
+            let panel = self.panel.upgrade()?;
+            panel.read_with(cx, |panel, cx| {
+                let agent_terminal = panel.terminals.get(&terminal_id)?;
+                let content = agent_terminal
+                    .view
+                    .read(cx)
+                    .terminal()
+                    .read(cx)
+                    .get_content();
+                Some(slice_terminal_content(content, head, tail))
+            })
+    }
+
+    fn list_terminals(&self, cx: &App) -> Vec<agent::terminal_provider::TerminalSummary> {
+        let Some(panel) = self.panel.upgrade() else {
+            return Vec::new();
+        };
+            panel.read_with(cx, |panel, cx| {
+                panel
+                    .terminals
+                    .iter()
+                    .map(|(id, agent_terminal)| {
+                        let title = agent_terminal.terminal_title(cx).to_string();
+                        let cwd = TerminalThreadMetadataStore::try_global(cx)
+                            .and_then(|store| store.read(cx).entry(*id))
+                            .and_then(|metadata| metadata.working_directory.clone())
+                            .map(|path| path.to_string_lossy().to_string());
+                        agent::terminal_provider::TerminalSummary {
+                            id: id.to_key_string(),
+                            title,
+                            cwd,
+                        }
+                    })
+                    .collect()
+            })
+    }
+}
+
+fn slice_terminal_content(content: String, head: Option<u32>, tail: Option<u32>) -> String {
+    let head = head.map(|n| n as usize);
+    let tail = tail.map(|n| n as usize);
+    match (head, tail) {
+        (None, None) => content,
+        (head, tail) => {
+            let lines: Vec<&str> = content.lines().collect();
+            let head_count = head.unwrap_or(lines.len()).min(lines.len());
+            let tail_count = tail.unwrap_or(0).min(lines.len().saturating_sub(head_count));
+            let mut result = lines[..head_count].join("\n");
+            if tail_count > 0 {
+                result.push_str("\n...\n");
+                let start = lines.len() - tail_count;
+                result.push_str(&lines[start..].join("\n"));
+            }
+            result
+        }
+    }
+}
+
 impl AgentPanel {
     fn serialize(&mut self, cx: &mut App) {
         let Some(workspace_id) = self.workspace_id else {
@@ -1590,6 +1664,13 @@ impl AgentPanel {
             last_context_source: None,
             is_active: false,
         };
+
+        agent::terminal_provider::set_terminal_content_provider(
+            Arc::new(AgentPanelTerminalContentProvider {
+                panel: cx.entity().downgrade(),
+            }),
+            cx,
+        );
 
         panel.ensure_native_agent_connection(cx);
         panel

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -8,6 +8,7 @@ use crate::DEFAULT_THREAD_TITLE;
 use crate::thread_metadata_store::{ThreadMetadata, ThreadMetadataStore};
 use acp_thread::MentionUri;
 use agent_client_protocol::schema::v1 as acp;
+use agent::terminal_provider::TerminalSummary;
 use anyhow::Result;
 use editor::{CompletionProvider, Editor, code_context_menus::COMPLETION_MENU_MAX_WIDTH};
 use futures::FutureExt as _;
@@ -299,6 +300,7 @@ pub(crate) enum Match {
     Skill(AvailableSkill),
     Entry(EntryMatch),
     BranchDiff(BranchDiffMatch),
+    Terminal(TerminalMatch),
 }
 
 #[derive(Debug, Clone)]
@@ -317,8 +319,16 @@ impl Match {
             Match::Skill(_) => 1.,
             Match::Fetch(_) => 1.,
             Match::BranchDiff(_) => 1.,
+            Match::Terminal(terminal) => terminal.mat.as_ref().map(|mat| mat.score).unwrap_or(1.),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct TerminalMatch {
+    pub id: String,
+    pub title: String,
+    pub mat: Option<StringMatch>,
 }
 
 #[derive(Debug, Clone)]
@@ -817,6 +827,47 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
         })
     }
 
+    fn completion_for_terminal(
+        id: String,
+        title: SharedString,
+        source_range: Range<Anchor>,
+        source: Arc<T>,
+        editor: WeakEntity<Editor>,
+        mention_set: WeakEntity<MentionSet>,
+        workspace: Entity<Workspace>,
+        cx: &mut App,
+    ) -> Completion {
+        let uri = MentionUri::Terminal {
+            id,
+            title: title.to_string(),
+        };
+        let new_text = format!("{} ", uri.as_link());
+        let new_text_len = new_text.len();
+        Completion {
+            replace_range: source_range.clone(),
+            new_text,
+            label: CodeLabel::plain(title.to_string(), None),
+            documentation: None,
+            insert_text_mode: None,
+            source: project::CompletionSource::Custom,
+            match_start: None,
+            snippet_deduplication_key: None,
+            icon_path: Some(uri.icon_path(cx)),
+            icon_color: None,
+            confirm: Some(confirm_completion_callback(
+                title,
+                source_range.start,
+                new_text_len - 1,
+                uri,
+                source,
+                editor,
+                mention_set,
+                workspace,
+            )),
+            group: None,
+        }
+    }
+
     pub(crate) fn completion_for_action(
         action: PromptContextAction,
         source_range: Range<Anchor>,
@@ -1099,6 +1150,7 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
         let Some(workspace) = self.workspace.upgrade() else {
             return Task::ready(Vec::default());
         };
+        let terminal_summaries = agent::terminal_provider::list_terminals(cx);
         match mode {
             Some(PromptContextType::File) => {
                 let search_files_task = search_files(query, cancellation_flag, &workspace, cx);
@@ -1181,9 +1233,12 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                     None
                 };
 
+                let terminal_task = self.terminal_matches(terminal_summaries, "", cx);
+
                 cx.spawn(async move |_cx| {
                     let mut matches = recent_task.await;
                     matches.extend(entries);
+                    matches.extend(terminal_task.await);
 
                     if let Some(branch_diff_task) = branch_diff_task {
                         if let Some(branch_diff_match) = branch_diff_task.await {
@@ -1216,6 +1271,8 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                     None
                 };
 
+                let terminal_task = self.terminal_matches(terminal_summaries, &query, cx);
+
                 cx.spawn(async move |cx| {
                     let mut matches = search_files_task
                         .await
@@ -1240,6 +1297,8 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                             mat: Some(mat),
                         })
                     }));
+
+                    matches.extend(terminal_task.await);
 
                     if let Some(branch_diff_task) = branch_diff_task {
                         let branch_diff_keyword = PromptContextType::BranchDiff.keyword();
@@ -1271,6 +1330,60 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                 })
             }
         }
+    }
+
+    fn terminal_matches(
+        &self,
+        terminal_summaries: Vec<TerminalSummary>,
+        query: &str,
+        cx: &mut App,
+    ) -> Task<Vec<Match>> {
+        if terminal_summaries.is_empty() {
+            return Task::ready(Vec::new());
+        }
+
+        if query.is_empty() {
+            return Task::ready(
+                terminal_summaries
+                    .into_iter()
+                    .map(|terminal| {
+                        Match::Terminal(TerminalMatch {
+                            id: terminal.id,
+                            title: terminal.title,
+                            mat: None,
+                        })
+                    })
+                    .collect(),
+            );
+        }
+
+        let query = query.to_string();
+        let candidates: Vec<StringMatchCandidate> = terminal_summaries
+            .iter()
+            .enumerate()
+            .map(|(ix, terminal)| StringMatchCandidate::new(ix, terminal.title.as_str()))
+            .collect();
+        let executor = cx.background_executor().clone();
+        cx.background_spawn(async move {
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &query,
+                false,
+                true,
+                100,
+                &Arc::new(AtomicBool::default()),
+                executor,
+            )
+            .await;
+            matches
+                .into_iter()
+                .map(|mat| Match::Terminal(TerminalMatch {
+                    id: terminal_summaries[mat.candidate_id].id.clone(),
+                    title: terminal_summaries[mat.candidate_id].title.clone(),
+                    mat: Some(mat),
+                }))
+                .collect()
+        })
     }
 
     fn recent_context_picker_entries(
@@ -1862,6 +1975,18 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                                     Match::BranchDiff(branch_diff) => {
                                         Some(Self::build_branch_diff_completion(
                                             branch_diff.base_ref,
+                                            source_range.clone(),
+                                            source.clone(),
+                                            editor.clone(),
+                                            mention_set.clone(),
+                                            workspace.clone(),
+                                            cx,
+                                        ))
+                                    }
+                                    Match::Terminal(terminal) => {
+                                        Some(Self::completion_for_terminal(
+                                            terminal.id,
+                                            terminal.title.into(),
                                             source_range.clone(),
                                             source.clone(),
                                             editor.clone(),

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -12607,6 +12607,7 @@ pub(crate) fn open_link(
             }
             MentionUri::Diagnostics { .. } => {}
             MentionUri::TerminalSelection { .. } => {}
+            MentionUri::Terminal { .. } => {}
             MentionUri::GitDiff { .. } => {}
             MentionUri::MergeConflict { .. } => {}
             MentionUri::Rule { name, .. } => {

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -166,6 +166,7 @@ impl MentionSet {
             ))),
             MentionUri::PastedImage { .. }
             | MentionUri::TerminalSelection { .. }
+            | MentionUri::Terminal { .. }
             | MentionUri::MergeConflict { .. }
             | MentionUri::Rule { .. } => {
                 Task::ready(Err(anyhow!("Unsupported mention URI type for paste")))
@@ -341,6 +342,7 @@ impl MentionSet {
                 debug_panic!("unexpected terminal URI");
                 Task::ready(Err(anyhow!("unexpected terminal URI")))
             }
+            MentionUri::Terminal { .. } => Task::ready(Ok(Mention::Link)),
             MentionUri::GitDiff { base_ref } => {
                 self.confirm_mention_for_git_diff(base_ref.into(), cx)
             }

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -209,6 +209,7 @@ fn open_mention_uri(
         | MentionUri::Selection { abs_path: None, .. }
         | MentionUri::Diagnostics { .. }
         | MentionUri::TerminalSelection { .. }
+        | MentionUri::Terminal { .. }
         | MentionUri::GitDiff { .. }
         | MentionUri::MergeConflict { .. } => {}
     });


### PR DESCRIPTION
## Summary
- Adds a `MentionUri::Terminal` variant so the agent can reference a user's open terminals in prompts (internal terminal id, user-visible title).
- Adds `read_terminal` and `list_terminals` tools (read-only; allowed in restricted mode) backed by a new `TerminalContentProvider` gpui global implemented in `agent_ui` against the workspace's `AgentPanel` terminals.
- The `@` mention popover lists open terminals by title and inserts a `MentionUri::Terminal` mention.
- Mentioned terminal contents are included in the `<terminals>` context block sent to the model.

## How it works
- `agent` cannot depend on UI terminals, so it defines `TerminalContentProvider` + a gpui global; `agent_ui` registers `AgentPanelTerminalContentProvider` (holding a `WeakEntity<AgentPanel>`) in `AgentPanel::new`.
- `ThreadEnvironment::read_terminal`/`list_terminals` delegate to the global. Falls back to an error when no provider is registered.

## Test plan
- Added `acp_thread` round-trip test for `MentionUri::Terminal` parse/to_uri.
- `cargo check -p agent -p agent_ui -p acp_thread` and `cargo clippy -p agent -p agent_ui` are clean.

Release Notes:

- Added terminal context: the agent can read open terminals via the `read_terminal`/`list_terminals` tools and reference them with `@terminal` mentions.