### PR TITLE
git_ui: Preserve staged changes when discarding unstaged file changes

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -363,11 +363,30 @@ impl GitRepository for FakeGitRepository {
 
     fn checkout_files(
         &self,
-        _commit: String,
-        _paths: Vec<RepoPath>,
+        commit: String,
+        paths: Vec<RepoPath>,
         _env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
-        unimplemented!()
+        let state = self.state.clone();
+        let fs = self.fs.clone();
+        let repo_dir = self.repository_dir_path.clone();
+        async move {
+            let state = state.lock();
+            for path in paths {
+                let content = if commit.is_empty() {
+                    state.index_contents.get(&path).cloned()
+                } else {
+                    state.head_contents.get(&path).cloned()
+                };
+                if let Some(content) = content {
+                    let file_path = repo_dir.join(path.as_ref());
+                    fs.save(&file_path, &content.as_slice().into(), Default::default())
+                        .await?;
+                }
+            }
+            Ok(())
+        }
+        .boxed()
     }
 
     fn path(&self) -> PathBuf {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1522,8 +1522,14 @@ impl GitRepository for RealGitRepository {
                 return Ok(());
             }
 
+            let mut args = vec!["checkout"];
+            if !commit.is_empty() {
+                args.push(&commit);
+            }
+            args.push("--");
+
             let output = git
-                .build_command(&["checkout", &commit, "--"])
+                .build_command(&args)
                 .envs(env.iter())
                 .args(paths.iter().map(|path| path.as_unix_str()))
                 .output()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2402,13 +2402,18 @@ impl GitPanel {
                 .repo_path_to_project_path(&entry.repo_path, cx)?;
             let workspace = self.workspace.clone();
 
-            if entry.status.staging().has_staged() {
-                self.change_file_stage(false, vec![entry.clone()], cx);
-            }
             let filename = path.path.file_name()?.to_string();
 
             if !entry.status.is_created() {
-                self.perform_checkout(vec![entry.clone()], window, cx);
+                let commit = if entry.staging == StageStatus::Unstaged {
+                    ""
+                } else {
+                    if entry.status.staging().has_staged() {
+                        self.change_file_stage(false, vec![entry.clone()], cx);
+                    }
+                    "HEAD"
+                };
+                self.perform_checkout(commit, vec![entry.clone()], window, cx);
             } else {
                 let prompt = prompt(&format!("Trash {}?", filename), None, window, cx);
                 cx.spawn_in(window, async move |_, cx| {
@@ -2439,6 +2444,7 @@ impl GitPanel {
 
     fn perform_checkout(
         &mut self,
+        commit: &'static str,
         entries: Vec<GitStatusEntry>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -2468,7 +2474,7 @@ impl GitPanel {
             this.update_in(cx, |this, window, cx| {
                 let task = active_repository.update(cx, |repo, cx| {
                     repo.checkout_files(
-                        "HEAD",
+                        commit,
                         entries
                             .into_iter()
                             .map(|entries| entries.repo_path)
@@ -2553,7 +2559,7 @@ impl GitPanel {
         cx.spawn_in(window, async move |this, cx| {
             if let Ok(RestoreCancel::RestoreTrackedFiles) = prompt.await {
                 this.update_in(cx, |this, window, cx| {
-                    this.perform_checkout(entries, window, cx);
+                    this.perform_checkout("HEAD", entries, window, cx);
                 })
                 .ok();
             }
@@ -13209,6 +13215,99 @@ mod tests {
             !detail.contains("unstaged.rs"),
             "prompt should NOT list unstaged.rs, got: {detail}"
         );
+    }
+
+    #[gpui::test]
+    async fn test_discard_unstaged_changes_preserves_staged(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "partially_staged.rs": "working tree modified\n",
+                }
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            Path::new(path!("/root/project/.git")),
+            &[(
+                "partially_staged.rs",
+                FileStatus::Tracked(TrackedStatus {
+                    index: StatusCode::Modified,
+                    worktree: StatusCode::Modified,
+                }),
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+        cx.executor().run_until_parked();
+
+        let unstaged_entry = panel.read_with(cx, |panel, _| {
+            panel
+                .entries
+                .iter()
+                .find(|e| {
+                    if let Some(s) = e.status_entry() {
+                        s.repo_path == repo_path("partially_staged.rs")
+                            && s.staging == StageStatus::Unstaged
+                    } else {
+                        false
+                    }
+                })
+                .cloned()
+        });
+        assert!(unstaged_entry.is_some(), "unstaged entry should exist");
+
+        panel.update_in(cx, |panel, window, cx| {
+            let entry_ix = panel
+                .entries
+                .iter()
+                .position(|e| {
+                    if let Some(s) = e.status_entry() {
+                        s.repo_path == repo_path("partially_staged.rs")
+                            && s.staging == StageStatus::Unstaged
+                    } else {
+                        false
+                    }
+                })
+                .expect("unstaged entry should be in entries");
+            panel.selected_entry = Some(entry_ix);
+            panel.revert_selected(&git::RestoreFile { skip_prompt: true }, window, cx);
+        });
+        cx.executor().run_until_parked();
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #63047

### Description
Previously, clicking "Discard Changes" on an unstaged entry of a partially staged file would unstage the file and check out `HEAD`, wiping out both staged and unstaged work.

This PR:
1. Prevents unstaging when reverting an entry from the unstaged section.
2. Checks out from the Git index (`git checkout -- <paths>`) when discarding unstaged changes, preserving staged modifications.
3. Adds unit test `test_discard_unstaged_changes_preserves_staged`.

### Testing
- Added unit test in `crates/git_ui/src/git_panel.rs`.
- Verified `checkout_files` supports index-based checkout.

Release Notes:

- Fixed an issue where discarding unstaged changes in the Git panel would also discard staged changes from the same file ([#63047](https://github.com/zed-industries/zed/issues/63047)).
