### PR TITLE
repl: Stop offering an ipykernel install that cannot succeed

### DIFF
--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -391,8 +391,17 @@ impl PickerDelegate for KernelPickerDelegate {
                                                     )
                                                 })
                                                 .when(!has_ipykernel, |flex| {
+                                                    // "not installed" reads as "pick me
+                                                    // and I will install it", which is a
+                                                    // dead end for an environment no
+                                                    // installer will write to.
+                                                    let label = if spec.can_install_ipykernel() {
+                                                        "ipykernel not installed"
+                                                    } else {
+                                                        "needs a virtual environment"
+                                                    };
                                                     flex.child(
-                                                        Label::new("ipykernel not installed")
+                                                        Label::new(label)
                                                             .size(LabelSize::XSmall)
                                                             .color(Color::Warning),
                                                     )

--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -202,6 +202,54 @@ pub fn start_kernel_tasks<S: KernelSession + 'static>(
     (request_tx, stdin_tx)
 }
 
+/// Asks an interpreter whether `ipykernel` is importable and, if not, whether it could
+/// be installed.
+///
+/// PEP 668 lets a distribution drop an `EXTERNALLY-MANAGED` marker beside the stdlib to
+/// say "an installer must refuse to write here"; Homebrew and uv both ship one. The
+/// marker alone is not the answer, though: a virtual environment shares its base
+/// interpreter's stdlib, so the marker is still visible from inside one even though
+/// installing there is fine. So the venv test has to come first, which is exactly the
+/// order pip itself uses.
+const IPYKERNEL_PROBE: &str = r#"
+import os, sys, sysconfig
+try:
+    import ipykernel
+    has = 1
+except Exception:
+    has = 0
+in_venv = sys.prefix != sys.base_prefix
+marker = os.path.join(sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED")
+can = 1 if in_venv or not os.path.exists(marker) else 0
+print(has, can)
+"#;
+
+/// Returns `(has_ipykernel, can_install_ipykernel)`.
+///
+/// A probe that does not run at all leaves installability `true`: that keeps the install
+/// offer for environments we could not classify, where attempting it and reporting the
+/// real error beats hiding the only route forward.
+async fn probe_ipykernel(python_path: &str) -> (bool, bool) {
+    let Ok(output) = util::command::new_command(python_path)
+        .args(["-c", IPYKERNEL_PROBE])
+        .output()
+        .await
+    else {
+        return (false, true);
+    };
+
+    if !output.status.success() {
+        return (false, true);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut fields = stdout.split_whitespace();
+    match (fields.next(), fields.next()) {
+        (Some(has), Some(can)) => (has == "1", can == "1"),
+        _ => (false, true),
+    }
+}
+
 pub trait KernelSession: Sized {
     fn route(&mut self, message: &JupyterMessage, window: &mut Window, cx: &mut Context<Self>);
     fn kernel_errored(&mut self, error_message: String, cx: &mut Context<Self>);
@@ -213,6 +261,11 @@ pub struct PythonEnvKernelSpecification {
     pub path: PathBuf,
     pub kernelspec: JupyterKernelspec,
     pub has_ipykernel: bool,
+    /// Whether `ipykernel` could be installed here if it is missing. PEP 668 lets an
+    /// interpreter mark itself externally managed, and pip and uv both refuse to write
+    /// to one, so offering an install for those environments only ever produces a
+    /// failure.
+    pub can_install_ipykernel: bool,
     /// Display label for the environment type: "venv", "Conda", "Pyenv", etc.
     pub environment_kind: Option<String>,
 }
@@ -346,6 +399,15 @@ impl KernelSpecification {
                 true
             }
             Self::PythonEnv(spec) => spec.has_ipykernel,
+        }
+    }
+
+    pub fn can_install_ipykernel(&self) -> bool {
+        match self {
+            Self::Jupyter(_) | Self::JupyterServer(_) | Self::SshRemote(_) | Self::WslRemote(_) => {
+                true
+            }
+            Self::PythonEnv(spec) => spec.can_install_ipykernel,
         }
     }
 
@@ -507,12 +569,8 @@ pub fn python_env_kernel_specifications(
                     let python_path = toolchain.path.to_string();
                     let environment_kind = extract_environment_kind(&toolchain.as_json);
 
-                    let has_ipykernel = util::command::new_command(&python_path)
-                        .args(&["-c", "import ipykernel"])
-                        .output()
-                        .await
-                        .map(|output| output.status.success())
-                        .unwrap_or(false);
+                    let (has_ipykernel, can_install_ipykernel) =
+                        probe_ipykernel(&python_path).await;
 
                     let mut env = HashMap::new();
                     if let Some(python_bin_dir) = PathBuf::from(&python_path).parent() {
@@ -560,6 +618,7 @@ pub fn python_env_kernel_specifications(
                         path: PathBuf::from(&python_path),
                         kernelspec,
                         has_ipykernel,
+                        can_install_ipykernel,
                         environment_kind,
                     }))
                 })

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -75,6 +75,33 @@ pub fn assign_kernelspec(
     Ok(())
 }
 
