### PR TITLE
crashes: Abort after reporting Windows panics

### DIFF
--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -539,10 +539,7 @@ pub fn panic_hook(crash_client: Arc<Client>, message: &str, location: Option<&Lo
         // https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
         CrashHandler.simulate_exception(Some(234)); // (MORE_DATA_AVAILABLE)
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-        std::process::abort();
-    }
+    std::process::abort();
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
On Windows, the panic hook generated a minidump by calling `simulate_exception`, but that function only invokes the crash callback and then returns. Rust could therefore unwind a panicking background thread while leaving the rest of the application running.

Abort unconditionally after minidump generation, matching the existing Linux and macOS behavior. The Windows-specific simulation still runs first so the crash sidecar can persist the exception context and panic metadata before the process terminates.

Testing:

- `cargo fmt -p crashes --check`
- `cargo nextest run -p crashes`

Release Notes:

- Fixed Windows processes remaining alive after a background thread panic.
