### PR TITLE
Fix SVG dark-mode rendering in markdown preview

### DIFF
--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -1,9 +1,9 @@
 use crate::{
-    AnyElement, AnyImageCache, App, Asset, AssetLogger, Bounds, DefiniteLength, Element, ElementId,
-    Entity, GlobalElementId, Hitbox, Image, ImageCache, InspectorElementId, InteractiveElement,
-    Interactivity, IntoElement, LayoutId, Length, ObjectFit, Pixels, RenderImage, Resource,
-    SharedString, SharedUri, StyleRefinement, Styled, Task, Window, decode_static_image,
-    decode_static_image_from_decoder, px,
+    AnyElement, AnyImageCache, App, Asset, AssetLogger, Bounds, DefaultAppearance, DefiniteLength,
+    Element, ElementId, Entity, GlobalElementId, Hitbox, Image, ImageCache, InspectorElementId,
+    InteractiveElement, Interactivity, IntoElement, LayoutId, Length, ObjectFit, Pixels,
+    RenderImage, Resource, SharedString, SharedUri, StyleRefinement, Styled, Task, Window,
+    decode_static_image, decode_static_image_from_decoder, px,
 };
 use anyhow::Result;
 
@@ -608,7 +608,12 @@ impl Asset for ImageDecoder {
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         let renderer = cx.svg_renderer();
-        async move { source.to_image_data(renderer).map_err(Into::into) }
+        let appearance = DefaultAppearance::from(cx.window_appearance());
+        async move {
+            source
+                .to_image_data(renderer, appearance)
+                .map_err(Into::into)
+        }
     }
 }
 
