### PR TITLE
git_ui: Fix graph line colors and rendering

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -3429,15 +3429,15 @@ impl GitGraph {
                     for (color_idx, builders) in lines {
                         let line_color = accent_colors.color_for_index(color_idx as u32);
 
-                        for builder in builders {
-                            if let Ok(path) = builder.build() {
-                                // we paint each color on it's own layer to stop overlapping lines
-                                // of different colors changing the color of a line
-                                window.paint_layer(bounds, |window| {
+                        // Each color gets its own layer so that overlapping lines of
+                        // different colors don't blend into each other.
+                        window.paint_layer(bounds, |window| {
+                            for builder in builders {
+                                if let Ok(path) = builder.build() {
                                     window.paint_path(path, line_color);
-                                });
+                                }
                             }
-                        }
+                        });
                     }
                 })
             },

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -873,7 +873,6 @@ struct CommitLineKey {
 
 struct GraphData {
     lane_states: SmallVec<[LaneState; 8]>,
-    lane_colors: HashMap<ActiveLaneIdx, BranchColor>,
     parent_to_lanes: HashMap<Oid, SmallVec<[usize; 1]>>,
     next_color: BranchColor,
     accent_colors_count: usize,
@@ -889,7 +888,6 @@ impl GraphData {
     fn new(accent_colors_count: usize) -> Self {
         GraphData {
             lane_states: SmallVec::default(),
-            lane_colors: HashMap::default(),
             parent_to_lanes: HashMap::default(),
             next_color: BranchColor(0),
             accent_colors_count,
@@ -904,7 +902,6 @@ impl GraphData {
 
     fn clear(&mut self) {
         self.lane_states.clear();
-        self.lane_colors.clear();
         self.parent_to_lanes.clear();
         self.commits.clear();
         self.lines.clear();
@@ -925,13 +922,10 @@ impl GraphData {
             })
     }
 
-    fn get_lane_color(&mut self, lane_idx: ActiveLaneIdx) -> BranchColor {
-        let accent_colors_count = self.accent_colors_count;
-        *self.lane_colors.entry(lane_idx).or_insert_with(|| {
-            let color_idx = self.next_color;
-            self.next_color = BranchColor((self.next_color.0 + 1) % accent_colors_count as u8);
-            color_idx
-        })
+    fn allocate_color(&mut self) -> BranchColor {
+        let color = self.next_color;
+        self.next_color = BranchColor((color.0 + 1) % self.accent_colors_count as u8);
+        color
     }
 
     fn add_commits(&mut self, commits: &[Arc<InitialGraphCommitData>]) {
@@ -948,7 +942,16 @@ impl GraphData {
 
             let commit_lane = commit_lane.unwrap_or_else(|| self.first_empty_lane_idx());
 
-            let commit_color = self.get_lane_color(commit_lane);
+            // Color identifies a branch, not a column: a commit keeps the color of the
+            // lane it continues, so a branch that gets pushed to a different column
+            // stays the same color and two unrelated branches that happen to reuse a
+            // column don't. A lane with no color yet is either a new tip or a merge
+            // parent whose color was deferred until it landed, and starts a new color.
+            let inherited_color = match self.lane_states.get(commit_lane) {
+                Some(LaneState::Active { color, .. }) => *color,
+                _ => None,
+            };
+            let commit_color = inherited_color.unwrap_or_else(|| self.allocate_color());
 
             if let Some(lanes) = self.parent_to_lanes.remove(&commit.sha) {
                 for lane_column in lanes {

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -3326,7 +3326,6 @@ impl GitGraph {
 
                                     current_row = dest_point.y;
                                     builder.line_to(dest_point);
-                                    builder.move_to(dest_point);
                                 }
                                 CommitLineSegment::Curve {
                                     to_column,
@@ -3375,11 +3374,8 @@ impl GitGraph {
                                                 point(current_column + signed_curve_width, to_row);
                                             let curve_control = point(current_column, to_row);
 
-                                            builder.move_to(point(current_column, current_row));
                                             builder.line_to(curve_start);
-                                            builder.move_to(curve_start);
                                             builder.curve_to(curve_end, curve_control);
-                                            builder.move_to(curve_end);
                                             builder.line_to(point(to_column, to_row));
                                         }
                                         CurveKind::Merge => {
@@ -3412,22 +3408,21 @@ impl GitGraph {
                                                 point(to_column, merge_start.y + curve_height);
                                             let curve_control = point(to_column, merge_start.y);
 
+                                            // A merge line starts clear of the child's commit
+                                            // circle rather than at the pen position, so this
+                                            // must remain a separate subpath.
                                             builder.move_to(merge_start);
                                             builder.line_to(curve_start);
-                                            builder.move_to(curve_start);
                                             builder.curve_to(curve_end, curve_control);
-                                            builder.move_to(curve_end);
                                             builder.line_to(point(to_column, to_row));
                                         }
                                     }
                                     current_row = to_row;
                                     current_column = to_column;
-                                    builder.move_to(point(current_column, current_row));
                                 }
                             }
                         }
 
-                        builder.close();
                         lines.entry(line.color_idx).or_default().push(builder);
                     }
 

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -922,9 +922,43 @@ impl GraphData {
             })
     }
 
-    fn allocate_color(&mut self) -> BranchColor {
-        let color = self.next_color;
-        self.next_color = BranchColor((color.0 + 1) % self.accent_colors_count as u8);
+    /// Two lanes that are alive at the same time must not share a color: where
+    /// they meet, a shared color hides which line ends where, and two branches
+    /// can only join while both are still active. Stepping over the colors
+    /// already in use keeps every junction readable for as long as there are
+    /// more colors than live lanes.
+    ///
+    /// Past that point some pair has to share one, and which pair it is
+    /// matters. Falling back to the lane's own column makes two lanes collide
+    /// only when their columns are a whole palette apart, which leaves the
+    /// short hops that most lines make readable. Handing out the next color in
+    /// sequence instead would spread those collisions evenly over every
+    /// distance, including the adjacent lanes that are hardest to tell apart.
+    fn allocate_color(&mut self, lane: ActiveLaneIdx) -> BranchColor {
+        let accent_colors_count = (self.accent_colors_count as u8).max(1);
+        let mut color = self.next_color;
+
+        for _ in 0..accent_colors_count {
+            let in_use = self.lane_states.iter().any(|lane_state| {
+                matches!(
+                    lane_state,
+                    LaneState::Active {
+                        color: Some(lane_color),
+                        ..
+                    } if lane_color.0 == color.0
+                )
+            });
+
+            if !in_use {
+                self.next_color = BranchColor((color.0 + 1) % accent_colors_count);
+                return color;
+            }
+
+            color = BranchColor((color.0 + 1) % accent_colors_count);
+        }
+
+        let color = BranchColor((lane % accent_colors_count as usize) as u8);
+        self.next_color = BranchColor((color.0 + 1) % accent_colors_count);
         color
     }
 
@@ -951,7 +985,7 @@ impl GraphData {
                 Some(LaneState::Active { color, .. }) => *color,
                 _ => None,
             };
-            let commit_color = inherited_color.unwrap_or_else(|| self.allocate_color());
+            let commit_color = inherited_color.unwrap_or_else(|| self.allocate_color(commit_lane));
 
             if let Some(lanes) = self.parent_to_lanes.remove(&commit.sha) {
                 for lane_column in lanes {
@@ -5268,6 +5302,143 @@ mod tests {
 
         if let Err(error) = verify_all_invariants(&graph_data, &commits) {
             panic!("Graph invariant violation for recycled lanes:\n{}", error);
+        }
+    }
+
+    /// A long-lived lane keeps its color for as long as it is drawn, so colors
+    /// handed out while it is alive have to step over it even once the palette
+    /// has wrapped around. Otherwise a branch joining that lane would be drawn
+    /// in the lane's own color and the junction would be unreadable.
+    #[test]
+    fn test_allocated_color_avoids_colors_still_in_use() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let long_lived_tip = Oid::random(&mut rng);
+        let long_lived_root = Oid::random(&mut rng);
+        let first_tip = Oid::random(&mut rng);
+        let first_root = Oid::random(&mut rng);
+        let second_tip = Oid::random(&mut rng);
+        let second_root = Oid::random(&mut rng);
+        let third_tip = Oid::random(&mut rng);
+        let third_root = Oid::random(&mut rng);
+
+        let branch = |sha, parent| {
+            Arc::new(InitialGraphCommitData {
+                sha,
+                parents: smallvec![parent],
+                ref_names: vec![],
+            })
+        };
+        let root = |sha| {
+            Arc::new(InitialGraphCommitData {
+                sha,
+                parents: smallvec![],
+                ref_names: vec![],
+            })
+        };
+
+        let commits = vec![
+            // Holds lane 0, and its color, for the whole graph.
+            branch(long_lived_tip, long_lived_root),
+            // Three short branches that take lane 1 one after another.
+            branch(first_tip, first_root),
+            root(first_root),
+            branch(second_tip, second_root),
+            root(second_root),
+            branch(third_tip, third_root),
+            root(third_root),
+            root(long_lived_root),
+        ];
+
+        // Only three colors, so the third short branch is where the palette
+        // wraps back onto the color lane 0 is still using.
+        let mut graph_data = GraphData::new(3);
+        graph_data.add_commits(&commits);
+
+        let lanes = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.lane)
+            .collect::<Vec<_>>();
+        let colors = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.color_idx)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lanes, vec![0, 1, 1, 1, 1, 1, 1, 0]);
+        assert_eq!(colors, vec![0, 1, 1, 2, 2, 1, 1, 0]);
+
+        if let Err(error) = verify_all_invariants(&graph_data, &commits) {
+            panic!("Graph invariant violation for color reuse:\n{}", error);
+        }
+    }
+
+    /// Once every color is taken, one has to be reused. Picking it from the
+    /// lane's own column keeps the reuse a whole palette apart, where the next
+    /// color in sequence would have landed it right next to an existing lane.
+    #[test]
+    fn test_exhausted_palette_falls_back_to_the_lane_column() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let shas: Vec<Oid> = (0..10).map(|_| Oid::random(&mut rng)).collect();
+        let branch = |sha, parent| {
+            Arc::new(InitialGraphCommitData {
+                sha,
+                parents: smallvec![parent],
+                ref_names: vec![],
+            })
+        };
+        let root = |sha| {
+            Arc::new(InitialGraphCommitData {
+                sha,
+                parents: smallvec![],
+                ref_names: vec![],
+            })
+        };
+
+        let commits = vec![
+            // Four branches against three colors, so the fourth has to reuse
+            // one. It lands on lane 3, which wraps to the color lane 0 holds.
+            branch(shas[0], shas[4]),
+            branch(shas[1], shas[6]),
+            branch(shas[2], shas[7]),
+            branch(shas[3], shas[8]),
+            // Frees lane 0 while lane 3 keeps that lane's color alive, so the
+            // palette stays exhausted.
+            root(shas[4]),
+            // Takes lane 0 back with every color still spoken for.
+            branch(shas[5], shas[9]),
+            root(shas[6]),
+            root(shas[7]),
+            root(shas[8]),
+            root(shas[9]),
+        ];
+
+        let mut graph_data = GraphData::new(3);
+        graph_data.add_commits(&commits);
+
+        let lanes = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.lane)
+            .collect::<Vec<_>>();
+        let colors = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.color_idx)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lanes, vec![0, 1, 2, 3, 0, 0, 1, 2, 3, 0]);
+        // Lane 0 wraps to color 0, not to color 1, which is what plain
+        // sequence would have handed out here.
+        assert_eq!(colors, vec![0, 1, 2, 0, 0, 0, 1, 2, 0, 0]);
+
+        if let Err(error) = verify_all_invariants(&graph_data, &commits) {
+            panic!(
+                "Graph invariant violation for exhausted palette:\n{}",
+                error
+            );
         }
     }
 

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -5199,6 +5199,78 @@ mod tests {
         }
     }
 
