### PR TITLE
editor: Fix completion label overlapping its inline documentation

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -54,6 +54,11 @@ pub const COMPLETION_MENU_MAX_WIDTH: Pixels = px(540.);
 pub const CODE_ACTION_MENU_MIN_WIDTH: Pixels = px(220.);
 pub const CODE_ACTION_MENU_MAX_WIDTH: Pixels = px(540.);
 
+// Shrink factor of the inline documentation shown next to a completion label. It is much larger
+// than the label container's factor of 1 so that narrow rows truncate the documentation instead of
+// the label.
+const DOCUMENTATION_FLEX_SHRINK: f32 = 1000.;
+
 // Constants for the markdown cache. The purpose of this cache is to reduce flickering due to
 // documentation not yet being parsed.
 //
@@ -1191,7 +1196,7 @@ impl CompletionsMenu {
                                     .when_some(documentation_label, |this, doc| {
                                         this.child(
                                             div()
-                                                .flex_shrink(1.0)
+                                                .flex_shrink(DOCUMENTATION_FLEX_SHRINK)
                                                 .ml_auto()
                                                 .min_w_0()
                                                 .child(doc.truncate()),


### PR DESCRIPTION
# Objective
The completion label is painted on top of its inline documentation when a row is
too narrow for both.

Fixes #63037
## Solution

Give the documentation a much larger `flex_shrink` factor so it gives up width before the label container does, which was being shrunk below its own non-shrinking label and letting it spill over the docs.

## test 

before : 
<img width="1626" height="452" alt="image" src="https://github.com/user-attachments/assets/8a58fb9b-f6fe-430b-a478-e90ba7ded4de" />

after:
<img width="1138" height="306" alt="image" src="https://github.com/user-attachments/assets/5e9d47b3-053e-4a17-9bd7-2b2e1b884f63" />


Release Notes:
- Fixed completion labels overlapping their inline documentation in the completions menu.
