### PR TITLE
vim: Match brackets inside strings

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2624,7 +2624,9 @@ fn matching(
     let line_range = line_range.start.to_offset(&map.buffer_snapshot())
         ..line_range.end.to_offset(&map.buffer_snapshot());
 
-    if let Some(preproc_range) = find_matching_c_preprocessor_directive(map, line_range, offset) {
+    if let Some(preproc_range) =
+        find_matching_c_preprocessor_directive(map, line_range.clone(), offset)
+    {
         return preproc_range.to_display_point(map);
     }
 
@@ -2688,6 +2690,16 @@ fn matching(
                     return opening_range.start.to_display_point(map);
                 }
             }
+        }
+    }
+
+    if snapshot
+        .chars_at(offset)
+        .next()
+        .is_some_and(|ch| get_bracket_pair(ch).is_some())
+    {
+        if let Some(destination) = find_matching_bracket_text_based(map, offset, line_range) {
+            return destination.to_display_point(map);
         }
     }
 
@@ -4195,6 +4207,27 @@ mod test {
         cx.shared_state()
             .await
             .assert_eq(indoc! {r"<Button onClick=ˇ{() => {}}></Button>"});
+    }
+
+    #[gpui::test]
+    async fn test_matching_brackets_in_tsx_strings(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new_tsx(cx).await;
+
+        cx.set_state(r#"<Button title='ˇ[this]' />"#, Mode::Normal);
+        cx.simulate_keystrokes("%");
+        cx.assert_state(r#"<Button title='[thisˇ]' />"#, Mode::Normal);
+
+        cx.set_state(r#"<Button title='[thisˇ]' />"#, Mode::Normal);
+        cx.simulate_keystrokes("%");
+        cx.assert_state(r#"<Button title='ˇ[this]' />"#, Mode::Normal);
+
+        cx.set_state(r#"const value = "ˇ[this]";"#, Mode::Normal);
+        cx.simulate_keystrokes("%");
+        cx.assert_state(r#"const value = "[thisˇ]";"#, Mode::Normal);
+
+        cx.set_state(r#"const value = "[thisˇ]";"#, Mode::Normal);
+        cx.simulate_keystrokes("%");
+        cx.assert_state(r#"const value = "ˇ[this]";"#, Mode::Normal);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Fixes #62820.

Vim's `%` motion does not match square brackets inside quoted TSX attributes or TypeScript strings because those brackets can be excluded from Tree-sitter bracket ranges by language overrides.

## Solution

When the cursor is directly on a bracket and syntax-aware matching does not find its pair, use the existing text-based bracket matcher before continuing with line-level quote and tag matching.

This preserves the existing syntax-aware, comment, preprocessor, quote, tag, scan-forward, and multibuffer behavior while allowing brackets hidden by string overrides to match normally.

The regression test covers single-quoted JSX attributes and double-quoted TypeScript strings in both matching directions.

## Testing

After rebasing on the latest `main`:

- `cargo test -p vim test_matching_brackets_in_tsx_strings -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`

Before the final rebase, the same patch also passed:

- `cargo test -p vim --lib -- --nocapture` (560 tests)
- `cargo test -p vim motion::test::test_matching -- --nocapture`
- `cargo test -p vim motion::test::test_unmatched -- --nocapture`
- `./script/clippy -p vim`

`cargo-nextest` was not installed locally, so the crate-wide suite was run with Cargo's built-in test runner.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Vim's `%` motion matching brackets inside quoted strings.
