### PR TITLE
worktree: Avoid scanner round trip when loading files

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1700,11 +1700,12 @@ impl LocalWorktree {
         let path = Arc::from(path);
         let abs_path = self.absolutize(&path);
         let fs = self.fs.clone();
-        let entry = self.refresh_entry(path.clone(), None, cx);
+        let snapshot_entry = self.entry_for_path(&path).cloned();
         let is_private = self.is_path_private(path.as_ref());
 
-        let this = cx.weak_entity();
-        cx.background_spawn(async move {
+        let load_fs = fs.clone();
+        let load_abs_path = abs_path.clone();
+        let load = cx.background_spawn(async move {
             // WARN: Temporary workaround for #27283.
             //       We are not efficient with our memory usage per file, and use in excess of 64GB for a 10GB file
             //       Therefore, as a temporary workaround to prevent system freezes, we just bail before opening a file
@@ -1712,18 +1713,39 @@ impl LocalWorktree {
             //       5GB seems to be more reasonable, peaking at ~16GB, while 6GB jumps up to >24GB which seems like a
             //       reasonable limit
             const FILE_SIZE_MAX: u64 = 6 * 1024 * 1024 * 1024; // 6GB
-            let metadata = fs.metadata(&abs_path).await?;
+            let metadata = load_fs.metadata(&load_abs_path).await?;
             if let Some(metadata) = metadata.as_ref()
                 && metadata.len >= FILE_SIZE_MAX
             {
                 anyhow::bail!("File is too large to load");
             }
             let (text, line_ending, encoding, has_bom) =
-                decode_file_text_to_rope(fs.as_ref(), &abs_path).await?;
+                decode_file_text_to_rope(load_fs.as_ref(), &load_abs_path).await?;
             let is_writable = metadata.is_some_and(|metadata| metadata.is_writable);
 
+            Ok((metadata, text, line_ending, encoding, has_bom, is_writable))
+        });
+
+        cx.spawn(async move |this, cx| {
+            let (metadata, text, line_ending, encoding, has_bom, is_writable) = load.await?;
+            let entry = if snapshot_entry.as_ref().is_some_and(|entry| {
+                metadata.is_some_and(|metadata| {
+                    entry.mtime == Some(metadata.mtime) && entry.size == metadata.len
+                })
+            }) {
+                snapshot_entry
+            } else {
+                this.update(cx, |this, cx| match this {
+                    Worktree::Local(worktree) => worktree.refresh_entry(path.clone(), None, cx),
+                    Worktree::Remote(_) => {
+                        Task::ready(Err(anyhow!("worktree changed from local to remote")))
+                    }
+                })?
+                .await?
+            };
+
             let worktree = this.upgrade().context("worktree was dropped")?;
-            let file = match entry.await? {
+            let file = match entry {
                 Some(entry) => File::for_entry(entry, worktree),
                 None => {
                     let metadata = fs

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -5522,6 +5522,172 @@ async fn wait_for_condition(
 }
 
 #[gpui::test]
+async fn test_load_file_uses_current_snapshot_entry(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree("/root", json!({ "file.txt": "contents" }))
+        .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs,
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    let snapshot_entry = tree.read_with(cx, |tree, _| {
+        tree.entry_for_path(rel_path("file.txt")).unwrap().clone()
+    });
+    let loaded = tree
+        .update(cx, |tree, cx| tree.load_file(rel_path("file.txt"), cx))
+        .await
+        .unwrap();
+
+    assert_eq!(loaded.file.entry_id, Some(snapshot_entry.id));
+    assert_eq!(loaded.file.disk_state.mtime(), snapshot_entry.mtime);
+}
+
+#[gpui::test]
+async fn test_load_file_refreshes_stale_snapshot_entry(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree("/root", json!({ "file.txt": "old" })).await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    fs.pause_events();
+    fs.write(Path::new("/root/file.txt"), b"new file contents")
+        .await
+        .unwrap();
+    let metadata = fs
+        .metadata(Path::new("/root/file.txt"))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let loaded = tree
+        .update(cx, |tree, cx| tree.load_file(rel_path("file.txt"), cx))
+        .await
+        .unwrap();
+
+    assert_eq!(loaded.file.disk_state.mtime(), Some(metadata.mtime));
+    assert_eq!(loaded.file.disk_state.size(), Some(metadata.len));
+    tree.read_with(cx, |tree, _| {
+        let entry = tree.entry_for_path(rel_path("file.txt")).unwrap();
+        assert_eq!(entry.mtime, Some(metadata.mtime));
+        assert_eq!(entry.size, metadata.len);
+    });
+}
+
+#[gpui::test]
+async fn test_load_file_refreshes_missing_gitignored_entry(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "ignored_dir\n",
+            "ignored_dir": { "file.txt": "contents" },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs,
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("ignored_dir/file.txt"))
+                .is_none()
+        );
+    });
+
+    let loaded = tree
+        .update(cx, |tree, cx| {
+            tree.load_file(rel_path("ignored_dir/file.txt"), cx)
+        })
+        .await
+        .unwrap();
+
+    assert!(loaded.file.entry_id.is_some());
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("ignored_dir/file.txt"))
+                .is_some()
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_load_file_excluded_path_has_no_entry(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_exclusions =
+                    Some(SplicingVec::from(vec!["excluded.txt".to_string()]));
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree("/root", json!({ "excluded.txt": "contents" }))
+        .await;
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs,
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    tree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("excluded.txt")).is_none());
+    });
+
+    let loaded = tree
+        .update(cx, |tree, cx| tree.load_file(rel_path("excluded.txt"), cx))
+        .await
+        .unwrap();
+
+    assert_eq!(loaded.file.entry_id, None);
+}
+
+#[gpui::test]
 async fn test_load_file_encoding(cx: &mut TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
# Objective

Opening an already-scanned file can wait behind the initial background scan because `LocalWorktree::load_file` always refreshes its entry through the scanner.

This delays opening files in large worktrees even when the file content and metadata are already current in the foreground snapshot. In a large monorepo this appeared to lock the editor for minutes at a time when first opening zed.

## Solution

Use the current snapshot entry when its mtime and size match freshly-read filesystem metadata.

When there is no snapshot entry, or either value differs, retain the existing `refresh_entry` path. Excluded paths continue to produce entry-less files.

## Testing

- `cargo test -p worktree`
- `./script/clippy -p worktree`

Added test coverage for:

- Loading an unchanged snapshot entry
- Refreshing a stale snapshot entry
- Loading a missing entry inside an unexpanded gitignored directory
- Loading an excluded path without an entry

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed delays when opening already-scanned files in large worktrees
