### PR TITLE
gpui: Simplify foreground work histogram in bench reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -66,32 +66,6 @@ const DEFAULT_FPS: u64 = 120;
 
 const NANOS_PER_SECOND: u128 = 1_000_000_000;
 
-/// Aggregate statistics for total foreground executor work observed during a
-/// measured interval, returned by [`BenchReport::foreground_work`].
-#[derive(Clone, Copy, Debug)]
-pub struct ForegroundWorkSummary {
-    /// Number of foreground work items recorded: task polls, action
-    /// handlers, input dispatches, and folded sub-floor poll flushes.
-    pub count: u64,
-    /// Sum of every recorded item's duration.
-    pub total: Duration,
-    /// The longest single recorded item.
-    pub max: Duration,
-    /// 50th percentile duration.
-    pub p50: Duration,
-    /// 90th percentile duration.
-    pub p90: Duration,
-    /// 95th percentile duration.
-    pub p95: Duration,
-    /// 99th percentile duration.
-    pub p99: Duration,
-    /// How many whole frame budgets (at the report's configured FPS) were
-    /// exceeded in total, summed across every recorded item.
-    pub frame_budget_overruns_total: u64,
-    /// How many whole frame budgets the longest recorded item exceeded.
-    pub frame_budget_overruns_max: u64,
-}
-
 /// A small report produced by GPUI benchmarks.
 #[derive(Clone)]
 pub struct BenchReport {
@@ -171,7 +145,11 @@ impl BenchReport {
                 ForegroundEvent::SmallPolls(flush) => flush.summary.total,
                 _ => event.duration(),
             };
-            snapshot.foreground_work.record(duration);
+            // Infallible: the histogram auto-resizes.
+            snapshot
+                .foreground_work
+                .record(duration.as_nanos() as u64)
+                .ok();
         }
     }
 
@@ -199,34 +177,18 @@ impl BenchReport {
         over_budget_nanos.div_ceil(self.frame_budget_nanos) as u64
     }
 
-    /// Returns aggregate statistics for total foreground executor work
-    /// observed during the measured interval: every task poll, action
-    /// handler, and input dispatch on the foreground thread, whether or not
-    /// it produced a window draw. This is captured through GPUI's foreground
-    /// journal, so it requires no window and surfaces a slow or stalled task
-    /// even when nothing was drawn while it ran.
+    /// Returns a snapshot of total foreground executor work observed during
+    /// the measured interval: every task poll, action handler, and input
+    /// dispatch on the foreground thread, whether or not it produced a
+    /// window draw. This is captured through GPUI's foreground journal, so
+    /// it requires no window and surfaces a slow or stalled task even when
+    /// nothing was drawn while it ran. Durations are recorded in
+    /// nanoseconds.
     ///
-    /// Returns `None` when no foreground work was recorded, e.g. a
+    /// Empty when no foreground work was recorded, e.g. a
     /// [`BenchAppContext::bench_iter`] measurement that does no async work.
