### PR TITLE
benchmarks: Stop requesting language's test-support feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,6 @@ dependencies = [
  "editor",
  "gpui",
  "gpui_platform",
- "itertools 0.14.0",
  "language",
  "markdown",
  "multi_buffer",

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -21,8 +21,7 @@ criterion.workspace = true
 editor.workspace = true
 gpui = { workspace = true, features = ["bench"] }
 gpui_platform = { workspace = true, features = ["bench", "font-kit"] }
-itertools.workspace = true
-language = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["benchmarks"] }
 markdown.workspace = true
 multi_buffer = { workspace = true, features = ["benchmarks"] }
 project.workspace = true
@@ -32,9 +31,6 @@ theme.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 zed_actions.workspace = true
-
-[package.metadata.cargo-shear]
-ignored = ["gpui_platform"]
 
 [[bench]]
 name = "editor_render"

--- a/crates/benchmarks/benches/display_map.rs
+++ b/crates/benchmarks/benches/display_map.rs
@@ -1,8 +1,7 @@
 use benchmarks::bench_utils::RandomCharIter;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use editor::{EditorStyle, MultiBuffer, display_map::*};
-use gpui::{AppContext as _, HighlightStyle, Hsla, TestDispatcher, font, px};
-use itertools::Itertools;
+use gpui::{AppContext as _, BenchAppContext, HighlightStyle, Hsla, font, px};
 use multi_buffer::MultiBufferOffset;
 use project::project_settings::DiagnosticSeverity;
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -10,95 +9,100 @@ use settings::SettingsStore;
 use std::{num::NonZeroU32, time::Duration};
 use text::Bias;
 
