### PR TITLE
gpui: Report stylus pressure on the mouse events

### DIFF
--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -7021,6 +7021,7 @@ async fn test_right_click_menu_behind_collab_panel(cx: &mut TestAppContext) {
         modifiers: Modifiers::default(),
         click_count: 1,
         first_mouse: false,
+        pressure: 1.0,
     });
 
     // regression test that the right click menu for tabs does not open.
@@ -7033,6 +7034,7 @@ async fn test_right_click_menu_behind_collab_panel(cx: &mut TestAppContext) {
         modifiers: Modifiers::default(),
         click_count: 1,
         first_mouse: false,
+        pressure: 1.0,
     });
     assert!(cx.debug_bounds("MENU_ITEM-Close").is_some());
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10577,6 +10577,7 @@ impl Editor {
                         position: window.mouse_position(),
                         pressed_button: None,
                         modifiers: window.modifiers(),
+                        pressure: 1.0,
                     },
                     &position_map,
                     None,

--- a/crates/editor/src/element/mouse.rs
+++ b/crates/editor/src/element/mouse.rs
@@ -1258,6 +1258,7 @@ mod tests {
                     position: mouse_drag_position,
                     modifiers: Modifiers::none(),
                     pressed_button: Some(MouseButton::Left),
+                    pressure: 1.0,
                 },
                 &position_map,
                 window,

--- a/crates/gpui/src/app/test_app.rs
+++ b/crates/gpui/src/app/test_app.rs
@@ -414,6 +414,7 @@ impl<V: 'static + Render> TestAppWindow<V> {
             position,
             modifiers: Default::default(),
             pressed_button: None,
+            pressure: 1.0,
         });
     }
 
@@ -425,6 +426,7 @@ impl<V: 'static + Render> TestAppWindow<V> {
             modifiers: Default::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
     }
 
@@ -435,6 +437,7 @@ impl<V: 'static + Render> TestAppWindow<V> {
             button,
             modifiers: Default::default(),
             click_count: 1,
+            pressure: 1.0,
         });
     }
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -812,6 +812,7 @@ impl VisualTestContext {
             position,
             modifiers,
             pressed_button: button.into(),
+            pressure: 1.0,
         })
     }
 
@@ -828,6 +829,7 @@ impl VisualTestContext {
             button,
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         })
     }
 
@@ -843,6 +845,7 @@ impl VisualTestContext {
             modifiers,
             button,
             click_count: 1,
+            pressure: 1.0,
         })
     }
 
@@ -854,12 +857,14 @@ impl VisualTestContext {
             button: MouseButton::Left,
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
         self.simulate_event(MouseUpEvent {
             position,
             modifiers,
             button: MouseButton::Left,
             click_count: 1,
+            pressure: 1.0,
         });
     }
 

--- a/crates/gpui/src/app/visual_test_context.rs
+++ b/crates/gpui/src/app/visual_test_context.rs
@@ -267,6 +267,7 @@ impl VisualTestAppContext {
                 position,
                 modifiers,
                 pressed_button: button.into(),
+                pressure: 1.0,
             },
         );
     }
@@ -287,6 +288,7 @@ impl VisualTestAppContext {
                 button,
                 click_count: 1,
                 first_mouse: false,
+                pressure: 1.0,
             },
         );
     }
@@ -306,6 +308,7 @@ impl VisualTestAppContext {
                 modifiers,
                 button,
                 click_count: 1,
+                pressure: 1.0,
             },
         );
     }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -4443,6 +4443,7 @@ mod tests {
                     modifiers: Default::default(),
                     click_count: 1,
                     first_mouse: false,
+                    pressure: 1.0,
                 }
                 .to_platform_input(),
                 cx,
@@ -4459,6 +4460,7 @@ mod tests {
                     button: MouseButton::Left,
                     modifiers: Default::default(),
                     click_count: 1,
+                    pressure: 1.0,
                 }
                 .to_platform_input(),
                 cx,
@@ -4646,6 +4648,7 @@ mod tests {
                         position: point(px(10.), px(10.)),
                         modifiers: Default::default(),
                         pressed_button: None,
+                        pressure: 1.0,
                     }
                     .to_platform_input(),
                     cx,
@@ -4765,6 +4768,7 @@ mod tests {
                         position: point(px(75.), px(75.)),
                         modifiers: Default::default(),
                         pressed_button: None,
+                        pressure: 1.0,
                     }
                     .to_platform_input(),
                     cx,
@@ -4817,6 +4821,7 @@ mod tests {
                             modifiers: Default::default(),
                             click_count: 1,
                             first_mouse: false,
+                            pressure: 1.0,
                         }
                         .to_platform_input(),
                         cx,

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -135,7 +135,7 @@ impl InputEvent for TouchEvent {
 }
 
 /// A mouse down event from the platform
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct MouseDownEvent {
     /// Which mouse button was pressed.
     pub button: MouseButton,
@@ -151,6 +151,24 @@ pub struct MouseDownEvent {
 
     /// Whether this is the first, focusing click.
     pub first_mouse: bool,
+
+    /// Stylus pressure, 0.0..=1.0. Always 1.0 for a mouse, and on
+    /// platforms whose tablet input is not wired up, so a caller can
+    /// multiply by it unconditionally.
+    pub pressure: f32,
+}
+
+impl Default for MouseDownEvent {
+    fn default() -> Self {
+        Self {
+            button: MouseButton::default(),
+            position: Point::default(),
+            modifiers: Modifiers::default(),
+            click_count: 0,
+            first_mouse: false,
+            pressure: 1.0,
+        }
+    }
 }
 
 impl Sealed for MouseDownEvent {}
@@ -172,7 +190,7 @@ impl MouseDownEvent {
 }
 
 /// A mouse up event from the platform
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct MouseUpEvent {
     /// Which mouse button was released.
     pub button: MouseButton,
@@ -185,6 +203,21 @@ pub struct MouseUpEvent {
 
     /// The number of times the button has been clicked.
     pub click_count: usize,
+
+    /// Stylus pressure, 0.0..=1.0. See [`MouseDownEvent::pressure`].
+    pub pressure: f32,
+}
+
+impl Default for MouseUpEvent {
+    fn default() -> Self {
+        Self {
+            button: MouseButton::default(),
+            position: Point::default(),
+            modifiers: Modifiers::default(),
+            click_count: 0,
+            pressure: 1.0,
+        }
+    }
 }
 
 impl Sealed for MouseUpEvent {}
@@ -481,7 +514,7 @@ pub enum NavigationDirection {
 }
 
 /// A mouse move event from the platform.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct MouseMoveEvent {
     /// The position of the mouse on the window.
     pub position: Point<Pixels>,
@@ -491,6 +524,20 @@ pub struct MouseMoveEvent {
 
     /// The modifiers that were held down when the mouse was moved.
     pub modifiers: Modifiers,
+
+    /// Stylus pressure, 0.0..=1.0. See [`MouseDownEvent::pressure`].
+    pub pressure: f32,
+}
+
+impl Default for MouseMoveEvent {
+    fn default() -> Self {
+        Self {
+            position: Point::default(),
+            pressed_button: None,
+            modifiers: Modifiers::default(),
+            pressure: 1.0,
+        }
+    }
 }
 
 impl Sealed for MouseMoveEvent {}
@@ -853,9 +900,11 @@ impl PlatformInput {
 mod test {
 
     use crate::{
-        self as gpui, AppContext as _, Context, FocusHandle, InteractiveElement, IntoElement,
-        KeyBinding, Keystroke, Modifiers, ParentElement, Render, TestAppContext, Window, div,
+        self as gpui, AnyWindowHandle, AppContext as _, Context, FocusHandle, InputEvent as _,
+        InteractiveElement, IntoElement, KeyBinding, Keystroke, Modifiers, ParentElement, Render,
+        Styled, TestAppContext, Window, div, point, px,
     };
+    use std::{cell::RefCell, rc::Rc};
 
     struct TestView {
         saw_key_down: bool,
@@ -948,5 +997,84 @@ mod test {
         cx.simulate_modifiers_change(Modifiers::shift());
         cx.simulate_modifiers_change(Modifiers::none());
         assert!(test_view.read_with(cx, |test_view, _| test_view.saw_action));
+    }
+
+    /// Records the pressure of every mouse event an element sees.
+    struct PressureView(Rc<RefCell<Vec<f32>>>);
+
+    impl Render for PressureView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let down = self.0.clone();
+            let moved = self.0.clone();
+            div()
+                .size_full()
+                .on_mouse_down(
+                    crate::MouseButton::Left,
+                    move |e: &crate::MouseDownEvent, _, _| down.borrow_mut().push(e.pressure),
+                )
+                .on_mouse_move(move |e: &crate::MouseMoveEvent, _, _| {
+                    moved.borrow_mut().push(e.pressure)
+                })
+        }
+    }
+
+    #[gpui::test]
+    fn test_pressure_reaches_handlers(cx: &mut TestAppContext) {
+        let log: Rc<RefCell<Vec<f32>>> = Default::default();
+        let window = cx.add_window({
+            let log = log.clone();
+            move |_, _| PressureView(log)
+        });
+        let any_window = AnyWindowHandle::from(window);
+
+        cx.update_window(any_window, |_, window, cx| {
+            window.draw(cx).clear(cx);
+            window.dispatch_event(
+                crate::MouseDownEvent {
+                    position: point(px(50.), px(50.)),
+                    button: crate::MouseButton::Left,
+                    modifiers: Default::default(),
+                    click_count: 1,
+                    first_mouse: false,
+                    pressure: 0.42,
+                }
+                .to_platform_input(),
+                cx,
+            );
+            window.dispatch_event(
+                crate::MouseMoveEvent {
+                    position: point(px(60.), px(50.)),
+                    pressed_button: Some(crate::MouseButton::Left),
+                    modifiers: Default::default(),
+                    pressure: 0.9,
+                }
+                .to_platform_input(),
+                cx,
+            );
+        })
+        .unwrap();
+
+        assert_eq!(log.borrow().as_slice(), &[0.42, 0.9]);
+    }
+
+    #[gpui::test]
+    fn test_a_mouse_reports_full_pressure(cx: &mut TestAppContext) {
+        // The default has to be 1.0, not 0.0: a brush that multiplies its
+        // opacity by pressure would paint nothing at all otherwise.
+        let log: Rc<RefCell<Vec<f32>>> = Default::default();
+        let window = cx.add_window({
+            let log = log.clone();
+            move |_, _| PressureView(log)
+        });
+        let any_window = AnyWindowHandle::from(window);
+
+        cx.update_window(any_window, |_, window, cx| {
+            window.draw(cx).clear(cx);
+            // The simulate helper is what a mouse-driven test uses.
+            window.simulate_mouse_move(point(px(50.), px(50.)), cx);
+        })
+        .unwrap();
+
+        assert_eq!(log.borrow().as_slice(), &[1.0]);
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5088,6 +5088,8 @@ impl Window {
                         position,
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Modifiers::default(),
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     })
                 }
                 FileDropEvent::Pending { position } => {
@@ -5096,6 +5098,8 @@ impl Window {
                         position,
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Modifiers::default(),
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     })
                 }
                 FileDropEvent::Submit { position } => {
@@ -5106,6 +5110,8 @@ impl Window {
                         position,
                         modifiers: Modifiers::default(),
                         click_count: 1,
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     })
                 }
                 FileDropEvent::Exited => {
@@ -6136,12 +6142,14 @@ impl Window {
                         modifiers: Modifiers::default(),
                         click_count: 1,
                         first_mouse: false,
+                        pressure: 1.0,
                     });
                     let mouse_up = PlatformInput::MouseUp(MouseUpEvent {
                         button: MouseButton::Left,
                         position: center,
                         modifiers: Modifiers::default(),
                         click_count: 1,
+                        pressure: 1.0,
                     });
                     self.dispatch_event(mouse_down, cx);
                     self.dispatch_event(mouse_up, cx);
