### PR TITLE
Document Tailwind CSS support for CSS files

### DIFF
--- a/docs/src/languages/css.md
+++ b/docs/src/languages/css.md
@@ -14,23 +14,9 @@ Zed has built-in support for CSS.
 
 ## Tailwind CSS
 
-Zed also supports [Tailwind CSS](./tailwindcss.md) out-of-the-box. To use Tailwind CSS IntelliSense in CSS files, configure the Tailwind CSS language server for the `CSS` language and disable the default CSS language server:
+Zed also supports [Tailwind CSS](./tailwindcss.md) out-of-the-box. To use Tailwind CSS IntelliSense in CSS files, configure the Tailwind CSS language server for the `CSS` language and disable the default CSS language server. See the [docs page](./tailwindcss.md#L45) for Tailwind CSS for more detail.
 
-```json [settings]
-{
-  "languages": {
-    "CSS": {
-      "language_servers": [
-        "tailwindcss-intellisense-css",
-        "!vscode-css-language-server",
-        "..."
-      ]
-    }
-  }
-}
-```
-
-This enables autocomplete, diagnostics, and hover previews for Tailwind-specific CSS such as `@apply`, `@layer`, and `@theme`. The `tailwindcss-intellisense-css` language server is provided by the Tailwind CSS extension and is an alternative to the default CSS language server; do not enable both at the same time.
+This enables autocomplete, diagnostics, and hover previews for Tailwind-specific CSS such as `@apply`, `@layer`, and `@theme`. The `tailwindcss-intellisense-css` language server is provided by Zed's built-in Tailwind CSS capabilities, and is an alternative to the default CSS language server; do not enable both at the same time.
 
 For Tailwind CSS classes in other languages and frameworks, see the [language-specific configuration examples](./tailwindcss.md).
 

--- a/docs/src/languages/css.md
+++ b/docs/src/languages/css.md
@@ -14,9 +14,25 @@ Zed has built-in support for CSS.
 
 ## Tailwind CSS
 
-Zed also supports [Tailwind CSS](./tailwindcss.md) out-of-the-box for languages and frameworks like JavaScript, Astro, Svelte, and more.
+Zed also supports [Tailwind CSS](./tailwindcss.md) out-of-the-box. To use Tailwind CSS IntelliSense in CSS files, configure the Tailwind CSS language server for the `CSS` language and disable the default CSS language server:
 
-<!-- TBD: Document CS -->
+```json [settings]
+{
+  "languages": {
+    "CSS": {
+      "language_servers": [
+        "tailwindcss-intellisense-css",
+        "!vscode-css-language-server",
+        "..."
+      ]
+    }
+  }
+}
+```
+
+This enables autocomplete, diagnostics, and hover previews for Tailwind-specific CSS such as `@apply`, `@layer`, and `@theme`. The `tailwindcss-intellisense-css` language server is provided by the Tailwind CSS extension and is an alternative to the default CSS language server; do not enable both at the same time.
+
+For Tailwind CSS classes in other languages and frameworks, see the [language-specific configuration examples](./tailwindcss.md).
 
 ## Recommended Reading
 


### PR DESCRIPTION
Fixes the CSS related item in Issue #43969 

## Summary

- Document how to enable Tailwind CSS IntelliSense for CSS files.
- Explain why the default CSS language server is disabled when using the Tailwind CSS language server.
- Link CSS readers to the language-specific Tailwind configuration examples for other languages and frameworks.

Release Notes:

- N/A