### PR TITLE
gpui_linux: Defer XIM IC creation until protocol handshake completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -729,19 +729,40 @@ impl X11Client {
     }
 
     pub fn enable_ime(&self) {
-        let mut state = self.0.borrow_mut();
+        let state = self.0.borrow_mut();
         if !state.has_xim() {
             return;
         }
 
-        let Some((mut ximc, xim_handler)) = state.take_xim() else {
+        let xim_handler = match state.xim_handler.as_ref() {
+            Some(xim_handler) => xim_handler,
+            None => return,
+        };
+
+        if !xim_handler.connected {
+            // XIM protocol negotiation hasn't completed yet.
+            // The IC creation will happen in `handle_get_im_values`
+            // as part of the proper XIM protocol flow.
+            // Attempting to create an IC here would use an
+            // uninitialized input_method_id (0), which causes
+            // a protocol state mismatch with Fcitx5.
+            return;
+        }
+
+        let im_id = xim_handler.im_id;
+        let ic_id = xim_handler.ic_id;
+        let window = xim_handler.window;
+        drop(state);
+
+        let mut state = self.0.borrow_mut();
+        let Some((mut ximc, _)) = state.take_xim() else {
             return;
         };
         let mut ic_attributes = ximc
             .build_ic_attributes()
             .push(AttributeName::InputStyle, InputStyle::PREEDIT_CALLBACKS)
-            .push(AttributeName::ClientWindow, xim_handler.window)
-            .push(AttributeName::FocusWindow, xim_handler.window);
+            .push(AttributeName::ClientWindow, window)
+            .push(AttributeName::FocusWindow, window);
 
         let window_id = state.keyboard_focused_window;
         drop(state);
@@ -750,7 +771,6 @@ impl X11Client {
                 log::error!("Failed to get window for IME positioning");
                 let mut state = self.0.borrow_mut();
                 state.ximc = Some(ximc);
-                state.xim_handler = Some(xim_handler);
                 return;
             };
             if let Some(scaled_area) = window.get_ime_area() {
@@ -766,10 +786,9 @@ impl X11Client {
                     });
             }
         }
-        ximc.create_ic(xim_handler.im_id, ic_attributes.build())
-            .ok();
+        ximc.set_ic_values(im_id, ic_id, ic_attributes.build()).ok();
         let mut state = self.0.borrow_mut();
-        state.restore_xim(ximc, xim_handler);
+        state.ximc = Some(ximc);
     }
 
     pub fn reset_ime(&self) {


### PR DESCRIPTION
## Summary

- Defer X11 XIM input-context creation until the protocol handshake has completed.
- Update the existing input context when IME focus is enabled instead of sending a second `CreateIc` request.

## Problem

On Linux/X11 with Fcitx5, `FocusIn` can call `enable_ime` while the XIM handshake is still in progress. The previous implementation then sends `CreateIc` with the default input method ID (`0`) before `OpenReply` has supplied the server-assigned ID. Fcitx5 responds with an out-of-sequence message and Zed logs:

```text
XIMClientError: Can't read xim message: Invalid Data ErrorCode: 0
```

After that error, the XIM client is discarded and Chinese input stops working in Zed until restart.

## Fix

`enable_ime` now returns until `XimHandler::connected` is true. The initial IC is created by the normal handshake callback after `GetImValuesReply`; subsequent focus changes use `set_ic_values` on that existing IC.

Fixes #59662

## Testing

- Reproduced the failure on Linux X11, Cinnamon, Ubuntu 24.04, Fcitx5 5.1.7, and Zed 1.16.2.
- Verified the failure is caused by `CreateIc` being sent before the server-assigned input method ID is available.
- Ran the source formatter check; the environment attempted to sync Rust toolchains and timed out before completing.

Release Notes:

- Fixed fcitx5 interoperability on Linux X11
