### PR TITLE
Use unstable sorts before deduplication

### DIFF
--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -648,7 +648,7 @@ fn identifiers_for_position(
         }
     }
 
-    ranges.sort_by(|a, b| a.start.cmp(&b.start).then(b.end.cmp(&a.end)));
+    ranges.sort_unstable_by(|a, b| a.start.cmp(&b.start).then(b.end.cmp(&a.end)));
     ranges.dedup_by(|a, b| {
         if a.start <= b.end {
             b.start = b.start.min(a.start);

--- a/crates/editor/src/bookmarks.rs
+++ b/crates/editor/src/bookmarks.rs
@@ -76,7 +76,7 @@ impl Editor {
         let multi_buffer_snapshot = snapshot.buffer_snapshot();
 
         let mut selections = self.selections.all::<Point>(&snapshot.display_snapshot);
-        selections.sort_by_key(|s| s.head());
+        selections.sort_unstable_by_key(|s| s.head());
         selections.dedup_by_key(|s| s.head().row);
 
         let mut exist_targets: Vec<BookmarkTarget> = vec![];

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -607,7 +607,7 @@ pub fn parse_numstat(output: &str) -> GitDiffStat {
         };
         entries.push((path, DiffStat { added, deleted }));
     }
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    entries.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     entries.dedup_by(|(a, _), (b, _)| a == b);
 
     GitDiffStat {

--- a/crates/language/src/buffer/bracket_ranges.rs
+++ b/crates/language/src/buffer/bracket_ranges.rs
@@ -817,7 +817,7 @@ impl<'a> ChunkBrackets<'a> {
             })
             .collect::<Vec<_>>();
 
-        opens.sort_by_key(|r| (r.start, r.end));
+        opens.sort_unstable_by_key(|r| (r.start, r.end));
         opens.dedup_by(|a, b| a.start == b.start && a.end == b.end);
         color_pairs.sort_by_key(|(_, close, _)| close.end);
 

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -439,7 +439,7 @@ impl LspLogView {
                     }),
             )
             .collect::<Vec<_>>();
-        rows.sort_by_key(|row| row.server_id);
+        rows.sort_unstable_by_key(|row| row.server_id);
         rows.dedup_by_key(|row| row.server_id);
         Some(rows)
     }

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -42,7 +42,7 @@ fn migrate(text: &str, patterns: MigrationPatterns, query: &Query) -> Result<Opt
         }
     }
 
-    edits.sort_by_key(|(range, _)| (range.start, Reverse(range.end)));
+    edits.sort_unstable_by_key(|(range, _)| (range.start, Reverse(range.end)));
     edits.dedup_by(|(range_b, _), (range_a, _)| {
         range_a.contains(&range_b.start) || range_a.contains(&range_b.end)
     });


### PR DESCRIPTION
# Objective

Get some speedups by using unstable sortts.
Supersedes #58761 after rebasing onto current `main`.

## Solution

replace `.sort()` by `.unstable_sort()`.

## Testing

All tests pass in affected crates:

```
cargo test -p edit_prediction_context -p editor -p git -p language -p language_tools -p migrator
```

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A