+/// Builds a benchmark app context backed by the same real headless platform
+/// `#[gpui::bench]` uses. The benchmarks below are plain `criterion_group!`
+/// functions rather than `#[gpui::bench]` because they need Criterion
+/// features the macro doesn't expose (a custom `measurement_time`, and
+/// several named benchmarks built from one fixture-building loop), but they
+/// must stay just as production-capable, rather than falling back to
+/// `TestAppContext`/`TestDispatcher`.
+fn bench_app_context<'a, 'measurement>(
+    name: &'static str,
+    bencher: &'a mut criterion::Bencher<'measurement>,
+) -> BenchAppContext<'a, 'measurement> {
+    BenchAppContext::new(
+        gpui::bench_platform(
+            Some(Box::new(|| gpui_platform::current_headless_renderer())),
+            gpui_platform::current_platform(true).text_system(),
+        ),
+        Some(name),
+        bencher,
+    )
+}
+
 fn to_tab_point_benchmark(c: &mut Criterion) {
-    let dispatcher = TestDispatcher::new(1);
-    let cx = gpui::TestAppContext::build(dispatcher, None);
-
-    let create_tab_map = |length: usize| {
-        let mut rng = StdRng::seed_from_u64(1);
-        let text = RandomCharIter::new(&mut rng)
-            .take(length)
-            .collect::<String>();
-        let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
-
-        let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
-        use editor::display_map::*;
-        let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
-        let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
-        let fold_point = fold_snapshot.to_fold_point(
-            inlay_snapshot.to_point(InlayOffset(
-                rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
-            )),
-            Bias::Left,
-        );
-        let (_, snapshot) = TabMap::new(fold_snapshot, NonZeroU32::new(4).unwrap());
-
-        (length, snapshot, fold_point)
-    };
-
-    let inputs = [1024].into_iter().map(create_tab_map).collect_vec();
+    const LENGTH: usize = 1024;
 
     let mut group = c.benchmark_group("To tab point");
+    group.bench_with_input(
+        BenchmarkId::new("to_tab_point", LENGTH),
+        &LENGTH,
+        |bencher, &length| {
+            let mut cx = bench_app_context("to_tab_point_benchmark", bencher);
 
-    for (batch_size, snapshot, fold_point) in inputs {
-        group.bench_with_input(
-            BenchmarkId::new("to_tab_point", batch_size),
-            &snapshot,
-            |bench, snapshot| {
-                bench.iter(|| {
-                    snapshot.fold_point_to_tab_point(fold_point);
-                });
-            },
-        );
-    }
+            let mut rng = StdRng::seed_from_u64(1);
+            let text = RandomCharIter::new(&mut rng)
+                .take(length)
+                .collect::<String>();
+            let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
+
+            let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+            let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
+            let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
+            let fold_point = fold_snapshot.to_fold_point(
+                inlay_snapshot.to_point(InlayOffset(
+                    rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
+                )),
+                Bias::Left,
+            );
+            let (_, snapshot) = TabMap::new(fold_snapshot, NonZeroU32::new(4).unwrap());
+
+            cx.bench_iter(|_| {
+                snapshot.fold_point_to_tab_point(fold_point);
+            });
+            cx.teardown();
+        },
+    );
 
     group.finish();
 }
 
 fn to_fold_point_benchmark(c: &mut Criterion) {
-    let dispatcher = TestDispatcher::new(1);
-    let cx = gpui::TestAppContext::build(dispatcher, None);
-
-    let create_tab_map = |length: usize| {
-        let mut rng = StdRng::seed_from_u64(1);
-        let text = RandomCharIter::new(&mut rng)
-            .take(length)
-            .collect::<String>();
-        let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
-
-        let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
-        use editor::display_map::*;
-        let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
-        let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
-
-        let fold_point = fold_snapshot.to_fold_point(
-            inlay_snapshot.to_point(InlayOffset(
-                rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
-            )),
-            Bias::Left,
-        );
-
-        let (_, snapshot) = TabMap::new(fold_snapshot, NonZeroU32::new(4).unwrap());
-        let tab_point = snapshot.fold_point_to_tab_point(fold_point);
-
-        (length, snapshot, tab_point)
-    };
-
-    let inputs = [1024].into_iter().map(create_tab_map).collect_vec();
+    const LENGTH: usize = 1024;
 
     let mut group = c.benchmark_group("To fold point");
+    group.bench_with_input(
+        BenchmarkId::new("to_fold_point", LENGTH),
+        &LENGTH,
+        |bencher, &length| {
+            let mut cx = bench_app_context("to_fold_point_benchmark", bencher);
 
-    for (batch_size, snapshot, tab_point) in inputs {
-        group.bench_with_input(
-            BenchmarkId::new("to_fold_point", batch_size),
-            &snapshot,
-            |bench, snapshot| {
-                bench.iter(|| {
-                    snapshot.tab_point_to_fold_point(tab_point, Bias::Left);
-                });
-            },
-        );
-    }
+            let mut rng = StdRng::seed_from_u64(1);
+            let text = RandomCharIter::new(&mut rng)
+                .take(length)
+                .collect::<String>();
+            let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
+
+            let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+            let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
+            let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
+
+            let fold_point = fold_snapshot.to_fold_point(
+                inlay_snapshot.to_point(InlayOffset(
+                    rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
+                )),
+                Bias::Left,
+            );
+
+            let (_, snapshot) = TabMap::new(fold_snapshot, NonZeroU32::new(4).unwrap());
+            let tab_point = snapshot.fold_point_to_tab_point(fold_point);
+
+            cx.bench_iter(|_| {
+                snapshot.tab_point_to_fold_point(tab_point, Bias::Left);
+            });
+            cx.teardown();
+        },
+    );
 
     group.finish();
 }
