### PR TITLE
project: Stop toolchain activation from re-emitting when unchanged

### DIFF
--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -486,11 +486,15 @@ impl LocalToolchainStore {
     ) -> Task<Option<()>> {
         cx.spawn(async move |this, cx| {
             this.update(cx, |this, cx| {
-                this.active_toolchains
+                let old_toolchain = this
+                    .active_toolchains
                     .entry((path.worktree_id, toolchain.language_name.clone()))
                     .or_default()
                     .insert(path.path, toolchain.clone());
-                cx.emit(ToolchainStoreEvent::ToolchainActivated);
+                // An unconditional emit here loops ActiveToolchain forever (zed-industries/zed#60472).
+                if old_toolchain.as_ref() != Some(&toolchain) {
+                    cx.emit(ToolchainStoreEvent::ToolchainActivated);
+                }
             })
             .ok();
             Some(())

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -63,6 +63,7 @@ use project::{
     git_store::{GitStoreEvent, Repository, RepositoryEvent, StatusEntry, pending_op},
     search::{SearchQuery, SearchResult},
     task_store::{TaskSettingsLocation, TaskStore},
+    toolchain_store::ToolchainStoreEvent,
     *,
 };
 use rand::{Rng as _, rngs::StdRng};
@@ -1536,19 +1537,20 @@ async fn test_running_multiple_instances_of_a_single_server_in_one_worktree(
         .await;
 
     assert!(currently_active_toolchain.is_none());
+    let selected_toolchain = available_toolchains_for_b
+        .toolchains
+        .into_iter()
+        .next()
+        .unwrap();
     let _ = project
         .update(cx, |this, cx| {
             let worktree_id = this.worktrees(cx).next().unwrap().read(cx).id();
             this.activate_toolchain(
                 ProjectPath {
                     worktree_id,
-                    path: root_path,
+                    path: root_path.clone(),
                 },
-                available_toolchains_for_b
-                    .toolchains
-                    .into_iter()
-                    .next()
-                    .unwrap(),
+                selected_toolchain.clone(),
                 cx,
             )
         })
@@ -1570,6 +1572,42 @@ async fn test_running_multiple_instances_of_a_single_server_in_one_worktree(
     assert_eq!(adapter.name(), LanguageServerName::new_static("ty"));
     // There's a new language server in town.
     assert_eq!(server.server_id(), LanguageServerId(1));
+
+    // Re-activating the same toolchain must not re-emit ToolchainActivated (zed-industries/zed#60472).
+    let toolchain_store = project
+        .read_with(cx, |project, _| project.toolchain_store())
+        .unwrap();
+    let activation_count = Arc::new(atomic::AtomicUsize::new(0));
+    let _subscription = project.update(cx, |_, cx| {
+        cx.subscribe(&toolchain_store, {
+            let activation_count = activation_count.clone();
+            move |_, _, event, _| {
+                if let ToolchainStoreEvent::ToolchainActivated = event {
+                    activation_count.fetch_add(1, atomic::Ordering::SeqCst);
+                }
+            }
+        })
+    });
+    let _ = project
+        .update(cx, |this, cx| {
+            let worktree_id = this.worktrees(cx).next().unwrap().read(cx).id();
+            this.activate_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: root_path,
+                },
+                selected_toolchain,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+    assert_eq!(
+        activation_count.load(atomic::Ordering::SeqCst),
+        0,
+        "re-activating the already-active toolchain must not re-emit ToolchainActivated"
+    );
 }
 
 #[gpui::test]


### PR DESCRIPTION
## Summary

Fixes #60472. `LocalToolchainStore::activate_toolchain` unconditionally
emitted `ToolchainStoreEvent::ToolchainActivated`, even when
re-activating an already-active toolchain for the same path.

`ActiveToolchain` (crates/toolchain_selector/src/active_toolchain.rs)
subscribes to that event and reacts by re-resolving and re-activating
the toolchain for the current buffer. When no toolchain was already
selected, that resolution runs the full, uncached `pet` environment
discovery scan and then calls `activate_toolchain` again with the
result — which re-emitted the event and re-triggered the same
subscriber, looping indefinitely. Each iteration re-scans every
locator against every candidate interpreter, which is what pegged all
64 background dispatch threads in the original report.

The fix compares the previous stored toolchain against the new one
(`Toolchain` already has a hand-written `PartialEq` that ignores the
non-user-facing `as_json` field) and only emits the event when it
actually changed.

`RemoteToolchainStore::activate_toolchain` has the same unconditional
emit, but it's a fire-and-forget RPC call with no local state to diff
against, so making it idempotent would need a protocol change. Left
out of scope for this PR since the report is about local projects.

## Test plan

- [x] `cargo test -p project --lib --test integration`: 394/394 pass
- [x] Added a regression test asserting that re-activating the same
      toolchain for the same path does not re-emit
      `ToolchainActivated`

Release Notes:

- Fixed Zed freezing for large Python projects due to a toolchain
  activation feedback loop that re-ran environment discovery
  indefinitely