### PR TITLE
git: Fix remote URL parsing for partial clones

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1682,9 +1682,13 @@ impl GitRepository for RealGitRepository {
                 let mut urls = HashMap::default();
                 if let Ok(stdout) = git.run(&["remote", "-v"]).await {
                     for line in stdout.lines() {
-                        if let Some(line) = line.strip_suffix(" (fetch)")
-                            && let Some((name, url)) = line.split_once(char::is_whitespace)
-                        {
+                        // On promisor remotes, `git` appends `[filter]` (e.g. `[blob:none]`)
+                        // after `(fetch)`/`(push)`; strip it so the suffix check matches.
+                        let line = line.split(" [").next().unwrap_or(line);
+                        let Some(rest) = line.strip_suffix(" (fetch)") else {
+                            continue;
+                        };
+                        if let Some((name, url)) = rest.split_once(char::is_whitespace) {
                             urls.insert(name.to_string(), url.trim_start().to_string());
                         }
                     }
@@ -6531,6 +6535,50 @@ mod tests {
         assert_eq!(
             remote_urls.get("upstream").unwrap(),
             "/Users/user/My Projects/upstream.git"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_get_remote_urls_with_partial_clone(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let remote_repo = tempfile::tempdir().unwrap();
+        git_init_repo(remote_repo.path());
+
+        // Seed the remote repo
+        let remote_path = remote_repo.path();
+        fs::write(remote_path.join("file.txt"), "initial").unwrap();
+        git_command(remote_path, ["add", "file.txt"]);
+        git_command(remote_path, ["commit", "-m", "initial commit"]);
+
+        // Clone with --filter=blob:none, which marks origin as a promisor remote
+        // and causes `git remote -v` to annotate its fetching lines with "[blob:none]"
+        let clone_repo = tempfile::tempdir().unwrap();
+        let clone_path = clone_repo.path();
+        git_command(
+            clone_path,
+            [
+                OsString::from("clone"),
+                OsString::from("--filter=blob:none"),
+                remote_path.as_os_str().into(),
+                clone_path.as_os_str().into(),
+            ],
+        );
+
+        let repo = RealGitRepository::new(
+            &clone_path.join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let remote_urls = repo.remote_urls().await;
+        assert_eq!(
+            remote_urls.get("origin"),
+            Some(&remote_path.to_string_lossy().to_string()),
+            "origin remote should be listed even though `git remote -v` includes a `[blob:none]` annotation"
         );
     }
 }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1682,10 +1682,11 @@ impl GitRepository for RealGitRepository {
                 let mut urls = HashMap::default();
                 if let Ok(stdout) = git.run(&["remote", "-v"]).await {
                     for line in stdout.lines() {
-                        // On promisor remotes, `git` appends `[filter]` (e.g. `[blob:none]`)
-                        // after `(fetch)`/`(push)`; strip it so the suffix check matches.
-                        let line = line.split(" [").next().unwrap_or(line);
-                        let Some(rest) = line.strip_suffix(" (fetch)") else {
+                        // Parse from the right around the final ` (fetch)` marker;
+                        // promisor remotes may be followed by a `[filter]`
+                        // annotation (e.g. `[blob:none]`), while URLs containing
+                        // `" ["` or `(fetch)` remain untouched.
+                        let Some((rest, _annotation)) = line.rsplit_once(" (fetch)") else {
                             continue;
                         };
                         if let Some((name, url)) = rest.split_once(char::is_whitespace) {
@@ -6579,6 +6580,45 @@ mod tests {
             remote_urls.get("origin"),
             Some(&remote_path.to_string_lossy().to_string()),
             "origin remote should be listed even though `git remote -v` includes a `[blob:none]` annotation"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_get_remote_urls_url_with_bracket_space(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        // A remote URL containing a `" ["` substring is legal and must not be
+        // confused with the `[filter]` annotation git appends on promisor remotes.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        git_init_repo(&repo_dir);
+
+        let url_with_bracket_space = format!("{} [archive].git", temp_dir.path().display());
+        git_command(
+            &repo_dir,
+            [
+                OsString::from("remote"),
+                OsString::from("add"),
+                OsString::from("origin"),
+                OsString::from(&url_with_bracket_space),
+            ],
+        );
+
+        let repo = RealGitRepository::new(
+            &repo_dir.join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let remote_urls = repo.remote_urls().await;
+        assert_eq!(
+            remote_urls.get("origin"),
+            Some(&url_with_bracket_space),
+            "remote whose URL contains ` [` must not be truncated"
         );
     }
 }


### PR DESCRIPTION
Fixes #63025.

As a disclaimer, I do not have any experience with Rust, so had an agent help with this. Feel free to use this PR or re-implement the fix as you wish.

## Summary

Zed parses `git remote -v` output with `strip_suffix(" (fetch)")`. On promisor remotes (every `--filter=blob:none` clone, the default for `gh repo clone` on large repos), git appends a filter annotation like `[blob:none]` to the fetch line, which broke the suffix match and dropped that remote's URL from the map. Downstream, `editor: open permalink to line` then failed with `Failed to open permalink: remote "origin" not found`.

This strips the trailing `[filter]` annotation *before* the suffix check, so the parser handles both plain and annotated lines uniformly. URLs containing `[` are unaffected.

## Test plan

- [x] New regression test `test_get_remote_urls_with_partial_clone` — clones a repo with `--filter=blob:none` and asserts the remote appears in `remote_urls()`.
- [x] Full `cargo test -p git --lib` — 67/67 passing including pre-existing spaces-in-URL test.

## Checklist

- [x] I've read the [contributor guide](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md)
- [x] My code follows Zed's style and lint rules (cargo fmt, clippy clean)

Release Notes:

- Fixed open/copy permalink for partially cloned git repositories