@@ -108,89 +112,89 @@ fn create_highlight_endpoints_benchmark(c: &mut Criterion) {
     const LINE_VIEW_PORT_COUNT: usize = 100;
     const HIGHLIGHTS_PER_LINE: usize = 4;
 
-    let dispatcher = TestDispatcher::new(1);
-    let mut cx = gpui::TestAppContext::build(dispatcher, None);
-    cx.update(|cx| {
-        let store = SettingsStore::benchmarks(cx);
-        cx.set_global(store);
-        editor::init(cx);
-    });
-
-    let mut text = String::new();
-    let mut highlight_ranges = Vec::with_capacity(LINE_COUNT * HIGHLIGHTS_PER_LINE);
-    for line in 0..LINE_COUNT {
-        text.push_str("fn item_");
-        text.push_str(&format!("{line:05}"));
-        text.push_str("() { ");
-
-        let start = text.len();
-        text.push_str("alpha_highlight");
-        highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
-
-        text.push_str(" + ");
-        let start = text.len();
-        text.push_str("beta_highlight");
-        highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
-
-        text.push_str(" + ");
-        let start = text.len();
-        text.push_str("gamma_highlight");
-        highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
-
-        text.push_str(" + ");
-        let start = text.len();
-        text.push_str("delta_highlight");
-        highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
-
-        text.push_str("; }\n");
-    }
-
-    let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
-    let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
-    let highlight_ranges = highlight_ranges
-        .into_iter()
-        .map(|range| {
-            buffer_snapshot.anchor_before(range.start)..buffer_snapshot.anchor_before(range.end)
-        })
-        .collect();
-
-    let map = cx.new(|cx| {
-        DisplayMap::new(
-            buffer,
-            font("Courier"),
-            px(16.0),
-            None,
-            1,
-            1,
-            FoldPlaceholder::default(),
-            DiagnosticSeverity::Warning,
-            cx,
-        )
-    });
-    cx.update(|cx| {
-        map.update(cx, |map, cx| {
-            map.highlight_text(
-                HighlightKey::Editor,
-                highlight_ranges,
-                HighlightStyle {
-                    color: Some(Hsla::blue()),
-                    ..Default::default()
-                },
-                false,
-                cx,
-            );
-        });
-    });
-    let snapshot = cx.update(|cx| map.update(cx, |map, cx| map.snapshot(cx)));
-
     let mut group = c.benchmark_group("Create highlight endpoints");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(10));
     group.bench_with_input(
         BenchmarkId::new("text_highlights", LINE_VIEW_PORT_COUNT),
-        &snapshot,
-        |bench, snapshot| {
-            bench.iter(|| {
+        &LINE_VIEW_PORT_COUNT,
+        |bencher, _| {
+            let mut cx = bench_app_context("create_highlight_endpoints_benchmark", bencher);
+            cx.update(|cx| {
+                let store = SettingsStore::benchmarks(cx);
+                cx.set_global(store);
+                editor::init(cx);
+            });
+
+            let mut text = String::new();
+            let mut highlight_ranges = Vec::with_capacity(LINE_COUNT * HIGHLIGHTS_PER_LINE);
+            for line in 0..LINE_COUNT {
+                text.push_str("fn item_");
+                text.push_str(&format!("{line:05}"));
+                text.push_str("() { ");
+
+                let start = text.len();
+                text.push_str("alpha_highlight");
+                highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
+
+                text.push_str(" + ");
+                let start = text.len();
+                text.push_str("beta_highlight");
+                highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
+
+                text.push_str(" + ");
+                let start = text.len();
+                text.push_str("gamma_highlight");
+                highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
+
+                text.push_str(" + ");
+                let start = text.len();
+                text.push_str("delta_highlight");
+                highlight_ranges.push(MultiBufferOffset(start)..MultiBufferOffset(text.len()));
+
+                text.push_str("; }\n");
+            }
+
+            let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
+            let buffer_snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+            let highlight_ranges = highlight_ranges
+                .into_iter()
+                .map(|range| {
+                    buffer_snapshot.anchor_before(range.start)
+                        ..buffer_snapshot.anchor_before(range.end)
+                })
+                .collect();
+
+            let map = cx.new(|cx| {
+                DisplayMap::new(
+                    buffer,
+                    font("Courier"),
+                    px(16.0),
+                    None,
+                    1,
+                    1,
+                    FoldPlaceholder::default(),
+                    DiagnosticSeverity::Warning,
+                    cx,
+                )
+            });
+            cx.update(|cx| {
+                map.update(cx, |map, cx| {
+                    map.highlight_text(
+                        HighlightKey::Editor,
+                        highlight_ranges,
+                        HighlightStyle {
+                            color: Some(Hsla::blue()),
+                            ..Default::default()
+                        },
+                        false,
+                        cx,
+                    );
+                });
+            });
+            let snapshot = cx.update(|cx| map.update(cx, |map, cx| map.snapshot(cx)));
+
+            cx.bench_iter(|_| {
                 black_box(snapshot.chunks(
                     DisplayRow(400)..DisplayRow(400 + LINE_VIEW_PORT_COUNT as u32),
                     language::LanguageAwareStyling {
@@ -200,6 +204,7 @@ fn create_highlight_endpoints_benchmark(c: &mut Criterion) {
                     Default::default(),
                 ));
             });
+            cx.teardown();
         },
     );
     group.finish();
@@ -208,14 +213,6 @@ fn create_highlight_endpoints_benchmark(c: &mut Criterion) {
 fn highlighted_chunks_benchmark(c: &mut Criterion) {
     const LINE_COUNT: usize = 500;
 
-    let dispatcher = TestDispatcher::new(1);
-    let mut cx = gpui::TestAppContext::build(dispatcher, None);
-    cx.update(|cx| {
-        let store = SettingsStore::benchmarks(cx);
-        cx.set_global(store);
-        editor::init(cx);
-    });
-
     let corpora = [
         (
             "ascii",
@@ -223,7 +220,7 @@ fn highlighted_chunks_benchmark(c: &mut Criterion) {
         ),
         (
             "unicode",
-            "の設定を変更する — émojis 🧑\u{200d}✈\u{fe0f} und Ümläute überall, здесь тоже текст",
+            "の設定を変更する — émojis 🧑‍✈️ und Ümläute überall, здесь тоже текст",
         ),
         (
             "sparse_invisibles",
@@ -240,27 +237,35 @@ fn highlighted_chunks_benchmark(c: &mut Criterion) {
         let text = std::iter::repeat_n(line, LINE_COUNT)
             .collect::<Vec<_>>()
             .join("\n");
-        let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(&text, cx));
-        let map = cx.new(|cx| {
-            DisplayMap::new(
-                buffer,
-                font("Courier"),
-                px(16.0),
-                None,
-                1,
-                1,
-                FoldPlaceholder::default(),
-                DiagnosticSeverity::Warning,
-                cx,
-            )
-        });
-        let snapshot = cx.update(|cx| map.update(cx, |map, cx| map.snapshot(cx)));
-        let editor_style = EditorStyle::default();
         group.bench_with_input(
             BenchmarkId::new("highlighted_chunks", name),
-            &snapshot,
-            |bench, snapshot| {
-                bench.iter(|| {
+            &text,
+            |bencher, text| {
+                let mut cx = bench_app_context("highlighted_chunks_benchmark", bencher);
+                cx.update(|cx| {
+                    let store = SettingsStore::benchmarks(cx);
+                    cx.set_global(store);
+                    editor::init(cx);
+                });
+
+                let buffer = cx.update(|cx| MultiBuffer::build_simple_for_benchmarks(text, cx));
+                let map = cx.new(|cx| {
+                    DisplayMap::new(
+                        buffer,
+                        font("Courier"),
+                        px(16.0),
+                        None,
+                        1,
+                        1,
+                        FoldPlaceholder::default(),
+                        DiagnosticSeverity::Warning,
+                        cx,
+                    )
+                });
+                let snapshot = cx.update(|cx| map.update(cx, |map, cx| map.snapshot(cx)));
+                let editor_style = EditorStyle::default();
+
+                cx.bench_iter(|_| {
                     let mut total_len = 0usize;
                     let chunks = snapshot.highlighted_chunks(
                         DisplayRow(0)..DisplayRow(LINE_COUNT as u32),
@@ -275,6 +280,7 @@ fn highlighted_chunks_benchmark(c: &mut Criterion) {
                     }
                     black_box(total_len);
                 });
+                cx.teardown();
             },
         );
     }

--- a/crates/benchmarks/benches/markdown_renderer.rs
+++ b/crates/benchmarks/benches/markdown_renderer.rs
@@ -322,8 +322,8 @@ fn choose(rng: &mut StdRng, items: &'static [&'static str]) -> &'static str {
 }
 
 fn markdown_language_registry(cx: &BenchAppContext) -> Arc<LanguageRegistry> {
-    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
-    registry.add(language::rust_lang());
+    let registry = Arc::new(LanguageRegistry::new(cx.background_executor().clone()));
+    registry.add(language::rust_lang_for_benchmarks());
     registry
 }
 

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -13,6 +13,12 @@ path = "src/language.rs"
 doctest = false
 
 [features]
+# Gates `rust_lang_for_benchmarks`, a production-faithful equivalent of
+# `rust_lang` for production-rendering benchmarks (`crates/benchmarks`).
+# Deliberately narrow: unlike `test-support`, this must not enable
+# `lsp/test-support` or `settings/test-support`, so `benchmarks` consumers
+# keep compiling production code only.
+benchmarks = ["grammars", "tree-sitter-rust"]
 test-support = [
     "rand",
     "collections/test-support",

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1643,7 +1643,21 @@ pub fn markdown_lang() -> Arc<Language> {
     test_language("markdown", tree_sitter_md::LANGUAGE.into())
 }
 
-#[cfg(any(test, feature = "test-support"))]
+/// A real Rust [`Language`] (the same `config.toml`/`highlights.scm`/etc. that
+/// production Rust editing uses, loaded through [`grammars::load_config`] and
+/// [`grammars::load_queries`]) for use by production-rendering benchmarks
+/// (`crates/benchmarks`) that need to exercise syntax highlighting without
+/// requesting the `test-support` feature, which would also pull in
+/// `lsp/test-support` and `settings/test-support`. Kept separate from
+/// [`rust_lang`] so enabling it doesn't require the rest of `test-support`'s
+/// surface (fake LSP servers, etc).
+#[doc(hidden)]
+#[cfg(any(test, feature = "benchmarks"))]
+pub fn rust_lang_for_benchmarks() -> Arc<Language> {
+    test_language("rust", tree_sitter_rust::LANGUAGE.into())
+}
+
+#[cfg(any(test, feature = "test-support", feature = "benchmarks"))]
 fn test_language(name: &str, grammar: tree_sitter::Language) -> Arc<Language> {
     Arc::new(
         Language::new(grammars::load_config(name), Some(grammar))
@@ -1691,6 +1705,50 @@ mod tests {
         assert_eq!(
             theme.get_capture_name(map.get(2).unwrap()),
             Some("variable.builtin")
+        );
+    }
+
+    /// Proves `rust_lang_for_benchmarks` (reachable without `test-support`,
+    /// through `language`'s narrow `benchmarks` feature) recognizes Rust and
+    /// highlights it exactly like `rust_lang` does, since
+    /// `crates/benchmarks`' `markdown_renderer` bench relies on this parity
+    /// to keep measuring the same rendering workload `test-support`'s
+    /// `LanguageRegistry::test`/`rust_lang` combination used to.
+    #[test]
+    fn rust_lang_for_benchmarks_matches_rust_lang_highlighting() {
+        let theme = SyntaxTheme::new(
+            [
+                ("keyword", rgba(0x100000ff)),
+                ("function", rgba(0x200000ff)),
+            ]
+            .iter()
+            .map(|(name, color)| (name.to_string(), (*color).into())),
+        );
+
+        let source = Rope::from("fn main() {\n    let value = 1;\n}\n");
+        let benchmark_language = rust_lang_for_benchmarks();
+        let production_language = rust_lang();
+        benchmark_language.set_theme(&theme);
+        production_language.set_theme(&theme);
+
+        let benchmark_highlights = benchmark_language.highlight_text(&source, 0..source.len());
+        let production_highlights = production_language.highlight_text(&source, 0..source.len());
+        assert_eq!(
+            benchmark_highlights, production_highlights,
+            "rust_lang_for_benchmarks should highlight identically to rust_lang"
+        );
+
+        let capture_names: Vec<&str> = benchmark_highlights
+            .iter()
+            .filter_map(|(_, highlight_id)| theme.get_capture_name(*highlight_id))
+            .collect();
+        assert!(
+            capture_names.contains(&"keyword"),
+            "expected a \"keyword\" capture (e.g. `fn`/`let`) in {capture_names:?}"
+        );
+        assert!(
+            capture_names.contains(&"function"),
+            "expected a \"function\" capture (e.g. `main`) in {capture_names:?}"
         );
     }
 

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -85,33 +85,22 @@ for isolated_crate in agent editor language_model project; do
   fi
 done
 
-# `lsp` and `language` are not part of the loop below: `markdown_renderer`
-# (the only benchmark left that needs either) directly calls test-only APIs
-# with no production equivalent — `LanguageRegistry::test`,
-# `language::rust_lang` — independent of `edit_file_tool`. `language/
-# test-support` enables both `lsp/test-support` and `settings/test-support`
-# directly, so both keep showing up transitively despite `benchmarks` no
-# longer requesting either itself. This is real, tracked debt, not a gap in
-# this script: `theme`, `util`, `settings`, and `multi_buffer` are the crates
-# whose benchmark usage turned out to need no test-only API at all
-# (`theme::LoadThemes`, `theme_settings::init`), one narrow enough to vendor
-# into `benchmarks::bench_utils` instead (`util::RandomCharIter`, a
-# synthetic-text generator with no production analogue), or one narrow
-# enough to move behind its own dedicated feature instead of `test-support`
-# (`settings`'s and `multi_buffer`'s `benchmarks` features, gating
-# `SettingsStore::benchmarks`/`benchmark_settings` and `MultiBuffer::
-# build_simple_for_benchmarks`/`build_random_for_benchmarks` respectively —
-# see `crates/settings/src/settings_file.rs` and
-# `crates/multi_buffer/src/multi_buffer.rs`, which keep their fixtures
-# byte-identical to the `test-support` versions' so switching does not change
-# what a benchmark measures). So `benchmarks` no longer needs a direct
-# `test-support` edge to any of the four. This checks only for a *direct*
-# edge from `benchmarks` to each crate's `test-support` feature, not for the
-# feature's absence from the whole resolved graph, since `language` keeps
-# populating `settings/test-support` (transitively) until it gets the same
-# treatment; `multi_buffer` is checked separately below since nothing else
-# `benchmarks` depends on populates its `test-support` feature at all
-# anymore.
+# `theme`, `util`, and `settings` are the crates whose benchmark usage turned
+# out to need no test-only API at all (`theme::LoadThemes`,
+# `theme_settings::init`), one narrow enough to vendor into
+# `benchmarks::bench_utils` instead (`util::RandomCharIter`, a synthetic-text
+# generator with no production analogue), or one narrow enough to move behind
+# its own dedicated feature instead of `test-support` (`settings`'s
+# `benchmarks` feature, gating `SettingsStore::benchmarks`/
+# `benchmark_settings` — see `crates/settings/src/settings_file.rs`, which
+# keeps its fixture byte-identical to the `test-support` version's so
+# switching does not change what a benchmark measures). This checks only for
+# a *direct* edge from `benchmarks` to each crate's `test-support` feature,
+# not for the feature's absence from the whole resolved graph, since
+# `language` used to keep populating `settings/test-support` (transitively)
+# until it got the same treatment below; `multi_buffer` and `language` are
+# checked separately since nothing else `benchmarks` depends on populates
+# either one's `test-support` feature at all anymore.
 for foundational_crate in theme util settings; do
   output=$(cargo tree \
     --offline \
@@ -189,6 +178,99 @@ output=$(cargo tree \
   --invert multi_buffer)
 if echo "${output}" | grep --quiet 'test-support'; then
   echo "multi_buffer's \"benchmarks\" feature pulls in \"test-support\":"
+  echo "${output}"
+  exit 1
+fi
+
+# `crates/benchmarks/Cargo.toml` used to also directly request `language`'s
+# `test-support` feature, entirely for `markdown_renderer`'s
+# `LanguageRegistry::test`/`language::rust_lang` (used to build a Rust
+# `Language` for its embedded-code-block fixtures). `language` now exposes
+# `rust_lang_for_benchmarks` behind its own narrow `benchmarks` feature
+# instead (see `crates/language/Cargo.toml` and
+# `crates/language/src/language.rs`), loading the same `config.toml`/
+# `highlights.scm`/etc. that `rust_lang` does through `grammars::load_config`/
+# `grammars::load_queries`, without requesting `lsp/test-support` or
+# `settings/test-support`. `markdown_renderer` also switched
+# `LanguageRegistry::test` for the always-available `LanguageRegistry::new`,
+# since the only difference between them is a fake language-server download
+# directory `markdown_renderer` never reads. So unlike `theme`/`util`/
+# `settings` above, this checks `language`'s `test-support` feature is absent
+# from `benchmarks`' whole resolved graph, not just as a direct edge: nothing
+# else `benchmarks` depends on has a legitimate reason to reach it either.
+# `lsp` is checked the same way here rather than getting its own loop, since
+# nothing requests `lsp/test-support` directly either: it, and `gpui/
+# test-support` below, only ever showed up because `language/test-support`
+# requested `lsp/test-support` directly and `settings/test-support` (which
+# `language/test-support` also requested) requested `gpui/test-support`, so
+# fixing `language` is what actually drops both.
+for freed_crate in language lsp; do
+  output=$(cargo tree \
+    --offline \
+    --package benchmarks \
+    --edges features \
+    --invert "${freed_crate}")
+
+  if echo "${output}" | grep --quiet "${freed_crate} feature \"test-support\""; then
+    echo "benchmarks pulls \"${freed_crate}\"'s \"test-support\" feature:"
+    echo "${output}"
+    exit 1
+  fi
+done
+
+# The loop above proves `benchmarks` no longer reaches `language`'s
+# `test-support` feature; this proves it still gets `rust_lang_for_benchmarks`
+# some other way, so a future edit can't silently drop the feature request
+# and have `markdown_renderer` start failing to compile without any isolation
+# check explaining why.
+output=$(cargo tree \
+  --offline \
+  --package benchmarks \
+  --edges features \
+  --invert language)
+if ! echo "${output}" | grep --quiet 'language feature "benchmarks"'; then
+  echo "benchmarks no longer requests language's \"benchmarks\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
+# This proves `language`'s own `benchmarks` feature (which
+# `rust_lang_for_benchmarks` lives behind) doesn't itself resolve to any
+# dependency's `test-support`, the same guarantee the top of this script
+# proves for `gpui`'s `bench` feature and the check above proves for
+# `multi_buffer`'s `benchmarks` feature.
+output=$(cargo tree \
+  --offline \
+  --package language \
+  --no-default-features \
+  --features benchmarks \
+  --edges features \
+  --invert language)
+if echo "${output}" | grep --quiet 'test-support'; then
+  echo "language's \"benchmarks\" feature pulls in \"test-support\":"
+  echo "${output}"
+  exit 1
+fi
+
+# `crates/benchmarks/benches/display_map.rs` used to build its Criterion
+# harness through `gpui::TestAppContext`/`TestDispatcher`, which only
+# resolved because `benchmarks` requested `language`'s `test-support` feature
+# elsewhere: Cargo unifies feature flags across every target built for the
+# same package, so `language/test-support` enabling `settings/test-support`
+# enabling `gpui/test-support` made `gpui::TestAppContext` available to
+# `display_map.rs` too, with no feature request of its own admitting it.
+# `display_map.rs` now builds its app context from `gpui::bench_platform`/
+# `gpui::BenchAppContext` instead, the same production-capable harness
+# `#[gpui::bench]` uses. This checks the whole resolved graph for `gpui`'s
+# `test-support` feature, not just a direct edge, since nothing `benchmarks`
+# depends on has a legitimate reason to reach it either.
+output=$(cargo tree \
+  --offline \
+  --package benchmarks \
+  --edges features \
+  --invert gpui)
+if echo "${output}" | grep --quiet 'gpui feature "test-support"'; then
+  echo "benchmarks pulls gpui's \"test-support\" feature:"
   echo "${output}"
   exit 1
 fi


### PR DESCRIPTION
This is the final PR in the `crates/benchmarks` test-support removal stack (stacked on #63054, which itself stacks on #63052/#63048/#63044/#63041/#63039). After it lands, the main production-rendering benchmark package (`crates/benchmarks`) no longer requests `test-support` from `gpui`, `gpui_platform`/`gpui_macos`/`gpui_apple`, `theme`, `util`, `settings`, `multi_buffer`, `language`, or `lsp` — the entire migration stack's target set. `edit_file_tool_benchmarks`, the isolated package `edit_file_tool` was previously moved into, keeps its `test-support` dependencies unchanged and is explicitly excluded from every check below; it's tracked separately.

## The remaining edge

`markdown_renderer.rs` used `LanguageRegistry::test` and `language::rust_lang`, both `test-support`-only, to build a Rust `Language` for its embedded Rust code-block fixtures. Requesting `language`'s `test-support` feature also pulled in `lsp/test-support` directly and `settings/test-support`, which in turn pulled in `gpui/test-support`.

`language` now exposes `rust_lang_for_benchmarks` (`crates/language/src/language.rs`) behind its own narrow `benchmarks` feature (`crates/language/Cargo.toml`), which enables only the `grammars` and `tree-sitter-rust` optional dependencies — not `lsp/test-support`, `settings/test-support`, or any of `test-support`'s other dependency features. It calls the exact same private `test_language` helper `rust_lang` does, loading the real `config.toml`/`highlights.scm`/etc. that production Rust editing uses through `grammars::load_config`/`grammars::load_queries`. `markdown_renderer` also swapped `LanguageRegistry::test` for the always-available `LanguageRegistry::new`; the only difference between them is a fake language-server download directory that `markdown_renderer` never reads.

A new test, `rust_lang_for_benchmarks_matches_rust_lang_highlighting`, parses and highlights the same Rust source with both `rust_lang_for_benchmarks` and `rust_lang` and asserts the highlight output is identical, then asserts the result actually contains `keyword` and `function` captures — proving the benchmark language recognizes real Rust syntax rather than merely constructing without panicking.

## A second edge this also uncovered

`display_map.rs` built its Criterion harness through `gpui::TestAppContext`/`TestDispatcher`, both `test-support`-only, with no `test-support` request of its own. That only compiled because Cargo unifies feature flags across every target built for the same package: `benchmarks`' now-removed direct request for `language/test-support` was enabling `settings/test-support` was enabling `gpui/test-support` for the whole `benchmarks` package, including `display_map.rs`. Removing the `language` edge unmasked this.

`display_map.rs` now builds its app context from `gpui::bench_platform`/`gpui::BenchAppContext` instead — the same production-capable harness `#[gpui::bench]` uses — through a small `bench_app_context` helper. It stays a plain `criterion_group!`/`criterion_main!` file rather than switching to `#[gpui::bench]`, since two of its benchmarks need a custom `measurement_time` and one loops over several named corpora that the macro's single-dimension `inputs` sweep can't express as cleanly. All four benchmark group/id names (`To tab point/to_tab_point/1024`, `To fold point/to_fold_point/1024`, `Create highlight endpoints/text_highlights/100`, `Highlighted chunks/highlighted_chunks/{ascii,unicode,sparse_invisibles,dense_invisibles}`) and the fixture-building/measured code are unchanged; only the App context construction changed.

## Dependency proof

`cargo tree --offline -p benchmarks --edges features` shows `test-support` appearing exactly once in `benchmarks`' whole resolved graph, down from 16 occurrences before this change: `http_client feature "test-support"`, requested directly (and unconditionally) by `context_server`'s own `[dependencies]`, unrelated to anything in this migration stack. `script/check-gpui-bench-feature-isolation` is extended with checks that `language`'s and `lsp`'s `test-support` features are absent from `benchmarks`' whole resolved graph, that `benchmarks` still requests `language`'s `benchmarks` feature, that `language`'s `benchmarks` feature doesn't itself resolve to any `test-support`, and that `gpui`'s `test-support` feature is absent from `benchmarks`' whole resolved graph (closing the `display_map.rs` gap). The script passes end-to-end.

## Tests and benchmark runs

- `cargo nextest run -p language --lib`: 157/157 passed, including the new parity test.
- `cargo nextest run -p multi_buffer --lib`: 59/59 passed.
- `cargo nextest run -p settings --lib`: 32/32 passed.
- `cargo check -p benchmarks --benches --tests`: compiles all three bench targets (`editor_render`, `display_map`, `markdown_renderer`).
- `cargo bench -p benchmarks --bench markdown_renderer -- --test` and `--bench display_map -- --test` and `--bench editor_render -- --test`: all pass (`--test` runs one measured iteration of each case without a full statistical sample).
- A short real `markdown_renderer` run (sizes 5000/50000, 10 samples each) completed in about 22 seconds and produced plausible non-zero timings (~1.1 ms and ~5.8 ms respectively), confirming real Rust syntax highlighting is exercised in the loop.
- `cargo fmt --check -p benchmarks -p language` and `cargo clippy -p benchmarks --benches --no-deps` / `cargo clippy -p language --lib --features benchmarks --no-deps`: clean.
- `cargo shear`: clean (also drops `itertools`, unused in `benchmarks` now that `display_map.rs` no longer needs `Itertools::collect_vec`, and an `ignored = ["gpui_platform"]` cargo-shear entry that's no longer needed now that `display_map.rs` references `gpui_platform` directly instead of only through macro-expanded code).

## Remaining debt

`edit_file_tool_benchmarks` still depends on `test-support` from `agent`, `editor`, `language`, `language_model`, `lsp`, `project`, and `settings`, for the same `TestAppContext`/`FakeFs`/`FakeLspAdapter`/`FakeLanguageModel`/`Project::test`/`SettingsStore::update_user_settings` harness it needed before this stack began. That package is intentionally out of scope for this bar and unaffected by this change.

Release Notes:

- N/A
