### PR TITLE
workspace: Preserve windows and tabs across update restarts

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1496,8 +1496,7 @@ impl MultiWorkspace {
     }
 
     /// Returns the in-flight serialization task (if any) so the caller can
-    /// await it. Used by the quit handler to ensure pending DB writes
-    /// complete before the process exits.
+    /// await it so pending DB writes complete before the process exits.
     pub fn flush_serialization(&mut self) -> Task<()> {
         self._serialize_task.take().unwrap_or(Task::ready(()))
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7114,20 +7114,35 @@ impl Workspace {
         })
     }
 
-    /// Bypass the 200ms serialization throttle and write workspace state to
-    /// the DB immediately. Returns a task the caller can await to ensure the
-    /// write completes. Used by the quit handler so the most recent state
-    /// isn't lost to a pending throttle timer when the process exits.
+    /// Bypass the serialization throttles and write workspace and item state
+    /// to the DB immediately. Returns a task the caller can await to ensure the
+    /// writes complete before the process exits.
     pub fn flush_serialization(&mut self, window: &mut Window, cx: &mut App) -> Task<()> {
         self._schedule_serialize_workspace.take();
         self._serialize_workspace_task.take();
         self.bounds_save_task_queued.take();
 
+        let serializable_items = self
+            .panes
+            .iter()
+            .flat_map(|pane| pane.read(cx).items())
+            .filter_map(|item| item.to_serializable_item_handle(cx))
+            .fold(HashMap::default(), |mut items, item| {
+                items.entry(item.item_id()).or_insert(item);
+                items
+            });
+        let item_tasks = serializable_items
+            .into_values()
+            .filter_map(|item| item.serialize(self, false, window, cx))
+            .collect::<Vec<_>>();
         let bounds_task = self.save_window_bounds(window, cx);
         let serialize_task = self.serialize_workspace_internal(window, cx);
         cx.spawn(async move |_| {
             bounds_task.await;
             serialize_task.await;
+            for result in futures::future::join_all(item_tasks).await {
+                result.log_err();
+            }
         })
     }
 
@@ -11213,22 +11228,75 @@ pub fn reload(cx: &mut App) {
             }
         }
 
-        // If the user cancels any save prompt, then keep the app open.
-        for window in workspace_windows {
-            if let Ok(should_close) = window.update(cx, |multi_workspace, window, cx| {
-                let workspace = multi_workspace.workspace().clone();
-                workspace.update(cx, |workspace, cx| {
-                    workspace.prepare_to_close(CloseIntent::Quit, window, cx)
-                })
-            }) && !should_close.await?
-            {
-                return anyhow::Ok(());
-            }
+        if !prepare_workspace_windows_for_app_close(&workspace_windows, cx).await? {
+            return anyhow::Ok(());
         }
+
         cx.update(|cx| cx.restart());
         anyhow::Ok(())
     })
     .detach_and_log_err(cx);
