### PR TITLE
debugger: Update debug panel when breakpoint store changes

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -71,7 +71,7 @@ pub struct DebugPanel {
     pub(crate) session_picker_menu_handle: PopoverMenuHandle<ContextMenu>,
     fs: Arc<dyn Fs>,
     is_zoomed: bool,
-    _subscriptions: [Subscription; 1],
+    _subscriptions: [Subscription; 2],
     breakpoint_list: Entity<BreakpointList>,
 }
 
@@ -95,6 +95,11 @@ impl DebugPanel {
                 },
             );
 
+            let breakpoint_subscription =
+                cx.observe(&project.read(cx).breakpoint_store(), |_, _, cx| {
+                    cx.notify();
+                });
+
             Self {
                 sessions_with_children: Default::default(),
                 active_session: None,
@@ -113,7 +118,7 @@ impl DebugPanel {
                 thread_picker_menu_handle,
                 session_picker_menu_handle,
                 is_zoomed: false,
-                _subscriptions: [focus_subscription],
+                _subscriptions: [focus_subscription, breakpoint_subscription],
                 debug_scenario_scheduled_last: true,
             }
         })


### PR DESCRIPTION
# Objective

- There is currently a bug where toggling breakpoints would not be immediately reflected in the breakpoint list of the debug panel
- For example, pressing `F9` to create a breakpoint would not immediately add an entry to the breakpoints list in the debug panel, instead requiring another event like mouse movement

## Solution

- Subscribe the debug panel to changes to the breakpoint store.

## Testing

- Manually tested

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/d2b7efab-0131-491e-8339-3657edaf7fcd


https://github.com/user-attachments/assets/4161a435-c59e-4f6a-9387-31528c127c80





---

Release Notes:

- Fixed debugger panel not immediately reflecting changes in toggled breakpoints