+/// Picks the line worth showing out of a failed `pip`/`uv` run.
+///
+/// Both write styled output, and uv ends a refusal with a `hint:` line, so taking the
+/// last line reliably surfaced the suggestion while dropping the reason: an externally
+/// managed environment reported "Consider creating a virtual environment" and never said
+/// why. Prefer the first line that names an error, and fall back to the last non-empty
+/// line for installers that do not label anything.
+fn installer_failure_reason(stderr: &[u8]) -> String {
+    let stderr = terminal::strip_ansi_text(stderr);
+
+    let labelled = stderr.lines().map(str::trim).find(|line| {
+        let lowered = line.to_ascii_lowercase();
+        lowered.starts_with("error:") || lowered.starts_with("error ")
+    });
+
+    if let Some(line) = labelled {
+        return line.to_string();
+    }
+
+    stderr
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+        .unwrap_or("unknown error")
+        .to_string()
+}
+
 pub fn install_ipykernel_and_assign(
     kernel_specification: KernelSpecification,
     weak_editor: WeakEntity<Editor>,
@@ -94,6 +121,31 @@ pub fn install_ipykernel_and_assign(
     let notification_id = NotificationId::unique::<IpykernelInstall>();
 
     let workspace = Workspace::for_window(window, cx);
+
+    // PEP 668: an externally managed interpreter turns every installer away, so say what
+    // would actually work instead of starting an install that cannot finish. Callers
+    // discard this function's `Result`, so the explanation has to reach the user as a
+    // toast rather than an error return.
+    if !env_spec.can_install_ipykernel {
+        if let Some(workspace) = &workspace {
+            workspace.update(cx, |workspace, cx| {
+                workspace.show_toast(
+                    workspace::Toast::new(
+                        notification_id.clone(),
+                        format!(
+                            "{} is externally managed, so ipykernel cannot be installed \
+                             into it. Create a virtual environment (for example `uv venv` \
+                             or `python -m venv .venv`) and select that instead.",
+                            env_name
+                        ),
+                    ),
+                    cx,
+                );
+            });
+        }
+        return Ok(());
+    }
+
     if let Some(workspace) = &workspace {
         workspace.update(cx, |workspace, cx| {
             workspace.show_toast(
@@ -133,8 +185,7 @@ pub fn install_ipykernel_and_assign(
         if output.status.success() {
             anyhow::Ok(())
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("{}", stderr.lines().last().unwrap_or("unknown error"))
+            anyhow::bail!("{}", installer_failure_reason(&output.stderr))
         }
     });
 
@@ -684,6 +735,65 @@ mod tests {
     use gpui::App;
     use indoc::indoc;
     use language::{Buffer, Language, LanguageConfig, LanguageRegistry};
+
+    /// Verbatim stderr from `uv pip install ipykernel` against a uv-managed
+    /// interpreter, ANSI styling and all. The reason is on the `error:` line and the
+    /// trailing line is a `hint:`, so taking the last line reported the suggestion and
+    /// dropped the cause.
+    const UV_EXTERNALLY_MANAGED_STDERR: &str = concat!(
+        "\x1b[2mUsing Python 3.11.15 environment at: /home/u/.local/share/uv/python/cpython-3.11.15\x1b[0m\n",
+        "\x1b[1m\x1b[31merror\x1b[39m\x1b[0m\x1b[1m:\x1b[0m The interpreter at ",
+        "\x1b[36m/home/u/.local/share/uv/python/cpython-3.11.15\x1b[39m is externally managed, ",
+        "and indicates the following:\n",
+        "\n",
+        "\x1b[32m  This Python installation is managed by uv and should not be modified.\x1b[39m\n",
+        "\n",
+        "\x1b[36m\x1b[1mhint\x1b[0m\x1b[39m\x1b[1m:\x1b[0m Consider creating a virtual environment, e.g., with `uv venv`\n",
+    );
+
+    #[test]
+    fn test_installer_failure_reason_prefers_the_error_over_the_hint() {
+        let reason = installer_failure_reason(UV_EXTERNALLY_MANAGED_STDERR.as_bytes());
+
+        assert!(
+            reason.contains("externally managed"),
+            "the reason the install failed must survive, got: {reason}"
+        );
+        assert!(
+            !reason.contains("hint"),
+            "the trailing hint must not be reported as the error, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn test_installer_failure_reason_strips_ansi() {
+        let reason = installer_failure_reason(UV_EXTERNALLY_MANAGED_STDERR.as_bytes());
+
+        assert!(
+            !reason.contains('\x1b'),
+            "escape sequences must not reach the toast, got: {reason:?}"
+        );
+        assert!(
+            reason.starts_with("error:"),
+            "the error label is split across escapes, so stripping has to happen first, got: {reason:?}"
+        );
+    }
+
+    #[test]
+    fn test_installer_failure_reason_falls_back_to_the_last_line() {
+        let stderr = b"Collecting ipykernel\nSomething went wrong\n\n";
+
+        assert_eq!(
+            installer_failure_reason(stderr),
+            "Something went wrong",
+            "installers that label nothing should still report their last real line"
+        );
+    }
+
+    #[test]
+    fn test_installer_failure_reason_handles_empty_output() {
+        assert_eq!(installer_failure_reason(b""), "unknown error");
+    }
 
     #[gpui::test]
     fn test_snippet_ranges(cx: &mut App) {


### PR DESCRIPTION
The REPL kernel picker lists Python environments that lack `ipykernel` as "ipykernel not installed" and offers to install it on selection. For an externally managed interpreter that install can never succeed, so selecting one starts a spinner and ends in a failure whose message does not say why.

This is the shipped toolbar menu in any `.py` file, not the flag-gated notebook UI. On a machine whose Pythons all come from uv or Homebrew — a common setup — every entry in the list is un-installable, including the one badged "Recommended".

## Why the install cannot succeed

`has_ipykernel` is a probe run at discovery (`python -c "import ipykernel"`). It answers *"is it installed?"* and is then used to decide *"should we offer to install it?"* — a question it was never asked:

```rust
if kernelspec.has_ipykernel() { assign_kernelspec(..) } else { install_ipykernel_and_assign(..) }
```

Under PEP 668 an interpreter may ship an `EXTERNALLY-MANAGED` marker meaning "an installer must refuse to write here". Both pip and uv honor it:

```
$ uv pip install ipykernel --python .../cpython-3.11.15/bin/python3
error: The interpreter at ... is externally managed
hint: Consider creating a virtual environment, e.g., with `uv venv`
```

## The marker alone is not the discriminator

A virtual environment shares its base interpreter's stdlib directory, so the marker is still visible from inside a venv created from an externally managed base — while installing into that venv is perfectly fine. Verified with `--dry-run` on both installers:

| Interpreter | `EXTERNALLY-MANAGED` visible | pip / uv |
| --- | --- | --- |
| uv-managed base | yes | refuses |
| venv created from it | yes | installs |

Keying off the marker alone would therefore mark every venv derived from a uv or Homebrew Python as un-installable — worse than the current bug, since those are the environments where installing works. The venv test has to come first, which is the order pip itself uses.

## Changes

- **`kernels/mod.rs`** — the discovery probe now reports installability alongside importability, in the same subprocess it already spawns, so this costs no extra process per environment. Stored as `can_install_ipykernel`.
- **`repl_editor.rs`** — `install_ipykernel_and_assign` refuses up front for such environments and explains that a virtual environment is needed, instead of running an installer that will be turned away. It surfaces as a toast because callers discard the returned `Result`.
- **`components/kernel_options.rs`** — those entries now read "needs a virtual environment" rather than "ipykernel not installed", which invites a click that cannot work.
- **`repl_editor.rs`** — failure reporting strips ANSI and prefers the `error:` line. uv ends a refusal with a `hint:` line, so taking the last line reliably surfaced the suggestion and dropped the cause; the word `error` is itself split across escape sequences, so stripping has to happen before matching.

A probe that cannot run leaves installability `true`, preserving today's behavior for environments that could not be classified — attempting and reporting the real error beats hiding the only route forward.

## Not changed

The issue this came from also suggested suppressing the "Recommended" badge for these entries. "Recommended" means "matches the active Python toolchain", so suppressing it would hide the user's actual selected interpreter; the label change already carries the warning.

## Tests

Unit tests for the failure-reason extraction use uv's verbatim stderr, escape sequences included: the reason survives, the hint is not mistaken for it, no escapes reach the toast, and unlabelled installer output still falls back to its last real line.

The probe was checked against real interpreters — a uv-managed base reports "no ipykernel, cannot install", a venv created from it reports "no ipykernel, can install", and that venv reports "has ipykernel" after an install that did in fact succeed.

Release Notes:

- Fixed the REPL kernel picker offering an `ipykernel` install for externally managed Python interpreters, where it could never succeed, and hiding the reason when an install failed
