### PR TITLE
settings_ui: Increase spacing above settings search field on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3177,7 +3177,7 @@ impl SettingsWindow {
             .w(SIDEBAR_WIDTH)
             .h_full()
             .p_2p5()
-            .when(cfg!(target_os = "macos"), |this| this.pt_10())
+            .when(cfg!(target_os = "macos"), |this| this.pt_12())
             .flex_none()
             .border_r_1()
             .border_color(cx.theme().colors().border)


### PR DESCRIPTION
# Objective

Improve spacing between the settings search field and macOS window control buttons to prevent the search field from sitting too close to the window traffic lights.

## Solution

Increased the top padding in `SettingsWindow::render_nav` from `pt_10()` (40px) to `pt_12()` (48px).

## Testing

- Tested on macOS to verify the increased spacing appears correctly
- The change is a single-line padding adjustment with no behavioral changes

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view before/after comparison</summary>

### Before
<img width="620" height="515" alt="Screenshot 2026-08-21 at 3 32 43 PM" src="https://github.com/user-attachments/assets/17980a03-a719-4a7c-b715-ebc1ba13437f" />

### After
<img width="616" height="515" alt="Screenshot 2026-08-21 at 3 32 49 PM" src="https://github.com/user-attachments/assets/b362a220-ef68-4635-a2b1-21f3713e4349" />

</details>

---

Release Notes:

- Improved spacing between the settings window search field and the macOS window controls