### PR TITLE
editor: Align soft wrap breaks with `editor::Rewrap`

### DIFF
--- a/crates/editor/src/config.rs
+++ b/crates/editor/src/config.rs
@@ -273,16 +273,16 @@ impl Editor {
 
     // Called by the element. This method is not designed to be called outside of the editor
     // element's layout code because it does not notify when rewrapping is computed synchronously.
-    pub(super) fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut App) -> bool {
+    pub(super) fn set_wrap_width(&self, widths: Option<WrapWidths>, cx: &mut App) -> bool {
         if self.is_empty(cx) {
             self.placeholder_display_map
                 .as_ref()
                 .map_or(false, |display_map| {
-                    display_map.update(cx, |map, cx| map.set_wrap_width(width, cx))
+                    display_map.update(cx, |map, cx| map.set_wrap_widths(widths, cx))
                 })
         } else {
             self.display_map
-                .update(cx, |map, cx| map.set_wrap_width(width, cx))
+                .update(cx, |map, cx| map.set_wrap_widths(widths, cx))
         }
     }
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -96,7 +96,7 @@ pub use wrap_map::{WrapPoint, WrapRow, WrapSnapshot};
 use collections::{HashMap, HashSet, IndexSet};
 use gpui::{
     App, Context, Entity, EntityId, Font, HighlightStyle, Hsla, LineLayout, Pixels, UnderlineStyle,
-    WeakEntity,
+    WeakEntity, WrapWidths,
 };
 use language::{
     LanguageAwareStyling, Point, Subscription as BufferSubscription,
@@ -369,7 +369,7 @@ impl DisplayMap {
         buffer: Entity<MultiBuffer>,
         font: Font,
         font_size: Pixels,
-        wrap_width: Option<Pixels>,
+        wrap_widths: Option<WrapWidths>,
         buffer_header_height: u32,
         excerpt_header_height: u32,
         fold_placeholder: FoldPlaceholder,
@@ -387,7 +387,7 @@ impl DisplayMap {
         let (inlay_map, snapshot) = InlayMap::new(buffer_snapshot);
         let (fold_map, snapshot) = FoldMap::new(snapshot);
         let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
-        let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_width, cx);
+        let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_widths, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
 
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
@@ -1243,9 +1243,9 @@ impl DisplayMap {
             .update(cx, |map, cx| map.set_font_with_size(font, font_size, cx))
     }
 
-    pub fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut Context<Self>) -> bool {
+    pub fn set_wrap_widths(&self, widths: Option<WrapWidths>, cx: &mut Context<Self>) -> bool {
         self.wrap_map
-            .update(cx, |map, cx| map.set_wrap_width(width, cx))
+            .update(cx, |map, cx| map.set_wrap_widths(widths, cx))
     }
 
     #[instrument(skip_all)]
@@ -2761,7 +2761,7 @@ pub mod tests {
                 buffer.clone(),
                 font,
                 font_size,
-                wrap_width,
+                wrap_width.map(Into::into),
                 buffer_start_excerpt_header_height,
                 excerpt_header_height,
                 FoldPlaceholder::test(),
@@ -2790,7 +2790,9 @@ pub mod tests {
                         Some(px(rng.random_range(0.0..=max_wrap_width)))
                     };
                     log::info!("setting wrap width to {:?}", wrap_width);
-                    map.update(cx, |map, cx| map.set_wrap_width(wrap_width, cx));
+                    map.update(cx, |map, cx| {
+                        map.set_wrap_widths(wrap_width.map(Into::into), cx)
+                    });
                 }
                 20..=29 => {
                     let mut tab_sizes = vec![1, 2, 3, 4];
@@ -3014,7 +3016,7 @@ pub mod tests {
                     buffer.clone(),
                     font("Helvetica"),
                     font_size,
-                    wrap_width,
+                    wrap_width.map(Into::into),
                     1,
                     1,
                     FoldPlaceholder::test(),
@@ -3733,7 +3735,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 font_size,
-                Some(px(40.0)),
+                Some(px(40.0).into()),
                 1,
                 1,
                 FoldPlaceholder::test(),

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -3287,7 +3287,8 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(multi_buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wraps_snapshot) = WrapMap::new(tab_snapshot, font, font_size, Some(wrap_width), cx);
+        let (_, wraps_snapshot) =
+            WrapMap::new(tab_snapshot, font, font_size, Some(wrap_width.into()), cx);
 
         let block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
         let snapshot = block_map.read(wraps_snapshot, Default::default(), None);
@@ -3426,7 +3427,13 @@ mod tests {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let (_, wraps_snapshot) = cx.update(|cx| {
-            WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), Some(px(90.)), cx)
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                Some(px(90.).into()),
+                cx,
+            )
         });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -3469,7 +3476,13 @@ mod tests {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let (_, wraps_snapshot) = cx.update(|cx| {
-            WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), Some(px(90.)), cx)
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                Some(px(90.).into()),
+                cx,
+            )
         });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -4093,8 +4106,15 @@ mod tests {
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let font = test_font();
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font, font_size, wrap_width, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font,
+                font_size,
+                wrap_width.map(Into::into),
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(
             wraps_snapshot,
             buffer_start_header_height,
@@ -4111,7 +4131,9 @@ mod tests {
                         Some(px(rng.random_range(0.0..=100.0)))
                     };
                     log::info!("Setting wrap width to {:?}", wrap_width);
-                    wrap_map.update(cx, |map, cx| map.set_wrap_width(wrap_width, cx));
+                    wrap_map.update(cx, |map, cx| {
+                        map.set_wrap_widths(wrap_width.map(Into::into), cx)
+                    });
                 }
                 20..=39 => {
                     let block_count = rng.random_range(1..=5);

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -10,6 +10,7 @@ use collections::HashMap;
 use futures_lite::future::yield_now;
 use gpui::{
     App, AppContext as _, Context, Entity, Font, FontId, LineWrapper, Pixels, Task, TextSystem,
+    WrapWidths,
 };
 use language::{LanguageAwareStyling, Point};
 use multi_buffer::RowInfo;
@@ -45,7 +46,7 @@ pub struct WrapMap {
     pending_edits: VecDeque<(TabSnapshot, Vec<TabEdit>)>,
     interpolated_edits: WrapPatch,
     edits_since_sync: WrapPatch,
-    wrap_width: Option<Pixels>,
+    wrap_widths: Option<WrapWidths>,
     background_task: Option<Task<()>>,
     font_with_size: (Font, Pixels),
 }
@@ -182,20 +183,20 @@ impl WrapMap {
         tab_snapshot: TabSnapshot,
         font: Font,
         font_size: Pixels,
-        wrap_width: Option<Pixels>,
+        wrap_widths: Option<WrapWidths>,
         cx: &mut App,
     ) -> (Entity<Self>, WrapSnapshot) {
         let handle = cx.new(|cx| {
             let mut this = Self {
                 font_with_size: (font, font_size),
-                wrap_width: None,
+                wrap_widths: None,
                 pending_edits: Default::default(),
                 interpolated_edits: Default::default(),
                 edits_since_sync: Default::default(),
                 snapshot: WrapSnapshot::new(tab_snapshot),
                 background_task: None,
             };
-            this.set_wrap_width(wrap_width, cx);
+            this.set_wrap_widths(wrap_widths, cx);
             mem::take(&mut this.edits_since_sync);
             this
         });
@@ -215,7 +216,7 @@ impl WrapMap {
         edits: Vec<TabEdit>,
         cx: &mut Context<Self>,
     ) -> (WrapSnapshot, WrapPatch) {
-        if self.wrap_width.is_some() {
+        if self.wrap_widths.is_some() {
             self.pending_edits.push_back((tab_snapshot, edits));
             self.flush_edits(cx);
         } else {
@@ -247,12 +248,16 @@ impl WrapMap {
     }
 
     #[ztracing::instrument(skip_all)]
-    pub fn set_wrap_width(&mut self, wrap_width: Option<Pixels>, cx: &mut Context<Self>) -> bool {
-        if wrap_width == self.wrap_width {
+    pub fn set_wrap_widths(
+        &mut self,
+        wrap_widths: Option<WrapWidths>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if wrap_widths == self.wrap_widths {
             return false;
         }
 
-        self.wrap_width = wrap_width;
+        self.wrap_widths = wrap_widths;
         self.rewrap(cx);
         true
     }
@@ -263,7 +268,7 @@ impl WrapMap {
         self.interpolated_edits.clear();
         self.pending_edits.clear();
 
-        if let Some(wrap_width) = self.wrap_width {
+        if let Some(wrap_widths) = self.wrap_widths {
             let mut new_snapshot = self.snapshot.clone();
 
             let text_system = cx.text_system();
@@ -283,7 +288,7 @@ impl WrapMap {
                 let edits = gpui::block_on(new_snapshot.update(
                     tab_snapshot,
                     &tab_edits,
-                    wrap_width,
+                    wrap_widths,
                     &mut line_wrapper,
                     &mut fragment_builder,
                 ));
@@ -295,7 +300,7 @@ impl WrapMap {
                         .update(
                             tab_snapshot,
                             &tab_edits,
-                            wrap_width,
+                            wrap_widths,
                             &mut line_wrapper,
                             &mut fragment_builder,
                         )
@@ -365,7 +370,7 @@ impl WrapMap {
             return;
         }
 
-        if let Some(wrap_width) = self.wrap_width
+        if let Some(wrap_widths) = self.wrap_widths
             && self.background_task.is_none()
         {
             let mut pending_edits = self.pending_edits.clone();
@@ -386,7 +391,7 @@ impl WrapMap {
                 let wrap_edits = gpui::block_on(snapshot.update(
                     tab_snapshot,
                     &tab_edits,
-                    wrap_width,
+                    wrap_widths,
                     &mut line_wrapper,
                     &mut fragment_builder,
                 ));
@@ -400,7 +405,7 @@ impl WrapMap {
                             .update(
                                 tab_snapshot,
                                 &tab_edits,
-                                wrap_width,
+                                wrap_widths,
                                 &mut line_wrapper,
                                 &mut fragment_builder,
                             )
@@ -547,7 +552,7 @@ impl WrapSnapshot {
         &mut self,
         new_tab_snapshot: TabSnapshot,
         tab_edits: &[TabEdit],
-        wrap_width: Pixels,
+        wrap_widths: WrapWidths,
         line_wrapper: &mut LineWrapper,
         fragment_builder: &mut LineFragmentBuilder,
     ) -> WrapPatch {
@@ -642,7 +647,7 @@ impl WrapSnapshot {
                     }
 
                     let mut prev_boundary_ix = 0;
-                    for boundary in line_wrapper.wrap_line(&line_fragments, wrap_width) {
+                    for boundary in line_wrapper.wrap_line(&line_fragments, wrap_widths) {
                         let wrapped = &line[prev_boundary_ix..boundary.ix];
                         push_isomorphic(&mut edit_transforms, TextSummary::from(wrapped));
                         edit_transforms.push(Transform::wrap(boundary.next_indent));
@@ -1488,8 +1493,15 @@ mod tests {
             let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
             let (mut tab_map, _) = TabMap::new(fold_snapshot, tab_size);
             let tabs_snapshot = tab_map.set_max_expansion_column(32);
-            let (_wrap_map, wrap_snapshot) =
-                cx.update(|cx| WrapMap::new(tabs_snapshot, font, font_size, soft_wrapping, cx));
+            let (_wrap_map, wrap_snapshot) = cx.update(|cx| {
+                WrapMap::new(
+                    tabs_snapshot,
+                    font,
+                    font_size,
+                    soft_wrapping.map(Into::into),
+                    cx,
+                )
+            });
 
             wrap_snapshot
         }
@@ -1611,8 +1623,8 @@ mod tests {
         let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, _) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let tabs_snapshot = tab_map.set_max_expansion_column(32);
-        let (_wrap_map, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tabs_snapshot, font, font_size, Some(wrap_width), cx));
+        let (_wrap_map, wrap_snapshot) = cx
+            .update(|cx| WrapMap::new(tabs_snapshot, font, font_size, Some(wrap_width.into()), cx));
 
         let wrapped_text = wrap_snapshot.text();
         for row in wrapped_text.split('\n') {
@@ -1686,8 +1698,15 @@ mod tests {
         let mut line_wrapper = text_system.line_wrapper(font.clone(), font_size);
         let expected_text = wrap_text(&tabs_snapshot, wrap_width, &mut line_wrapper);
 
-        let (wrap_map, _) =
-            cx.update(|cx| WrapMap::new(tabs_snapshot.clone(), font, font_size, wrap_width, cx));
+        let (wrap_map, _) = cx.update(|cx| {
+            WrapMap::new(
+                tabs_snapshot.clone(),
+                font,
+                font_size,
+                wrap_width.map(Into::into),
+                cx,
+            )
+        });
         let mut notifications = observe(&wrap_map, cx);
 
         if wrap_map.read_with(cx, |map, _| map.is_rewrapping()) {
@@ -1722,7 +1741,9 @@ mod tests {
                         Some(px(rng.random_range(0.0..=1000.0)))
                     };
                     log::info!("Setting wrap width to {:?}", wrap_width);
-                    wrap_map.update(cx, |map, cx| map.set_wrap_width(wrap_width, cx));
+                    wrap_map.update(cx, |map, cx| {
+                        map.set_wrap_widths(wrap_width.map(Into::into), cx)
+                    });
                 }
                 20..=39 => {
                     for (fold_snapshot, fold_edits) in fold_map.randomly_mutate(&mut rng) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -167,8 +167,8 @@ use gpui::{
     KeyContext, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement,
     Pixels, PressureStage, Render, ScrollHandle, SharedString, SharedUri, Size, Stateful, Styled,
     Subscription, Task, TextRun, TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle,
-    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div, point, prelude::*,
-    pulsating_between, px, relative, size,
+    UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, WrapWidths, div, point,
+    prelude::*, pulsating_between, px, relative, size,
 };
 use hover_links::{HoverLink, HoveredLinkState, find_file};
 use hover_popover::{HoverState, hide_hover};

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2764,7 +2764,7 @@ fn test_beginning_end_of_line_ignore_soft_wrap(cx: &mut TestAppContext) {
     });
 
     _ = editor.update(cx, |editor, window, cx| {
-        editor.set_wrap_width(Some(140.0.into()), cx);
+        editor.set_wrap_width(Some(px(140.0).into()), cx);
 
         // We expect the following lines after wrapping
         // ```
@@ -3059,7 +3059,7 @@ fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut TestAppContext) {
     });
 
     _ = editor.update(cx, |editor, window, cx| {
-        editor.set_wrap_width(Some(140.0.into()), cx);
+        editor.set_wrap_width(Some(px(140.0).into()), cx);
         assert_eq!(
             editor.display_text(cx),
             "use one::{\n    two::three::\n    four::five\n};"
@@ -37137,7 +37137,7 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     cx.update_editor(|editor, window, cx| {
         // Enable soft wrapping with a narrow width to force soft wrapping and
         // confirm that more than 2 rows are being displayed.
-        editor.set_wrap_width(Some(100.0.into()), cx);
+        editor.set_wrap_width(Some(px(100.0).into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
         editor.add_selection_below(
@@ -37211,7 +37211,7 @@ async fn test_add_selection_skip_soft_wrap_option(cx: &mut TestAppContext) {
     cx.update_editor(|editor, window, cx| {
         // Enable soft wrapping with a narrow width to force soft wrapping and
         // confirm that more than 2 rows are being displayed.
-        editor.set_wrap_width(Some(100.0.into()), cx);
+        editor.set_wrap_width(Some(px(100.0).into()), cx);
         assert!(editor.display_text(cx).lines().count() > 2);
 
         editor.add_selection_below(
@@ -39317,7 +39317,7 @@ fn test_relative_line_numbers(cx: &mut TestAppContext) {
 
     let editor = cx.add_window(|window, cx| build_editor(multibuffer, window, cx));
     _ = editor.update(cx, |editor, window, cx| {
-        editor.set_wrap_width(Some(30.0.into()), cx); // every 3 characters
+        editor.set_wrap_width(Some(px(30.0).into()), cx); // every 3 characters
 
         // includes trailing newlines.
         let expected_line_numbers = [2, 6, 7, 10, 14, 15, 18, 19, 23];
@@ -43208,7 +43208,7 @@ async fn test_align_selections_with_soft_wrap(cx: &mut TestAppContext) {
     let before = "aaaaaaaaaaaaˇx\nbbbbbˇy";
     let after = "aaaaaaaaaaaaˇx\nbbbbb       ˇy";
     cx.set_state(before);
-    cx.update_editor(|e, _, cx| e.set_wrap_width(Some(100.0.into()), cx));
+    cx.update_editor(|e, _, cx| e.set_wrap_width(Some(px(100.0).into()), cx));
     cx.update_editor(|e, window, cx| {
         assert!(e.display_text(cx).lines().count() > 2);
         e.align_selections(&AlignSelections, window, cx)
@@ -43560,7 +43560,7 @@ async fn test_columnar_selection_with_soft_wrap(cx: &mut TestAppContext) {
     "});
 
     let soft_wrap_second_line_row = |editor: &mut Editor, cx: &mut Context<Editor>| {
-        editor.set_wrap_width(Some(100.0.into()), cx);
+        editor.set_wrap_width(Some(px(100.0).into()), cx);
         let snapshot = editor.display_snapshot(cx);
         let second_line_row = Point::new(1, 0).to_display_point(&snapshot).row();
         assert!(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -48,8 +48,8 @@ use gpui::{
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
     ParentElement, Pixels, ScrollHandle, ShapedLine, SharedString, Size,
     StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun,
-    TextStyleRefinement, WeakEntity, Window, div, fill, outline, pattern_slash, point, px, quad,
-    relative, size, solid_background, transparent_black,
+    TextStyleRefinement, WeakEntity, Window, WrapWidths, div, fill, outline, pattern_slash, point,
+    px, quad, relative, size, solid_background, transparent_black,
 };
 use itertools::Itertools;
 use language::{
@@ -8081,13 +8081,13 @@ impl Element for EditorElement {
                         ) {
                             snapshot
                         } else {
-                            let wrap_width = calculate_wrap_width(
+                            let wrap_widths = calculate_wrap_width(
                                 editor.soft_wrap_mode(cx),
                                 editor_width,
                                 em_layout_width,
                             );
 
-                            if editor.set_wrap_width(wrap_width, cx) {
+                            if editor.set_wrap_width(wrap_widths, cx) {
                                 editor.snapshot(window, cx)
                             } else {
                                 snapshot
@@ -10671,15 +10671,24 @@ fn calculate_wrap_width(
     soft_wrap: SoftWrap,
     editor_width: Pixels,
     em_width: Pixels,
-) -> Option<Pixels> {
+) -> Option<WrapWidths> {
     let wrap_width_for = |column: u32| (column as f32 * em_width).ceil();
 
-    match soft_wrap {
-        SoftWrap::GitDiff => None,
-        SoftWrap::None => Some(wrap_width_for(MAX_LINE_LEN as u32 / 2)),
-        SoftWrap::EditorWidth => Some(editor_width),
-        SoftWrap::Bounded(column) => Some(editor_width.min(wrap_width_for(column))),
-    }
+    let wrap_width = match soft_wrap {
+        SoftWrap::GitDiff => return None,
+        SoftWrap::None => wrap_width_for(MAX_LINE_LEN as u32 / 2),
+        SoftWrap::EditorWidth => editor_width,
+        SoftWrap::Bounded(column) => editor_width.min(wrap_width_for(column)),
+    };
+
+    Some(WrapWidths {
+        wrap_width,
+        // Trailing whitespace may run past the wrap column as long as it stays within the
+        // editor, so that a line whose last word ends exactly at the column is not pushed onto
+        // the next line by the space that follows it. When words already wrap at the editor's
+        // width there is no room to give, and letting whitespace overflow would scroll.
+        whitespace_wrap_width: editor_width.max(wrap_width),
+    })
 }
 
 fn compute_auto_height_layout(
@@ -10716,9 +10725,14 @@ fn compute_auto_height_layout(
     let overscroll = size(em_width, px(0.));
 
     let editor_width = text_width - gutter_dimensions.margin - overscroll.width - em_width;
-    let wrap_width = calculate_wrap_width(editor.soft_wrap_mode(cx), editor_width, em_width)
-        .map(|width| width.min(editor_width));
-    if wrap_width.is_some() && editor.set_wrap_width(wrap_width, cx) {
+    let wrap_widths =
+        calculate_wrap_width(editor.soft_wrap_mode(cx), editor_width, em_width).map(|widths| {
+            WrapWidths {
+                wrap_width: widths.wrap_width.min(editor_width),
+                whitespace_wrap_width: widths.whitespace_wrap_width.min(editor_width),
+            }
+        });
+    if wrap_widths.is_some() && editor.set_wrap_width(wrap_widths, cx) {
         snapshot = editor.snapshot(window, cx);
     }
 
@@ -12131,7 +12145,7 @@ mod tests {
         window
             .update(cx, |editor, _, cx| {
                 editor.set_soft_wrap_mode(language_settings::SoftWrap::EditorWidth, cx);
-                editor.set_wrap_width(Some(editor_width), cx);
+                editor.set_wrap_width(Some(editor_width.into()), cx);
                 editor.set_show_line_numbers(show_line_numbers, cx);
             })
             .unwrap();
@@ -12511,21 +12525,24 @@ mod tests {
 
         assert_eq!(
             calculate_wrap_width(SoftWrap::None, editor_width, em_width),
-            Some(px((MAX_LINE_LEN as f32 / 2.0 * 8.0).ceil())),
+            Some(px((MAX_LINE_LEN as f32 / 2.0 * 8.0).ceil()).into()),
         );
 
         assert_eq!(
             calculate_wrap_width(SoftWrap::EditorWidth, editor_width, em_width),
-            Some(px(800.0)),
+            Some(px(800.0).into()),
         );
 
         assert_eq!(
             calculate_wrap_width(SoftWrap::Bounded(72), editor_width, em_width),
-            Some(px((72.0 * 8.0_f32).ceil())),
+            Some(WrapWidths {
+                wrap_width: px((72.0 * 8.0_f32).ceil()),
+                whitespace_wrap_width: editor_width,
+            }),
         );
         assert_eq!(
             calculate_wrap_width(SoftWrap::Bounded(200), px(400.0), em_width),
-            Some(px(400.0)),
+            Some(px(400.0).into()),
         );
     }
 }

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1502,7 +1502,7 @@ mod tests {
                 buffer.clone(),
                 test_font(),
                 px(14.),
-                Some(px(rng.random_range(80.0..=180.0))),
+                Some(px(rng.random_range(80.0..=180.0)).into()),
                 1,
                 1,
                 FoldPlaceholder::test(),

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -40,8 +40,12 @@ impl LineWrapper {
     pub fn wrap_line<'a>(
         &'a mut self,
         fragments: &'a [LineFragment],
-        wrap_width: Pixels,
+        widths: impl Into<WrapWidths>,
     ) -> impl Iterator<Item = Boundary> + 'a {
+        let WrapWidths {
+            wrap_width,
+            whitespace_wrap_width,
+        } = widths.into();
         let mut width = px(0.);
         let mut first_non_whitespace_ix = None;
         let mut indent = None;
@@ -59,11 +63,14 @@ impl LineWrapper {
                 let ix = index;
                 index += candidate.len_utf8();
                 let mut new_prev_c = prev_c;
+                let mut is_whitespace = false;
                 let item_width = match candidate {
                     WrapBoundaryCandidate::Char { character: c } => {
                         if c == '\n' {
                             continue;
                         }
+
+                        is_whitespace = c.is_whitespace();
 
                         if Self::is_word_char(c) {
                             if prev_c == ' ' && c != ' ' && first_non_whitespace_ix.is_some() {
@@ -104,7 +111,12 @@ impl LineWrapper {
                 };
 
                 width += item_width;
-                if width > wrap_width && ix > last_wrap_ix {
+                let width_limit = if is_whitespace {
+                    whitespace_wrap_width
+                } else {
+                    wrap_width
+                };
+                if width > width_limit && ix > last_wrap_ix {
                     if let (None, Some(first_non_whitespace_ix)) = (indent, first_non_whitespace_ix)
                     {
                         indent = Some(
@@ -663,6 +675,26 @@ impl WrapBoundaryCandidate {
     }
 }
 
+/// The widths a line is wrapped at.
+/// Words are wrapped at `wrap_width`, while whitespace may extend to `whitespace_wrap_width`
+/// before a wrap is forced
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct WrapWidths {
+    /// The width that words are wrapped at.
+    pub wrap_width: Pixels,
+    /// The width that whitespace is wrapped at. Should be at least `wrap_width`.
+    pub whitespace_wrap_width: Pixels,
+}
+
+impl From<Pixels> for WrapWidths {
+    fn from(wrap_width: Pixels) -> Self {
+        Self {
+            wrap_width,
+            whitespace_wrap_width: wrap_width,
+        }
+    }
+}
+
 /// A boundary between two lines of text.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Boundary {
@@ -707,6 +739,37 @@ mod tests {
                 ..Default::default()
             })
             .collect()
+    }
+
+    #[test]
+    fn test_wrap_line_allows_whitespace_to_overflow() {
+        let mut wrapper = build_wrapper();
+        // The test font is 0.6em per character, so 9.6px at a font size of 16px.
+        let wrap_width = px(52.8); // 5.5 characters
+
+        // Wrapping everything at one width breaks before `bb`, because the space that follows it
+        // is what exceeds the width.
+        assert_eq!(
+            wrapper
+                .wrap_line(&[LineFragment::text("aa bb cc")], wrap_width)
+                .collect::<Vec<_>>(),
+            &[Boundary::new(3, 0)],
+        );
+
+        // Letting whitespace overflow keeps `bb` and the space after it on the first line, and
+        // wraps at the start of the next word instead.
+        assert_eq!(
+            wrapper
+                .wrap_line(
+                    &[LineFragment::text("aa bb cc")],
+                    WrapWidths {
+                        wrap_width,
+                        whitespace_wrap_width: px(76.8), // 8 characters
+                    },
+                )
+                .collect::<Vec<_>>(),
+            &[Boundary::new(6, 0)],
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Soft wrap and `editor::Rewrap` break the same text in different places, so
rewrapped text still gets soft wrapped one word earlier.
Fixes #22274

## Solution

The space after a word was counted against the wrap column, so a word that ended
right at the column got pushed to the next row.

Whitespace now gets its own, wider limit, so a trailing space overhangs
invisibly instead of pushing the word down. Only `SoftWrap::Bounded` uses it;
`SoftWrap::EditorWidth` is unchanged.

## Testing
added new test and ran the previous tests 

Release Notes:

- Fixed soft wrap breaking a line one word earlier than `editor::Rewrap` when a word ends exactly at the wrap column.
