### PR TITLE
benchmarks: Stop requesting settings' test-support feature

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -26,7 +26,7 @@ language = { workspace = true, features = ["test-support"] }
 markdown.workspace = true
 multi_buffer = { workspace = true, features = ["test-support"] }
 project.workspace = true
-settings = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["benchmarks"] }
 text.workspace = true
 theme.workspace = true
 theme_settings.workspace = true

--- a/crates/benchmarks/benches/display_map.rs
+++ b/crates/benchmarks/benches/display_map.rs
@@ -111,7 +111,7 @@ fn create_highlight_endpoints_benchmark(c: &mut Criterion) {
     let dispatcher = TestDispatcher::new(1);
     let mut cx = gpui::TestAppContext::build(dispatcher, None);
     cx.update(|cx| {
-        let store = SettingsStore::test(cx);
+        let store = SettingsStore::benchmarks(cx);
         cx.set_global(store);
         editor::init(cx);
     });
@@ -211,7 +211,7 @@ fn highlighted_chunks_benchmark(c: &mut Criterion) {
     let dispatcher = TestDispatcher::new(1);
     let mut cx = gpui::TestAppContext::build(dispatcher, None);
     cx.update(|cx| {
-        let store = SettingsStore::test(cx);
+        let store = SettingsStore::benchmarks(cx);
         cx.set_global(store);
         editor::init(cx);
     });

--- a/crates/benchmarks/benches/editor_render.rs
+++ b/crates/benchmarks/benches/editor_render.rs
@@ -126,7 +126,7 @@ fn editor_render(cx: &mut BenchAppContext) {
 
 fn init_context(cx: &mut BenchAppContext) {
     cx.update(|cx| {
-        let store = SettingsStore::test(cx);
+        let store = SettingsStore::benchmarks(cx);
         cx.set_global(store);
         assets::Assets.load_test_fonts(cx);
         theme_settings::init(theme::LoadThemes::JustBase, cx);

--- a/crates/benchmarks/benches/markdown_renderer.rs
+++ b/crates/benchmarks/benches/markdown_renderer.rs
@@ -329,7 +329,7 @@ fn markdown_language_registry(cx: &BenchAppContext) -> Arc<LanguageRegistry> {
 
 fn init_context(cx: &mut BenchAppContext) {
     cx.update(|cx| {
-        let store = SettingsStore::test(cx);
+        let store = SettingsStore::benchmarks(cx);
         cx.set_global(store);
         assets::Assets.load_test_fonts(cx);
         theme_settings::init(theme::LoadThemes::JustBase, cx);

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -14,6 +14,11 @@ doctest = false
 
 [features]
 test-support = ["gpui/test-support", "fs/test-support"]
+# For production-rendering benchmarks that need `SettingsStore::benchmarks`'s
+# deterministic font/theme settings without pulling in `test-support`'s wider
+# surface (settings-file mutation, `gpui`/`fs` test doubles). Enables nothing
+# else, so it cannot re-enable any crate's `test-support` transitively.
+benchmarks = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/settings/src/settings_file.rs
+++ b/crates/settings/src/settings_file.rs
@@ -123,48 +123,70 @@ pub fn visual_test_settings() -> String {
     serde_json::to_string(&value).unwrap()
 }
 
+/// Builds the default settings overridden with a deterministic monospace
+/// font and no real theme, shared by `test_settings` and `benchmark_settings`
+/// so the two stay identical: production-rendering benchmarks measure the
+/// same font/theme inputs that unit tests do, rather than drifting apart as
+/// each is edited independently.
+#[cfg(any(test, feature = "test-support", feature = "benchmarks"))]
+fn deterministic_font_and_theme_settings() -> String {
+    let mut value =
+        crate::parse_json_with_comments::<serde_json::Value>(crate::default_settings().as_ref())
+            .unwrap();
+    #[cfg(not(target_os = "windows"))]
+    util::merge_non_null_json_value_into(
+        serde_json::json!({
+            "format_on_save": "on",
+            "ui_font_family": "Courier",
+            "ui_font_features": {},
+            "ui_font_size": 14,
+            "ui_font_fallback": [],
+            "buffer_font_family": "Courier",
+            "buffer_font_features": {},
+            "buffer_font_size": 14,
+            "buffer_font_fallbacks": [],
+            "theme": EMPTY_THEME_NAME,
+        }),
+        &mut value,
+    );
+    #[cfg(target_os = "windows")]
+    util::merge_non_null_json_value_into(
+        serde_json::json!({
+            "format_on_save": "on",
+            "ui_font_family": "Courier New",
+            "ui_font_features": {},
+            "ui_font_size": 14,
+            "ui_font_fallback": [],
+            "buffer_font_family": "Courier New",
+            "buffer_font_features": {},
+            "buffer_font_size": 14,
+            "buffer_font_fallbacks": [],
+            "theme": EMPTY_THEME_NAME,
+        }),
+        &mut value,
+    );
+    value.as_object_mut().unwrap().remove("languages");
+    serde_json::to_string(&value).unwrap()
+}
+
 #[cfg(any(test, feature = "test-support"))]
 pub fn test_settings() -> &'static str {
-    static CACHED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-        let mut value = crate::parse_json_with_comments::<serde_json::Value>(
-            crate::default_settings().as_ref(),
-        )
-        .unwrap();
-        #[cfg(not(target_os = "windows"))]
-        util::merge_non_null_json_value_into(
-            serde_json::json!({
-                "format_on_save": "on",
-                "ui_font_family": "Courier",
-                "ui_font_features": {},
-                "ui_font_size": 14,
-                "ui_font_fallback": [],
-                "buffer_font_family": "Courier",
-                "buffer_font_features": {},
-                "buffer_font_size": 14,
-                "buffer_font_fallbacks": [],
-                "theme": EMPTY_THEME_NAME,
-            }),
-            &mut value,
-        );
-        #[cfg(target_os = "windows")]
-        util::merge_non_null_json_value_into(
-            serde_json::json!({
-                "format_on_save": "on",
-                "ui_font_family": "Courier New",
-                "ui_font_features": {},
-                "ui_font_size": 14,
-                "ui_font_fallback": [],
-                "buffer_font_family": "Courier New",
-                "buffer_font_features": {},
-                "buffer_font_size": 14,
-                "buffer_font_fallbacks": [],
-                "theme": EMPTY_THEME_NAME,
-            }),
-            &mut value,
-        );
-        value.as_object_mut().unwrap().remove("languages");
-        serde_json::to_string(&value).unwrap()
-    });
+    static CACHED: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(deterministic_font_and_theme_settings);
+    &CACHED
+}
+
+/// Settings content for production-rendering benchmarks (`display_map`,
+/// `editor_render`, `markdown_renderer`): identical to `test_settings`, so a
+/// benchmark measures the same font/theme inputs regardless of which one
+/// initializes its `SettingsStore`. Gated on the narrow `benchmarks` feature
+/// rather than `test-support`, since it needs none of `test-support`'s wider
+/// surface (settings-file mutation, `gpui`/`fs` test doubles) and enables
+/// neither.
+#[cfg(feature = "benchmarks")]
+pub fn benchmark_settings() -> &'static str {
+    static CACHED: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(deterministic_font_and_theme_settings);
     &CACHED
 }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -519,6 +519,21 @@ impl SettingsStore {
         Self::from_settings_content(cx, CACHED_SETTINGS_CONTENT.clone())
     }
 
+    /// Initializes a `SettingsStore` for production-rendering benchmarks,
+    /// with the same settings content as `SettingsStore::test` (see
+    /// `benchmark_settings`), without requiring any crate's `test-support`
+    /// feature. This intentionally exposes no further test-only surface
+    /// (e.g. no settings-file mutation API): benchmarks that need one belong
+    /// in a package that depends on `test-support` directly instead.
+    #[cfg(feature = "benchmarks")]
+    pub fn benchmarks(cx: &mut App) -> Self {
+        static CACHED_SETTINGS_CONTENT: std::sync::LazyLock<SettingsContent> =
+            std::sync::LazyLock::new(|| {
+                SettingsContent::parse_json_with_comments(crate::benchmark_settings()).unwrap()
+            });
+        Self::from_settings_content(cx, CACHED_SETTINGS_CONTENT.clone())
+    }
+
     /// Updates the value of a setting in the user's global configuration.
     ///
     /// This is only for tests. Normally, settings are only loaded from
@@ -3265,5 +3280,49 @@ mod tests {
 
         assert!(user_schema_str.contains("\"auto_update\""));
         assert!(!project_schema_str.contains("\"auto_update\""));
+    }
+
+    /// `cargo test -p settings --features benchmarks --lib`: the `benchmarks`
+    /// feature isn't implied by `cfg(test)`, so this only compiles when that
+    /// feature is explicitly requested.
+    #[cfg(feature = "benchmarks")]
+    #[gpui::test]
+    fn test_benchmark_settings_match_test_settings(cx: &mut App) {
+        use settings_content::{FontSize, ThemeName, ThemeSelection};
+
+        assert_eq!(
+            crate::benchmark_settings(),
+            crate::test_settings(),
+            "benchmark_settings must stay identical to test_settings, so a benchmark measures \
+             the same font/theme inputs regardless of which one initializes its SettingsStore"
+        );
+
+        let store = SettingsStore::benchmarks(cx);
+        let theme_settings = &store.merged_settings().theme;
+
+        #[cfg(not(target_os = "windows"))]
+        let expected_font_family = "Courier";
+        #[cfg(target_os = "windows")]
+        let expected_font_family = "Courier New";
+
+        assert_eq!(
+            theme_settings
+                .buffer_font_family
+                .as_ref()
+                .map(|f| f.0.as_ref()),
+            Some(expected_font_family),
+        );
+        assert_eq!(
+            theme_settings.ui_font_family.as_ref().map(|f| f.0.as_ref()),
+            Some(expected_font_family),
+        );
+        assert_eq!(theme_settings.buffer_font_size, Some(FontSize(14.0)));
+        assert_eq!(theme_settings.ui_font_size, Some(FontSize(14.0)));
+        assert_eq!(
+            theme_settings.theme,
+            Some(ThemeSelection::Static(ThemeName(
+                crate::EMPTY_THEME_NAME.into()
+            ))),
+        );
     }
 }

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -85,25 +85,30 @@ for isolated_crate in agent editor language_model project; do
   fi
 done
 
-# `lsp`, `language`, `multi_buffer`, and `settings` are not part of the loop
-# above: `display_map`/`editor_render`/`markdown_renderer` (the benchmarks
-# that remain in this package) directly call test-only APIs with no
-# production equivalent — `SettingsStore::test`, `LanguageRegistry::test`,
-# `language::rust_lang`, `MultiBuffer::build_simple`/`build_random` —
-# independent of `edit_file_tool`. `settings/test-support` also enables
-# `gpui/test-support`, and `language/test-support` also enables
-# `lsp/test-support`, so both show up transitively too. This is real,
-# tracked debt, not a gap in this script: `theme` and `util` are the two
-# foundational crates whose benchmark usage turned out to need no test-only
-# API at all (`theme::LoadThemes`, `theme_settings::init`) or one narrow
-# enough to vendor into `benchmarks::bench_utils` instead
-# (`util::RandomCharIter`, a synthetic-text generator with no production
-# analogue), so `benchmarks` no longer needs a direct `test-support` edge to
-# either. This checks only for a *direct* edge from `benchmarks` to each
-# crate's `test-support` feature, not for the feature's absence from the
-# whole resolved graph, since `language`/`multi_buffer`/`settings` keep
-# populating it until they get the same treatment.
-for foundational_crate in theme util; do
+# `lsp`, `language`, and `multi_buffer` are not part of the loop below:
+# `display_map`/`editor_render`/`markdown_renderer` (the benchmarks that
+# remain in this package) directly call test-only APIs with no production
+# equivalent — `LanguageRegistry::test`, `language::rust_lang`,
+# `MultiBuffer::build_simple`/`build_random` — independent of
+# `edit_file_tool`. `language/test-support` enables both `lsp/test-support`
+# and `settings/test-support` directly, so both keep showing up transitively
+# despite `benchmarks` no longer requesting either itself. This is real,
+# tracked debt, not a gap in this script: `theme`, `util`, and `settings` are
+# the crates whose benchmark usage turned out to need no test-only API at all
+# (`theme::LoadThemes`, `theme_settings::init`), one narrow enough to vendor
+# into `benchmarks::bench_utils` instead (`util::RandomCharIter`, a
+# synthetic-text generator with no production analogue), or one narrow
+# enough to move behind its own dedicated feature instead of `test-support`
+# (`settings`'s `benchmarks` feature, gating `SettingsStore::benchmarks` and
+# `benchmark_settings` — see `crates/settings/src/settings_file.rs`, which
+# keeps their settings content byte-identical to `SettingsStore::test`'s so
+# switching does not change what a benchmark measures). So `benchmarks` no
+# longer needs a direct `test-support` edge to any of the three. This checks
+# only for a *direct* edge from `benchmarks` to each crate's `test-support`
+# feature, not for the feature's absence from the whole resolved graph, since
+# `language`/`multi_buffer` keep populating `settings/test-support`
+# (transitively, through `language`) until they get the same treatment.
+for foundational_crate in theme util settings; do
   output=$(cargo tree \
     --offline \
     --package benchmarks \
@@ -117,7 +122,7 @@ for foundational_crate in theme util; do
   # un-suffixed "test-support" feature line is where its direct dependents
   # are actually listed; checking the couple of lines after it for a
   # "benchmarks" edge is enough to catch a direct request without also
-  # matching the expected indirect one from `language`/`multi_buffer`/`settings`.
+  # matching the expected indirect one from `language`/`multi_buffer`.
   if echo "${output}" \
     | grep -A2 "[|\`]-- ${foundational_crate} feature \"test-support\"\$" \
     | grep --quiet 'benchmarks v'; then
@@ -127,14 +132,33 @@ for foundational_crate in theme util; do
   fi
 done
 
+# The loop above proves `benchmarks` no longer *requests* `settings`'
+# `test-support`; this proves it still gets the deterministic settings it
+# needs some other way, so a future edit can't silently drop the feature
+# request and have `display_map`/`editor_render`/`markdown_renderer` start
+# reading plain default settings (different font/size/theme) without any
+# isolation check catching it.
+output=$(cargo tree \
+  --offline \
+  --package benchmarks \
+  --edges features \
+  --invert settings)
+if ! echo "${output}" | grep --quiet 'settings feature "benchmarks"'; then
+  echo "benchmarks no longer requests settings' \"benchmarks\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
 # `edit_file_tool_benchmarks` is the isolated package `edit_file_tool` moved
-# into. It is intentionally *not* held to the isolation bar above: it still
-# needs `test-support` from `agent`, `editor`, `language`, `language_model`,
-# `lsp`, `project`, and `settings` for the same harness this script used to
-# document against `benchmarks`. That is tracked debt toward eventually
-# having no benchmark depend on `test-support` at all, not a gap this script
-# hides — confirm the package still exists and builds rather than silently
-# skipping it.
+# into. It is intentionally *not* held to the isolation bar above, including
+# the `settings` checks just above: it still needs `test-support` from
+# `agent`, `editor`, `language`, `language_model`, `lsp`, `project`, and
+# `settings` (via `SettingsStore::update_user_settings`, which has no
+# production-capable equivalent for mutating already-loaded settings
+# content) for the same harness this script used to document against
+# `benchmarks`. That is tracked debt toward eventually having no benchmark
+# depend on `test-support` at all, not a gap this script hides — confirm the
+# package still exists and builds rather than silently skipping it.
 if ! cargo tree --offline --package edit_file_tool_benchmarks >/dev/null; then
   echo "edit_file_tool_benchmarks package is missing or fails to resolve"
   exit 1


### PR DESCRIPTION
`crates/benchmarks/Cargo.toml` requested `settings`'s `test-support` feature directly so `display_map.rs`, `editor_render.rs`, and `markdown_renderer.rs` could each call `SettingsStore::test` to build the global `SettingsStore` they render against. `test-support` is a much wider surface than that one call needs: it also enables `gpui/test-support` and `fs/test-support`, and (per `settings`'s own crate) exposes settings-file mutation APIs meant for interactive tests, not benchmarks. This removes that direct edge by giving `settings` a narrow `benchmarks` feature that exposes exactly the initializer these three benchmarks need, with the same settings content as before.

`settings::src::settings_file.rs` already built its `test_settings()` content (default settings overridden with a deterministic monospace font, `empty-theme`, and `format_on_save: on`) entirely from production APIs (`default_settings()`, `parse_json_with_comments`, `util::merge_non_null_json_value_into`); the only reason it needed `test-support` was the `#[cfg(...)]` gate on the function itself. I extracted that body into a private `deterministic_font_and_theme_settings()` helper and added a sibling `benchmark_settings()` accessor that calls the same helper, gated on `feature = "benchmarks"` instead. `SettingsStore` gets a matching `SettingsStore::benchmarks(cx)` constructor next to `SettingsStore::test`, built the same way from `benchmark_settings()`. `settings`'s new `benchmarks = []` feature enables nothing else, so it cannot re-enable `gpui/test-support` or `fs/test-support` transitively, and it exposes no mutation API (`update_user_settings` stays gated to `test`/`test-support` only).

Because `benchmark_settings()` and `test_settings()` call the exact same helper function, their content is guaranteed byte-identical rather than merely intended to match, so switching `display_map`/`editor_render`/`markdown_renderer` over does not change the font, size, or theme fallback those benchmarks measure. I confirmed this is a true no-op for the theme in particular: `empty-theme` is never registered under the `LoadThemes::JustBase` these benchmarks use, so `theme_settings::configured_theme` already fell back silently to the same default theme it would use for any unrecognized name; only the font settings (Courier/Courier New at 14px) are load-bearing, and those are now sourced identically to before. `crates/settings/src/settings_store.rs` gains a `#[cfg(feature = "benchmarks")]` test, `test_benchmark_settings_match_test_settings`, that asserts the string equality directly and reads back `buffer_font_family`/`buffer_font_size`/`ui_font_family`/`ui_font_size`/`theme` from a real `SettingsStore::benchmarks(cx)` to confirm the representative settings a rendering benchmark reads still resolve as expected.

`crates/benchmarks/Cargo.toml` now requests `settings`'s `benchmarks` feature instead of `test-support`, and the three bench files call `SettingsStore::benchmarks(cx)` instead of `SettingsStore::test(cx)` — their only change. `cargo tree -p benchmarks --edges features --invert settings` before this change showed `benchmarks` as a direct dependent of `settings feature "test-support"`; after this change that direct edge is gone, and `benchmarks` instead is a direct dependent of `settings feature "benchmarks"`.

`settings/test-support` is not fully gone from `benchmarks`' resolved graph, and cannot be in this scope: `language/test-support` (needed directly by `markdown_renderer.rs`'s `LanguageRegistry::test`/`language::rust_lang`, with no production equivalent) enables `settings/test-support` itself, so it still resolves transitively through `language`. This is the same shape as the existing `theme`/`util` debt this script already tracked, so I folded `settings` into that same loop (`for foundational_crate in theme util settings`) instead of inventing a new check shape, and updated its comments to describe `language`/`multi_buffer` as the remaining crates keeping `test-support` populated in the graph. I also added a second, positive assertion that `benchmarks` still resolves `settings feature "benchmarks"`, so a future edit can't silently drop that feature request and have these three benchmarks start reading unrelated plain-default settings without any isolation check catching it. `edit_file_tool_benchmarks` (the sibling package `edit_file_tool.rs` lives in, added in #63048) is unchanged and explicitly excluded from all of this: it still needs `settings/test-support` for `SettingsStore::update_user_settings`, which has no production-capable equivalent for mutating already-loaded settings content, and the script's existing sanity check for that package's continued existence is untouched.

Testing performed:
- `cargo tree -p settings --no-default-features --features benchmarks -e no-dev --edges features`: no `test-support` edge anywhere, confirming the `benchmarks` feature alone enables nothing test-only.
- `cargo tree -p benchmarks --edges features --invert settings` before/after: the direct `test-support` edge from `benchmarks` is gone; only the transitive edge through `language feature "test-support"` remains. A direct edge to `settings feature "benchmarks"` is now present instead.
- `cargo check -p settings --no-default-features --features benchmarks`: compiles cleanly standalone.
- `cargo test -p settings --lib` (default features) and `cargo test -p settings --features benchmarks --lib`: 32 and 33 tests pass respectively, including the new `test_benchmark_settings_match_test_settings`.
- `cargo check -p benchmarks --benches` and `cargo check -p edit_file_tool_benchmarks --benches`: both compile cleanly.
- `cargo bench -p benchmarks --bench display_map/--bench editor_render/--bench markdown_renderer -- --test` (quick mode): all cases across all three targets report Success, including the headless-renderer-backed `editor_render`/`markdown_render` cases.
- `script/check-gpui-bench-feature-isolation`: passes; manually confirmed it fails (correctly) when `settings`'s Cargo.toml entry is reverted to `test-support` and separately when its `benchmarks` feature request is dropped entirely.
- `script/shellcheck-scripts` and `cargo fmt --check` (whole repo) both pass.
- `./script/clippy -p settings -p benchmarks -p edit_file_tool_benchmarks` (release, all features, deny warnings) passes, including `cargo shear --locked --deny-warnings`.

Remaining debt, tracked honestly rather than hidden: `language` and `multi_buffer` still request `test-support` directly (for `LanguageRegistry::test`/`language::rust_lang` and `MultiBuffer::build_simple`/`build_random`, none of which have a production equivalent), which keeps `settings/test-support` and `gpui/test-support` resolved transitively in `benchmarks`' graph regardless of this change. `edit_file_tool_benchmarks` is unaffected and continues to depend on `test-support` from `agent`, `editor`, `language`, `language_model`, `lsp`, `project`, and `settings` for its fake-project agent-tool harness, as documented since #63048.

Release Notes:

- N/A
