### PR TITLE
movement: Remove unused `stop_at_soft_boundaries` parameter from `line_beginning`

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -190,24 +190,16 @@ pub(crate) fn down_by_rows(
 }
 
 /// Returns a position of the start of line.
-/// If `stop_at_soft_boundaries` is true, the returned position is that of the
-/// displayed line (e.g. it could actually be in the middle of a text line if that line is soft-wrapped).
-/// Otherwise it's always going to be the start of a logical line.
-pub fn line_beginning(
-    map: &DisplaySnapshot,
-    display_point: DisplayPoint,
-    stop_at_soft_boundaries: bool,
-) -> DisplayPoint {
-    let soft_line_start = map.clip_point(DisplayPoint::new(display_point.row(), 0), Bias::Right);
-
-    if stop_at_soft_boundaries && display_point != soft_line_start {
-        soft_line_start
-    } else {
-        map.prev_line_boundary(display_point.to_point(map)).1
-    }
+///
+/// It's always going to be the start of a logical line.
+/// If you want to stop at last indented position or soft boundaries,
+/// use [`indented_line_beginning`] instead.
+pub fn line_beginning(map: &DisplaySnapshot, display_point: DisplayPoint) -> DisplayPoint {
+    map.prev_line_boundary(display_point.to_point(map)).1
 }
 
-/// Returns the last indented position on a given line.
+/// Returns the last indented position or the start of a given line.
+///
 /// If `stop_at_soft_boundaries` is true, the returned [`DisplayPoint`] is that of a
 /// displayed line (e.g. if there's soft wrap it's gonna be returned),
 /// otherwise it's always going to be a start of a logical line.

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -198,13 +198,12 @@ pub fn line_beginning(
     display_point: DisplayPoint,
     stop_at_soft_boundaries: bool,
 ) -> DisplayPoint {
-    let point = display_point.to_point(map);
     let soft_line_start = map.clip_point(DisplayPoint::new(display_point.row(), 0), Bias::Right);
 
     if stop_at_soft_boundaries && display_point != soft_line_start {
         soft_line_start
     } else {
-        map.prev_line_boundary(point).1
+        map.prev_line_boundary(display_point.to_point(map)).1
     }
 }
 

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -200,12 +200,11 @@ pub fn line_beginning(
 ) -> DisplayPoint {
     let point = display_point.to_point(map);
     let soft_line_start = map.clip_point(DisplayPoint::new(display_point.row(), 0), Bias::Right);
-    let line_start = map.prev_line_boundary(point).1;
 
     if stop_at_soft_boundaries && display_point != soft_line_start {
         soft_line_start
     } else {
-        line_start
+        map.prev_line_boundary(point).1
     }
 }
 

--- a/crates/vim/src/helix/paste.rs
+++ b/crates/vim/src/helix/paste.rs
@@ -93,7 +93,7 @@ impl Vim {
                     // Pasting before means pasting before the whole selection.
                     let display_point = if line_mode {
                         if action.before {
-                            movement::line_beginning(&display_map, sel.start, false)
+                            movement::line_beginning(&display_map, sel.start)
                         } else {
                             if sel.start == sel.end {
                                 movement::right(

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -166,7 +166,7 @@ impl Vim {
                         selection.start..end_point
                     } else if line_mode {
                         let point = if before {
-                            movement::line_beginning(&display_map, selection.start, false)
+                            movement::line_beginning(&display_map, selection.start)
                         } else {
                             movement::line_end(&display_map, selection.start, false)
                         };


### PR DESCRIPTION
# Objective

remove the entire `stop_at_soft_boundaries` parameter from `line_beginning`, since it was never used

---

Release Notes:

- N/A
