### PR TITLE
multibuffer: Fix indent guides disappearing across blank lines in side indents

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29156,12 +29156,28 @@ async fn test_indent_guide_ends_before_empty_line(cx: &mut TestAppContext) {
     assert_indent_guides(
         0..6,
         vec![
-            indent_guide(buffer_id, 1, 2, 0),
-            indent_guide(buffer_id, 2, 2, 1),
+            indent_guide(buffer_id, 1, 3, 0),
+            indent_guide(buffer_id, 2, 3, 1),
         ],
         None,
         &mut cx,
     );
+}
+
+#[gpui::test]
+async fn test_indent_guide_closing_brace_after_blank_lines(cx: &mut TestAppContext) {
+    let (buffer_id, mut cx) = setup_indent_guides_editor(
+        &"
+        fn main() {
+            println!(\"hello\");
+
+        }"
+        .unindent(),
+        cx,
+    )
+    .await;
+
+    assert_indent_guides(0..4, vec![indent_guide(buffer_id, 1, 2, 0)], None, &mut cx);
 }
 
 #[gpui::test]

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6083,6 +6083,7 @@ impl MultiBufferSnapshot {
             // then add to the indent stack with the depth found
             let mut found_indent = false;
             let mut last_row = first_row;
+            let mut next_content_row = None;
             if line_indent.is_line_blank() {
                 while !found_indent {
                     let Some((target_row, new_line_indent, _)) = row_indents.next() else {
@@ -6097,6 +6098,7 @@ impl MultiBufferSnapshot {
                         continue;
                     }
                     last_row = target_row.min(end_row);
+                    next_content_row = Some(target_row);
                     line_indent = new_line_indent;
                     found_indent = true;
                     break;
@@ -6115,13 +6117,9 @@ impl MultiBufferSnapshot {
                 cmp::Ordering::Less => {
                     for _ in 0..(current_depth - depth) {
                         let mut indent = indent_stack.pop().unwrap();
-                        if last_row != first_row {
-                            // In this case, we landed on an empty row, had to seek forward,
-                            // and discovered that the indent we where on is ending.
-                            // This means that the last display row must
-                            // be on line that ends this indent range, so we
-                            // should display the range up to the first non-empty line
-                            indent.end_row = MultiBufferRow(first_row.0.saturating_sub(1));
+                        if let Some(next_content_row) = next_content_row {
+                            indent.end_row =
+                                MultiBufferRow(next_content_row.0.saturating_sub(1)).min(end_row);
                         }
 
                         result.push(indent)


### PR DESCRIPTION
# Objective
Fixes #62285

## Solution

When the scanner hits blank lines, it remembers where the blanks ended and stretches each ending guide through those blank rows.

## Testing
A new test case was added and a previous one modified. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="356" height="287" alt="image" src="https://github.com/user-attachments/assets/b7df47a1-3451-4420-890c-4434b71a9d5b" />


Release Notes:

- Fix indent guides disappearing across blank lines in side indents
