### PR TITLE
workspace: Fix trust scope paths when connecting to Windows hosts from Unix

### DIFF
--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -90,8 +90,8 @@ impl Render for SecurityModal {
             format!("Unrecognized Projects ({})", restricted_count).into()
         };
 
-        let trust_label = self.build_trust_label();
         let path_style = self.path_style(cx);
+        let trust_label = self.build_trust_label(path_style);
 
         // The editable trust-scope field is shown only when a single project is
         // being prompted for (Delta opens one worktree per thread).
@@ -345,7 +345,7 @@ impl SecurityModal {
         this
     }
 
-    fn build_trust_label(&self) -> Option<Cow<'static, str>> {
+    fn build_trust_label(&self, path_style: PathStyle) -> Option<Cow<'static, str>> {
         let mut has_restricted_files = false;
         let available_parents = self
             .restricted_paths
@@ -354,7 +354,7 @@ impl SecurityModal {
                 has_restricted_files |= restricted_path.is_file;
                 !restricted_path.is_file
             })
-            .filter_map(|restricted_path| restricted_path.abs_path.parent())
+            .filter_map(|restricted_path| path_style.parent(&restricted_path.abs_path))
             .collect::<SmallVec<[_; 2]>>();
         match available_parents.len() {
             0 => {
@@ -540,7 +540,7 @@ fn validate_trust_scope(
     Ok(expanded)
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -522,10 +522,13 @@ fn validate_trust_scope(
         return Err("Enter a folder to trust".into());
     }
     let expanded = match (trimmed.strip_prefix('~'), home_dir) {
-        (Some(rest), Some(home_dir)) => home_dir.join(
-            rest.strip_prefix(path_style.primary_separator())
-                .unwrap_or(rest),
-        ),
+        (Some(rest), Some(home_dir)) => path_style
+            .join_path(
+                home_dir,
+                rest.strip_prefix(path_style.primary_separator())
+                    .unwrap_or(rest),
+            )
+            .map_err(|error| SharedString::from(error.to_string()))?,
         _ => PathBuf::from(trimmed),
     };
     if !util::paths::is_absolute(&expanded.to_string_lossy(), path_style) {

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -575,6 +575,61 @@ mod tests {
     }
 
     #[test]
+    fn accepts_windows_style_ancestor() {
+        let project = Path::new(r"C:\Users\me\dev\wt\t1");
+        let style = PathStyle::Windows;
+
+        assert_eq!(
+            validate_trust_scope(r"C:\Users\me\dev\wt", project, None, style).unwrap(),
+            PathBuf::from(r"C:\Users\me\dev\wt"),
+        );
+
+        assert_eq!(
+            validate_trust_scope(r"C:\Users\me\dev\wt\t1", project, None, style).unwrap(),
+            PathBuf::from(r"C:\Users\me\dev\wt\t1")
+        );
+
+        // Forward slashes are normalized to backslashes.
+        assert_eq!(
+            validate_trust_scope("C:/Users/me/dev/wt", project, None, style).unwrap(),
+            PathBuf::from(r"C:\Users\me\dev\wt"),
+        );
+        // Double separators and "." components are collapsed during normalization.
+        assert_eq!(
+            validate_trust_scope(r"C:\Users\me\\dev\.\wt", project, None, style).unwrap(),
+            PathBuf::from(r"C:\Users\me\dev\wt"),
+        );
+        // Drive letters are matched case-insensitively.
+        assert_eq!(
+            validate_trust_scope(r"c:\Users\me\dev\wt", project, None, style).unwrap(),
+            PathBuf::from(r"c:\Users\me\dev\wt")
+        );
+        // A distant ancestor is allowed.
+        assert!(validate_trust_scope(r"C:\Users\me", project, None, style).is_ok());
+    }
+
+    #[test]
+    fn rejects_windows_style_non_ancestor() {
+        let project = Path::new(r"C:\Users\me\dev\wt\t1");
+        let style = PathStyle::Windows;
+        assert!(validate_trust_scope(r"C:\Users\other", project, None, style).is_err());
+        // Relative paths are not absolute.
+        assert!(validate_trust_scope(r"dev\wt", project, None, style).is_err());
+        // Deeper than the project is not an ancestor.
+        assert!(validate_trust_scope(r"C:\Users\me\dev\wt\t1\sub", project, None, style).is_err());
+        // A prefix that is not a component boundary is not an ancestor.
+        assert!(
+            validate_trust_scope(
+                r"C:\Users\me\dev\wt",
+                Path::new(r"C:\Users\me\dev\wt2"),
+                None,
+                style,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn expands_leading_tilde() {
         let home = Path::new("/Users/me");
         let project = Path::new("/Users/me/dev/wt/t1");

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -91,6 +91,7 @@ impl Render for SecurityModal {
         };
 
         let trust_label = self.build_trust_label();
+        let path_style = self.path_style(cx);
 
         // The editable trust-scope field is shown only when a single project is
         // being prompted for (Delta opens one worktree per thread).
@@ -138,7 +139,7 @@ impl Render for SecurityModal {
                                         self.restricted_paths.values().filter_map(
                                             |restricted_path| {
                                                 let abs_path = if restricted_path.is_file {
-                                                    restricted_path.abs_path.parent()
+                                                    path_style.parent(&restricted_path.abs_path)
                                                 } else {
                                                     Some(restricted_path.abs_path.as_ref())
                                                 }?;
@@ -329,7 +330,11 @@ impl SecurityModal {
         // Pre-fill with the single project's parent folder (today's static
         // scope), read-only until the checkbox is ticked.
         if let Some(project) = this.single_trustable_path() {
-            let default_scope = project.parent().unwrap_or(&project).to_path_buf();
+            let path_style = this.path_style(cx);
+            let default_scope = path_style
+                .parent(&project)
+                .unwrap_or(&project)
+                .to_path_buf();
             this.trust_path_input.update(cx, |field, cx| {
                 field.set_text(&default_scope.to_string_lossy(), window, cx);
             });
@@ -367,6 +372,13 @@ impl SecurityModal {
         }
     }
 
+    fn path_style(&self, cx: &App) -> PathStyle {
+        self.worktree_store
+            .upgrade()
+            .map(|store| store.read(cx).path_style())
+            .unwrap_or_else(PathStyle::local)
+    }
+
     fn shorten_path<'a>(&self, path: &'a Path) -> Cow<'a, Path> {
         match &self.home_dir {
             Some(home_dir) => path
@@ -389,11 +401,7 @@ impl SecurityModal {
             return Ok(None);
         };
         let typed = self.trust_path_input.read(cx).text(cx);
-        let path_style = self
-            .worktree_store
-            .upgrade()
-            .map(|store| store.read(cx).path_style())
-            .unwrap_or_else(PathStyle::local);
+        let path_style = self.path_style(cx);
         validate_trust_scope(&typed, &project, self.home_dir.as_deref(), path_style).map(Some)
     }
 
@@ -422,13 +430,15 @@ impl SecurityModal {
                     if let Some(scope) = scope_override {
                         paths_to_trust.insert(PathTrust::AbsPath(scope));
                     } else {
+                        let path_style = self.path_style(cx);
                         paths_to_trust.extend(self.restricted_paths.values().filter_map(
                             |restricted_paths| {
                                 if restricted_paths.is_file {
                                     None
                                 } else {
-                                    let parent_abs_path =
-                                        restricted_paths.abs_path.parent()?.to_owned();
+                                    let parent_abs_path = path_style
+                                        .parent(&restricted_paths.abs_path)?
+                                        .to_path_buf();
                                     Some(PathTrust::AbsPath(parent_abs_path))
                                 }
                             },
@@ -521,7 +531,7 @@ fn validate_trust_scope(
     if !util::paths::is_absolute(&expanded.to_string_lossy(), path_style) {
         return Err("Enter an absolute folder path".into());
     }
-    if !project.starts_with(&expanded) {
+    if path_style.strip_prefix(&project, &expanded).is_none() {
         return Err("Must be a parent folder of the project".into());
     }
     Ok(expanded)

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -531,6 +531,9 @@ fn validate_trust_scope(
     if !util::paths::is_absolute(&expanded.to_string_lossy(), path_style) {
         return Err("Enter an absolute folder path".into());
     }
+
+    let expanded = PathBuf::from(path_style.normalize(&expanded.to_string_lossy()));
+    let project = PathBuf::from(path_style.normalize(&project.to_string_lossy()));
     if path_style.strip_prefix(&project, &expanded).is_none() {
         return Err("Must be a parent folder of the project".into());
     }


### PR DESCRIPTION
# Objective

This is another fix related to the path handling issue when connecting from Unix to Windows, similar to #62038 and #63075, but confined to the path handling in the security modal. The root cause is the same: when using the standard library `Path` API across platforms — especially connecting from Unix to Windows — these `Path` methods give wrong results.

The bugs I have observed include:
1. When opening a single file, its parent folder is not shown properly in the project list.
2. When opening a folder, no parent folder is auto-filled into the input field after "Trust all projects in".
3. When Zed runs in debug mode, opening two untrusted folders, checking "Trust parents", and then trusting would result in a panic.

## Solution

Use the corresponding methods in `PathStyle`, which is designed for handling paths across platforms, instead of the `Path` methods in the relevant code.

## Testing

Built and tested locally, with comparison screenshots attached.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

|| Before | After |
|:--:|:--:|:--:|
| Auto fill |<img width="657" height="343" alt="auto_fill_before" src="https://github.com/user-attachments/assets/e36ca3d5-998c-4bed-94e9-f97dd0e7ebf4" />| <img width="654" height="333" alt="auto_fill_after" src="https://github.com/user-attachments/assets/c8413fb5-d2dd-427a-afb0-9cbebc033742" /> |
| Single file | <img width="654" height="322" alt="single_file_before" src="https://github.com/user-attachments/assets/bfe87ab0-bf87-491a-8f85-b5a2681763a9" />| <img width="657" height="325" alt="single_file_after" src="https://github.com/user-attachments/assets/0437cbde-42c3-44f6-847b-abd33e54cd2c" /> |

---

Release Notes:

- Fixed trusting projects on remote Windows machines from Unix systems