### PR TITLE
worktree: Yield during large scan snapshot updates

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1399,6 +1399,7 @@ impl LocalWorktree {
             }
         });
         let scan_state_updater = cx.spawn(async move |this, cx| {
+            // Yield after each message so a big backlog can't block the UI thread (#62545).
             while let Some((state, this)) = scan_states_rx.next().await.zip(this.upgrade()) {
                 this.update(cx, |this, cx| {
                     let this = this.as_local_mut().unwrap();
@@ -1428,6 +1429,8 @@ impl LocalWorktree {
                         }
                     }
                 });
+
+                yield_now().await;
             }
         });
         self._background_scanner_tasks = vec![background_scanner, scan_state_updater];


### PR DESCRIPTION
## Summary

Fixes #62545. On a large tree, the worktree background scanner queues
one `ScanState::Updated` message roughly every `FS_WATCH_LATENCY`
(100ms) for the whole scan. The foreground loop that applies these
drains any already-buffered messages back to back, since
`rx.next().await` resolves without yielding when data is already
queued. On a tree with ~1M entries this ties up the UI thread for
20+ seconds straight, and the compositor shows a "not responding"
dialog because the run loop never comes up for air.

This adds one `yield_now().await` after each applied message, so the
platform gets a turn to paint and answer input between messages even
under a sustained backlog. Snapshot application, diffing, and event
emission are unchanged.

## Test plan

- [x] `cargo test -p worktree --features test-support`: 80/80 pass
- [x] The two randomized property tests
      (`test_random_worktree_changes`,
      `test_random_worktree_operations_during_initial_scan`) each
      re-run 10x with fresh seeds: 20/20 pass
- [ ] Manual: open a large `node_modules`-heavy tree and confirm no
      more multi-second freeze / ANR dialog during the initial scan

Release Notes:

- Fixed the editor freezing for several seconds (and Linux compositors
  showing a "not responding" dialog) while scanning large project
  trees