### PR TITLE
Fix shallow diffs causing a lot of computations

### DIFF
--- a/crates/collab/tests/integration/editor_tests.rs
+++ b/crates/collab/tests/integration/editor_tests.rs
@@ -6448,5 +6448,6 @@ fn blame_entry(sha: &str, range: Range<u32>) -> git::blame::BlameEntry {
         summary: None,
         previous: None,
         filename: String::new(),
+        boundary: false,
     }
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -34450,6 +34450,7 @@ async fn test_hide_pending_blame_popover_when_modal_opens(cx: &mut TestAppContex
                 summary: None,
                 previous: None,
                 filename: String::new(),
+                boundary: false,
             },
             gpui::point(gpui::px(0.), gpui::px(0.)),
             false,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -11113,6 +11113,7 @@ mod tests {
                         summary: None,
                         previous: None,
                         filename: String::new(),
+                        boundary: false,
                     }],
                     ..Default::default()
                 },

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -1604,6 +1604,7 @@ mod tests {
             summary: None,
             previous: None,
             filename: String::new(),
+            boundary: false,
         }
     }
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -180,9 +180,16 @@ impl GitRepository for FakeGitRepository {
     fn load_commit(
         &self,
         _commit: String,
+        _ignore_shallow_boundary: bool,
         _cx: AsyncApp,
     ) -> BoxFuture<'_, Result<git::repository::CommitDiff>> {
-        async { Ok(git::repository::CommitDiff { files: Vec::new() }) }.boxed()
+        async {
+            Ok(git::repository::CommitDiff {
+                files: Vec::new(),
+                is_shallow_boundary: false,
+            })
+        }
+        .boxed()
     }
 
     fn set_index_text(

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -214,6 +214,9 @@ pub struct BlameEntry {
 
     pub previous: Option<String>,
     pub filename: String,
+
+    #[serde(default)]
+    pub boundary: bool,
 }
 
 impl BlameEntry {
@@ -262,6 +265,7 @@ impl BlameEntry {
             summary: None,
             previous: None,
             filename: String::new(),
+            boundary: false,
         })
     }
 
