### PR TITLE
benchmarks: Drop direct test-support edges to theme and util

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -36,10 +36,10 @@ prompt_store.workspace = true
 serde_json.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 text.workspace = true
-theme = { workspace = true, features = ["test-support"] }
+theme.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
-util = { workspace = true, features = ["test-support"] }
+util.workspace = true
 zed_actions.workspace = true
 
 [package.metadata.cargo-shear]

--- a/crates/benchmarks/benches/display_map.rs
+++ b/crates/benchmarks/benches/display_map.rs
@@ -1,3 +1,4 @@
+use benchmarks::bench_utils::RandomCharIter;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use editor::{EditorStyle, MultiBuffer, display_map::*};
 use gpui::{AppContext as _, HighlightStyle, Hsla, TestDispatcher, font, px};
@@ -8,7 +9,6 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use settings::SettingsStore;
 use std::{num::NonZeroU32, time::Duration};
 use text::Bias;
-use util::RandomCharIter;
 
 fn to_tab_point_benchmark(c: &mut Criterion) {
     let dispatcher = TestDispatcher::new(1);

--- a/crates/benchmarks/benches/editor_render.rs
+++ b/crates/benchmarks/benches/editor_render.rs
@@ -1,3 +1,4 @@
+use benchmarks::bench_utils::RandomCharIter;
 use editor::{
     Editor, EditorMode, MultiBuffer,
     actions::{DeleteToPreviousWordStart, SelectAll, SplitSelectionIntoLines},
@@ -5,7 +6,6 @@ use editor::{
 use gpui::{AppContext as _, BenchAppContext, Focusable as _};
 use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
 use settings::SettingsStore;
-use util::RandomCharIter;
 use zed_actions::editor::{MoveDown, MoveUp};
 
 #[gpui::bench(

--- a/crates/benchmarks/src/bench_utils.rs
+++ b/crates/benchmarks/src/bench_utils.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use rand::seq::IndexedRandom as _;
 
 pub const RUST_MODULE_HEADER_LINES: usize = 10;
 pub const RUST_FUNCTION_LINES: usize = 12;
@@ -86,4 +87,43 @@ pub fn rust_identifier(rng: &mut impl Rng, salt: usize) -> String {
         salt,
         rng.random_range(0..10_000)
     )
+}
+
+/// Generates random text mixing whitespace, ASCII letters, and multi-byte
+/// characters (Greek letters, symbols, emoji), so buffer/display-map
+/// benchmarks exercise the same multi-byte-aware code paths real documents
+/// do.
+///
+/// This mirrors `util::RandomCharIter`, which is test-support-only, so that
+/// benchmarks generating input data don't need to enable `util`'s
+/// `test-support` feature and everything else it pulls in.
+pub struct RandomCharIter<T: Rng> {
+    rng: T,
+}
+
+impl<T: Rng> RandomCharIter<T> {
+    pub fn new(rng: T) -> Self {
+        Self { rng }
+    }
+}
+
+impl<T: Rng> Iterator for RandomCharIter<T> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.rng.random_range(0..100) {
+            // whitespace
+            0..=19 => [' ', '\n', '\r', '\t'].choose(&mut self.rng).copied(),
+            // two-byte greek letters
+            20..=32 => char::from_u32(self.rng.random_range(('α' as u32)..('ω' as u32 + 1))),
+            // three-byte characters
+            33..=45 => ['✋', '✅', '❌', '❎', '⭐']
+                .choose(&mut self.rng)
+                .copied(),
+            // four-byte characters
+            46..=58 => ['🍐', '🏀', '🍗', '🎉'].choose(&mut self.rng).copied(),
+            // ascii letters
+            _ => Some(self.rng.random_range(b'a'..b'z' + 1).into()),
+        }
+    }
 }

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -49,3 +49,50 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     fi
   done
 fi
