### PR TITLE
worktree: Avoid panic on non-prefixed paths in IgnoreStack

### DIFF
--- a/crates/worktree/src/ignore.rs
+++ b/crates/worktree/src/ignore.rs
@@ -136,16 +136,27 @@ impl IgnoreStack {
                 abs_base_path,
                 ignore,
                 parent: prev,
-            } => match ignore.matched(abs_path.strip_prefix(abs_base_path).unwrap(), is_dir) {
-                ignore::Match::None => IgnoreStack {
-                    repo_root: self.repo_root.clone(),
-                    global_ignore_root: self.global_ignore_root.clone(),
-                    top: prev.clone(),
+            } => {
+                let Ok(relative_path) = abs_path.strip_prefix(abs_base_path) else {
+                    return IgnoreStack {
+                        repo_root: self.repo_root.clone(),
+                        global_ignore_root: self.global_ignore_root.clone(),
+                        top: prev.clone(),
+                    }
+                    .is_abs_path_ignored(abs_path, is_dir);
+                };
+
+                match ignore.matched(relative_path, is_dir) {
+                    ignore::Match::None => IgnoreStack {
+                        repo_root: self.repo_root.clone(),
+                        global_ignore_root: self.global_ignore_root.clone(),
+                        top: prev.clone(),
+                    }
+                    .is_abs_path_ignored(abs_path, is_dir),
+                    ignore::Match::Ignore(_) => true,
+                    ignore::Match::Whitelist(_) => false,
                 }
-                .is_abs_path_ignored(abs_path, is_dir),
-                ignore::Match::Ignore(_) => true,
-                ignore::Match::Whitelist(_) => false,
-            },
+            }
         }
     }
 }

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -6581,6 +6581,30 @@ fn test_repo_exclude_does_not_match_outside_its_work_directory() {
     );
 }
 
+#[test]
+fn test_gitignore_does_not_panic_outside_its_base_directory() {
+    use ignore::gitignore::GitignoreBuilder;
+    use worktree::{IgnoreKind, IgnoreStack};
+
+    let mut builder = GitignoreBuilder::new("/repo/subdir");
+    builder.add_line(None, "target").unwrap();
+    let gitignore = Arc::new(builder.build().unwrap());
+
+    let stack = IgnoreStack::none().append(
+        IgnoreKind::Gitignore(Arc::from(Path::new("/repo/subdir"))),
+        gitignore,
+    );
+
+    assert!(
+        stack.is_abs_path_ignored(Path::new("/repo/subdir/target"), true),
+        "patterns must apply within the base directory"
+    );
+    assert!(
+        !stack.is_abs_path_ignored(Path::new("/other/path/file.rs"), false),
+        "paths outside the base directory must not panic and not match"
+    );
+}
+
 #[gpui::test]
 async fn test_file_scan_depth_outside_repo(cx: &mut TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
 # Objective

- In `IgnoreStack::is_abs_path_ignored`, the `IgnoreStackEntry::Some` variant unconditionally called `.unwrap()` on `abs_path. strip_prefix(abs_base_path)`.
- If an absolute path is checked that does not share `abs_base_path` as an exact prefix (e.g. symlinks pointing outside the subtree, Windows casing mismatches like `C:\` vs `c:\`, or external paths), `strip_prefix` returns a `StripPrefixError`, causing the background file scanning/indexing worker thread to panic.

## Solution

- Replaced `abs_path.strip_prefix(abs_base_path).unwrap()` with a safe `let Ok(relative_path) = abs_path.strip_prefix(abs_base_path) else { ... }` pattern.
- If the path is not rooted under `abs_base_path`, it safely delegates to the parent ignore stack in `prev. is_abs_path_ignored(abs_path, is_dir)`, matching the existing behavior of `IgnoreStackEntry::RepoExclude` and `IgnoreStackEntry::Global`.
- Added a unit test `test_gitignore_does_not_panic_outside_its_base_directory` to `crates/worktree/tests/integration/worktree_tests.rs`.

## Testing

- Added `test_gitignore_does_not_panic_outside_its_base_directory` covering paths both inside and outside the base directory.
- Verified that non-prefixed paths return `false` without panicking and prefixed ignored paths are properly ignored.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

    ---

Release Notes:

- Fixed a crash in worktree file scanning when encountering paths outside the repository root.