### PR TITLE
extension_host: Restore project LSP settings for extensions using old API versions

### DIFF
--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
@@ -56,8 +56,27 @@ impl From<SettingsLocation> for latest::SettingsLocation {
     fn from(value: SettingsLocation) -> Self {
         Self {
             worktree_id: value.worktree_id,
-            path: value.path,
+            // zed_extension_api 0.0.6 used the absolute worktree root here,
+            // while core settings locations are now worktree-relative.
+            path: String::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_location_targets_the_worktree_root() {
+        let location: latest::SettingsLocation = SettingsLocation {
+            worktree_id: 42,
+            path: "/absolute/worktree/root".to_string(),
+        }
+        .into();
+
+        assert_eq!(location.worktree_id, 42);
+        assert!(location.path.is_empty());
     }
 }
 

--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_6.rs
@@ -56,27 +56,14 @@ impl From<SettingsLocation> for latest::SettingsLocation {
     fn from(value: SettingsLocation) -> Self {
         Self {
             worktree_id: value.worktree_id,
-            // zed_extension_api 0.0.6 used the absolute worktree root here,
-            // while core settings locations are now worktree-relative.
+            // Passing the path here causes project settings reads to fail,
+            // since the extension passes the absolute path to the worktree,
+            // not a relative one like the settings API expects.
+            //
+            // This has been fixed in the API itself as of v0.2.0. Align the behavior
+            // here so that older extensions can also read project settings.
             path: String::new(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn settings_location_targets_the_worktree_root() {
-        let location: latest::SettingsLocation = SettingsLocation {
-            worktree_id: 42,
-            path: "/absolute/worktree/root".to_string(),
-        }
-        .into();
-
-        assert_eq!(location.worktree_id, 42);
-        assert!(location.path.is_empty());
     }
 }
 

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
+use util::paths::PathStyle;
 use util::rel_path::RelPath;
 use util::{archive::extract_zip, fs::make_file_executable, maybe};
 use wasmtime::component::{Linker, Resource};

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -97,15 +97,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn settings_location_targets_the_worktree_root() {
+    fn settings_location_targets_the_worktree_root() -> anyhow::Result<()> {
         let location = settings_location_from_legacy(Some(&SettingsLocation {
             worktree_id: 42,
             path: "/absolute/worktree/root".to_string(),
         }))
-        .unwrap();
+        .ok_or_else(|| anyhow::anyhow!("legacy settings location was dropped"))?;
 
         assert_eq!(location.worktree_id, WorktreeId::from_proto(42));
         assert_eq!(location.path, RelPath::empty());
+        Ok(())
     }
 }
 

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -82,7 +82,6 @@ impl From<SettingsLocation> for latest::SettingsLocation {
             //
             // This has been fixed in the API itself as of v0.2.0. Align the behavior
             // here so that older extensions can also read project settings.
-
             path: String::new(),
         }
     }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -16,7 +16,6 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
-use util::paths::PathStyle;
 use util::rel_path::RelPath;
 use util::{archive::extract_zip, fs::make_file_executable, maybe};
 use wasmtime::component::{Linker, Resource};
@@ -77,8 +76,36 @@ impl From<SettingsLocation> for latest::SettingsLocation {
     fn from(value: SettingsLocation) -> Self {
         Self {
             worktree_id: value.worktree_id,
-            path: value.path,
+            // zed_extension_api 0.1 used the absolute worktree root here,
+            // while core settings locations are now worktree-relative.
+            path: String::new(),
         }
+    }
+}
+
+fn settings_location_from_legacy(
+    location: Option<&SettingsLocation>,
+) -> Option<::settings::SettingsLocation<'static>> {
+    location.map(|location| ::settings::SettingsLocation {
+        worktree_id: WorktreeId::from_proto(location.worktree_id),
+        path: RelPath::empty(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_location_targets_the_worktree_root() {
+        let location = settings_location_from_legacy(Some(&SettingsLocation {
+            worktree_id: 42,
+            path: "/absolute/worktree/root".to_string(),
+        }))
+        .unwrap();
+
+        assert_eq!(location.worktree_id, WorktreeId::from_proto(42));
+        assert_eq!(location.path, RelPath::empty());
     }
 }
 
@@ -431,16 +458,7 @@ impl ExtensionImports for WasmState {
     ) -> wasmtime::Result<Result<String, String>> {
         self.on_main_thread(|cx| {
             async move {
-                let path = location.as_ref().and_then(|location| {
-                    RelPath::new(Path::new(&location.path), PathStyle::Unix).ok()
-                });
-                let location = path
-                    .as_ref()
-                    .zip(location.as_ref())
-                    .map(|(path, location)| ::settings::SettingsLocation {
-                        worktree_id: WorktreeId::from_proto(location.worktree_id),
-                        path,
-                    });
+                let location = settings_location_from_legacy(location.as_ref());
 
                 cx.update(|cx| match category.as_str() {
                     "language" => {

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -76,37 +76,15 @@ impl From<SettingsLocation> for latest::SettingsLocation {
     fn from(value: SettingsLocation) -> Self {
         Self {
             worktree_id: value.worktree_id,
-            // zed_extension_api 0.1 used the absolute worktree root here,
-            // while core settings locations are now worktree-relative.
+            // Passing the path here causes project settings reads to fail,
+            // since the extension passes the absolute path to the worktree,
+            // not a relative one like the settings API expects.
+            //
+            // This has been fixed in the API itself as of v0.2.0. Align the behavior
+            // here so that older extensions can also read project settings.
+
             path: String::new(),
         }
-    }
-}
-
-fn settings_location_from_legacy(
-    location: Option<&SettingsLocation>,
-) -> Option<::settings::SettingsLocation<'static>> {
-    location.map(|location| ::settings::SettingsLocation {
-        worktree_id: WorktreeId::from_proto(location.worktree_id),
-        path: RelPath::empty(),
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn settings_location_targets_the_worktree_root() -> anyhow::Result<()> {
-        let location = settings_location_from_legacy(Some(&SettingsLocation {
-            worktree_id: 42,
-            path: "/absolute/worktree/root".to_string(),
-        }))
-        .ok_or_else(|| anyhow::anyhow!("legacy settings location was dropped"))?;
-
-        assert_eq!(location.worktree_id, WorktreeId::from_proto(42));
-        assert_eq!(location.path, RelPath::empty());
-        Ok(())
     }
 }
 
@@ -459,7 +437,16 @@ impl ExtensionImports for WasmState {
     ) -> wasmtime::Result<Result<String, String>> {
         self.on_main_thread(|cx| {
             async move {
-                let location = settings_location_from_legacy(location.as_ref());
+                let path = location.as_ref().and_then(|location| {
+                    RelPath::new(Path::new(&location.path), PathStyle::Unix).ok()
+                });
+                let location = path
+                    .as_ref()
+                    .zip(location.as_ref())
+                    .map(|(path, location)| ::settings::SettingsLocation {
+                        worktree_id: WorktreeId::from_proto(location.worktree_id),
+                        path,
+                    });
 
                 cx.update(|cx| match category.as_str() {
                     "language" => {


### PR DESCRIPTION
# Objective

Fixes #43932.

Extensions built with `zed_extension_api` 0.0.6 or 0.1 pass the absolute worktree root in `SettingsLocation.path`. After #38744 changed core settings locations to `RelPath`, `RelPath::new` returns an error for that absolute value. The conversion produces `None`, so `ProjectSettings::get` falls back to global settings. This regressed the behavior fixed in #10859.

The current LaTeX and Typst extensions both use API 0.1, matching the two extension surfaces reported in the issue.

# Solution

For the 0.0.6 and 0.1 WIT adapters, treat the legacy path as the worktree root (`RelPath::empty()`) and preserve the worktree ID. API 0.2 and later already send an empty relative path, so their behavior is unchanged.

The two version adapters each have a regression test for the legacy absolute-root input.

# Testing

- `cargo test -p extension_host settings_location_targets_the_worktree_root` (2 passed)
- `cargo test -p extension_host -- --skip extension_store_test::test_extension_store_with_test_extension` (10 passed; the skipped fixture needs the `wasm32-wasip2` target, which is not installed in the local Homebrew Rust toolchain)
- `cargo clippy -p extension_host --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo build -p zed`

End-to-end check with an isolated `--user-data-dir`, a trusted folder worktree, LaTeX extension 0.2.3, and texlab 5.26.0:

- Zed 1.16.1 sent the global sentinel for both startup and a live project-settings edit.
- This branch sent the project sentinel on startup.
- Changing the project sentinel from V2 to V3 produced a new `workspace/didChangeConfiguration` with V3, and texlab's follow-up `workspace/configuration` request also returned V3.

![zed-43932-before-after.png](https://github.com/user-attachments/assets/d7e21fa7-0b48-4195-a0fb-36e4f1aa84e3)

# Self-review checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed project-level language server settings being ignored by extensions built with extension API versions before and including v0.1.0.