@@ -6372,6 +6380,7 @@ impl Window {
             position,
             modifiers: self.modifiers,
             pressed_button: None,
+            pressure: 1.0,
         });
         let _ = self.dispatch_event(event, cx);
     }
@@ -7300,6 +7309,7 @@ mod tests {
                         modifiers: Default::default(),
                         click_count: 1,
                         first_mouse: false,
+                        pressure: 1.0,
                     }
                     .to_platform_input(),
                     cx,
@@ -7309,6 +7319,7 @@ mod tests {
                         position: point(px(20.), px(20.)),
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Default::default(),
+                        pressure: 1.0,
                     }
                     .to_platform_input(),
                     cx,
@@ -7337,6 +7348,7 @@ mod tests {
                     position: outside_position,
                     pressed_button: Some(MouseButton::Left),
                     modifiers: Default::default(),
+                    pressure: 1.0,
                 }
                 .to_platform_input(),
                 cx,
@@ -7465,6 +7477,7 @@ mod tests {
                     position: outside_position,
                     pressed_button: Some(MouseButton::Left),
                     modifiers: Default::default(),
+                    pressure: 1.0,
                 }
                 .to_platform_input(),
                 cx,
@@ -7502,6 +7515,7 @@ mod tests {
                     position: outside_position,
                     pressed_button: Some(MouseButton::Left),
                     modifiers: Default::default(),
+                    pressure: 1.0,
                 }
                 .to_platform_input(),
                 cx,
@@ -7524,6 +7538,7 @@ mod tests {
                         position: point(px(x_position), px(20.)),
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Default::default(),
+                        pressure: 1.0,
                     }
                     .to_platform_input(),
                     cx,

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -47,6 +47,11 @@ use wayland_protocols::wp::primary_selection::zv1::client::{
     zwp_primary_selection_device_manager_v1, zwp_primary_selection_device_v1,
     zwp_primary_selection_source_v1,
 };
+use wayland_protocols::wp::tablet::zv2::client::{
+    zwp_tablet_manager_v2, zwp_tablet_pad_group_v2, zwp_tablet_pad_ring_v2,
+    zwp_tablet_pad_strip_v2, zwp_tablet_pad_v2, zwp_tablet_seat_v2, zwp_tablet_tool_v2,
+    zwp_tablet_v2,
+};
 use wayland_protocols::wp::text_input::zv3::client::zwp_text_input_v3::{
     ContentHint, ContentPurpose,
 };
