### PR TITLE
gpui_platform: Stop bench feature from pulling in test-support

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -24,7 +24,7 @@ criterion.workspace = true
 editor = { workspace = true, features = ["test-support"] }
 futures.workspace = true
 gpui = { workspace = true, features = ["bench"] }
-gpui_platform = { workspace = true, features = ["test-support", "font-kit"] }
+gpui_platform = { workspace = true, features = ["bench", "font-kit"] }
 itertools.workspace = true
 language = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }

--- a/crates/gpui_apple/Cargo.toml
+++ b/crates/gpui_apple/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/gpui_apple.rs"
 [features]
 default = []
 test-support = ["gpui/test-support"]
+bench = ["gpui/bench"]
 runtime_shaders = []
 
 [dependencies]

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -10,7 +10,7 @@ use gpui::{
     AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, PaintSurface, Path, Point,
     PrimitiveBatch, ScaledPixels, Scene, Size, point, size,
 };
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "bench"))]
 use image::RgbaImage;
 
 use core_foundation::base::TCFType;
@@ -136,7 +136,7 @@ pub struct MetalRenderer {
     path_sample_count: u32,
     /// Offscreen render target reused across `render_scene` calls when
     /// rendering headlessly without reading pixels back.
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(any(test, feature = "test-support", feature = "bench"))]
     headless_render_target: Option<metal::Texture>,
 }
 
@@ -180,7 +180,7 @@ impl MetalRenderer {
     ///
     /// This renderer can render scenes to images without requiring a CAMetalLayer,
     /// window, or AppKit. Use `render_scene_to_image()` to render scenes.
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(any(test, feature = "test-support", feature = "bench"))]
     pub fn new_headless(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>) -> Self {
         let device = Self::create_device();
         Self::new_internal(device, None, true, instance_buffer_pool)
@@ -352,7 +352,7 @@ impl MetalRenderer {
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
-            #[cfg(any(test, feature = "test-support"))]
+            #[cfg(any(test, feature = "test-support", feature = "bench"))]
             headless_render_target: None,
         }
     }
