### PR TITLE
gpui: Keep explicitly sized images at their given size

### DIFF
--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -347,7 +347,9 @@ impl Element for Img {
 
                             let image_size = data.render_size(frame_index);
 
-                            if style.aspect_ratio.is_none() {
+                            let sized = matches!(style.size.width, Length::Definite(_))
+                                && matches!(style.size.height, Length::Definite(_));
+                            if style.aspect_ratio.is_none() && !sized {
                                 style.aspect_ratio = Some(image_size.width / image_size.height);
                             }
 
@@ -841,6 +843,61 @@ mod tests {
             .draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
                 img(ImageSource::Render(test_image(0))).into_any_element()
             });
+    }
+
+    #[gpui::test]
+    fn image_object_fit_cover_crops_portrait_to_fixed_element_bounds(cx: &mut TestAppContext) {
+        let window = cx.add_empty_window();
+        let image = test_image_with_size(100, 200);
+        window.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            img(ImageSource::Render(image.clone()))
+                .size(px(100.))
+                .object_fit(ObjectFit::Fill)
+                .into_any_element()
+        });
+        let full_tile_bounds = window.update(|window, _| {
+            window
+                .rendered_frame
+                .scene
+                .polychrome_sprites
+                .last()
+                .expect("fill image should paint a sprite")
+                .tile
+                .bounds
+        });
+
+        window.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            img(ImageSource::Render(image))
+                .size(px(100.))
+                .object_fit(ObjectFit::Cover)
+                .into_any_element()
+        });
+
+        let (rendered_bounds, rendered_tile_bounds, scale_factor) = window.update(|window, _| {
+            let sprite = window
+                .rendered_frame
+                .scene
+                .polychrome_sprites
+                .last()
+                .expect("cover image should paint a sprite");
+            (sprite.bounds, sprite.tile.bounds, window.scale_factor())
+        });
+        assert_eq!(
+            rendered_bounds,
+            Bounds {
+                origin: point(px(0.).scale(scale_factor), px(0.).scale(scale_factor)),
+                size: size(px(100.).scale(scale_factor), px(100.).scale(scale_factor)),
+            }
+        );
+        assert_eq!(
+            (
+                rendered_tile_bounds.origin.x.0 - full_tile_bounds.origin.x.0,
+                rendered_tile_bounds.origin.y.0 - full_tile_bounds.origin.y.0,
+                rendered_tile_bounds.size.width.0,
+                rendered_tile_bounds.size.height.0,
+            ),
+            (0, 50, 100, 100),
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

`img` sets the image's intrinsic aspect ratio on the element style whenever the caller didn't set one. When the element also has an explicit width and height, the intrinsic ratio still participates in layout and can resize the element.

This also defeats `ObjectFit::Cover` (#61383): once the element grows to match the image's ratio, there is nothing left to crop, so the image renders whole and rounded corners are computed against the inflated rectangle.

## Solution

Only assign the intrinsic aspect ratio when at least one dimension of the element is `Auto`, i.e. when the ratio is actually needed to derive a missing size. The element now keeps its given size with both dimensions definite.

## Testing

- Added `image_object_fit_cover_crops_portrait_to_fixed_element_bounds`, a portrait counterpart of the existing cover test that uses an absolute `.size(px(100.))` instead of `size_full()`. It fails on main (sprite bounds come out 100x200) and passes with this change.
- `cargo test -p gpui` passes.
- Verified visually on Linux Wayland with the example below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

A 300x400 portrait image rendered at a fixed square size:

```rust
img(portrait_300x400)
    .size(px(160.))
    .rounded_full()
    .object_fit(ObjectFit::Cover)
```
| Before | After |
| --- | --- |
| <img width="530" height="373" alt="before" src="https://github.com/user-attachments/assets/516f665f-0844-40e2-90c9-0c315da10f41" /> | <img width="528" height="290" alt="after" src="https://github.com/user-attachments/assets/1055f746-a9ce-400c-ab63-3beb9936ed10" /> |

