### PR TITLE
docs: Improve the Linux uninstall instructions

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -97,29 +97,31 @@ sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/bin/zed|g" ~/.local/share/applicati
 
 ### Standard Uninstall
 
-If Zed was installed using the default installation script, it can be uninstalled by supplying the `--uninstall` flag to the `zed` shell command
+If Zed was installed using the default installation script, it can be uninstalled by supplying the `--uninstall` flag to the `zed` shell command:
 
 ```sh
 zed --uninstall
 ```
 
+Note that this will uninstall the Zed variant that the symlink points to. If you have multiple, parallel installations (such as both Stable and Preview), then you should instead use its absolute path as described further down in this section.
+
 If there are no errors, the shell will then prompt you whether you'd like to keep your preferences or delete them. After making a choice, you should see a message that Zed was successfully uninstalled.
 
-In the case that the `zed` shell command was not found in your PATH, you can try one of the following commands
+In the case that the `zed` shell command was not found in your PATH, you can try one of the following commands:
 
 ```sh
 $HOME/.local/bin/zed --uninstall
 ```
 
-or
+or the absolute path to your installation, such as
 
 ```sh
-$HOME/.local/zed.app/bin.zed --uninstall
+$HOME/.local/zed.app/bin/zed --uninstall
 ```
 
-The first case might fail if a symlink was not properly established between `$HOME/.local/bin/zed` and `$HOME/.local/zed.app/bin.zed`. But the second case should work as long as Zed was installed to its default location.
+The first case might fail if a symlink was not properly established between `$HOME/.local/bin/zed` and `$HOME/.local/zed.app/bin/zed`, or if the symlink was overwritten by having parallel installations of different versions of Zed. But the second command should always work as long as Zed was installed to its default location.
 
-If Zed was installed to a different location, you must invoke the `zed` binary stored in that installation directory and pass the `--uninstall` flag to it in the same format as the previous commands.
+If Zed was installed to a different location (such as the `zed-preview.app` variant), you must invoke the `zed` binary stored in that installation directory and pass the `--uninstall` flag to it in the same format as the previous commands.
 
 ### Package Manager
 


### PR DESCRIPTION
# Objective

- Fixes incorrect Linux uninstall instructions.

## Solution

- Fixes a typo in the instructions and clarifies the correct uninstall method when having parallel installations on Linux.

## Testing

- I tested the commands. :man_shrugging: 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