@@ -364,11 +368,16 @@ impl GitBlameParser {
                         .committer_tz
                         .clone_from(&existing_entry.committer_tz);
                     new_entry.summary.clone_from(&existing_entry.summary);
+                    new_entry.boundary = existing_entry.boundary;
                 }
 
                 self.current_entry.replace(new_entry);
             }
             Some(entry) => {
+                if line == "boundary" {
+                    entry.boundary = true;
+                    return Ok(());
+                }
                 let Some((key, value)) = line.split_once(' ') else {
                     return Ok(());
                 };
@@ -544,6 +553,41 @@ mod tests {
         let output = read_test_data("blame_incremental_complex");
         let entries = parse_git_blame(&output).unwrap();
         assert_eq_golden(&entries, "blame_incremental_complex");
+    }
+
+    #[test]
+    fn test_parse_git_blame_boundary() {
+        let output = read_test_data("blame_incremental_not_committed");
+        let entries = parse_git_blame(&output).unwrap();
+        let boundary_flags = entries
+            .iter()
+            .map(|entry| (entry.sha.to_string(), entry.boundary))
+            .collect::<Vec<_>>();
+        let boundary_sha = "e6d34e8fb494fe2b576d16037c61ba9d10722ba3".to_string();
+        assert_eq!(
+            boundary_flags,
+            vec![
+                (
+                    "4aaba34cb86b12f3a749dd6ddbf185de88de6527".to_string(),
+                    false
+                ),
+                (
+                    "4aaba34cb86b12f3a749dd6ddbf185de88de6527".to_string(),
+                    false
+                ),
+                (
+                    "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913".to_string(),
+                    false
+                ),
+                (
+                    "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913".to_string(),
+                    false
+                ),
+                (boundary_sha.clone(), true),
+                (boundary_sha.clone(), true),
+                (boundary_sha, true),
+            ]
+        );
     }
 
     #[test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -530,6 +530,7 @@ pub struct CommitDetails {
 #[derive(Debug)]
 pub struct CommitDiff {
     pub files: Vec<CommitFile>,
+    pub is_shallow_boundary: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -620,6 +621,28 @@ async fn load_commit_object<R: smol::io::AsyncBufRead + Unpin>(
         Some(_) => Ok(Some(read_commit_blob(stdout, info_line, newline).await?)),
         None => Ok(None),
     }
+}
+
+async fn is_shallow_boundary_commit(
+    git: &GitBinary,
+    shallow_file_path: &Path,
+    commit: &str,
+) -> Result<bool> {
+    let shallow_contents = match smol::fs::read_to_string(shallow_file_path).await {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error).context("reading shallow file");
+        }
+    };
+
+    let oid = git
+        .run(&["rev-parse", "--verify", &format!("{commit}^{{commit}}")])
+        .await
+        .context("resolving commit for shallow boundary check")?;
+    Ok(shallow_contents
+        .lines()
+        .any(|line| line.trim() == oid.trim()))
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -878,7 +901,12 @@ pub trait GitRepository: Send + Sync {
 
     fn show(&self, commit: String) -> BoxFuture<'_, Result<CommitDetails>>;
 
-    fn load_commit(&self, commit: String, cx: AsyncApp) -> BoxFuture<'_, Result<CommitDiff>>;
+    fn load_commit(
+        &self,
+        commit: String,
+        ignore_shallow_boundary: bool,
+        cx: AsyncApp,
+    ) -> BoxFuture<'_, Result<CommitDiff>>;
     fn blame(
         &self,
         path: RepoPath,
@@ -1384,9 +1412,24 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
-    fn load_commit(&self, commit: String, cx: AsyncApp) -> BoxFuture<'_, Result<CommitDiff>> {
+    fn load_commit(
+        &self,
+        commit: String,
+        ignore_shallow_boundary: bool,
+        cx: AsyncApp,
+    ) -> BoxFuture<'_, Result<CommitDiff>> {
         let git = self.git_binary();
+        let shallow_file_path = self.common_dir.join("shallow");
         cx.background_spawn(async move {
+            if !ignore_shallow_boundary
+                && is_shallow_boundary_commit(&git, &shallow_file_path, &commit).await?
+            {
+                return Ok(CommitDiff {
+                    files: Vec::new(),
+                    is_shallow_boundary: true,
+                });
+            }
+
             let show_output = git
                 .build_command(&[
                     "show",
@@ -1475,7 +1518,10 @@ impl GitRepository for RealGitRepository {
                 })
             }
 
-            Ok(CommitDiff { files })
+            Ok(CommitDiff {
+                files,
+                is_shallow_boundary: false,
+            })
         })
         .boxed()
     }
@@ -4548,7 +4594,7 @@ mod tests {
         git_command(repo_dir.path(), ["commit", "-m", "type change"]);
 
         let commit_diff = repository
-            .load_commit("HEAD".to_string(), cx.to_async())
+            .load_commit("HEAD".to_string(), false, cx.to_async())
             .await
             .expect("failed to load type-changed commit");
         assert_eq!(commit_diff.files.len(), 1);
@@ -4601,7 +4647,7 @@ mod tests {
         .expect("failed to open repository");
 
         let commit_diff = repository
-            .load_commit("HEAD".to_string(), cx.to_async())
+            .load_commit("HEAD".to_string(), false, cx.to_async())
             .await
             .expect("failed to load commit that adds a gitlink");
         assert_eq!(commit_diff.files.len(), 2);
@@ -4631,7 +4677,7 @@ mod tests {
         git_command(repo_dir.path(), ["commit", "-m", "update submodule"]);
 
         let commit_diff = repository
-            .load_commit("HEAD".to_string(), cx.to_async())
+            .load_commit("HEAD".to_string(), false, cx.to_async())
             .await
             .expect("failed to load commit that updates a gitlink");
         let [gitlink] = commit_diff.files.as_slice() else {
@@ -4652,7 +4698,7 @@ mod tests {
         git_command(repo_dir.path(), ["commit", "-m", "remove submodule"]);
 
         let commit_diff = repository
-            .load_commit("HEAD".to_string(), cx.to_async())
+            .load_commit("HEAD".to_string(), false, cx.to_async())
             .await
             .expect("failed to load commit that deletes a gitlink");
         let [gitlink] = commit_diff.files.as_slice() else {
@@ -4665,6 +4711,86 @@ mod tests {
         );
         assert_eq!(gitlink.new_content, None);
         assert!(!gitlink.is_binary);
+    }
+
+    #[gpui::test]
+    async fn test_load_commit_shallow_boundary(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let source_dir = tempfile::tempdir().expect("failed to create source repository");
+        git_init_repo(source_dir.path());
+        fs::write(source_dir.path().join("a.txt"), "one\n").expect("failed to write a.txt");
+        git_command(source_dir.path(), ["add", "a.txt"]);
+        git_command(source_dir.path(), ["commit", "-m", "first"]);
+        fs::write(source_dir.path().join("a.txt"), "two\n").expect("failed to update a.txt");
+        fs::write(source_dir.path().join("b.txt"), "new\n").expect("failed to write b.txt");
+        git_command(source_dir.path(), ["add", "a.txt", "b.txt"]);
+        git_command(source_dir.path(), ["commit", "-m", "second"]);
+
+        let clone_dir = tempfile::tempdir().expect("failed to create clone directory");
+        git_command(
+            clone_dir.path(),
+            [
+                "clone".to_string(),
+                "--depth=1".to_string(),
+                format!("file://{}", source_dir.path().display()),
+                "shallow".to_string(),
+            ],
+        );
+
+        let repository = RealGitRepository::new(
+            &clone_dir.path().join("shallow").join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .expect("failed to open shallow repository");
+
+        let commit_diff = repository
+            .load_commit("HEAD".to_string(), false, cx.to_async())
+            .await
+            .expect("failed to load boundary commit");
+        assert!(commit_diff.is_shallow_boundary);
+        assert_eq!(commit_diff.files.len(), 0);
+
+        let commit_diff = repository
+            .load_commit("HEAD".to_string(), true, cx.to_async())
+            .await
+            .expect("failed to load boundary commit snapshot");
+        assert!(!commit_diff.is_shallow_boundary);
+        let files = commit_diff
+            .files
+            .iter()
+            .map(|file| {
+                (
+                    file.path.as_unix_str().to_owned(),
+                    file.old_content.clone(),
+                    file.status(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            files,
+            vec![
+                ("a.txt".to_string(), None, CommitFileStatus::Added),
+                ("b.txt".to_string(), None, CommitFileStatus::Added),
+            ]
+        );
+
+        let source_repository = RealGitRepository::new(
+            &source_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .expect("failed to open source repository");
+        let commit_diff = source_repository
+            .load_commit("HEAD~1".to_string(), false, cx.to_async())
+            .await
+            .expect("failed to load root commit");
+        assert!(!commit_diff.is_shallow_boundary);
+        assert_eq!(commit_diff.files.len(), 1);
     }
 
     #[gpui::test]

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -666,18 +666,22 @@ pub enum ResetMode {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum FetchOptions {
     All,
+    Unshallow,
     Remote(Remote),
 }
 
 impl FetchOptions {
     pub fn to_proto(&self) -> Option<String> {
         match self {
-            FetchOptions::All => None,
+            FetchOptions::All | FetchOptions::Unshallow => None,
             FetchOptions::Remote(remote) => Some(remote.clone().name.into()),
         }
     }
 
-    pub fn from_proto(remote_name: Option<String>) -> Self {
+    pub fn from_proto(remote_name: Option<String>, unshallow: bool) -> Self {
+        if unshallow {
+            return FetchOptions::Unshallow;
+        }
         match remote_name {
             Some(name) => FetchOptions::Remote(Remote { name: name.into() }),
             None => FetchOptions::All,
@@ -687,6 +691,7 @@ impl FetchOptions {
     pub fn name(&self) -> SharedString {
         match self {
             Self::All => "Fetch all remotes".into(),
+            Self::Unshallow => "Fetch missing history".into(),
             Self::Remote(remote) => remote.name.clone(),
         }
     }
@@ -696,6 +701,7 @@ impl std::fmt::Display for FetchOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FetchOptions::All => write!(f, "--all"),
+            FetchOptions::Unshallow => write!(f, "--unshallow"),
             FetchOptions::Remote(remote) => write!(f, "{}", remote.name),
         }
     }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -623,17 +623,21 @@ async fn load_commit_object<R: smol::io::AsyncBufRead + Unpin>(
     }
 }
 
+async fn read_shallow_file(shallow_file_path: &Path) -> Result<Option<String>> {
+    match smol::fs::read_to_string(shallow_file_path).await {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).context("reading shallow file"),
+    }
+}
+
 async fn is_shallow_boundary_commit(
     git: &GitBinary,
     shallow_file_path: &Path,
     commit: &str,
 ) -> Result<bool> {
-    let shallow_contents = match smol::fs::read_to_string(shallow_file_path).await {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => {
-            return Err(error).context("reading shallow file");
-        }
+    let Some(shallow_contents) = read_shallow_file(shallow_file_path).await? else {
+        return Ok(false);
     };
 
     let oid = git
@@ -3483,6 +3487,7 @@ impl GitRepository for RealGitRepository {
         commit_limit: usize,
     ) -> BoxFuture<'_, Result<Vec<FileHistoryChangedFileSets>>> {
         let git = self.git_binary();
+        let shallow_file_path = self.common_dir.join("shallow");
 
         async move {
             if paths.is_empty() {
@@ -3501,7 +3506,7 @@ impl GitRepository for RealGitRepository {
                 "--no-renames",
                 "--name-only",
                 "-z",
-                "--format=%x1e",
+                "--format=%x1e%H",
                 "--",
             ]
             .map(OsString::from)
@@ -3515,8 +3520,22 @@ impl GitRepository for RealGitRepository {
                 String::from_utf8_lossy(&output.stderr)
             );
 
+            let shallow_boundary_oids = read_shallow_file(&shallow_file_path)
+                .await?
+                .map(|contents| {
+                    contents
+                        .lines()
+                        .map(|line| line.trim().to_string())
+                        .collect::<HashSet<_>>()
+                })
+                .unwrap_or_default();
+
             let stdout = String::from_utf8_lossy(&output.stdout);
-            Ok(parse_file_history_changed_files_output(&stdout, &paths))
+            Ok(parse_file_history_changed_files_output(
+                &stdout,
+                &paths,
+                &shallow_boundary_oids,
+            ))
         }
         .boxed()
     }
@@ -3633,12 +3652,17 @@ async fn read_single_commit_response<R: smol::io::AsyncBufRead + Unpin>(
 fn parse_file_history_changed_files_output(
     output: &str,
     queried_paths: &[RepoPath],
+    shallow_boundary_oids: &HashSet<String>,
 ) -> Vec<FileHistoryChangedFileSets> {
     let mut histories = vec![FileHistoryChangedFileSets::default(); queried_paths.len()];
 
     for record in output.split('\x1e') {
-        let changed_files = record
-            .split('\0')
+        let mut fields = record.split('\0');
+        let sha = fields.next().unwrap_or_default().trim();
+        if shallow_boundary_oids.contains(sha) {
+            continue;
+        }
+        let changed_files = fields
             .filter_map(|field| {
                 let path = field.trim_start_matches('\n');
                 if path.is_empty() {
@@ -3685,6 +3709,7 @@ fn parse_initial_graph_output<'a>(
             } else {
                 ref_names_str
                     .split(", ")
+                    .filter(|decoration| *decoration != "grafted" && *decoration != "replaced")
                     .map(|s| SharedString::from(s.to_string()))
                     .collect()
             };
@@ -5121,12 +5146,13 @@ mod tests {
             RepoPath::new("src/b.rs").unwrap(),
         ];
         let output = concat!(
-            "\x1e\0\nsrc/a.rs\0src/shared.rs\0",
-            "\x1e\0\nsrc/b.rs\0src/shared.rs\0",
-            "\x1e\0\nsrc/a.rs\0src/b.rs\0src/shared.rs\0",
+            "\x1e1111111111111111111111111111111111111111\0\nsrc/a.rs\0src/shared.rs\0",
+            "\x1e2222222222222222222222222222222222222222\0\nsrc/b.rs\0src/shared.rs\0",
+            "\x1e3333333333333333333333333333333333333333\0\nsrc/a.rs\0src/b.rs\0src/shared.rs\0",
         );
 
-        let histories = parse_file_history_changed_files_output(output, &queried_paths);
+        let histories =
+            parse_file_history_changed_files_output(output, &queried_paths, &HashSet::default());
 
         assert_eq!(histories.len(), 2);
         assert_eq!(
@@ -5155,6 +5181,44 @@ mod tests {
                     RepoPath::new("src/b.rs").unwrap(),
                     RepoPath::new("src/shared.rs").unwrap(),
                 ],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_file_history_changed_files_output_skips_shallow_boundary() {
+        let queried_paths = vec![RepoPath::new("src/a.rs").unwrap()];
+        let output = concat!(
+            "\x1e1111111111111111111111111111111111111111\0\nsrc/a.rs\0src/shared.rs\0",
+            "\x1e2222222222222222222222222222222222222222\0\nsrc/a.rs\0src/b.rs\0src/shared.rs\0",
+        );
+        let shallow_boundary_oids =
+            HashSet::from_iter(["2222222222222222222222222222222222222222".to_string()]);
+
+        let histories =
+            parse_file_history_changed_files_output(output, &queried_paths, &shallow_boundary_oids);
+
+        assert_eq!(histories.len(), 1);
+        assert_eq!(
+            histories[0].file_sets,
+            vec![vec![
+                RepoPath::new("src/a.rs").unwrap(),
+                RepoPath::new("src/shared.rs").unwrap(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn test_parse_initial_graph_output_filters_graft_decorations() {
+        let line = "0f36a166633a057bf7dd660508d237cad2606cab\x00\x00grafted, HEAD -> refs/heads/main, refs/remotes/origin/main";
+        let commits = parse_initial_graph_output([line].into_iter());
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].parents.len(), 0);
+        assert_eq!(
+            commits[0].ref_names,
+            vec![
+                SharedString::from("HEAD -> refs/heads/main"),
+                SharedString::from("refs/remotes/origin/main"),
             ]
         );
     }

--- a/crates/git/test_data/golden/blame_incremental_complex.json
+++ b/crates/git/test_data/golden/blame_incremental_complex.json
@@ -16,7 +16,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -35,7 +36,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -54,7 +56,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -73,7 +76,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -92,7 +96,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -111,7 +116,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "5c4f3c0ceaa0b2270c8f4fc8ee32b85c70810206",
@@ -130,7 +136,8 @@
     "committer_tz": "-0700",
     "summary": "Add option to either use system clipboard or vim clipboard (#7936)",
     "previous": "c6826a61a0a947acf09d65ada568c9c4e4494cb2 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -149,7 +156,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -168,7 +176,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -187,7 +196,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -206,7 +216,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -225,7 +236,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -244,7 +256,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -263,7 +276,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -282,7 +296,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -301,7 +316,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -320,7 +336,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "3635d2dcedd83f1b6702f33ca2673317f7fa4695",
@@ -339,7 +356,8 @@
     "committer_tz": "-0700",
     "summary": "Highlight selections on vim yank (#7638)",
     "previous": "efe23ebfcdd653b13be79132b1e2925bcd7bde45 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "b65cf6d2d9576171edb407f5bbaa231c33af1f71",
@@ -358,7 +376,8 @@
     "committer_tz": "-0800",
     "summary": "Merge branch 'main' into language-api-docs",
     "previous": "6457ccf9ece3b36a37e675783abee9748a443115 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "b65cf6d2d9576171edb407f5bbaa231c33af1f71",
@@ -377,7 +396,8 @@
     "committer_tz": "-0800",
     "summary": "Merge branch 'main' into language-api-docs",
     "previous": "6457ccf9ece3b36a37e675783abee9748a443115 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "b02bd9bce1db3a68dcd606718fa02709020860af",
@@ -396,7 +416,8 @@
     "committer_tz": "-0600",
     "summary": "Fix Y on last line with no trailing new line",
     "previous": "7c77baa7c17eea106330622e70513ea9389d50a1 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "b02bd9bce1db3a68dcd606718fa02709020860af",
@@ -415,7 +436,8 @@
     "committer_tz": "-0600",
     "summary": "Fix Y on last line with no trailing new line",
     "previous": "7c77baa7c17eea106330622e70513ea9389d50a1 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e4794e3134b6449e36ed2771a8849046489cc252",
@@ -434,7 +456,8 @@
     "committer_tz": "-0600",
     "summary": "vim: Fix linewise copy of last line with no trailing newline",
     "previous": "26c3312049a9c73bc3350528c1defd3820a7a8c7 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e4794e3134b6449e36ed2771a8849046489cc252",
@@ -453,7 +476,8 @@
     "committer_tz": "-0600",
     "summary": "vim: Fix linewise copy of last line with no trailing newline",
     "previous": "26c3312049a9c73bc3350528c1defd3820a7a8c7 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e4794e3134b6449e36ed2771a8849046489cc252",
@@ -472,7 +496,8 @@
     "committer_tz": "-0600",
     "summary": "vim: Fix linewise copy of last line with no trailing newline",
     "previous": "26c3312049a9c73bc3350528c1defd3820a7a8c7 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e4794e3134b6449e36ed2771a8849046489cc252",
@@ -491,7 +516,8 @@
     "committer_tz": "-0600",
     "summary": "vim: Fix linewise copy of last line with no trailing newline",
     "previous": "26c3312049a9c73bc3350528c1defd3820a7a8c7 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e4794e3134b6449e36ed2771a8849046489cc252",
@@ -510,7 +536,8 @@
     "committer_tz": "-0600",
     "summary": "vim: Fix linewise copy of last line with no trailing newline",
     "previous": "26c3312049a9c73bc3350528c1defd3820a7a8c7 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "33d7fe02ee560f6ed57d1425c43e60aef3b66e64",
@@ -529,7 +556,8 @@
     "committer_tz": "-0600",
     "summary": "Rewrite paste",
     "previous": "31db5e4f62e8fca75aa0870f903ae044524c3580 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "33d7fe02ee560f6ed57d1425c43e60aef3b66e64",
@@ -548,7 +576,8 @@
     "committer_tz": "-0600",
     "summary": "Rewrite paste",
     "previous": "31db5e4f62e8fca75aa0870f903ae044524c3580 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "868c46062008bb0bcab2d41a38b4295996b9b958",
@@ -567,7 +596,8 @@
     "committer_tz": "-0700",
     "summary": ":art: Rename and simplify some autoindent stuff",
     "previous": "7a26fa18c7fee3fe031b991e18b55fd8f9c4eb1b crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "e93c49f4f02b3edaddae6a6a4cc0ac433f242357",
@@ -586,7 +616,8 @@
     "committer_tz": "-0700",
     "summary": "Unify visual line_mode and non line_mode operators",
     "previous": "11569a869a72f786a9798c53266e28c05c79f824 crates/vim/src/utils.rs",
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -605,7 +636,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -624,7 +656,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -643,7 +676,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -662,7 +696,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -681,7 +716,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -700,7 +736,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -719,7 +756,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -738,7 +776,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -757,7 +796,8 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   },
   {
     "sha": "082036161fd3815c831ceedfd28ba15b0ed6eb9f",
@@ -776,6 +816,7 @@
     "committer_tz": "-0700",
     "summary": "Enable copy and paste in vim mode",
     "previous": null,
-    "filename": "crates/vim/src/utils.rs"
+    "filename": "crates/vim/src/utils.rs",
+    "boundary": false
   }
 ]

--- a/crates/git/test_data/golden/blame_incremental_not_committed.json
+++ b/crates/git/test_data/golden/blame_incremental_not_committed.json
@@ -16,7 +16,8 @@
     "committer_tz": "+0100",
     "summary": "Another commit",
     "previous": "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913 file_b.txt",
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": false
   },
   {
     "sha": "4aaba34cb86b12f3a749dd6ddbf185de88de6527",
@@ -35,7 +36,8 @@
     "committer_tz": "+0100",
     "summary": "Another commit",
     "previous": "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913 file_b.txt",
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": false
   },
   {
     "sha": "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913",
@@ -54,7 +56,8 @@
     "committer_tz": "+0100",
     "summary": "Another commit",
     "previous": "7aef8a9a211ebc86824769c89f48e4f64aa6183f file_b.txt",
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": false
   },
   {
     "sha": "b2f6b0d982a9e7654bbb6d979c9ccb00b1d2e913",
@@ -73,7 +76,8 @@
     "committer_tz": "+0100",
     "summary": "Another commit",
     "previous": "7aef8a9a211ebc86824769c89f48e4f64aa6183f file_b.txt",
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": false
   },
   {
     "sha": "e6d34e8fb494fe2b576d16037c61ba9d10722ba3",
@@ -92,7 +96,8 @@
     "committer_tz": "+0100",
     "summary": "Initial",
     "previous": null,
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": true
   },
   {
     "sha": "e6d34e8fb494fe2b576d16037c61ba9d10722ba3",
@@ -111,7 +116,8 @@
     "committer_tz": "+0100",
     "summary": "Initial",
     "previous": null,
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": true
   },
   {
     "sha": "e6d34e8fb494fe2b576d16037c61ba9d10722ba3",
@@ -130,6 +136,7 @@
     "committer_tz": "+0100",
     "summary": "Initial",
     "previous": null,
-    "filename": "file_b.txt"
+    "filename": "file_b.txt",
+    "boundary": true
   }
 ]

--- a/crates/git/test_data/golden/blame_incremental_simple.json
+++ b/crates/git/test_data/golden/blame_incremental_simple.json
@@ -16,7 +16,8 @@
     "committer_tz": "+0100",
     "summary": "Make a commit",
     "previous": "6ad46b5257ba16d12c5ca9f0d4900320959df7f4 index.js",
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "6ad46b5257ba16d12c5ca9f0d4900320959df7f4",
@@ -35,7 +36,8 @@
     "committer_tz": "+0100",
     "summary": "Joe's cool commit",
     "previous": "486c2409237a2c627230589e567024a96751d475 index.js",
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "6ad46b5257ba16d12c5ca9f0d4900320959df7f4",
@@ -54,7 +56,8 @@
     "committer_tz": "+0100",
     "summary": "Joe's cool commit",
     "previous": "486c2409237a2c627230589e567024a96751d475 index.js",
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "6ad46b5257ba16d12c5ca9f0d4900320959df7f4",
@@ -73,7 +76,8 @@
     "committer_tz": "+0100",
     "summary": "Joe's cool commit",
     "previous": "486c2409237a2c627230589e567024a96751d475 index.js",
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "486c2409237a2c627230589e567024a96751d475",
@@ -92,7 +96,8 @@
     "committer_tz": "+0100",
     "summary": "Get to a state where eslint would change code and imports",
     "previous": "504065e448b467e79920040f22153e9d2ea0fd6e index.js",
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "504065e448b467e79920040f22153e9d2ea0fd6e",
@@ -111,7 +116,8 @@
     "committer_tz": "+0100",
     "summary": "Add some stuff",
     "previous": null,
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   },
   {
     "sha": "504065e448b467e79920040f22153e9d2ea0fd6e",
@@ -130,6 +136,7 @@
     "committer_tz": "+0100",
     "summary": "Add some stuff",
     "previous": null,
-    "filename": "index.js"
+    "filename": "index.js",
+    "boundary": false
   }
 ]

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commit_tooltip::{CommitAvatar, CommitTooltip, commit_tag_chips},
+    commit_tooltip::{CommitAvatar, CommitTooltip, commit_tag_chips, shallow_boundary_notice},
     commit_view::{CommitView, GitBlob, build_buffer, worktree_id_for_repo_path},
 };
 use anyhow::Context as _;
@@ -399,6 +399,10 @@ impl BlameRenderer for GitBlameRenderer {
             author_name: author.clone(),
             has_parent: false,
         };
+        let boundary_notice = blame
+            .boundary
+            .then(|| shallow_boundary_notice(repository.clone(), workspace.clone(), cx))
+            .flatten();
 
         Some(
             tooltip_container(cx, |this, cx| {
@@ -426,6 +430,7 @@ impl BlameRenderer for GitBlameRenderer {
                                         )
                                     }),
                             )
+                            .children(boundary_notice)
                             .child(
                                 div()
                                     .id("inline-blame-commit-message")

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -401,7 +401,7 @@ impl BlameRenderer for GitBlameRenderer {
         };
         let boundary_notice = blame
             .boundary
-            .then(|| shallow_boundary_notice(repository.clone(), workspace.clone(), cx))
+            .then(|| shallow_boundary_notice(repository.clone(), workspace.clone(), window, cx))
             .flatten();
 
         Some(

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -25,6 +25,7 @@ pub struct CommitDetails {
     pub commit_time: OffsetDateTime,
     pub message: Option<ParsedCommitMessage>,
     pub tag_names: Vec<SharedString>,
+    pub boundary: bool,
 }
 
 const MAX_COMMIT_TOOLTIP_TAG_CHIPS: usize = 2;
@@ -242,6 +243,7 @@ impl CommitTooltip {
                 author_email: blame.author_mail.clone().unwrap_or("".to_string()).into(),
                 message: details,
                 tag_names,
+                boundary: blame.boundary,
             },
             repository,
             workspace,
@@ -381,6 +383,25 @@ impl Render for CommitTooltip {
                                 .overflow_y_scroll()
                                 .child(message),
                         )
+                        .when(self.commit.boundary, |this| {
+                            this.child(
+                                h_flex()
+                                    .pb_1p5()
+                                    .gap_1()
+                                    .child(
+                                        Icon::new(IconName::Warning)
+                                            .size(IconSize::Small)
+                                            .color(Color::Warning),
+                                    )
+                                    .child(
+                                        Label::new(
+                                            "Shallow clone boundary: earlier history is missing, so these lines may come from an older commit.",
+                                        )
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                    ),
+                            )
+                        })
                         .child(
                             h_flex()
                                 .text_color(cx.theme().colors().text_muted)

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -1,15 +1,20 @@
 use crate::commit_view::CommitView;
+use anyhow::Result;
+use askpass::AskPassDelegate;
 use editor::hover_markdown_style;
 use futures::Future;
 use git::blame::BlameEntry;
 use git::repository::CommitSummary;
 use git::{GitRemote, commit::ParsedCommitMessage};
+use git_ui_core::askpass_modal::AskPassModal;
+use git_ui_core::notifications::show_error_toast;
 use gpui::{
     AbsoluteLength, App, Asset, Element, Entity, MouseButton, ParentElement, Pixels, Render,
-    ScrollHandle, StatefulInteractiveElement, WeakEntity, prelude::*,
+    ScrollHandle, StatefulInteractiveElement, Task, WeakEntity, Window, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement};
-use project::git_store::Repository;
+use notifications::status_toast::StatusToast;
+use project::git_store::{Repository, UnshallowState};
 use settings::Settings;
 use std::hash::Hash;
 use theme_settings::ThemeSettings;
@@ -348,6 +353,11 @@ impl Render for CommitTooltip {
             author_name: self.commit.author_name.clone(),
             has_parent: false,
         };
+        let boundary_notice = self
+            .commit
+            .boundary
+            .then(|| shallow_boundary_notice(self.repository.clone(), self.workspace.clone(), cx))
+            .flatten();
 
         tooltip_container(cx, move |this, cx| {
             this.occlude()
@@ -374,6 +384,7 @@ impl Render for CommitTooltip {
                                 .border_b_1()
                                 .border_color(cx.theme().colors().border_variant),
                         )
+                        .children(boundary_notice)
                         .child(
                             div()
                                 .id("inline-blame-commit-message")
@@ -383,25 +394,6 @@ impl Render for CommitTooltip {
                                 .overflow_y_scroll()
                                 .child(message),
                         )
-                        .when(self.commit.boundary, |this| {
-                            this.child(
-                                h_flex()
-                                    .pb_1p5()
-                                    .gap_1()
-                                    .child(
-                                        Icon::new(IconName::Warning)
-                                            .size(IconSize::Small)
-                                            .color(Color::Warning),
-                                    )
-                                    .child(
-                                        Label::new(
-                                            "Shallow clone boundary: earlier history is missing, so these lines may come from an older commit.",
-                                        )
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted),
-                                    ),
-                            )
-                        })
                         .child(
                             h_flex()
                                 .text_color(cx.theme().colors().text_muted)
@@ -492,4 +484,149 @@ fn blame_entry_timestamp(blame_entry: &BlameEntry, format: time_format::Timestam
 
 pub fn blame_entry_relative_timestamp(blame_entry: &BlameEntry) -> String {
     blame_entry_timestamp(blame_entry, time_format::TimestampFormat::Relative)
+}
+
+pub(crate) fn shallow_boundary_notice(
+    repository: Entity<Repository>,
+    workspace: WeakEntity<Workspace>,
+    cx: &App,
+) -> Option<impl IntoElement + use<>> {
+    let unshallow_state = repository.read(cx).unshallow_state();
+    if unshallow_state == UnshallowState::Unshallowed {
+        return None;
+    }
+    let in_flight = unshallow_state == UnshallowState::InProgress;
+    let can_fetch = workspace
+        .read_with(cx, |workspace, cx| {
+            !workspace.project().read(cx).is_via_collab()
+        })
+        .unwrap_or(false);
+    Some(
+        h_flex()
+            .pt_1p5()
+            .gap_2()
+            .items_start()
+            .child(
+                Icon::new(IconName::Warning)
+                    .size(IconSize::Small)
+                    .color(Color::Warning),
+            )
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .gap_1()
+                    .child(
+                        Label::new(
+                            "Shallow clone boundary: earlier history is missing, so these lines may come from an older commit.",
+                        )
+                        .size(LabelSize::Small),
+                    )
+                    .when(can_fetch, |this| {
+                        this.child(
+                            h_flex().child(
+                                Button::new(
+                                    "fetch-unshallow",
+                                    if in_flight {
+                                        "Fetching…"
+                                    } else {
+                                        "Fetch Missing History"
+                                    },
+                                )
+                                .style(ButtonStyle::Outlined)
+                                .label_size(LabelSize::Small)
+                                .disabled(in_flight)
+                                .tooltip(Tooltip::text(
+                                    "Run `git fetch --unshallow` to download the full history",
+                                ))
+                                .on_click(move |_, window, cx| {
+                                    cx.stop_propagation();
+                                    fetch_unshallow(
+                                        repository.clone(),
+                                        workspace.clone(),
+                                        window,
+                                        cx,
+                                    )
+                                    .detach_and_log_err(cx);
+                                }),
+                            ),
+                        )
+                    }),
+            ),
+    )
+}
+
+pub(crate) fn fetch_unshallow(
+    repository: Entity<Repository>,
+    workspace: WeakEntity<Workspace>,
+    window: &mut Window,
+    cx: &mut App,
+) -> Task<Result<()>> {
+    if repository.read(cx).unshallow_state() != UnshallowState::Idle {
+        return Task::ready(Ok(()));
+    }
+    let askpass = {
+        let workspace = workspace.clone();
+        let window_handle = window.window_handle();
+        AskPassDelegate::new_with_cancellation(
+            &mut cx.to_async(),
+            move |prompt, tx, cancellation, cx| {
+                window_handle
+                    .update(cx, |_, window, cx| {
+                        workspace
+                            .update(cx, |workspace, cx| {
+                                workspace.toggle_modal(window, cx, |window, cx| {
+                                    AskPassModal::new(
+                                        "git fetch --unshallow".into(),
+                                        prompt.into(),
+                                        tx,
+                                        cancellation,
+                                        window,
+                                        cx,
+                                    )
+                                });
+                            })
+                            .ok();
+                    })
+                    .ok();
+            },
+        )
+    };
+    let fetch = repository.update(cx, |repository, cx| repository.fetch_unshallow(askpass, cx));
+    window.refresh();
+    window.spawn(cx, async move |cx| {
+        let result = match fetch.await {
+            Ok(result) => result,
+            Err(canceled) => Err(anyhow::Error::from(canceled)),
+        };
+        cx.update(|window, cx| {
+            window.refresh();
+            let Some(workspace) = workspace.upgrade() else {
+                return Ok(());
+            };
+            match result {
+                Ok(_) => {
+                    workspace.update(cx, |workspace, cx| {
+                        let toast = StatusToast::new(
+                            "Fetched the missing commit history",
+                            cx,
+                            |this, _| {
+                                this.icon(
+                                    Icon::new(IconName::GitBranch)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                            },
+                        );
+                        workspace.toggle_status_toast(toast, cx);
+                    });
+                    Ok(())
+                }
+                Err(error) => {
+                    show_error_toast(workspace, "fetch --unshallow", error, cx);
+                    Err(anyhow::anyhow!("git fetch --unshallow failed"))
+                }
+            }
+        })?
+    })
 }

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -356,7 +356,9 @@ impl Render for CommitTooltip {
         let boundary_notice = self
             .commit
             .boundary
-            .then(|| shallow_boundary_notice(self.repository.clone(), self.workspace.clone(), cx))
+            .then(|| {
+                shallow_boundary_notice(self.repository.clone(), self.workspace.clone(), window, cx)
+            })
             .flatten();
 
         tooltip_container(cx, move |this, cx| {
@@ -489,6 +491,7 @@ pub fn blame_entry_relative_timestamp(blame_entry: &BlameEntry) -> String {
 pub(crate) fn shallow_boundary_notice(
     repository: Entity<Repository>,
     workspace: WeakEntity<Workspace>,
+    window: &Window,
     cx: &App,
 ) -> Option<impl IntoElement + use<>> {
     let unshallow_state = repository.read(cx).unshallow_state();
@@ -496,63 +499,72 @@ pub(crate) fn shallow_boundary_notice(
         return None;
     }
     let in_flight = unshallow_state == UnshallowState::InProgress;
+    let avatar_width = CommitAvatar::rendered_size(rems(1.), window);
     let can_fetch = workspace
         .read_with(cx, |workspace, cx| {
             !workspace.project().read(cx).is_via_collab()
         })
         .unwrap_or(false);
     Some(
-        h_flex()
-            .pt_1p5()
+        v_flex()
+            .py_1()
             .gap_2()
-            .items_start()
+            .border_b_1()
+            .border_color(cx.theme().colors().border_variant)
             .child(
-                Icon::new(IconName::Warning)
-                    .size(IconSize::Small)
-                    .color(Color::Warning),
-            )
-            .child(
-                v_flex()
-                    .flex_1()
-                    .min_w_0()
-                    .gap_1()
+                h_flex()
+                    .gap_2()
+                    .items_start()
                     .child(
-                        Label::new(
-                            "Shallow clone boundary: earlier history is missing, so these lines may come from an older commit.",
-                        )
-                        .size(LabelSize::Small),
+                        h_flex().w(avatar_width).justify_center().child(
+                            Icon::new(IconName::Warning)
+                                .size(IconSize::Small)
+                                .color(Color::Warning),
+                        ),
                     )
-                    .when(can_fetch, |this| {
-                        this.child(
-                            h_flex().child(
-                                Button::new(
-                                    "fetch-unshallow",
-                                    if in_flight {
-                                        "Fetching…"
-                                    } else {
-                                        "Fetch Missing History"
-                                    },
+                    .child(
+                        div().flex_1().min_w_0().child(
+                            Label::new(
+                                "Shallow clone boundary: earlier history is missing, so these lines may come from an older commit.",
+                            )
+                            .size(LabelSize::Small)
+                            .line_height_style(LineHeightStyle::UiLabel),
+                        ),
+                    ),
+            )
+            .when(can_fetch, |this| {
+                this.child(
+                    h_flex()
+                        .gap_2()
+                        .child(div().w(avatar_width))
+                        .child(
+                            Button::new(
+                                "fetch-unshallow",
+                                if in_flight {
+                                    "Fetching…"
+                                } else {
+                                    "Fetch Missing History"
+                                },
+                            )
+                            .style(ButtonStyle::Outlined)
+                            .label_size(LabelSize::Small)
+                            .disabled(in_flight)
+                            .tooltip(Tooltip::text(
+                                "Run `git fetch --unshallow` to download the full history",
+                            ))
+                            .on_click(move |_, window, cx| {
+                                cx.stop_propagation();
+                                fetch_unshallow(
+                                    repository.clone(),
+                                    workspace.clone(),
+                                    window,
+                                    cx,
                                 )
-                                .style(ButtonStyle::Outlined)
-                                .label_size(LabelSize::Small)
-                                .disabled(in_flight)
-                                .tooltip(Tooltip::text(
-                                    "Run `git fetch --unshallow` to download the full history",
-                                ))
-                                .on_click(move |_, window, cx| {
-                                    cx.stop_propagation();
-                                    fetch_unshallow(
-                                        repository.clone(),
-                                        workspace.clone(),
-                                        window,
-                                        cx,
-                                    )
-                                    .detach_and_log_err(cx);
-                                }),
-                            ),
-                        )
-                    }),
-            ),
+                                .detach_and_log_err(cx);
+                            }),
+                        ),
+                )
+            }),
     )
 }
 

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -86,6 +86,7 @@ pub struct CommitView {
     workspace: WeakEntity<Workspace>,
     remote: Option<GitRemote>,
     is_shallow_boundary: bool,
+    file_filter: Option<RepoPath>,
     _load_diff_task: Task<Result<()>>,
 }
 
@@ -248,6 +249,7 @@ impl CommitView {
                                 workspace_entity,
                                 workspace_handle,
                                 stash,
+                                file_filter,
                                 window,
                                 cx,
                             )
@@ -294,6 +296,7 @@ impl CommitView {
         workspace_entity: Entity<Workspace>,
         workspace: WeakEntity<Workspace>,
         stash: Option<usize>,
+        file_filter: Option<RepoPath>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -524,6 +527,7 @@ impl CommitView {
             workspace,
             remote,
             is_shallow_boundary,
+            file_filter,
             _load_diff_task: load_diff_task,
         }
     }
@@ -533,6 +537,7 @@ impl CommitView {
         let repository = self.repository.downgrade();
         let workspace = self.workspace.clone();
         let stash = self.stash;
+        let file_filter = self.file_filter.clone();
         v_flex()
             .flex_grow(1.)
             .items_center()
@@ -549,18 +554,27 @@ impl CommitView {
                 .color(Color::Muted),
             )
             .child(
-                Button::new("load-shallow-snapshot", "Load Full Snapshot")
+                Button::new(
+                    "load-shallow-snapshot",
+                    if file_filter.is_some() {
+                        "Load File Snapshot"
+                    } else {
+                        "Load Full Snapshot"
+                    },
+                )
                     .style(ButtonStyle::Filled)
-                    .tooltip(Tooltip::text(
-                        "Show every file at this commit as added. This can be slow in large repositories.",
-                    ))
+                    .tooltip(Tooltip::text(if file_filter.is_some() {
+                        "Show this file's full contents at this commit as added."
+                    } else {
+                        "Show every file at this commit as added. This can be slow in large repositories."
+                    }))
                     .on_click(move |_, window, cx| {
                         Self::open_with_options(
                             commit_sha.clone(),
                             repository.clone(),
                             workspace.clone(),
                             stash,
-                            None,
+                            file_filter.clone(),
                             true,
                             window,
                             cx,
@@ -1309,6 +1323,7 @@ impl Item for CommitView {
                 workspace: self.workspace.clone(),
                 remote: self.remote.clone(),
                 is_shallow_boundary: self.is_shallow_boundary,
+                file_filter: self.file_filter.clone(),
                 _load_diff_task: Task::ready(Ok(())),
             }
         })))

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -26,7 +26,7 @@ use markdown::{Markdown, MarkdownElement};
 use multi_buffer::PathKey;
 use project::{
     Project, ProjectPath, WorktreeId,
-    git_store::{CommitDiff, Repository},
+    git_store::{CommitDiff, Repository, UnshallowState},
 };
 use settings::{DiffViewStyle, Settings};
 use std::{
@@ -532,12 +532,16 @@ impl CommitView {
         }
     }
 
-    fn render_shallow_boundary_notice(&self) -> impl IntoElement {
+    fn render_shallow_boundary_notice(&self, cx: &App) -> impl IntoElement {
         let commit_sha = self.commit.sha.to_string();
-        let repository = self.repository.downgrade();
+        let repository = self.repository.clone();
         let workspace = self.workspace.clone();
         let stash = self.stash;
         let file_filter = self.file_filter.clone();
+        let unshallow_state = self.repository.read(cx).unshallow_state();
+        let can_fetch = !self.project.read(cx).is_via_collab()
+            && unshallow_state != UnshallowState::Unshallowed;
+        let fetch_in_flight = unshallow_state == UnshallowState::InProgress;
         v_flex()
             .flex_grow(1.)
             .items_center()
@@ -554,32 +558,86 @@ impl CommitView {
                 .color(Color::Muted),
             )
             .child(
-                Button::new(
-                    "load-shallow-snapshot",
-                    if file_filter.is_some() {
-                        "Load File Snapshot"
-                    } else {
-                        "Load Full Snapshot"
-                    },
-                )
-                    .style(ButtonStyle::Filled)
-                    .tooltip(Tooltip::text(if file_filter.is_some() {
-                        "Show this file's full contents at this commit as added."
-                    } else {
-                        "Show every file at this commit as added. This can be slow in large repositories."
-                    }))
-                    .on_click(move |_, window, cx| {
-                        Self::open_with_options(
-                            commit_sha.clone(),
-                            repository.clone(),
-                            workspace.clone(),
-                            stash,
-                            file_filter.clone(),
-                            true,
-                            window,
-                            cx,
-                        );
-                    }),
+                h_flex()
+                    .gap_2()
+                    .when(can_fetch, |this| {
+                        let commit_sha = commit_sha.clone();
+                        let repository = repository.clone();
+                        let workspace = workspace.clone();
+                        let file_filter = file_filter.clone();
+                        this.child(
+                            Button::new(
+                                "fetch-unshallow",
+                                if fetch_in_flight {
+                                    "Fetching…"
+                                } else {
+                                    "Fetch Missing History"
+                                },
+                            )
+                                .style(ButtonStyle::Filled)
+                                .disabled(fetch_in_flight)
+                                .tooltip(Tooltip::text(
+                                    "Run `git fetch --unshallow` to download the full history, then show this commit's changes.",
+                                ))
+                                .on_click(move |_, window, cx| {
+                                    let fetch = crate::commit_tooltip::fetch_unshallow(
+                                        repository.clone(),
+                                        workspace.clone(),
+                                        window,
+                                        cx,
+                                    );
+                                    let commit_sha = commit_sha.clone();
+                                    let repository = repository.downgrade();
+                                    let workspace = workspace.clone();
+                                    let file_filter = file_filter.clone();
+                                    window
+                                        .spawn(cx, async move |cx| {
+                                            fetch.await?;
+                                            cx.update(|window, cx| {
+                                                Self::open_with_options(
+                                                    commit_sha,
+                                                    repository,
+                                                    workspace,
+                                                    stash,
+                                                    file_filter,
+                                                    false,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
+                                        })
+                                        .detach_and_log_err(cx);
+                                }),
+                        )
+                    })
+                    .child(
+                        Button::new(
+                            "load-shallow-snapshot",
+                            if file_filter.is_some() {
+                                "Load File Snapshot"
+                            } else {
+                                "Load Full Snapshot"
+                            },
+                        )
+                            .style(ButtonStyle::Outlined)
+                            .tooltip(Tooltip::text(if file_filter.is_some() {
+                                "Show this file's full contents at this commit as added."
+                            } else {
+                                "Show every file at this commit as added. This can be slow in large repositories."
+                            }))
+                            .on_click(move |_, window, cx| {
+                                Self::open_with_options(
+                                    commit_sha.clone(),
+                                    repository.downgrade(),
+                                    workspace.clone(),
+                                    stash,
+                                    file_filter.clone(),
+                                    true,
+                                    window,
+                                    cx,
+                                );
+                            }),
+                    ),
             )
     }
 
@@ -1345,7 +1403,7 @@ impl Render for CommitView {
                 |this| this.child(div().flex_grow(1.).child(self.editor.clone())),
             )
             .when(self.is_shallow_boundary, |this| {
-                this.child(self.render_shallow_boundary_notice())
+                this.child(self.render_shallow_boundary_notice(cx))
             })
     }
 }

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -85,6 +85,7 @@ pub struct CommitView {
     project: Entity<Project>,
     workspace: WeakEntity<Workspace>,
     remote: Option<GitRemote>,
+    is_shallow_boundary: bool,
     _load_diff_task: Task<Result<()>>,
 }
 
@@ -187,8 +188,32 @@ impl CommitView {
         window: &mut Window,
         cx: &mut App,
     ) {
+        Self::open_with_options(
+            commit_sha,
+            repo,
+            workspace,
+            stash,
+            file_filter,
+            false,
+            window,
+            cx,
+        )
+    }
+
+    fn open_with_options(
+        commit_sha: String,
+        repo: WeakEntity<Repository>,
+        workspace: WeakEntity<Workspace>,
+        stash: Option<usize>,
+        file_filter: Option<RepoPath>,
+        ignore_shallow_boundary: bool,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
         let commit_diff = repo
-            .update(cx, |repo, _| repo.load_commit_diff(commit_sha.clone()))
+            .update(cx, |repo, _| {
+                repo.load_commit_diff(commit_sha.clone(), ignore_shallow_boundary)
+            })
             .ok();
         let commit_details = repo
             .update(cx, |repo, _| repo.show(commit_sha.clone()))
@@ -273,6 +298,7 @@ impl CommitView {
         cx: &mut Context<Self>,
     ) -> Self {
         let language_registry = project.read(cx).languages().clone();
+        let is_shallow_boundary = commit_diff.is_shallow_boundary;
         let multibuffer = cx.new(|cx| {
             let mut multibuffer = MultiBuffer::new(Capability::ReadOnly);
             multibuffer.set_all_diff_hunks_expanded(cx);
@@ -497,8 +523,50 @@ impl CommitView {
             project,
             workspace,
             remote,
+            is_shallow_boundary,
             _load_diff_task: load_diff_task,
         }
+    }
+
+    fn render_shallow_boundary_notice(&self) -> impl IntoElement {
+        let commit_sha = self.commit.sha.to_string();
+        let repository = self.repository.downgrade();
+        let workspace = self.workspace.clone();
+        let stash = self.stash;
+        v_flex()
+            .flex_grow(1.)
+            .items_center()
+            .justify_center()
+            .gap_2()
+            .child(
+                Label::new("This commit is at the boundary of a shallow clone.")
+                    .color(Color::Muted),
+            )
+            .child(
+                Label::new(
+                    "Its parent history was not fetched, so the changes it introduced cannot be shown.",
+                )
+                .color(Color::Muted),
+            )
+            .child(
+                Button::new("load-shallow-snapshot", "Load Full Snapshot")
+                    .style(ButtonStyle::Filled)
+                    .tooltip(Tooltip::text(
+                        "Show every file at this commit as added. This can be slow in large repositories.",
+                    ))
+                    .on_click(move |_, window, cx| {
+                        Self::open_with_options(
+                            commit_sha.clone(),
+                            repository.clone(),
+                            workspace.clone(),
+                            stash,
+                            None,
+                            true,
+                            window,
+                            cx,
+                        );
+                    }),
+            )
     }
 
     fn render_commit_avatar(
@@ -1240,6 +1308,7 @@ impl Item for CommitView {
                 project: self.project.clone(),
                 workspace: self.workspace.clone(),
                 remote: self.remote.clone(),
+                is_shallow_boundary: self.is_shallow_boundary,
                 _load_diff_task: Task::ready(Ok(())),
             }
         })))
@@ -1260,6 +1329,9 @@ impl Render for CommitView {
                 !self.editor.read(cx).rhs_editor().read(cx).is_empty(cx),
                 |this| this.child(div().flex_grow(1.).child(self.editor.clone())),
             )
+            .when(self.is_shallow_boundary, |this| {
+                this.child(self.render_shallow_boundary_notice())
+            })
     }
 }
 

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -2154,7 +2154,8 @@ impl GitGraph {
 
         self.load_selected_commit_message(cx, &commit_message_handle, &repository);
 
-        let diff_receiver = repository.update(cx, |repo, _| repo.load_commit_diff(diff_handle));
+        let diff_receiver =
+            repository.update(cx, |repo, _| repo.load_commit_diff(diff_handle, false));
 
         self._commit_diff_task = Some(cx.spawn(async move |this, cx| {
             if let Ok(Ok(diff)) = diff_receiver.await {
@@ -7431,6 +7432,7 @@ mod tests {
                     new_text: Some("updated content".into()),
                     is_binary: false,
                 }],
+                is_shallow_boundary: false,
             });
             graph.selected_commit_diff_stats = Some((1, 1));
             cx.notify();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3914,7 +3914,7 @@ impl GitPanel {
                 let remote_message = fetch.await?;
                 this.update(cx, |this, cx| {
                     let action = match fetch_options {
-                        FetchOptions::All => RemoteAction::Fetch(None),
+                        FetchOptions::All | FetchOptions::Unshallow => RemoteAction::Fetch(None),
                         FetchOptions::Remote(remote) => RemoteAction::Fetch(Some(remote)),
                     };
                     match remote_message {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8783,6 +8783,7 @@ impl GitPanelMessageTooltip {
                         provider_registry,
                     )),
                     tag_names: Vec::new(),
+                    boundary: false,
                 };
 
                 this.update(cx, |this: &mut GitPanelMessageTooltip, cx| {

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -10752,6 +10752,7 @@ fn serialize_blame_entry(entry: git::blame::BlameEntry) -> proto::BlameEntry {
         summary: entry.summary,
         previous: entry.previous,
         filename: entry.filename,
+        boundary: entry.boundary,
     }
 }
 
@@ -10771,6 +10772,7 @@ fn deserialize_blame_entry(entry: proto::BlameEntry) -> Option<git::blame::Blame
         summary: entry.summary,
         previous: entry.previous,
         filename: entry.filename,
+        boundary: entry.boundary,
     })
 }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -215,6 +215,7 @@ fn decode_git_text(bytes: Vec<u8>) -> Result<String> {
 #[derive(Debug)]
 pub struct CommitDiff {
     pub files: Vec<CommitFile>,
+    pub is_shallow_boundary: bool,
 }
 
 #[derive(Debug)]
@@ -284,7 +285,10 @@ fn decode_commit_diff(diff: git::repository::CommitDiff) -> CommitDiff {
             }
         })
         .collect();
-    CommitDiff { files }
+    CommitDiff {
+        files,
+        is_shallow_boundary: diff.is_shallow_boundary,
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -4371,7 +4375,10 @@ impl GitStore {
 
         let commit_diff = repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.load_commit_diff(envelope.payload.commit)
+                repository_handle.load_commit_diff(
+                    envelope.payload.commit,
+                    envelope.payload.ignore_shallow_boundary,
+                )
             })
             .await??;
         Ok(proto::LoadCommitDiffResponse {
@@ -4385,6 +4392,7 @@ impl GitStore {
                     is_binary: file.is_binary,
                 })
                 .collect(),
+            is_shallow_boundary: commit_diff.is_shallow_boundary,
         })
     }
 
@@ -6980,12 +6988,16 @@ impl Repository {
         })
     }
 
-    pub fn load_commit_diff(&mut self, commit: String) -> oneshot::Receiver<Result<CommitDiff>> {
+    pub fn load_commit_diff(
+        &mut self,
+        commit: String,
+        ignore_shallow_boundary: bool,
+    ) -> oneshot::Receiver<Result<CommitDiff>> {
         let id = self.id;
         self.send_job("load_commit_diff", None, move |git_repo, cx| async move {
             match git_repo {
                 RepositoryState::Local(LocalRepositoryState { backend, .. }) => backend
-                    .load_commit(commit, cx)
+                    .load_commit(commit, ignore_shallow_boundary, cx)
                     .await
                     .map(decode_commit_diff),
                 RepositoryState::Remote(RemoteRepositoryState {
@@ -6996,6 +7008,7 @@ impl Repository {
                             project_id: project_id.0,
                             repository_id: id.to_proto(),
                             commit,
+                            ignore_shallow_boundary,
                         })
                         .await?;
                     Ok(CommitDiff {
@@ -7011,6 +7024,7 @@ impl Repository {
                                 })
                             })
                             .collect::<Result<Vec<_>>>()?,
+                        is_shallow_boundary: response.is_shallow_boundary,
                     })
                 }
             }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -604,9 +604,18 @@ pub struct GraphDataResponse<'a> {
     pub error: Option<SharedString>,
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum UnshallowState {
+    #[default]
+    Idle,
+    InProgress,
+    Unshallowed,
+}
+
 pub struct Repository {
     this: WeakEntity<Self>,
     snapshot: RepositorySnapshot,
+    unshallow_state: UnshallowState,
     commit_message_buffer: Option<Entity<Buffer>>,
     git_store: WeakEntity<GitStore>,
     // For a local repository, holds paths that have had worktree events since the last status scan completed,
@@ -3326,7 +3335,8 @@ impl GitStore {
     ) -> Result<proto::RemoteMessageResponse> {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
-        let fetch_options = FetchOptions::from_proto(envelope.payload.remote);
+        let fetch_options =
+            FetchOptions::from_proto(envelope.payload.remote, envelope.payload.unshallow);
         let askpass_id = envelope.payload.askpass_id;
 
         let askpass = make_remote_delegate(
@@ -6358,6 +6368,7 @@ impl Repository {
             this: cx.weak_entity(),
             git_store,
             snapshot,
+            unshallow_state: UnshallowState::default(),
             pending_ops: Default::default(),
             repository_state: Task::ready(Err("not yet initialized".into())).shared(),
             _worker_task: Task::ready(()),
@@ -6406,6 +6417,7 @@ impl Repository {
         Self {
             this: cx.weak_entity(),
             snapshot,
+            unshallow_state: UnshallowState::default(),
             commit_message_buffer: None,
             git_store,
             pending_ops: Default::default(),
@@ -8440,6 +8452,39 @@ impl Repository {
         Ok(())
     }
 
+    pub fn unshallow_state(&self) -> UnshallowState {
+        self.unshallow_state
+    }
+
+    pub fn fetch_unshallow(
+        &mut self,
+        askpass: AskPassDelegate,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<RemoteCommandOutput>> {
+        let receiver = self.fetch(FetchOptions::Unshallow, askpass, cx);
+        self.unshallow_state = UnshallowState::InProgress;
+        cx.notify();
+        let (tx, rx) = oneshot::channel();
+        cx.spawn(async move |this, cx| {
+            let result = receiver.await;
+            let succeeded = matches!(&result, Ok(Ok(_)));
+            this.update(cx, |this, cx| {
+                this.unshallow_state = if succeeded {
+                    UnshallowState::Unshallowed
+                } else {
+                    UnshallowState::Idle
+                };
+                cx.notify();
+            })
+            .ok();
+            if let Ok(result) = result {
+                tx.send(result).ok();
+            }
+        })
+        .detach();
+        rx
+    }
+
     pub fn fetch(
         &mut self,
         fetch_options: FetchOptions,
@@ -8488,6 +8533,7 @@ impl Repository {
                                 repository_id: id.to_proto(),
                                 askpass_id,
                                 remote: fetch_options.to_proto(),
+                                unshallow: fetch_options == FetchOptions::Unshallow,
                             })
                             .await?;
 

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -450,6 +450,7 @@ message Fetch {
   uint64 repository_id = 3;
   uint64 askpass_id = 4;
   optional string remote = 5;
+  bool unshallow = 6;
 }
 
 message GetRemotes {

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -511,6 +511,7 @@ message BlameEntry {
   optional string previous = 14;
 
   string filename = 15;
+  bool boundary = 16;
 }
 
 message CommitMessage {

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -289,10 +289,12 @@ message LoadCommitDiff {
   reserved 2;
   uint64 repository_id = 3;
   string commit = 4;
+  bool ignore_shallow_boundary = 5;
 }
 
 message LoadCommitDiffResponse {
   repeated CommitFile files = 1;
+  bool is_shallow_boundary = 2;
 }
 
 message CommitFile {


### PR DESCRIPTION
For repositories with shallow mode enabled, before, Zed instantly loaded diff changes which could be very large and CPU-demanding:

https://github.com/user-attachments/assets/5577730a-efef-424f-b749-501394a8b51f

Now, we show the following state instead of loading:

<img width="1728" height="1084" alt="after" src="https://github.com/user-attachments/assets/03cc47fe-7074-4e8b-ba12-2fefa101377d" />

(the button allows to move on and do the load nonetheless)


Release Notes:

- Fixed shallow diffs causing a lot of computations