@@ -224,6 +229,7 @@ pub struct Globals {
     pub blur_manager: Option<org_kde_kwin_blur_manager::OrgKdeKwinBlurManager>,
     pub text_input_manager: Option<zwp_text_input_manager_v3::ZwpTextInputManagerV3>,
     pub gesture_manager: Option<zwp_pointer_gestures_v1::ZwpPointerGesturesV1>,
+    pub tablet_manager: Option<zwp_tablet_manager_v2::ZwpTabletManagerV2>,
     pub dialog: Option<xdg_wm_dialog_v1::XdgWmDialogV1>,
     pub system_bell: Option<xdg_system_bell_v1::XdgSystemBellV1>,
     pub executor: ForegroundExecutor,
@@ -268,6 +274,9 @@ impl Globals {
             blur_manager: globals.bind(&qh, 1..=1, ()).ok(),
             text_input_manager: globals.bind(&qh, 1..=1, ()).ok(),
             gesture_manager: globals.bind(&qh, 1..=3, ()).ok(),
+            // Optional in the same way as the gesture manager: only seats
+            // with a graphics tablet attached advertise it.
+            tablet_manager: globals.bind(&qh, 1..=1, ()).ok(),
             dialog: globals.bind(&qh, dialog_v..=dialog_v, ()).ok(),
             system_bell: globals.bind(&qh, 1..=1, ()).ok(),
             executor,
@@ -319,6 +328,9 @@ pub(crate) struct WaylandClientState {
     wl_pointer: Option<wl_pointer::WlPointer>,
     pinch_gesture: Option<zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1>,
     pinch_scale: f32,
+    tablet_seat: Option<zwp_tablet_seat_v2::ZwpTabletSeatV2>,
+    /// Every tablet tool the seat has announced, keyed by the tool object.
+    tablet_tools: HashMap<ObjectId, TabletTool>,
     wl_keyboard: Option<wl_keyboard::WlKeyboard>,
     cursor_shape_device: Option<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>,
     data_device: Option<wl_data_device::WlDataDevice>,
@@ -403,6 +415,120 @@ pub struct ClickState {
     last_click: Instant,
     last_location: Point<Pixels>,
     current_count: usize,
+}
+
+impl ClickState {
+    /// Folds a press of `button` at `location` into the current double-click
+    /// run and returns the click count to report with it.
+    fn press(&mut self, button: MouseButton, location: Point<Pixels>) -> usize {
+        if self.last_click.elapsed() < DOUBLE_CLICK_INTERVAL
+            && self
+                .last_mouse_button
+                .is_some_and(|prev_button| prev_button == button)
+            && is_within_click_distance(self.last_location, location)
+        {
+            self.current_count += 1;
+        } else {
+            self.current_count = 1;
+        }
+
+        self.last_click = Instant::now();
+        self.last_mouse_button = Some(button);
+        self.last_location = location;
+        self.current_count
+    }
+}
+
+/// A tablet tool -- a stylus, an eraser, or a puck -- announced by
+/// `zwp_tablet_seat_v2`.
+///
+/// Tablet input arrives on its own protocol rather than through `wl_pointer`,
+/// and a compositor stops emulating pointer events for a tool once the client
+/// binds the tablet protocol. So each tool is turned back into the ordinary
+/// mouse event stream here, with the tip acting as the left button and the
+/// pressure axis riding along on the events that carry a `pressure` field.
+struct TabletTool {
+    tool: zwp_tablet_tool_v2::ZwpTabletToolV2,
+    /// Whether the tool announced the pressure axis in its initial burst of
+    /// capability events. A tool without one -- a puck, or a mouse-shaped
+    /// tool -- reports full pressure, as an ordinary mouse does.
+    has_pressure: bool,
+    /// Cursor shape handle for this tool, when the compositor supports
+    /// cursor-shape-v1. Each tool carries its own cursor, distinct from the
+    /// pointer's.
+    cursor_shape_device: Option<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>,
+    /// Serial of the most recent `proximity_in`, which `set_cursor` needs.
+    proximity_serial: u32,
+    /// Window the tool is currently in proximity of.
+    focused_window: Option<WaylandWindowStatePtr>,
+    /// Latest pressure reading, 0.0..=1.0. Kept across frames because the
+    /// axis is only resent when it changes.
+    pressure: f32,
+    /// Surface-local position of the tool. Tracked here rather than read back
+    /// from `mouse_location` so that a tool that has never reported a motion
+    /// cannot make the pointer path's `unwrap`s reachable.
+    position: Point<Pixels>,
+    /// What has arrived since the last `frame` event.
+    pending: TabletFrame,
+}
+
+impl TabletTool {
+    fn new(
+        tool: zwp_tablet_tool_v2::ZwpTabletToolV2,
+        cursor_shape_device: Option<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>,
+    ) -> Self {
+        Self {
+            tool,
+            has_pressure: false,
+            cursor_shape_device,
+            proximity_serial: 0,
+            focused_window: None,
+            pressure: 0.0,
+            position: Point::default(),
+            pending: TabletFrame::default(),
+        }
+    }
+
+    /// The pressure to put on a mouse event, per the `MouseDownEvent::pressure`
+    /// contract: a device with no pressure axis reports 1.0 so that callers can
+    /// multiply by it unconditionally. A tool that *does* have the axis reports
+    /// what it measured, so a hovering stylus reads a true zero -- the same
+    /// distinction X11 draws.
+    fn reported_pressure(&self) -> f32 {
+        if self.has_pressure {
+            self.pressure
+        } else {
+            1.0
+        }
+    }
+
+    /// Applies `style` to this tool's cursor.
+    ///
+    /// A tool's cursor is independent of the pointer's, and the pointer's
+    /// cursor surface cannot be reused for it -- a `wl_surface` may only ever
+    /// hold one cursor role -- so without cursor-shape-v1 there is nothing to
+    /// set and the compositor's default cursor stays put.
+    fn set_cursor(&self, style: CursorStyle) {
+        if let Some(cursor_shape_device) = &self.cursor_shape_device {
+            cursor_shape_device.set_shape(self.proximity_serial, to_shape(style));
+        }
+    }
+}
+
+/// Tablet events are batched: everything between two `frame` events describes
+/// one hardware sample and is dispatched together. The batching matters --
+/// the `pressure` belonging to a tip-down arrives *after* the `down` event.
+#[derive(Default)]
+struct TabletFrame {
+    /// Whether the tool moved, i.e. whether a `MouseMoveEvent` is owed.
+    motion: bool,
+    /// `Some(true)` if the tip came down in this frame, `Some(false)` if it
+    /// lifted.
+    tip: Option<bool>,
+    /// Barrel buttons pressed (`true`) or released (`false`), in arrival order.
+    buttons: SmallVec<[(MouseButton, bool); 2]>,
+    /// Whether the tool left proximity, which ends the frame.
+    proximity_out: bool,
 }
 
 pub(crate) struct KeyRepeat {
@@ -706,6 +832,15 @@ impl Drop for WaylandClient {
         if let Some(cursor_shape_device) = &state.cursor_shape_device {
             cursor_shape_device.destroy();
         }
+        for (_, tablet_tool) in state.tablet_tools.drain() {
+            if let Some(cursor_shape_device) = &tablet_tool.cursor_shape_device {
+                cursor_shape_device.destroy();
+            }
+            tablet_tool.tool.destroy();
+        }
+        if let Some(tablet_seat) = &state.tablet_seat {
+            tablet_seat.destroy();
+        }
         if let Some(data_device) = &state.data_device {
             data_device.release();
         }
@@ -848,6 +983,13 @@ impl WaylandClient {
             .as_ref()
             .map(|primary_selection_manager| primary_selection_manager.get_device(&seat, &qh, ()));
 
+        // Tablets hang off the seat but are not a `wl_seat` capability, so
+        // unlike the pointer and keyboard this is set up once, here.
+        let tablet_seat = globals
+            .tablet_manager
+            .as_ref()
+            .map(|tablet_manager| tablet_manager.get_tablet_seat(&seat, &qh, ()));
+
         let cursor = Cursor::new(&conn, &globals, 24);
 
         handle
@@ -953,6 +1095,8 @@ impl WaylandClient {
             vertical_modifier: -1.0,
             horizontal_modifier: -1.0,
             button_pressed: None,
+            tablet_seat,
+            tablet_tools: HashMap::default(),
             mouse_focused_window: None,
             keyboard_focused_window: None,
             loop_handle: handle.clone(),
@@ -1122,21 +1266,33 @@ impl LinuxClient for WaylandClient {
         }
 
         let serial = state.serial_tracker.get(SerialKind::MouseEnter);
-        if let Some(cursor_shape_device) = &state.cursor_shape_device {
-            cursor_shape_device.set_shape(serial.as_raw(), to_shape(style));
-        } else if let Some(focused_window) = &state.mouse_focused_window {
-            // cursor-shape-v1 isn't supported, set the cursor using a surface.
-            let wl_pointer = state
-                .wl_pointer
-                .clone()
-                .expect("window is focused by pointer");
-            let scale = focused_window.primary_output_scale();
-            state.cursor.set_icon(
-                &wl_pointer,
-                serial.as_raw(),
-                cursor_style_to_icon_names(style),
-                scale,
-            );
+        // A seat with a tablet but no mouse has no `wl_pointer` at all, so
+        // the pointer's cursor is only worth setting when one exists.
+        if state.wl_pointer.is_some() {
+            if let Some(cursor_shape_device) = &state.cursor_shape_device {
+                cursor_shape_device.set_shape(serial.as_raw(), to_shape(style));
+            } else if let Some(focused_window) = &state.mouse_focused_window {
+                // cursor-shape-v1 isn't supported, set the cursor using a surface.
+                let wl_pointer = state
+                    .wl_pointer
+                    .clone()
+                    .expect("window is focused by pointer");
+                let scale = focused_window.primary_output_scale();
+                state.cursor.set_icon(
+                    &wl_pointer,
+                    serial.as_raw(),
+                    cursor_style_to_icon_names(style),
+                    scale,
+                );
+            }
+        }
+
+        // Tablet tools carry their own cursor, so a style set while a
+        // stylus is hovering has to be pushed to the tool as well.
+        for tablet_tool in state.tablet_tools.values() {
+            if tablet_tool.focused_window.is_some() {
+                tablet_tool.set_cursor(style);
+            }
         }
     }
 
@@ -1435,6 +1591,9 @@ delegate_noop!(WaylandClientStatePtr: ignore zwp_text_input_manager_v3::ZwpTextI
 delegate_noop!(WaylandClientStatePtr: ignore org_kde_kwin_blur::OrgKdeKwinBlur);
 delegate_noop!(WaylandClientStatePtr: ignore wp_viewporter::WpViewporter);
 delegate_noop!(WaylandClientStatePtr: ignore wp_viewport::WpViewport);
+delegate_noop!(WaylandClientStatePtr: ignore zwp_tablet_manager_v2::ZwpTabletManagerV2);
+delegate_noop!(WaylandClientStatePtr: ignore zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2);
+delegate_noop!(WaylandClientStatePtr: ignore zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2);
 
 impl Dispatch<WlCallback, ObjectId> for WaylandClientStatePtr {
     fn event(
@@ -2076,6 +2235,335 @@ fn linux_button_to_gpui(button: u32) -> Option<MouseButton> {
     })
 }
 
+fn tablet_button_to_gpui(button: u32) -> Option<MouseButton> {
+    // Also from <linux/input-event-codes.h>. A stylus' barrel buttons are
+    // conventionally the right and middle mouse buttons -- that is what the
+    // X11 wacom driver and Windows pen input both report them as -- so a
+    // caller written against a mouse keeps working with a stylus.
+    const BTN_STYLUS: u32 = 0x14b;
+    const BTN_STYLUS2: u32 = 0x14c;
+
+    match button {
+        BTN_STYLUS => Some(MouseButton::Right),
+        BTN_STYLUS2 => Some(MouseButton::Middle),
+        // Puck-shaped tools report ordinary mouse buttons.
+        _ => linux_button_to_gpui(button),
+    }
+}
+
+impl Dispatch<zwp_tablet_seat_v2::ZwpTabletSeatV2, ()> for WaylandClientStatePtr {
+    fn event(
+        this: &mut Self,
+        _: &zwp_tablet_seat_v2::ZwpTabletSeatV2,
+        event: zwp_tablet_seat_v2::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        // Only tools carry input. Tablets and pads are announced whether or
+        // not anything here wants them, so they get handlers below, but
+        // nothing is done with them.
+        let zwp_tablet_seat_v2::Event::ToolAdded { id } = event else {
+            return;
+        };
+
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+        let tool_id = id.id();
+        let cursor_shape_device = state
+            .globals
+            .cursor_shape_manager
+            .as_ref()
+            .map(|cursor_shape_manager| cursor_shape_manager.get_tablet_tool_v2(&id, qh, ()));
+        state
+            .tablet_tools
+            .insert(tool_id, TabletTool::new(id, cursor_shape_device));
+    }
+
+    event_created_child!(WaylandClientStatePtr, zwp_tablet_seat_v2::ZwpTabletSeatV2, [
+        zwp_tablet_seat_v2::EVT_TABLET_ADDED_OPCODE => (zwp_tablet_v2::ZwpTabletV2, ()),
+        zwp_tablet_seat_v2::EVT_TOOL_ADDED_OPCODE => (zwp_tablet_tool_v2::ZwpTabletToolV2, ()),
+        zwp_tablet_seat_v2::EVT_PAD_ADDED_OPCODE => (zwp_tablet_pad_v2::ZwpTabletPadV2, ()),
+    ]);
+}
+
+impl Dispatch<zwp_tablet_tool_v2::ZwpTabletToolV2, ()> for WaylandClientStatePtr {
+    fn event(
+        this: &mut Self,
+        tool: &zwp_tablet_tool_v2::ZwpTabletToolV2,
+        event: zwp_tablet_tool_v2::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+        let tool_id = tool.id();
+
+        match event {
+            zwp_tablet_tool_v2::Event::Capability {
+                capability: WEnum::Value(capability),
+            } => {
+                if capability == zwp_tablet_tool_v2::Capability::Pressure
+                    && let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id)
+                {
+                    tablet_tool.has_pressure = true;
+                }
+            }
+            zwp_tablet_tool_v2::Event::ProximityIn {
+                serial, surface, ..
+            } => {
+                state.serial_tracker.update(SerialKind::MouseEnter, serial);
+                let Some(window) = get_window(&mut state, &surface.id()) else {
+                    return;
+                };
+
+                let cursor_style = state.cursor_style;
+                let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) else {
+                    return;
+                };
+                tablet_tool.proximity_serial = serial;
+                tablet_tool.focused_window = Some(window.clone());
+                // Whatever was mid-frame belonged to the surface being left.
+                tablet_tool.pending = TabletFrame::default();
+                if let Some(cursor_style) = cursor_style {
+                    tablet_tool.set_cursor(cursor_style);
+                }
+
+                // A stylus and a mouse share one notion of what the pointer is
+                // over, so proximity takes the focus the same way an enter does.
+                state.mouse_focused_window = Some(window.clone());
+                state.button_pressed = None;
+
+                drop(state);
+                window.set_hovered(true);
+            }
+            zwp_tablet_tool_v2::Event::ProximityOut => {
+                // Button releases are sent before this but within the same
+                // frame, so the exit is dispatched from the frame handler.
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    tablet_tool.pending.proximity_out = true;
+                }
+            }
+            zwp_tablet_tool_v2::Event::Motion { x, y } => {
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    tablet_tool.position = point(px(x as f32), px(y as f32));
+                    tablet_tool.pending.motion = true;
+                }
+            }
+            zwp_tablet_tool_v2::Event::Pressure { pressure } => {
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    // The protocol normalizes the axis to 0..=65535.
+                    tablet_tool.pressure = (pressure as f32 / 65535.0).clamp(0.0, 1.0);
+                }
+            }
+            zwp_tablet_tool_v2::Event::Down { serial } => {
+                state.serial_tracker.update(SerialKind::MousePress, serial);
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    tablet_tool.pending.tip = Some(true);
+                }
+            }
+            zwp_tablet_tool_v2::Event::Up => {
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    tablet_tool.pending.tip = Some(false);
+                }
+            }
+            zwp_tablet_tool_v2::Event::Button {
+                serial,
+                button,
+                state: WEnum::Value(button_state),
+            } => {
+                state.serial_tracker.update(SerialKind::MousePress, serial);
+                let Some(button) = tablet_button_to_gpui(button) else {
+                    return;
+                };
+                let pressed = button_state == zwp_tablet_tool_v2::ButtonState::Pressed;
+                if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                    tablet_tool.pending.buttons.push((button, pressed));
+                }
+            }
+            zwp_tablet_tool_v2::Event::Frame { .. } => {
+                let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) else {
+                    return;
+                };
+                let pending = std::mem::take(&mut tablet_tool.pending);
+                let position = tablet_tool.position;
+                // Read once for the whole frame: every event in it describes
+                // the same hardware sample, including the pressure that arrived
+                // after the `down` it belongs to.
+                let pressure = tablet_tool.reported_pressure();
+                let Some(window) = tablet_tool.focused_window.clone() else {
+                    return;
+                };
+                let left_proximity = pending.proximity_out;
+
+                let mut inputs: SmallVec<[PlatformInput; 4]> = SmallVec::new();
+
+                if pending.motion {
+                    state.mouse_location = Some(position);
+                    inputs.push(PlatformInput::MouseMove(MouseMoveEvent {
+                        position,
+                        pressed_button: state.button_pressed,
+                        modifiers: state.modifiers,
+                        pressure,
+                    }));
+                }
+
+                // The tip acts as the left button. It is reported after the
+                // move, so that the press lands at the position the tool
+                // travelled to within this same frame.
+                if pending.tip == Some(true) {
+                    let click_count = state.click.press(MouseButton::Left, position);
+                    state.button_pressed = Some(MouseButton::Left);
+                    inputs.push(PlatformInput::MouseDown(MouseDownEvent {
+                        button: MouseButton::Left,
+                        position,
+                        modifiers: state.modifiers,
+                        click_count,
+                        first_mouse: state.enter_token.take().is_some(),
+                        pressure,
+                    }));
+                }
+
+                for (button, pressed) in pending.buttons {
+                    if pressed {
+                        let click_count = state.click.press(button, position);
+                        state.button_pressed = Some(button);
+                        inputs.push(PlatformInput::MouseDown(MouseDownEvent {
+                            button,
+                            position,
+                            modifiers: state.modifiers,
+                            click_count,
+                            first_mouse: state.enter_token.take().is_some(),
+                            pressure,
+                        }));
+                    } else {
+                        state.button_pressed = None;
+                        inputs.push(PlatformInput::MouseUp(MouseUpEvent {
+                            button,
+                            position,
+                            modifiers: state.modifiers,
+                            click_count: state.click.current_count,
+                            pressure,
+                        }));
+                    }
+                }
+
+                if pending.tip == Some(false) {
+                    state.button_pressed = None;
+                    inputs.push(PlatformInput::MouseUp(MouseUpEvent {
+                        button: MouseButton::Left,
+                        position,
+                        modifiers: state.modifiers,
+                        click_count: state.click.current_count,
+                        pressure,
+                    }));
+                }
+
+                if left_proximity {
+                    inputs.push(PlatformInput::MouseExited(MouseExitEvent {
+                        position,
+                        pressed_button: state.button_pressed,
+                        modifiers: state.modifiers,
+                    }));
+
+                    if let Some(tablet_tool) = state.tablet_tools.get_mut(&tool_id) {
+                        tablet_tool.focused_window = None;
+                        tablet_tool.pressure = 0.0;
+                    }
+                    state.button_pressed = None;
+                    // Only hand back the shared focus if a mouse has not taken
+                    // it in the meantime.
+                    if state
+                        .mouse_focused_window
+                        .as_ref()
+                        .is_some_and(|focused_window| focused_window.ptr_eq(&window))
+                    {
+                        state.mouse_focused_window = None;
+                        state.mouse_location = None;
+                    }
+                }
+
+                drop(state);
+                for input in inputs {
+                    window.handle_input(input);
+                }
+                if left_proximity {
+                    window.set_hovered(false);
+                }
+            }
+            zwp_tablet_tool_v2::Event::Removed => {
+                // A tool in proximity is taken out of it first, so the focus
+                // has already been handed back by the time this arrives.
+                if let Some(tablet_tool) = state.tablet_tools.remove(&tool_id)
+                    && let Some(cursor_shape_device) = &tablet_tool.cursor_shape_device
+                {
+                    cursor_shape_device.destroy();
+                }
+                tool.destroy();
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<zwp_tablet_v2::ZwpTabletV2, ()> for WaylandClientStatePtr {
+    fn event(
+        _: &mut Self,
+        tablet: &zwp_tablet_v2::ZwpTabletV2,
+        event: zwp_tablet_v2::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // The device's name, vid/pid and path are of no use here; all the
+        // protocol asks is that the object be destroyed once it is removed.
+        if let zwp_tablet_v2::Event::Removed = event {
+            tablet.destroy();
+        }
+    }
+}
+
+impl Dispatch<zwp_tablet_pad_v2::ZwpTabletPadV2, ()> for WaylandClientStatePtr {
+    fn event(
+        _: &mut Self,
+        pad: &zwp_tablet_pad_v2::ZwpTabletPadV2,
+        event: zwp_tablet_pad_v2::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // A pad's buttons, rings and strips have no GPUI event to map onto, so
+        // they are ignored -- but the seat announces pads regardless of that,
+        // and the group/ring/strip objects it hangs off them still need
+        // handlers to keep the queue from panicking on an unclaimed new_id.
+        if let zwp_tablet_pad_v2::Event::Removed = event {
+            pad.destroy();
+        }
+    }
+
+    event_created_child!(WaylandClientStatePtr, zwp_tablet_pad_v2::ZwpTabletPadV2, [
+        zwp_tablet_pad_v2::EVT_GROUP_OPCODE => (zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2, ()),
+    ]);
+}
+
+impl Dispatch<zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2, ()> for WaylandClientStatePtr {
+    fn event(
+        _: &mut Self,
+        _: &zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2,
+        _: zwp_tablet_pad_group_v2::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+
+    event_created_child!(WaylandClientStatePtr, zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2, [
+        zwp_tablet_pad_group_v2::EVT_RING_OPCODE => (zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2, ()),
+        zwp_tablet_pad_group_v2::EVT_STRIP_OPCODE => (zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2, ()),
+    ]);
+}
+
 impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
     fn event(
         this: &mut Self,
@@ -2242,35 +2730,17 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                                 state = client.borrow_mut();
                             }
                         }
-                        let click_elapsed = state.click.last_click.elapsed();
-
-                        if click_elapsed < DOUBLE_CLICK_INTERVAL
-                            && state
-                                .click
-                                .last_mouse_button
-                                .is_some_and(|prev_button| prev_button == button)
-                            && is_within_click_distance(
-                                state.click.last_location,
-                                state.mouse_location.unwrap(),
-                            )
-                        {
-                            state.click.current_count += 1;
-                        } else {
-                            state.click.current_count = 1;
-                        }
-
-                        state.click.last_click = Instant::now();
-                        state.click.last_mouse_button = Some(button);
-                        state.click.last_location = state.mouse_location.unwrap();
+                        let position = state.mouse_location.unwrap();
+                        let click_count = state.click.press(button, position);
 
                         state.button_pressed = Some(button);
 
                         if let Some(window) = state.mouse_focused_window.clone() {
                             let input = PlatformInput::MouseDown(MouseDownEvent {
                                 button,
-                                position: state.mouse_location.unwrap(),
+                                position,
                                 modifiers: state.modifiers,
-                                click_count: state.click.current_count,
+                                click_count,
                                 first_mouse: state.enter_token.take().is_some(),
                                 // A mouse reports full pressure; tablets override this.
                                 pressure: 1.0,
@@ -3024,5 +3494,51 @@ mod tests {
             text_input.cursor_rectangles.borrow().as_slice(),
             &[(10, 20, 1, 18)]
         );
+    }
+
+    fn click_state() -> ClickState {
+        ClickState {
+            last_mouse_button: None,
+            last_click: Instant::now() - DOUBLE_CLICK_INTERVAL,
+            last_location: Point::default(),
+            current_count: 0,
+        }
+    }
+
+    /// The pointer and the tablet share this run counting, so a stylus tapping
+    /// twice has to double-click exactly as a mouse does.
+    #[test]
+    fn test_click_state_counts_runs() {
+        let mut click = click_state();
+        let origin = point(px(10.), px(10.));
+
+        assert_eq!(click.press(MouseButton::Left, origin), 1);
+        assert_eq!(click.press(MouseButton::Left, origin), 2);
+        assert_eq!(click.press(MouseButton::Left, origin), 3);
+
+        // A different button starts a new run,
+        assert_eq!(click.press(MouseButton::Right, origin), 1);
+        // as does a press far enough away to not be the same click.
+        assert_eq!(
+            click.press(MouseButton::Right, point(px(500.), px(500.))),
+            1
+        );
+
+        // ...and so does a press that came too late.
+        click.last_click = Instant::now() - DOUBLE_CLICK_INTERVAL;
+        assert_eq!(
+            click.press(MouseButton::Right, point(px(500.), px(500.))),
+            1
+        );
+    }
+
+    #[test]
+    fn test_tablet_barrel_buttons_map_to_mouse_buttons() {
+        assert_eq!(tablet_button_to_gpui(0x14b), Some(MouseButton::Right));
+        assert_eq!(tablet_button_to_gpui(0x14c), Some(MouseButton::Middle));
+        // A puck reports ordinary mouse buttons, which still have to map.
+        assert_eq!(tablet_button_to_gpui(0x110), Some(MouseButton::Left));
+        // Anything else -- the third barrel button, say -- has no mapping.
+        assert_eq!(tablet_button_to_gpui(0x149), None);
     }
 }

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -2130,6 +2130,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                         position,
                         pressed_button: None,
                         modifiers,
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     }));
                 }
             }
