### PR TITLE
Retain worktrees with uncommitted changes when archiving agent threads

### DIFF
--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -60,6 +60,12 @@ pub struct RootPlan {
     pub recorded_created_at: SystemTime,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RemoveRootOutcome {
+    Removed,
+    Retained,
+}
+
 /// A `Project` that references a worktree being archived, paired with the
 /// `WorktreeId` it uses for that worktree.
 ///
@@ -180,6 +186,11 @@ pub fn build_root_plan(
         return None;
     }
 
+    // Leave worktrees with staged, unstaged, or untracked changes on disk.
+    if linked_snapshot.status().next().is_some() {
+        return None;
+    }
+
     // Only archive worktrees that Zed explicitly created. The directory
     // check above constrains paths, but the database record is what
     // distinguishes a Zed-created worktree from one the user manually
@@ -211,9 +222,17 @@ pub fn build_root_plan(
 /// This is the destructive counterpart to [`persist_worktree_state`]. It
 /// first detaches the worktree from every [`AffectedProject`], waits for
 /// each project to fully release it, then asks the main repository to
-/// delete the worktree directory. If the git removal fails, the worktree
-/// is re-added to each project via [`rollback_root`].
-pub async fn remove_root(root: RootPlan, cx: &mut AsyncApp) -> Result<()> {
+/// delete the worktree directory. If the worktree gained uncommitted changes
+/// after planning, it is retained. If the git removal fails, the worktree is
+/// re-added to each project via [`rollback_root`].
+pub async fn remove_root(root: RootPlan, cx: &mut AsyncApp) -> Result<RemoveRootOutcome> {
+    if root
+        .worktree_repo
+        .read_with(cx, |repo, _cx| repo.cached_status().next().is_some())
+    {
+        return Ok(RemoveRootOutcome::Retained);
+    }
+
     verify_created_by_zed(&root, cx).await?;
 
     let release_tasks: Vec<_> = root
@@ -249,7 +268,7 @@ pub async fn remove_root(root: RootPlan, cx: &mut AsyncApp) -> Result<()> {
     .await
     .log_err();
 
-    Ok(())
+    Ok(RemoveRootOutcome::Removed)
 }
 
 /// Confirms that the worktree on disk is still the one Zed created, by

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -5604,17 +5604,28 @@ impl Sidebar {
                 return Ok(ArchiveWorktreeOutcome::Cancelled);
             }
 
-            if let Err(error) = thread_worktree_archive::remove_root(root.clone(), cx).await {
-                if let Some(&(id, ref completed_root)) = completed_persists.last() {
-                    if completed_root.root_path == root.root_path {
+            match thread_worktree_archive::remove_root(root.clone(), cx).await {
+                Ok(thread_worktree_archive::RemoveRootOutcome::Removed) => {}
+                Ok(thread_worktree_archive::RemoveRootOutcome::Retained) => {
+                    if let Some(&(id, ref completed_root)) = completed_persists.last()
+                        && completed_root.root_path == root.root_path
+                    {
                         thread_worktree_archive::rollback_persist(id, completed_root, cx).await;
                         completed_persists.pop();
                     }
                 }
-                for &(id, ref completed_root) in completed_persists.iter().rev() {
-                    thread_worktree_archive::rollback_persist(id, completed_root, cx).await;
+                Err(error) => {
+                    if let Some(&(id, ref completed_root)) = completed_persists.last() {
+                        if completed_root.root_path == root.root_path {
+                            thread_worktree_archive::rollback_persist(id, completed_root, cx).await;
+                            completed_persists.pop();
+                        }
+                    }
+                    for &(id, ref completed_root) in completed_persists.iter().rev() {
+                        thread_worktree_archive::rollback_persist(id, completed_root, cx).await;
+                    }
+                    return Err(error);
                 }
-                return Err(error);
             }
         }
 

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -8232,6 +8232,125 @@ async fn test_archive_thread_uses_next_threads_own_workspace(cx: &mut TestAppCon
 }
 
 #[gpui::test]
+async fn test_archive_worktree_thread_retains_worktree_with_uncommitted_changes(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {
+                "worktrees": {
+                    "feature-a": {
+                        "commondir": "../../",
+                        "HEAD": "ref: refs/heads/feature-a",
+                    },
+                },
+            },
+            "src": {},
+        }),
+    )
+    .await;
+
+    fs.insert_tree(
+        "/worktrees/project/feature-a/project",
+        serde_json::json!({
+            ".git": "gitdir: /project/.git/worktrees/feature-a",
+            "src": {
+                "uncommitted.rs": "fn uncommitted() {}",
+            },
+        }),
+    )
+    .await;
+
+    let worktree_path = Path::new(util::path!("/worktrees/project/feature-a/project"));
+    let uncommitted_path = worktree_path.join("src/uncommitted.rs");
+    fs.add_linked_worktree_for_repo(
+        Path::new(util::path!("/project/.git")),
+        false,
+        git::repository::Worktree {
+            path: worktree_path.to_path_buf(),
+            ref_name: Some("refs/heads/feature-a".into()),
+            sha: "abc".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    fs.set_status_for_repo(
+        &worktree_path.join(".git"),
+        &[("src/uncommitted.rs", git::status::FileStatus::Untracked)],
+    );
+    agent_ui::test_support::record_zed_created_worktree(fs.as_ref(), worktree_path, None, cx).await;
+
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let main_project =
+        project::Project::test(fs.clone(), [Path::new(util::path!("/project"))], cx).await;
+    let worktree_project = project::Project::test(fs.clone(), [worktree_path], cx).await;
+
+    main_project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    worktree_project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(main_project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+    multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+        multi_workspace.test_add_workspace(worktree_project.clone(), window, cx)
+    });
+
+    save_thread_metadata(
+        acp::SessionId::new(Arc::from("main-thread")),
+        Some("Main Thread".into()),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 2, 0, 0, 0).unwrap(),
+        None,
+        None,
+        &main_project,
+        cx,
+    );
+
+    let worktree_session_id = acp::SessionId::new(Arc::from("worktree-thread"));
+    save_thread_metadata(
+        worktree_session_id.clone(),
+        Some("Worktree Thread".into()),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        None,
+        None,
+        &worktree_project,
+        cx,
+    );
+    cx.run_until_parked();
+
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.archive_thread(&worktree_session_id, window, cx);
+    });
+    cx.run_until_parked();
+
+    assert!(
+        fs.is_dir(worktree_path).await,
+        "worktree with uncommitted changes should remain on disk after archiving its thread"
+    );
+    assert!(
+        fs.is_file(&uncommitted_path).await,
+        "uncommitted file should remain on disk after archiving its thread"
+    );
+    cx.update(|_window, cx| {
+        let metadata = ThreadMetadataStore::global(cx)
+            .read(cx)
+            .entry_by_session(&worktree_session_id)
+            .expect("archived thread metadata should remain available")
+            .clone();
+        assert!(metadata.archived, "thread should still be archived");
+    });
+}
+
+#[gpui::test]
 async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppContext) {
     // When the last non-archived thread for a linked worktree is archived,
     // the linked worktree workspace should be removed from the multi-workspace.


### PR DESCRIPTION
## Summary

Archiving an agent-panel thread could silently delete its associated Git worktree from disk, including uncommitted changes. The existing check added in #58275 only verifies *provenance* (was the worktree created by Zed vs. the user) before deleting — it does not check whether the worktree has uncommitted work. An agent-created worktree with uncommitted changes was still deleted on archive.

Fixes #63081.

## Fix

Adds an uncommitted-changes check at two points in the worktree removal path in `crates/agent_ui/src/thread_worktree_archive.rs`:

- `build_root_plan` skips planning removal for a worktree that already has staged/unstaged/untracked changes (via the linked worktree's git status snapshot).
- `remove_root` re-checks status immediately before deletion (in case changes appeared after planning, closing a race) and returns a new `RemoveRootOutcome::Retained` instead of deleting when the worktree is dirty. `RemoveRootOutcome::Removed` preserves prior behavior for clean worktrees.

The thread itself is still archived either way — only the worktree deletion is skipped when there are uncommitted changes. This errs on the side of never deleting rather than trying to be clever about what's "safe" to remove, per the data-loss risk described in the issue.

`crates/sidebar/src/sidebar.rs` is updated at the single call site to match on the new `RemoveRootOutcome` and roll back persisted state correctly when a worktree is retained instead of removed.

## Testing

Added `test_archive_worktree_thread_retains_worktree_with_uncommitted_changes` in `crates/sidebar/src/sidebar_tests.rs`, which archives a thread whose linked worktree has an untracked file and asserts the worktree directory and file remain on disk afterward, and that the thread is still marked archived.

```
cargo build -p agent_ui -p sidebar
cargo test -p sidebar sidebar_tests::test_archive -- --nocapture
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 125 filtered out
```

All existing archive/worktree tests (including #58275's provenance-check coverage) continue to pass.

## Related

#60907 describes a related but distinct bug: closing a *terminal-mode* session that was converted from an agent session can also delete its worktree, via a different trigger path (terminal-mode conversion + close, rather than thread archive). That path is not touched by this PR — it may need the same uncommitted-changes check applied separately, since it likely goes through different code than the sidebar archive-thread path fixed here.