### PR TITLE
gpui_windows: Make frame scheduling demand-driven

### DIFF
--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -264,6 +264,7 @@ impl WindowsWindowInner {
             self.state
                 .invalidate_devices
                 .store(true, std::sync::atomic::Ordering::Release);
+            // Wake the demand-driven VSync thread so it can recreate the devices.
             self.state.frame_requester.request();
         }
         if let Some(mut callback) = self.state.callbacks.resize.take() {

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -1287,8 +1287,9 @@ impl WindowsWindowInner {
             }
             // Validate the region so a nested message pump doesn't keep
             // re-dispatching WM_PAINT for the still-invalid region in a busy
-            // loop until the in-progress draw unwinds. Re-arm this window's
-            // demand so the VSync thread delivers the deferred frame.
+            // loop until the in-progress draw unwinds. Queue another request
+            // so the deferred draw is delivered on the next VSync, at most one
+            // VSync late.
             unsafe { ValidateRect(Some(handle), None).ok().log_err() };
             self.state.frame_requester.request();
             return Some(0);

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -264,6 +264,7 @@ impl WindowsWindowInner {
             self.state
                 .invalidate_devices
                 .store(true, std::sync::atomic::Ordering::Release);
+            self.state.frame_requester.request();
         }
         if let Some(mut callback) = self.state.callbacks.resize.take() {
             callback(new_logical_size, scale_factor);
@@ -1284,11 +1285,10 @@ impl WindowsWindowInner {
             }
             // Validate the region so a nested message pump doesn't keep
             // re-dispatching WM_PAINT for the still-invalid region in a busy
-            // loop until the in-progress draw unwinds. The vsync thread
-            // re-invalidates every window on each vsync (see
-            // `begin_vsync_thread`), so the deferred frame still gets drawn,
-            // at most one vsync late.
+            // loop until the in-progress draw unwinds. Re-arm this window's
+            // demand so the VSync thread delivers the deferred frame.
             unsafe { ValidateRect(Some(handle), None).ok().log_err() };
+            self.state.frame_requester.request();
             return Some(0);
         };
         let mut request_frame = self.state.callbacks.request_frame.take()?;

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -321,6 +321,7 @@ impl WindowsWindowInner {
     }
 
     fn handle_destroy_msg(&self, handle: HWND) -> Option<isize> {
+        self.state.frame_requester.close();
         let callback = { self.state.callbacks.close.take() };
         // Re-enable parent window if this was a modal dialog
         if let Some(parent_hwnd) = self.parent_hwnd {

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -46,7 +46,7 @@ pub struct WindowsPlatform {
     /// as resizing them has failed, causing us to have lost at least the render target.
     invalidate_devices: Arc<AtomicBool>,
     frame_request_sender: FrameRequestSender,
-    frame_request_receiver: RefCell<Option<FrameRequestReceiver>>,
+    frame_request_receiver: Cell<Option<FrameRequestReceiver>>,
     handle: HWND,
     suspend_resume_notification: RefCell<Option<HPOWERNOTIFY>>,
     disable_direct_composition: bool,
@@ -212,7 +212,7 @@ impl WindowsPlatform {
             drop_target_helper,
             invalidate_devices: Arc::new(AtomicBool::new(false)),
             frame_request_sender,
-            frame_request_receiver: RefCell::new(Some(frame_request_receiver)),
+            frame_request_receiver: Cell::new(Some(frame_request_receiver)),
             app_identity: RefCell::new(None),
             system_notifications: RefCell::new(SystemNotificationState::new()),
         })
@@ -328,8 +328,7 @@ impl WindowsPlatform {
         let all_windows = Arc::downgrade(&self.raw_window_handles);
         let text_system = Arc::downgrade(direct_write_text_system);
         let invalidate_devices = self.invalidate_devices.clone();
-        let Some(mut frame_request_receiver) = self.frame_request_receiver.borrow_mut().take()
-        else {
+        let Some(mut frame_request_receiver) = self.frame_request_receiver.take() else {
             log::error!("VSync thread already started");
             return;
         };

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -45,6 +45,8 @@ pub struct WindowsPlatform {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     invalidate_devices: Arc<AtomicBool>,
+    frame_request_sender: FrameRequestSender,
+    frame_request_receiver: RefCell<Option<FrameRequestReceiver>>,
     handle: HWND,
     suspend_resume_notification: RefCell<Option<HPOWERNOTIFY>>,
     disable_direct_composition: bool,
@@ -137,6 +139,7 @@ impl WindowsPlatform {
             rand::random::<u32>() as usize
         };
         let raw_window_handles = Arc::new(RwLock::new(SmallVec::new()));
+        let (frame_request_sender, frame_request_receiver) = frame_request_channel();
 
         register_platform_window_class();
         let mut context = PlatformWindowCreateContext {
@@ -208,6 +211,8 @@ impl WindowsPlatform {
             has_package_identity: has_package_identity(),
             drop_target_helper,
             invalidate_devices: Arc::new(AtomicBool::new(false)),
+            frame_request_sender,
+            frame_request_receiver: RefCell::new(Some(frame_request_receiver)),
             app_identity: RefCell::new(None),
             system_notifications: RefCell::new(SystemNotificationState::new()),
         })
@@ -244,6 +249,7 @@ impl WindowsPlatform {
             disable_direct_composition: self.disable_direct_composition,
             directx_devices: self.inner.state.directx_devices.borrow().clone().unwrap(),
             invalidate_devices: self.invalidate_devices.clone(),
+            frame_request_sender: self.frame_request_sender.clone(),
             draw_coordinator: self.inner.state.draw_coordinator.clone(),
         }
     }
@@ -322,12 +328,20 @@ impl WindowsPlatform {
         let all_windows = Arc::downgrade(&self.raw_window_handles);
         let text_system = Arc::downgrade(direct_write_text_system);
         let invalidate_devices = self.invalidate_devices.clone();
+        let Some(mut frame_request_receiver) = self.frame_request_receiver.borrow_mut().take()
+        else {
+            log::error!("VSync thread already started");
+            return;
+        };
 
         std::thread::Builder::new()
             .name("VSyncProvider".to_owned())
             .spawn(move || {
                 let vsync_provider = VSyncProvider::new();
                 loop {
+                    if !frame_request_receiver.wait() {
+                        break;
+                    }
                     vsync_provider.wait_for_vsync();
                     if check_device_lost(&directx_device.device)
                         || invalidate_devices.fetch_and(false, Ordering::Acquire)
@@ -345,9 +359,19 @@ impl WindowsPlatform {
                     let Some(all_windows) = all_windows.upgrade() else {
                         break;
                     };
-                    for hwnd in all_windows.read().iter() {
+                    let requested_windows = frame_request_receiver.take_requested_windows();
+                    let all_windows = all_windows.read();
+                    for hwnd in requested_windows {
+                        if !all_windows
+                            .iter()
+                            .any(|window| window.as_raw() == hwnd.as_raw())
+                        {
+                            continue;
+                        }
                         unsafe {
-                            let _ = RedrawWindow(Some(hwnd.as_raw()), None, None, RDW_INVALIDATE);
+                            RedrawWindow(Some(hwnd.as_raw()), None, None, RDW_INVALIDATE)
+                                .ok()
+                                .log_err();
                         }
                     }
                 }
@@ -1181,6 +1205,7 @@ pub(crate) struct WindowCreationInfo {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     pub(crate) invalidate_devices: Arc<AtomicBool>,
+    pub(crate) frame_request_sender: FrameRequestSender,
     /// Shared with [`WindowsPlatformState::draw_coordinator`] and every other window.
     pub(crate) draw_coordinator: Rc<DrawCoordinator>,
 }

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -356,18 +356,14 @@ impl WindowsPlatform {
                             panic!("Device lost: {err}");
                         }
                     }
-                    let Some(all_windows) = all_windows.upgrade() else {
+                    if all_windows.upgrade().is_none() {
                         break;
-                    };
+                    }
                     let requested_windows = frame_request_receiver.take_requested_windows();
-                    let all_windows = all_windows.read();
-                    for hwnd in requested_windows {
-                        if !all_windows
-                            .iter()
-                            .any(|window| window.as_raw() == hwnd.as_raw())
-                        {
+                    for requested_window in requested_windows {
+                        let Some(hwnd) = requested_window.hwnd_if_open() else {
                             continue;
-                        }
+                        };
                         unsafe {
                             RedrawWindow(Some(hwnd.as_raw()), None, None, RDW_INVALIDATE)
                                 .ok()

--- a/crates/gpui_windows/src/vsync.rs
+++ b/crates/gpui_windows/src/vsync.rs
@@ -29,13 +29,23 @@ pub(crate) struct FrameRequestReceiver {
 #[derive(Clone)]
 pub(crate) struct FrameRequester {
     hwnd: SafeHwnd,
-    queued: Arc<AtomicBool>,
+    state: Arc<FrameRequestState>,
     sender: FrameRequestSender,
+}
+
+struct FrameRequestState {
+    queued: AtomicBool,
+    closed: AtomicBool,
 }
 
 struct FrameRequest {
     hwnd: SafeHwnd,
-    queued: Arc<AtomicBool>,
+    state: Arc<FrameRequestState>,
+}
+
+pub(crate) struct RequestedWindow {
+    hwnd: SafeHwnd,
+    state: Arc<FrameRequestState>,
 }
 
 pub(crate) fn frame_request_channel() -> (FrameRequestSender, FrameRequestReceiver) {
@@ -53,7 +63,10 @@ impl FrameRequestSender {
     pub(crate) fn requester_for(&self, hwnd: SafeHwnd) -> FrameRequester {
         FrameRequester {
             hwnd,
-            queued: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(FrameRequestState {
+                queued: AtomicBool::new(false),
+                closed: AtomicBool::new(false),
+            }),
             sender: self.clone(),
         }
     }
@@ -61,17 +74,29 @@ impl FrameRequestSender {
 
 impl FrameRequester {
     pub(crate) fn request(&self) {
-        if self.queued.swap(true, Ordering::AcqRel) {
+        if self.state.closed.load(Ordering::Acquire)
+            || self.state.queued.swap(true, Ordering::AcqRel)
+        {
             return;
         }
 
         let request = FrameRequest {
             hwnd: self.hwnd,
-            queued: self.queued.clone(),
+            state: self.state.clone(),
         };
         if self.sender.0.send(request).is_err() {
-            self.queued.store(false, Ordering::Release);
+            self.state.queued.store(false, Ordering::Release);
         }
+    }
+
+    pub(crate) fn close(&self) {
+        self.state.closed.store(true, Ordering::Release);
+    }
+}
+
+impl RequestedWindow {
+    pub(crate) fn hwnd_if_open(&self) -> Option<SafeHwnd> {
+        (!self.state.closed.load(Ordering::Acquire)).then_some(self.hwnd)
     }
 }
 
@@ -86,16 +111,22 @@ impl FrameRequestReceiver {
         }
     }
 
-    pub(crate) fn take_requested_windows(&mut self) -> SmallVec<[SafeHwnd; 4]> {
+    pub(crate) fn take_requested_windows(&mut self) -> SmallVec<[RequestedWindow; 4]> {
         let requests = self
             .first_request
             .take()
             .into_iter()
             .chain(self.receiver.try_iter());
         requests
-            .map(|request| {
-                request.queued.store(false, Ordering::Release);
-                request.hwnd
+            .filter_map(|request| {
+                request.state.queued.store(false, Ordering::Release);
+                if request.state.closed.load(Ordering::Acquire) {
+                    return None;
+                }
+                Some(RequestedWindow {
+                    hwnd: request.hwnd,
+                    state: request.state,
+                })
             })
             .collect()
     }
@@ -213,7 +244,12 @@ mod tests {
         assert!(receiver.wait());
         let requested_windows = receiver.take_requested_windows();
         assert_eq!(requested_windows.len(), 1);
-        assert_eq!(requested_windows[0].as_raw(), test_hwnd(1).as_raw());
+        assert_eq!(
+            requested_windows[0]
+                .hwnd_if_open()
+                .map(|hwnd| hwnd.as_raw()),
+            Some(test_hwnd(1).as_raw())
+        );
 
         requester.request();
         assert!(receiver.wait());
@@ -232,7 +268,79 @@ mod tests {
 
         let requested_windows = receiver.take_requested_windows();
         assert_eq!(requested_windows.len(), 2);
-        assert_eq!(requested_windows[0].as_raw(), test_hwnd(1).as_raw());
-        assert_eq!(requested_windows[1].as_raw(), test_hwnd(2).as_raw());
+        assert_eq!(
+            requested_windows[0]
+                .hwnd_if_open()
+                .map(|hwnd| hwnd.as_raw()),
+            Some(test_hwnd(1).as_raw())
+        );
+        assert_eq!(
+            requested_windows[1]
+                .hwnd_if_open()
+                .map(|hwnd| hwnd.as_raw()),
+            Some(test_hwnd(2).as_raw())
+        );
+    }
+
+    #[test]
+    fn closed_frame_requester_discards_its_pending_request() {
+        let (sender, mut receiver) = frame_request_channel();
+        let requester = sender.requester_for(test_hwnd(1));
+
+        requester.request();
+        assert!(receiver.wait());
+        requester.close();
+
+        assert!(receiver.take_requested_windows().is_empty());
+    }
+
+    #[test]
+    fn closed_frame_requester_ignores_new_requests() {
+        let (sender, mut receiver) = frame_request_channel();
+        let requester = sender.requester_for(test_hwnd(1));
+
+        requester.close();
+        requester.request();
+        drop(requester);
+        drop(sender);
+
+        assert!(!receiver.wait());
+    }
+
+    #[test]
+    fn closing_after_take_cancels_dispatch() {
+        let (sender, mut receiver) = frame_request_channel();
+        let requester = sender.requester_for(test_hwnd(1));
+
+        requester.request();
+        assert!(receiver.wait());
+        let requested_windows = receiver.take_requested_windows();
+        assert_eq!(requested_windows.len(), 1);
+
+        requester.close();
+
+        assert!(requested_windows[0].hwnd_if_open().is_none());
+    }
+
+    #[test]
+    fn closed_request_does_not_target_a_new_window_with_the_same_hwnd() {
+        let (sender, mut receiver) = frame_request_channel();
+        let closed_window = sender.requester_for(test_hwnd(1));
+        let new_window = sender.requester_for(test_hwnd(1));
+
+        closed_window.request();
+        assert!(receiver.wait());
+        closed_window.close();
+        new_window.request();
+
+        let requested_windows = receiver.take_requested_windows();
+        assert_eq!(requested_windows.len(), 1);
+        assert!(Arc::ptr_eq(&requested_windows[0].state, &new_window.state));
+        assert_eq!(
+            requested_windows[0]
+                .hwnd_if_open()
+                .map(|hwnd| hwnd.as_raw()),
+            Some(test_hwnd(1).as_raw())
+        );
     }
 }

--- a/crates/gpui_windows/src/vsync.rs
+++ b/crates/gpui_windows/src/vsync.rs
@@ -38,12 +38,7 @@ struct FrameRequestState {
     closed: AtomicBool,
 }
 
-struct FrameRequest {
-    hwnd: SafeHwnd,
-    state: Arc<FrameRequestState>,
-}
-
-pub(crate) struct RequestedWindow {
+pub(crate) struct FrameRequest {
     hwnd: SafeHwnd,
     state: Arc<FrameRequestState>,
 }
@@ -94,7 +89,7 @@ impl FrameRequester {
     }
 }
 
-impl RequestedWindow {
+impl FrameRequest {
     pub(crate) fn hwnd_if_open(&self) -> Option<SafeHwnd> {
         (!self.state.closed.load(Ordering::Acquire)).then_some(self.hwnd)
     }
@@ -111,7 +106,7 @@ impl FrameRequestReceiver {
         }
     }
 
-    pub(crate) fn take_requested_windows(&mut self) -> SmallVec<[RequestedWindow; 4]> {
+    pub(crate) fn take_requested_windows(&mut self) -> SmallVec<[FrameRequest; 4]> {
         let requests = self
             .first_request
             .take()
@@ -123,10 +118,7 @@ impl FrameRequestReceiver {
                 if request.state.closed.load(Ordering::Acquire) {
                     return None;
                 }
-                Some(RequestedWindow {
-                    hwnd: request.hwnd,
-                    state: request.state,
-                })
+                Some(request)
             })
             .collect()
     }

--- a/crates/gpui_windows/src/vsync.rs
+++ b/crates/gpui_windows/src/vsync.rs
@@ -1,15 +1,105 @@
 use std::{
-    sync::LazyLock,
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
 use gpui_util::ResultExt;
+use smallvec::SmallVec;
 use windows::Win32::{
     Foundation::HWND,
     Graphics::Dwm::{DWM_TIMING_INFO, DwmFlush, DwmGetCompositionTimingInfo},
     System::Performance::QueryPerformanceFrequency,
 };
+
+use crate::SafeHwnd;
+
+#[derive(Clone)]
+pub(crate) struct FrameRequestSender(mpsc::Sender<FrameRequest>);
+
+pub(crate) struct FrameRequestReceiver {
+    receiver: mpsc::Receiver<FrameRequest>,
+    first_request: Option<FrameRequest>,
+}
+
+#[derive(Clone)]
+pub(crate) struct FrameRequester {
+    hwnd: SafeHwnd,
+    queued: Arc<AtomicBool>,
+    sender: FrameRequestSender,
+}
+
+struct FrameRequest {
+    hwnd: SafeHwnd,
+    queued: Arc<AtomicBool>,
+}
+
+pub(crate) fn frame_request_channel() -> (FrameRequestSender, FrameRequestReceiver) {
+    let (sender, receiver) = mpsc::channel();
+    (
+        FrameRequestSender(sender),
+        FrameRequestReceiver {
+            receiver,
+            first_request: None,
+        },
+    )
+}
+
+impl FrameRequestSender {
+    pub(crate) fn requester_for(&self, hwnd: SafeHwnd) -> FrameRequester {
+        FrameRequester {
+            hwnd,
+            queued: Arc::new(AtomicBool::new(false)),
+            sender: self.clone(),
+        }
+    }
+}
+
+impl FrameRequester {
+    pub(crate) fn request(&self) {
+        if self.queued.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let request = FrameRequest {
+            hwnd: self.hwnd,
+            queued: self.queued.clone(),
+        };
+        if self.sender.0.send(request).is_err() {
+            self.queued.store(false, Ordering::Release);
+        }
+    }
+}
+
+impl FrameRequestReceiver {
+    pub(crate) fn wait(&mut self) -> bool {
+        match self.receiver.recv() {
+            Ok(request) => {
+                self.first_request = Some(request);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    pub(crate) fn take_requested_windows(&mut self) -> SmallVec<[SafeHwnd; 4]> {
+        let requests = self
+            .first_request
+            .take()
+            .into_iter()
+            .chain(self.receiver.try_iter());
+        requests
+            .map(|request| {
+                request.queued.store(false, Ordering::Release);
+                request.hwnd
+            })
+            .collect()
+    }
+}
 
 static QPC_TICKS_PER_SECOND: LazyLock<u64> = LazyLock::new(|| {
     let mut frequency = 0;
@@ -78,4 +168,71 @@ fn get_dwm_interval() -> Result<Duration> {
 fn retrieve_duration(counts: u64, ticks_per_second: u64) -> Duration {
     let ticks_per_microsecond = ticks_per_second / 1_000_000;
     Duration::from_micros(counts / ticks_per_microsecond)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_hwnd(value: isize) -> SafeHwnd {
+        HWND(value as _).into()
+    }
+
+    #[test]
+    fn frame_request_receiver_waits_for_demand() {
+        let (sender, mut receiver) = frame_request_channel();
+        let requester = sender.requester_for(test_hwnd(1));
+        let (completed_sender, completed_receiver) = mpsc::sync_channel(1);
+
+        std::thread::spawn(move || {
+            let received = receiver.wait();
+            completed_sender
+                .send((received, receiver.take_requested_windows().len()))
+                .unwrap();
+        });
+
+        assert!(matches!(
+            completed_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+        requester.request();
+        assert_eq!(
+            completed_receiver.recv_timeout(Duration::from_secs(1)),
+            Ok((true, 1))
+        );
+    }
+
+    #[test]
+    fn frame_requester_coalesces_until_the_request_is_taken() {
+        let (sender, mut receiver) = frame_request_channel();
+        let requester = sender.requester_for(test_hwnd(1));
+
+        requester.request();
+        requester.request();
+
+        assert!(receiver.wait());
+        let requested_windows = receiver.take_requested_windows();
+        assert_eq!(requested_windows.len(), 1);
+        assert_eq!(requested_windows[0].as_raw(), test_hwnd(1).as_raw());
+
+        requester.request();
+        assert!(receiver.wait());
+        assert_eq!(receiver.take_requested_windows().len(), 1);
+    }
+
+    #[test]
+    fn frame_request_receiver_batches_distinct_windows_before_vsync() {
+        let (sender, mut receiver) = frame_request_channel();
+        let first = sender.requester_for(test_hwnd(1));
+        let second = sender.requester_for(test_hwnd(2));
+
+        first.request();
+        assert!(receiver.wait());
+        second.request();
+
+        let requested_windows = receiver.take_requested_windows();
+        assert_eq!(requested_windows.len(), 2);
+        assert_eq!(requested_windows[0].as_raw(), test_hwnd(1).as_raw());
+        assert_eq!(requested_windows[1].as_raw(), test_hwnd(2).as_raw());
+    }
 }

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -82,6 +82,7 @@ pub struct WindowsWindowState {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     pub invalidate_devices: Arc<AtomicBool>,
+    pub(crate) frame_requester: FrameRequester,
     /// Shared with [`WindowsPlatformState::draw_coordinator`] and every other window.
     pub(crate) draw_coordinator: Rc<DrawCoordinator>,
     fullscreen: Cell<Option<StyleAndBounds>>,
@@ -119,6 +120,7 @@ impl WindowsWindowState {
         appearance: WindowAppearance,
         disable_direct_composition: bool,
         invalidate_devices: Arc<AtomicBool>,
+        frame_request_sender: FrameRequestSender,
         draw_coordinator: Rc<DrawCoordinator>,
     ) -> Result<Self> {
         let scale_factor = {
@@ -183,6 +185,7 @@ impl WindowsWindowState {
             initial_placement: Cell::new(initial_placement),
             hwnd,
             invalidate_devices,
+            frame_requester: frame_request_sender.requester_for(hwnd.into()),
             draw_coordinator,
             direct_manipulation,
             a11y: RefCell::new(None),
@@ -261,6 +264,7 @@ impl WindowsWindowInner {
             context.appearance,
             context.disable_direct_composition,
             context.invalidate_devices.clone(),
+            context.frame_request_sender.clone(),
             context.draw_coordinator.clone(),
         )?;
 
@@ -409,6 +413,7 @@ struct WindowCreateContext {
     disable_direct_composition: bool,
     directx_devices: DirectXDevices,
     invalidate_devices: Arc<AtomicBool>,
+    frame_request_sender: FrameRequestSender,
     draw_coordinator: Rc<DrawCoordinator>,
     parent_hwnd: Option<HWND>,
 }
@@ -437,6 +442,7 @@ impl WindowsWindow {
             disable_direct_composition,
             directx_devices,
             invalidate_devices,
+            frame_request_sender,
             draw_coordinator,
         } = creation_info;
         register_window_class(icon);
@@ -522,6 +528,7 @@ impl WindowsWindow {
             disable_direct_composition,
             directx_devices,
             invalidate_devices,
+            frame_request_sender,
             draw_coordinator,
             parent_hwnd,
         };
@@ -930,6 +937,11 @@ impl PlatformWindow for WindowsWindow {
 
     fn is_fullscreen(&self) -> bool {
         self.state.is_fullscreen()
+    }
+
+    fn frame_waker(&self) -> Option<Rc<dyn Fn()>> {
+        let frame_requester = self.state.frame_requester.clone();
+        Some(Rc::new(move || frame_requester.request()))
     }
 
     fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>) {

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -601,6 +601,7 @@ impl rwh::HasDisplayHandle for WindowsWindow {
 
 impl Drop for WindowsWindow {
     fn drop(&mut self) {
+        self.0.state.frame_requester.close();
         // clone this `Rc` to prevent early release of the pointer
         let this = self.0.clone();
         self.0


### PR DESCRIPTION
# Objective

Reduce idle CPU usage in GPUI's Windows platform.

The Windows VSync thread currently marks every tracked window for repaint after every VSync, even when no window has requested a frame. GPUI can skip rebuilding and presenting a clean scene, but the repeated `WM_PAINT` dispatch and frame callback processing still continue while the application is idle.

## Solution

Make Windows frame scheduling demand-driven:

- Implement `PlatformWindow::frame_waker` and connect it to a thread-safe frame-request channel.
- Keep the VSync thread blocked while no window has requested a frame.
- After one or more requests arrive, wait for the next VSync and mark only the requested windows for repaint with `RedrawWindow(..., RDW_INVALIDATE)`.
- Coalesce repeated requests for the same window.
- Process requests from multiple windows in the same VSync interval.

Preserve existing behavior and window lifecycle safety under demand-driven scheduling:

- If a re-entrant paint request arrives while another draw is in progress, allow the current draw to finish and queue the deferred draw for the next VSync.
- Wake the VSync thread when renderer resize failure requires device recovery.
- Mark a window's request state as closed when the native window is destroyed or its Rust window object is dropped, so pending and future requests are ignored.
- Associate queued requests with per-window lifecycle state rather than relying only on the raw `HWND` value. Requests whose original window is already known to be closed are ignored even if a later window receives the same raw handle value.

## Testing

Tested on native Windows x64.

Automated tests cover:

- waiting for frame demand
- duplicate request coalescing
- multi-window batching
- closing a window with a pending request
- ignoring requests after close
- closing after dequeue but before dispatch
- reuse of the same raw `HWND` by a new window
- existing GPUI frame-waker and next-frame callback behavior

Commands run:

```text
cargo test -p gpui_windows --lib --tests
cargo test -p gpui --lib --tests
cargo fmt -p gpui_windows -- --check
cargo clippy -p gpui_windows --all-targets -- -D warnings
```

Results:

- `gpui_windows`: 14 passed
- `gpui`: 261 unit tests and 1 integration test passed
- Formatting passed
- Clippy passed with warnings denied

Manual native Windows validation covered:

- visible single-window creation and GPU rendering
- reactive updates
- pointer and wheel input
- resize
- close and process termination

Idle CPU was measured on a Windows x64 system with 16 logical processors. Measurements were taken for approximately 10 seconds after allowing the application to settle. CPU percentages are averaged across all logical processors.

| Test case | Before | After |
| --- | ---: | ---: |
| Static application UI with 264 attached nodes | 4.731% | 0.019% |
| Existing GPUI `hello_world` example (dev profile) | 0.049% | <0.010% |

The `hello_world` sampler reported no additional CPU time during the 10-second post-change measurement. The result is shown as `<0.010%` rather than zero to account for the timer resolution of the Windows process CPU measurement.

These are local native Windows measurements rather than CI benchmarks. GPUI's benchmark harness does not drive the Windows VSync path.

Manual testing did not cover the following cases:

- Visible multi-window rendering. Request batching and window-close races are covered by unit tests.
- Actual GPU device-loss recovery. A real device loss was not forced during manual testing.

The changes are confined to `gpui_windows`; macOS and Linux were not manually tested.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md)) guidelines
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved Windows CPU usage while application windows are idle.