@@ -2198,6 +2200,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                         position: state.mouse_location.unwrap(),
                         pressed_button: state.button_pressed,
                         modifiers: state.modifiers,
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     });
                     drop(state);
                     window.handle_input(input);
@@ -2268,6 +2272,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                                 modifiers: state.modifiers,
                                 click_count: state.click.current_count,
                                 first_mouse: state.enter_token.take().is_some(),
+                                // A mouse reports full pressure; tablets override this.
+                                pressure: 1.0,
                             });
                             drop(state);
                             window.handle_input(input);
@@ -2282,6 +2288,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                                 position: state.mouse_location.unwrap(),
                                 modifiers: state.modifiers,
                                 click_count: state.click.current_count,
+                                // A mouse reports full pressure; tablets override this.
+                                pressure: 1.0,
                             });
                             drop(state);
                             window.handle_input(input);

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -152,6 +152,22 @@ pub struct Xdnd {
 struct PointerDeviceState {
     horizontal: ScrollAxisState,
     vertical: ScrollAxisState,
+    pressure: Option<PressureAxisState>,
+}
+
+/// State of a device's stylus pressure valuator ("Abs Pressure"). Ordinary
+/// mice have no such valuator and get `PointerDeviceState::pressure = None`.
+#[derive(Debug)]
+struct PressureAxisState {
+    /// Valuator number for looking up this axis's pressure value.
+    valuator_number: u16,
+    /// Lower bound of the axis's reported range.
+    min: f32,
+    /// Width of the axis's reported range, always positive.
+    range: f32,
+    /// Last normalized pressure seen, cached because XInput only includes the
+    /// valuators that changed in each event.
+    last_value: f32,
 }
 
 #[derive(Debug, Default)]
@@ -375,13 +391,14 @@ impl X11Client {
             supports_xinput_gestures,
         );
 
-        let pointer_device_states =
-            current_pointer_device_states(&xcb_connection, &BTreeMap::new()).unwrap_or_default();
-
         let atoms = XcbAtoms::new(&xcb_connection)
             .context("Failed to get XCB atoms")?
             .reply()
             .context("Failed to get XCB atoms")?;
+
+        let pointer_device_states =
+            current_pointer_device_states(&xcb_connection, &BTreeMap::new(), atoms.AbsPressure)
+                .unwrap_or_default();
 
         let root = xcb_connection.setup().roots[0].root;
         let compositor_present = check_compositor_present(&xcb_connection, root);
@@ -1168,6 +1185,8 @@ impl X11Client {
                     window.handle_ime_commit(text);
                     state = self.0.borrow_mut();
                 }
+                let pressure =
+                    get_pressure_and_update_state(&mut state.pointer_device_states, &event);
                 match button_or_scroll_from_event_detail(event.detail) {
                     Some(ButtonOrScroll::Button(button)) => {
                         let click_elapsed = state.last_click.elapsed();
@@ -1194,8 +1213,7 @@ impl X11Client {
                             modifiers,
                             click_count: current_count,
                             first_mouse: false,
-                            // A mouse reports full pressure; tablets override this.
-                            pressure: 1.0,
+                            pressure,
                         }));
                     }
                     Some(ButtonOrScroll::Scroll(direction)) => {
@@ -1232,6 +1250,8 @@ impl X11Client {
                     px(event.event_x as f32 / u16::MAX as f32 / state.scale_factor),
                     px(event.event_y as f32 / u16::MAX as f32 / state.scale_factor),
                 );
+                let pressure =
+                    get_pressure_and_update_state(&mut state.pointer_device_states, &event);
                 match button_or_scroll_from_event_detail(event.detail) {
                     Some(ButtonOrScroll::Button(button)) => {
                         let click_count = state.current_count;
@@ -1241,8 +1261,7 @@ impl X11Client {
                             position,
                             modifiers,
                             click_count,
-                            // A mouse reports full pressure; tablets override this.
-                            pressure: 1.0,
+                            pressure,
                         }));
                     }
                     Some(ButtonOrScroll::Scroll(_)) => {}
