### PR TITLE
open_ai: Classify additional overload errors

### DIFF
--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -1672,7 +1672,9 @@ pub(crate) fn response_error_category(
         Some("api_error" | "internal_server_error" | "server_error") => {
             ProviderErrorCategory::InternalServer
         }
-        Some("overloaded_error") => ProviderErrorCategory::Overloaded,
+        Some("overloaded_error" | "server_is_overloaded" | "slow_down") => {
+            ProviderErrorCategory::Overloaded
+        }
         Some(_) | None => status
             .map(|status| ProviderErrorCategory::from_http_status(status, message))
             .unwrap_or(ProviderErrorCategory::Other),
@@ -3259,6 +3261,17 @@ mod tests {
             response_error_category(Some("invalid_prompt"), None, ""),
             ProviderErrorCategory::ContentPolicy
         );
+    }
+
+    #[test]
+    fn responses_stream_maps_overload_codes_to_overloaded() {
+        for code in ["overloaded_error", "server_is_overloaded", "slow_down"] {
+            assert_eq!(
+                response_error_category(Some(code), None, ""),
+                ProviderErrorCategory::Overloaded,
+                "{code}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
OpenAI can return streamed overload errors with the codes `server_is_overloaded` and `slow_down`. Zed previously only recognized `overloaded_error`, so these responses fell through to `ProviderErrorCategory::Other`. Downstream consumers could then treat a routine provider-capacity failure as an unexpected error.

Classify all three codes as `ProviderErrorCategory::Overloaded`. This lets existing retry and error-reporting behavior handle them consistently without matching provider-specific messages outside the OpenAI response parser.

This matches Codex’s handling. Codex classifies both [`server_is_overloaded` and `slow_down` in streamed responses](https://github.com/openai/codex/blob/a26f1806a4f4b8cfec2ea1be129963815a61e58c/codex-rs/codex-api/src/sse/responses.rs#L696-L699), and performs the [same classification for HTTP 503 response bodies](https://github.com/openai/codex/blob/a26f1806a4f4b8cfec2ea1be129963815a61e58c/codex-rs/codex-api/src/api_bridge.rs#L63-L74).

Release Notes:

- Improved OpenAI error handling