@@ -565,7 +565,7 @@ impl MetalRenderer {
     ///
     /// This is the primary method for headless rendering. It creates an offscreen
     /// texture, renders the scene to it, and returns the pixel data as an RGBA image.
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(any(test, feature = "test-support", feature = "bench"))]
     pub fn render_scene_to_image(
         &mut self,
         scene: &Scene,
@@ -613,7 +613,7 @@ impl MetalRenderer {
     /// encoding, instance buffer writes, command submission) and is used by
     /// headless benchmark rendering, where the produced pixels are never
     /// inspected.
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(any(test, feature = "test-support", feature = "bench"))]
     pub fn render_scene(&mut self, scene: &Scene, size: Size<DevicePixels>) -> Result<()> {
         if size.width.0 <= 0 || size.height.0 <= 0 {
             anyhow::bail!("Invalid size for render_scene: {:?}", size);
@@ -1236,7 +1236,7 @@ fn new_command_encoder_for_texture<'a>(
     command_encoder
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "bench"))]
 fn read_texture_to_image(texture: &metal::TextureRef) -> Result<RgbaImage> {
     let width = texture.width() as u32;
     let height = texture.height() as u32;
@@ -1592,12 +1592,12 @@ pub struct SurfaceBounds {
     pub content_mask: ContentMask<ScaledPixels>,
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "bench"))]
 pub struct MetalHeadlessRenderer {
     renderer: MetalRenderer,
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "bench"))]
 impl MetalHeadlessRenderer {
     pub fn new() -> Self {
         let instance_buffer_pool = Arc::new(Mutex::new(InstanceBufferPool::default()));
@@ -1606,7 +1606,7 @@ impl MetalHeadlessRenderer {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "bench"))]
 impl gpui::PlatformHeadlessRenderer for MetalHeadlessRenderer {
     fn render_scene_to_image(
         &mut self,

--- a/crates/gpui_macos/Cargo.toml
+++ b/crates/gpui_macos/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/gpui_macos.rs"
 [features]
 default = ["gpui/default"]
 test-support = ["gpui/test-support", "gpui_apple/test-support"]
+bench = ["gpui/bench", "gpui_apple/bench"]
 runtime_shaders = ["gpui_apple/runtime_shaders"]
 font-kit = ["dep:font-kit"]
 screen-capture = ["gpui/screen-capture"]

--- a/crates/gpui_macos/src/gpui_macos.rs
+++ b/crates/gpui_macos/src/gpui_macos.rs
@@ -20,7 +20,7 @@ use gpui_apple::metal_renderer as renderer;
 pub mod metal_renderer {
     pub use gpui_apple::metal_renderer::{PathRasterizationVertex, PathSprite, SurfaceBounds};
 
-    #[cfg(any(test, feature = "test-support"))]
+    #[cfg(any(test, feature = "test-support", feature = "bench"))]
     pub use gpui_apple::metal_renderer::MetalHeadlessRenderer;
 }
 

--- a/crates/gpui_platform/Cargo.toml
+++ b/crates/gpui_platform/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/gpui_platform.rs"
 default = []
 font-kit = ["gpui_macos/font-kit"]
 test-support = ["gpui/test-support", "gpui_macos/test-support"]
+bench = ["gpui/bench", "gpui_macos/bench"]
 screen-capture = ["gpui/screen-capture", "gpui_macos/screen-capture", "gpui_windows/screen-capture", "gpui_linux/screen-capture"]
 runtime_shaders = ["gpui_macos/runtime_shaders"]
 wayland = ["gpui_linux/wayland"]

--- a/crates/gpui_platform/src/gpui_platform.rs
+++ b/crates/gpui_platform/src/gpui_platform.rs
@@ -81,7 +81,7 @@ pub fn current_platform(headless: bool) -> Rc<dyn Platform> {
 }
 
 /// Returns a new [`HeadlessRenderer`] for the current platform, if available.
-#[cfg(feature = "test-support")]
+#[cfg(any(feature = "test-support", feature = "bench"))]
 pub fn current_headless_renderer() -> Option<Box<dyn gpui::PlatformHeadlessRenderer>> {
     #[cfg(target_os = "macos")]
     {

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -22,3 +22,30 @@ if echo "${output}" | grep --quiet 'gpui feature "test-support"'; then
   echo "${output}"
   exit 1
 fi
+
+# The real `crates/benchmarks` package requests `current_headless_renderer()`
+# through `gpui_platform`, which on macOS delegates to `gpui_macos` and
+# `gpui_apple` for the real Metal-backed headless renderer. Each of those
+# crates gates that renderer behind its own `test-support` feature as well as
+# a narrower `bench` feature, so `benchmarks` must resolve only `bench` on
+# them: otherwise `#[gpui::bench]` consumers in `benchmarks` would compile
+# whichever crate's interactive-only test doubles alongside their production
+# code, same as the `gpui`-level problem this script already guards against.
+# `gpui_macos`/`gpui_apple` only exist in the dependency graph on macOS, since
+# their crate roots are `#![cfg(target_os = "macos")]`, so this half of the
+# check only runs there.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  for platform_crate in gpui_platform gpui_macos gpui_apple; do
+    output=$(cargo tree \
+      --offline \
+      --package benchmarks \
+      --edges features \
+      --invert "${platform_crate}")
+
+    if echo "${output}" | grep --quiet "${platform_crate} feature \"test-support\""; then
+      echo "benchmarks pulls \"test-support\" into \"${platform_crate}\":"
+      echo "${output}"
+      exit 1
+    fi
+  done
+fi


### PR DESCRIPTION
Depends on #63039 ("gpui: Stop bench feature from pulling in test-support") and stacks on top of `gpui-separate-bench-test-support`. This PR carries that fix one layer down into the platform split crates that back gpui on macOS.

## Motivation

`crates/benchmarks` requests `gpui_platform`'s `current_headless_renderer()` to get a real Metal-backed headless renderer for `#[gpui::bench]` consumers. Reaching it previously required enabling `gpui_platform`'s `test-support` feature, which also enables `gpui_macos`'s and `gpui_apple`'s interactive test-double code. That means benchmark binaries could silently link against test-only doubles instead of exercising the same code paths production does, defeating the point of measuring them.

## What changed

Each platform crate now exposes a `bench` feature alongside its existing `test-support` feature, narrowly covering only the pieces `benchmarks` actually needs:

- `gpui_apple`: `bench = ["gpui/bench"]`. The headless Metal renderer (`MetalHeadlessRenderer`, `render_scene`, `render_scene_to_image`, and the state backing them) is now gated `cfg(any(test, feature = "test-support", feature = "bench"))` instead of `cfg(any(test, feature = "test-support"))`.
- `gpui_macos`: `bench = ["gpui/bench", "gpui_apple/bench"]`. Its re-export of `MetalHeadlessRenderer` uses the same widened cfg.
- `gpui_platform`: `bench = ["gpui/bench", "gpui_macos/bench"]`. `current_headless_renderer()` is now gated `cfg(any(feature = "test-support", feature = "bench"))` instead of only `cfg(feature = "test-support")`.
- `crates/benchmarks/Cargo.toml` now depends on `gpui_platform` with `["bench", "font-kit"]` instead of `["test-support", "font-kit"]`.

### Before / after feature edges

Before, `cargo tree -p benchmarks --edges features --invert gpui_platform` (and the equivalent for `gpui_macos`/`gpui_apple`) showed a `test-support` edge from `benchmarks` into each platform crate. After this change, the same commands show only a `bench` edge; none of the three resolve `test-support` from `benchmarks` anymore.

`script/check-gpui-bench-feature-isolation` gained a macOS-only loop that runs exactly that `cargo tree --invert` check for `gpui_platform`, `gpui_macos`, and `gpui_apple`, and fails the way the existing gpui-level check does if any of them still resolve `test-support`. The platform crates only appear in the dependency graph on macOS (their crate roots are `#![cfg(target_os = "macos")]`), so this half of the script only runs there.

## Validation

- `cargo check` for `gpui_apple`, `gpui_macos`, and `gpui_platform` with `--no-default-features --features bench` each pass, with no `test-support` in the resolved feature set.
- All four `benchmarks` bench targets compile (`cargo check -p benchmarks --benches`).
- `cargo tree` before/after comparison for `benchmarks` against each platform crate confirms the `test-support` edge is gone and replaced by `bench`.
- `script/check-gpui-bench-feature-isolation` passes, including the new macOS-only platform-crate loop.
- `gpui_apple` and `gpui_macos` test suites pass.
- `gpui_platform`'s test failure is pre-existing and reproduces on the base branch (`main`), unrelated to this change.
- `cargo fmt --check` and targeted `clippy` pass for the touched crates.
- `git diff --check` is clean.

## Remaining edges, out of scope

`crates/benchmarks/Cargo.toml` still requests `test-support` from several application crates (`agent`, `editor`, `language`, `language_model`, `lsp`, `project`, `settings`, `theme`, `util`) to build the fixtures and harnesses those benchmarks exercise. Those are unrelated to the gpui platform split this PR addresses; narrowing them would need per-crate `bench` features analogous to this one and is left as separate follow-up work.

## Suggested .rules additions

- When a `bench` feature on a crate needs functionality that a sibling or dependency crate currently only exposes behind `test-support`, add a matching `bench` feature to that crate too (mirroring, not aliasing, `test-support`) rather than depending on `test-support` from the `bench` consumer. Verify the fix with `cargo tree --edges features --invert <crate>` from the real benchmark package to confirm `test-support` is no longer resolved.

Release Notes:

- N/A