@@ -1287,15 +1306,28 @@ impl X11Client {
                 );
                 let modifiers = modifiers_from_xinput_info(event.mods);
                 state.modifiers = modifiers;
+                // A stylus pressed harder without moving reports only its
+                // pressure valuator; that must still reach the application, so
+                // it counts as a move alongside the x/y valuators (bits 0 and
+                // 1) below. Scroll-wheel valuators keep not counting.
+                let pressure_valuator_changed = state
+                    .pointer_device_states
+                    .get(&event.sourceid)
+                    .and_then(|device| device.pressure.as_ref())
+                    .is_some_and(|pressure| {
+                        get_valuator_axis_index(&event.valuator_mask, pressure.valuator_number)
+                            .is_some()
+                    });
+                let pressure =
+                    get_pressure_and_update_state(&mut state.pointer_device_states, &event);
                 drop(state);
 
-                if event.valuator_mask[0] & 3 != 0 {
+                if event.valuator_mask[0] & 3 != 0 || pressure_valuator_changed {
                     window.handle_input(PlatformInput::MouseMove(gpui::MouseMoveEvent {
                         position,
                         pressed_button,
                         modifiers,
-                        // A mouse reports full pressure; tablets override this.
-                        pressure: 1.0,
+                        pressure,
                     }));
                 }
 
@@ -1354,6 +1386,7 @@ impl X11Client {
                 if let Some(pointer_device_states) = current_pointer_device_states(
                     &state.xcb_connection,
                     &state.pointer_device_states,
+                    state.atoms.AbsPressure,
                 ) {
                     state.pointer_device_states = pointer_device_states;
                 }
@@ -2381,6 +2414,7 @@ fn xdnd_send_status(
 fn current_pointer_device_states(
     xcb_connection: &XCBConnection,
     scroll_values_to_preserve: &BTreeMap<xinput::DeviceId, PointerDeviceState>,
+    abs_pressure_atom: xproto::Atom,
 ) -> Option<BTreeMap<xinput::DeviceId, PointerDeviceState>> {
     let devices_query_result = get_reply(
         || "Failed to query XInput devices",
@@ -2413,7 +2447,13 @@ fn current_pointer_device_states(
                     .iter()
                     .find(|data| data.scroll_type == xinput::ScrollType::VERTICAL)
                     .map(|data| scroll_data_to_axis_state(data, old_vertical));
-                if horizontal.is_none() && vertical.is_none() {
+                let pressure = info
+                    .classes
+                    .iter()
+                    .filter_map(|class| class.data.as_valuator())
+                    .find(|valuator| valuator.label == abs_pressure_atom)
+                    .and_then(pressure_valuator_to_axis_state);
+                if horizontal.is_none() && vertical.is_none() && pressure.is_none() {
                     None
                 } else {
                     Some((
@@ -2421,6 +2461,7 @@ fn current_pointer_device_states(
                         PointerDeviceState {
                             horizontal: horizontal.unwrap_or_else(Default::default),
                             vertical: vertical.unwrap_or_else(Default::default),
+                            pressure,
                         },
                     ))
                 }
@@ -2446,6 +2487,50 @@ fn scroll_data_to_axis_state(
         multiplier: SCROLL_LINES / fp3232_to_f32(data.increment),
         scroll_value: old_axis_state_with_valid_scroll_value.and_then(|state| state.scroll_value),
     }
+}
+
+fn pressure_valuator_to_axis_state(
+    valuator: &xinput::DeviceClassDataValuator,
+) -> Option<PressureAxisState> {
+    let min = fp3232_to_f32(valuator.min);
+    let range = fp3232_to_f32(valuator.max) - min;
+    // A degenerate range would make every event divide by zero (or report
+    // inverted pressure); treat such a device as having no pressure axis.
+    if !(range.is_finite() && range > 0.0) {
+        return None;
+    }
+    Some(PressureAxisState {
+        valuator_number: valuator.number,
+        min,
+        range,
+        // Seed from the axis's current value so events that arrive before the
+        // first pressure change still report something sensible.
+        last_value: ((fp3232_to_f32(valuator.value) - min) / range).clamp(0.0, 1.0),
+    })
+}
+
+/// Returns the stylus pressure to report for a pointer event, 0.0..=1.0,
+/// updating the device's cached value from the event's valuators. Devices
+/// without a pressure valuator -- ordinary mice -- report full pressure, per
+/// the `MouseDownEvent::pressure` contract.
+fn get_pressure_and_update_state(
+    pointer_device_states: &mut BTreeMap<xinput::DeviceId, PointerDeviceState>,
+    event: &xinput::ButtonPressEvent,
+) -> f32 {
+    let Some(pressure) = pointer_device_states
+        .get_mut(&event.sourceid)
+        .and_then(|device| device.pressure.as_mut())
+    else {
+        return 1.0;
+    };
+    if let Some(axis_index) =
+        get_valuator_axis_index(&event.valuator_mask, pressure.valuator_number)
+        && let Some(axis_value) = event.axisvalues.get(axis_index)
+    {
+        pressure.last_value =
+            ((fp3232_to_f32(*axis_value) - pressure.min) / pressure.range).clamp(0.0, 1.0);
+    }
+    pressure.last_value
 }
 
 fn reset_all_pointer_device_scroll_positions(

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -1194,6 +1194,8 @@ impl X11Client {
                             modifiers,
                             click_count: current_count,
                             first_mouse: false,
+                            // A mouse reports full pressure; tablets override this.
+                            pressure: 1.0,
                         }));
                     }
                     Some(ButtonOrScroll::Scroll(direction)) => {
@@ -1239,6 +1241,8 @@ impl X11Client {
                             position,
                             modifiers,
                             click_count,
+                            // A mouse reports full pressure; tablets override this.
+                            pressure: 1.0,
                         }));
                     }
                     Some(ButtonOrScroll::Scroll(_)) => {}
@@ -1290,6 +1294,8 @@ impl X11Client {
                         position,
                         pressed_button,
                         modifiers,
+                        // A mouse reports full pressure; tablets override this.
+                        pressure: 1.0,
                     }));
                 }
 

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -47,6 +47,7 @@ x11rb::atom_manager! {
         XdndFinished,
         XdndTypeList,
         XdndActionCopy,
+        AbsPressure: b"Abs Pressure",
         TextUriList: b"text/uri-list",
         UTF8_STRING,
         TEXT,

--- a/crates/gpui_macos/src/events.rs
+++ b/crates/gpui_macos/src/events.rs
@@ -26,6 +26,16 @@ pub(crate) const ESCAPE_KEY: u16 = 0x1b;
 const TAB_KEY: u16 = 0x09;
 const SHIFT_TAB_KEY: u16 = 0x19;
 
+/// Stylus pressure for an event, 0.0..=1.0.
+///
+/// AppKit reports 0 for an ordinary mouse click, which would silently
+/// make every brush stroke invisible, so anything at or below zero is
+/// treated as "no tablet" and reported as full pressure.
+unsafe fn read_pressure(native_event: id) -> f32 {
+    let p = unsafe { native_event.pressure() } as f32;
+    if p > 0.0 { p.min(1.0) } else { 1.0 }
+}
+
 pub fn key_to_native(key: &str) -> Cow<'_, str> {
     use cocoa::appkit::*;
     let code = match key {
@@ -159,6 +169,7 @@ pub(crate) unsafe fn platform_input_from_native(
                         modifiers: read_modifiers(native_event),
                         click_count: native_event.clickCount() as usize,
                         first_mouse: false,
+                        pressure: read_pressure(native_event),
                     })
                 })
             }
