### PR TITLE
Disable ask_user by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1199,7 +1199,7 @@
           "delete_path": true,
           "diagnostics": true,
           "apply_code_action": true,
-          "ask_user": true,
+          "ask_user": false,
           "edit_file": true,
           "write_file": true,
           "fetch": true,
@@ -1226,7 +1226,7 @@
         "tools": {
           "create_thread": true,
           "diagnostics": true,
-          "ask_user": true,
+          "ask_user": false,
           "fetch": true,
           "list_agents_and_models": true,
           "list_directory": true,


### PR DESCRIPTION
## Objective 

There are [some formatting issues](https://github.com/zed-industries/zed/issues/62955) with the `ask_user` tool, but more importantly they seem to be confusing when sub-agents are used, which are not always visible immediately. (Some team members flat out also don't like being given options, which is the purpose of the tool).

## Solution

disable the `ask_user` tool by default, allowing users who want it to enable it in settings by setting `"ask_user": true,` as such:

```json
"agent": {
    "profiles": {
      "write": {
        "name": "Write",
        "enable_all_context_servers": true,
        "tools": {
          "copy_path": true,
          "create_directory": true,
          "create_thread": true,
          "delete_path": true,
          "diagnostics": true,
          "apply_code_action": true,
          "ask_user": true,
          "edit_file": true,
          "write_file": true,
          "fetch": true,
          "find_path": true,
          "find_references": true,
          "get_code_actions": true,
          "go_to_definition": true,
          "list_agents_and_models": true,
          "list_directory": true,
          "move_path": true,
          "rename_symbol": true,
          "read_file": true,
          "grep": true,
          "skill": true,
          "spawn_agent": true,
          "terminal": true,
          "search_web": true,
        },
      },
    },
},
```

## Testing

Ask an agent to ask you a question. By default, options should not be shown, with the above configuration options should be shown.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Without tool:

<img width="1138" height="556" alt="CleanShot 2026-08-21 at 10 21 35@2x" src="https://github.com/user-attachments/assets/6fd2cdbb-af84-49e9-acc5-db5a4359acbe" />

With tool:

<img width="1160" height="974" alt="CleanShot 2026-08-21 at 10 22 57@2x" src="https://github.com/user-attachments/assets/7a4488e4-96f0-40d4-a4c4-70f489b70f12" />


---

Release Notes:

- Disable ask_user tool by default
