### PR TITLE
context_server: Stop requesting http_client's test-support feature in production dependencies

### DIFF
--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -23,7 +23,7 @@ collections.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
 gpui.workspace = true
-http_client = { workspace = true, features = ["test-support"] }
+http_client.workspace = true
 log.workspace = true
 net.workspace = true
 oauth_callback_server.workspace = true
@@ -42,3 +42,4 @@ util.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
+http_client = { workspace = true, features = ["test-support"] }

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+# Every match test below feeds a captured `cargo tree` output into `grep
+# --quiet` through `<<<` rather than `echo "${output}" | grep --quiet ...`.
+# `grep --quiet` exits as soon as it finds the first match instead of reading
+# the rest of its input, so with `pipefail` set, a large enough `echo` can
+# still be writing when `grep` exits and receive `SIGPIPE`; that turns a real
+# match into a nonzero pipeline status, which `if` reads as "no match" (or,
+# for a negated `if !` check, as a false failure). `<<<` avoids the pipe
+# entirely.
+
 # `gpui`'s `bench` feature must stay usable without pulling in `test-support`,
 # so that `#[gpui::bench]` consumers only compile production-capable code
 # rather than transitively depending on test-only APIs. This walks the
@@ -17,7 +26,7 @@ output=$(cargo tree \
   --edges features \
   --invert gpui)
 
-if echo "${output}" | grep --quiet 'gpui feature "test-support"'; then
+if grep --quiet 'gpui feature "test-support"' <<< "${output}"; then
   echo "gpui's \"bench\" feature pulls in \"test-support\":"
   echo "${output}"
   exit 1
@@ -42,7 +51,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
       --edges features \
       --invert "${platform_crate}")
 
-    if echo "${output}" | grep --quiet "${platform_crate} feature \"test-support\""; then
+    if grep --quiet "${platform_crate} feature \"test-support\"" <<< "${output}"; then
       echo "benchmarks pulls \"test-support\" into \"${platform_crate}\":"
       echo "${output}"
       exit 1
@@ -70,7 +79,7 @@ for isolated_crate in agent editor language_model project; do
     --package benchmarks \
     --edges features \
     --invert "${isolated_crate}" 2>&1); then
-    if echo "${output}" | grep --quiet 'did not match any packages'; then
+    if grep --quiet 'did not match any packages' <<< "${output}"; then
       continue
     fi
     echo "failed to resolve \"${isolated_crate}\" in benchmarks' dependency graph:"
@@ -78,7 +87,7 @@ for isolated_crate in agent editor language_model project; do
     exit 1
   fi
 
-  if echo "${output}" | grep --quiet "${isolated_crate} feature \"test-support\""; then
+  if grep --quiet "${isolated_crate} feature \"test-support\"" <<< "${output}"; then
     echo "benchmarks pulls \"test-support\" into \"${isolated_crate}\":"
     echo "${output}"
     exit 1
@@ -116,9 +125,8 @@ for foundational_crate in theme util settings; do
   # are actually listed; checking the couple of lines after it for a
   # "benchmarks" edge is enough to catch a direct request without also
   # matching the expected indirect one from `language`.
-  if echo "${output}" \
-    | grep -A2 "[|\`]-- ${foundational_crate} feature \"test-support\"\$" \
-    | grep --quiet 'benchmarks v'; then
+  direct_dependents=$(grep -A2 "[|\`]-- ${foundational_crate} feature \"test-support\"\$" <<< "${output}" || true)
+  if grep --quiet 'benchmarks v' <<< "${direct_dependents}"; then
     echo "benchmarks directly requests \"${foundational_crate}\"'s \"test-support\" feature:"
     echo "${output}"
     exit 1
@@ -136,7 +144,7 @@ output=$(cargo tree \
   --package benchmarks \
   --edges features \
   --invert settings)
-if ! echo "${output}" | grep --quiet 'settings feature "benchmarks"'; then
+if ! grep --quiet 'settings feature "benchmarks"' <<< "${output}"; then
   echo "benchmarks no longer requests settings' \"benchmarks\" feature:"
   echo "${output}"
   exit 1
@@ -157,7 +165,7 @@ output=$(cargo tree \
   --package benchmarks \
   --edges features \
   --invert multi_buffer)
