### PR TITLE
Open as text feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8778,6 +8778,7 @@ dependencies = [
  "log",
  "menu",
  "project",
+ "rpc",
  "settings",
  "theme",
  "theme_settings",

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -75,6 +75,7 @@ use util::{
 use workspace::{
     CloseActiveItem, CloseAllItems, CloseOtherItems, MultiWorkspace, NavigationEntry, OpenOptions,
     ToolbarItemLocation, ViewId,
+    invalid_item_view::InvalidItemView,
     item::{FollowEvent, FollowableItem, Item, ItemHandle, SaveOptions},
     register_project_item,
 };
@@ -37491,6 +37492,91 @@ async fn test_non_utf_8_opens(cx: &mut TestAppContext) {
     // Previously, this fell back to `InvalidItemView` because it wasn't valid UTF-8.
     // With auto-detection enabled, this is now recognized as UTF-16 and opens in the Editor.
     assert_eq!(handle.to_any_view().entity_type(), TypeId::of::<Editor>());
+}
+
+#[gpui::test]
+async fn test_open_binary_file_as_text(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    cx.update(|cx| {
+        register_project_item::<Editor>(cx);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root1", json!({})).await;
+    // The NUL bytes make this look like binary data rather than text.
+    let content = b"boot ok\n\0\0\0\x01ready\n".to_vec();
+    fs.insert_file("/root1/device.log", content.clone()).await;
+
+    let project = Project::test(fs.clone(), ["/root1".as_ref()], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let worktree_id = project.update(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+
+    let handle = workspace
+        .update_in(cx, |workspace, window, cx| {
+            let project_path = (worktree_id, rel_path("device.log"));
+            workspace.open_path(project_path, None, true, window, cx)
+        })
+        .await
+        .unwrap();
+    let invalid_item = handle
+        .downcast::<InvalidItemView>()
+        .expect("binary content should not open in an editor");
+    // The "Open as Text" button is only rendered when the error is recognized
+    // as the binary content check.
+    invalid_item.read_with(cx, |invalid_item, _| assert!(invalid_item.is_binary));
+
+    invalid_item.update_in(cx, |invalid_item, window, cx| {
+        invalid_item.open_as_text(window, cx)
+    });
+    cx.run_until_parked();
+
+    let editor = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace
+                .active_item(cx)
+                .and_then(|item| item.downcast::<Editor>())
+        })
+        .expect("the file should be open as text");
+    editor.update(cx, |editor, cx| {
+        assert_eq!(editor.text(cx), String::from_utf8(content.clone()).unwrap());
+        assert!(!editor.read_only(cx));
+    });
+    // The view reporting the failure is replaced by the editor.
+    assert_eq!(
+        workspace.read_with(cx, |workspace, cx| workspace.items(cx).count()),
+        1
+    );
+
+    // An accidental save of the unedited buffer must not touch the file.
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.save(SaveOptions::default(), project.clone(), window, cx)
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load("/root1/device.log".as_ref()).await.unwrap(),
+        String::from_utf8(content.clone()).unwrap()
+    );
+
+    // An actual edit saves normally.
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.insert("fixed ", window, cx);
+            editor.save(SaveOptions::default(), project.clone(), window, cx)
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load("/root1/device.log".as_ref()).await.unwrap(),
+        format!("fixed {}", String::from_utf8(content).unwrap())
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -971,6 +971,15 @@ impl Item for Editor {
 
         let buffers_to_save = if self.buffer.read(cx).is_singleton() && !options.autosave {
             buffers
+                .into_iter()
+                // Forced-text buffers are only saved when actually edited, so
+                // that an accidental save (and its format-on-save pass) cannot
+                // rewrite the file with re-encoded content.
+                .filter(|buffer| {
+                    let buffer = buffer.read(cx);
+                    !buffer.force_text() || buffer.is_dirty()
+                })
+                .collect()
         } else {
             buffers
                 .into_iter()

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -30,7 +30,10 @@ use project::{
     project_settings::ProjectSettings, search::SearchQuery,
 };
 use rope::TextSummary;
-use rpc::proto::{self, update_view};
+use rpc::{
+    ErrorCode, ErrorExt as _,
+    proto::{self, update_view},
+};
 use settings::Settings;
 use std::{
     any::{Any, TypeId},
@@ -1597,11 +1600,17 @@ impl ProjectItem for Editor {
     fn for_broken_project_item(
         abs_path: &Path,
         is_local: bool,
-        e: &anyhow::Error,
+        error: &anyhow::Error,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<InvalidItemView> {
-        Some(InvalidItemView::new(abs_path, is_local, e, window, cx))
+        if !matches!(
+            error.error_code(),
+            ErrorCode::Internal | ErrorCode::BinaryFile
+        ) {
+            return None;
+        }
+        Some(InvalidItemView::new(abs_path, is_local, error, window, cx))
     }
 }
 

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -25,6 +25,7 @@ language.workspace = true
 log.workspace = true
 menu.workspace = true
 project.workspace = true
+rpc.workspace = true
 settings.workspace = true
 theme_settings.workspace = true
 ui.workspace = true

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -22,6 +22,7 @@ use persistence::ImageViewerDb;
 use project::{
     ImageItem, Project, ProjectPath, git_store::GitStoreEvent, image_store::ImageItemEvent,
 };
+use rpc::{ErrorCode, ErrorExt as _};
 use settings::Settings;
 use theme_settings::ThemeSettings;
 use ui::{Tooltip, prelude::*};
@@ -821,14 +822,17 @@ impl ProjectItem for ImageView {
     fn for_broken_project_item(
         abs_path: &Path,
         is_local: bool,
-        e: &anyhow::Error,
+        error: &anyhow::Error,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<InvalidItemView>
     where
         Self: Sized,
     {
-        Some(InvalidItemView::new(abs_path, is_local, e, window, cx))
+        if error.error_code() != ErrorCode::Internal {
+            return None;
+        }
+        Some(InvalidItemView::new(abs_path, is_local, error, window, cx))
     }
 }
 
@@ -1088,6 +1092,7 @@ pub fn init(cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
     use fs::{FakeFs, Fs as _};
     use gpui::{TestAppContext, VisualTestContext};
     use settings::SettingsStore;
@@ -1347,6 +1352,43 @@ mod tests {
         cx.draw(point(px(0.), px(0.)), size(px(1.), px(1.)), |_, _| {
             split_image_view.clone().into_any_element()
         });
+    }
+
+    #[gpui::test]
+    async fn test_failure_view_is_only_for_undecodable_images(cx: &mut TestAppContext) {
+        init_test(cx);
+        let cx = cx.add_empty_window();
+        let abs_path = Path::new("/root/image.ppm");
+
+        let for_typed_error = cx.update(|window, cx| {
+            ImageView::for_broken_project_item(
+                abs_path,
+                true,
+                &anyhow!(ErrorCode::Disconnected),
+                window,
+                cx,
+            )
+        });
+        assert!(
+            for_typed_error.is_none(),
+            "a typed failure has to keep propagating, so that its own handling \
+             (reporting the lost connection, here) still happens"
+        );
+
+        let for_internal_error = cx.update(|window, cx| {
+            ImageView::for_broken_project_item(
+                abs_path,
+                true,
+                &anyhow!("Image format Farbfeld not supported"),
+                window,
+                cx,
+            )
+        });
+        assert!(
+            for_internal_error.is_some(),
+            "a file that is really there but cannot be shown as an image should \
+             report that in its own tab"
+        );
     }
 }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -8,6 +8,7 @@ use crate::{
     PLAIN_TEXT, RunnableTag, TextObject, TreeSitterOptions, analyze_byte_content,
     binary_file_error,
     diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup},
+    from_utf8_lossy_owned,
     language_settings::{AutoIndentMode, LanguageSettings},
     outline::OutlineItem,
     row_chunk::RowChunks,
@@ -142,6 +143,7 @@ pub struct Buffer {
     tree_sitter_data: Arc<TreeSitterData>,
     encoding: &'static Encoding,
     has_bom: bool,
+    force_text: bool,
     reload_with_encoding_txns: HashMap<TransactionId, (&'static Encoding, bool)>,
 }
 
@@ -1156,6 +1158,7 @@ impl Buffer {
             _subscriptions: Vec::new(),
             encoding: encoding_rs::UTF_8,
             has_bom: false,
+            force_text: false,
             reload_with_encoding_txns: HashMap::default(),
         }
     }
@@ -1460,6 +1463,19 @@ impl Buffer {
         self.encoding
     }
 
+    /// Marks this buffer as being read as text even though its content looks like
+    /// binary data, so that reloading it from disk does not reject it again, its
+    /// line endings are never normalized, and saving it without edits is a no-op.
+    pub fn set_force_text(&mut self, force_text: bool) {
+        self.force_text = force_text;
+    }
+
+    /// Whether this buffer was read as text even though its content looks like
+    /// binary data.
+    pub fn force_text(&self) -> bool {
+        self.force_text
+    }
+
     /// Sets the character encoding of the buffer.
     pub fn set_encoding(&mut self, encoding: &'static Encoding) {
         self.encoding = encoding;
@@ -1597,13 +1613,15 @@ impl Buffer {
         let prev_version = self.text.version();
 
         self.reload_task = Some(cx.spawn(async move |this, cx| {
-            let Some((new_mtime, load_bytes_task, current_encoding)) =
+            let Some((new_mtime, load_bytes_task, current_encoding, current_has_bom, force_text)) =
                 this.update(cx, |this, cx| {
                     let file = this.file.as_ref()?.as_local()?;
                     Some((
                         file.disk_state().mtime(),
                         file.load_bytes(cx),
                         this.encoding,
+                        this.has_bom,
+                        this.force_text,
                     ))
                 })?
             else {
@@ -1614,7 +1632,7 @@ impl Buffer {
 
             let bytes = load_bytes_task.await?;
 
-            if analyze_byte_content(&bytes) == ByteContent::Binary {
+            if !force_text && analyze_byte_content(&bytes) == ByteContent::Binary {
                 return Err(binary_file_error());
             }
 
@@ -1622,7 +1640,14 @@ impl Buffer {
                 || target_encoding == encoding_rs::UTF_16LE
                 || target_encoding == encoding_rs::UTF_16BE;
 
-            let (new_text, has_bom, encoding_used) = if force_encoding.is_some() && !is_unicode {
+            let reload_as_raw_utf8 = force_text
+                && force_encoding.is_none()
+                && current_encoding == encoding_rs::UTF_8
+                && !current_has_bom;
+
+            let (new_text, has_bom, encoding_used) = if reload_as_raw_utf8 {
+                (from_utf8_lossy_owned(bytes), false, encoding_rs::UTF_8)
+            } else if force_encoding.is_some() && !is_unicode {
                 let (cow, _had_errors) = target_encoding.decode_without_bom_handling(&bytes);
                 (cow.into_owned(), false, target_encoding)
             } else {
@@ -2282,7 +2307,9 @@ impl Buffer {
             let old_text = old_text.to_string();
             let mut new_text = new_text.as_ref().to_owned();
             // Raw content must reflect the file's exact bytes, so its carriage
-            // returns are kept rather than normalized away.
+            // returns are kept rather than normalized away. Unlike the
+            // host-only `force_text` flag, the line ending is replicated, so
+            // this holds on remote replicas too.
             let line_ending = if current_line_ending == LineEnding::Raw {
                 current_line_ending
             } else {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2277,11 +2277,19 @@ impl Buffer {
     {
         let old_text = self.as_rope().clone();
         let base_version = self.version();
+        let current_line_ending = self.line_ending();
         cx.background_spawn(async move {
             let old_text = old_text.to_string();
             let mut new_text = new_text.as_ref().to_owned();
-            let line_ending = LineEnding::detect(&new_text);
-            LineEnding::normalize(&mut new_text);
+            // Raw content must reflect the file's exact bytes, so its carriage
+            // returns are kept rather than normalized away.
+            let line_ending = if current_line_ending == LineEnding::Raw {
+                current_line_ending
+            } else {
+                let line_ending = LineEnding::detect(&new_text);
+                LineEnding::normalize(&mut new_text);
+                line_ending
+            };
             let edits = text_diff(&old_text, &new_text);
             Diff {
                 base_version,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -6,6 +6,7 @@ pub use bracket_ranges::BracketMatch;
 use crate::{
     ByteContent, DebuggerTextObject, LanguageScope, ModelineSettings, Outline, OutlineConfig,
     PLAIN_TEXT, RunnableTag, TextObject, TreeSitterOptions, analyze_byte_content,
+    binary_file_error,
     diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup},
     language_settings::{AutoIndentMode, LanguageSettings},
     outline::OutlineItem,
@@ -1613,10 +1614,9 @@ impl Buffer {
 
             let bytes = load_bytes_task.await?;
 
-            anyhow::ensure!(
-                analyze_byte_content(&bytes) != ByteContent::Binary,
-                "Binary files are not supported"
-            );
+            if analyze_byte_content(&bytes) == ByteContent::Binary {
+                return Err(binary_file_error());
+            }
 
             let is_unicode = target_encoding == encoding_rs::UTF_8
                 || target_encoding == encoding_rs::UTF_16LE

--- a/crates/language/src/file_content.rs
+++ b/crates/language/src/file_content.rs
@@ -1,8 +1,24 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use chardetng::EncodingDetector;
 use encoding_rs::{Encoding, UTF_8, UTF_16BE, UTF_16LE};
+use rpc::proto::{ErrorCode, ErrorCodeExt as _, ErrorExt as _};
 
 pub const FILE_ANALYSIS_BYTES: usize = 1024;
+
+/// The error reported when a file is rejected for looking like binary data.
+/// Carries [`ErrorCode::BinaryFile`] so that the UI can recognize it (also
+/// across RPC) and offer opening the file as text anyway.
+pub fn binary_file_error() -> anyhow::Error {
+    ErrorCode::BinaryFile
+        .message("Binary files are not supported".to_string())
+        .anyhow()
+}
+
+/// Whether a failure to open a file was caused by the binary content check,
+/// which the user can override by opening the file as text.
+pub fn is_binary_file_error(error: &anyhow::Error) -> bool {
+    error.error_code() == ErrorCode::BinaryFile
+}
 
 pub struct DecodedText {
     pub text: String,
@@ -23,7 +39,7 @@ pub fn decode_text(bytes: Vec<u8>) -> Result<DecodedText> {
     let encoding = match analyze_byte_content(&bytes) {
         ByteContent::Utf16Le => UTF_16LE,
         ByteContent::Utf16Be => UTF_16BE,
-        ByteContent::Binary => bail!("Binary files are not supported"),
+        ByteContent::Binary => return Err(binary_file_error()),
         ByteContent::Unknown => {
             return match String::from_utf8(bytes) {
                 Ok(text) if !text.contains('\x1b') => Ok(DecodedText {

--- a/crates/language/src/file_content.rs
+++ b/crates/language/src/file_content.rs
@@ -20,13 +20,22 @@ pub fn is_binary_file_error(error: &anyhow::Error) -> bool {
     error.error_code() == ErrorCode::BinaryFile
 }
 
+pub fn from_utf8_lossy_owned(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes) {
+        Ok(text) => text,
+        Err(error) => String::from_utf8_lossy(error.as_bytes()).into_owned(),
+    }
+}
+
 pub struct DecodedText {
     pub text: String,
     pub encoding: &'static Encoding,
     pub has_bom: bool,
 }
 
-pub fn decode_text(bytes: Vec<u8>) -> Result<DecodedText> {
+/// When `force_text` is set, content that looks like binary data is decoded
+/// as UTF-8 (lossily if it is invalid) instead of being rejected.
+pub fn decode_text(bytes: Vec<u8>, force_text: bool) -> Result<DecodedText> {
     if let Some((encoding, _bom_len)) = Encoding::for_bom(&bytes) {
         let (text, _) = encoding.decode_with_bom_removal(&bytes);
         return Ok(DecodedText {
@@ -39,6 +48,16 @@ pub fn decode_text(bytes: Vec<u8>) -> Result<DecodedText> {
     let encoding = match analyze_byte_content(&bytes) {
         ByteContent::Utf16Le => UTF_16LE,
         ByteContent::Utf16Be => UTF_16BE,
+        // Encoding detection is meaningless for content that only looks like
+        // text and would remap its bytes, so forced text is decoded as UTF-8,
+        // lossily if need be, to stay as close to the file's bytes as possible.
+        ByteContent::Binary | ByteContent::Unknown if force_text => {
+            return Ok(DecodedText {
+                text: from_utf8_lossy_owned(bytes),
+                encoding: UTF_8,
+                has_bom: false,
+            });
+        }
         ByteContent::Binary => return Err(binary_file_error()),
         ByteContent::Unknown => {
             return match String::from_utf8(bytes) {
@@ -294,7 +313,7 @@ mod tests {
         let expected = "строка один\nстрока два\n";
         let (bytes, _, _) = encoding_rs::WINDOWS_1251.encode(expected);
 
-        let decoded = decode_text(bytes.clone().into_owned()).unwrap();
+        let decoded = decode_text(bytes.clone().into_owned(), false).unwrap();
 
         assert_eq!(decoded.text, expected);
         assert_eq!(decoded.encoding, encoding_rs::WINDOWS_1251);
@@ -310,7 +329,7 @@ mod tests {
         let expected = "Hello, мир\n";
         for encoding in [UTF_8, UTF_16LE, UTF_16BE] {
             let bytes = encode_text(expected.to_owned(), encoding, true);
-            let decoded = decode_text(bytes.clone()).unwrap();
+            let decoded = decode_text(bytes.clone(), false).unwrap();
 
             assert_eq!(decoded.text, expected);
             assert_eq!(decoded.encoding, encoding);
@@ -320,5 +339,24 @@ mod tests {
                 bytes
             );
         }
+    }
+
+    #[test]
+    fn decodes_binary_content_when_forced() {
+        let bytes = b"boot ok\n\0\0\0\x01ready\n".to_vec();
+        assert_eq!(analyze_byte_content(&bytes), ByteContent::Binary);
+        let error = decode_text(bytes.clone(), false).err().unwrap();
+        assert!(is_binary_file_error(&error));
+
+        let decoded = decode_text(bytes.clone(), true).unwrap();
+        assert_eq!(decoded.text.as_bytes(), bytes.as_slice());
+        assert_eq!(decoded.encoding, UTF_8);
+        assert!(!decoded.has_bom);
+
+        let invalid_utf8 = b"boot ok\n\0\0\0\xffready\n".to_vec();
+        assert_eq!(analyze_byte_content(&invalid_utf8), ByteContent::Binary);
+        let decoded = decode_text(invalid_utf8, true).unwrap();
+        assert_eq!(decoded.text, "boot ok\n\0\0\0\u{FFFD}ready\n");
+        assert_eq!(decoded.encoding, UTF_8);
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -104,7 +104,7 @@ pub use diagnostic::{Diagnostic, DiagnosticSourceKind, RelatedInformation, Relat
 pub use diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup};
 pub use file_content::{
     ByteContent, DecodedText, FILE_ANALYSIS_BYTES, analyze_byte_content, binary_file_error,
-    decode_text, encode_text, is_binary_file_error,
+    decode_text, encode_text, from_utf8_lossy_owned, is_binary_file_error,
 };
 pub use language_registry::{
     BinaryStatus, LanguageNotFound, LanguageQueries, LanguageRegistry, QueryFile,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -103,7 +103,8 @@ pub use buffer::*;
 pub use diagnostic::{Diagnostic, DiagnosticSourceKind, RelatedInformation, RelatedLocation};
 pub use diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup};
 pub use file_content::{
-    ByteContent, DecodedText, FILE_ANALYSIS_BYTES, analyze_byte_content, decode_text, encode_text,
+    ByteContent, DecodedText, FILE_ANALYSIS_BYTES, analyze_byte_content, binary_file_error,
+    decode_text, encode_text, is_binary_file_error,
 };
 pub use language_registry::{
     BinaryStatus, LanguageNotFound, LanguageQueries, LanguageRegistry, QueryFile,

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -19,6 +19,7 @@ pub fn deserialize_line_ending(message: proto::LineEnding) -> text::LineEnding {
     match message {
         proto::LineEnding::Unix => text::LineEnding::Unix,
         proto::LineEnding::Windows => text::LineEnding::Windows,
+        proto::LineEnding::Raw => text::LineEnding::Raw,
     }
 }
 
@@ -27,6 +28,7 @@ pub fn serialize_line_ending(message: text::LineEnding) -> proto::LineEnding {
     match message {
         text::LineEnding::Unix => proto::LineEnding::Unix,
         text::LineEnding::Windows => proto::LineEnding::Windows,
+        text::LineEnding::Raw => proto::LineEnding::Raw,
     }
 }
 

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -13,6 +13,7 @@ use gpui::{
 };
 use language::{
     Buffer, BufferEvent, Capability, DiskState, File as _, Language, LineEnding, Operation,
+    is_binary_file_error,
     language_settings::{AllLanguageSettings, LineEndingSetting},
     proto::{
         deserialize_line_ending, deserialize_version, serialize_line_ending, serialize_version,
@@ -34,7 +35,13 @@ use worktree::{File, PathChange, ProjectEntryId, Worktree, WorktreeId, WorktreeS
 pub struct BufferStore {
     state: BufferStoreState,
     #[allow(clippy::type_complexity)]
-    loading_buffers: HashMap<ProjectPath, Shared<Task<Result<Entity<Buffer>, Arc<anyhow::Error>>>>>,
+    loading_buffers: HashMap<
+        ProjectPath,
+        (
+            bool,
+            Shared<Task<Result<Entity<Buffer>, Arc<anyhow::Error>>>>,
+        ),
+    >,
     worktree_store: Entity<WorktreeStore>,
     opened_buffers: HashMap<BufferId, OpenBuffer>,
     path_to_buffer_id: HashMap<ProjectPath, BufferId>,
@@ -302,6 +309,7 @@ impl RemoteBufferStore {
         &self,
         path: Arc<RelPath>,
         worktree: Entity<Worktree>,
+        force_text: bool,
         cx: &mut Context<BufferStore>,
     ) -> Task<Result<Entity<Buffer>>> {
         let worktree_id = worktree.read(cx).id().to_proto();
@@ -313,6 +321,7 @@ impl RemoteBufferStore {
                     project_id,
                     worktree_id,
                     path: path.as_unix_str().to_owned(),
+                    force_text,
                 })
                 .await?;
             let buffer_id = BufferId::new(response.buffer_id)?;
@@ -322,6 +331,10 @@ impl RemoteBufferStore {
                     |this, cx| this.wait_for_remote_buffer(buffer_id, cx)
                 })?
                 .await?;
+
+            if force_text {
+                buffer.update(cx, |buffer, _| buffer.set_force_text(true));
+            }
 
             Ok(buffer)
         })
@@ -391,6 +404,18 @@ impl LocalBufferStore {
         cx: &mut Context<BufferStore>,
     ) -> Task<Result<()>> {
         let buffer = buffer_handle.read(cx);
+
+        // Saving re-encodes the content, so a forced-text buffer must not
+        // rewrite its file unless it was actually edited. Only skip the save
+        // while the file still exists, though: an unedited buffer is not
+        // dirty even when its file was deleted on disk, and saving then must
+        // still recreate the file.
+        let file_exists_on_disk = buffer
+            .file()
+            .is_some_and(|file| matches!(file.disk_state(), DiskState::Present { .. }));
+        if buffer.force_text() && !buffer.is_dirty() && !has_changed_file && file_exists_on_disk {
+            return Task::ready(Ok(()));
+        }
 
         let text = buffer.as_rope().clone();
         let line_ending = buffer.line_ending();
@@ -679,9 +704,16 @@ impl LocalBufferStore {
         &self,
         path: Arc<RelPath>,
         worktree: Entity<Worktree>,
+        force_text: bool,
         cx: &mut Context<BufferStore>,
     ) -> Task<Result<Entity<Buffer>>> {
-        let load_file = worktree.update(cx, |worktree, cx| worktree.load_file(path.as_ref(), cx));
+        let load_file = worktree.update(cx, |worktree, cx| {
+            if force_text {
+                worktree.load_file_forcing_text(path.as_ref(), cx)
+            } else {
+                worktree.load_file(path.as_ref(), cx)
+            }
+        });
         cx.spawn(async move |this, cx| {
             let path = path.clone();
             let buffer = match load_file.await {
@@ -708,6 +740,7 @@ impl LocalBufferStore {
                         let mut buffer = Buffer::build(text_buffer, Some(loaded.file), capability);
                         buffer.set_encoding(loaded.encoding);
                         buffer.set_has_bom(loaded.has_bom);
+                        buffer.set_force_text(force_text);
                         buffer
                     })
                 }
@@ -905,12 +938,52 @@ impl BufferStore {
         project_path: ProjectPath,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
+        self.open_buffer_impl(project_path, false, cx)
+    }
+
+    /// Like [`BufferStore::open_buffer`], but reads content that looks like
+    /// binary data as text instead of refusing to open it.
+    pub fn open_buffer_forcing_text(
+        &mut self,
+        project_path: ProjectPath,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Buffer>>> {
+        self.open_buffer_impl(project_path, true, cx)
+    }
+
+    fn open_buffer_impl(
+        &mut self,
+        project_path: ProjectPath,
+        force_text: bool,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Buffer>>> {
+        // A path maps to at most one buffer entity at a time, so a buffer that
+        // is already open is returned whatever mode either open used.
         if let Some(buffer) = self.get_by_path(&project_path) {
             return Task::ready(Ok(buffer));
         }
 
         let task = match self.loading_buffers.entry(project_path.clone()) {
-            hash_map::Entry::Occupied(e) => e.get().clone(),
+            hash_map::Entry::Occupied(entry) => {
+                let (loading_force_text, task) = entry.get();
+                // A forced open that joined an in-flight plain load would fail
+                // with the very binary content error the caller chose to
+                // override, so wait that load out and retry forced instead.
+                if force_text && !loading_force_text {
+                    let task = task.clone();
+                    return cx.spawn(async move |this, cx| match task.await {
+                        Ok(buffer) => Ok(buffer),
+                        Err(error) if is_binary_file_error(&error) => {
+                            this.update(cx, |this, cx| {
+                                this.open_buffer_impl(project_path, true, cx)
+                            })?
+                            .await
+                        }
+                        Err(error) => Err(shared_load_error(&error)),
+                    });
+                }
+                task.clone()
+            }
             hash_map::Entry::Vacant(entry) => {
                 let path = project_path.path.clone();
                 let Some(worktree) = self
@@ -921,37 +994,32 @@ impl BufferStore {
                     return Task::ready(Err(anyhow!("no such worktree")));
                 };
                 let load_buffer = match &self.state {
-                    BufferStoreState::Local(this) => this.open_buffer(path, worktree, cx),
-                    BufferStoreState::Remote(this) => this.open_buffer(path, worktree, cx),
+                    BufferStoreState::Local(this) => {
+                        this.open_buffer(path, worktree, force_text, cx)
+                    }
+                    BufferStoreState::Remote(this) => {
+                        this.open_buffer(path, worktree, force_text, cx)
+                    }
                 };
 
-                entry
-                    .insert(
-                        cx.spawn(async move |this, cx| {
-                            let load_result = load_buffer.await;
-                            this.update(cx, |this, _cx| {
-                                // Record the fact that the buffer is no longer loading.
-                                this.loading_buffers.remove(&project_path);
+                let task = cx
+                    .spawn(async move |this, cx| {
+                        let load_result = load_buffer.await;
+                        this.update(cx, |this, _cx| {
+                            // Record the fact that the buffer is no longer loading.
+                            this.loading_buffers.remove(&project_path);
 
-                                let buffer = load_result.map_err(Arc::new)?;
-                                Ok(buffer)
-                            })?
-                        })
-                        .shared(),
-                    )
-                    .clone()
+                            let buffer = load_result.map_err(Arc::new)?;
+                            Ok(buffer)
+                        })?
+                    })
+                    .shared();
+                entry.insert((force_text, task.clone()));
+                task
             }
         };
 
-        cx.background_spawn(async move {
-            task.await.map_err(|e| {
-                if e.error_code() != ErrorCode::Internal {
-                    anyhow!(e.error_code())
-                } else {
-                    anyhow!("{e}")
-                }
-            })
-        })
+        cx.background_spawn(async move { task.await.map_err(|error| shared_load_error(&error)) })
     }
 
     pub fn create_buffer(
@@ -1072,16 +1140,10 @@ impl BufferStore {
     pub fn loading_buffers(
         &self,
     ) -> impl Iterator<Item = (&ProjectPath, impl Future<Output = Result<Entity<Buffer>>>)> {
-        self.loading_buffers.iter().map(|(path, task)| {
+        self.loading_buffers.iter().map(|(path, (_, task))| {
             let task = task.clone();
             (path, async move {
-                task.await.map_err(|e| {
-                    if e.error_code() != ErrorCode::Internal {
-                        anyhow!(e.error_code())
-                    } else {
-                        anyhow!("{e}")
-                    }
-                })
+                task.await.map_err(|error| shared_load_error(&error))
             })
         })
     }
@@ -1847,6 +1909,14 @@ impl OpenBuffer {
             OpenBuffer::Complete { buffer, .. } => buffer.upgrade(),
             OpenBuffer::Operations(_) => None,
         }
+    }
+}
+
+fn shared_load_error(error: &anyhow::Error) -> anyhow::Error {
+    if error.error_code() != ErrorCode::Internal {
+        error.cloned()
+    } else {
+        anyhow!("{error}")
     }
 }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -209,7 +209,7 @@ fn pending_hunks(
 }
 
 fn decode_git_text(bytes: Vec<u8>) -> Result<String> {
-    Ok(decode_text(bytes)?.text)
+    Ok(decode_text(bytes, false)?.text)
 }
 
 #[derive(Debug)]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3270,6 +3270,22 @@ impl Project {
         })
     }
 
+    /// Like [`Project::open_buffer`], but reads content that looks like binary
+    /// data as text instead of refusing to open it.
+    pub fn open_buffer_forcing_text(
+        &mut self,
+        path: impl Into<ProjectPath>,
+        cx: &mut App,
+    ) -> Task<Result<Entity<Buffer>>> {
+        if self.is_disconnected(cx) {
+            return Task::ready(Err(anyhow!(ErrorCode::Disconnected)));
+        }
+
+        self.buffer_store.update(cx, |buffer_store, cx| {
+            buffer_store.open_buffer_forcing_text(path.into(), cx)
+        })
+    }
+
     #[cfg(feature = "test-support")]
     pub fn open_buffer_with_lsp(
         &mut self,
@@ -5845,9 +5861,15 @@ impl Project {
         let peer_id = envelope.original_sender_id()?;
         let worktree_id = WorktreeId::from_proto(envelope.payload.worktree_id);
         let path = RelPath::from_unix_str(&envelope.payload.path)?.into();
+        let force_text = envelope.payload.force_text;
         let open_buffer = this
             .update(&mut cx, |this, cx| {
-                this.open_buffer(ProjectPath { worktree_id, path }, cx)
+                let project_path = ProjectPath { worktree_id, path };
+                if force_text {
+                    this.open_buffer_forcing_text(project_path, cx)
+                } else {
+                    this.open_buffer(project_path, cx)
+                }
             })
             .await?;
         Project::respond_to_open_buffer_request(this, open_buffer, peer_id, &mut cx)

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -834,7 +834,7 @@ impl RequestHandler<'_> {
         fs: &dyn Fs,
         abs_path: &Path,
     ) -> anyhow::Result<Option<MatchPositionHint>> {
-        let (text, _encoding, _has_bom) = decode_file_text(fs, abs_path).await?;
+        let (text, _encoding, _has_bom) = decode_file_text(fs, abs_path, false).await?;
         let reader: Box<dyn Read + Send + Sync> = Box::new(Cursor::new(text.into_bytes()));
         self.query.detect(BufReader::new(reader)).await
     }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -16142,6 +16142,131 @@ async fn test_undo_encoding_change(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_reloading_binary_buffer_opened_as_text(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    // The NUL bytes make this look like binary data rather than text; the
+    // carriage returns must survive as-is rather than being normalized.
+    fs.insert_file(path!("/dir/device.log"), b"boot\r\n\0\0\0ok\r\n".to_vec())
+        .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let project_path = project.read_with(cx, |project, cx| {
+        (
+            project.worktrees(cx).next().unwrap().read(cx).id(),
+            rel_path("device.log"),
+        )
+    });
+
+    project
+        .update(cx, |project, cx| project.open_buffer(project_path, cx))
+        .await
+        .expect_err("binary content should not open as text by default");
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer_forcing_text(project_path, cx)
+        })
+        .await
+        .unwrap();
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "boot\r\n\0\0\0ok\r\n");
+    });
+
+    // Saving the unedited buffer must not touch the file.
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load(path!("/dir/device.log").as_ref()).await.unwrap(),
+        "boot\r\n\0\0\0ok\r\n"
+    );
+
+    // An external append whose inserted text itself contains CRLF: the reload
+    // diff must keep the insertion verbatim rather than normalizing it away.
+    fs.save(
+        path!("/dir/device.log").as_ref(),
+        &"boot\r\n\0\0\0ok\r\nagain\r\n".into(),
+        LineEnding::Raw,
+    )
+    .await
+    .unwrap();
+    let reload = buffer.update(cx, |buffer, cx| buffer.reload(cx));
+    cx.executor().run_until_parked();
+    reload
+        .await
+        .expect("reloading should not reject the binary content");
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "boot\r\n\0\0\0ok\r\nagain\r\n");
+        assert!(!buffer.is_dirty());
+    });
+
+    // An actual edit saves normally, writing the text back byte for byte.
+    buffer.update(cx, |buffer, cx| buffer.edit([(0..4, "init")], None, cx));
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load(path!("/dir/device.log").as_ref()).await.unwrap(),
+        "init\r\n\0\0\0ok\r\nagain\r\n"
+    );
+
+    // Deleting the file on disk and saving again must recreate it, even
+    // though the unedited buffer is not dirty.
+    fs.remove_file(path!("/dir/device.log").as_ref(), Default::default())
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load(path!("/dir/device.log").as_ref()).await.unwrap(),
+        "init\r\n\0\0\0ok\r\nagain\r\n"
+    );
+}
+
+#[gpui::test]
+async fn test_open_as_text_joining_plain_binary_open(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+    fs.insert_file(path!("/dir/device.log"), b"boot\0\0\0ok\n".to_vec())
+        .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let project_path = project.read_with(cx, |project, cx| {
+        (
+            project.worktrees(cx).next().unwrap().read(cx).id(),
+            rel_path("device.log"),
+        )
+    });
+
+    // A forced open racing a plain open of the same path must not inherit the
+    // plain load's binary rejection.
+    let (plain, forced) = project.update(cx, |project, cx| {
+        (
+            project.open_buffer(project_path, cx),
+            project.open_buffer_forcing_text(project_path, cx),
+        )
+    });
+    plain
+        .await
+        .expect_err("binary content should not open as text by default");
+    let buffer = forced
+        .await
+        .expect("the forced open should retry after the plain load fails");
+    buffer.read_with(cx, |buffer, _| assert_eq!(buffer.text(), "boot\0\0\0ok\n"));
+}
+
+#[gpui::test]
 async fn test_initial_scan_complete(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -31,6 +31,7 @@ message OpenBufferByPath {
   uint64 project_id = 1;
   uint64 worktree_id = 2;
   string path = 3;
+  bool force_text = 4;
 }
 
 message OpenBufferById {

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -117,6 +117,7 @@ message BufferChunk {
 enum LineEnding {
   Unix = 0;
   Windows = 1;
+  Raw = 2;
 }
 
 message VectorClockEntry {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -570,6 +570,7 @@ enum ErrorCode {
   RemoteUpgradeRequired = 17;
   RateLimitExceeded = 18;
   CommitFailed = 19;
+  BinaryFile = 20;
   reserved 6;
   reserved 14 to 15;
 }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -586,10 +586,16 @@ impl HeadlessProject {
     ) -> Result<proto::OpenBufferResponse> {
         let worktree_id = WorktreeId::from_proto(message.payload.worktree_id);
         let path = RelPath::from_unix_str(&message.payload.path)?.into();
+        let force_text = message.payload.force_text;
         let (buffer_store, buffer) = this.update(&mut cx, |this, cx| {
             let buffer_store = this.buffer_store.clone();
             let buffer = this.buffer_store.update(cx, |buffer_store, cx| {
-                buffer_store.open_buffer(ProjectPath { worktree_id, path }, cx)
+                let project_path = ProjectPath { worktree_id, path };
+                if force_text {
+                    buffer_store.open_buffer_forcing_text(project_path, cx)
+                } else {
+                    buffer_store.open_buffer(project_path, cx)
+                }
             });
             (buffer_store, buffer)
         });

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -2147,6 +2147,67 @@ async fn test_remote_reload(cx: &mut TestAppContext, server_cx: &mut TestAppCont
 }
 
 #[gpui::test]
+async fn test_remote_open_binary_file_as_text(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(path!("/code"), json!({ "project1": {} }))
+        .await;
+    // The NUL bytes make this look like binary data rather than text.
+    fs.insert_file(
+        path!("/code/project1/device.log"),
+        b"boot\0\0\0ok\n".to_vec(),
+    )
+    .await;
+
+    let (project, _headless) = init_test(&fs, cx, server_cx).await;
+    let (worktree, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/code/project1"), true, cx)
+        })
+        .await
+        .unwrap();
+    let worktree_id = cx.update(|cx| worktree.read(cx).id());
+
+    let error = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, rel_path("device.log")), cx)
+        })
+        .await
+        .expect_err("binary content should not open as text by default");
+    // The client relies on recognizing this error to offer opening the file as text.
+    assert!(language::is_binary_file_error(&error));
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer_forcing_text((worktree_id, rel_path("device.log")), cx)
+        })
+        .await
+        .unwrap();
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "boot\0\0\0ok\n");
+        // The replica must carry the forced-open state, so that client-side
+        // guards (the editor's save filter, diff normalization) apply on
+        // remote projects too.
+        assert!(buffer.force_text());
+        assert_eq!(buffer.line_ending(), language::LineEnding::Raw);
+    });
+
+    // Saving the unedited buffer must not touch the file on the server.
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.load(path!("/code/project1/device.log").as_ref())
+            .await
+            .unwrap(),
+        "boot\0\0\0ok\n"
+    );
+}
+
+#[gpui::test]
 async fn test_remote_resolve_path_in_buffer(
     cx: &mut TestAppContext,
     server_cx: &mut TestAppContext,

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1944,7 +1944,13 @@ impl BufferSnapshot {
 
         let mut fragment_start = old_fragments.start().visible;
         for (range, new_text) in edits {
-            let new_text: Arc<str> = LineEnding::normalize_arc(new_text);
+            // Raw buffers keep inserted text verbatim; normalizing would break
+            // their byte-transparency (e.g. reload diffs re-inserting CRLF).
+            let new_text: Arc<str> = if self.line_ending == LineEnding::Raw {
+                new_text
+            } else {
+                LineEnding::normalize_arc(new_text)
+            };
             let fragment_end = old_fragments.end().visible;
 
             if fragment_end < range.start {
@@ -3582,6 +3588,10 @@ impl FromAnchor for usize {
 pub enum LineEnding {
     Unix,
     Windows,
+    /// The buffer's text is kept and written back exactly as it is, with no
+    /// line ending rewriting in either direction. Used for content that must
+    /// stay byte-transparent, such as binary files opened as text.
+    Raw,
 }
 
 impl Default for LineEnding {
@@ -3597,7 +3607,7 @@ impl Default for LineEnding {
 impl LineEnding {
     pub fn as_str(&self) -> &'static str {
         match self {
-            LineEnding::Unix => "\n",
+            LineEnding::Unix | LineEnding::Raw => "\n",
             LineEnding::Windows => "\r\n",
         }
     }
@@ -3606,6 +3616,7 @@ impl LineEnding {
         match self {
             LineEnding::Unix => "LF",
             LineEnding::Windows => "CRLF",
+            LineEnding::Raw => "Raw",
         }
     }
 
@@ -3655,6 +3666,7 @@ impl LineEnding {
     /// supported: detection is based on the first newline found.
     pub fn apply(&self, text: String) -> String {
         match (LineEnding::detect(&text), self) {
+            (_, LineEnding::Raw) | (LineEnding::Raw, _) => text,
             (LineEnding::Unix, LineEnding::Unix) | (LineEnding::Windows, LineEnding::Windows) => {
                 text
             }
@@ -3670,20 +3682,29 @@ impl LineEnding {
 
 pub fn chunks_with_line_ending(rope: &Rope, line_ending: LineEnding) -> impl Iterator<Item = &str> {
     rope.chunks().flat_map(move |chunk| {
+        // Raw content passes through untouched: rewriting via `str::lines`
+        // would strip the carriage returns that non-normalized content
+        // deliberately keeps.
+        let (intact, to_rewrite) = match line_ending {
+            LineEnding::Raw => (Some(chunk), ""),
+            LineEnding::Unix | LineEnding::Windows => (None, chunk),
+        };
         let mut newline = false;
-        let end_with_newline = chunk.ends_with('\n').then_some(line_ending.as_str());
-        chunk
-            .lines()
-            .flat_map(move |line| {
-                let ending = if newline {
-                    Some(line_ending.as_str())
-                } else {
-                    None
-                };
-                newline = true;
-                ending.into_iter().chain([line])
-            })
-            .chain(end_with_newline)
+        let end_with_newline = to_rewrite.ends_with('\n').then_some(line_ending.as_str());
+        intact.into_iter().chain(
+            to_rewrite
+                .lines()
+                .flat_map(move |line| {
+                    let ending = if newline {
+                        Some(line_ending.as_str())
+                    } else {
+                        None
+                    };
+                    newline = true;
+                    ending.into_iter().chain([line])
+                })
+                .chain(end_with_newline),
+        )
     })
 }
 

--- a/crates/workspace/src/invalid_item_view.rs
+++ b/crates/workspace/src/invalid_item_view.rs
@@ -1,14 +1,15 @@
 use std::{path::Path, sync::Arc};
 
-use gpui::{EventEmitter, FocusHandle, Focusable};
+use gpui::{EventEmitter, FocusHandle, Focusable, Task, WeakEntity};
 use ui::{
     App, Button, ButtonCommon, ButtonStyle, Clickable, Context, FluentBuilder, InteractiveElement,
     KeyBinding, Label, LabelCommon, LabelSize, ParentElement, Render, SharedString, Styled as _,
     Window, h_flex, v_flex,
 };
+use util::ResultExt as _;
 use zed_actions::workspace::OpenWithSystem;
 
-use crate::Item;
+use crate::{Item, SaveIntent, Workspace};
 
 /// A view to display when a certain buffer/image/other item fails to open.
 #[derive(Debug)]
@@ -18,6 +19,9 @@ pub struct InvalidItemView {
     /// An error message, happened when opening the item.
     pub error: SharedString,
     is_local: bool,
+    pub is_binary: bool,
+    workspace: Option<WeakEntity<Workspace>>,
+    open_as_text_task: Option<Task<()>>,
     focus_handle: FocusHandle,
 }
 
@@ -25,21 +29,94 @@ impl InvalidItemView {
     pub fn new(
         abs_path: &Path,
         is_local: bool,
-        e: &anyhow::Error,
+        error: &anyhow::Error,
         _: &mut Window,
         cx: &mut App,
     ) -> Self {
         Self {
             is_local,
+            is_binary: language::is_binary_file_error(error),
             abs_path: Arc::from(abs_path),
-            error: format!("{}", e.root_cause()).into(),
+            error: format!("{}", error.root_cause()).into(),
+            workspace: None,
+            open_as_text_task: None,
             focus_handle: cx.focus_handle(),
         }
+    }
+
+    pub fn open_as_text(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(workspace) = self.workspace.clone() else {
+            log::error!(
+                "cannot open {:?} as text: not in a workspace",
+                self.abs_path
+            );
+            return;
+        };
+        let abs_path = self.abs_path.clone();
+        let item_id = cx.entity_id();
+        self.open_as_text_task = Some(cx.spawn_in(window, async move |_, cx| {
+            let result = async {
+                let (_worktree, project_path) = workspace
+                    .update(cx, |workspace, cx| {
+                        Workspace::project_path_for_path(
+                            workspace.project().clone(),
+                            &abs_path,
+                            false,
+                            cx,
+                        )
+                    })?
+                    .await?;
+                // Force the buffer open first: the regular open below then
+                // reuses it (a path maps to at most one buffer at a time)
+                // while building the item through the standard open flow. The
+                // handle must stay alive until then, or the buffer would be
+                // released before the regular open gets to it.
+                let buffer = workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.project().update(cx, |project, cx| {
+                            project.open_buffer_forcing_text(project_path.clone(), cx)
+                        })
+                    })?
+                    .await?;
+                let pane = workspace.update(cx, |workspace, _| {
+                    workspace
+                        .pane_for_item_id(item_id)
+                        .unwrap_or_else(|| workspace.active_pane().clone())
+                })?;
+                workspace
+                    .update_in(cx, |workspace, window, cx| {
+                        workspace.open_path(project_path, Some(pane.downgrade()), true, window, cx)
+                    })?
+                    .await?;
+                drop(buffer);
+                // A no-op when this view is no longer in the pane.
+                pane.update_in(cx, |pane, window, cx| {
+                    pane.close_item_by_id(item_id, SaveIntent::Skip, window, cx)
+                })?
+                .await?;
+                anyhow::Ok(())
+            }
+            .await;
+            if let Err(error) = result {
+                workspace
+                    .update(cx, |workspace, cx| workspace.show_error(error, cx))
+                    .log_err();
+            }
+        }));
     }
 }
 
 impl Item for InvalidItemView {
     type Event = ();
+
+    fn added_to_workspace(
+        &mut self,
+        workspace: &mut Workspace,
+        _: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+        self.workspace = Some(workspace.weak_handle());
+    }
 
     fn tab_content_text(&self, mut detail: usize, _: &App) -> SharedString {
         // Ensure we always render at least the filename.
@@ -96,6 +173,17 @@ impl Render for InvalidItemView {
                                 .justify_center()
                                 .child(Label::new(self.error.clone()).size(LabelSize::Small)),
                         )
+                        .when(self.is_binary, |contents| {
+                            contents.child(
+                                h_flex().justify_center().child(
+                                    Button::new("open-as-text", "Open as Text")
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.open_as_text(window, cx);
+                                        }))
+                                        .style(ButtonStyle::Outlined),
+                                ),
+                            )
+                        })
                         .when(self.is_local, |contents| {
                             contents.child(
                                 h_flex().justify_center().child(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -893,25 +893,21 @@ impl ProjectItemRegistry {
                         }
                         Err(e) => {
                             log::warn!("Failed to open a project item: {e:#}");
-                            if e.error_code() == ErrorCode::Internal {
-                                if let Some(abs_path) =
-                                    entry_abs_path.as_deref().filter(|_| is_file)
-                                {
-                                    if let Some(broken_project_item_view) =
-                                        cx.update(|window, cx| {
-                                            T::for_broken_project_item(
-                                                abs_path, is_local, &e, window, cx,
-                                            )
-                                        })?
-                                    {
-                                        let build_workspace_item = Box::new(
-                                            move |_: &mut Pane, _: &mut Window, cx: &mut Context<Pane>| {
-                                                cx.new(|_| broken_project_item_view).boxed_clone()
-                                            },
+                            if let Some(abs_path) = entry_abs_path.as_deref().filter(|_| is_file) {
+                                if let Some(broken_project_item_view) =
+                                    cx.update(|window, cx| {
+                                        T::for_broken_project_item(
+                                            abs_path, is_local, &e, window, cx,
                                         )
-                                        as Box<_>;
-                                        return Ok((None, build_workspace_item));
-                                    }
+                                    })?
+                                {
+                                    let build_workspace_item = Box::new(
+                                        move |_: &mut Pane, _: &mut Window, cx: &mut Context<Pane>| {
+                                            cx.new(|_| broken_project_item_view).boxed_clone()
+                                        },
+                                    )
+                                    as Box<_>;
+                                    return Ok((None, build_workspace_item));
                                 }
                             }
                             Err(e)

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -33,7 +33,8 @@ use gpui::{
 };
 pub use ignore::{IgnoreKind, IgnoreStack};
 use language::{
-    ByteContent, DiskState, FILE_ANALYSIS_BYTES, analyze_byte_content, decode_text, encode_text,
+    ByteContent, DiskState, FILE_ANALYSIS_BYTES, analyze_byte_content, binary_file_error,
+    decode_text, encode_text,
 };
 
 use async_channel::{self, Sender};
@@ -7246,10 +7247,9 @@ pub async fn decode_file_text(
 
     let (file_first_bytes, reached_eof) = read_file_header(&mut *file, abs_path)?;
     let (_, byte_content) = decode_byte_header(&file_first_bytes);
-    anyhow::ensure!(
-        byte_content != ByteContent::Binary,
-        "Binary files are not supported"
-    );
+    if byte_content == ByteContent::Binary {
+        return Err(binary_file_error());
+    }
 
     // If the file is eligible for opening, read the rest of the file.
     let mut content = file_first_bytes;
@@ -7274,10 +7274,9 @@ pub async fn decode_file_text_to_rope(
 
     let (prefix, reached_eof) = read_file_header(&mut *file, abs_path)?;
     let (bom_encoding, byte_content) = decode_byte_header(&prefix);
-    anyhow::ensure!(
-        byte_content != ByteContent::Binary,
-        "Binary files are not supported"
-    );
+    if byte_content == ByteContent::Binary {
+        return Err(binary_file_error());
+    }
 
     // Only BOM-less, non-UTF-16 files are candidates for streaming: everything
     // else needs the whole byte buffer in hand to decode or to detect encoding.

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1865,7 +1865,7 @@ impl LocalWorktree {
                 // refactor of the `fs` crate to expose a Writer interface.
                 let text_string = text.to_string();
                 let normalized_text = match line_ending {
-                    LineEnding::Unix => text_string,
+                    LineEnding::Unix | LineEnding::Raw => text_string,
                     LineEnding::Windows => text_string.replace('\n', "\r\n"),
                 };
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -915,8 +915,27 @@ impl Worktree {
     }
 
     pub fn load_file(&self, path: &RelPath, cx: &Context<Worktree>) -> Task<Result<LoadedFile>> {
+        self.load_file_impl(path, false, cx)
+    }
+
+    /// Like [`Worktree::load_file`], but decodes content that looks like binary
+    /// data as text instead of refusing to load it.
+    pub fn load_file_forcing_text(
+        &self,
+        path: &RelPath,
+        cx: &Context<Worktree>,
+    ) -> Task<Result<LoadedFile>> {
+        self.load_file_impl(path, true, cx)
+    }
+
+    fn load_file_impl(
+        &self,
+        path: &RelPath,
+        force_text: bool,
+        cx: &Context<Worktree>,
+    ) -> Task<Result<LoadedFile>> {
         match self {
-            Worktree::Local(this) => this.load_file(path, cx),
+            Worktree::Local(this) => this.load_file(path, force_text, cx),
             Worktree::Remote(_) => {
                 Task::ready(Err(anyhow!("remote worktrees can't yet load files")))
             }
@@ -1697,7 +1716,12 @@ impl LocalWorktree {
     }
 
     #[ztracing::instrument(skip_all)]
-    fn load_file(&self, path: &RelPath, cx: &Context<Worktree>) -> Task<Result<LoadedFile>> {
+    fn load_file(
+        &self,
+        path: &RelPath,
+        force_text: bool,
+        cx: &Context<Worktree>,
+    ) -> Task<Result<LoadedFile>> {
         let path = Arc::from(path);
         let abs_path = self.absolutize(&path);
         let fs = self.fs.clone();
@@ -1720,7 +1744,7 @@ impl LocalWorktree {
                 anyhow::bail!("File is too large to load");
             }
             let (text, line_ending, encoding, has_bom) =
-                decode_file_text_to_rope(fs.as_ref(), &abs_path).await?;
+                decode_file_text_to_rope(fs.as_ref(), &abs_path, force_text).await?;
             let is_writable = metadata.is_some_and(|metadata| metadata.is_writable);
 
             let worktree = this.upgrade().context("worktree was dropped")?;
@@ -7239,6 +7263,7 @@ async fn read_file_to_end(
 pub async fn decode_file_text(
     fs: &dyn Fs,
     abs_path: &Path,
+    force_text: bool,
 ) -> Result<(String, &'static Encoding, bool)> {
     let mut file = fs
         .open_sync(&abs_path)
@@ -7247,7 +7272,7 @@ pub async fn decode_file_text(
 
     let (file_first_bytes, reached_eof) = read_file_header(&mut *file, abs_path)?;
     let (_, byte_content) = decode_byte_header(&file_first_bytes);
-    if byte_content == ByteContent::Binary {
+    if !force_text && byte_content == ByteContent::Binary {
         return Err(binary_file_error());
     }
 
@@ -7256,16 +7281,21 @@ pub async fn decode_file_text(
     if !reached_eof {
         read_file_to_end(&mut *file, &mut content, abs_path).await?;
     }
-    let decoded = decode_text(content)?;
+    let decoded = decode_text(content, force_text)?;
     Ok((decoded.text, decoded.encoding, decoded.has_bom))
 }
 
 /// Reads and decodes a file straight into a [`Rope`].
 /// The returned rope has already had its line endings normalized, the
 /// [`LineEnding`] detected before normalizing is returned alongside it.
+///
+/// When `force_text` is set, content that looks like binary data is decoded
+/// anyway, and line endings are left exactly as they are in the file so that
+/// the text reflects the file's bytes.
 pub async fn decode_file_text_to_rope(
     fs: &dyn Fs,
     abs_path: &Path,
+    force_text: bool,
 ) -> Result<(Rope, LineEnding, &'static Encoding, bool)> {
     let mut file = fs
         .open_sync(abs_path)
@@ -7274,24 +7304,33 @@ pub async fn decode_file_text_to_rope(
 
     let (prefix, reached_eof) = read_file_header(&mut *file, abs_path)?;
     let (bom_encoding, byte_content) = decode_byte_header(&prefix);
-    if byte_content == ByteContent::Binary {
+    if !force_text && byte_content == ByteContent::Binary {
         return Err(binary_file_error());
     }
 
     // Only BOM-less, non-UTF-16 files are candidates for streaming: everything
     // else needs the whole byte buffer in hand to decode or to detect encoding.
     if bom_encoding.is_none()
-        && byte_content == ByteContent::Unknown
+        && (byte_content == ByteContent::Unknown
+            || (force_text && byte_content == ByteContent::Binary))
         && let Some((rope, line_ending)) =
-            stream_utf8_into_rope(&mut *file, prefix, reached_eof, abs_path).await?
+            stream_utf8_into_rope(&mut *file, prefix, reached_eof, force_text, abs_path).await?
     {
         return Ok((rope, line_ending, encoding_rs::UTF_8, false));
     }
 
     // Not plain UTF-8 after all. Re-read the file and decode it all at once.
-    let (mut text, encoding, has_bom) = decode_file_text(fs, abs_path).await?;
-    let line_ending = LineEnding::detect(&text);
-    LineEnding::normalize(&mut text);
+    let (mut text, encoding, has_bom) = decode_file_text(fs, abs_path, force_text).await?;
+    let line_ending = if force_text {
+        // Forced-text content must reflect the file's exact bytes, so carriage
+        // returns are kept in the text rather than normalized away. Raw line
+        // endings keep writes byte-transparent in turn.
+        LineEnding::Raw
+    } else {
+        let line_ending = LineEnding::detect(&text);
+        LineEnding::normalize(&mut text);
+        line_ending
+    };
     Ok((Rope::from(text), line_ending, encoding, has_bom))
 }
 
@@ -7301,10 +7340,16 @@ pub async fn decode_file_text_to_rope(
 /// Returns `None` if the file turns out not to be plain UTF-8, in which case the
 /// caller re-reads it and decodes it the slow way. `prefix` is the portion of
 /// the file already consumed from `file` for encoding detection.
+///
+/// With `force_text` the stream never gives up: invalid UTF-8 sequences become
+/// replacement characters, the bytes are otherwise kept exactly as they are,
+/// and the returned [`LineEnding`] is [`LineEnding::Raw`] so that writing the
+/// rope back does not transform them either.
 async fn stream_utf8_into_rope(
     file: &mut (dyn Read + Send),
     prefix: Vec<u8>,
     reached_eof: bool,
+    force_text: bool,
     abs_path: &Path,
 ) -> Result<Option<(Rope, LineEnding)>> {
     let mut rope = Rope::new();
@@ -7313,6 +7358,8 @@ async fn stream_utf8_into_rope(
     let mut pending = prefix;
     let mut buf = vec![0u8; STREAM_BLOCK_BYTES];
     let mut eof = reached_eof;
+    let mut lossy_decoder =
+        force_text.then(|| encoding_rs::UTF_8.new_decoder_without_bom_handling());
 
     loop {
         // Fill a whole block before decoding, so that each `Rope::push` gets a
@@ -7326,6 +7373,38 @@ async fn stream_utf8_into_rope(
             } else {
                 pending.extend_from_slice(&buf[..n]);
             }
+        }
+
+        if let Some(decoder) = lossy_decoder.as_mut() {
+            // Decode the block lossily, so that the whole-file fallback (which
+            // buffers several copies of the file in memory) is never needed.
+            // The decoder holds multi-byte characters straddling the block
+            // boundary back until the next block, and the scratch string
+            // batches the decoded fragments so that each block still becomes
+            // a single `Rope::push`.
+            let mut input: &[u8] = &pending;
+            loop {
+                scratch.clear();
+                // A zero reservation would make `decode_to_string` return
+                // `OutputFull` without progress, so always reserve something.
+                let worst_case_len = decoder
+                    .max_utf8_buffer_length(input.len())
+                    .unwrap_or(STREAM_BLOCK_BYTES);
+                scratch.reserve(worst_case_len.max(16));
+                let (result, bytes_read, _had_replacements) =
+                    decoder.decode_to_string(input, &mut scratch, eof);
+                rope.push(&scratch);
+                input = &input[bytes_read..];
+                if matches!(result, encoding_rs::CoderResult::InputEmpty) {
+                    break;
+                }
+            }
+            pending.clear();
+            if eof {
+                break;
+            }
+            yield_now().await;
+            continue;
         }
 
         // Decode as much of `pending` as forms complete UTF-8.
@@ -7359,7 +7438,6 @@ async fn stream_utf8_into_rope(
         if line_ending.is_none() && !text.is_empty() {
             line_ending = Some(LineEnding::detect(text));
         }
-
         push_normalized(&mut rope, text, &mut scratch);
         pending.drain(..emit_len);
 
@@ -7376,7 +7454,12 @@ async fn stream_utf8_into_rope(
         return Ok(None);
     }
 
-    Ok(Some((rope, line_ending.unwrap_or_default())))
+    let line_ending = if force_text {
+        LineEnding::Raw
+    } else {
+        line_ending.unwrap_or_default()
+    };
+    Ok(Some((rope, line_ending)))
 }
 
 /// Appends `text` to `rope`, rewriting CRLF and lone CR as LF, matching
@@ -7425,10 +7508,50 @@ mod tests {
     /// decoded text and detected line ending, or `None` if the fast path bailed.
     async fn stream(bytes: &[u8]) -> Option<(String, LineEnding)> {
         let mut reader = std::io::Cursor::new(bytes.to_vec());
-        stream_utf8_into_rope(&mut reader, Vec::new(), false, Path::new("test"))
+        stream_utf8_into_rope(&mut reader, Vec::new(), false, false, Path::new("test"))
             .await
             .unwrap()
             .map(|(rope, line_ending)| (rope.to_string(), line_ending))
+    }
+
+    /// Streams `bytes` in forced-text mode.
+    async fn stream_forced(bytes: &[u8]) -> (String, LineEnding) {
+        let mut reader = std::io::Cursor::new(bytes.to_vec());
+        stream_utf8_into_rope(&mut reader, Vec::new(), false, true, Path::new("test"))
+            .await
+            .unwrap()
+            .map(|(rope, line_ending)| (rope.to_string(), line_ending))
+            .expect("forced-text streaming never falls back")
+    }
+
+    #[gpui::test]
+    async fn test_stream_utf8_without_normalization() {
+        let crlf = "one\r\ntwo\rthree\n".repeat(40);
+        let (text, line_ending) = stream_forced(crlf.as_bytes()).await;
+        assert_eq!(text, crlf);
+        assert_eq!(line_ending, LineEnding::Raw);
+    }
+
+    #[gpui::test]
+    async fn test_stream_utf8_lossily_when_forced() {
+        let (text, line_ending) = stream_forced(b"boot\r\n\0\0\0\xff\xfeok\x1b[0m\n\xe4").await;
+        assert_eq!(
+            text, "boot\r\n\0\0\0\u{FFFD}\u{FFFD}ok\x1b[0m\n\u{FFFD}",
+            "invalid bytes become replacement characters, everything else stays"
+        );
+        assert_eq!(line_ending, LineEnding::Raw);
+
+        // A multi-byte character straddling the one-megabyte block boundary is
+        // held back until its remaining bytes arrive with the next block.
+        let mut big = "x".repeat(STREAM_BLOCK_BYTES - 1).into_bytes();
+        big.extend_from_slice("é".as_bytes());
+        big.extend_from_slice(b"\xfftail");
+        let (text, _) = stream_forced(&big).await;
+        assert_eq!(
+            text.len(),
+            STREAM_BLOCK_BYTES - 1 + "é".len() + "\u{FFFD}tail".len()
+        );
+        assert!(text.ends_with("é\u{FFFD}tail"));
     }
 
     #[test]
@@ -7436,7 +7559,7 @@ mod tests {
         let mut reader = std::io::Cursor::new(vec![b'a'; STREAM_BLOCK_BYTES * 2]);
 
         assert!(
-            stream_utf8_into_rope(&mut reader, Vec::new(), false, Path::new("test"))
+            stream_utf8_into_rope(&mut reader, Vec::new(), false, false, Path::new("test"))
                 .now_or_never()
                 .is_none()
         );

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -5671,6 +5671,12 @@ async fn test_load_file_encoding(cx: &mut TestAppContext) {
         );
         let err_msg = loaded.unwrap_err().to_string();
         println!("Got expected error for {}: {}", case.name, err_msg);
+
+        tree.update(cx, |tree, cx| {
+            tree.load_file_forcing_text(&rel_path(case.name), cx)
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to force '{}' to load as text: {:?}", case.name, e));
     }
 }
 


### PR DESCRIPTION
Closes #11704 

# Objective

- Zed refuses to open any file whose leading bytes look like binary data, showing `Binary files are not supported`, and there is no way to override that. Files that are *mostly* text with a few stray bytes — logs with embedded PDF/blob payloads, firmware dumps with binary headers, dumps of mixed-encoding data — are unreachable, even just to read them.
- Addresses the request in [Support files with binary content · Discussion #45711](https://github.com/zed-industries/zed/discussions/45711) (see also [#11704](https://github.com/zed-industries/zed/issues/11704), closed as duplicate). This PR does not add a hex viewer, which some of the discussion also asks for; it adds the "open it anyway as text" escape hatch.
- This mirrors what VS Code already does. There, a file detected as binary opens to a placeholder reading *"The file is not displayed in the editor because it is either binary or uses an unsupported text encoding. Do you want to open it anyway?"*, and taking that option opens the file as plain text. Both #45711 and #11704 point at that behavior as the expected baseline — #11704 words it as "VSCode supports this out of the box".

## Solution

The tab that already appears for a file that failed to open now offers an **Open as Text** button when — and only when — the failure was the binary content check. Like VS Code's "open it anyway", the affordance lives inline in the placeholder the user is already looking at rather than behind a modal or a command. The whole point is that merely looking at such a file must never rewrite it, so most of the change is about making that safe rather than about the button itself.

Built up in six steps, one per commit:

- **`text`: add `LineEnding::Raw`.** A buffer marked `Raw` is byte-transparent: inserted text is kept verbatim instead of being CRLF-normalized, and writing the rope back out does not rewrite line endings either.
- **`language`: give binary rejections a dedicated error code.** The refusal is now `ErrorCode::BinaryFile` instead of a plain string, so callers — including remote ones, across RPC — can recognize it without matching on an error message.
- **`worktree`: allow decoding binary-looking content as text.** A `force_text` mode decodes the bytes as UTF-8 (lossily, `U+FFFD` for invalid sequences) and keeps line endings exactly as they are on disk. The streaming fast path handles the mode itself, so a forced load never falls back to buffering the whole file.
- **`project`: add `Project::open_buffer_forcing_text`.** Opens a path the plain open refuses, and marks the buffer as forced text. Such a buffer never rejects its content on reload, never normalizes line endings, and is not saved unless it was actually edited. The flag travels to remote hosts as part of the open request and the raw line ending is replicated, so the guards hold for remote projects too. A forced open that lands on an in-flight *plain* load of the same path waits it out and retries instead of inheriting the rejection it means to override.
- **`workspace`: let project items decide which open failures they display.** The failure view was gated on `ErrorCode::Internal`, which excluded typed failures like the binary refusal. That decision moves into `for_broken_project_item`, where the item knows what it can render: the editor accepts internal *and* binary-file errors, the image viewer stays with internal errors only. A typed failure such as a lost connection keeps propagating so its own reporting still happens, instead of being shown as a broken image.
- **`workspace`: add the "Open as Text" button.** Clicking it forces the buffer open, hands the path to the regular open flow so the file gets a normal editor (a path maps to at most one buffer, so the regular open reuses the forced one), and closes the failure tab.

Safety properties this gives the resulting editor:

- Saving is skipped unless the buffer is actually dirty, so neither an accidental <kbd>cmd-s</kbd> nor its format-on-save pass can rewrite the file with re-encoded content.
- Reload from disk does not re-reject the file and re-reads it the same lossy-UTF-8 way.
- No line ending normalization in either direction, so an untouched round-trip preserves the bytes Zed could represent.

## Testing

Automated coverage added:

| Test | Covers |
| --- | --- |
| `language::file_content::decodes_binary_content_when_forced` | forced decode is byte-identical for valid UTF-8 with NULs, lossy for invalid sequences; unforced decode still errors with `ErrorCode::BinaryFile` |
| `worktree::test_stream_utf8_without_normalization`, `test_stream_utf8_lossily_when_forced` | the streaming path under `force_text`, including CRLF preservation |
| `worktree_tests::test_load_file_encoding` | every case the encoding test rejects can be loaded via `load_file_forcing_text` |
| `project_tests::test_reloading_binary_buffer_opened_as_text` | reload does not re-reject and does not normalize |
| `project_tests::test_open_as_text_joining_plain_binary_open` | a forced open racing an in-flight plain open of the same path |
| `editor_tests::test_open_binary_file_as_text` | the failure view reports `is_binary`, and the button yields a normal, editable editor |
| `image_viewer::test_failure_view_is_only_for_undecodable_images` | the image viewer shows the failure view for internal errors and lets typed ones (e.g. `Disconnected`) propagate |
| `remote_editing_tests::test_remote_open_binary_file_as_text` | the flag and the raw line ending survive the round trip to a remote host |

Manual repro for reviewers:

```sh
printf 'boot ok\n\0\0\0\x01ready\n' > /tmp/binary.log
```

1. Open `/tmp/binary.log` in Zed — you get the "Binary files are not supported" tab with an **Open as Text** button.
2. Click it: the file opens in a regular editor, NUL bytes and all, and the failure tab closes.
3. Save without editing, then `xxd /tmp/binary.log` — the bytes are unchanged.
4. Edit something, save, and confirm only your edit landed (in particular that CRLFs elsewhere in the file were not rewritten).
5. Repeat over a remote project to confirm the same behavior there.

Worth extra reviewer attention:

- `LineEnding::Raw` is a new variant on a widely matched enum; the interesting spots are `chunks_with_line_ending` and `LineEnding::apply`.
- The save guard lives in the singleton, non-autosave branch of `Item::save` for `Editor` (`crates/editor/src/items.rs`); the other branch already filtered on `is_dirty()` and is unchanged.

Tested on Linux and Windows. Not verified on macOS.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/e7a719b3-92ff-4e94-a1ab-aba308b6ba91" />

</details>

---

Release Notes:

- Added an "Open as Text" action for files that Zed refuses to open because their content looks like binary data.
