### PR TITLE
sqlez: Remove stray println in Statement::single

### DIFF
--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -325,7 +325,6 @@ impl<'a> Statement<'a> {
             this: &mut Statement,
             callback: impl FnOnce(&mut Statement) -> Result<R>,
         ) -> Result<R> {
-            println!("{:?}", std::any::type_name::<R>());
             anyhow::ensure!(
                 this.step()? == StepResult::Row,
                 "single called with query that returns no rows."


### PR DESCRIPTION
 # Objective

- Clean up a stray debug `println!("{:?}", std::any::type_name::<R>());` statement in `Statement::single` that was left in production code.
- Prevent unintended output to standard output whenever single-row database queries are executed.

## Solution

- Removed the `println!` call from `crates/sqlez/src/statement.rs` inside `Statement::single`.

## Testing

- Existing unit and integration tests in `crates/sqlez` cover `Statement::single` query execution.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-
  checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

    ---

Release Notes:

- N/A