@@ -184,6 +195,7 @@ pub(crate) unsafe fn platform_input_from_native(
                         ),
                         modifiers: read_modifiers(native_event),
                         click_count: native_event.clickCount() as usize,
+                        pressure: read_pressure(native_event),
                     })
                 })
             }
@@ -229,6 +241,9 @@ pub(crate) unsafe fn platform_input_from_native(
                             modifiers: read_modifiers(native_event),
                             click_count: 1,
                             first_mouse: false,
+                            // A swipe comes from a mouse or trackpad,
+                            // never a stylus.
+                            pressure: 1.0,
                         })
                     }),
                     _ => None,
@@ -306,6 +321,7 @@ pub(crate) unsafe fn platform_input_from_native(
                             window_height - px(native_event.locationInWindow().y as f32),
                         ),
                         modifiers: read_modifiers(native_event),
+                        pressure: read_pressure(native_event),
                     })
                 })
             }
@@ -317,6 +333,7 @@ pub(crate) unsafe fn platform_input_from_native(
                     ),
                     pressed_button: None,
                     modifiers: read_modifiers(native_event),
+                    pressure: read_pressure(native_event),
                 })
             }),
             NSEventType::NSMouseExited => window_height.map(|window_height| {

--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -228,6 +228,8 @@ impl WebWindowInner {
                 modifiers,
                 click_count,
                 first_mouse: false,
+                // The web backend does not read PointerEvent pressure yet.
+                pressure: 1.0,
             }));
         })
     }
