### PR TITLE
language_models: Add custom provider headers with agent thread ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -3837,6 +3837,7 @@ impl Thread {
             return Task::ready(None).shared();
         };
         let mut request = LanguageModelRequest {
+            thread_id: Some(self.id.to_string()),
             intent: Some(CompletionIntent::ThreadContextSummarization),
             temperature: AgentSettings::temperature_for_model(&model, cx),
             ..Default::default()
@@ -3925,7 +3926,8 @@ impl Thread {
         log::debug!("Generating title with model: {:?}", model.name());
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
-        let request = build_thread_title_request(&self.messages, temperature);
+        let mut request = build_thread_title_request(&self.messages, temperature);
+        request.thread_id = Some(self.id.to_string());
 
         let title_generation = cx.spawn(async move |_this, cx| {
             stream_thread_title(model, request, cx)

--- a/crates/language_models/src/provider.rs
+++ b/crates/language_models/src/provider.rs
@@ -1,6 +1,9 @@
 use collections::HashMap;
 use http_client::CustomHeaders;
 use http_client::http::{HeaderName, HeaderValue};
+use language_model::LanguageModelRequest;
+use settings::settings_content::{CustomHeaderSourceContent, CustomHeaderValueContent};
+use std::sync::Arc;
 
 pub mod anthropic;
 pub mod anthropic_compatible;
@@ -25,15 +28,68 @@ pub mod x_ai;
 
 const COMMON_RESERVED_HEADER_NAMES: &[&str] = &["Authorization", "Content-Type", "Accept"];
 
+/// User-configured custom headers for a language model provider: static
+/// `(name, value)` pairs plus dynamic definitions resolved per request.
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct CustomHeaderDefinitions {
+    definitions: Arc<[CustomHeaderDefinition]>,
+}
+
+impl CustomHeaderDefinitions {
+    /// Resolves the headers for a single outgoing request, substituting any
+    /// dynamic values (such as the agent thread ID) from `request`.
+    pub(crate) fn resolve(&self, request: &LanguageModelRequest) -> CustomHeaders {
+        self.resolve_agent_thread_id(request.thread_id.as_deref())
+    }
+
+    /// Resolves the static headers only; dynamic values are omitted. Used for
+    /// requests without a thread context, such as model discovery.
+    pub(crate) fn resolve_static(&self) -> CustomHeaders {
+        self.resolve_agent_thread_id(None)
+    }
+
+    fn resolve_agent_thread_id(&self, agent_thread_id: Option<&str>) -> CustomHeaders {
+        let headers = self
+            .definitions
+            .iter()
+            .filter_map(|definition| match definition {
+                CustomHeaderDefinition::Static(name, value) => {
+                    Some((name.clone(), value.clone()))
+                }
+                CustomHeaderDefinition::AgentThreadId(name) => {
+                    let thread_id = agent_thread_id?;
+                    match HeaderValue::from_str(thread_id) {
+                        Ok(value) => Some((name.clone(), value)),
+                        Err(error) => {
+                            log::warn!(
+                                "ignoring custom header `{name}` from agent thread ID: invalid \
+                                 header value ({error})"
+                            );
+                            None
+                        }
+                    }
+                }
+            })
+            .collect();
+        CustomHeaders::new(headers)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum CustomHeaderDefinition {
+    Static(HeaderName, HeaderValue),
+    AgentThreadId(HeaderName),
+}
+
 /// Validate the user-supplied custom-headers map once at settings load time,
 /// dropping reserved or malformed entries (each with a `log::warn!`) and
-/// returning a typed `CustomHeaders` ready to be appended to outgoing requests.
+/// returning definitions ready to be resolved onto outgoing requests.
 pub(crate) fn resolve_custom_headers(
     provider_name: &str,
-    settings: &HashMap<String, String>,
+    settings: &HashMap<String, CustomHeaderValueContent>,
     reserved_header_names: &[&str],
-) -> CustomHeaders {
-    let headers = settings
+) -> CustomHeaderDefinitions {
+    let definitions: Vec<_> = settings
         .iter()
         .filter_map(|(name, value)| {
             if COMMON_RESERVED_HEADER_NAMES
@@ -53,29 +109,45 @@ pub(crate) fn resolve_custom_headers(
                     return None;
                 }
             };
-            let header_value = match HeaderValue::from_str(value) {
-                Ok(header_value) => header_value,
-                Err(err) => {
-                    log::warn!(
-                        "ignoring custom {provider_name} header `{name}`: invalid header value ({err})"
-                    );
-                    return None;
+            match value {
+                CustomHeaderValueContent::Static(value) => {
+                    let header_value = match HeaderValue::from_str(value) {
+                        Ok(header_value) => header_value,
+                        Err(err) => {
+                            log::warn!(
+                                "ignoring custom {provider_name} header `{name}`: invalid header value ({err})"
+                            );
+                            return None;
+                        }
+                    };
+                    Some(CustomHeaderDefinition::Static(header_name, header_value))
                 }
-            };
-            Some((header_name, header_value))
+                CustomHeaderValueContent::Dynamic { source } => match source {
+                    CustomHeaderSourceContent::AgentThreadId => Some(
+                        CustomHeaderDefinition::AgentThreadId(header_name),
+                    ),
+                },
+            }
         })
         .collect();
-    CustomHeaders::new(headers)
+    CustomHeaderDefinitions {
+        definitions: definitions.into(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    fn map(pairs: &[(&str, &str)]) -> HashMap<String, CustomHeaderValueContent> {
         pairs
             .iter()
-            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .map(|(key, value)| {
+                (
+                    (*key).to_string(),
+                    CustomHeaderValueContent::Static((*value).to_string()),
+                )
+            })
             .collect()
     }
 
@@ -98,7 +170,7 @@ mod tests {
             ("X-Allowed", "yes"),
         ]);
         let merged = resolve_custom_headers("Test", &settings, &["X-Api-Key"]);
-        assert_eq!(names(&merged), vec!["x-allowed".to_string()]);
+        assert_eq!(names(&merged.resolve_static()), vec!["x-allowed".to_string()]);
     }
 
     #[test]
@@ -110,7 +182,7 @@ mod tests {
             ("X-Allowed", "yes"),
         ]);
         let merged = resolve_custom_headers("Test", &settings, &["X-Api-Key"]);
-        assert_eq!(names(&merged), vec!["x-allowed".to_string()]);
+        assert_eq!(names(&merged.resolve_static()), vec!["x-allowed".to_string()]);
     }
 
     #[test]
@@ -118,7 +190,7 @@ mod tests {
         let settings = map(&[("Authorization-Forwarded", "ok"), ("X-Api-Key-Trace", "ok")]);
         let merged = resolve_custom_headers("Test", &settings, &["X-Api-Key"]);
         assert_eq!(
-            names(&merged),
+            names(&merged.resolve_static()),
             vec![
                 "authorization-forwarded".to_string(),
                 "x-api-key-trace".to_string(),
@@ -134,6 +206,43 @@ mod tests {
             ("X-Allowed", "yes"),
         ]);
         let merged = resolve_custom_headers("Test", &settings, &[]);
-        assert_eq!(names(&merged), vec!["x-allowed".to_string()]);
+        assert_eq!(names(&merged.resolve_static()), vec!["x-allowed".to_string()]);
+    }
+
+    #[test]
+    fn resolves_agent_thread_id_from_request() {
+        let settings = HashMap::from([(
+            "X-Agent-Thread".to_string(),
+            CustomHeaderValueContent::Dynamic {
+                source: CustomHeaderSourceContent::AgentThreadId,
+            },
+        )]);
+        let definitions =
+            resolve_custom_headers("Test", &settings, &[]);
+        assert!(definitions.resolve_static().is_empty());
+
+        let request = LanguageModelRequest {
+            thread_id: Some("thread-uuid".into()),
+            ..Default::default()
+        };
+        let headers = definitions.resolve(&request);
+        let mut iter = headers.iter();
+        let (name, value) = iter.next().expect("expected agent thread header");
+        assert_eq!(name.as_str(), "x-agent-thread");
+        assert_eq!(value.to_str().unwrap(), "thread-uuid");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn agent_thread_id_header_omitted_without_thread() {
+        let settings = HashMap::from([(
+            "X-Agent-Thread".to_string(),
+            CustomHeaderValueContent::Dynamic {
+                source: CustomHeaderSourceContent::AgentThreadId,
+            },
+        )]);
+        let definitions = resolve_custom_headers("Test", &settings, &[]);
+        let request = LanguageModelRequest::default();
+        assert!(definitions.resolve(&request).is_empty());
     }
 }

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -19,6 +19,7 @@ use settings::{Settings, SettingsStore};
 use std::sync::{Arc, LazyLock};
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
 use anthropic::completion::collect_compaction_result;
 pub use anthropic::completion::{AnthropicEventMapper, AnthropicPromptCacheMode, into_anthropic};
 pub use settings::AnthropicAvailableModel as AvailableModel;
@@ -32,7 +33,7 @@ pub struct AnthropicSettings {
     /// Extend Zed's list of Anthropic models.
     pub available_models: Vec<AvailableModel>,
     /// User-configured headers added to every Anthropic request.
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct AnthropicLanguageModelProvider {
@@ -111,7 +112,7 @@ impl State {
         };
         let extra_headers = AnthropicLanguageModelProvider::settings(cx)
             .custom_headers
-            .clone();
+            .resolve_static();
 
         cx.spawn(async move |this, cx| {
             let models = anthropic::list_models(
@@ -691,6 +692,7 @@ impl AnthropicModel {
     fn stream_completion(
         &self,
         request: anthropic::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -701,12 +703,9 @@ impl AnthropicModel {
     > {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = AnthropicLanguageModelProvider::api_url(cx);
-            let extra_headers = AnthropicLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let beta_headers = self.model.beta_headers();
@@ -811,6 +810,11 @@ impl LanguageModel for AnthropicModel {
             .boxed();
         }
 
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            AnthropicLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let mut request = match into_anthropic(
             request,
             self.model.request_id(false).to_string(),
@@ -826,7 +830,7 @@ impl LanguageModel for AnthropicModel {
         if !self.model.supports_speed {
             request.speed = None;
         }
-        let request = self.stream_completion(request, cx);
+        let request = self.stream_completion(request, extra_headers, cx);
         let future = self.request_limiter.run(async move {
             let response = request.await?;
             let stream = AnthropicEventMapper::new(PROVIDER_NAME, PROVIDER_ID).map_stream(response);
@@ -888,6 +892,11 @@ impl LanguageModel for AnthropicModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            AnthropicLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let has_tools = !request.tools.is_empty();
         let request_id = self.model.request_id(has_tools).to_string();
         let mut request = match into_anthropic(
@@ -905,7 +914,7 @@ impl LanguageModel for AnthropicModel {
         if !self.model.supports_speed {
             request.speed = None;
         }
-        let request = self.stream_completion(request, cx);
+        let request = self.stream_completion(request, extra_headers, cx);
         let future = self.request_limiter.stream(async move {
             let response = request.await?;
             Ok(AnthropicEventMapper::new(PROVIDER_NAME, PROVIDER_ID).map_stream(response))

--- a/crates/language_models/src/provider/anthropic_compatible.rs
+++ b/crates/language_models/src/provider/anthropic_compatible.rs
@@ -16,6 +16,7 @@ use settings::Settings;
 use std::sync::Arc;
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
 use crate::provider::api_compatible::{
     ApiCompatibleProviderConfigurationView, ApiCompatibleProviderSettings,
     ApiCompatibleProviderState,
@@ -30,7 +31,7 @@ const API_KEY_PLACEHOLDER: &str = "sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 pub struct AnthropicCompatibleSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct AnthropicCompatibleLanguageModelProvider {
@@ -306,6 +307,7 @@ impl AnthropicCompatibleLanguageModel {
     fn stream_completion(
         &self,
         request: anthropic::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -317,13 +319,9 @@ impl AnthropicCompatibleLanguageModel {
         let http_client = self.http_client.clone();
         let provider_name = self.provider_name.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, _cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, _cx| {
             let api_url = state.settings.api_url.clone();
-            (
-                state.api_key_state.key(&api_url),
-                api_url,
-                state.settings.custom_headers.clone(),
-            )
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let beta_headers = self.model.beta_headers();
@@ -437,6 +435,9 @@ impl LanguageModel for AnthropicCompatibleLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self
+            .state
+            .read_with(cx, |state, _cx| state.settings.custom_headers.resolve(&request));
         let has_tools = !request.tools.is_empty();
         let request_id = self.model.request_id(has_tools).to_string();
         let mut request = match into_anthropic(
@@ -454,7 +455,7 @@ impl LanguageModel for AnthropicCompatibleLanguageModel {
         if !self.model.supports_speed {
             request.speed = None;
         }
-        let completion_request = self.stream_completion(request, cx);
+        let completion_request = self.stream_completion(request, extra_headers, cx);
         let provider_name = self.provider_name.clone();
         let provider_id = self.provider_id.clone();
         let future = self.request_limiter.stream(async move {

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -39,6 +39,8 @@ use http_client::{
     AsyncBody, CustomHeaders, HttpClient, Method, Request as HttpRequest, RequestBuilderExt,
     http::{HeaderValue, header::AUTHORIZATION},
 };
+
+use crate::provider::CustomHeaderDefinitions;
 use language_model::{
     AuthenticateError, EnvVar, IconOrSvg, InlineDescription, LanguageModel,
     LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelEffortLevel,
@@ -137,7 +139,7 @@ impl BedrockCredentials {
 pub struct AmazonBedrockSettings {
     pub available_models: Vec<AvailableModel>,
     pub mantle_available_models: Vec<MantleAvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
     pub region: Option<String>,
     pub endpoint: Option<String>,
     pub profile_name: Option<String>,
@@ -793,6 +795,7 @@ impl BedrockModel {
     fn stream_completion(
         &self,
         request: bedrock::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -806,12 +809,6 @@ impl BedrockModel {
             return futures::future::ready(Err(BedrockError::Other(anyhow!("App state dropped"))))
                 .boxed();
         };
-        let extra_headers = self.state.read_with(cx, |_, cx| {
-            AllLanguageModelSettings::get_global(cx)
-                .bedrock
-                .custom_headers
-                .clone()
-        });
 
         let task = Tokio::spawn(
             cx,
@@ -960,6 +957,12 @@ impl LanguageModel for BedrockModel {
 
         let deny_tool_calls = request.tool_choice == Some(LanguageModelToolChoice::None);
 
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            AllLanguageModelSettings::get_global(cx)
+                .bedrock
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match into_bedrock(
             request,
             model_id,
@@ -975,7 +978,7 @@ impl LanguageModel for BedrockModel {
             Err(err) => return futures::future::ready(Err(err.into())).boxed(),
         };
 
-        let request = self.stream_completion(request, cx);
+        let request = self.stream_completion(request, extra_headers, cx);
         let display_name = self.model.display_name().to_string();
         let future = self.request_limiter.stream(async move {
             let response = request.await.map_err(|err| match err {
@@ -1723,6 +1726,7 @@ impl BedrockMantleModel {
     fn stream_mantle_request<Request, Event>(
         &self,
         request: Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
         endpoint: &'static str,
         parse_stream_line: fn(&str) -> Result<Event>,
@@ -1738,12 +1742,6 @@ impl BedrockMantleModel {
             (state.auth.clone(), state.get_region())
         });
         let url = format!("{}/{}", mantle_endpoint_url(&region), endpoint);
-        let extra_headers = cx.read_entity(&self.state, |_, cx| {
-            AllLanguageModelSettings::get_global(cx)
-                .bedrock
-                .custom_headers
-                .clone()
-        });
         let provider_name = PROVIDER_NAME.0.to_string();
         let auth_task = Tokio::spawn_result(
             cx,
@@ -1774,6 +1772,7 @@ impl BedrockMantleModel {
     fn stream_completion(
         &self,
         request: open_ai::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -1781,6 +1780,7 @@ impl BedrockMantleModel {
     > {
         self.stream_mantle_request(
             request,
+            extra_headers,
             cx,
             "chat/completions",
             parse_mantle_chat_stream_line,
@@ -1790,6 +1790,7 @@ impl BedrockMantleModel {
     fn stream_response(
         &self,
         request: OpenAiResponseRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -1800,7 +1801,13 @@ impl BedrockMantleModel {
     > {
         let mut request = request;
         strip_unsupported_mantle_response_fields(&mut request);
-        self.stream_mantle_request(request, cx, "responses", parse_mantle_response_stream_line)
+        self.stream_mantle_request(
+            request,
+            extra_headers,
+            cx,
+            "responses",
+            parse_mantle_response_stream_line,
+        )
     }
 }
 
@@ -1896,6 +1903,12 @@ impl LanguageModel for BedrockMantleModel {
         let model_id = self.model.request_id().to_string();
         let max_output_tokens = Some(self.model.max_output_tokens());
 
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            AllLanguageModelSettings::get_global(cx)
+                .bedrock
+                .custom_headers
+                .resolve(&request)
+        });
         match self.model.protocol() {
             MantleProtocol::Responses => {
                 let request = match into_open_ai_response(
@@ -1911,7 +1924,7 @@ impl LanguageModel for BedrockMantleModel {
                     Ok(request) => request,
                     Err(error) => return async move { Err(error.into()) }.boxed(),
                 };
-                let completions = self.stream_response(request, cx);
+                let completions = self.stream_response(request, extra_headers, cx);
                 async move {
                     let mapper = MantleResponseEventMapper::new();
                     Ok(mapper.map_stream(completions.await?).boxed())
@@ -1933,7 +1946,7 @@ impl LanguageModel for BedrockMantleModel {
                     Ok(request) => request,
                     Err(error) => return async move { Err(error.into()) }.boxed(),
                 };
-                let completions = self.stream_completion(request, cx);
+                let completions = self.stream_completion(request, extra_headers, cx);
                 async move {
                     let mapper = OpenAiEventMapper::new();
                     Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -20,6 +20,7 @@ use settings::{Settings, SettingsStore};
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 
+use crate::provider::CustomHeaderDefinitions;
 use ui::IconName;
 
 use language_model::util::{fix_streamed_json, parse_tool_arguments};
@@ -41,7 +42,7 @@ struct RawToolCall {
 pub struct DeepSeekSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 pub struct DeepSeekLanguageModelProvider {
     http_client: Arc<dyn HttpClient>,
@@ -223,16 +224,14 @@ impl DeepSeekLanguageModel {
     fn stream_completion(
         &self,
         request: deepseek::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<BoxStream<'static, Result<deepseek::StreamResponse>>>> {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = DeepSeekLanguageModelProvider::api_url(cx);
-            let extra_headers = DeepSeekLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -343,11 +342,16 @@ impl LanguageModel for DeepSeekLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            DeepSeekLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match into_deepseek(request, &self.model, self.max_output_tokens()) {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let stream = self.stream_completion(request, cx);
+        let stream = self.stream_completion(request, extra_headers, cx);
 
         async move {
             let mapper = DeepSeekEventMapper::new();

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -22,6 +22,8 @@ pub use settings::GoogleAvailableModel as AvailableModel;
 use settings::{Settings, SettingsStore};
 use std::sync::{Arc, LazyLock};
 use strum::IntoEnumIterator;
+
+use crate::provider::CustomHeaderDefinitions;
 use ui::IconName;
 
 use language_model::ApiKeyState;
@@ -33,7 +35,7 @@ const PROVIDER_NAME: LanguageModelProviderName = GOOGLE_PROVIDER_NAME;
 pub struct GoogleSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -248,6 +250,7 @@ impl GoogleLanguageModel {
     fn stream_completion(
         &self,
         request: google_ai::GenerateContentRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -255,12 +258,9 @@ impl GoogleLanguageModel {
     > {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = GoogleLanguageModelProvider::api_url(cx);
-            let extra_headers = GoogleLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         async move {
@@ -358,6 +358,11 @@ impl LanguageModel for GoogleLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            GoogleLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match into_google(
             request,
             self.model.request_id().to_string(),
@@ -366,7 +371,7 @@ impl LanguageModel for GoogleLanguageModel {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let request = self.stream_completion(request, cx);
+        let request = self.stream_completion(request, extra_headers, cx);
         let future = self.request_limiter.stream(async move {
             let response = request.await.map_err(LanguageModelCompletionError::from)?;
             Ok(GoogleEventMapper::new().map_stream(response))

--- a/crates/language_models/src/provider/llama_cpp.rs
+++ b/crates/language_models/src/provider/llama_cpp.rs
@@ -32,6 +32,7 @@ use ui_input::InputField;
 use util::ResultExt;
 
 use crate::AllLanguageModelSettings;
+use crate::provider::CustomHeaderDefinitions;
 
 const LLAMA_CPP_DOWNLOAD_URL: &str = "https://llama.app";
 const LLAMA_CPP_MODELS_URL: &str = "https://huggingface.co/models?library=gguf&sort=trending";
@@ -56,7 +57,7 @@ pub struct LlamaCppSettings {
     pub auto_discover: bool,
     pub available_models: Vec<AvailableModel>,
     pub context_window: Option<u64>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct LlamaCppLanguageModelProvider {
@@ -159,7 +160,7 @@ impl State {
         let settings = LlamaCppLanguageModelProvider::settings(cx);
         let api_url = LlamaCppLanguageModelProvider::api_url(cx);
         let api_key = self.api_key_state.key(&api_url);
-        let extra_headers = settings.custom_headers.clone();
+        let extra_headers = settings.custom_headers.resolve_static();
 
         cx.spawn(async move |this, cx| {
             let entries = get_models(
@@ -262,7 +263,7 @@ impl State {
         let api_key = self.api_key_state.key(&api_url);
         let extra_headers = LlamaCppLanguageModelProvider::settings(cx)
             .custom_headers
-            .clone();
+            .resolve_static();
 
         self.model_event_task = Some(cx.spawn(async move |this, cx| {
             loop {
@@ -662,18 +663,16 @@ impl LlamaCppLanguageModel {
     fn stream_completion(
         &self,
         request: llama_cpp::ChatCompletionRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
         Result<futures::stream::BoxStream<'static, Result<llama_cpp::ResponseStreamEvent>>>,
     > {
         let http_client = self.http_client.clone();
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = LlamaCppLanguageModelProvider::api_url(cx);
-            let extra_headers = LlamaCppLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -936,11 +935,16 @@ impl LanguageModel for LlamaCppLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            LlamaCppLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match self.to_llama_cpp_request(request) {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let completions = self.stream_completion(request, cx);
+        let completions = self.stream_completion(request, extra_headers, cx);
         async move {
             let mapper = LlamaCppEventMapper::new();
             Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -29,6 +29,7 @@ use ui::{ButtonLike, ConfiguredApiCard, Divider, List, ListBulletItem, Tooltip, 
 use ui_input::InputField;
 
 use crate::AllLanguageModelSettings;
+use crate::provider::CustomHeaderDefinitions;
 use language_model::util::parse_tool_arguments;
 
 const LMSTUDIO_DOWNLOAD_URL: &str = "https://lmstudio.ai/download";
@@ -45,7 +46,7 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 pub struct LmStudioSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct LmStudioLanguageModelProvider {
@@ -86,7 +87,7 @@ impl State {
         let http_client = self.http_client.clone();
         let api_url = settings.api_url.clone();
         let api_key = self.api_key_state.key(&api_url);
-        let extra_headers = settings.custom_headers.clone();
+        let extra_headers = settings.custom_headers.resolve_static();
 
         // As a proxy for the server being "authenticated", we'll check if its up by fetching the models
         cx.spawn(async move |this, cx| {
@@ -469,19 +470,16 @@ impl LmStudioLanguageModel {
     fn stream_completion(
         &self,
         request: lmstudio::ChatCompletionRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
         Result<futures::stream::BoxStream<'static, Result<lmstudio::ResponseStreamEvent>>>,
     > {
         let http_client = self.http_client.clone();
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = LmStudioLanguageModelProvider::api_url(cx);
-            let extra_headers = AllLanguageModelSettings::get_global(cx)
-                .lmstudio
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -553,11 +551,17 @@ impl LanguageModel for LmStudioLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            AllLanguageModelSettings::get_global(cx)
+                .lmstudio
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match self.to_lmstudio_request(request) {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let completions = self.stream_completion(request, cx);
+        let completions = self.stream_completion(request, extra_headers, cx);
         async move {
             let mapper = LmStudioEventMapper::new();
             Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -19,6 +19,8 @@ use settings::{Settings, SettingsStore};
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use strum::IntoEnumIterator;
+
+use crate::provider::CustomHeaderDefinitions;
 use ui::IconName;
 
 use language_model::util::{fix_streamed_json, parse_tool_arguments};
@@ -34,7 +36,7 @@ pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &["x-affinity"];
 pub struct MistralSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct MistralLanguageModelProvider {
@@ -249,6 +251,7 @@ impl MistralLanguageModel {
         &self,
         request: mistral::Request,
         affinity: Option<String>,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -256,12 +259,9 @@ impl MistralLanguageModel {
     > {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = MistralLanguageModelProvider::api_url(cx);
-            let extra_headers = MistralLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -342,12 +342,17 @@ impl LanguageModel for MistralLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            MistralLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let (request, affinity) =
             match into_mistral(request, self.model.clone(), self.max_output_tokens()) {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-        let stream = self.stream_completion(request, affinity, cx);
+        let stream = self.stream_completion(request, affinity, extra_headers, cx);
 
         async move {
             let stream = stream.await?;

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -31,6 +31,7 @@ use ui::{
 use ui_input::InputField;
 
 use crate::AllLanguageModelSettings;
+use crate::provider::CustomHeaderDefinitions;
 
 const OLLAMA_DOWNLOAD_URL: &str = "https://ollama.com/download";
 const OLLAMA_LIBRARY_URL: &str = "https://ollama.com/library";
@@ -48,7 +49,7 @@ pub struct OllamaSettings {
     pub auto_discover: bool,
     pub available_models: Vec<AvailableModel>,
     pub context_window: Option<u64>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct OllamaLanguageModelProvider {
@@ -115,7 +116,7 @@ impl State {
         let settings = OllamaLanguageModelProvider::settings(cx);
         let api_url = OllamaLanguageModelProvider::api_url(cx);
         let api_key = self.api_key_state.key(&api_url);
-        let extra_headers = settings.custom_headers.clone();
+        let extra_headers = settings.custom_headers.resolve_static();
 
         // As a proxy for the server being "authenticated", we'll check if its up by fetching the models
         cx.spawn(async move |this, cx| {
@@ -553,18 +554,20 @@ impl LanguageModel for OllamaLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            OllamaLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match self.to_ollama_request(request) {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
 
         let http_client = self.http_client.clone();
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = OllamaLanguageModelProvider::api_url(cx);
-            let extra_headers = OllamaLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -25,6 +25,7 @@ use std::sync::{Arc, LazyLock};
 use strum::IntoEnumIterator;
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
 use open_ai::completion::token_usage_from_response_usage;
 pub use open_ai::completion::{
     ChatCompletionMaxTokensParameter, OpenAiEventMapper, OpenAiResponseEventMapper, into_open_ai,
@@ -41,7 +42,7 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 pub struct OpenAiSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct OpenAiLanguageModelProvider {
@@ -365,17 +366,15 @@ impl OpenAiLanguageModel {
     fn stream_completion(
         &self,
         request: open_ai::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<ResponseStreamEvent>>>>
     {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = OpenAiLanguageModelProvider::api_url(cx);
-            let extra_headers = OpenAiLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -401,17 +400,15 @@ impl OpenAiLanguageModel {
     fn stream_response(
         &self,
         request: ResponseRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<ResponsesStreamEvent>>>>
     {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = OpenAiLanguageModelProvider::api_url(cx);
-            let extra_headers = OpenAiLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let provider = PROVIDER_NAME;
@@ -437,16 +434,14 @@ impl OpenAiLanguageModel {
     fn compact_response(
         &self,
         request: CompactRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<CompactedResponse, LanguageModelCompletionError>> {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = OpenAiLanguageModelProvider::api_url(cx);
-            let extra_headers = OpenAiLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let provider = PROVIDER_NAME;
@@ -559,6 +554,11 @@ impl LanguageModel for OpenAiLanguageModel {
             .boxed();
         }
 
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            OpenAiLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         normalize_open_ai_response_thinking_effort(&mut request, &self.model);
         let request = match into_open_ai_response(
             request,
@@ -576,7 +576,7 @@ impl LanguageModel for OpenAiLanguageModel {
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
         let request = request.into_compact_request();
-        let response = self.compact_response(request, cx);
+        let response = self.compact_response(request, extra_headers, cx);
         async move {
             let response = response.await?;
             let usage = token_usage_from_response_usage(&response.usage);
@@ -625,6 +625,11 @@ impl LanguageModel for OpenAiLanguageModel {
         if !self.model.supports_priority() {
             request.speed = None;
         }
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            OpenAiLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         if self.model.uses_responses_api() {
             normalize_open_ai_response_thinking_effort(&mut request, &self.model);
             let request = match into_open_ai_response(
@@ -642,7 +647,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-            let completions = self.stream_response(request, cx);
+            let completions = self.stream_response(request, extra_headers, cx);
             async move {
                 let mapper = OpenAiResponseEventMapper::new(OPEN_AI_PROVIDER_ID);
                 Ok(mapper.map_stream(completions.await?).boxed())
@@ -662,7 +667,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-            let completions = self.stream_completion(request, cx);
+            let completions = self.stream_completion(request, extra_headers, cx);
             async move {
                 let mapper = OpenAiEventMapper::new();
                 Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -19,6 +19,7 @@ use settings::Settings;
 use std::sync::Arc;
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
 use crate::provider::api_compatible::{
     ApiCompatibleProviderConfigurationView, ApiCompatibleProviderSettings,
     ApiCompatibleProviderState,
@@ -35,7 +36,7 @@ const API_KEY_PLACEHOLDER: &str = "000000000000000000000000000000000000000000000
 pub struct OpenAiCompatibleSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 impl ApiCompatibleProviderSettings for OpenAiCompatibleSettings {
@@ -182,6 +183,7 @@ impl OpenAiCompatibleLanguageModel {
     fn stream_completion(
         &self,
         request: open_ai::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -192,13 +194,9 @@ impl OpenAiCompatibleLanguageModel {
     > {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, _cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, _cx| {
             let api_url = &state.settings.api_url;
-            (
-                state.api_key_state.key(api_url),
-                state.settings.api_url.clone(),
-                state.settings.custom_headers.clone(),
-            )
+            (state.api_key_state.key(api_url), state.settings.api_url.clone())
         });
 
         let provider = self.provider_name.clone();
@@ -224,18 +222,15 @@ impl OpenAiCompatibleLanguageModel {
     fn stream_response(
         &self,
         request: ResponseRequest,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<ResponsesStreamEvent>>>>
     {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, _cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, _cx| {
             let api_url = &state.settings.api_url;
-            (
-                state.api_key_state.key(api_url),
-                state.settings.api_url.clone(),
-                state.settings.custom_headers.clone(),
-            )
+            (state.api_key_state.key(api_url), state.settings.api_url.clone())
         });
 
         let provider = self.provider_name.clone();
@@ -422,6 +417,9 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
             request.speed = None;
         }
 
+        let extra_headers = self
+            .state
+            .read_with(cx, |state, _cx| state.settings.custom_headers.resolve(&request));
         if self.model.capabilities.chat_completions {
             let reasoning_effort = chat_completion_reasoning_effort(&request, &self.model);
             let request = match into_open_ai(
@@ -437,7 +435,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-            let completions = self.stream_completion(request, cx);
+            let completions = self.stream_completion(request, extra_headers, cx);
             async move {
                 let mapper = OpenAiEventMapper::new();
                 Ok(mapper.map_stream(completions.await?).boxed())
@@ -458,7 +456,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-            let completions = self.stream_response(request, cx);
+            let completions = self.stream_response(request, extra_headers, cx);
             let compaction_state_owner = self.provider_id.clone();
             async move {
                 let mapper = OpenAiResponseEventMapper::new(compaction_state_owner);

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -22,6 +22,7 @@ use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
 use language_model::util::{fix_streamed_json, parse_tool_arguments};
 
 const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openrouter");
@@ -35,7 +36,7 @@ pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &["HTTP-Referer", "X-Title"];
 pub struct OpenRouterSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct OpenRouterLanguageModelProvider {
@@ -101,7 +102,7 @@ impl State {
         let api_url = OpenRouterLanguageModelProvider::api_url(cx);
         let extra_headers = OpenRouterLanguageModelProvider::settings(cx)
             .custom_headers
-            .clone();
+            .resolve_static();
         let Some(api_key) = self.api_key_state.key(&api_url) else {
             return Task::ready(Err(LanguageModelCompletionError::NoApiKey {
                 provider: PROVIDER_NAME,
@@ -286,6 +287,7 @@ impl OpenRouterLanguageModel {
     fn stream_completion(
         &self,
         request: open_router::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -298,12 +300,9 @@ impl OpenRouterLanguageModel {
         >,
     > {
         let http_client = self.http_client.clone();
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = OpenRouterLanguageModelProvider::api_url(cx);
-            let extra_headers = OpenRouterLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         async move {
@@ -401,12 +400,17 @@ impl LanguageModel for OpenRouterLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            OpenRouterLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let openrouter_request =
             match into_open_router(request, &self.model, self.max_output_tokens()) {
                 Ok(request) => request,
                 Err(error) => return async move { Err(error.into()) }.boxed(),
             };
-        let request = self.stream_completion(openrouter_request, cx);
+        let request = self.stream_completion(openrouter_request, extra_headers, cx);
         let future = self.request_limiter.stream(async move {
             let response = request.await?;
             Ok(OpenRouterEventMapper::new().map_stream(response))

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -26,6 +26,7 @@ use ui::{
 use ui_input::InputField;
 use util::ResultExt;
 
+use crate::provider::CustomHeaderDefinitions;
 use crate::provider::anthropic::{AnthropicEventMapper, into_anthropic};
 use crate::provider::google::{GoogleEventMapper, into_google};
 use crate::provider::open_ai::{
@@ -69,7 +70,7 @@ pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &["x-opencode-session"];
 pub struct OpenCodeSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
     pub show_zen_models: bool,
     pub show_go_models: bool,
 }
@@ -368,11 +369,11 @@ impl OpenCodeLanguageModel {
         })
     }
 
-    fn custom_headers(&self, cx: &AsyncApp) -> CustomHeaders {
+    fn custom_headers(&self, request: &LanguageModelRequest, cx: &AsyncApp) -> CustomHeaders {
         self.state.read_with(cx, |_, cx| {
             OpenCodeLanguageModelProvider::settings(cx)
                 .custom_headers
-                .clone()
+                .resolve(request)
         })
     }
 
@@ -645,7 +646,7 @@ impl LanguageModel for OpenCodeLanguageModel {
         } else {
             self.http_client.clone()
         };
-        let extra_headers = self.custom_headers(cx);
+        let extra_headers = self.custom_headers(&request, cx);
 
         match self.model.protocol(self.subscription) {
             ApiProtocol::Anthropic => {

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -21,6 +21,8 @@ use settings::{Settings, SettingsStore};
 use std::sync::{Arc, LazyLock};
 use ui::IconName;
 
+use crate::provider::CustomHeaderDefinitions;
+
 const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("vercel_ai_gateway");
 const PROVIDER_NAME: LanguageModelProviderName =
     LanguageModelProviderName::new("Vercel AI Gateway");
@@ -33,7 +35,7 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 pub struct VercelAiGatewaySettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct VercelAiGatewayLanguageModelProvider {
@@ -93,7 +95,7 @@ impl State {
         let api_key = self.api_key_state.key(&api_url);
         let extra_headers = VercelAiGatewayLanguageModelProvider::settings(cx)
             .custom_headers
-            .clone();
+            .resolve_static();
         cx.spawn(async move |this, cx| {
             let models = list_models(
                 http_client.as_ref(),
@@ -273,6 +275,7 @@ impl VercelAiGatewayLanguageModel {
     fn stream_open_ai(
         &self,
         request: open_ai::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -282,12 +285,9 @@ impl VercelAiGatewayLanguageModel {
         >,
     > {
         let http_client = self.http_client.clone();
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = VercelAiGatewayLanguageModelProvider::api_url(cx);
-            let extra_headers = VercelAiGatewayLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -451,6 +451,11 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            VercelAiGatewayLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let request = match crate::provider::open_ai::into_open_ai(
             request,
             &self.model.name,
@@ -464,7 +469,7 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let completions = self.stream_open_ai(request, cx);
+        let completions = self.stream_open_ai(request, extra_headers, cx);
         async move {
             let mapper = crate::provider::open_ai::OpenAiEventMapper::new();
             Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -20,6 +20,8 @@ use strum::IntoEnumIterator;
 use ui::IconName;
 use x_ai::XAI_API_URL;
 
+use crate::provider::CustomHeaderDefinitions;
+
 const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("x_ai");
 const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("xAI");
 
@@ -30,7 +32,7 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 pub struct XAiSettings {
     pub api_url: String,
     pub available_models: Vec<AvailableModel>,
-    pub custom_headers: CustomHeaders,
+    pub custom_headers: CustomHeaderDefinitions,
 }
 
 pub struct XAiLanguageModelProvider {
@@ -220,6 +222,7 @@ impl XAiLanguageModel {
     fn stream_completion(
         &self,
         request: open_ai::Request,
+        extra_headers: CustomHeaders,
         cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -230,12 +233,9 @@ impl XAiLanguageModel {
     > {
         let http_client = self.http_client.clone();
 
-        let (api_key, api_url, extra_headers) = self.state.read_with(cx, |state, cx| {
+        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
             let api_url = XAiLanguageModelProvider::api_url(cx);
-            let extra_headers = XAiLanguageModelProvider::settings(cx)
-                .custom_headers
-                .clone();
-            (state.api_key_state.key(&api_url), api_url, extra_headers)
+            (state.api_key_state.key(&api_url), api_url)
         });
 
         let future = self.request_limiter.stream(async move {
@@ -412,6 +412,11 @@ impl LanguageModel for XAiLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let extra_headers = self.state.read_with(cx, |_, cx| {
+            XAiLanguageModelProvider::settings(cx)
+                .custom_headers
+                .resolve(&request)
+        });
         let reasoning_effort = reasoning_effort_for_request(&request, &self.model);
         let request = match crate::provider::open_ai::into_open_ai(
             request,
@@ -426,7 +431,7 @@ impl LanguageModel for XAiLanguageModel {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };
-        let completions = self.stream_completion(request, cx);
+        let completions = self.stream_completion(request, extra_headers, cx);
         async move {
             let mapper = crate::provider::open_ai::OpenAiEventMapper::new();
             Ok(mapper.map_stream(completions.await?).boxed())

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use collections::HashMap;
 use settings::RegisterSetting;
+use settings::settings_content::CustomHeaderValueContent;
 
 use crate::provider::{
     anthropic, anthropic::AnthropicSettings, anthropic_compatible::AnthropicCompatibleSettings,
@@ -35,9 +36,9 @@ pub struct AllLanguageModelSettings {
 
 fn custom_headers_from(
     provider_name: &str,
-    raw: Option<HashMap<String, String>>,
+    raw: Option<HashMap<String, CustomHeaderValueContent>>,
     reserved: &[&str],
-) -> http_client::CustomHeaders {
+) -> crate::provider::CustomHeaderDefinitions {
     raw.as_ref()
         .filter(|map| !map.is_empty())
         .map(|map| resolve_custom_headers(provider_name, map, reserved))

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -7,6 +7,22 @@ use settings_macros::{MergeFrom, with_fallible_options};
 
 use std::sync::Arc;
 
+/// A custom language model header value from settings.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
+#[serde(untagged)]
+pub enum CustomHeaderValueContent {
+    Static(String),
+    Dynamic { source: CustomHeaderSourceContent },
+}
+
+/// A dynamic value source for a custom language model header.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CustomHeaderSourceContent {
+    /// The current Agent Thread's stable identifier.
+    AgentThreadId,
+}
+
 #[with_fallible_options]
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
 pub struct AllLanguageModelSettingsContent {
@@ -35,7 +51,7 @@ pub struct AllLanguageModelSettingsContent {
 pub struct AnthropicSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<AnthropicAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -43,7 +59,7 @@ pub struct AnthropicSettingsContent {
 pub struct AnthropicCompatibleSettingsContent {
     pub api_url: String,
     pub available_models: Vec<AnthropicCompatibleAvailableModel>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -120,7 +136,7 @@ pub struct AmazonBedrockSettingsContent {
     /// OpenAI-compatible APIs, in addition to the built-in Mantle models
     /// (GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5, GPT-5.4, Grok 4.3).
     pub mantle_available_models: Option<Vec<BedrockMantleAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
     pub endpoint_url: Option<String>,
     pub region: Option<String>,
     pub profile: Option<String>,
@@ -191,7 +207,7 @@ pub struct OllamaSettingsContent {
     pub auto_discover: Option<bool>,
     pub available_models: Option<Vec<OllamaAvailableModel>>,
     pub context_window: Option<u64>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -240,7 +256,7 @@ impl Default for KeepAlive {
 pub struct OpenCodeSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<OpenCodeAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
     /// Whether to show OpenCode Zen models. Defaults to true.
     pub show_zen_models: Option<bool>,
     /// Whether to show OpenCode Go models. Defaults to true.
@@ -292,7 +308,7 @@ pub struct LmStudioSettingsContent {
     pub api_url: Option<String>,
     pub api_key: Option<String>,
     pub available_models: Option<Vec<LmStudioAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -315,7 +331,7 @@ pub struct LlamaCppSettingsContent {
     pub available_models: Option<Vec<LlamaCppAvailableModel>>,
     /// Overrides the context length reported for every llama.cpp model.
     pub context_window: Option<u64>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -340,7 +356,7 @@ pub struct LlamaCppAvailableModel {
 pub struct DeepseekSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<DeepseekAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -357,7 +373,7 @@ pub struct DeepseekAvailableModel {
 pub struct MistralSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<MistralAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -378,7 +394,7 @@ pub struct MistralAvailableModel {
 pub struct OpenAiSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<OpenAiAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -407,7 +423,7 @@ impl MergeFrom for OpenAiReasoningEffort {
 pub struct OpenAiCompatibleSettingsContent {
     pub api_url: String,
     pub available_models: Vec<OpenAiCompatibleAvailableModel>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -475,7 +491,7 @@ impl Default for OpenAiCompatibleModelCapabilities {
 pub struct VercelAiGatewaySettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<VercelAiGatewayAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -495,7 +511,7 @@ pub struct VercelAiGatewayAvailableModel {
 pub struct GoogleSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<GoogleAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -512,7 +528,7 @@ pub struct GoogleAvailableModel {
 pub struct XAiSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<XaiAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -576,7 +592,7 @@ pub enum ZedDotDevAvailableProvider {
 pub struct OpenRouterSettingsContent {
     pub api_url: Option<String>,
     pub available_models: Option<Vec<OpenRouterAvailableModel>>,
-    pub custom_headers: Option<HashMap<String, String>>,
+    pub custom_headers: Option<HashMap<String, CustomHeaderValueContent>>,
 }
 
 #[with_fallible_options]
@@ -635,5 +651,30 @@ pub use language_model_core::ModelMode;
 impl MergeFrom for ModelMode {
     fn merge_from(&mut self, other: &Self) {
         *self = *other;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_static_custom_header_value() {
+        let value = serde_json::from_str::<CustomHeaderValueContent>(r#""static""#).unwrap();
+        assert_eq!(value, CustomHeaderValueContent::Static("static".into()));
+    }
+
+    #[test]
+    fn parses_agent_thread_id_custom_header_source() {
+        let value = serde_json::from_str::<CustomHeaderValueContent>(
+            r#"{"source":"agent_thread_id"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            value,
+            CustomHeaderValueContent::Dynamic {
+                source: CustomHeaderSourceContent::AgentThreadId,
+            }
+        );
     }
 }

--- a/docs/src/ai/use-api-access.md
+++ b/docs/src/ai/use-api-access.md
@@ -80,6 +80,24 @@ Configure them with `language_models.<provider>.custom_headers`:
 }
 ```
 
+Each value is either a static string or an object resolving a dynamic value per request:
+
+```json [settings]
+{
+  "language_models": {
+    "openai": {
+      "custom_headers": {
+        "X-Agent-Thread": {
+          "source": "agent_thread_id"
+        }
+      }
+    }
+  }
+}
+```
+
+`agent_thread_id` sends the current Agent Thread's stable identifier: a UUID generated when the thread is created and preserved across restarts. It is included on the thread's completion, compaction, title-generation, and summary requests. Headers with no thread context (for example, model discovery) omit dynamic values.
+
 `custom_headers` is supported by Amazon Bedrock, Anthropic, DeepSeek, Google AI, LM Studio, Mistral, Ollama, OpenAI, OpenAI-compatible providers, OpenCode, OpenRouter, Vercel AI Gateway, and xAI.
 
 Headers managed by Zed for each provider, such as `Authorization`, `Content-Type`, `Accept`, and provider-specific authentication headers, are ignored with a warning if you try to override them.


### PR DESCRIPTION
# Objective

Currently `custom_headers` only support static values. A common use case for custom headers is to set the session identifier for Tracing. As Zed support multiple concurrent Agents, those will share the same identifier, which makes it hard to separate sessions (Threads). This patch introduces support for setting using the each thread identifier in custom headers.

## Solution

Add a `custom_headers` setting for HTTP-based language model providers, allowing static extra headers plus a dynamic `agent_thread_id` value that tags each request with the current agent thread's stable ID. Headers managed by Zed are reserved and cannot be overridden.

## Testing

- confirmed that this new  custom header works: `"x-litellm-session-id": { "source": "agent_thread_id" }` 
- confirmed that agent thread resumption after a restart works (same `session.id` in Traces)
- unit tests

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added `custom_headers` for language model providers, including a dynamic `agent_thread_id` header for per-thread request correlation.
