### PR TITLE
Remove four unnecessary copies

### DIFF
--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -217,7 +217,7 @@ async fn fetch_extensions_from_blob_store(
             .list_objects()
             .bucket(blob_store_bucket)
             .prefix("extensions/")
-            .set_marker(next_marker.clone())
+            .set_marker(next_marker.take())
             .send()
             .await?;
         let objects = list.contents.unwrap_or_default();

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -592,9 +592,14 @@ impl NotificationSubscriptionSet {
             return;
         };
 
-        for handler_id in handler_ids {
-            if let Some(handler) = self.handlers.get_mut(*handler_id) {
-                handler(payload.clone(), cx.clone());
+        if let Some((last_handler_id, handler_ids)) = handler_ids.split_last() {
+            for handler_id in handler_ids {
+                if let Some(handler) = self.handlers.get_mut(*handler_id) {
+                    handler(payload.clone(), cx.clone());
+                }
+            }
+            if let Some(handler) = self.handlers.get_mut(*last_handler_id) {
+                handler(payload, cx.clone());
             }
         }
     }

--- a/crates/editor/src/rewrap.rs
+++ b/crates/editor/src/rewrap.rs
@@ -191,13 +191,14 @@ impl Editor {
                         Point::new(current_range_start, 0)
                             ..Point::new(prev_row, buffer.line_len(MultiBufferRow(prev_row))),
                         current_range_indent,
-                        current_range_comment_delimiters.clone(),
-                        current_range_rewrap_prefix.clone(),
+                        std::mem::replace(
+                            &mut current_range_comment_delimiters,
+                            row_comment_delimiters,
+                        ),
+                        std::mem::replace(&mut current_range_rewrap_prefix, row_rewrap_prefix),
                     ));
                     current_range_start = row;
                     current_range_indent = row_indent;
-                    current_range_comment_delimiters = row_comment_delimiters;
-                    current_range_rewrap_prefix = row_rewrap_prefix;
                 }
                 prev_row = row;
             }

--- a/crates/project/src/manifest_tree/path_trie.rs
+++ b/crates/project/src/manifest_tree/path_trie.rs
@@ -64,9 +64,9 @@ impl<Label: Ord + Clone> RootPathTrie<Label> {
         for key in path.0.iter() {
             path_so_far = path_so_far.join(RelPath::from_unix_str(key.as_ref()).unwrap());
             current = match current.children.entry(key.clone()) {
-                Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(RootPathTrie::new_with_key(path_so_far.clone().into()))
-                }
+                Entry::Vacant(vacant_entry) => vacant_entry.insert(RootPathTrie::new_with_key(
+                    Arc::from(path_so_far.as_rel_path()),
+                )),
                 Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             };
         }


### PR DESCRIPTION
This change removes four unnecessary copies. It uses moves when the old values are no longer needed.

PR #62763 inspired this follow-up.

Release Notes:

- Improved performance by removing unnecessary data copies.