### PR TITLE
editor: Hide edit prediction popover in Vim normal mode

### DIFF
--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -607,7 +607,8 @@ impl Editor {
     /// like we are not previewing and the LSP autocomplete menu is visible
     /// or we are in `when_holding_modifier` mode.
     pub fn edit_prediction_visible_in_cursor_popover(&self, has_completion: bool) -> bool {
-        if self.edit_prediction_preview_is_active()
+        if self.edit_predictions_hidden_for_vim_mode
+            || self.edit_prediction_preview_is_active()
             || !self.show_edit_predictions_in_menu()
             || !self.edit_predictions_enabled()
         {

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -199,6 +199,45 @@ async fn test_edit_prediction_insert(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_cursor_popover_respects_vim_mode_edit_prediction_visibility(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+
+    cx.editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(editor.edit_prediction_visible_in_cursor_popover(true));
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.set_edit_predictions_hidden_for_vim_mode(true, window, cx);
+    });
+    cx.editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(!editor.edit_prediction_visible_in_cursor_popover(true));
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.set_edit_predictions_hidden_for_vim_mode(false, window, cx);
+    });
+    cx.editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(editor.edit_prediction_visible_in_cursor_popover(true));
+    });
+}
+
+#[gpui::test]
 async fn test_edit_prediction_cursor_position_inside_insertion(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {
         eprintln!("");


### PR DESCRIPTION
# Objective

Fixes #62537.

Edit prediction cursor popovers could appear in Vim normal mode even when `vim.show_edit_predictions_in_normal_mode` was disabled.

## Solution

Make the cursor-popover visibility predicate respect the existing `edit_predictions_hidden_for_vim_mode` state propagated by Vim.

Add a regression test covering both hiding the popover and re-enabling it.

## Testing

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p editor test_cursor_popover_respects_vim_mode_edit_prediction_visibility -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p editor edit_prediction_tests -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p editor --lib`
- `GITHUB_ACTIONS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_RELEASE_DEBUG=0 ./script/clippy -p editor`

- Manually verified on macOS that edit prediction popovers remain hidden in Vim normal mode when `vim.show_edit_predictions_in_normal_mode` is false.
- Verified that insert-mode predictions and the normal-mode opt-in continue to work.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed edit prediction popovers appearing in Vim normal mode when edit predictions are disabled.