### PR TITLE
git_ui: Prevent context menu binding flicker

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1624,7 +1624,11 @@ impl GitPanel {
 
         if self.commit_editor.read(cx).is_focused(window) {
             dispatch_context.add("CommitEditor");
-        } else if self.focus_handle.contains_focused(window, cx) {
+        } else if self.focus_handle.contains_focused(window, cx) || self.context_menu.is_some() {
+            // Preserve the panel's `ChangesList` context while a context menu
+            // is open. Its focus handle may not appear as a descendant of the
+            // panel until the next frame, so `FocusHandle::contains_focused`
+            // would return `false`.
             dispatch_context.add("menu");
             dispatch_context.add("ChangesList");
         }
@@ -12885,6 +12889,49 @@ mod tests {
                 "should have ChangesList context after re-focusing changes list"
             );
         });
+
+        // Case 5: Focus a newly opened context menu before it appears in the
+        // rendered dispatch tree. It should preserve the "menu" and
+        // "ChangesList" contexts so the resolved bindings do not flicker.
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_editor(&FocusEditor, window, cx);
+        });
+        cx.simulate_resize(gpui::size(px(800.), px(600.)));
+
+        panel.update_in(cx, |panel, window, cx| {
+            assert!(panel.commit_editor.read(cx).is_focused(window));
+
+            let context_menu = ContextMenu::build(window, cx, |menu, _, _| {
+                menu.context(panel.focus_handle.clone())
+                    .action("Stage All", StageAll.boxed_clone())
+            });
+
+            panel.set_context_menu(
+                context_menu.clone(),
+                gpui::point(px(0.), px(0.)),
+                None,
+                window,
+                cx,
+            );
+
+            let context_menu_focus_handle = context_menu.focus_handle(cx);
+            context_menu_focus_handle.focus(window, cx);
+
+            // The menu was focused without rendering another frame, so the
+            // previous dispatch tree does not yet recognize it as a descendant
+            // of `GitPanel`.
+            assert!(context_menu_focus_handle.is_focused(window));
+            assert!(!panel.focus_handle.contains_focused(window, cx));
+
+            // Ensure that, even if the panel doesn't contain the focused
+            // handle, we still have the `menu` and `ChangesList` contexts
+            // present if the context menu is opened.
+            let context = panel.dispatch_context(window, cx);
+            assert!(context.contains("GitPanel"));
+            assert!(context.contains("ChangesList"));
+            assert!(context.contains("menu"));
+            assert!(!context.contains("CommitEditor"));
+        })
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Ensure that the bindings displayed in the Git Panel's context menu do not change between the first and subsequent frames.

## Solution

Git panel context menus could briefly display bindings from the generic `GitPanel` context before switching to the more specific `ChangesList` bindings. This was especially noticeable with Vim mode enabled, where "Stage All" changed from `ctrl-cmd-y` to `shift-x`.

Since `GitPanel::dispatch_context` relies on `FocusHandle::contains_focused` to be `true` in order to add the `menu` and `ChangesList` contexts it could fail on the first frame the context menu is shown, as the menu's focus handle is absent from the previous frame's dispatch tree when first focused.

The simplest fix in this case is to fallback to `GitPanel::context_menu::is_some()` in case `GitPanel::focus_handle::contains_focused` returns `false`.

## Testing

Tested both manually as well as updated an existing test to ensure that, when the context menu is first focused, both the `menu` and `ChangesList` context are still present, even if no frame is rendered.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>

  Notice how the "Stage All" binding changes from `ctrl-cmd-y` (macOS) to `shift-x` (vim).

  https://github.com/user-attachments/assets/1d2e2de5-dce4-422c-8d63-4bcd93375431
</details>

<details>
  <summary>After</summary>

  https://github.com/user-attachments/assets/79e74c3f-8358-4e7c-8eb9-74fa36adde67
</details>

## Future Work

It's still possible for the bug to show up the first time the very first time the context menu is actually opened, if the Git Panel was not previously focused, that is, using `right-click` on the Git Panel while the editor was focused, for example. I suspect this has to do with how `Window::highest_precedence_binding_for_action_in` also relies on the previous frame's dispatch tree, at which point the `GitPanel` was not yet available in the context.

---

Release Notes:

- Fixed issue where the bindings shown in the Git Panel's context menu would change after the first frame.
