### PR TITLE
agent: Silence llama.cpp authentication probe failures

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -369,8 +369,8 @@ impl LanguageModels {
                             // that we know are safe to ignore here, like what we do
                             // with `CredentialsNotFound` above.
                             match provider_id.0.as_ref() {
-                                "lmstudio" | "ollama" => {
-                                    // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
+                                "lmstudio" | "ollama" | "llama.cpp" => {
+                                    // LM Studio, Ollama, and llama.cpp all make fetch requests to the local APIs to determine if they are "authenticated".
                                     //
                                     // These fail noisily, so we don't log them.
                                 }


### PR DESCRIPTION
The built-in llama.cpp provider (#59964) probes `GET {api_url}/v1/models` against `http://localhost:8080` to detect a local server, exactly like the LM Studio and Ollama providers do. Unlike them, it was never added to the list of providers whose expected authentication failures are skipped when logging, so every machine without a local llama.cpp server logs a spurious error each time language model providers are authenticated (e.g. when the agent panel initializes):

    ERROR [agent] Failed to authenticate provider: llama.cpp: Failed to connect to llama.cpp API: 503 Service Unavailable

This adds `llama.cpp` to the same silence list as `lmstudio` and `ollama` in `crates/agent/src/agent.rs`.

Release Notes:

- Fixed a spurious "Failed to authenticate provider: llama.cpp" error being logged when no local llama.cpp server is running
