### PR TITLE
fs: Stream recursive copies without materializing full trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3418,6 +3418,11 @@ pub async fn copy_recursive<'a>(
     target: &'a Path,
     options: CopyOptions,
 ) -> Result<()> {
+    if !target.starts_with(source) {
+        return copy_recursive_streaming(fs, source, target, options).await;
+    }
+
+    // Snapshot the source tree when copying into itself so newly-created targets are not revisited.
     for (item, is_dir) in read_dir_items(fs, source).await? {
         let Ok(item_relative_path) = item.strip_prefix(source) else {
             continue;
@@ -3450,6 +3455,64 @@ pub async fn copy_recursive<'a>(
         }
     }
     Ok(())
+}
+
+fn copy_recursive_streaming<'a>(
+    fs: &'a dyn Fs,
+    source: &'a Path,
+    target: &'a Path,
+    options: CopyOptions,
+) -> BoxFuture<'a, Result<()>> {
+    use futures::future::FutureExt;
+
+    async move {
+        let metadata = fs
+            .metadata(source)
+            .await?
+            .with_context(|| format!("path does not exist: {source:?}"))?;
+
+        if !metadata.is_dir {
+            return fs.copy_file(source, target, options).await;
+        }
+
+        let target_exists = fs
+            .metadata(target)
+            .await
+            .is_ok_and(|metadata| metadata.is_some());
+        if target_exists && !options.overwrite {
+            if options.ignore_if_exists {
+                return Ok(());
+            }
+            anyhow::bail!("{target:?} already exists");
+        }
+
+        if target_exists {
+            fs.remove_dir(
+                target,
+                RemoveOptions {
+                    recursive: true,
+                    ignore_if_not_exists: true,
+                },
+            )
+            .await?;
+        }
+        fs.create_dir(target).await?;
+
+        let mut children = fs.read_dir(source).await?;
+        while let Some(child_path) = children.next().await {
+            let Ok(child_path) = child_path else {
+                continue;
+            };
+            let Some(file_name) = child_path.file_name() else {
+                continue;
+            };
+            let child_target = target.join(file_name);
+            copy_recursive_streaming(fs, &child_path, &child_target, options).await?;
+        }
+
+        Ok(())
+    }
+    .boxed()
 }
 
 /// Recursively reads all of the paths in the given directory.


### PR DESCRIPTION
## Summary

`copy_recursive` currently calls `read_dir_items` before copying, which materializes every path in the source tree in memory before the first copy is performed. For large directory trees, that makes recursive copies require memory proportional to the total number and length of paths.

This change streams ordinary, non-overlapping recursive copies one directory at a time. It preserves the existing snapshot behavior when the destination is inside the source tree, because those copies must not discover and recursively copy the destination they just created.

The existing `CopyOptions` behavior is preserved, including `overwrite` and `ignore_if_exists` handling.

## Testing

The exact source change was qualified on the fork against the current upstream base with:

- `cargo fmt --all -- --check`
- `cargo check -p fs --all-targets`
- `cargo test -p fs`
- `cargo check -p worktree --all-targets`
- `cargo test -p worktree`

All passed. The existing recursive-copy integration tests include copying a directory into one of its own descendants; that coverage caught an earlier streaming-only implementation, which was rejected and replaced with the overlap-safe hybrid used here.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's contribution guidelines
- [x] Tests cover the changed behavior
- [x] Performance impact has been considered and is the purpose of this change

Release Notes:

- N/A