### PR TITLE
project: Reload a clean cached buffer before returning it on reopen

### DIFF
--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -906,7 +906,18 @@ impl BufferStore {
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
         if let Some(buffer) = self.get_by_path(&project_path) {
-            return Task::ready(Ok(buffer));
+            // A clean buffer left over from a previous open can be stale if the file changed on
+            // disk since (e.g. `zed --wait` as $GIT_EDITOR reused for a second commit before the
+            // file watcher caught up, zed-industries/zed#61278). Reload before handing it back;
+            // `reload` is a no-op for buffers with unsaved edits or without a local file.
+            if buffer.read(cx).is_dirty() {
+                return Task::ready(Ok(buffer));
+            }
+            return cx.spawn(async move |_, cx| {
+                let reload = buffer.update(cx, |buffer, cx| buffer.reload(cx));
+                reload.await.ok();
+                Ok(buffer)
+            });
         }
 
         let task = match self.loading_buffers.entry(project_path.clone()) {

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -7121,6 +7121,54 @@ async fn test_dirty_buffer_reloads_after_undo(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_reopening_clean_buffer_reflects_external_disk_change(cx: &mut gpui::TestAppContext) {
+    // Simulates `zed --wait` as $GIT_EDITOR: the same path gets opened, closed, and reopened
+    // by an external process (git) rewriting the file in between (zed-industries/zed#61278).
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "COMMIT_EDITMSG": "first commit message",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/COMMIT_EDITMSG"), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "first commit message");
+        assert!(!buffer.is_dirty());
+    });
+
+    // git rewrites the file for the next commit while nothing has the buffer open.
+    fs.save(
+        path!("/dir/COMMIT_EDITMSG").as_ref(),
+        &"second commit message".into(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    // Reopening the same path (as `zed --wait` does) must reflect current disk content,
+    // not the buffer cached from the first open.
+    let reopened_buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/COMMIT_EDITMSG"), cx))
+        .await
+        .unwrap();
+
+    reopened_buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "second commit message");
+        assert!(!buffer.is_dirty());
+    });
+}
+
+#[gpui::test]
 async fn test_buffer_file_change_to_binary_fails(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
## Summary

Fixes #61278. Using Zed as `$GIT_EDITOR` (`zed --wait`) and running
`git commit` twice in a row shows the *first* commit's message on the
second commit — `COMMIT_EDITMSG` has changed on disk, but Zed doesn't
reflect it.

`BufferStore::open_buffer` (`crates/project/src/buffer_store.rs:908`)
returns a cached in-memory buffer for an already-loaded path without
checking whether the file changed on disk since. A brand-new buffer
always goes through `worktree.load_file`, a real disk read, so the
staleness only shows up on this cache-hit path. Normally the file
watcher's async update catches external changes before anyone looks
at the buffer again, but the reported case is a tight race: git
rewrites the file and `zed --wait` reopens the same path fast enough
that the watcher hasn't caught up yet.

The fix reloads a cached buffer before returning it, but only when
it's not dirty — `Buffer::reload` is a no-op for buffers with unsaved
edits (so it never clobbers in-progress work) and for buffers without
a local file (so it's also a no-op for remote projects, which don't
hit this code path meaningfully differently).

## Test plan

- [x] `cargo test -p project --lib`: 53/53 pass
- [x] `cargo test -p project --test integration`: 342/342 pass
- [x] Added `test_reopening_clean_buffer_reflects_external_disk_change`:
      open a buffer, rewrite the file on disk via `fs.save` (no editor
      has it open), reopen the same path, assert the new content is
      returned
- [x] Verified the new test actually catches the bug: reverted just
      the `buffer_store.rs` change and confirmed the test fails
      (returns the stale first-commit content) before reapplying the
      fix

Release Notes:

- Fixed Zed showing a stale commit message when used as `$GIT_EDITOR`
  for consecutive `git commit` invocations