-    pub fn foreground_work(&self) -> Option<ForegroundWorkSummary> {
-        let frame_snapshot = self.frame_snapshot.borrow();
-        let foreground_work = &frame_snapshot.foreground_work;
-        if foreground_work.histogram.is_empty() {
-            return None;
-        }
-
-        let max = Duration::from_nanos(foreground_work.histogram.max());
-        Some(ForegroundWorkSummary {
-            count: foreground_work.histogram.len(),
-            total: Duration::from_nanos(foreground_work.total_nanos),
-            max,
-            p50: Duration::from_nanos(foreground_work.histogram.value_at_quantile(0.50)),
-            p90: Duration::from_nanos(foreground_work.histogram.value_at_quantile(0.90)),
-            p95: Duration::from_nanos(foreground_work.histogram.value_at_quantile(0.95)),
-            p99: Duration::from_nanos(foreground_work.histogram.value_at_quantile(0.99)),
-            frame_budget_overruns_total: self.total_budget_overruns(&foreground_work.histogram),
-            frame_budget_overruns_max: self.budget_overruns(max),
-        })
+    pub fn foreground_work(&self) -> Histogram<u64> {
+        self.frame_snapshot.borrow().foreground_work.clone()
     }
 
     /// Prints this report to stderr.
@@ -261,18 +223,14 @@ impl BenchReport {
         self.print_histogram_body(histogram);
     }
 
-    fn print_foreground_work(&self, foreground_work: &DurationHistogram) {
-        if foreground_work.histogram.is_empty() {
+    fn print_foreground_work(&self, foreground_work: &Histogram<u64>) {
+        if foreground_work.is_empty() {
             return;
         }
 
         eprintln!("  foreground executor work (task polls, actions, input dispatch):");
         eprintln!("    note: excludes window draw/present, reported separately above");
-        eprintln!(
-            "    total: {}",
-            format_duration(Duration::from_nanos(foreground_work.total_nanos))
-        );
-        self.print_histogram_body(&foreground_work.histogram);
+        self.print_histogram_body(foreground_work);
     }
 
     fn print_histogram_body(&self, histogram: &Histogram<u64>) {
@@ -315,7 +273,7 @@ struct WindowFrameSnapshot {
     draw: Histogram<u64>,
     present_interval: Histogram<u64>,
     invalidations_per_frame: Histogram<u64>,
-    foreground_work: DurationHistogram,
+    foreground_work: Histogram<u64>,
 }
 
 impl WindowFrameSnapshot {
@@ -325,7 +283,7 @@ impl WindowFrameSnapshot {
             draw: Histogram::new(3).expect("3 significant digits is valid"),
             present_interval: Histogram::new(3).expect("3 significant digits is valid"),
             invalidations_per_frame: Histogram::new(3).expect("3 significant digits is valid"),
-            foreground_work: DurationHistogram::new(),
+            foreground_work: Histogram::new(3).expect("3 significant digits is valid"),
         }
     }
 
@@ -333,31 +291,7 @@ impl WindowFrameSnapshot {
         self.dirty_to_draw.is_empty()
             && self.draw.is_empty()
             && self.present_interval.is_empty()
-            && self.foreground_work.histogram.is_empty()
-    }
-}
-
-/// A duration histogram paired with an exact running total, since the
-/// histogram's bucketed values (3 significant digits) approximate a sum less
-/// precisely than tracking it directly.
-struct DurationHistogram {
-    histogram: Histogram<u64>,
-    total_nanos: u64,
-}
-
-impl DurationHistogram {
-    fn new() -> Self {
-        Self {
-            histogram: Histogram::new(3).expect("3 significant digits is valid"),
-            total_nanos: 0,
-        }
-    }
-
-    fn record(&mut self, duration: Duration) {
-        let nanos = duration.as_nanos() as u64;
-        // Infallible: the histogram auto-resizes.
-        self.histogram.record(nanos).ok();
-        self.total_nanos += nanos;
+            && self.foreground_work.is_empty()
     }
 }
 
@@ -1150,25 +1084,20 @@ mod tests {
         let report = BenchReport::default();
         report.record_foreground_events(events.foreground_events());
 
-        let summary = report
-            .foreground_work()
-            .expect("a long task poll should be reported even without a window draw");
+        let histogram = report.foreground_work();
+        assert!(
+            !histogram.is_empty(),
+            "a long task poll should be reported even without a window draw"
+        );
         // The spawned task's own poll is one sample; the tiny wrapper poll
         // that observes its completion in `run_task_to_completion` folds
         // into a second, near-zero sample rather than being dropped.
-        assert!(summary.count >= 1, "expected at least one recorded item");
+        assert!(histogram.len() >= 1, "expected at least one recorded item");
+        let max = Duration::from_nanos(histogram.max());
         assert!(
-            summary.max >= Duration::from_millis(55),
+            max >= Duration::from_millis(55),
             "expected the long poll's duration to be recorded, got {:?}",
-            summary.max
-        );
-        // `total` is an exact sum, while `max` may be rounded up to its
-        // histogram bucket's boundary, so compare each against the expected
-        // floor directly instead of against each other.
-        assert!(
-            summary.total >= Duration::from_millis(55),
-            "expected the long poll's duration to be included in the total, got {:?}",
-            summary.total
+            max
         );
     }
 
@@ -1197,18 +1126,16 @@ mod tests {
         let report = BenchReport::default();
         report.record_foreground_events(events.foreground_events());
 
-        let summary = report
-            .foreground_work()
-            .expect("the measured task's poll should be reported");
+        let histogram = report.foreground_work();
         assert!(
-            summary.max < Duration::from_millis(40),
-            "setup work's 80ms poll must not leak into the measured summary, got {:?}",
-            summary.max
+            !histogram.is_empty(),
+            "the measured task's poll should be reported"
         );
+        let max = Duration::from_nanos(histogram.max());
         assert!(
-            summary.total < Duration::from_millis(40),
-            "setup work's 80ms poll must not leak into the measured total, got {:?}",
-            summary.total
+            max < Duration::from_millis(40),
+            "setup work's 80ms poll must not leak into the measured summary, got {:?}",
+            max
         );
     }
 
@@ -1239,13 +1166,16 @@ mod tests {
             cx.teardown();
         });
 
-        let summary = report
-            .foreground_work()
-            .expect("bench_task should report foreground work with no window involved");
+        let histogram = report.foreground_work();
         assert!(
-            summary.max >= Duration::from_millis(15),
+            !histogram.is_empty(),
+            "bench_task should report foreground work with no window involved"
+        );
+        let max = Duration::from_nanos(histogram.max());
+        assert!(
+            max >= Duration::from_millis(15),
             "expected a ~20ms task poll to be recorded, got {:?}",
-            summary.max
+            max
         );
     }
 


### PR DESCRIPTION
This follows up on merged #63035, which wired GPUI's foreground journal into `BenchAppContext`/`BenchReport` so benchmarks can see foreground executor work (task polls, action handlers, input dispatch) even when no window ever drew. To report that, it added a public `ForegroundWorkSummary` struct and a private `DurationHistogram` wrapper (an `hdrhistogram::Histogram<u64>` paired with a separately tracked exact `total_nanos`).

Anthony asked why this didn't simply expose `hdrhistogram::Histogram<u64>` directly, since GPUI already does that elsewhere (`profiler::FrameDurationSnapshot`, `profiler::InputLatencySnapshot`), and the exact-total convenience didn't justify the extra types. This PR removes both wrappers.

## API change

- `BenchReport::foreground_work()` now returns `hdrhistogram::Histogram<u64>` (a clone of the internally tracked histogram of recorded nanosecond durations) instead of `Option<ForegroundWorkSummary>`. Callers use `is_empty`/`len`/`max`/`value_at_quantile`/iteration directly, without holding a `RefCell` borrow. No foreground work recorded is now represented as an empty histogram rather than `None`.
- `ForegroundWorkSummary` and the private `DurationHistogram` wrapper are removed. The internal `WindowFrameSnapshot::foreground_work` field is now a plain `Histogram<u64>`, matching the other frame histograms it sits alongside.
- The printed report drops the previously side-tracked exact total (it required the wrapper's separate counter) rather than replace it with a less precise substitute. Sample count, mean, percentiles, max, and frame-budget overruns are still printed, computed straight from the histogram the same way the other histograms in the report already do.

This is a pure simplification: no location grouping or other benchmark behavior changed.

## Testing

- `cargo nextest run -p gpui --features bench --lib bench_context` - all 4 tests pass, updated to assert directly on the returned histogram (`is_empty`, `len`, `max`) instead of the removed summary fields.
- `cargo nextest run -p gpui --features bench --lib profiler` - all 48 tests pass, unchanged.
- `cargo check -p benchmarks --benches` - the existing `#[gpui::bench]` consumers still compile against the simplified API.
- `cargo fmt --package gpui -- --check` and `./script/clippy -p gpui --features bench` are clean.

Release Notes:

- N/A