+}
+
+pub async fn prepare_workspace_windows_for_app_close(
+    workspace_windows: &[WindowHandle<MultiWorkspace>],
+    cx: &mut AsyncApp,
+) -> Result<bool> {
+    for window in workspace_windows {
+        let window = *window;
+        let active_and_workspaces = window
+            .update(cx, |multi_workspace, _, _cx| {
+                (
+                    multi_workspace.workspace().clone(),
+                    multi_workspace.workspaces().cloned().collect::<Vec<_>>(),
+                )
+            })
+            .log_err();
+
+        let Some((originally_active, workspaces)) = active_and_workspaces else {
+            continue;
+        };
+
+        for workspace in workspaces {
+            if let Some(should_close) = window
+                .update(cx, |multi_workspace, window, cx| {
+                    multi_workspace.activate(workspace.clone(), None, window, cx);
+                    window.activate_window();
+                    workspace.update(cx, |workspace, cx| {
+                        workspace.prepare_to_close(CloseIntent::Quit, window, cx)
+                    })
+                })
+                .log_err()
+            {
+                if !should_close.await? {
+                    window
+                        .update(cx, |multi_workspace, window, cx| {
+                            multi_workspace.activate(originally_active.clone(), None, window, cx);
+                        })
+                        .log_err();
+                    return Ok(false);
+                }
+            }
+        }
+
+        window
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.activate(originally_active, None, window, cx);
+            })
+            .log_err();
+    }
+
+    let mut flush_tasks = Vec::new();
+    for window in workspace_windows {
+        window
+            .update(cx, |multi_workspace, window, cx| {
+                flush_tasks.extend(multi_workspace.flush_pending_serialization(window, cx));
+            })
+            .log_err();
+    }
+    futures::future::join_all(flush_tasks).await;
+
+    Ok(true)
 }
 
 fn parse_pixel_position_env_var(value: &str) -> Option<Point<Pixels>> {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -102,9 +102,7 @@ use workspace::{
     WorkspaceSettings, create_and_open_local_file,
     notifications::simple_message_notification::MessageNotification, open_new,
 };
-use workspace::{
-    CloseIntent, CloseProject, CloseWindow, RestoreBanner, with_active_or_new_workspace,
-};
+use workspace::{CloseProject, CloseWindow, RestoreBanner, with_active_or_new_workspace};
 use workspace::{Pane, notifications::DetachAndPromptErr};
 use zed_actions::{
     About, GetMerch, OpenAccountSettings, OpenBrowser, OpenDocs, OpenProjectTasks,
@@ -1807,74 +1805,9 @@ fn quit(_: &Quit, cx: &mut App) {
             }
         }
 
-        // If the user cancels any save prompt, then keep the app open.
-        for window in &workspace_windows {
-            let window = *window;
-            let active_and_workspaces = window
-                .update(cx, |multi_workspace, _, _cx| {
-                    (
-                        multi_workspace.workspace().clone(),
-                        multi_workspace.workspaces().cloned().collect::<Vec<_>>(),
-                    )
-                })
-                .log_err();
-
-            let Some((originally_active, workspaces)) = active_and_workspaces else {
-                continue;
-            };
-
-            for workspace in workspaces {
-                if let Some(should_close) = window
-                    .update(cx, |multi_workspace, window, cx| {
-                        multi_workspace.activate(workspace.clone(), None, window, cx);
-                        window.activate_window();
-                        workspace.update(cx, |workspace, cx| {
-                            workspace.prepare_to_close(CloseIntent::Quit, window, cx)
-                        })
-                    })
-                    .log_err()
-                {
-                    if !should_close.await? {
-                        // Activating each workspace above to surface its save
-                        // prompts changed which workspace is active. Restore the
-                        // user's focused workspace before bailing so the window
-                        // is left as they had it.
-                        window
-                            .update(cx, |multi_workspace, window, cx| {
-                                multi_workspace.activate(
-                                    originally_active.clone(),
-                                    None,
-                                    window,
-                                    cx,
-                                );
-                            })
-                            .log_err();
-                        return Ok(());
-                    }
-                }
-            }
-
-            // The loop above activated each workspace in turn, overwriting the
-            // persisted active workspace. Re-activate the workspace the user
-            // actually had focused so it is the one serialized (and restored on
-            // next launch) as active, rather than whichever happened to be last.
-            window
-                .update(cx, |multi_workspace, window, cx| {
-                    multi_workspace.activate(originally_active, None, window, cx);
-                })
-                .log_err();
+        if !workspace::prepare_workspace_windows_for_app_close(&workspace_windows, cx).await? {
+            return Ok(());
         }
-        // Flush all pending workspace serialization before quitting so that
-        // session_id/window_id are up-to-date in the database.
-        let mut flush_tasks = Vec::new();
-        for window in &workspace_windows {
-            window
-                .update(cx, |multi_workspace, window, cx| {
-                    flush_tasks.extend(multi_workspace.flush_pending_serialization(window, cx));
-                })
-                .log_err();
-        }
-        futures::future::join_all(flush_tasks).await;
 
         cx.update(|cx| cx.quit());
         anyhow::Ok(())
@@ -2977,6 +2910,56 @@ mod tests {
             .unwrap();
 
         futures::future::join_all(all_tasks).await;
+    }
+
+    async fn open_test_project_window_with_tabs(
+        app_state: &Arc<AppState>,
+        root_path: &Path,
+        tab_paths: &[&RelPath],
+        cx: &mut TestAppContext,
+    ) -> WindowHandle<MultiWorkspace> {
+        let workspace::OpenResult { window, .. } = cx
+            .update(|cx| {
+                Workspace::new_local(
+                    vec![root_path.into()],
+                    app_state.clone(),
+                    None,
+                    None,
+                    None,
+                    workspace::OpenMode::Activate,
+                    cx,
+                )
+            })
+            .await
+            .expect("failed to open project workspace");
+
+        let workspace = window
+            .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+            .expect("workspace window was closed");
+        let worktree_id = workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .expect("project should have a worktree")
+                .read(cx)
+                .id()
+        });
+
+        for tab_path in tab_paths {
+            window
+                .update(cx, |_, window, cx| {
+                    workspace.update(cx, |workspace, cx| {
+                        workspace.open_path((worktree_id, *tab_path), None, true, window, cx)
+                    })
+                })
+                .expect("workspace window was closed")
+                .await
+                .expect("failed to open project tab");
+        }
+
+        window
     }
 
     #[gpui::test]
