### PR TITLE
google_ai: Remove deprecated Gemini models

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -499,35 +499,8 @@ impl<'de> Deserialize<'de> for ModelName {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, strum::EnumIter)]
 pub enum Model {
-    #[serde(
-        rename = "gemini-2.5-flash-lite",
-        alias = "gemini-2.5-flash-lite-preview-06-17",
-        alias = "gemini-2.0-flash-lite-preview"
-    )]
-    Gemini25FlashLite,
-    #[serde(
-        rename = "gemini-2.5-flash",
-        alias = "gemini-2.0-flash-thinking-exp",
-        alias = "gemini-2.5-flash-preview-04-17",
-        alias = "gemini-2.5-flash-preview-05-20",
-        alias = "gemini-2.5-flash-preview-latest",
-        alias = "gemini-2.0-flash"
-    )]
-    #[default]
-    Gemini25Flash,
-    #[serde(
-        rename = "gemini-2.5-pro",
-        alias = "gemini-2.0-pro-exp",
-        alias = "gemini-2.5-pro-preview-latest",
-        alias = "gemini-2.5-pro-exp-03-25",
-        alias = "gemini-2.5-pro-preview-03-25",
-        alias = "gemini-2.5-pro-preview-05-06",
-        alias = "gemini-2.5-pro-preview-06-05"
-    )]
-    Gemini25Pro,
-    #[serde(rename = "gemini-3.1-flash-lite")]
-    Gemini31FlashLite,
     #[serde(rename = "gemini-3.5-flash-lite")]
+    #[default]
     Gemini35FlashLite,
     #[serde(rename = "gemini-3-flash-preview")]
     Gemini3Flash,
@@ -537,7 +510,7 @@ pub enum Model {
     Gemini36Flash,
     #[serde(rename = "gemini-3.7-flash")]
     Gemini37Flash,
-    #[serde(rename = "gemini-3.1-pro-preview", alias = "gemini-3-pro-preview")]
+    #[serde(rename = "gemini-3.1-pro-preview")]
     Gemini31Pro,
     #[serde(rename = "custom")]
     Custom {
@@ -552,15 +525,11 @@ pub enum Model {
 
 impl Model {
     pub fn default_fast() -> Self {
-        Self::Gemini31FlashLite
+        Self::Gemini35FlashLite
     }
 
     pub fn id(&self) -> &str {
         match self {
-            Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
-            Self::Gemini25Flash => "gemini-2.5-flash",
-            Self::Gemini25Pro => "gemini-2.5-pro",
-            Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
             Self::Gemini35Flash => "gemini-3.5-flash",
@@ -572,10 +541,6 @@ impl Model {
     }
     pub fn request_id(&self) -> &str {
         match self {
-            Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
-            Self::Gemini25Flash => "gemini-2.5-flash",
-            Self::Gemini25Pro => "gemini-2.5-pro",
-            Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini35FlashLite => "gemini-3.5-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
             Self::Gemini35Flash => "gemini-3.5-flash",
@@ -588,10 +553,6 @@ impl Model {
 
     pub fn display_name(&self) -> &str {
         match self {
-            Self::Gemini25FlashLite => "Gemini 2.5 Flash-Lite",
-            Self::Gemini25Flash => "Gemini 2.5 Flash",
-            Self::Gemini25Pro => "Gemini 2.5 Pro",
-            Self::Gemini31FlashLite => "Gemini 3.1 Flash-Lite",
             Self::Gemini35FlashLite => "Gemini 3.5 Flash-Lite",
             Self::Gemini3Flash => "Gemini 3 Flash",
             Self::Gemini35Flash => "Gemini 3.5 Flash",
@@ -606,11 +567,7 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gemini25FlashLite
-            | Self::Gemini25Flash
-            | Self::Gemini25Pro
-            | Self::Gemini31FlashLite
-            | Self::Gemini35FlashLite
+            Self::Gemini35FlashLite
             | Self::Gemini3Flash
             | Self::Gemini35Flash
             | Self::Gemini36Flash
@@ -622,11 +579,7 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
-            Model::Gemini25FlashLite
-            | Model::Gemini25Flash
-            | Model::Gemini25Pro
-            | Model::Gemini31FlashLite
-            | Model::Gemini35FlashLite
+            Model::Gemini35FlashLite
             | Model::Gemini3Flash
             | Model::Gemini35Flash
             | Model::Gemini36Flash
@@ -647,11 +600,7 @@ impl Model {
     pub fn supports_thinking(&self) -> bool {
         matches!(
             self,
-            Self::Gemini25FlashLite
-                | Self::Gemini25Flash
-                | Self::Gemini25Pro
-                | Self::Gemini31FlashLite
-                | Self::Gemini35FlashLite
+            Self::Gemini35FlashLite
                 | Self::Gemini3Flash
                 | Self::Gemini35Flash
                 | Self::Gemini36Flash
@@ -666,8 +615,7 @@ impl Model {
 
     pub fn supported_thinking_levels(&self) -> &'static [ThinkingLevel] {
         match self {
-            Self::Gemini31FlashLite
-            | Self::Gemini35FlashLite
+            Self::Gemini35FlashLite
             | Self::Gemini3Flash
             | Self::Gemini35Flash
             | Self::Gemini36Flash => &[
@@ -687,7 +635,6 @@ impl Model {
 
     pub fn default_thinking_level(&self) -> Option<ThinkingLevel> {
         match self {
-            Self::Gemini31FlashLite => Some(ThinkingLevel::Minimal),
             Self::Gemini35FlashLite => Some(ThinkingLevel::Minimal),
             Self::Gemini3Flash => Some(ThinkingLevel::High),
             Self::Gemini35Flash => Some(ThinkingLevel::Medium),
@@ -700,15 +647,7 @@ impl Model {
 
     pub fn mode(&self) -> GoogleModelMode {
         match self {
-            Self::Gemini25FlashLite | Self::Gemini25Flash | Self::Gemini25Pro => {
-                GoogleModelMode::Thinking {
-                    // By default these models are set to "auto", so we preserve that behavior
-                    // but indicate they are capable of thinking mode
-                    budget_tokens: None,
-                }
-            }
-            Self::Gemini31FlashLite
-            | Self::Gemini35FlashLite
+            Self::Gemini35FlashLite
             | Self::Gemini3Flash
             | Self::Gemini35Flash
             | Self::Gemini36Flash


### PR DESCRIPTION
Google has announced shutdown dates for the Gemini 2.5 models and Gemini 3.1 Flash-Lite, but they remained available in the Google AI model picker. Deprecated aliases could also still be deserialized as supported models.

Remove those deprecated models and aliases from the built-in model list. Gemini 3.5 Flash-Lite is now the default and fast model, matching Google's recommended replacement for Gemini 3.1 Flash-Lite.

Release Notes:

- agent: Remove deprecated Gemini models
