### PR TITLE
edit_file_tool_benchmarks: Drop language_model and lsp test-support edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,7 +5336,6 @@ dependencies = [
  "futures 0.3.32",
  "gpui",
  "language",
- "language_model",
  "lsp",
  "project",
  "prompt_store",

--- a/crates/edit_file_tool_benchmarks/Cargo.toml
+++ b/crates/edit_file_tool_benchmarks/Cargo.toml
@@ -23,8 +23,7 @@ editor = { workspace = true, features = ["test-support"] }
 futures.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
-language_model = { workspace = true, features = ["test-support"] }
-lsp = { workspace = true, features = ["test-support"] }
+lsp.workspace = true
 project = { workspace = true, features = ["test-support"] }
 prompt_store.workspace = true
 rand.workspace = true

--- a/crates/edit_file_tool_benchmarks/benches/edit_file_tool.rs
+++ b/crates/edit_file_tool_benchmarks/benches/edit_file_tool.rs
@@ -26,7 +26,6 @@ use gpui::{
     UpdateGlobal as _,
 };
 use language::{FakeLspAdapter, rust_lang};
-use language_model::fake_provider::FakeLanguageModel;
 use project::{FakeFs, Project};
 use prompt_store::ProjectContext;
 use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
@@ -206,14 +205,17 @@ async fn setup_editor_and_tool(cx: &mut TestAppContext, file_text: String) -> Ha
 
     let context_server_registry =
         cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
-    let model = Arc::new(FakeLanguageModel::default());
+    // `edit_file` never reads the thread's configured model (see
+    // `EditSessionContext`/`authorize_file_edit`, which only touch the
+    // project, action log, and agent settings), so leaving it unset measures
+    // the same tool path without needing a fake language model.
     let thread = cx.new(|cx| {
         Thread::new(
             project.clone(),
             cx.new(|_cx| ProjectContext::default()),
             context_server_registry,
             Templates::new(),
-            Some(model),
+            None,
             cx,
         )
     });

--- a/crates/edit_file_tool_benchmarks/src/edit_file_tool_benchmarks.rs
+++ b/crates/edit_file_tool_benchmarks/src/edit_file_tool_benchmarks.rs
@@ -1,13 +1,25 @@
 //! Benchmark for the agent's `edit_file` tool.
 //!
 //! This crate is split out from `benchmarks` because its harness drives the
-//! tool through `TestAppContext`/`FakeFs`/`FakeLspAdapter`/`FakeLanguageModel`
-//! and `Project::test`, which pull `test-support` into `agent`, `editor`,
-//! `language`, `language_model`, `lsp`, `project`, and `settings`. Cargo's
-//! feature unification would otherwise apply those test-only builds to every
-//! other benchmark target in the same package, including the ones that render
-//! production code paths. Keeping this benchmark in its own package confines
-//! that contamination to the one benchmark that actually needs it.
+//! tool through `TestAppContext`/`FakeFs`/`FakeLspAdapter` and `Project::test`,
+//! which pull `test-support` into `agent`, `editor`, `language`, `lsp`,
+//! `project`, and `settings`. Cargo's feature unification would otherwise
+//! apply those test-only builds to every other benchmark target in the same
+//! package, including the ones that render production code paths. Keeping
+//! this benchmark in its own package confines that contamination to the one
+//! benchmark that actually needs it.
+//!
+//! It no longer needs `language_model`'s `test-support` feature: `edit_file`
+//! never reads a thread's configured model (see `EditSessionContext`/
+//! `authorize_file_edit` in `agent::tools`), so the harness leaves it unset
+//! instead of constructing a `FakeLanguageModel`, which measures the same
+//! tool path while dropping that fake object entirely. It also no longer
+//! directly requests `lsp`'s `test-support` feature: everything it uses from
+//! `lsp`'s test-only surface (`FakeLanguageServer::handle_notification`/
+//! `notify`, reached through `language::LanguageRegistry::register_fake_lsp`)
+//! is already pulled in by the direct request of `language`'s `test-support`
+//! feature, which requests `lsp/test-support` itself; the direct request was
+//! redundant manifest debt, not a distinct capability this benchmark needed.
 //!
 //! This is a staging step, not a destination: the long-term goal is a harness
 //! with no `test-support` dependency at all. See `benches/edit_file_tool.rs`

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -310,14 +310,61 @@ fi
 # `edit_file_tool_benchmarks` is the isolated package `edit_file_tool` moved
 # into. It is intentionally *not* held to the isolation bar above, including
 # the `settings` checks just above: it still needs `test-support` from
-# `agent`, `editor`, `language`, `language_model`, `lsp`, `project`, and
-# `settings` (via `SettingsStore::update_user_settings`, which has no
-# production-capable equivalent for mutating already-loaded settings
-# content) for the same harness this script used to document against
-# `benchmarks`. That is tracked debt toward eventually having no benchmark
-# depend on `test-support` at all, not a gap this script hides — confirm the
-# package still exists and builds rather than silently skipping it.
+# `agent`, `editor`, `language`, `lsp`, `project`, and `settings` (via
+# `SettingsStore::update_user_settings`, which has no production-capable
+# equivalent for mutating already-loaded settings content) for the same
+# harness this script used to document against `benchmarks`. That is tracked
+# debt toward eventually having no benchmark depend on `test-support` at all,
+# not a gap this script hides — confirm the package still exists and builds
+# rather than silently skipping it.
 if ! cargo tree --offline --package edit_file_tool_benchmarks >/dev/null; then
   echo "edit_file_tool_benchmarks package is missing or fails to resolve"
+  exit 1
+fi
+
+# `edit_file_tool_benchmarks` used to also directly request `language_model`'s
+# `test-support` feature, entirely to build a `FakeLanguageModel` to satisfy
+# `Thread::new`'s model parameter. `edit_file` never reads a thread's
+# configured model (see `EditSessionContext`/`authorize_file_edit` in
+# `agent::tools`, which only touch the project, action log, and agent
+# settings), so the harness now passes `None` instead, dropping that fake
+# object and its `test-support` edge entirely rather than merely renaming it.
+# Unlike the crates named above, nothing else `edit_file_tool_benchmarks`
+# depends on has a legitimate reason to reach `language_model`'s
+# `test-support` feature either, so this checks the whole resolved graph.
+output=$(cargo tree \
+  --offline \
+  --package edit_file_tool_benchmarks \
+  --edges features \
+  --invert language_model)
+if grep --quiet 'language_model feature "test-support"' <<< "${output}"; then
+  echo "edit_file_tool_benchmarks pulls language_model's \"test-support\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
+# `edit_file_tool_benchmarks` also used to directly request `lsp`'s
+# `test-support` feature, but everything it uses from `lsp`'s test-only
+# surface (`FakeLanguageServer::handle_notification`/`notify`, reached
+# through `language::LanguageRegistry::register_fake_lsp`) is already pulled
+# in by its direct request of `language`'s `test-support` feature, which
+# requests `lsp/test-support` itself. The direct request to `lsp` was
+# therefore fully redundant, not a `test-support` edge this benchmark still
+# needs on its own; dropping it does not change the resolved feature graph
+# (`lsp/test-support` stays on, tracked as debt above), only which crate asks
+# for it. This checks only the direct edge, the same way the `theme`/`util`/
+# `settings` checks above do for `benchmarks`, since `lsp/test-support`
+# itself is expected to remain in the whole resolved graph until `language`
+# is migrated too.
+output=$(cargo tree \
+  --offline \
+  --package edit_file_tool_benchmarks \
+  --edges features \
+  --charset ascii \
+  --invert lsp)
+direct_dependents=$(grep -A2 '[|`]-- lsp feature "test-support"$' <<< "${output}" || true)
+if grep --quiet 'edit_file_tool_benchmarks v' <<< "${direct_dependents}"; then
+  echo "edit_file_tool_benchmarks directly requests lsp's \"test-support\" feature:"
+  echo "${output}"
   exit 1
 fi


### PR DESCRIPTION
This is the next stage after #63061 toward making `edit_file_tool_benchmarks` production-shaped and test-support-free. That package intentionally still enables `test-support` from `agent`, `editor`, `language`, `lsp`, `project`, and `settings` to drive the `edit_file` tool through `TestAppContext`/`FakeFs`/`FakeLspAdapter`/`Project::test`, because Cargo's feature unification would otherwise spread those test-only builds to the other benchmark targets that were split out earlier in this stack.

Tracing the harness's setup path against what `EditFileTool::run` actually reaches (`EditSessionContext`/`authorize_file_edit`, which only touch the project, action log, and agent settings) shows the fake language model passed to `Thread::new` was never read. This PR passes `None` instead of constructing a `FakeLanguageModel`, which measures exactly the same tool path while dropping that fake object and the `language_model` dependency's `test-support` feature entirely. `cargo tree`'s resolved feature graph confirms `language_model`'s `test-support` feature no longer appears anywhere in the package's dependency graph, not just that the direct request line was deleted.

While tracing that graph I also found the package's direct request of `lsp`'s `test-support` feature was fully redundant: everything the harness uses from `lsp`'s test-only surface (`FakeLanguageServer::handle_notification`/`notify`, reached through `language::LanguageRegistry::register_fake_lsp`) is already pulled in by the direct request of `language`'s `test-support` feature, which requests `lsp/test-support` itself. Removing the redundant direct edge doesn't change the resolved feature graph (`lsp/test-support` stays on, requested via `language`) or runtime behavior at all — it's a manifest-only cleanup, called out honestly as such rather than presented as a capability removal.

`script/check-gpui-bench-feature-isolation` is extended with two checks: the whole resolved graph for `edit_file_tool_benchmarks` no longer contains `language_model`'s `test-support` feature (proving the removal is complete, not just the one call site), and the package no longer directly requests `lsp`'s `test-support` feature (proving the redundant edge doesn't silently come back). Both were sanity-tested by temporarily reintroducing the corresponding Cargo.toml line and confirming the script fails.

## Remaining test-support debt

`edit_file_tool_benchmarks` still needs `test-support` from `agent` (`ToolInput::test`/`ToolCallEventStream::test`, which wrap `pub(crate)` channel constructors `Thread` itself uses to dispatch a streaming tool call — no public production equivalent exists yet), `editor` (`TestAppContext`/`VisualTestContext` for windowing; `Editor::for_buffer`/`EditorStyle::default`/`editor::init` are already plain production APIs, but attempting to drop editor's `test-support` request alone breaks `workspace`'s `RemoteConnectionIdentity` match exhaustiveness once `workspace/test-support` and `remote/test-support` fall out of sync — a real cross-crate coupling gap, not just a missing benchmark feature), `language` (`FakeLspAdapter`/`rust_lang`/`register_fake_lsp`), `lsp` transitively via `language` (an in-process fake LSP transport with no production-capable equivalent — spawning a real language server binary isn't practical for CI benchmarks), `project` (`FakeFs`/`Project::test`; a production-capable local `Project` construction path would need a real or benchmark-specific `Client`/`Fs`), and `settings` (`SettingsStore::update_user_settings`, which has no production-capable equivalent for mutating already-loaded settings content — `SettingsStore::benchmarks`/`AllLanguageSettings::override_global` could replace the two content tweaks this harness needs, but that edge is entangled with `editor`/`project`'s `test-support` through Cargo feature unification, so it can't be removed on its own).

## Testing

- `cargo check -p edit_file_tool_benchmarks --benches`
- `cargo build -p edit_file_tool_benchmarks --benches --release`
- `cargo bench -p edit_file_tool_benchmarks --bench edit_file_tool -- --test` (all 5 fixtures report `Success`)
- `cargo bench -p edit_file_tool_benchmarks --bench edit_file_tool -- --quick` (sanity timing run, longest fixture ~0.8s)
- `cargo fmt -p edit_file_tool_benchmarks -- --check`
- `./script/clippy -p edit_file_tool_benchmarks`
- `bash script/check-gpui-bench-feature-isolation`, including a temporary reintroduction of each removed Cargo.toml line to confirm the new checks catch a regression
- `cargo check -p benchmarks --benches` (confirms the sibling package is unaffected)

Release Notes:

- N/A