+    /// A lane that goes empty can be handed to an unrelated branch later. That
+    /// branch has to start its own color rather than pick up the color of
+    /// whatever used the column before it.
+    #[test]
+    fn test_recycled_lane_does_not_reuse_the_previous_branch_color() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let first_tip = Oid::random(&mut rng);
+        let first_tip_parent = Oid::random(&mut rng);
+        let second_tip = Oid::random(&mut rng);
+        let second_tip_parent = Oid::random(&mut rng);
+        let third_tip = Oid::random(&mut rng);
+        let shared_root = Oid::random(&mut rng);
+
+        let commits = vec![
+            Arc::new(InitialGraphCommitData {
+                sha: first_tip,
+                parents: smallvec![first_tip_parent],
+                ref_names: vec![],
+            }),
+            Arc::new(InitialGraphCommitData {
+                sha: first_tip_parent,
+                parents: smallvec![shared_root],
+                ref_names: vec![],
+            }),
+            // Starts a branch of its own, so it takes the first free lane, 1.
+            Arc::new(InitialGraphCommitData {
+                sha: second_tip,
+                parents: smallvec![second_tip_parent],
+                ref_names: vec![],
+            }),
+            // Ends that branch, which frees lane 1 again.
+            Arc::new(InitialGraphCommitData {
+                sha: second_tip_parent,
+                parents: smallvec![],
+                ref_names: vec![],
+            }),
+            // Unrelated to the branch above, but reuses its lane.
+            Arc::new(InitialGraphCommitData {
+                sha: third_tip,
+                parents: smallvec![],
+                ref_names: vec![],
+            }),
+            Arc::new(InitialGraphCommitData {
+                sha: shared_root,
+                parents: smallvec![],
+                ref_names: vec![],
+            }),
+        ];
+
+        let mut graph_data = GraphData::new(8);
+        graph_data.add_commits(&commits);
+
+        let lanes = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.lane)
+            .collect::<Vec<_>>();
+        let colors = graph_data
+            .commits
+            .iter()
+            .map(|commit| commit.color_idx)
+            .collect::<Vec<_>>();
+
+        assert_eq!(lanes, vec![0, 0, 1, 1, 1, 0]);
+        assert_eq!(colors, vec![0, 0, 1, 1, 2, 0]);
+
+        if let Err(error) = verify_all_invariants(&graph_data, &commits) {
+            panic!("Graph invariant violation for recycled lanes:\n{}", error);
+        }
+    }
+
     #[test]
     fn test_git_graph_linear_commits() {
         let mut rng = StdRng::seed_from_u64(42);


### PR DESCRIPTION
# Objective

> Git Graph draws its branch lines in a way that makes them hard to follow. Two
> of the branches leaving `fb4ec2e` in the screenshots below are drawn in the
> same blue. The second dissolves into the first, so there is no telling where it ends.
>
> Two things in the color logic cause that. While I was in the rendering code I
> found two more problems — one in how each line's path is built, one in how
> those paths are painted. All four are small, but they're real. Left alone I'd
> end up folding the fixes into whatever I work on next, and that PR would be
> doing far too much at once. So they're here on their own, one commit each.

Git Graph vẽ các đường nhánh theo cách rất khó lần theo. Trong ảnh bên dưới, hai
nhánh tách ra từ `fb4ec2e` được vẽ cùng một màu xanh dương. Cái thứ hai tan
vào cái thứ nhất, không cách nào biết nó kết thúc ở đâu.

Hai chỗ trong phần chọn màu gây ra chuyện đó. Nhân lúc đọc code render tôi thấy
thêm hai chỗ nữa — một ở cách dựng path cho mỗi đường, một ở cách vẽ các path đó.
Cả bốn đều nhỏ, nhưng đều có thật. Để nguyên thì sau này tôi sẽ phải bỏ ké chúng
vào các PR khác, mà như thế thì một PR ôm quá nhiều việc. Nên tôi tách riêng ở
đây, mỗi lỗi một commit.

## Solution

One commit each.

**1. Colors followed the column, not the branch.** Lane colors were memoized in a
map keyed by the lane's column index, and that map was never cleared when a lane
went empty. So a lane handed to an unrelated branch later kept serving the
previous occupant's color, and a branch pushed into a different column changed
color partway down the graph. The color now lives on `LaneState`: a commit
inherits the color of the lane it continues, and a new color is allocated only
when the lane has none yet — a new tip, or a merge parent whose color was
deferred until it landed.

**2. A new branch could reuse a color that was still on screen.** Colors were
handed out by stepping through the palette without checking which were still in
use. A lane that spans a long stretch of history keeps its color the whole time,
so once the palette wrapped around a new branch could be handed the color of a
lane that was still being drawn — the line out to `b1cc260` in the screenshots. Allocation now
steps over the colors held by active lanes. Two branches can only join while
both lanes are active, so as long as there are more colors than live lanes this
leaves every junction distinctly colored.

Wide graphs do run out — a lane per concurrent branch easily outnumbers a narrow
theme palette — and past that point some pair has to share. There the fallback
is the lane's own column, so two lanes collide only when their columns are a
whole palette apart and the short hops most lines make stay readable. I measured
this over a 6000-commit repository, counting lines that change column and land
on a commit of their own color:

| palette | before | this PR |
|---|---|---|
| 4 | 137 | 121 |
| 6 | 65 | 48 |
| 8 | 36 | 21 |
| 13 (the default accent set) | 11 | 2 |
| 16 | 4 | 2 |

Continuing the sequence on exhaustion instead of falling back to the column
scored worse than `main` on every palette below 8, which is how I arrived at
this shape.

**3. Each line was built as a chain of disconnected subpaths.** Every segment
re-seated the pen with `move_to` before and after drawing, so what should be one
polyline was a series of separate subpaths that merely shared endpoints, each
carrying its own pair of butt caps through the stroke tessellator; the whole
thing was then closed, which for an open polyline means nothing. Those joins are
tangent-continuous, so this was **not** leaving gaps in the drawn line — the
change builds the shape that was meant, with less to tessellate. The pen now
stays where the previous segment left it. The one remaining `move_to` starts a
merge line, which deliberately begins clear of the child commit's circle.

**4. `paint_layer` was called per path instead of per color.** The layer is there
so that lines of different colors don't blend where they overlap, but it was
opened once per path. A graph showing a few hundred lines therefore opened a few
hundred layers a frame, when the palette holds only as many colors as the theme
defines — thirteen by default. Hoisting it out of the loop also means lines
sharing a color compose as one shape instead of blending into each other, which
is what the layer was meant to prevent. There is an open report of high GPU usage
in Git Graph (#54040); I have not tried to establish any connection and am not
claiming this as a fix for it.

## Testing

- `cargo test -p git_ui` — 137 passing. `script/clippy -p git_ui` and
  `cargo fmt --check` are clean.
- Added `test_recycled_lane_does_not_reuse_the_previous_branch_color`, which
  builds a graph where a lane goes empty and is then taken by an unrelated
  branch, and asserts lanes and colors directly.
- Added `test_allocated_color_avoids_colors_still_in_use`, which pins one lane
  across the whole graph and then starts short branches against a deliberately
  tiny palette so the wrap-around happens, and
  `test_exhausted_palette_falls_back_to_the_lane_column` for the case where
  every color is already spoken for.
- I checked all three against the code before their respective fixes and
  confirmed they fail there, so they pin the regressions rather than restate
  current behaviour.
- The existing `verify_all_invariants` fuzz tests
  (`test_git_graph_random_commits`, `test_git_graph_random_integration`) cover
  the structural side and still pass.
- Fixes 3 and 4 change how the drawing is submitted rather than fixing a
  defect I can demonstrate on screen, and aren't covered by a test.
- Checked by eye with `cargo run -p zed` on macOS 26.5.2 (Apple Silicon),
  against a private repository with a lot of branching — the screenshots below
  come from there. I have not been able to test on Windows or Linux.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Both shots cover the same commits in the same repository, cropped to the junction in question (`4fb8724` through `fb4ec2e`).

BEFORE: 
<img width="442" height="224" alt="image" src="https://github.com/user-attachments/assets/691b7e2f-8c67-4e0d-9cce-98cd318a2274" />

AFTER:
<img width="350" height="249" alt="image" src="https://github.com/user-attachments/assets/f7c87458-2b8c-4500-b637-da247ca8d400" />

Read bottom up. Four branches leave `fb4ec2e`; before, the one going straight up
column 0 to `7f228a3` and the one reaching six columns right to `b1cc260` are
the same blue, and the second is lost in the first. After, the line out to
`b1cc260` has a color of its own and stands clear of the lane it left.

---

Release Notes:

- Fixed Git Graph drawing unrelated branches in the same color, which made it impossible to tell them apart where they meet

