### PR TITLE
gpui: Use scheduler::Instant for action timings

### DIFF
--- a/crates/gpui/src/profiler/actions.rs
+++ b/crates/gpui/src/profiler/actions.rs
@@ -1,6 +1,7 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use itertools::Itertools;
+use scheduler::Instant;
 
 #[cfg(feature = "profiler")]
 use crate::action::Action;


### PR DESCRIPTION
`cargo check -p gpui --target wasm32-unknown-unknown --features profiler` fails
with five type errors:

```
error[E0308]: `match` arms have incompatible types
   --> crates/gpui/src/profiler/journal.rs:87:37
   --> crates/gpui/src/profiler/journal.rs:99:37
error[E0308]: mismatched types
   --> crates/gpui/src/profiler/hang.rs:315
   --> crates/gpui/src/profiler.rs:1002
   --> crates/gpui/src/profiler.rs:1003
    = note: `std::time::Instant` and `scheduler::Instant` have similar names,
            but are actually distinct types
```

`crates/gpui/src/profiler/actions.rs` imports `std::time::Instant`, while every
other module under `profiler/` imports `scheduler::Instant`. `ActionTiming`
therefore carries std's type, and `ForegroundEvent::start_time()`/`end_time()`
match over `ActionTiming` alongside the `Draw`, `Present` and `TaskPoll`
timings that use `scheduler::Instant` — so the arms disagree.

This only shows up on wasm. `scheduler::Instant` re-exports `web_time::Instant`,
which off wasm *is* `std::time::Instant`, so the two names are the same type on
every target CI builds and the mismatch is invisible.

There is a second problem hiding behind the type error. On
`wasm32-unknown-unknown`, `std::time::Instant::now()` is the
unsupported-platform stub and panics — "time not implemented on this platform".
The three `Instant::now()` calls in `actions.rs` would abort as soon as an
action was dispatched in a browser, even if they had compiled.
`scheduler::Instant` reads `performance.now()` instead.

## Change

Import `Instant` from `scheduler` in `profiler/actions.rs`, matching its sibling
modules. No other change.

## Verification

| | before | after |
|---|---|---|
| `cargo check -p gpui --target wasm32-unknown-unknown --features profiler` | 5 errors | passes |
| `cargo check -p gpui --target wasm32-unknown-unknown` | passes | passes |
| `cargo check -p gpui --features profiler` (native) | passes | passes |
| `cargo fmt -p gpui -- --check` | clean | clean |

No test is added: the failure is a compile error under a target/feature
combination, so what would catch a regression is a CI entry building `gpui` for
`wasm32-unknown-unknown` with `--features profiler`, not a `#[test]`. Nothing
appears to build that combination today, which is how this landed. Happy to add
that job if you'd like it in this PR.

Found while building a GPUI app for the browser: `gpui-component` enabled
`gpui/profiler` workspace-wide, so every downstream consumer of its `gpui-base`
crate compiled the profiler and hit this. That side is fixed separately
(longbridge/gpui-component#2823), but the gpui bug is still here for anyone who
wants the frame HUD on the web.
