### PR TITLE
open_ai: Fix parsing stream usage chunks with null prompt cache tokens

### DIFF
--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -820,11 +820,13 @@ impl OpenAiEventMapper {
             let cache_creation_input_tokens = usage
                 .prompt_tokens_details
                 .as_ref()
-                .map_or(0, |details| details.cache_write_tokens);
+                .and_then(|details| details.cache_write_tokens)
+                .unwrap_or(0);
             let cache_read_input_tokens = usage
                 .prompt_tokens_details
                 .as_ref()
-                .map_or(0, |details| details.cached_tokens);
+                .and_then(|details| details.cached_tokens)
+                .unwrap_or(0);
             events.push(Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
                 input_tokens: prompt_tokens
                     .saturating_sub(cache_creation_input_tokens)

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -515,6 +515,25 @@ mod tests {
             expected_efforts.as_slice()
         );
     }
+
+    #[test]
+    fn stream_usage_with_null_prompt_cache_tokens_is_not_an_error() {
+        let chunk = r#"{"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":null}}}"#;
+
+        let super::ResponseStreamResult::Ok(event) =
+            serde_json::from_str::<super::ResponseStreamResult>(chunk).unwrap()
+        else {
+            panic!("usage-only chunk with null cache token fields must not fail to parse");
+        };
+
+        let details = event
+            .usage
+            .unwrap()
+            .prompt_tokens_details
+            .expect("prompt_tokens_details should be present");
+        assert_eq!(details.cached_tokens, Some(0));
+        assert_eq!(details.cache_write_tokens, None);
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -754,11 +773,9 @@ pub struct FunctionChunk {
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct PromptTokensDetails {
     /// Tokens read from a prompt cache.
-    #[serde(default)]
-    pub cached_tokens: u64,
+    pub cached_tokens: Option<u64>,
     /// Tokens written to a prompt cache.
-    #[serde(default)]
-    pub cache_write_tokens: u64,
+    pub cache_write_tokens: Option<u64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
# Objective

Some OpenAI-compatible models end a stream with a usage-only chunk (`"choices": []`) where the cache token fields are `null`. Such as, the `deepseek-v4-flash` model in `OpenCode Go` provider. 

Zed chokes on it and kills the whole turn:

```text
ERROR [open_ai] Failed to parse OpenAI response into ResponseStreamResult: `data did not match any variant of untagged enum ResponseStreamResult`
Response: `{"id":"chatcmpl-xxx","object":"chat.completion.chunk","created":1787286372,"model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":12191,"completion_tokens":95,"total_tokens":12286,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":null}}}`
ERROR [agent::thread] Turn execution failed: data did not match any variant of untagged enum ResponseStreamResult
```

## Solution

`PromptTokensDetails` stored these as `u64` with `#[serde(default)]`, which handles a missing field but not `null`. Switched them to `Option<u64>` so `null` parses to `None`, and updated the one consumer (`OpenAiEventMapper::map_event`) to `.and_then(...).unwrap_or(0)`. 
Behavior is unchanged.

## Testing

- Added a regression test using the failing `null` chunk.
- `cargo test -p open_ai` — 78 tests + doc-test pass.
- `./script/clippy -p open_ai` — clean.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards (UX/UI and icon guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed a crash when an OpenAI-compatible model sends a usage-only stream chunk with null cache token fields.
