### PR TITLE
grammars: Prevent duplicate `$` signs in Svelte rune completions

### DIFF
--- a/crates/grammars/src/javascript/config.toml
+++ b/crates/grammars/src/javascript/config.toml
@@ -20,6 +20,7 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 word_characters = ["$", "#"]
+completion_query_characters = ["$"]
 tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 prettier_parser_name = "babel"

--- a/crates/grammars/src/typescript/config.toml
+++ b/crates/grammars/src/typescript/config.toml
@@ -19,6 +19,7 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
 word_characters = ["#", "$"]
+completion_query_characters = ["$"]
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]


### PR DESCRIPTION
Svelte language-server completions may omit an edit range. Zed then derives one from the active language’s completion query characters. Because `$` was excluded, accepting a rune completion preserved the typed prefix and inserted a second dollar sign. Treat `$` as part of JavaScript and TypeScript completion queries so the fallback replaces the complete rune prefix.

Closes #53468.

---

Release Notes:

- Fixed Svelte rune completions inserting a duplicate dollar sign
