### PR TITLE
cloud_api_client: Add yield point to prevent background task hangs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,6 +3191,7 @@ dependencies = [
  "async-lock",
  "cloud_api_types",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "gpui",
  "gpui_tokio",
  "http_client",

--- a/crates/cloud_api_client/Cargo.toml
+++ b/crates/cloud_api_client/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/cloud_api_client.rs"
 [dependencies]
 anyhow.workspace = true
 cloud_api_types.workspace = true
+futures-lite.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true

--- a/crates/cloud_api_client/src/websocket/native.rs
+++ b/crates/cloud_api_client/src/websocket/native.rs
@@ -5,6 +5,7 @@ use cloud_api_types::websocket_protocol::{PROTOCOL_VERSION, PROTOCOL_VERSION_HEA
 use futures::channel::mpsc::unbounded;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{FutureExt as _, SinkExt as _, StreamExt as _, TryStreamExt as _};
+use futures_lite::future::yield_now;
 use gpui::{App, AppContext, Task};
 use http_client::http::request;
 use yawc::frame::Frame;
@@ -52,6 +53,8 @@ impl Connection {
                         }
                     }
                 }
+
+                yield_now().await;
             }
         });
 


### PR DESCRIPTION
Follow-up: https://github.com/zed-industries/zed/pull/62874

# Objective

After having Zed open for a while I'm getting some foreground and background hang warnings, like this one.

```
2026-08-19T11:25:45+02:00 INFO [zed::reliability::hang_detection::logging] New foreground hang detected: Tasks(s) that ran too long 215.24375ms          - crates/cloud_api_client/src/websocket/native.rs:34:23
```

## Solution

My solution is to add yield points so a single task doesn't block the executor thread for too long.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
