### PR TITLE
agent: Stop requesting agent's test-support feature in edit_file_tool_benchmarks

### DIFF
--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -10,6 +10,13 @@ path = "src/agent.rs"
 
 [features]
 test-support = ["db/test-support"]
+# Gates `ToolInput::for_benchmarks`/`ToolCallEventStream::for_benchmarks`,
+# production-faithful equivalents of `ToolInput::test`/`ToolCallEventStream::test`
+# for production-rendering benchmarks (`crates/edit_file_tool_benchmarks`).
+# Deliberately empty: unlike `test-support`, this must not enable any
+# dependency's test-only surface, so `benchmarks` consumers keep compiling
+# production code only.
+benchmarks = []
 unit-eval = []
 e2e = []
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4992,6 +4992,19 @@ impl<T: DeserializeOwned> ToolInput<T> {
         (sender, input.cast())
     }
 
+    /// Constructs a channel-backed [`ToolInput`] through the exact same
+    /// [`ToolInputSender::channel`] production tools stream input through,
+    /// for production-rendering benchmarks that need to feed streamed input
+    /// without depending on the `test-support` feature (see this crate's
+    /// `benchmarks` feature). Behaves identically to [`Self::test`]; kept as
+    /// a separate, narrowly gated constructor so benchmark consumers never
+    /// need to enable `test-support` to reach it.
+    #[cfg(any(test, feature = "benchmarks"))]
+    pub fn for_benchmarks() -> (ToolInputSender, Self) {
+        let (sender, input) = ToolInputSender::channel();
+        (sender, input.cast())
+    }
+
     /// Wait for the final deserialized input, ignoring all partial updates.
     /// Non-streaming tools can use this to wait until the whole input is available.
     pub async fn recv(mut self) -> Result<T> {
@@ -5554,6 +5567,32 @@ impl ToolCallEventStream {
             ToolCallEventStreamReceiver(events_rx),
             cancellation_tx,
         )
+    }
+
+    /// Constructs a self-contained [`ToolCallEventStream`] through the exact
+    /// same [`ToolCallEventStream::new`] construction production tool calls
+    /// use, with its own throwaway channels and no owning [`Thread`], for
+    /// production-rendering benchmarks that need to run a tool without a live
+    /// thread (see this crate's `benchmarks` feature). Behaves identically to
+    /// [`Self::test`]; kept as a separate, narrowly gated constructor — rather
+    /// than widening `test`'s own `cfg` — so benchmark consumers never need to
+    /// enable `test-support` to reach it.
+    #[cfg(any(test, feature = "benchmarks"))]
+    pub fn for_benchmarks() -> (Self, ToolCallEventStreamReceiver) {
+        let (events_tx, events_rx) = mpsc::unbounded::<Result<ThreadEvent>>();
+        let (_cancellation_tx, cancellation_rx) = watch::channel(false);
+
+        let stream = ToolCallEventStream::new(
+            "test_id".into(),
+            acp::ToolCallId::new("0:test_id"),
+            ThreadEventStream(events_tx),
+            None,
+            cancellation_rx,
+            Rc::new(RefCell::new(ThreadSandboxGrants::default())),
+            None,
+        );
+
+        (stream, ToolCallEventStreamReceiver(events_rx))
     }
 
     /// Signal cancellation for this event stream. Only available in tests.