-if echo "${output}" | grep --quiet 'multi_buffer feature "test-support"'; then
+if grep --quiet 'multi_buffer feature "test-support"' <<< "${output}"; then
   echo "benchmarks pulls multi_buffer's \"test-support\" feature:"
   echo "${output}"
   exit 1
@@ -176,7 +184,7 @@ output=$(cargo tree \
   --features benchmarks \
   --edges features \
   --invert multi_buffer)
-if echo "${output}" | grep --quiet 'test-support'; then
+if grep --quiet 'test-support' <<< "${output}"; then
   echo "multi_buffer's \"benchmarks\" feature pulls in \"test-support\":"
   echo "${output}"
   exit 1
@@ -211,7 +219,7 @@ for freed_crate in language lsp; do
     --edges features \
     --invert "${freed_crate}")
 
-  if echo "${output}" | grep --quiet "${freed_crate} feature \"test-support\""; then
+  if grep --quiet "${freed_crate} feature \"test-support\"" <<< "${output}"; then
     echo "benchmarks pulls \"${freed_crate}\"'s \"test-support\" feature:"
     echo "${output}"
     exit 1
@@ -228,7 +236,7 @@ output=$(cargo tree \
   --package benchmarks \
   --edges features \
   --invert language)
-if ! echo "${output}" | grep --quiet 'language feature "benchmarks"'; then
+if ! grep --quiet 'language feature "benchmarks"' <<< "${output}"; then
   echo "benchmarks no longer requests language's \"benchmarks\" feature:"
   echo "${output}"
   exit 1
@@ -246,7 +254,7 @@ output=$(cargo tree \
   --features benchmarks \
   --edges features \
   --invert language)
-if echo "${output}" | grep --quiet 'test-support'; then
+if grep --quiet 'test-support' <<< "${output}"; then
   echo "language's \"benchmarks\" feature pulls in \"test-support\":"
   echo "${output}"
   exit 1
@@ -269,8 +277,32 @@ output=$(cargo tree \
   --package benchmarks \
   --edges features \
   --invert gpui)
-if echo "${output}" | grep --quiet 'gpui feature "test-support"'; then
+if grep --quiet 'gpui feature "test-support"' <<< "${output}"; then
   echo "benchmarks pulls gpui's \"test-support\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
+# `crates/context_server/Cargo.toml` used to unconditionally request
+# `http_client`'s `test-support` feature from its normal `[dependencies]`,
+# entirely so `context_server`'s own `#[cfg(test)]` modules could build
+# `http_client::FakeHttpClient` transports. Because that request lived in
+# `[dependencies]` rather than `[dev-dependencies]`, it activated
+# `http_client/test-support` for every build that links `context_server` at
+# all, including a plain release build of the `zed` binary itself, not merely
+# `context_server`'s own test target; moving it to `context_server`'s
+# `[dev-dependencies]` (see `crates/context_server/Cargo.toml`) fixed that.
+# All of the checks above confirm individual crates don't leak `test-support`
+# into `benchmarks` through a specific edge; this instead scans `benchmarks`'
+# entire resolved feature graph for the literal feature name, so a future
+# direct or transitive dependency reintroducing `test-support` anywhere — not
+# just through one of the crates named above — fails here too.
+output=$(cargo tree \
+  --offline \
+  --package benchmarks \
+  --edges features)
+if grep --quiet 'feature "test-support"' <<< "${output}"; then
+  echo "benchmarks' resolved feature graph still contains \"test-support\":"
   echo "${output}"
   exit 1
 fi


### PR DESCRIPTION
This is stacked on #63056 (and its underlying benchmark-isolation series), which left `cargo tree -p benchmarks --edges features` with exactly one `test-support` occurrence: `http_client/test-support`, pulled in through `context_server`.

## Root cause

`crates/context_server/Cargo.toml` requested `http_client`'s `test-support` feature from its normal `[dependencies]`, not from `[dev-dependencies]`:

```toml
[dependencies]
http_client = { workspace = true, features = ["test-support"] }
```

Cargo unifies a package's enabled features across an entire build, so this activated `http_client/test-support` for *every* build that links `context_server`, not just `context_server`'s own tests. That includes a plain, non-test build of the `zed` binary itself: `cargo tree -p zed -e normal,features --invert http_client` showed the feature resolved through `context_server` with no dev-dependency in the path at all. `benchmarks` inherited the same contamination transitively, through `project`'s normal dependency on `context_server`.

