### PR TITLE
markdown: Highlight HTML character entities

### DIFF
--- a/crates/grammars/src/markdown-inline/highlights.scm
+++ b/crates/grammars/src/markdown-inline/highlights.scm
@@ -33,3 +33,5 @@
   (uri_autolink)
   (email_autolink)
 ] @link_uri.markup
+
+(entity_reference) @string.special

--- a/crates/grammars/src/markdown-inline/highlights.scm
+++ b/crates/grammars/src/markdown-inline/highlights.scm
@@ -34,4 +34,7 @@
   (email_autolink)
 ] @link_uri.markup
 
-(entity_reference) @string.special
+[
+  (entity_reference)
+  (numeric_character_reference)
+] @string.special

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3517,6 +3517,78 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_markdown_inline_entity_reference_highlighting(cx: &mut TestAppContext) {
+    let markdown_language = markdown_lang();
+    let markdown_inline_language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "markdown-inline".into(),
+                grammar: Some("markdown-inline".into()),
+                ..Default::default()
+            },
+            Some(tree_sitter_md::INLINE_LANGUAGE.into()),
+        )
+        .with_highlights_query(include_str!(
+            "../../grammars/src/markdown-inline/highlights.scm"
+        ))
+        .unwrap()
+        .with_injection_query(include_str!(
+            "../../grammars/src/markdown-inline/injections.scm"
+        ))
+        .unwrap(),
+    );
+    let syntax_theme =
+        SyntaxTheme::new([("string.special".to_string(), gpui::rgba(0xff0000ff).into())]);
+    markdown_language.set_theme(&syntax_theme);
+    markdown_inline_language.set_theme(&syntax_theme);
+    let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor.clone()));
+    language_registry.add(markdown_language.clone());
+    language_registry.add(markdown_inline_language);
+
+    let text = indoc! {"
+        Entities like &lt; &gt; &amp; &nbsp; should be highlighted.
+        But plain ampersands & and words should not.
+    "};
+    let buffer = cx.new(|cx| {
+        let mut buffer = Buffer::local(text, cx);
+        buffer.set_language_registry(language_registry);
+        buffer.set_language(Some(markdown_language), cx);
+        buffer
+    });
+
+    cx.run_until_parked();
+
+    buffer.read_with(cx, |buffer, _cx| {
+        let snapshot = buffer.snapshot();
+        let highlight_id = syntax_theme
+            .highlight_id("string.special")
+            .map(HighlightId::new);
+        assert!(highlight_id.is_some(), "string.special not in test theme");
+        let mut runs: Vec<String> = Vec::new();
+        let mut previous_chunk_matched = false;
+        let chunks = snapshot.chunks(
+            0..snapshot.len(),
+            LanguageAwareStyling {
+                tree_sitter: true,
+                diagnostics: false,
+            },
+        );
+        for chunk in chunks {
+            let chunk_matches = chunk.syntax_highlight_id == highlight_id;
+            if chunk_matches {
+                match runs.last_mut() {
+                    Some(last_run) if previous_chunk_matched => last_run.push_str(chunk.text),
+                    _ => runs.push(chunk.text.to_string()),
+                }
+            }
+            previous_chunk_matched = chunk_matches;
+        }
+
+        assert_eq!(runs, vec!["&lt;", "&gt;", "&amp;", "&nbsp;"]);
+    });
+}
+
+#[gpui::test]
 fn test_syntax_layer_at_for_combined_injections(cx: &mut App) {
     init_settings(cx, |_| {});
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3453,6 +3453,7 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
     let syntax_theme = SyntaxTheme::new([
         ("comment".to_string(), gpui::rgba(0xffffffff).into()),
         ("tag".to_string(), gpui::rgba(0xff0000ff).into()),
+        ("string.special".to_string(), gpui::rgba(0xff0000ff).into()),
     ]);
     markdown_language.set_theme(&syntax_theme);
     markdown_inline_language.set_theme(&syntax_theme);
@@ -3465,7 +3466,8 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
     let text = "<!--Annotation from the start is OK-->\n\n\
         Annotation in the middle <!--is rendered badly.-->\n\n\
         An inline comment can span <!--multiple\nlines--> within a paragraph.\n\n\
-        Ordinary inline HTML: <em>emphasized</em>.";
+        Ordinary inline HTML: <em>emphasized</em>.\n\n\
+        Entities like &lt; &gt; &amp; &nbsp; are highlighted.";
     let buffer = cx.new(|cx| {
         let mut buffer = Buffer::local(text, cx);
         buffer.set_language_registry(language_registry);
@@ -3513,78 +3515,6 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
             ]
         );
         assert_eq!(highlighted_text("tag"), vec!["em", "em"]);
-    });
-}
-
-#[gpui::test]
-async fn test_markdown_inline_entity_reference_highlighting(cx: &mut TestAppContext) {
-    let markdown_language = markdown_lang();
-    let markdown_inline_language = Arc::new(
-        Language::new(
-            LanguageConfig {
-                name: "markdown-inline".into(),
-                grammar: Some("markdown-inline".into()),
-                ..Default::default()
-            },
-            Some(tree_sitter_md::INLINE_LANGUAGE.into()),
-        )
-        .with_highlights_query(include_str!(
-            "../../grammars/src/markdown-inline/highlights.scm"
-        ))
-        .unwrap()
-        .with_injection_query(include_str!(
-            "../../grammars/src/markdown-inline/injections.scm"
-        ))
-        .unwrap(),
-    );
-    let syntax_theme =
-        SyntaxTheme::new([("string.special".to_string(), gpui::rgba(0xff0000ff).into())]);
-    markdown_language.set_theme(&syntax_theme);
-    markdown_inline_language.set_theme(&syntax_theme);
-    let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor.clone()));
-    language_registry.add(markdown_language.clone());
-    language_registry.add(markdown_inline_language);
-
-    let text = indoc! {"
-        Entities like &lt; &gt; &amp; &nbsp; should be highlighted.
-        But plain ampersands & and words should not.
-    "};
-    let buffer = cx.new(|cx| {
-        let mut buffer = Buffer::local(text, cx);
-        buffer.set_language_registry(language_registry);
-        buffer.set_language(Some(markdown_language), cx);
-        buffer
-    });
-
-    cx.run_until_parked();
-
-    buffer.read_with(cx, |buffer, _cx| {
-        let snapshot = buffer.snapshot();
-        let highlight_id = syntax_theme
-            .highlight_id("string.special")
-            .map(HighlightId::new);
-        assert!(highlight_id.is_some(), "string.special not in test theme");
-        let mut runs: Vec<String> = Vec::new();
-        let mut previous_chunk_matched = false;
-        let chunks = snapshot.chunks(
-            0..snapshot.len(),
-            LanguageAwareStyling {
-                tree_sitter: true,
-                diagnostics: false,
-            },
-        );
-        for chunk in chunks {
-            let chunk_matches = chunk.syntax_highlight_id == highlight_id;
-            if chunk_matches {
-                match runs.last_mut() {
-                    Some(last_run) if previous_chunk_matched => last_run.push_str(chunk.text),
-                    _ => runs.push(chunk.text.to_string()),
-                }
-            }
-            previous_chunk_matched = chunk_matches;
-        }
-
-        assert_eq!(runs, vec!["&lt;", "&gt;", "&amp;", "&nbsp;"]);
     });
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3467,7 +3467,7 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
         Annotation in the middle <!--is rendered badly.-->\n\n\
         An inline comment can span <!--multiple\nlines--> within a paragraph.\n\n\
         Ordinary inline HTML: <em>emphasized</em>.\n\n\
-        Entities like &lt; &gt; &amp; &nbsp; are highlighted.";
+        Entities like &lt; &gt; &amp; &nbsp; &#169; are highlighted.";
     let buffer = cx.new(|cx| {
         let mut buffer = Buffer::local(text, cx);
         buffer.set_language_registry(language_registry);
@@ -3515,6 +3515,10 @@ async fn test_markdown_inline_html_highlighting(cx: &mut TestAppContext) {
             ]
         );
         assert_eq!(highlighted_text("tag"), vec!["em", "em"]);
+        assert_eq!(
+            highlighted_text("string.special"),
+            vec!["&lt;", "&gt;", "&amp;", "&nbsp;", "&#169;"]
+        );
     });
 }
 


