### PR TITLE
workspace: Don't guess wrong when a relative path click is ambiguous

### DIFF
--- a/crates/terminal_view/src/terminal_path_like_target.rs
+++ b/crates/terminal_view/src/terminal_path_like_target.rs
@@ -528,6 +528,44 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn ambiguous_relative_path_without_cwd_is_not_guessed(cx: &mut TestAppContext) {
+        let mut test_path_like = init_test(
+            cx,
+            vec![
+                (
+                    path!("/project-a"),
+                    json!({ "src": { "main.go": "" } }),
+                ),
+                (
+                    path!("/project-b"),
+                    json!({ "src": { "main.go": "" } }),
+                ),
+            ],
+            vec![path!("/project-a"), path!("/project-b")],
+        )
+        .await;
+
+        let (_, open_target) = test_path_like(
+            HoveredWord {
+                word: "src/main.go".to_string(),
+                word_match: Range::new(Point::new(0, 0), Point::new(0, 0)),
+                id: 0,
+            },
+            PathLikeTarget {
+                maybe_path: "src/main.go".to_string(),
+                working_directory: None,
+            },
+            BackgroundPathChecks::LocalFileSystem,
+        )
+        .await;
+
+        assert!(
+            open_target.is_none(),
+            "an ambiguous relative path with no known cwd must not silently pick a worktree"
+        );
+    }
+
+    #[gpui::test]
     async fn worktree_file_preferred(cx: &mut TestAppContext) {
         test_path_likes!(
             cx,

--- a/crates/workspace/src/path_link.rs
+++ b/crates/workspace/src/path_link.rs
@@ -221,6 +221,8 @@ fn resolve_open_target_internal(
     let mut worktree_paths_to_check = Vec::new();
     let mut is_cwd_in_worktree = false;
     let mut open_target = None;
+    // Without a known cwd, a match found in one worktree can't be trusted if another also matches (zed-industries/zed#62513).
+    let mut unconfirmed_match_is_ambiguous = false;
     'worktree_loop: for worktree in &worktree_candidates {
         let worktree_root = worktree.read(cx).abs_path();
         let mut paths_to_check = Vec::with_capacity(potential_paths.len());
@@ -233,6 +235,8 @@ fn resolve_open_target_internal(
                     cwd_stripped
                 })
             });
+        // Gate on cwd being known at all, not `relative_cwd`, which is also `None` when cwd equals this worktree's root.
+        let cwd_is_known = cwd.is_some();
 
         for path_with_position in &potential_paths {
             let path_to_check = if worktree_root.ends_with(&path_with_position.path) {
@@ -292,7 +296,7 @@ fn resolve_open_target_internal(
                             .and_then(|path| worktree.read(cx).entry_for_path(path.as_ref()))
                     })
             {
-                open_target = Some(OpenTarget::Worktree(
+                let candidate = OpenTarget::Worktree(
                     PathWithPosition {
                         path: worktree.read(cx).absolutize(&entry.path),
                         row: path_to_check.row,
@@ -301,8 +305,19 @@ fn resolve_open_target_internal(
                     entry.clone(),
                     #[cfg(any(test, feature = "test-support"))]
                     OpenTargetFoundBy::WorktreeExact,
-                ));
-                break 'worktree_loop;
+                );
+                if cwd_is_known {
+                    open_target = Some(candidate);
+                    break 'worktree_loop;
+                } else if open_target.is_none() {
+                    // Keep scanning the remaining worktrees to check for ambiguity
+                    // instead of committing to the first unconfirmed guess.
+                    open_target = Some(candidate);
+                } else {
+                    unconfirmed_match_is_ambiguous = true;
+                    break 'worktree_loop;
+                }
+                break;
             }
 
             paths_to_check.push(path_to_check);
@@ -311,6 +326,10 @@ fn resolve_open_target_internal(
         if !paths_to_check.is_empty() {
             worktree_paths_to_check.push((worktree.clone(), paths_to_check));
         }
+    }
+
+    if unconfirmed_match_is_ambiguous {
+        return Task::ready(None);
     }
 
     if open_target.is_some() {


### PR DESCRIPTION
## Summary

Fixes #62513. Cmd/ctrl-clicking a relative path in a multi-project
workspace could open the wrong project's file when the same relative
path existed in more than one worktree.

`resolve_open_target_internal` (`crates/workspace/src/path_link.rs`)
sorts worktree candidates by proximity to the terminal's cwd and
resolves against the closest one. That breaks down specifically for
remote (SSH) terminals: `Terminal::working_directory` unconditionally
returns `None` for `is_remote_terminal` terminals
(`crates/terminal/src/terminal.rs:2801`), since the cwd-tracking
mechanism (`record_cwd_change`, driven by OS-level process
introspection in `crates/terminal/src/pty_info.rs`) has no remote
equivalent — Zed's local OS has no visibility into a process running
on the far end of an SSH connection. With `cwd` unknown, the
worktree-proximity sort becomes a no-op and the code falls back to
whichever worktree happens to be checked first and contains a
matching file — not necessarily the one the shell is actually in.

I initially looked at extending the existing cwd-tracking to remote
terminals by reusing OSC7 escape-sequence-based tracking, but that
mechanism doesn't exist anywhere in this codebase yet (confirmed) —
building it would be a separate, materially larger feature with its
own feasibility caveats (only works if the remote shell is configured
to emit OSC7). This PR takes the narrower, safe fix instead: when cwd
is unknown and a relative-path click matches more than one worktree,
don't guess — resolve to no target rather than silently opening the
wrong file. When cwd is known (the common local-terminal case), or
when the match is unambiguous (only one worktree contains the path),
behavior is unchanged.

## Test plan

- [x] `cargo test -p workspace --lib`: 250/250 pass
- [x] `cargo test -p terminal_view --lib`: 81/81 pass (including the
      existing `mixed_worktrees` cwd-aware duplicate-filename test,
      unaffected)
- [x] Added `ambiguous_relative_path_without_cwd_is_not_guessed`:
      two sibling worktrees both containing `src/main.go`, clicking
      `src/main.go` with no known cwd now resolves to no target
      instead of picking one

Release Notes:

- Fixed cmd/ctrl-click on a relative path in the terminal
  incorrectly opening a same-named file from the wrong project when
  the terminal's working directory can't be determined (e.g. over
  SSH) and more than one worktree contains a matching path