@@ -266,6 +268,8 @@ impl WebWindowInner {
                 position,
                 modifiers,
                 click_count,
+                // The web backend does not read PointerEvent pressure yet.
+                pressure: 1.0,
             }));
 
             if event.pointer_type() == "touch" {
@@ -377,6 +381,8 @@ impl WebWindowInner {
                 position,
                 pressed_button: current_pressed,
                 modifiers,
+                // The web backend does not read PointerEvent pressure yet.
+                pressure: 1.0,
             }));
         })
     }

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -388,6 +388,8 @@ impl WindowsWindowInner {
             position: logical_point(x, y, scale_factor),
             pressed_button,
             modifiers: current_modifiers(),
+            // A mouse reports full pressure; tablets override this.
+            pressure: 1.0,
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -502,6 +504,8 @@ impl WindowsWindowInner {
             modifiers: current_modifiers(),
             click_count,
             first_mouse: false,
+            // A mouse reports full pressure; tablets override this.
+            pressure: 1.0,
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -530,6 +534,8 @@ impl WindowsWindowInner {
             position: logical_point(x, y, scale_factor),
             modifiers: current_modifiers(),
             click_count,
+            // A mouse reports full pressure; tablets override this.
+            pressure: 1.0,
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -1040,6 +1046,8 @@ impl WindowsWindowInner {
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
             pressed_button: None,
             modifiers: current_modifiers(),
+            // A mouse reports full pressure; tablets override this.
+            pressure: 1.0,
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -1070,6 +1078,8 @@ impl WindowsWindowInner {
                 modifiers: current_modifiers(),
                 click_count,
                 first_mouse: false,
+                // A mouse reports full pressure; tablets override this.
+                pressure: 1.0,
             });
             let handled = !func(input).propagate;
             self.state.callbacks.input.set(Some(func));
@@ -1114,6 +1124,8 @@ impl WindowsWindowInner {
                 position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
                 modifiers: current_modifiers(),
                 click_count: 1,
+                // A mouse reports full pressure; tablets override this.
+                pressure: 1.0,
             });
             let handled = !func(input).propagate;
             self.state.callbacks.input.set(Some(func));

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -10,7 +10,7 @@ use windows::{
         UI::{
             Controls::*,
             HiDpi::*,
-            Input::{Ime::*, KeyboardAndMouse::*},
+            Input::{Ime::*, KeyboardAndMouse::*, Pointer::*},
             WindowsAndMessaging::*,
         },
     },
@@ -111,6 +111,7 @@ impl WindowsWindowInner {
             WM_DESTROY => self.handle_destroy_msg(handle),
             WM_QUERYENDSESSION => Some(1),
             WM_ENDSESSION => self.handle_end_session_msg(wparam),
+            WM_POINTERDOWN | WM_POINTERUPDATE | WM_POINTERUP => self.handle_pointer_msg(wparam),
             WM_MOUSEMOVE => self.handle_mouse_move_msg(handle, lparam, wparam),
             WM_MOUSELEAVE | WM_NCMOUSELEAVE => self.handle_mouse_leave_msg(),
             WM_NCMOUSEMOVE => self.handle_nc_mouse_move_msg(handle, lparam),
@@ -361,6 +362,51 @@ impl WindowsWindowInner {
         Some(0)
     }
 
+    /// Caches the pressure of a pen in contact, so the legacy mouse messages
+    /// that `DefWindowProc` synthesises from the same pointer input can carry
+    /// it. Deliberately never handles the message: the rest of this backend is
+    /// built on those synthesised `WM_MOUSE*` messages, and consuming pointer
+    /// messages here would suppress them.
+    fn handle_pointer_msg(&self, wparam: WPARAM) -> Option<isize> {
+        let pointer_id = wparam.loword() as u32;
+        let mut pointer_type = POINTER_INPUT_TYPE::default();
+        if unsafe { GetPointerType(pointer_id, &mut pointer_type) }.is_err()
+            || pointer_type != PT_PEN
+        {
+            return None;
+        }
+        let mut pen_info = POINTER_PEN_INFO::default();
+        if unsafe { GetPointerPenInfo(pointer_id, &mut pen_info) }.is_err() {
+            return None;
+        }
+        // 0..=1024, and 0 whenever the pen hovers without touching.
+        self.state
+            .pen_pressure
+            .set(pen_info.pressure as f32 / 1024.0);
+        None
+    }
+
+    /// The pressure to report on the mouse message currently being handled:
+    /// the cached pen pressure when the message was synthesised from pen
+    /// input, and full pressure for an ordinary mouse -- or for a hovering
+    /// pen, whose zero reading is indistinguishable from no reading at all.
+    fn current_mouse_pressure(&self) -> f32 {
+        // Mouse messages synthesised from pen or touch input carry this
+        // signature in their extra info (documented under "distinguishing pen
+        // input from mouse and touch"); bit 7 is set for touch, clear for pen.
+        const MI_WP_SIGNATURE: u32 = 0xFF515700;
+        const SIGNATURE_MASK: u32 = 0xFFFFFF00;
+        const TOUCH_FLAG: u32 = 0x80;
+        let extra_info = unsafe { GetMessageExtraInfo() }.0 as u32;
+        if extra_info & SIGNATURE_MASK == MI_WP_SIGNATURE && extra_info & TOUCH_FLAG == 0 {
+            let pressure = self.state.pen_pressure.get();
+            if pressure > 0.0 {
+                return pressure;
+            }
+        }
+        1.0
+    }
+
     fn handle_mouse_move_msg(&self, handle: HWND, lparam: LPARAM, wparam: WPARAM) -> Option<isize> {
         self.start_tracking_mouse(handle, TME_LEAVE);
         self.restore_cursor_after_hide();
@@ -388,8 +434,7 @@ impl WindowsWindowInner {
             position: logical_point(x, y, scale_factor),
             pressed_button,
             modifiers: current_modifiers(),
-            // A mouse reports full pressure; tablets override this.
-            pressure: 1.0,
+            pressure: self.current_mouse_pressure(),
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -504,8 +549,7 @@ impl WindowsWindowInner {
             modifiers: current_modifiers(),
             click_count,
             first_mouse: false,
-            // A mouse reports full pressure; tablets override this.
-            pressure: 1.0,
+            pressure: self.current_mouse_pressure(),
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));
@@ -534,8 +578,7 @@ impl WindowsWindowInner {
             position: logical_point(x, y, scale_factor),
             modifiers: current_modifiers(),
             click_count,
-            // A mouse reports full pressure; tablets override this.
-            pressure: 1.0,
+            pressure: self.current_mouse_pressure(),
         });
         let handled = !func(input).propagate;
         self.state.callbacks.input.set(Some(func));

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -73,6 +73,10 @@ pub struct WindowsWindowState {
     pub force_render_pending: Cell<bool>,
 
     pub click_state: ClickState,
+    /// Pressure of the pen currently in contact, 0.0..=1.0, cached from
+    /// `WM_POINTER*` messages so the legacy mouse messages synthesised from
+    /// them can report it. Zero whenever no pen is touching.
+    pub pen_pressure: Cell<f32>,
     pub current_cursor: Cell<Option<HCURSOR>>,
     /// Shared with [`WindowsPlatformState::cursor_visible`].
     pub cursor_visible: Arc<AtomicBool>,
@@ -175,6 +179,7 @@ impl WindowsWindowState {
             renderer: RefCell::new(renderer),
             force_render_pending: Cell::new(false),
             click_state,
+            pen_pressure: Cell::new(0.0),
             current_cursor: Cell::new(current_cursor),
             cursor_visible,
             nc_button_pressed: Cell::new(nc_button_pressed),
@@ -549,6 +554,7 @@ impl WindowsWindow {
         let this = this.unwrap();
 
         register_drag_drop(&this)?;
+        disable_pen_gesture_feedback(hwnd);
         set_non_rude_hwnd(hwnd, true);
         configure_dwm_dark_mode(hwnd, appearance);
         this.state.border_offset.update(hwnd)?;
@@ -1472,6 +1478,32 @@ fn register_drag_drop(window: &Rc<WindowsWindowInner>) -> Result<()> {
             .context("unable to register drag-drop event")?;
     }
     Ok(())
+}
+
+/// Turns off the system pen gestures that stand between a pen and immediate
+/// mouse events: press-and-hold for right-click (which delays every pen-down
+/// until the hold timeout or a movement threshold decides it was not a hold),
+/// tap feedback animations, and flicks. Without this a pen cannot start a
+/// paint stroke, or place a dot, at the moment it touches.
+fn disable_pen_gesture_feedback(hwnd: HWND) {
+    // Values documented for the MicrosoftTabletPenServiceProperty window
+    // property, which has no constants in the Windows crate.
+    const TABLET_DISABLE_PRESSANDHOLD: usize = 0x00000001;
+    const TABLET_DISABLE_PENTAPFEEDBACK: usize = 0x00000008;
+    const TABLET_DISABLE_PENBARRELFEEDBACK: usize = 0x00000010;
+    const TABLET_DISABLE_FLICKS: usize = 0x00010000;
+    let value = TABLET_DISABLE_PRESSANDHOLD
+        | TABLET_DISABLE_PENTAPFEEDBACK
+        | TABLET_DISABLE_PENBARRELFEEDBACK
+        | TABLET_DISABLE_FLICKS;
+    unsafe {
+        SetPropW(
+            hwnd,
+            w!("MicrosoftTabletPenServiceProperty"),
+            Some(HANDLE(value as _)),
+        )
+        .log_err();
+    }
 }
 
 fn calculate_window_rect(bounds: Bounds<DevicePixels>, border_offset: &WindowBorderOffset) -> RECT {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -3827,6 +3827,7 @@ mod tests {
             modifiers: Modifiers::none(),
             click_count: 1,
             first_mouse: true,
+            pressure: 1.0,
         };
         terminal.mouse_down(&mouse_down, cx);
     }
@@ -3841,6 +3842,7 @@ mod tests {
             position,
             modifiers: Modifiers::none(),
             click_count: 1,
+            pressure: 1.0,
         };
         terminal.mouse_up(&mouse_up, cx);
     }
@@ -3855,6 +3857,7 @@ mod tests {
             position,
             pressed_button: Some(MouseButton::Left),
             modifiers: Modifiers::none(),
+            pressure: 1.0,
         };
         terminal.mouse_drag(&drag_event, region, cx);
     }
@@ -3932,6 +3935,7 @@ mod tests {
                     modifiers: shift,
                     click_count: 1,
                     first_mouse: true,
+                    pressure: 1.0,
                 },
                 cx,
             );
@@ -3953,6 +3957,7 @@ mod tests {
                     position: point(px(90.0), px(10.0)),
                     pressed_button: Some(MouseButton::Left),
                     modifiers: shift,
+                    pressure: 1.0,
                 },
                 region,
                 cx,
@@ -3994,6 +3999,7 @@ mod tests {
                     },
                     click_count: 1,
                     first_mouse: true,
+                    pressure: 1.0,
                 },
                 cx,
             );