### PR DESCRIPTION
## Description

HTML character entity references such as `&lt;`, `&gt;`, `&amp;` and `&nbsp;` were parsed as `entity_reference` nodes by the markdown-inline grammar, but no highlight rule captured them, so they rendered as plain text in Markdown files while being highlighted correctly in `.html` files.

This adds captures for `entity_reference` and `numeric_character_reference` as `string.special` in the markdown-inline highlights query, matching how the built-in HTML language highlights entities (extensions/html/languages/html/highlights.scm), so named entities like `&copy;` and numeric references like `&#169;` now get the same color in Markdown as they do in HTML files.

Fixes #62974

## Testing

- Extended `test_markdown_inline_html_highlighting` to also verify that `&lt;`, `&gt;`, `&amp;`, `&nbsp;` and `&#169;` are highlighted via the markdown → markdown-inline injection pipeline.
- Manually verified named entities, decimal/hex numeric references, uppercase names (`&AMP;`, `&Copy;`), entities inside headings/lists/blockquotes/table cells are highlighted, while malformed references (`&amp`, `&notanentity;`, `&#xZZ;`) and plain ampersands stay unhighlighted.
- `cargo test -p language test_markdown_inline` passes.
- `./script/clippy` passes.

Release Notes:

- Fixed HTML character entities like `&lt;` and `&#169;` not being syntax highlighted in Markdown files