### PR TITLE
extensions_ui: Prevent extension tags from overlapping actions

### DIFF
--- a/crates/extensions_ui/src/components/extension_card.rs
+++ b/crates/extensions_ui/src/components/extension_card.rs
@@ -635,10 +635,14 @@ impl RenderOnce for ExtensionCard {
                 .rounded_md()
                 .child(
                     h_flex()
+                        .gap_2()
                         .justify_between()
                         .child(
                             h_flex()
                                 .flex_shrink_1()
+                                .min_w_0()
+                                .overflow_hidden()
+                                .whitespace_nowrap()
                                 .gap_2()
                                 .child(Headline::new(name).size(HeadlineSize::Small))
                                 .child(
@@ -662,7 +666,12 @@ impl RenderOnce for ExtensionCard {
                                     )
                                 }),
                         )
-                        .child(h_flex().gap_1().children(actions.into_iter().flatten())),
+                        .child(
+                            h_flex()
+                                .flex_shrink_0()
+                                .gap_1()
+                                .children(actions.into_iter().flatten()),
+                        ),
                 )
                 .child(
                     h_flex()


### PR DESCRIPTION
# Objective

Prevent extension feature tags from overlapping card actions when horizontal space is constrained.

## Solution

Let the metadata row shrink and clip while reserving space and a gap for the action buttons.

## Testing

- `cargo fmt --check`
- `cargo test -p extensions_ui`
- `./script/clippy -p extensions_ui`
- `git diff --check`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [ ] Tests cover the new/changed behavior (layout-only change; before/after videos to follow)
- [x] Performance impact has been considered and is acceptable

## Showcase

Before

https://github.com/user-attachments/assets/4268ff59-d1ec-4081-b977-c748e2dd8351

After

https://github.com/user-attachments/assets/d8617b90-45e2-41b4-9504-7eb8a808e5e2

---

Release Notes:

- Fixed extension tags obscuring action buttons on extension cards.