+
+# `crates/benchmarks/Cargo.toml` also directly requests `test-support` from
+# several application crates, to build fixtures and harnesses its benchmarks
+# exercise. `theme` and `util` are the two of those whose benchmark usage
+# turned out to need no test-only API at all (`theme::LoadThemes`,
+# `theme_settings::init`) or one narrow enough to vendor into
+# `benchmarks::bench_utils` instead (`util::RandomCharIter`, a
+# synthetic-text generator with no production analogue), so `benchmarks` no
+# longer needs a direct `test-support` edge to either.
+#
+# `editor` and `project` remain out of scope: their own `test-support`
+# features are load-bearing for other benchmarks (e.g. `edit_file_tool`, via
+# `TestAppContext`/`FakeFs`/`FakeLspAdapter`/`Project::test`) and both
+# require `theme`/`util`'s `test-support` internally regardless of what
+# `benchmarks` itself requests. So this checks only for a *direct* edge from
+# `benchmarks` to each crate's `test-support` feature (the one path this
+# change controls), not for the feature's absence from the whole resolved
+# graph, which `editor`/`project` will keep populating until they get the
+# same treatment. `agent`, `language`, `language_model`, `lsp`, and
+# `settings` remain direct edges too: `edit_file_tool.rs` relies on
+# genuinely test-only APIs from them (`SettingsStore::update_user_settings`,
+# `FakeLspAdapter`, `FakeLanguageModel`, agent's own test-support surface)
+# with no production equivalent, deeply coupled to the same
+# `agent`/`editor`/`project` harness.
+for foundational_crate in theme util; do
+  output=$(cargo tree \
+    --offline \
+    --package benchmarks \
+    --edges features \
+    --charset ascii \
+    --invert "${foundational_crate}")
+
+  # Cargo tree fully expands a given (package, feature-set) node only the
+  # first time it appears, printing every later re-visit as a bare `(*)`
+  # back-reference instead of repeating its dependents. So the crate's
+  # un-suffixed "test-support" feature line is where its direct dependents
+  # are actually listed; checking the couple of lines after it for a
+  # "benchmarks" edge is enough to catch a direct request without also
+  # matching the expected indirect one from `editor`/`project`.
+  if echo "${output}" \
+    | grep -A2 "[|\`]-- ${foundational_crate} feature \"test-support\"\$" \
+    | grep --quiet 'benchmarks v'; then
+    echo "benchmarks directly requests \"${foundational_crate}\"'s \"test-support\" feature:"
+    echo "${output}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
This is a narrow follow-up to #63039 and #63041, stacked on
`gpui-platform-bench-without-test-support` (#63041). Those two PRs stopped
`crates/benchmarks` from needing `test-support` on `gpui`,
`gpui_platform`, `gpui_macos`, and `gpui_apple`. `crates/benchmarks/Cargo.toml`
still directly requests `test-support` from eight application crates
(`agent`, `editor`, `language`, `language_model`, `lsp`, `project`,
`settings`, `theme`, `util`) to build fixtures the real benches exercise.
This PR traces those eight edges and removes the two that turned out to be
safely removable: `theme` and `util`.

`theme` needed no test-only API at all. The benchmark-visible calls
(`theme::LoadThemes::JustBase`, `theme_settings::init`) are both ordinary
production APIs; `theme`'s `test-support` feature only gates
`ThemeRegistry::register_test_themes`/`register_test_icon_themes`, neither
of which any bench calls. Declaring `theme`'s `test-support` in benchmarks'
manifest was already a no-op edge, so removing it changes nothing about how
the benches run.

`util` needed exactly one test-only API: `util::RandomCharIter`, a
synthetic multi-byte-aware text generator the `display_map` and
`editor_render` benches use to build random buffer contents. It has no
production analogue — it exists purely to generate adversarial test/bench
input — so rather than inventing a production-capable substitute, this
vendors an equivalent generator into `benchmarks::bench_utils::RandomCharIter`,
following the same precedent as the existing
`benchmarks::bench_utils::random_rust_file` used by `markdown_renderer`.
Both benches now import it from there instead of from `util`.

`settings`, `agent`, `editor`, `language`, `language_model`, `lsp`, and
`project` remain untouched, and can't be trimmed in this scope. The
`edit_file_tool` bench calls `SettingsStore::update_user_settings`, which
only exists under `cfg(any(test, feature = "test-support"))` with no
production equivalent for mutating already-loaded settings content, and it
also depends on `TestAppContext`, `FakeFs`, `FakeLspAdapter`,
`FakeLanguageModel`, and `Project::test` — a deeply test-double harness for
benchmarking the agent's edit-file tool against a fake project. None of
that has a narrow production-capable substitute; building one would be a
larger architectural change than this PR's scope. Because `edit_file_tool`
shares the `benchmarks` package with the other three bench targets, Cargo's
feature unification keeps `settings` (and by extension
`agent`/`language`/`language_model`/`lsp`/`project`) on `test-support` for
the whole package regardless of what the other three targets need on their
own.

`theme` and `util`'s `test-support` features still resolve elsewhere in the
`benchmarks` dependency graph after this change, because `editor`'s own
`test-support` feature (needed for `edit_file_tool`, `editor_render`, and
`display_map`, and out of scope here) requires
`theme`/`test-support` and `util`/`test-support` directly, independent of
anything `benchmarks` itself requests. This PR only removes the edge it
controls: `benchmarks`' own direct request. `script/check-gpui-bench-feature-isolation`
gains a check for that: for `theme` and `util`, it walks
`cargo tree -p benchmarks --edges features --invert <crate>` and fails if
`benchmarks` appears as a direct dependent of that crate's `test-support`
feature. Unlike the existing `gpui`/`gpui_platform` checks in this script,
it can't assert `test-support`'s total absence from the graph, since
`editor`/`project` keep it resolved regardless; it specifically targets the
one edge this change controls.

## Before/after feature edges

Before this change, `cargo tree -p benchmarks --edges features --invert theme`
(and the `util` equivalent) showed a direct `[dev-dependencies] -> benchmarks`
edge into each crate's `test-support` feature, alongside the pre-existing
indirect edge through `editor`:

```
`-- theme feature "test-support"
    [dev-dependencies]
    `-- benchmarks v0.1.0 (.../crates/benchmarks) (*)
    `-- editor feature "test-support" (*)
```

After this change, only the indirect edge through `editor` remains:

```
`-- theme feature "test-support"
    `-- editor feature "test-support" (*)
```

The same before/after shape applies to `util`.

## Testing performed

- `cargo check -p benchmarks --benches`: clean, no warnings.
- `cargo build -p benchmarks --benches` and `--release`: all four bench
  targets (`display_map`, `edit_file_tool`, `editor_render`,
  `markdown_renderer`) compile.
- `cargo bench -p benchmarks --bench display_map` and `--bench editor_render`
  (quick mode): both run successfully, including the `display_map`
  "unicode" case, which exercises multi-byte text from the vendored
  `RandomCharIter`.
- `cargo tree` before/after comparison for `benchmarks` against `theme` and
  `util` confirms the direct edge is gone.
- `script/check-gpui-bench-feature-isolation` passes; manually confirmed it
  fails (correctly) against the prior `Cargo.toml`.
- `cargo fmt --check` (whole repo) and `./script/clippy -p benchmarks --benches`
  (deny warnings) both pass.

## Remaining edges out of scope

`crates/benchmarks/Cargo.toml` still requests `test-support` directly from
`agent`, `editor`, `language`, `language_model`, `lsp`, `project`, and
`settings`. All of them are load-bearing for `edit_file_tool`'s
fake-project agent-tool harness (or, for `settings`, blocked by that same
target's use of a genuinely test-only settings-mutation API), which would
need a larger, separate rework to give it a production-capable path.

## Suggested .rules additions

- When writing a `cargo tree --invert <crate> --edges features` regression
  check, remember `cargo tree` fully expands a given (package, feature-set)
  node only the *first* time it's reached, printing every later revisit as a
  bare `(*)` back-reference instead of repeating its dependents. Anchoring a
  grep on the un-suffixed feature line (e.g. `foo feature "test-support"$`,
  no trailing ` (*)`) finds that one true expansion; matching the feature
  name anywhere in the tree instead will also match harmless `(*)` reprints
  and can hide (or falsely flag) which dependent actually requested it.

Release Notes:

- N/A