@@ -4724,6 +4730,7 @@ mod tests {
                 modifiers: Modifiers::secondary_key(),
                 click_count: 1,
                 first_mouse: true,
+                pressure: 1.0,
             };
             terminal.mouse_down(&mouse_down, cx);
         }
@@ -4738,6 +4745,7 @@ mod tests {
                 position,
                 pressed_button: Some(MouseButton::Left),
                 modifiers: Modifiers::secondary_key(),
+                pressure: 1.0,
             };
             terminal.mouse_drag(&drag_event, terminal_bounds, cx);
         }
@@ -4752,6 +4760,7 @@ mod tests {
                 position,
                 modifiers: Modifiers::secondary_key(),
                 click_count: 1,
+                pressure: 1.0,
             };
             terminal.mouse_up(&mouse_up, cx);
         }
@@ -4822,6 +4831,7 @@ mod tests {
                     position: up_position,
                     pressed_button: Some(MouseButton::Left),
                     modifiers: Modifiers::secondary_key(),
+                    pressure: 1.0,
                 },
                 cx,
             );

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -847,12 +847,14 @@ impl RenderOnce for ButtonLike {
                                     modifiers: event.modifiers,
                                     click_count: 1,
                                     first_mouse: false,
+                                    pressure: 1.0,
                                 },
                                 up: MouseUpEvent {
                                     button: MouseButton::Right,
                                     position: event.position,
                                     modifiers: event.modifiers,
                                     click_count: 1,
+                                    pressure: 1.0,
                                 },
                             });
                             (on_right_click)(&click_event, window, cx)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -6784,12 +6784,14 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseMoveEvent {
             position: tab_c_bounds.center(),
             pressed_button: Some(MouseButton::Left),
             modifiers: Modifiers::default(),
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseUpEvent {
@@ -6797,6 +6799,7 @@ mod tests {
             button: MouseButton::Left,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
         cx.run_until_parked();
 
@@ -6859,12 +6862,14 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseMoveEvent {
             position: tab_c_bounds.center(),
             pressed_button: Some(MouseButton::Left),
             modifiers: Modifiers::default(),
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseUpEvent {
@@ -6872,6 +6877,7 @@ mod tests {
             button: MouseButton::Left,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
         cx.run_until_parked();
 
@@ -6911,12 +6917,14 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseMoveEvent {
             position: tab_c_bounds.center(),
             pressed_button: Some(MouseButton::Left),
             modifiers: Modifiers::default(),
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseUpEvent {
@@ -6924,6 +6932,7 @@ mod tests {
             button: MouseButton::Left,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
         cx.run_until_parked();
 
@@ -6978,12 +6987,14 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseMoveEvent {
             position: tab_e_bounds.center(),
             pressed_button: Some(MouseButton::Left),
             modifiers: Modifiers::default(),
+            pressure: 1.0,
         });
         cx.run_until_parked();
         cx.simulate_event(MouseUpEvent {
@@ -6991,6 +7002,7 @@ mod tests {
             button: MouseButton::Left,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
         cx.run_until_parked();
 
@@ -7033,6 +7045,7 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();
@@ -7042,6 +7055,7 @@ mod tests {
             button: MouseButton::Middle,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();
@@ -7052,6 +7066,7 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 1,
             first_mouse: false,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();
@@ -7061,6 +7076,7 @@ mod tests {
             button: MouseButton::Middle,
             modifiers: Modifiers::default(),
             click_count: 1,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();
@@ -7115,6 +7131,7 @@ mod tests {
             modifiers: Modifiers::default(),
             click_count: 2,
             first_mouse: false,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();
@@ -7124,6 +7141,7 @@ mod tests {
             button: MouseButton::Left,
             modifiers: Modifiers::default(),
             click_count: 2,
+            pressure: 1.0,
         });
 
         cx.run_until_parked();


### PR DESCRIPTION
# Objective

GPUI's mouse events carry no stylus pressure, so an application cannot tell a stylus pressed hard from one barely touching the tablet — which is most of what a tablet is for in a paint program. `MousePressureEvent` is a different thing: it reports force-click stages on a force-sensitive trackpad, not the contact pressure of a pen on the events an application actually draws with (`MouseDown`/`MouseMove`/`MouseUp`).

This PR adds a `pressure` field to the three mouse events and wires it up on every backend, one commit per platform:

1. **Core + macOS** — the field, its contract, tests, and `NSEvent.pressure`.
2. **Windows** — `WM_POINTER` pen info, carried onto the legacy mouse messages the backend is built on.
3. **X11** — the XInput2 "Abs Pressure" valuator, alongside the existing scroll-valuator handling.
4. **Wayland** — `zwp_tablet_v2`, which is a whole input path of its own (see below).

## Solution

**The contract.** `pressure` is `f32` in `0.0..=1.0`, and it is **1.0 for a mouse** (and on any device without a pressure axis), deliberately not 0.0: a brush that multiplies its opacity by pressure would otherwise paint nothing at all with a mouse. A test pins this. The `Default` impls for the three events are manual now, for the same reason. A hovering stylus that reports a true 0 is treated per-platform as described in each commit.

**macOS** reads `NSEvent.pressure` on the mouse events, treating anything at or below zero as "no tablet" — AppKit reports 0 for an ordinary mouse click, which is indistinguishable from a stylus barely in contact.

**Windows** intercepts `WM_POINTERDOWN/UPDATE/UP` just long enough to cache the pen's pressure, then leaves the messages unhandled so `DefWindowProc` keeps synthesising the legacy `WM_MOUSE*` stream the backend is built on; each client-area mouse handler checks `GetMessageExtraInfo` for the documented pen signature and reports the cached value. Pen system gestures (press-and-hold for right click, etc.) are disabled per window via `MicrosoftTabletPenServiceProperty`, since they otherwise delay every pen-down past the point where a paint stroke can start when the pen touches. Touch and the Direct Manipulation path are untouched.

**X11** picks the "Abs Pressure" valuator class out of the same device walk that already collects scroll valuators, normalises it into `0..=1`, and caches the last value per device because XInput only includes valuators that changed. A stylus pressed harder without moving emits a motion event with only the pressure valuator set; those now count as moves so a stroke can deepen in place (scroll-only valuator events still don't).

**Wayland** is the odd one out: tablet input is a separate protocol rather than an axis on the pointer, and a compositor *stops emulating pointer events* for a tool the moment a client binds `zwp_tablet_v2`. So this commit synthesises the mouse stream from `zwp_tablet_tool_v2`: tip = left button, barrel buttons = right/middle (matching what the X11 wacom driver and Windows pen input report), proximity = enter/exit. Tool events are frame-batched and the batching is load-bearing — the `pressure` belonging to a tip-down arrives *after* the `down`, so events accumulate in a `TabletFrame` and dispatch together on `frame`. Pads are ignored but still need `Dispatch` impls, since the seat announces them unconditionally and an unclaimed `new_id` panics the queue. Two things fall out: double-click run counting moves into `ClickState::press` so stylus and pointer share one implementation, and `set_cursor_style` also updates tool cursors (each tool carries its own).

## Testing

- Two new `#[gpui::test]`s in `interactive.rs`: pressure reaches element handlers, and the mouse/default path reports 1.0. Unit tests for `ClickState::press` run counting and the tablet button mapping in the Wayland client.
- `cargo check --tests` for `gpui`, `gpui_linux`, `editor`, `terminal`, `workspace`, `ui`, `settings_ui`; `cargo test -p gpui`.
- Windows type-checked from Linux with `cargo check -p gpui_windows --target x86_64-pc-windows-gnu`. macOS reviewed by hand (every literal of the three structs was grepped for, not just the ones the compiler names first).
- Hardware caveat, stated up front: I developed this against a pressure-less X11 session, so the mouse path (device without the valuator) is the one exercised live. The X11 stylus path follows the shape of the scroll-valuator code beside it; Windows pen and Wayland tablet need real hardware to confirm. Happy to iterate if someone with a pen/tablet can try it.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added stylus pressure to GPUI's mouse events on macOS, Windows, X11 and Wayland; ordinary mice report full pressure.