@@ -7529,6 +7512,132 @@ mod tests {
                 );
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_reload_restores_project_windows_and_tabs(cx: &mut TestAppContext) {
+        use session::Session;
+
+        let app_state = init_test(cx);
+        cx.update(init);
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/"),
+                json!({
+                    "dir1": {
+                        "a.txt": "a",
+                        "b.txt": "b"
+                    },
+                    "dir2": {
+                        "c.txt": "c",
+                        "d.txt": "d"
+                    }
+                }),
+            )
+            .await;
+
+        let session_id = cx.read(|cx| app_state.session.read(cx).id().to_owned());
+        let first_window = open_test_project_window_with_tabs(
+            &app_state,
+            Path::new(path!("/dir1")),
+            &[rel_path("a.txt"), rel_path("b.txt")],
+            cx,
+        )
+        .await;
+        let second_window = open_test_project_window_with_tabs(
+            &app_state,
+            Path::new(path!("/dir2")),
+            &[rel_path("c.txt"), rel_path("d.txt")],
+            cx,
+        )
+        .await;
+
+        let restart = cx.expect_restart();
+        cx.update(workspace::reload);
+        let (restart_path, restart_arguments) = restart.await.expect("restart was not requested");
+        assert_eq!(restart_path, None);
+        assert!(restart_arguments.is_empty());
+
+        let database = cx.update(|cx| workspace::WorkspaceDb::global(cx));
+        let locations = workspace::last_session_workspace_locations(
+            &database,
+            &session_id,
+            None,
+            app_state.fs.as_ref(),
+        )
+        .await
+        .expect("failed to read session workspaces");
+        assert_eq!(locations.len(), 2);
+
+        for window in [first_window, second_window] {
+            window
+                .update(cx, |_, window, _| window.remove_window())
+                .expect("workspace window was closed");
+        }
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            app_state.session.update(cx, |app_session, _cx| {
+                app_session
+                    .replace_session_for_test(Session::test_with_old_session(session_id.clone()));
+            });
+        });
+
+        let mut async_cx = cx.to_async();
+        crate::restore_or_create_workspace(app_state.clone(), &mut async_cx)
+            .await
+            .expect("failed to restore workspaces");
+        cx.run_until_parked();
+
+        let mut restored_tabs = cx.read(|cx| {
+            cx.windows()
+                .into_iter()
+                .filter_map(|window| window.downcast::<MultiWorkspace>())
+                .map(|window| {
+                    window
+                        .read_with(cx, |multi_workspace, cx| {
+                            let workspace = multi_workspace.workspace().read(cx);
+                            let root_path = workspace
+                                .root_paths(cx)
+                                .into_iter()
+                                .next()
+                                .expect("restored project should have a root path")
+                                .as_ref()
+                                .to_path_buf();
+                            let tab_paths = workspace
+                                .active_pane()
+                                .read(cx)
+                                .items()
+                                .map(|item| {
+                                    item.project_path(cx)
+                                        .expect("restored tab should have a project path")
+                                        .path
+                                })
+                                .collect::<Vec<_>>();
+                            (root_path, tab_paths)
+                        })
+                        .expect("restored workspace window was closed")
+                })
+                .collect::<Vec<_>>()
+        });
+        restored_tabs.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(
+            restored_tabs,
+            vec![
+                (
+                    PathBuf::from(path!("/dir1")),
+                    vec![rel_path("a.txt").into(), rel_path("b.txt").into()]
+                ),
+                (
+                    PathBuf::from(path!("/dir2")),
+                    vec![rel_path("c.txt").into(), rel_path("d.txt").into()]
+                ),
+            ]
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #25022.
Related to #60684.

`workspace::reload` prepared only the active workspace in each window and restarted without waiting for pending workspace and item serialization. That could leave the previous session without its window bindings or tab records when Restart to Update exited the process.

Use the same all-window close preparation for Quit and Reload, restore each window’s originally active workspace, and await forced workspace, multi-workspace, and open-item serialization before restarting.

Testing:

- `cargo test -p zed test_reload_restores_project_windows_and_tabs -- --nocapture`
- `ITERATIONS=20 cargo test -p zed -p gpui_apple --features gpui_apple/runtime_shaders test_reload_restores_project_windows_and_tabs`
- `cargo test -p zed -p gpui_apple --features gpui_apple/runtime_shaders test_quit_ -- --nocapture`
- `cargo test -p zed -p gpui_apple --features gpui_apple/runtime_shaders test_multi_workspace_session_restore -- --nocapture`
- `cargo test -p workspace -p gpui_apple --features gpui_apple/runtime_shaders test_flush_serialization_completes_before_quit -- --nocapture`
- `./script/clippy -p workspace -p zed`

Release Notes:

- Fixed open windows and tabs not being restored after restarting Zed for an update.