### PR TITLE
grammars: Inject SurrealQL syntax in comment-labeled template literals in TypeScript/JavaScript

### DIFF
--- a/crates/grammars/src/javascript/injections.scm
+++ b/crates/grammars/src/javascript/injections.scm
@@ -164,3 +164,14 @@
   ])
   (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
   (#set! injection.language "WGSL/WESL"))
+
+; '/* surql */' or '/*surql*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*surql\\s*\\*\\/")
+  (#set! injection.language "surrealql"))

--- a/crates/grammars/src/javascript/injections.scm
+++ b/crates/grammars/src/javascript/injections.scm
@@ -165,6 +165,13 @@
   (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
   (#set! injection.language "WGSL/WESL"))
 
+(call_expression
+  function: (identifier) @_name
+  (#eq? @_name "surql")
+  arguments: (template_string
+    (string_fragment) @injection.content
+    (#set! injection.language "surrealql")))
+
 ; '/* surql */' or '/*surql*/'
 (((comment) @_ecma_comment
   [

--- a/crates/grammars/src/typescript/injections.scm
+++ b/crates/grammars/src/typescript/injections.scm
@@ -219,3 +219,14 @@
   ])
   (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
   (#set! injection.language "WGSL/WESL"))
+
+; '/* surql */' or '/*surql*/'
+(((comment) @_ecma_comment
+  [
+    (string
+      (string_fragment) @injection.content)
+    (template_string
+      (string_fragment) @injection.content)
+  ])
+  (#match? @_ecma_comment "^\\/\\*\\s*surql\\s*\\*\\/")
+  (#set! injection.language "surrealql"))

--- a/crates/grammars/src/typescript/injections.scm
+++ b/crates/grammars/src/typescript/injections.scm
@@ -220,6 +220,13 @@
   (#match? @_ecma_comment "^\\/\\*\\s*wgsl\\s*\\*\\/")
   (#set! injection.language "WGSL/WESL"))
 
+(call_expression
+  function: (identifier) @_name
+  (#eq? @_name "surql")
+  arguments: (template_string
+    (string_fragment) @injection.content
+    (#set! injection.language "surrealql")))
+
 ; '/* surql */' or '/*surql*/'
 (((comment) @_ecma_comment
   [


### PR DESCRIPTION
This is essentially a verbatim copy of: https://github.com/zed-industries/zed/pull/55341

I would have preferred to quickly add this with a custom tree-sitter query via https://github.com/zed-industries/zed/pull/46547

## Description


Extends the existing ECMAScript comment-label injection system to support the [SurrealQL](https://surrealdb.com/docs/reference/query-language) language inside JS/TS strings and template literals.

The pattern `/* language */` before a string is already used for `html`, `sql`, `graphql`, `css`, `glsl` and `wgsl`. This adds the same support for embedding [SurrealDB](https://surrealdb.com) SurrealQL queries as strings.

Syntax highlighting activates when the corresponding community extension is installed:
- [SurrealDB SurrealQL Language Extension](https://zed.dev/extensions/surrealql)

Both `/*surql*/` and `/* surql */` forms are accepted (same behavior as the existing patterns).

I've also added support for `surql` tagged template functions. Which is just a copy of the existing `sql` tagged template function injection.

Release Notes:

- Added `/*surql*/` comment-label syntax injection for JavaScript and TypeScript template literals
- Added syntax injection for the `surql` JavaScript and TypeScript tag function