The only thing in `context_server` that needed the feature was `http_client::FakeHttpClient`, used exclusively inside `#[cfg(test)]` modules in `oauth.rs` and `transport/http.rs` (`http_client`'s `test-support` feature gates `FakeHttpClient` behind `#[cfg(feature = "test-support")]`, not `#[cfg(any(test, feature = "test-support"))]`, so the feature genuinely had to be requested somewhere). `context_server`'s own `test-support` feature (used by `project`, `agent`, etc. for their own tests) only requests `gpui/test-support` and never touches `http_client` at all.

## Fix

Moved the `http_client` feature request to `[dev-dependencies]`, matching the existing `gpui = { workspace = true, features = ["test-support"] }` entry already there:

```toml
[dependencies]
http_client.workspace = true

[dev-dependencies]
gpui = { workspace = true, features = ["test-support"] }
http_client = { workspace = true, features = ["test-support"] }
```

This is a 2-line diff. No fake HTTP behavior is exposed to production or benchmark code; `FakeHttpClient` remains reachable only when building `context_server`'s own test target, exactly as before.

## Isolation check

Extended `script/check-gpui-bench-feature-isolation` with a check that scans `benchmarks`' *entire* resolved feature graph (not just one crate's edge) for the literal `test-support` feature name, with its own explanatory comment and failure message. Every prior check in the script proved one crate's edge was clean; this one is the capstone that proves the whole graph is clean, so a future dependency reintroducing `test-support` through any path fails here even if it doesn't match one of the specific crates already named above. `edit_file_tool_benchmarks` keeps its existing, separately documented exemption at the bottom of the script — it still legitimately needs `test-support` from several crates for its `TestAppContext`-based harness, and is out of scope for this change.

While adding that check I found a real, pre-existing bug in every check already in the script: `echo "${output}" | grep --quiet 'PATTERN'` under `set -o pipefail`. `grep --quiet` exits as soon as it finds its first match instead of draining the rest of its input, so for large enough `output` the writing `echo` can still be mid-write when `grep` exits, receive `SIGPIPE`, and die with a nonzero status; `pipefail` then reports that nonzero status for the whole pipeline even though `grep` itself matched. `if` reads that as "no match" (or, for the script's two negated `if !` checks, as a false failure). This reproduced reliably once I added a check over the full (much larger) `benchmarks` graph, since a big enough `echo` is far more likely to still be writing when `grep` exits. I fixed every instance in the file by replacing the pipe with a here-string (`grep --quiet 'PATTERN' <<< "${output}"`), which never pipes at all, and added a comment at the top of the script documenting why. I verified the fix with a reverted copy of the `context_server` change: before the here-string fix the new whole-graph check silently passed under the regression; after it, the same reverted code fails reliably across multiple runs with the intended message.

## Testing

- `cargo tree -p benchmarks --edges features` — before: one `test-support` line (`http_client`, via `context_server`); after: zero occurrences anywhere in the graph.
- `cargo tree -p zed -e normal,features --invert http_client` — before: showed `http_client feature "test-support"` resolved via `context_server` with no dev-dependency involved; after: gone, confirming the fix also removes `test-support` from an ordinary release build of the `zed` binary, not just from `benchmarks`.
- `bash script/check-gpui-bench-feature-isolation` — passes reliably across 5 consecutive runs on the fix; fails reliably across 3 consecutive runs with the explicit new message when `context_server`'s `Cargo.toml` change is reverted.
- `cargo nextest run -p context_server` — 97/97 passed, including the `FakeHttpClient`-based `oauth`/`transport::http` test modules that exercise the feature now living in `[dev-dependencies]`.
- `cargo nextest run -p http_client` — 2/2 passed.
- `cargo check -p context_server -p project -p agent -p agent_ui -p settings_ui` — clean.
- `cargo check -p context_server --features test-support --tests` — clean.
- `cargo clippy -p context_server --tests --all-targets -- -D warnings` and `script/clippy -p context_server` — clean, including `cargo shear`/`typos`/`buf` checks bundled into `script/clippy`.
- `cargo fmt --check -p context_server` — clean (no `.rs` files changed).
- Compiled all three `benchmarks` bench binaries (`editor_render`, `display_map`, `markdown_renderer`) and ran each with `--quick`; all ran to completion with plausible timings and no errors.

Release Notes:

- N/A
