### PR TITLE
editor: Skip highlighting and diagnostics for pathologically long lines

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -292,6 +292,10 @@ pub const BUFFER_HEADER_PADDING: Rems = rems(0.25);
 pub const MULTI_BUFFER_EXCERPT_HEADER_HEIGHT: u32 = 1;
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_LINE_LEN: usize = 1024;
+// Lines past this length skip tree-sitter highlighting and diagnostics entirely, not just
+// shaping past `MAX_LINE_LEN`, so a single pathological line doesn't cost a full syntax
+// highlight pass every frame (zed-industries/zed#61944).
+const PATHOLOGICAL_LINE_LEN: usize = MAX_LINE_LEN * 64;
 const MIN_NAVIGATION_HISTORY_ROW_DELTA: i64 = 10;
 const MAX_SELECTION_HISTORY_LEN: usize = 1024;
 pub(crate) const CURSORS_VISIBLE_FOR: Duration = Duration::from_millis(2000);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -40442,6 +40442,31 @@ fn test_editor_rendering_when_positioned_above_viewport(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
+fn test_editor_rendering_with_pathologically_long_line(cx: &mut TestAppContext) {
+    // A single very long line (e.g. a minified bundle or a pg_dump COPY block) must not make
+    // every paint pay for a full syntax-highlight pass over it (zed-industries/zed#61944).
+    init_test(cx, |_| {});
+
+    let window = cx.add_window(|_, _| gpui::Empty);
+    let mut cx = VisualTestContext::from_window(*window, cx);
+
+    let long_line = "x".repeat(200_000);
+    let text = format!("before\n{long_line}\nafter\n");
+    let buffer = cx.update(|_, cx| MultiBuffer::build_simple(&text, cx));
+    let editor = cx.new_window_entity(|window, cx| build_editor(buffer, window, cx));
+
+    cx.simulate_resize(gpui::size(px(500.), px(500.)));
+
+    cx.draw(
+        gpui::point(px(0.), px(0.)),
+        gpui::size(px(500.), px(500.)),
+        |_, _| editor.clone().into_any_element(),
+    );
+
+    // If we get here without hanging, the test passes.
+}
+
+#[gpui::test]
 async fn test_diff_review_indicator_created_on_gutter_hover(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13,7 +13,8 @@ use crate::{
     EditDisplayMode, EditPrediction, Editor, EditorMode, EditorSettings, EditorSnapshot,
     EditorStyle, FILE_HEADER_HEIGHT, FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp,
     HandleInput, HoveredCursor, InlayHintRefreshReason, LineDown, LineHighlight, LineUp,
-    MAX_LINE_LEN, MINIMAP_FONT_SIZE, PageDown, PageUp, Point, RowExt, RowRangeExt, Selection,
+    MAX_LINE_LEN, MINIMAP_FONT_SIZE, PATHOLOGICAL_LINE_LEN, PageDown, PageUp, Point, RowExt,
+    RowRangeExt, Selection,
     SelectionDragState, SizingBehavior, SoftWrap, ToPoint,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     column_pixels,
@@ -3117,23 +3118,63 @@ impl EditorElement {
         } else {
             let use_tree_sitter = !snapshot.semantic_tokens_enabled
                 || snapshot.use_tree_sitter_for_syntax(rows.start, cx);
-            let language_aware = LanguageAwareStyling {
-                tree_sitter: use_tree_sitter,
-                diagnostics: true,
-            };
-            let chunks = snapshot.highlighted_chunks(rows.clone(), language_aware, style);
-            LineWithInvisibles::from_chunks(
-                chunks,
-                style,
-                MAX_LINE_LEN,
-                rows.len(),
-                &snapshot.mode,
-                editor_width,
-                is_row_soft_wrapped,
-                bg_segments_per_row,
-                window,
-                cx,
-            )
+
+            let longest_row = snapshot.longest_row_in_range(rows.clone());
+            let has_pathological_row =
+                snapshot.line_len(longest_row) as usize > PATHOLOGICAL_LINE_LEN;
+
+            if !has_pathological_row {
+                let language_aware = LanguageAwareStyling {
+                    tree_sitter: use_tree_sitter,
+                    diagnostics: true,
+                };
+                let chunks = snapshot.highlighted_chunks(rows.clone(), language_aware, style);
+                LineWithInvisibles::from_chunks(
+                    chunks,
+                    style,
+                    MAX_LINE_LEN,
+                    rows.len(),
+                    &snapshot.mode,
+                    editor_width,
+                    is_row_soft_wrapped,
+                    bg_segments_per_row,
+                    window,
+                    cx,
+                )
+            } else {
+                // Fetch one row at a time so tree-sitter highlighting and diagnostics can be
+                // skipped for just the pathological row(s), instead of paying full syntax-highlight
+                // cost on a multi-megabyte line every frame (zed-industries/zed#61944).
+                let mut layouts = Vec::with_capacity(rows.len());
+                for row in rows.start.0..rows.end.0 {
+                    let row = DisplayRow(row);
+                    let row_is_pathological =
+                        snapshot.line_len(row) as usize > PATHOLOGICAL_LINE_LEN;
+                    let language_aware = LanguageAwareStyling {
+                        tree_sitter: use_tree_sitter && !row_is_pathological,
+                        diagnostics: !row_is_pathological,
+                    };
+                    let chunks =
+                        snapshot.highlighted_chunks(row..row.next_row(), language_aware, style);
+                    let row_index = (row.0 - rows.start.0) as usize;
+                    let bg_segments_for_row = bg_segments_per_row
+                        .get(row_index..row_index + 1)
+                        .unwrap_or(&[]);
+                    layouts.extend(LineWithInvisibles::from_chunks(
+                        chunks,
+                        style,
+                        MAX_LINE_LEN,
+                        1,
+                        &snapshot.mode,
+                        editor_width,
+                        is_row_soft_wrapped,
+                        bg_segments_for_row,
+                        window,
+                        cx,
+                    ));
+                }
+                layouts
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses part of #61944 (frozen UI opening/searching a file with a
few very long lines — reporter's file was 1133 lines / 1.8GB, ~1.6MB
average line length).

Rendering already caps glyph shaping at `MAX_LINE_LEN` (1024 chars,
`crates/editor/src/editor.rs`) via `line_exceeded_max_len` in
`LineWithInvisibles::from_chunks`. But that cap only stops shaping —
the outer loop still pulls every chunk from the underlying
`highlighted_chunks` iterator for the rest of the line, so tree-sitter
highlighting and diagnostics still ran over the line's full content
first. For a multi-megabyte line, that's a full syntax-highlight pass
paid on every paint frame the line is visible.

This adds a much larger threshold (`PATHOLOGICAL_LINE_LEN`,
`MAX_LINE_LEN * 64`) at which a row skips tree-sitter highlighting and
diagnostics entirely, not just shaping past the smaller cap.
`layout_lines` checks `longest_row_in_range` (an existing O(log n)
lookup) before its normal batched `highlighted_chunks` call; if no row
in the batch is pathological, behavior is unchanged. If one is, it
falls back to fetching chunks one row at a time so only the
pathological row(s) lose highlighting, not the whole visible batch.

## Known limitation

This only helps when soft wrap is off for the affected line. When
soft wrap is on, GPUI's line-wrapping (`compute_wrap_boundaries`,
`crates/gpui/src/text_system/line_layout.rs`) needs a full shape of
the line to determine wrap points, and that happens upstream of this
code, in `WrapMap`'s row-structure computation — before `layout_lines`
is even called with a row range. Fixing that would mean touching
GPUI's shared text-shaping/wrapping code, a materially larger and
more cross-cutting change than this one. I considered a full
column-windowed rendering rewrite (matching what a from-scratch
buffer engine can do) but concluded it isn't safely deliverable as a
single-session change in a production codebase this size — it would
mean threading a column range through five stacked coordinate-
transform layers (Inlay → Fold → Tab → Wrap → Block), each with its
own correctness invariants, plus new interactive-editing questions
(cursor movement/selection/editing into a windowed line's hidden
portion) that don't have established answers here yet.

This PR covers the no-wrap case correctly and is a strict
improvement with no behavior change for normal files; it does not
close #61944 on its own for wrapped pathological lines, or for the
"search" half of that report (unexamined here).

## Test plan

- [x] `cargo test -p editor --lib`: 911/911 pass, no regressions
- [x] Added `test_editor_rendering_with_pathologically_long_line`: a
      buffer with one 200K-character line draws without hanging or
      panicking

Release Notes:

- Improved editor responsiveness for files containing a very long
  single line (e.g. minified bundles, `pg_dump` output) when soft
  wrap is disabled