### PR TITLE
multi_buffer: Support Bound::Excluded in excerpt_boundaries_in_range

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5466,8 +5466,9 @@ impl MultiBufferSnapshot {
                 start_offset = start.to_offset(self);
                 Bound::Included(start_offset)
             }
-            Bound::Excluded(_) => {
-                panic!("not supported")
+            Bound::Excluded(start) => {
+                start_offset = start.to_offset(self);
+                Bound::Excluded(start_offset)
             }
             Bound::Unbounded => {
                 start_offset = MultiBufferOffset::ZERO;

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -379,6 +379,45 @@ fn test_excerpt_boundaries_and_clipping(cx: &mut App) {
             })
             .collect::<Vec<_>>()
     }
+
+    #[gpui::test]
+    async fn test_excerpt_boundaries_in_range_with_excluded_bound(cx: &mut TestAppContext) {
+        use std::ops::Bound;
+
+        let buffer1 = cx.new(|cx| Buffer::local("buffer 1\n", cx));
+        let buffer2 = cx.new(|cx| Buffer::local("buffer 2\n", cx));
+        let multibuffer = cx.new(|cx| {
+            let mut mb = MultiBuffer::new(0, language::Capability::ReadWrite);
+            mb.push_excerpts(
+                buffer1,
+                [language::ExcerptRange {
+                    context: Point::new(0, 0)..Point::new(1, 0),
+                    primary: None,
+                }],
+                cx,
+            );
+            mb.push_excerpts(
+                buffer2,
+                [language::ExcerptRange {
+                    context: Point::new(0, 0)..Point::new(1, 0),
+                    primary: None,
+                }],
+                cx,
+            );
+            mb
+        });
+
+        let snapshot = multibuffer.read_with(cx, |mb, cx| mb.snapshot(cx));
+        let boundaries = snapshot
+            .excerpt_boundaries_in_range((
+                Bound::Excluded(MultiBufferOffset(0)),
+                Bound::Unbounded,
+            ))
+            .collect::<Vec<_>>();
+
+        assert_eq!(boundaries.len(), 1);
+        assert_eq!(boundaries[0].row, MultiBufferRow(1));
+    }
 }
 
 #[gpui::test]


### PR DESCRIPTION
 # Objective

- `MultiBufferSnapshot::excerpt_boundaries_in_range` panicked with `"not supported"` when passed a range with an exclusive start bound (`Bound::Excluded`).
- Callers passing standard `RangeBounds` with `Bound::Excluded` bounds should be supported without crashing.

## Solution

- Mapped `Bound::Excluded(start)` to `Bound::Excluded(start_offset)` in the `bounds` range tuple so standard Rust range boundary filtering works as expected.
- Added `test_excerpt_boundaries_in_range_with_excluded_bound` unit test in `multi_buffer_tests.rs`.

## Testing

- Added unit test `test_excerpt_boundaries_in_range_with_excluded_bound` verifying that `(Bound::Excluded(MultiBufferOffset(0)), Bound::Unbounded)` correctly excludes boundary 0 and returns subsequent boundaries without panicking.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed a crash in MultiBuffer when querying excerpt boundaries with exclusive start bounds.