@@ -6673,7 +6712,12 @@ impl ToolCallEventStream {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
+// Also constructed by `ToolCallEventStream::for_benchmarks` under the
+// `benchmarks` feature, so `Deref`/`DerefMut` below (needed to read the
+// wrapped receiver at all) share that gate; the panic-based `expect_*`
+// assertion helpers stay `test-support`-only since benchmarks never need
+// them.
+#[cfg(any(test, feature = "test-support", feature = "benchmarks"))]
 pub struct ToolCallEventStreamReceiver(mpsc::UnboundedReceiver<Result<ThreadEvent>>);
 
 #[cfg(any(test, feature = "test-support"))]
@@ -6748,7 +6792,7 @@ impl ToolCallEventStreamReceiver {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "benchmarks"))]
 impl std::ops::Deref for ToolCallEventStreamReceiver {
     type Target = mpsc::UnboundedReceiver<Result<ThreadEvent>>;
 
@@ -6757,7 +6801,7 @@ impl std::ops::Deref for ToolCallEventStreamReceiver {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "test-support", feature = "benchmarks"))]
 impl std::ops::DerefMut for ToolCallEventStreamReceiver {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
@@ -6864,6 +6908,69 @@ mod tests {
     use serde_json::json;
     use settings::LanguageModelProviderSetting;
     use std::sync::Arc;
+
+    /// Proves `ToolInput::for_benchmarks` feeds a consumer the exact same
+    /// sequence of partial/full payloads as `ToolInput::test`, rather than
+    /// merely compiling to the same type.
+    #[test]
+    fn tool_input_for_benchmarks_matches_test() {
+        fn drain(mut input: ToolInput<serde_json::Value>) -> Vec<serde_json::Value> {
+            let mut values = Vec::new();
+            loop {
+                match futures::executor::block_on(input.next()) {
+                    Ok(ToolInputPayload::Partial(value)) => values.push(value),
+                    Ok(ToolInputPayload::Full(value)) => {
+                        values.push(value);
+                        break;
+                    }
+                    Ok(ToolInputPayload::InvalidJson { .. }) | Err(_) => break,
+                }
+            }
+            values
+        }
+
+        let (mut benchmark_sender, benchmark_input) = ToolInput::for_benchmarks();
+        benchmark_sender.send_partial(json!({"a": 1}));
+        benchmark_sender.send_partial(json!({"a": 1, "b": 2}));
+        benchmark_sender.send_full(json!({"a": 1, "b": 2, "c": 3}));
+
+        let (mut test_sender, test_input) = ToolInput::test();
+        test_sender.send_partial(json!({"a": 1}));
+        test_sender.send_partial(json!({"a": 1, "b": 2}));
+        test_sender.send_full(json!({"a": 1, "b": 2, "c": 3}));
+
+        assert_eq!(drain(benchmark_input), drain(test_input));
+    }
+
+    /// Proves `ToolCallEventStream::for_benchmarks` delivers the same events
+    /// to its receiver, through the same `update_tool_call_fields` production
+    /// path, as `ToolCallEventStream::test` does.
+    #[test]
+    fn tool_call_event_stream_for_benchmarks_matches_test() {
+        let (benchmark_stream, mut benchmark_rx) = ToolCallEventStream::for_benchmarks();
+        let (test_stream, mut test_rx) = ToolCallEventStream::test();
+
+        let fields = acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress);
+        benchmark_stream.update_fields(fields.clone());
+        test_stream.update_fields(fields);
+
+        let benchmark_fields = futures::executor::block_on(benchmark_rx.expect_update_fields());
+        let test_fields = futures::executor::block_on(test_rx.expect_update_fields());
+        assert_eq!(benchmark_fields, test_fields);
+
+        // Neither stream is tied to a live thread, so cancellation never
+        // resolves on its own; this proves `for_benchmarks` shares that
+        // same never-cancelled-by-default watch-channel wiring rather than
+        // some other cancellation semantics.
+        use futures::FutureExt as _;
+        assert!(
+            benchmark_stream
+                .cancelled_by_user()
+                .now_or_never()
+                .is_none()
+        );
+        assert!(test_stream.cancelled_by_user().now_or_never().is_none());
+    }
 
     async fn setup_thread_for_test(cx: &mut TestAppContext) -> (Entity<Thread>, ThreadEventStream) {
         cx.update(|cx| {

--- a/crates/edit_file_tool_benchmarks/Cargo.toml
+++ b/crates/edit_file_tool_benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dev-dependencies]
 action_log.workspace = true
-agent = { workspace = true, features = ["test-support"] }
+agent = { workspace = true, features = ["benchmarks"] }
 agent_settings.workspace = true
 assets.workspace = true
 benchmarks.workspace = true

--- a/crates/edit_file_tool_benchmarks/benches/edit_file_tool.rs
+++ b/crates/edit_file_tool_benchmarks/benches/edit_file_tool.rs
@@ -335,13 +335,13 @@ fn init_context() -> TestAppContext {
 }
 
 fn run_streamed_edit(harness: &mut BenchmarkHarness) -> EditFileToolOutput {
-    let (mut sender, input): (_, ToolInput<EditFileToolInput>) = ToolInput::test();
+    let (mut sender, input): (_, ToolInput<EditFileToolInput>) = ToolInput::for_benchmarks();
     for payload in &harness.partial_payloads {
         sender.send_partial(payload.clone());
     }
     sender.send_full(harness.final_payload.clone());
 
-    let (event_stream, _event_rx) = ToolCallEventStream::test();
+    let (event_stream, _event_rx) = ToolCallEventStream::for_benchmarks();
     let cx = harness
         .cx
         .as_ref()

--- a/crates/edit_file_tool_benchmarks/src/edit_file_tool_benchmarks.rs
+++ b/crates/edit_file_tool_benchmarks/src/edit_file_tool_benchmarks.rs
@@ -2,11 +2,11 @@
 //!
 //! This crate is split out from `benchmarks` because its harness drives the
 //! tool through `TestAppContext`/`FakeFs`/`FakeLspAdapter` and `Project::test`,
-//! which pull `test-support` into `agent`, `editor`, `language`, `lsp`,
-//! `project`, and `settings`. Cargo's feature unification would otherwise
-//! apply those test-only builds to every other benchmark target in the same
-//! package, including the ones that render production code paths. Keeping
-//! this benchmark in its own package confines that contamination to the one
+//! which pull `test-support` into `editor`, `language`, `lsp`, `project`, and
+//! `settings`. Cargo's feature unification would otherwise apply those
+//! test-only builds to every other benchmark target in the same package,
+//! including the ones that render production code paths. Keeping this
+//! benchmark in its own package confines that contamination to the one
 //! benchmark that actually needs it.
 //!
 //! It no longer needs `language_model`'s `test-support` feature: `edit_file`
@@ -21,6 +21,19 @@
 //! feature, which requests `lsp/test-support` itself; the direct request was
 //! redundant manifest debt, not a distinct capability this benchmark needed.
 //!
+//! It also no longer requests `agent`'s `test-support` feature. The only two
+//! symbols this benchmark ever needed from it, `ToolInput::test` and
+//! `ToolCallEventStream::test`, merely construct the same channel primitives
+//! (`ToolInputSender::channel`, `ToolCallEventStream::new`) that a live
+//! `Thread` uses internally to feed a running tool call. `agent` now exposes
+//! `ToolInput::for_benchmarks`/`ToolCallEventStream::for_benchmarks` behind
+//! its own narrow `benchmarks` feature that delegates to those exact
+//! constructors, so this harness reaches them without enabling any of
+//! `test-support`'s much larger surface (fake providers, settings mutation,
+//! etc.) across the rest of `agent`.
+//!
 //! This is a staging step, not a destination: the long-term goal is a harness
 //! with no `test-support` dependency at all. See `benches/edit_file_tool.rs`
-//! for the remaining test-only APIs this benchmark still relies on.
+//! for the remaining test-only APIs this benchmark still relies on
+//! (`editor`, `language`, `project`, and `settings`, all reached through
+//! `TestAppContext`/`FakeFs`/`Project::test`/`FakeLspAdapter`).

--- a/script/check-gpui-bench-feature-isolation
+++ b/script/check-gpui-bench-feature-isolation
@@ -310,7 +310,7 @@ fi
 # `edit_file_tool_benchmarks` is the isolated package `edit_file_tool` moved
 # into. It is intentionally *not* held to the isolation bar above, including
 # the `settings` checks just above: it still needs `test-support` from
-# `agent`, `editor`, `language`, `lsp`, `project`, and `settings` (via
+# `editor`, `language`, `lsp`, `project`, and `settings` (via
 # `SettingsStore::update_user_settings`, which has no production-capable
 # equivalent for mutating already-loaded settings content) for the same
 # harness this script used to document against `benchmarks`. That is tracked
@@ -365,6 +365,51 @@ output=$(cargo tree \
 direct_dependents=$(grep -A2 '[|`]-- lsp feature "test-support"$' <<< "${output}" || true)
 if grep --quiet 'edit_file_tool_benchmarks v' <<< "${direct_dependents}"; then
   echo "edit_file_tool_benchmarks directly requests lsp's \"test-support\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
+# `edit_file_tool_benchmarks` used to also directly request `agent`'s
+# `test-support` feature, entirely to reach `ToolInput::test`/
+# `ToolCallEventStream::test` for feeding the `edit_file` tool streamed input
+# and collecting its tool-call events. Both merely construct the same channel
+# primitives (`ToolInputSender::channel`, `ToolCallEventStream::new`) that a
+# live `Thread` already uses internally to run a streaming tool call (see
+# `Thread::handle_tool_use_event`/`Thread::run_tool` in `crates/agent/src/
+# thread.rs`), so `agent` now exposes `ToolInput::for_benchmarks`/
+# `ToolCallEventStream::for_benchmarks` behind its own narrow `benchmarks`
+# feature that delegates to those exact constructors. Unlike the `lsp` check
+# above, `agent`'s `test-support` feature is fully gone from this benchmark's
+# resolved graph, not just redundant as a direct edge: nothing else
+# `edit_file_tool_benchmarks` depends on has a legitimate reason to reach it
+# either.
+output=$(cargo tree \
+  --offline \
+  --package edit_file_tool_benchmarks \
+  --edges features \
+  --invert agent)
+if grep --quiet 'agent feature "test-support"' <<< "${output}"; then
+  echo "edit_file_tool_benchmarks pulls agent's \"test-support\" feature:"
+  echo "${output}"
+  exit 1
+fi
+
+# The check above proves `edit_file_tool_benchmarks` no longer reaches
+# `agent`'s `test-support` feature; this proves `agent`'s own `benchmarks`
+# feature (which `ToolInput::for_benchmarks`/`ToolCallEventStream::
+# for_benchmarks` live behind) doesn't itself resolve to any dependency's
+# `test-support`, the same guarantee this script proves above for `gpui`'s
+# `bench` feature and `multi_buffer`'s/`language`'s own `benchmarks`
+# features.
+output=$(cargo tree \
+  --offline \
+  --package agent \
+  --no-default-features \
+  --features benchmarks \
+  --edges features \
+  --invert agent)
+if grep --quiet 'test-support' <<< "${output}"; then
+  echo "agent's \"benchmarks\" feature pulls in \"test-support\":"
   echo "${output}"
   exit 1
 fi


### PR DESCRIPTION
`edit_file_tool_benchmarks` was the last of the isolated benchmark harnesses still requesting `agent`'s `test-support` feature, entirely to reach `ToolInput::test`/`ToolCallEventStream::test` for feeding the `edit_file` tool streamed input and collecting its tool-call events during the benchmark run.

Tracing both helpers back to how a live `Thread` runs a streaming tool call (`Thread::handle_tool_use_event`/`Thread::run_tool` in `crates/agent/src/thread.rs`) shows they don't fake anything: `ToolInput::test` calls the exact same `ToolInputSender::channel()` a running thread uses to hand a tool its streamed JSON payloads, and `ToolCallEventStream::test` calls the exact same `ToolCallEventStream::new` construction a running thread uses to build a tool call's event stream, just with a throwaway channel pair and no owning thread. The benchmark's only actual need is that channel construction, not any test-only behavior.

This PR adds `ToolInput::for_benchmarks`/`ToolCallEventStream::for_benchmarks` to `agent`, gated behind a new, deliberately empty `benchmarks` feature (mirroring the pattern already used by `multi_buffer`'s and `language`'s own `benchmarks` features). Both constructors delegate to the identical production channel calls `test`/`test_with_cancellation` use, just under a narrower feature gate that doesn't pull in `test-support`'s much larger surface (fake language model providers, settings mutation, and so on) across the rest of `agent`. `edit_file_tool_benchmarks` now depends on `agent/benchmarks` instead of `agent/test-support`, with no other change to its harness, fixture names, or output.

Two parity tests in `crates/agent/src/thread.rs` (`tool_input_for_benchmarks_matches_test`, `tool_call_event_stream_for_benchmarks_matches_test`) drive both the `for_benchmarks` and `test` constructors with the same inputs and assert they deliver the same streamed payload sequence, the same tool-call update event, and the same never-cancelled-by-default watch-channel semantics, so parity is proven behaviorally rather than only by both compiling.

`script/check-gpui-bench-feature-isolation` now asserts two things: `edit_file_tool_benchmarks`'s whole resolved feature graph no longer contains `agent`'s `test-support` feature at all (not merely as a redundant direct edge, the bar the existing `lsp` check in this same script applies), and `agent`'s own `benchmarks` feature does not itself resolve to any dependency's `test-support` feature, the same guarantee the script already proves for `gpui`'s `bench` feature and `multi_buffer`'s/`language`'s own `benchmarks` features.

This closes out the `agent` edge of `edit_file_tool_benchmarks`'s tracked `test-support` debt. It still needs `test-support` from `editor`, `language`, `lsp`, `project`, and `settings` for its `TestAppContext`/`FakeFs`/`FakeLspAdapter`/`Project::test` harness, unchanged by this PR and tracked by this same isolation script.

Testing:
- `cargo tree --offline --package edit_file_tool_benchmarks --edges features --invert agent` no longer shows `agent feature "test-support"` (it did before this change).
- `cargo tree --offline --package agent --no-default-features --features benchmarks --edges features --invert agent` shows no `test-support` feature anywhere.
- `bash script/check-gpui-bench-feature-isolation` passes.
- `cargo nextest run -p agent --lib`: 727 passed, 0 failed (includes the two new parity tests).
- `cargo check -p agent`, `--features test-support`, `--no-default-features --features benchmarks`: all clean, no warnings.
- `cargo check -p edit_file_tool_benchmarks --benches` and `cargo check -p benchmarks --benches` (sibling package): clean.
- `cargo bench -p edit_file_tool_benchmarks --bench edit_file_tool -- --test`: all five fixtures (`tiny_function_rewrite`, `small_function_rewrite`, `medium_many_small_changes`, `medium_insertions`, `large_multi_edit`) report `Success`.
- Full `cargo bench -p edit_file_tool_benchmarks --bench edit_file_tool` run completed in 1m9s (under the 120s budget), same benchmark IDs/throughput units as before; Criterion's reported deltas versus its saved baseline are consistent with ordinary run-to-run noise on this machine, not a behavioral change, since the tool-call execution path itself is untouched.
- `script/clippy -p agent -p edit_file_tool_benchmarks` (release, all-targets, all-features, deny warnings): clean, plus `cargo shear` and `typos` clean.
- `cargo fmt --check -p agent -p edit_file_tool_benchmarks`: clean.

Release Notes:

- N/A
