### PR TITLE
Add support for Visual Line select in terminal vi mode

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2276,6 +2276,15 @@ impl Terminal {
                     .push_back(InternalEvent::SetSelection(Some(selection)));
             }
 
+            "V" => {
+                let point = self.last_content.cursor.point;
+                let selection_type = SelectionType::Lines;
+                let side = SelectionSide::Right;
+                let selection = Selection::new(selection_type, point, side);
+                self.events
+                    .push_back(InternalEvent::SetSelection(Some(selection)));
+            }
+
             "escape" => {
                 self.events.push_back(InternalEvent::SetSelection(None));
             }


### PR DESCRIPTION
# Objective

Add support for Visual Line Select in terminal vi mode.

## Solution

Add handling for "V" akin to Visual Line Select mode in vim.

## Testing

manually tested these changes by running locally (`cargo run`)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/a39636cd-a82e-444d-bdac-8f86d76f03f4



---

Release Notes:

- Added support for Visual Line Select in terminal vi mode
