### PR TITLE
Fix `PythonLocator` to pass through `env` variables from the task template

### DIFF
--- a/crates/project/src/debugger/locators/python.rs
+++ b/crates/project/src/debugger/locators/python.rs
@@ -67,7 +67,8 @@ impl DapLocator for PythonLocator {
             "request": "launch",
             "python": command,
             "args": args,
-            "cwd": build_config.cwd.clone()
+            "cwd": build_config.cwd.clone(),
+            "env": build_config.env.clone(),
         });
         if let Some(config_obj) = config.as_object_mut() {
             if let Some(module) = mod_name {

--- a/crates/project/tests/integration/debugger.rs
+++ b/crates/project/tests/integration/debugger.rs
@@ -241,6 +241,7 @@ mod go_locator {
 }
 
 mod python_locator {
+    use collections::HashMap;
     use dap::{DapLocator, adapters::DebugAdapterName};
     use serde_json::json;
 
@@ -254,7 +255,11 @@ mod python_locator {
             label: "run module '$ZED_FILE'".into(),
             command: "$ZED_CUSTOM_PYTHON_ACTIVE_ZED_TOOLCHAIN".into(),
             args: vec!["-m".into(), "$ZED_CUSTOM_PYTHON_MODULE_NAME".into()],
-            env: Default::default(),
+            env: {
+                let mut env = HashMap::default();
+                env.insert("PYTHON_ENV".to_string(), "production".to_string());
+                env
+            },
             cwd: Some("$ZED_WORKTREE_ROOT".into()),
             use_new_terminal: false,
             allow_concurrent_runs: false,
@@ -279,6 +284,7 @@ mod python_locator {
                 "args": [],
                 "cwd": "$ZED_WORKTREE_ROOT",
                 "module": "$ZED_CUSTOM_PYTHON_MODULE_NAME",
+                "env": { "PYTHON_ENV": "production" },
             }),
             tcp_connection: None,
         };


### PR DESCRIPTION
This matches `GoLocator` and `NodeLocator`

# Objective

The problem: `env` variables defined in `tasks.json` aren't used when the task runs in debug mode.

Example:

```json
[
  {
    "label": "pytest (custom)",
    "env": {
      "DATABASE_URL": "...",
    },
    "command": "$ZED_CUSTOM_PYTHON_ACTIVE_ZED_TOOLCHAIN",
    "args": [
      "-m",
      "pytest",
      "$ZED_CUSTOM_PYTHON_TEST_TARGET",
    ],
    "tags": ["python-pytest-class", "python-pytest-method"],
    "cwd": "$ZED_WORKTREE_ROOT",
  },
]
```

When a test runs normally, the `DATABASE_URL` variable is set correctly. When the test runs in debug mode, the variable is not set.

## Solution

`PythonLocator` copies the `env` value from the `TaskTemplate`. This matches other locators, such as `GoLocator` and `NodeLocator`

## Testing

- Did you test these changes? If so, how?
  - The existing integration test is updated to verify the change
- Are there any parts that need more testing?
  - No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run `cargo test -p project --test integration debugger::python_locator::test_python_locator`
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - Linux (NixOS), the change is platform-agnostic.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

N/A

---

Release Notes:

- Fix `PythonLocator` to pass through `env` variables from the task template
