### PR TITLE
gpui_windows: Run prompt dialogs on a dedicated thread to avoid UI hangs

### DIFF
--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -706,11 +706,22 @@ impl PlatformWindow for WindowsWindow {
         let (done_tx, done_rx) = oneshot::channel();
         let msg = msg.to_string();
         let detail_string = detail.map(|detail| detail.to_string());
-        let handle = self.0.hwnd;
+        let handle = self.0.hwnd.0 as isize;
         let answers = answers.to_vec();
-        self.0
-            .executor
-            .spawn(async move {
+        // `TaskDialogIndirect` blocks in its own modal message loop. It must not run on
+        // the UI thread: that loop keeps servicing WM_PAINT for the (disabled) main
+        // window, so when frames are expensive and constantly re-requested (e.g. an
+        // actively streaming agent session) the loop starves and both the dialog and
+        // the window appear hung. Run it on a dedicated thread instead, and serialize
+        // prompts to preserve the previous one-prompt-at-a-time behavior.
+        static PROMPT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let spawn_result = std::thread::Builder::new()
+            .name("gpui-prompt".into())
+            .spawn(move || {
+                let _prompt_guard = PROMPT_MUTEX
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                let handle = HWND(handle as _);
                 unsafe {
                     let mut config = TASKDIALOGCONFIG::default();
                     config.cbSize = std::mem::size_of::<TASKDIALOGCONFIG>() as _;
@@ -774,8 +785,10 @@ impl PlatformWindow for WindowsWindow {
                         let _ = done_tx.send(clicked);
                     }
                 }
-            })
-            .detach();
+            });
+        if let Err(error) = spawn_result {
+            log::error!("failed to spawn prompt thread: {error}");
+        }
 
         Some(done_rx)
     }


### PR DESCRIPTION
# Objective

Fix a soft UI hang on Windows that occurs whenever a native confirmation prompt (file trash/delete, unsaved-changes-on-close, ...) is shown while the agent is actively streaming or running a long terminal command: the whole window stops responding (clicks only produce the Windows "ding") until agent output stops, at which point the queued dialog finally appears.

The bug lives in code that predates the agent era — agent sessions merely make it visible, because they are what makes frames both expensive and continuous.

Closes #62100 

Closes #62741 

## Solution

`window.prompt` called `TaskDialogIndirect` synchronously on the UI thread (inside a foreground-executor task). `TaskDialogIndirect` blocks in its own modal message loop, and that loop keeps servicing `WM_PAINT` for the now-disabled main window. During an active agent session the window is continuously re-invalidated (every streamed token / tool-call update) and each full `Window::draw` (layout + prepaint + paint of the whole tree) is expensive, so the modal loop never goes idle: the dialog can't paint or accept input, and clicking the disabled window just dings. macOS is unaffected because its prompt is an asynchronous sheet (`beginSheetModalForWindow:completionHandler:`).

The prompt now runs on a dedicated `"gpui-prompt"` thread instead of the UI thread, keeping `hwndParent` ownership and the existing oneshot result channel. The main event loop keeps processing paints and input normally, and the dialog stays responsive under any render load. Concurrent prompts are serialized with a static mutex, preserving the previous one-prompt-at-a-time behavior (formerly implied by the foreground-executor queue).

Root cause was confirmed from full-memory dumps captured during live hangs (the main thread sat in `gpui_windows::window::prompt` → `TaskDialogIndirect` → `DialogBoxIndirectParamW` modal loop → `WM_PAINT` → `Window::draw`, and a post-recovery dump shows the same draw completing inside the still-open dialog loop right as the popup appeared). A detailed investigation report is attached in the Showcase section.

## Testing

- `cargo check -p gpui_windows`, `./script/clippy -p gpui_windows` (release, `--deny warnings`).
- Real-workspace A/B comparison during an active agent session (video in Showcase): before, opening the trash-confirm dialog while the agent streamed hung the window until streaming stopped; after, the dialog appears promptly and stays interactive while the agent keeps running.
- Also covered: deleting files the agent never touched, hanging during a long-running terminal tool call (recovers immediately once the command is killed), and confirming that rename (inline, no dialog) never hung.
- No automated tests: the change moves a blocking native call off the UI thread; it was verified on a real Windows workspace build. This is a Windows-only change.
- Reviewer repro: start an agent session with heavy streaming (or a long-running terminal tool call), then press Del on any file in the project panel — the confirm dialog should appear immediately and stay usable.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior (verified manually on a real Windows workspace instead; see Testing)
- [x] Performance impact has been considered and is acceptable

## Showcase

### Before/after comparison video (trash a file during an active agent session)

https://github.com/user-attachments/assets/7260c752-3f15-4857-a0b4-878ac1e0cb2e

**NOTE:** you may enable the sound for this video, as it plays Windows 'DING' when the window hang.

### Detailed root-cause investigation report

[hang_investigation_report.md](https://github.com/user-attachments/files/31351671/hang_investigation_report.md)

---

Release Notes:

- Fixed Windows UI hangs when a confirmation prompt (e.g. file trash/delete) opened while the agent was actively streaming or running terminal commands
