### PR TITLE
editor: Coalesce selection-drag updates to once per frame

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -938,6 +938,7 @@ pub struct Editor {
     /// typing enters text into each of them, even the ones that aren't focused.
     pub(crate) show_cursor_when_unfocused: bool,
     columnar_selection_state: Option<ColumnarSelectionState>,
+    pending_selection_drag_update: Option<SelectPhase>,
     add_selections_state: Option<AddSelectionsState>,
     select_next_state: Option<SelectNextState>,
     select_prev_state: Option<SelectNextState>,
@@ -2263,6 +2264,7 @@ impl Editor {
             selections,
             scroll_manager: ScrollManager::new(cx),
             columnar_selection_state: None,
+            pending_selection_drag_update: None,
             add_selections_state: None,
             select_next_state: None,
             select_prev_state: None,

--- a/crates/editor/src/element/mouse.rs
+++ b/crates/editor/src/element/mouse.rs
@@ -981,6 +981,26 @@ impl EditorElement {
         }
     }
 
+    // Coalesces selection updates to once per frame instead of once per mouse-move (zed-industries/zed#53711).
+    fn queue_selection_drag_update(
+        editor: &mut Editor,
+        update: SelectPhase,
+        window: &mut Window,
+        cx: &mut Context<Editor>,
+    ) {
+        if editor.pending_selection_drag_update.is_none() {
+            let this = cx.entity();
+            window.on_next_frame(move |window, cx| {
+                this.update(cx, |editor, cx| {
+                    if let Some(update) = editor.pending_selection_drag_update.take() {
+                        editor.select(update, window, cx);
+                    }
+                });
+            });
+        }
+        editor.pending_selection_drag_update = Some(update);
+    }
+
     fn mouse_dragged(
         editor: &mut Editor,
         event: &MouseMoveEvent,
@@ -1090,7 +1110,8 @@ impl EditorElement {
                             window,
                             cx,
                         );
-                        editor.select(
+                        Self::queue_selection_drag_update(
+                            editor,
                             SelectPhase::Update {
                                 position: point_for_position.nearest_valid,
                                 goal_column: point_for_position.exact_unclipped.column(),
@@ -1104,7 +1125,8 @@ impl EditorElement {
                 _ => {}
             }
         } else {
-            editor.select(
+            Self::queue_selection_drag_update(
+                editor,
                 SelectPhase::Update {
                     position: point_for_position.nearest_valid,
                     goal_column: point_for_position.exact_unclipped.column(),

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1457,6 +1457,7 @@ impl Editor {
 
     pub(super) fn end_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.columnar_selection_state.take();
+        self.pending_selection_drag_update.take();
         if let Some(pending_mode) = self.selections.pending_mode() {
             let selections = self
                 .selections


### PR DESCRIPTION
## Summary

Fixes #53711. Every raw `MouseMoveEvent` during a selection drag
called `editor.select(SelectPhase::Update { .. })` synchronously,
dispatched directly from the input handler
(`crates/editor/src/element/mouse.rs`), unthrottled.

For a columnar (block) selection, applying that update means
`select_columns` (`crates/editor/src/selection.rs`) walks every
display row between the drag start and the current mouse position and
calls `display_map.layout_row` on each one — real per-row syntax-chunk
iteration and text shaping, not free even with the line-shape cache.
OS mouse-move events can fire far faster than the display refreshes
(especially on Wayland, matching the original report), so dragging a
block selection across many rows meant an O(rows) layout pass on every
pixel of movement, independent of file content or LSP state — matches
the report's "any file, fresh boot, no extensions" reproducibility.

The fix coalesces to at most one applied update per frame, using
GPUI's existing `Window::on_next_frame` idiom (same pattern already
used in `crates/editor/src/mouse_context_menu.rs`). A burst of
mouse-move events within one frame now stores only the latest
position/goal_column/scroll_delta and applies it once; the drag still
tracks the mouse smoothly since frame rate is the perceptual limit
either way. `end_selection` clears the pending update so a stale
queued update can't fire after the drag has already ended.

This doesn't reduce the O(rows) cost of a single update, only its
frequency — worst case is capped at the display refresh rate instead
of the raw input event rate.

## Test plan

- [x] `cargo test -p editor --lib`: 910/910 pass, no regressions
- [ ] Manual: block-select across a few hundred lines and confirm no
      stutter (I don't have a way to drive real mouse-drag input or
      profile CPU in this environment, so I couldn't verify the
      before/after difference directly)

Release Notes:

- Fixed stuttering while dragging a block (columnar) selection across
  many lines