### PR TITLE
extension_cli: Error on unrecognized files and queries in language directories

### DIFF
--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -15,6 +15,7 @@ use extension::extension_builder::CompilationConcurrency;
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 use extension::{ExtensionManifest, ExtensionSnippets};
 use language::LanguageConfig;
+use language::QueryFile;
 use reqwest_client::ReqwestClient;
 use settings_content::SemanticTokenRules;
 use snippet_provider::file_to_snippets;
@@ -22,6 +23,28 @@ use snippet_provider::format::VsSnippetsFile;
 use task::TaskTemplates;
 use tokio::process::Command;
 use tree_sitter::{Language, Query, WasmStore};
+
+struct TestingContext {
+    known_resources: BTreeSet<PathBuf>,
+}
+
+impl TestingContext {
+    fn new(manifest: &ExtensionManifest, extension_path: &Path) -> Self {
+        let known_resources = manifest
+            .snippets
+            .as_ref()
+            .map(ExtensionSnippets::paths)
+            .into_iter()
+            .flatten()
+            .map(|relative_path| extension_path.join(relative_path))
+            .collect();
+        Self { known_resources }
+    }
+
+    fn is_known_resource(&self, path: &Path) -> bool {
+        self.known_resources.contains(path)
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "zed-extension")]
@@ -95,8 +118,9 @@ async fn main() -> Result<()> {
     let extension_provides = manifest.provides();
     validate_extension_features(&extension_provides)?;
 
+    let cx = TestingContext::new(&manifest, &extension_path);
     let grammars = test_grammars(&manifest, &extension_path, &mut wasm_store)?;
-    test_languages(&manifest, &extension_path, &grammars)?;
+    test_languages(&manifest, &extension_path, &grammars, &cx)?;
     test_themes(&manifest, &extension_path, fs.clone()).await?;
     test_snippets(&manifest, &extension_path, fs.clone()).await?;
     test_debug_adapter_schemas(&manifest, &extension_path, fs.clone()).await?;
@@ -436,6 +460,7 @@ fn test_languages(
     manifest: &ExtensionManifest,
     extension_path: &Path,
     grammars: &HashMap<String, Language>,
+    context: &TestingContext,
 ) -> Result<()> {
     for relative_language_dir in &manifest.languages {
         let language_dir = extension_path.join(relative_language_dir);
@@ -483,19 +508,28 @@ fn test_languages(
                                 )
                             })?;
                 }
-                _ if file_name.ends_with(".scm") => {
-                    let grammar = grammar.with_context(|| {
-                        format! {
-                            "language {} provides query {} but no grammar",
-                            config.name,
-                            file_path.display()
-                        }
-                    })?;
+                _ => {
+                    if let Ok(_query) = file_name.parse::<QueryFile>() {
+                        let grammar = grammar.with_context(|| {
+                            format! {
+                                "language {} provides query {} but no grammar",
+                                config.name,
+                                file_path.display()
+                            }
+                        })?;
 
-                    let query_source = fs::read_to_string(&file_path)?;
-                    let _query = Query::new(grammar, &query_source)?;
+                        let query_source = fs::read_to_string(&file_path)?;
+                        let _query = Query::new(grammar, &query_source)?;
+                    } else if file_name.ends_with(".scm") {
+                        bail!(
+                            "unrecognized query found: Query {file_name} is not supported by Zed and should be removed"
+                        )
+                    } else if !context.is_known_resource(&file_path) {
+                        bail!(
+                            "file {file_name} is not recognized within languages and should be removed"
+                        )
+                    }
                 }
-                _ => {}
             }
         }
 

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -521,12 +521,10 @@ fn test_languages(
                         let query_source = fs::read_to_string(&file_path)?;
                         let _query = Query::new(grammar, &query_source)?;
                     } else if file_name.ends_with(".scm") {
-                        bail!(
-                            "unrecognized query found: Query {file_name} is not supported by Zed and should be removed"
-                        )
+                        bail!("query {file_name} is not supported by Zed and should be removed")
                     } else if !context.is_known_resource(&file_path) {
                         bail!(
-                            "file {file_name} is not recognized within languages and should be removed"
+                            "'{file_name}' is not a supported file in a language directory and should be removed"
                         )
                     }
                 }


### PR DESCRIPTION
This ensures that we do not copy over resources we do not need for languages. We enforce this at this stage so that potential contributors to these extensions do not think these files might be needed for the given language.

Release Notes:

- N/A
