### PR TITLE
bedrock: Mark GPT-5.6 as supporting 1M token context window

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -958,8 +958,8 @@ impl MantleModel {
         match self {
             Self::Gpt5_6Sol
             | Self::Gpt5_6Terra
-            | Self::Gpt5_6Luna
-            | Self::Gpt5_5
+            | Self::Gpt5_6Luna => 1_000_000,
+            Self::Gpt5_5
             | Self::Gpt5_4 => 272_000,
             Self::Grok4_3 => 1_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -956,11 +956,8 @@ impl MantleModel {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gpt5_6Sol
-            | Self::Gpt5_6Terra
-            | Self::Gpt5_6Luna => 1_000_000,
-            Self::Gpt5_5
-            | Self::Gpt5_4 => 272_000,
+            Self::Gpt5_6Sol | Self::Gpt5_6Terra | Self::Gpt5_6Luna => 1_000_000,
+            Self::Gpt5_5 | Self::Gpt5_4 => 272_000,
             Self::Grok4_3 => 1_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -1069,7 +1066,7 @@ mod tests {
             assert_eq!(model.id(), id);
             assert_eq!(model.request_id(), request_id);
             assert_eq!(model.display_name(), display_name);
-            assert_eq!(model.max_token_count(), 272_000);
+            assert_eq!(model.max_token_count(), 1_000_000);
             assert!(model.supports_tools());
             assert!(model.supports_images());
             assert!(model.supports_thinking());


### PR DESCRIPTION
# Objective

Zed should support the 1M token context window for GPT-5.6

https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
https://aws.amazon.com/about-aws/whats-new/2026/08/gpt-sol-terra-luna-long-context-bedrock/

## Solution

Changed the `max_token_count` for the models that support 1M tokens now.

## Testing

- Literally just loaded 900k tokens by loading a codebase and have the LLM respond :)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- GPT-5.6 on Amazon Bedrock now supports 1M token context window.