@@ -627,6 +632,7 @@ impl Asset for ImageAssetLoader {
         let client = cx.http_client();
         // TODO: Can we make SVGs always rescale?
         // let scale_factor = cx.scale_factor();
+        let appearance = DefaultAppearance::from(cx.window_appearance());
         let svg_renderer = cx.svg_renderer();
         let asset_source = cx.asset_source().clone();
         async move {
@@ -738,7 +744,7 @@ impl Asset for ImageAssetLoader {
                 Ok(Arc::new(RenderImage::new(data)))
             } else {
                 svg_renderer
-                    .render_single_frame(&bytes, 1.0)
+                    .render_single_frame_with_appearance(&bytes, 1.0, appearance)
                     .map_err(Into::into)
             }
         }

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -97,6 +97,7 @@ pub(crate) use arena::*;
 pub use asset_cache::*;
 pub use assets::*;
 pub use color::*;
+pub use colors::DefaultAppearance;
 pub use ctor::ctor;
 #[cfg(feature = "profiler")]
 pub use debug_overlay::*;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -36,11 +36,12 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
-    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalDragPayload, Font,
-    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
-    LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
-    RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
-    Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
+    DEFAULT_WINDOW_SIZE, DefaultAppearance, DevicePixels, DispatchEventResult, Edges,
+    ExternalDragPayload, Font, FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs,
+    Hsla, ImageSource, Keymap, LineLayout, Pixels, PlatformGestures, PlatformInput, Point,
+    Priority, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene,
+    ShapedGlyph, ShapedRun, SharedString, Size, SvgRenderer, SystemWindowTab, Task, Window,
+    WindowControlArea, hash, point, px, size,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use anyhow::bail;
@@ -2652,7 +2653,11 @@ impl Image {
     }
 
     /// Convert the clipboard image to an `ImageData` object.
-    pub fn to_image_data(&self, svg_renderer: SvgRenderer) -> Result<Arc<RenderImage>> {
+    pub fn to_image_data(
+        &self,
+        svg_renderer: SvgRenderer,
+        appearance: DefaultAppearance,
+    ) -> Result<Arc<RenderImage>> {
         let frames = match self.format {
             ImageFormat::Gif => {
                 let decoder = GifDecoder::new(Cursor::new(&self.bytes))?;
@@ -2687,7 +2692,7 @@ impl Image {
             ImageFormat::Ico => decode_static_image(&self.bytes, image::ImageFormat::Ico)?,
             ImageFormat::Svg => {
                 return svg_renderer
-                    .render_single_frame(&self.bytes, 1.0)
+                    .render_single_frame_with_appearance(&self.bytes, 1.0, appearance)
                     .map_err(Into::into);
             }
             ImageFormat::Pnm => decode_static_image(&self.bytes, image::ImageFormat::Pnm)?,
@@ -2782,7 +2787,9 @@ mod image_tests {
             include_bytes!("../examples/image/exif-orientation-rotate-180.jpg").to_vec(),
         );
 
-        let render_image = image.to_image_data(SvgRenderer::new(Arc::new(()))).unwrap();
+        let render_image = image
+            .to_image_data(SvgRenderer::new(Arc::new(())), DefaultAppearance::Light)
+            .unwrap();
 
         assert_eq!(render_image.size(0), size(16.into(), 32.into()));
 
@@ -2801,7 +2808,9 @@ mod image_tests {
                 .to_vec(),
         );
 
-        let render_image = image.to_image_data(SvgRenderer::new(Arc::new(()))).unwrap();
+        let render_image = image
+            .to_image_data(SvgRenderer::new(Arc::new(())), DefaultAppearance::Light)
+            .unwrap();
         let bytes = render_image.as_bytes(0).unwrap();
 
         for pixel in bytes.chunks_exact(4) {

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -1,12 +1,14 @@
 use crate::{
-    AssetSource, DevicePixels, IsZero, RenderImage, Result, SharedString, Size,
+    AssetSource, DefaultAppearance, DevicePixels, IsZero, RenderImage, Result, SharedString, Size,
     swap_rgba_pa_to_bgra,
 };
 use image::Frame;
 use resvg::tiny_skia::Pixmap;
 use smallvec::SmallVec;
 use std::{
+    borrow::Cow,
     hash::Hash,
+    ops::Range,
     sync::{Arc, LazyLock, OnceLock},
 };
 
@@ -230,6 +232,35 @@ impl SvgRenderer {
         self.render_parsed(&svg, scale_factor)
     }
 
+    /// Parses SVG data into a [`ParsedSvg`] that can be rasterized at any scale.
+    ///
+    /// Unlike [`SvgRenderer::parse_svg`], `@media (prefers-color-scheme: ...)`
+    /// rules are resolved against the provided appearance before parsing. usvg's
+    /// CSS parser drops at-rules entirely, so without this such rules would be
+    /// ignored and the SVG would always render with its default palette.
+    pub fn parse_svg_with_appearance(
+        &self,
+        bytes: &[u8],
+        appearance: DefaultAppearance,
+    ) -> Result<ParsedSvg, usvg::Error> {
+        self.parse_svg(resolve_preferred_color_scheme(bytes, appearance).as_ref())
+    }
+
+    /// Renders the given bytes into an image buffer, resolving
+    /// `@media (prefers-color-scheme: ...)` rules against the provided
+    /// appearance before parsing. See [`SvgRenderer::parse_svg_with_appearance`].
+    pub fn render_single_frame_with_appearance(
+        &self,
+        bytes: &[u8],
+        scale_factor: f32,
+        appearance: DefaultAppearance,
+    ) -> Result<Arc<RenderImage>, usvg::Error> {
+        self.render_single_frame(
+            resolve_preferred_color_scheme(bytes, appearance).as_ref(),
+            scale_factor,
+        )
+    }
+
     pub(crate) fn render_alpha_mask(
         &self,
         params: &RenderSvgParams,
@@ -308,6 +339,229 @@ fn rasterize_tree(tree: &usvg::Tree, size: SvgSize) -> Result<Pixmap, usvg::Erro
     Ok(pixmap)
 }
 
+/// Maximum nesting of `@media` blocks we resolve. Deeply nested media queries
+/// are invalid CSS in practice; the cap guards against pathological inputs.
+const MAX_MEDIA_QUERY_DEPTH: usize = 8;
+
+/// Resolves `@media (prefers-color-scheme: ...)` rules in the given SVG data
+/// for the provided appearance.
+///
+/// usvg's CSS parser (simplecss) skips all at-rules, so media queries would be
+/// dropped and the SVG would always render with its default palette. To match
+/// browser behavior, blocks whose condition matches the appearance are unwrapped
+/// (their declarations apply), all other `@media` blocks are removed. Conditions
+/// that can't be evaluated count as non-matching, which preserves the previous
+/// behavior of dropping the block.
+pub(crate) fn resolve_preferred_color_scheme<'a>(
+    bytes: &'a [u8],
+    appearance: DefaultAppearance,
+) -> Cow<'a, [u8]> {
+    let Ok(svg) = str::from_utf8(bytes) else {
+        return Cow::Borrowed(bytes);
+    };
+    // Fast path: bail out before allocating a lowercased copy.
+    if !svg.to_ascii_lowercase().contains("@media") {
+        return Cow::Borrowed(bytes);
+    }
+    Cow::Owned(rewrite_media_queries(svg, appearance, 0).into_bytes())
+}
+
+fn rewrite_media_queries(svg: &str, appearance: DefaultAppearance, depth: usize) -> String {
+    // Media queries are case-insensitive; lowercase once for scanning. This is
+    // byte-for-byte length preserving, so offsets stay valid for `svg`.
+    let lowered = svg.to_ascii_lowercase();
+    let mut output = String::with_capacity(svg.len());
+    let mut cursor = 0;
+
+    while let Some(at_rule_start) = lowered[cursor..]
+        .find("@media")
+        .map(|offset| cursor + offset)
+    {
+        let Some(query) = scan_media_query(svg, &lowered, at_rule_start, appearance) else {
+            // Malformed at-rule: keep everything from here on untouched rather
+            // than risk corrupting the SVG.
+            break;
+        };
+        output.push_str(&svg[cursor..query.at_rule_start]);
+        if query.matches {
+            if depth < MAX_MEDIA_QUERY_DEPTH {
+                output.push_str(&rewrite_media_queries(
+                    &svg[query.contents.clone()],
+                    appearance,
+                    depth + 1,
+                ));
+            } else {
+                output.push_str(&svg[query.contents.clone()]);
+            }
+        }
+        cursor = query.end;
+    }
+
+    output.push_str(&svg[cursor..]);
+    output
+}
+
+struct MediaQueryScan {
+    at_rule_start: usize,
+    /// Offset just past the closing brace of the at-rule's block.
+    end: usize,
+    matches: bool,
+    contents: Range<usize>,
+}
+
+fn scan_media_query(
+    svg: &str,
+    lowered: &str,
+    at_rule_start: usize,
+    appearance: DefaultAppearance,
+) -> Option<MediaQueryScan> {
+    // Media conditions may hold several parenthesized features, so rather than
+    // matching a single paren pair, take everything between the keyword and the
+    // block's opening brace as the condition.
+    let condition_start = skip_whitespace(&lowered[at_rule_start + "@media".len()..])
+        + at_rule_start
+        + "@media".len();
+    let brace_open = lowered[condition_start..].find('{')? + condition_start;
+    let condition = lowered[condition_start..brace_open].trim();
+    if !is_plausible_media_condition(condition) {
+        return None;
+    }
+    let matches = evaluate_color_scheme_condition(condition, appearance);
+
+    let (contents, end) = scan_balanced_block(svg, brace_open)?;
+    Some(MediaQueryScan {
+        at_rule_start,
+        end,
+        matches,
+        contents,
+    })
+}
+
+/// Guards against treating occurrences of `@media` in SVG text content as
+/// at-rules: real conditions are short, and every comma-separated query starts
+/// with a media feature, a leading `not`/`only`, or a legacy media type keyword.
+fn is_plausible_media_condition(condition: &str) -> bool {
+    const MAX_CONDITION_LEN: usize = 256;
+    if condition.is_empty() || condition.len() > MAX_CONDITION_LEN {
+        return false;
+    }
+    let body = condition
+        .strip_prefix("not ")
+        .or_else(|| condition.strip_prefix("only "))
+        .map(str::trim)
+        .unwrap_or(condition);
+    body.split(',').any(|query| {
+        let query = query.trim();
+        if query.starts_with('(') {
+            return true;
+        }
+        let media_type = query
+            .split_once(char::is_whitespace)
+            .map(|(media_type, _)| media_type)
+            .unwrap_or(query);
+        matches!(media_type, "all" | "print" | "screen" | "speech")
+    })
+}
+
+/// Returns the number of bytes of leading whitespace.
+fn skip_whitespace(text: &str) -> usize {
+    text.find(|c: char| !c.is_whitespace())
+        .unwrap_or(text.len())
+}
+
+fn evaluate_color_scheme_condition(condition: &str, appearance: DefaultAppearance) -> bool {
+    let mut body = condition.trim();
+    let mut negated = false;
+    if let Some(rest) = body.strip_prefix("not ") {
+        negated = true;
+        body = rest.trim();
+    } else if let Some(rest) = body.strip_prefix("only ") {
+        body = rest.trim();
+    }
+    // Normalize whitespace so logical keywords can be matched reliably even
+    // though feature values may contain spaces.
+    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Comma-separated queries match if any of them matches.
+    let matches = normalized.split(',').any(|query| {
+        query.split(" or ").any(|disjunct| {
+            disjunct
+                .split(" and ")
+                .all(|feature| evaluate_color_scheme_feature(feature, appearance).unwrap_or(false))
+        })
+    });
+    matches != negated
+}
+
+/// Evaluates one media feature or legacy media type. Returns `None` for
+/// features we can't evaluate, which makes their whole `and`-chain non-matching.
+fn evaluate_color_scheme_feature(feature: &str, appearance: DefaultAppearance) -> Option<bool> {
+    let feature = feature.trim();
+    let feature = feature
+        .strip_prefix('(')
+        .and_then(|feature| feature.strip_suffix(')'))
+        .unwrap_or(feature);
+    let Some((name, value)) = feature.split_once(':') else {
+        // Legacy media types: Zed renders to a screen.
+        return match feature.trim() {
+            "all" | "screen" => Some(true),
+            "print" | "speech" => Some(false),
+            _ => None,
+        };
+    };
+    if name.trim() != "prefers-color-scheme" {
+        return None;
+    }
+    match value.trim() {
+        "dark" => Some(appearance == DefaultAppearance::Dark),
+        "light" | "no-preference" => Some(appearance == DefaultAppearance::Light),
+        _ => None,
+    }
+}
+
+/// Given the offset of an opening brace, finds its matching closing brace,
+/// skipping braces inside quoted strings and comments. Returns the contents
+/// range and the offset just past the closing brace.
+fn scan_balanced_block(svg: &str, open_brace: usize) -> Option<(Range<usize>, usize)> {
+    let mut depth = 1usize;
+    let mut chars = svg[open_brace + 1..].char_indices().peekable();
+    while let Some((offset, c)) = chars.next() {
+        match c {
+            '"' | '\'' => {
+                let mut escaped = false;
+                for (_, quoted) in chars.by_ref() {
+                    if escaped {
+                        escaped = false;
+                    } else if quoted == '\\' {
+                        escaped = true;
+                    } else if quoted == c {
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek().is_some_and(|(_, next)| *next == '*') => {
+                chars.next();
+                let mut pending_star = false;
+                for (_, commented) in chars.by_ref() {
+                    if pending_star && commented == '/' {
+                        break;
+                    }
+                    pending_star = commented == '*';
+                }
+            }
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let close = open_brace + 1 + offset;
+                    return Some((open_brace + 1..close, close + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn load_bundled_fonts(asset_source: &dyn AssetSource, db: &mut usvg::fontdb::Database) {
     let font_paths = [
         "fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf",
@@ -363,6 +617,238 @@ mod tests {
     const IBM_PLEX_REGULAR: &[u8] =
         include_bytes!("../../../assets/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf");
     const LILEX_REGULAR: &[u8] = include_bytes!("../../../assets/fonts/lilex/Lilex-Regular.ttf");
+
+    fn color_scheme_svg(default_fill: &str, media_fill: &str, scheme: &str) -> Vec<u8> {
+        format!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>rect{{fill:{default_fill}}}@media (prefers-color-scheme: {scheme}){{rect{{fill:{media_fill}}}}}</style><rect width="10" height="10"/></svg>"#
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn unwraps_matching_media_block_and_removes_non_matching() {
+        let svg = color_scheme_svg("black", "white", "dark");
+        let resolved = resolve_preferred_color_scheme(&svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>rect{fill:black}rect{fill:white}</style><rect width="10" height="10"/></svg>"#
+        );
+
+        let svg = color_scheme_svg("black", "white", "dark");
+        let resolved = resolve_preferred_color_scheme(&svg, DefaultAppearance::Light);
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>rect{fill:black}</style><rect width="10" height="10"/></svg>"#
+        );
+    }
+
+    #[test]
+    fn unwrapped_declarations_override_in_cascade_order() {
+        // A dark-first SVG whose light palette arrives via the media query must
+        // end up with the light declaration last so it wins the cascade.
+        let svg = color_scheme_svg("white", "black", "light");
+        let resolved = resolve_preferred_color_scheme(&svg, DefaultAppearance::Light);
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>rect{fill:white}rect{fill:black}</style><rect width="10" height="10"/></svg>"#
+        );
+    }
+
+    #[test]
+    fn media_keyword_and_condition_are_case_insensitive() {
+        let svg =
+            br#"<svg><style>@MEDIA ( PREFERS-COLOR-SCHEME: DARK ){a{fill:red}}</style></svg>"#;
+        let resolved = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            "<svg><style>a{fill:red}</style></svg>"
+        );
+    }
+
+    #[test]
+    fn conditions_with_unevaluable_features_never_match() {
+        let svg = br#"<svg><style>@media (min-width: 10px) and (prefers-color-scheme: dark){a{fill:red}}</style></svg>"#;
+        for appearance in [DefaultAppearance::Light, DefaultAppearance::Dark] {
+            let resolved = resolve_preferred_color_scheme(svg, appearance);
+            assert_eq!(
+                String::from_utf8(resolved.into_owned()).unwrap(),
+                "<svg><style></style></svg>"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_media_type_queries_never_match() {
+        let svg = br#"<svg><style>@media print {a{fill:red}}</style><style>@media screen and (prefers-color-scheme: dark) {b{fill:red}}</style></svg>"#;
+        for appearance in [DefaultAppearance::Light, DefaultAppearance::Dark] {
+            let resolved = resolve_preferred_color_scheme(svg, appearance);
+            assert_eq!(
+                String::from_utf8(resolved.into_owned()).unwrap(),
+                if appearance == DefaultAppearance::Dark {
+                    "<svg><style></style><style>b{fill:red}</style></svg>"
+                } else {
+                    "<svg><style></style><style></style></svg>"
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn negated_conditions_invert_the_result() {
+        let svg =
+            br#"<svg><style>@media not (prefers-color-scheme: dark){a{fill:red}}</style></svg>"#;
+        let light = resolve_preferred_color_scheme(svg, DefaultAppearance::Light);
+        assert_eq!(
+            String::from_utf8(light.into_owned()).unwrap(),
+            "<svg><style>a{fill:red}</style></svg>"
+        );
+        let dark = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(dark.into_owned()).unwrap(),
+            "<svg><style></style></svg>"
+        );
+    }
+
+    #[test]
+    fn only_prefix_does_not_affect_matching() {
+        let svg = br#"<svg><style>@media only screen and (prefers-color-scheme: dark){a{fill:red}}</style></svg>"#;
+        let dark = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(dark.into_owned()).unwrap(),
+            "<svg><style>a{fill:red}</style></svg>"
+        );
+        let light = resolve_preferred_color_scheme(svg, DefaultAppearance::Light);
+        assert_eq!(
+            String::from_utf8(light.into_owned()).unwrap(),
+            "<svg><style></style></svg>"
+        );
+    }
+
+    #[test]
+    fn comma_separated_queries_match_if_any_query_matches() {
+        let svg =
+            br#"<svg><style>@media print, (prefers-color-scheme: dark){a{fill:red}}</style></svg>"#;
+        let dark = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(dark.into_owned()).unwrap(),
+            "<svg><style>a{fill:red}</style></svg>"
+        );
+        let light = resolve_preferred_color_scheme(svg, DefaultAppearance::Light);
+        assert_eq!(
+            String::from_utf8(light.into_owned()).unwrap(),
+            "<svg><style></style></svg>"
+        );
+    }
+
+    #[test]
+    fn braces_inside_strings_and_comments_do_not_confuse_block_scanning() {
+        let svg =
+            br#"<svg><style>@media (prefers-color-scheme: dark) {/* } */a{content:"}"}}</style></svg>"#;
+        let resolved = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            "<svg><style>/* } */a{content:\"}\"}</style></svg>"
+        );
+    }
+
+    #[test]
+    fn malformed_media_rules_are_left_untouched() {
+        let svg = br#"<svg><text>@media screen</text><style>a{fill:red}</style></svg>"#;
+        let resolved = resolve_preferred_color_scheme(svg, DefaultAppearance::Dark);
+        assert!(matches!(resolved, Cow::Owned(_)));
+        assert_eq!(
+            String::from_utf8(resolved.into_owned()).unwrap(),
+            String::from_utf8_lossy(svg)
+        );
+    }
+
+    #[test]
+    fn data_without_media_queries_is_passed_through_unchanged() {
+        let svg = br#"<svg><style>a{fill:red}</style></svg>"#;
+        match resolve_preferred_color_scheme(svg, DefaultAppearance::Dark) {
+            Cow::Borrowed(borrowed) => assert_eq!(borrowed, svg),
+            Cow::Owned(_) => panic!("expected borrowed data"),
+        }
+
+        let invalid_utf8: &[u8] = &[0xff, 0xfe, b'@', b'm', b'e'];
+        match resolve_preferred_color_scheme(invalid_utf8, DefaultAppearance::Dark) {
+            Cow::Borrowed(borrowed) => assert_eq!(borrowed, invalid_utf8),
+            Cow::Owned(_) => panic!("expected borrowed data"),
+        }
+    }
+
+    #[test]
+    fn rendered_pixels_follow_prefers_color_scheme() -> Result<()> {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>rect{fill:black}@media (prefers-color-scheme: dark){rect{fill:white}}</style><rect width="10" height="10"/></svg>"#;
+
+        let luminance_range = |image: &RenderImage| -> Option<(u32, u32)> {
+            let mut min_luminance = u32::MAX;
+            let mut max_luminance = 0;
+            for pixel in image.as_bytes(0)?.chunks_exact(4) {
+                let alpha = pixel[3] as u32;
+                if alpha < 128 {
+                    continue;
+                }
+                let blue = pixel[0] as u32;
+                let green = pixel[1] as u32;
+                let red = pixel[2] as u32;
+                let luminance = (red * 299 + green * 587 + blue * 114) / 1000;
+                min_luminance = min_luminance.min(luminance);
+                max_luminance = max_luminance.max(luminance);
+            }
+            Some((min_luminance, max_luminance))
+        };
+
+        let dark_image =
+            renderer.render_single_frame_with_appearance(svg, 1.0, DefaultAppearance::Dark)?;
+        let (_, dark_max_luminance) = luminance_range(&dark_image).unwrap();
+        assert!(
+            dark_max_luminance > 200,
+            "expected white pixels when rendering for dark appearance"
+        );
+
+        let light_image =
+            renderer.render_single_frame_with_appearance(svg, 1.0, DefaultAppearance::Light)?;
+        let (light_min_luminance, _) = luminance_range(&light_image).unwrap();
+        assert!(
+            light_min_luminance < 50,
+            "expected black pixels when rendering for light appearance"
+        );
+
+        // Without appearance resolution the media query is dropped and only the
+        // default palette renders.
+        let legacy_image = renderer.render_single_frame(svg, 1.0)?;
+        let (_, legacy_max_luminance) = luminance_range(&legacy_image).unwrap();
+        assert!(
+            legacy_max_luminance < 50,
+            "expected legacy rendering to keep the default palette"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_svg_with_appearance_accepts_issue_report() -> Result<()> {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <style>
+      text {
+          fill: black;
+      }
+      @media (prefers-color-scheme: dark) {
+          text {
+              fill: white;
+          }
+      }
+  </style> <text x="10" y="25">Hello</text>
+</svg>"#;
+        let dark = renderer.parse_svg_with_appearance(svg, DefaultAppearance::Dark)?;
+        let _image = renderer.render_parsed(&dark, SvgSize::ScaleFactor(1.0))?;
+        let light = renderer.parse_svg_with_appearance(svg, DefaultAppearance::Light)?;
+        let _image = renderer.render_parsed(&light, SvgSize::ScaleFactor(1.0))?;
+        Ok(())
+    }
 
     #[test]
     fn renders_parsed_svg_at_requested_size() -> Result<()> {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -363,6 +363,16 @@ impl MarkdownPreviewView {
                 }
             }
 
+            // SVGs are rasterized with the window's current appearance, so cached
+            // images must be dropped when it changes.
+            cx.observe_window_appearance(window, |this, window, cx| {
+                this.image_cache.update(cx, |image_cache, cx| {
+                    image_cache.clear(window, cx);
+                });
+                cx.notify();
+            })
+            .detach();
+
             this
         })
     }

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -6,8 +6,8 @@ use anyhow::{Context as _, Result};
 use collections::{HashMap, HashSet, hash_map};
 use futures::{StreamExt, channel::oneshot};
 use gpui::{
-    App, Asset, AssetLogger, AsyncApp, Context, Entity, EventEmitter, ImageCacheError, ImageSource,
-    Img, RenderImage, Subscription, Task, WeakEntity, prelude::*,
+    App, Asset, AssetLogger, AsyncApp, Context, DefaultAppearance, Entity, EventEmitter,
+    ImageCacheError, ImageSource, Img, RenderImage, Subscription, Task, WeakEntity, prelude::*,
 };
 pub use image::ImageFormat;
 use image::{ExtendedColorType, GenericImageView, ImageReader};
@@ -126,6 +126,7 @@ impl Asset for ProjectImageAsset {
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         let svg_renderer = cx.svg_renderer();
+        let appearance = DefaultAppearance::from(cx.window_appearance());
         let load_image = cx.spawn(async move |cx| {
             let open_image = source
                 .project
@@ -136,7 +137,9 @@ impl Asset for ProjectImageAsset {
 
         async move {
             let image = load_image.await?;
-            image.to_image_data(svg_renderer).map_err(Into::into)
+            image
+                .to_image_data(svg_renderer, appearance)
+                .map_err(Into::into)
         }
     }
 }

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -21,6 +21,7 @@ pub struct SvgPreviewView {
     _refresh: Task<()>,
     _buffer_subscription: Option<Subscription>,
     _workspace_subscription: Option<Subscription>,
+    _appearance_subscription: Subscription,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -60,6 +61,14 @@ impl SvgPreviewView {
                 current_svg: None,
                 _buffer_subscription: subscription,
                 _workspace_subscription: workspace_subscription,
+                _appearance_subscription: cx.observe_window_appearance(
+                    window,
+                    |this, window, cx| {
+                        // SVGs are rasterized with the window's appearance, so the
+                        // preview must be re-rendered when it changes.
+                        this.render_image(window, cx);
+                    },
+                ),
                 _refresh: Task::ready(()),
             };
             this.render_image(window, cx);


### PR DESCRIPTION
Fixes #63098

SVGs that embed `@media (prefers-color-scheme: ...)` rules always rendered with their default palette: usvg's CSS parser (simplecss) silently drops every at-rule, so the media query was discarded and only the base styles applied.

This resolves those queries against the window's current appearance before parsing: blocks whose condition matches are unwrapped so their declarations join the cascade in place, non-matching blocks are removed — matching browser behavior. Supported condition syntax includes `and`/`or` chains, comma-separated query lists, `not`, the `only` prefix, and legacy media types; unevaluable features count as non-matching, which preserves the previous behavior.

Cached raster images are invalidated when the window appearance changes, so toggling dark/light mode re-renders previews live. This covers markdown preview images (local and HTTP), the SVG preview, and project/clipboard images decoded through gpui. UI icons are unaffected since they render through an alpha mask, and mermaid diagrams keep their own theming.

| Dark | Light |
| --- | --- |
| ![Dark mode](https://raw.githubusercontent.com/xcb3d/zed/pr-assets/svg-dark-mode.png) | ![Light mode](https://raw.githubusercontent.com/xcb3d/zed/pr-assets/svg-light-mode.png) |

Release Notes:

- Fixed SVGs with `prefers-color-scheme` styles always rendering with their light palette in the markdown and SVG previews
