### PR TITLE
agent: Add tool guidance templates for tool descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "fs",
  "futures 0.3.32",
  "gpui",
+ "handlebars 4.5.0",
  "language_model",
  "log",
  "paths",

--- a/crates/agent/build.rs
+++ b/crates/agent/build.rs
@@ -1,0 +1,29 @@
+// RustEmbed expands embedded files during proc-macro expansion, which cargo
+// cannot track: editing only an embedded template or guidance file would not
+// rebuild this crate, and the binary would keep serving stale content.
+// Watch each embedded *.hbs individually so unrelated files in these
+// directories don't trigger rebuilds.
+//
+// Limitation: a newly added *.hbs file is not tracked until the build script
+// re-runs for another reason — after adding one, touch this file (or any
+// already-tracked .hbs) once to register it. Deletions are detected, since
+// losing a tracked file re-runs the build script.
+fn main() {
+    for dir in ["src/templates", "src/tool_guidance"] {
+        watch_hbs_files(std::path::Path::new(dir));
+    }
+}
+
+fn watch_hbs_files(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            watch_hbs_files(&path);
+        } else if path.extension().is_some_and(|ext| ext == "hbs") {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+}

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -9,6 +9,7 @@ mod templates;
 mod tests;
 mod thread;
 mod thread_store;
+mod tool_guidance;
 mod tool_permissions;
 mod tools;
 

--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -14,9 +14,7 @@ pub struct Templates(Handlebars<'static>);
 
 impl Templates {
     pub fn new() -> Arc<Self> {
-        let mut handlebars = Handlebars::new();
-        handlebars.set_strict_mode(true);
-        handlebars.register_helper("contains", Box::new(contains));
+        let mut handlebars = agent_settings::template_engine();
         handlebars.register_embed_templates::<Assets>().unwrap();
         Arc::new(Self(handlebars))
     }
@@ -62,31 +60,6 @@ pub struct SystemPromptTemplate<'a> {
 
 impl Template for SystemPromptTemplate<'_> {
     const TEMPLATE_NAME: &'static str = "system_prompt.hbs";
-}
-
-/// Handlebars helper for checking if an item is in a list
-fn contains(
-    h: &handlebars::Helper,
-    _: &handlebars::Handlebars,
-    _: &handlebars::Context,
-    _: &mut handlebars::RenderContext,
-    out: &mut dyn handlebars::Output,
-) -> handlebars::HelperResult {
-    let list = h
-        .param(0)
-        .and_then(|v| v.value().as_array())
-        .ok_or_else(|| {
-            handlebars::RenderError::new("contains: missing or invalid list parameter")
-        })?;
-    let query = h.param(1).map(|v| v.value()).ok_or_else(|| {
-        handlebars::RenderError::new("contains: missing or invalid query parameter")
-    })?;
-
-    if list.contains(query) {
-        out.write("true")?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4049,41 +4049,51 @@ impl Thread {
         let model = self
             .model()
             .ok_or_else(|| anyhow!(NoModelConfiguredError))?;
-        let sandboxing_enabled = crate::sandboxing::sandboxing_enabled(cx);
+        let available_tools: Vec<SharedString> = self
+            .running_turn
+            .as_ref()
+            .map(|turn| turn.tools.keys().cloned().collect())
+            .unwrap_or_default();
         let tools = if let Some(turn) = self.running_turn.as_ref() {
+            let model_name = model.name().0.to_string();
+            let date = Local::now().format("%Y-%m-%d").to_string();
+            let guidance_context = agent_settings::ToolGuidanceContext {
+                available_tools: &available_tools,
+                model_name: Some(model_name.as_str()),
+                date: &date,
+                is_linux: cfg!(target_os = "linux"),
+                is_windows: cfg!(target_os = "windows"),
+                is_macos: cfg!(target_os = "macos"),
+                // The same gate the system prompt applies to its sandbox
+                // section, so guidance text only describes behavior the
+                // session's runtime paths actually provide.
+                sandboxing: sandboxing_enabled_for_project(self.project.read(cx), cx),
+            };
             turn.tools
                 .iter()
                 .filter_map(|(tool_name, tool)| {
                     log::trace!("Including tool: {}", tool_name);
                     let mut description = tool.description().to_string();
                     let mut schema = tool.input_schema(model.tool_input_format()).log_err()?;
-                    // TEMPORARY (sandboxing feature flag): with the flag off,
-                    // the fetch and create_directory descriptions/schemas must
-                    // not advertise sandbox-dependent behavior (host grants,
-                    // out-of-project creation via the `reason` field), since
-                    // the corresponding runtime paths are disabled. Restore
-                    // the pre-sandboxing model-facing surface here rather than
-                    // forking the tools; delete this when the flag is removed
-                    // again.
-                    if !sandboxing_enabled {
-                        if tool_name.as_ref() == FetchTool::NAME {
-                            description =
-                                "Fetches a URL and returns the content as Markdown.".to_string();
-                        } else if tool_name.as_ref() == CreateDirectoryTool::NAME {
-                            description = "Creates a new directory at the specified path within \
-                                the project. Returns confirmation that the directory was \
-                                created.\n\nThis tool creates a directory and all necessary \
-                                parent directories. It should be used whenever you need to \
-                                create new directories within the project.\nThe only supported \
-                                path outside the project is `~/.agents/skills` or a descendant, \
-                                for global agent skills."
-                                .to_string();
-                            if let Some(properties) = schema
-                                .get_mut("properties")
-                                .and_then(|value| value.as_object_mut())
-                            {
-                                properties.remove("reason");
-                            }
+                    if let Some(guidance) =
+                        crate::tool_guidance::render(tool_name.as_ref(), &guidance_context)
+                    {
+                        description = guidance.to_string();
+                    }
+                    // The schema-level counterpart to the guidance tier:
+                    // `create_directory`'s `reason` input only justifies
+                    // out-of-project creation, which exists under the same
+                    // sandboxing conditions the guidance template gates on.
+                    // Schemas aren't templates, so the field is stripped here
+                    // to keep the schema consistent with the description.
+                    if !guidance_context.sandboxing
+                        && tool_name.as_ref() == CreateDirectoryTool::NAME
+                    {
+                        if let Some(properties) = schema
+                            .get_mut("properties")
+                            .and_then(|value| value.as_object_mut())
+                        {
+                            properties.remove("reason");
                         }
                     }
                     Some(LanguageModelRequestTool::function(
@@ -4100,12 +4110,6 @@ impl Thread {
 
         log::debug!("Building completion request");
         log::debug!("Completion intent: {:?}", completion_intent);
-
-        let available_tools: Vec<_> = self
-            .running_turn
-            .as_ref()
-            .map(|turn| turn.tools.keys().cloned().collect())
-            .unwrap_or_default();
 
         log::debug!("Request includes {} tools", available_tools.len());
         let messages = self.build_request_messages(available_tools, cx);

--- a/crates/agent/src/tool_guidance.rs
+++ b/crates/agent/src/tool_guidance.rs
@@ -1,0 +1,134 @@
+//! Per-tool guidance templates: a tool's model-facing description.
+//!
+//! A tool's model-facing description is an embedded Handlebars template
+//! `src/tool_guidance/<tool>.hbs`, rendered against the session context
+//! ([`agent_settings::ToolGuidanceContext`]) when the completion request is
+//! built (`Thread::build_completion_request`) and used as the tool's
+//! description, replacing the Rust doc comment. This lets the description
+//! condition on the session's tool set, platform, and sandboxing state.
+//!
+//! Because rendering happens at request-build time and the description rides
+//! on the tool's own entry in the request's `tools` array, it reaches the
+//! model exactly when the tool itself is available — sub-agents and reduced
+//! profiles included — and tools without a guidance template cost nothing
+//! (their Rust doc comment is used as-is).
+
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use agent_settings::ToolGuidanceContext;
+use gpui::SharedString;
+use rust_embed::RustEmbed;
+use util::ResultExt as _;
+
+/// Built-in guidance templates, embedded from `src/tool_guidance/*.hbs`.
+#[derive(RustEmbed)]
+#[folder = "src/tool_guidance"]
+#[include = "*.hbs"]
+struct BuiltinGuidance;
+
+/// Tool name (template file stem) → template source.
+static BUILTIN_GUIDANCE: LazyLock<BTreeMap<String, String>> = LazyLock::new(|| {
+    let mut templates = BTreeMap::new();
+    for path in BuiltinGuidance::iter() {
+        let Some(tool_name) = path.strip_suffix(".hbs") else {
+            continue;
+        };
+        if let Some(source) = BuiltinGuidance::get(&path)
+            .and_then(|file| String::from_utf8(file.data.into_owned()).log_err())
+        {
+            templates.insert(tool_name.to_string(), source);
+        }
+    }
+    templates
+});
+
+/// Renders the guidance template for `tool_name` against the session context,
+/// returning the tool's full model-facing description. Returns `None` when the
+/// tool has no guidance template or the template renders empty. A render
+/// failure is logged and returns `None` — a broken template must not break the
+/// request build.
+pub fn render(tool_name: &str, context: &ToolGuidanceContext) -> Option<SharedString> {
+    let source = BUILTIN_GUIDANCE.get(tool_name)?;
+    match agent_settings::render_template(source, context) {
+        Ok(rendered) => {
+            let rendered = rendered.trim();
+            if rendered.is_empty() {
+                None
+            } else {
+                Some(SharedString::from(rendered.to_string()))
+            }
+        }
+        Err(error) => {
+            log::error!("Failed to render tool guidance for `{tool_name}`: {error:#}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(sandboxing: bool, is_linux: bool, is_macos: bool) -> ToolGuidanceContext<'static> {
+        ToolGuidanceContext {
+            available_tools: &[],
+            model_name: Some("test-model"),
+            date: "2026-01-01",
+            is_linux,
+            is_windows: !is_linux && !is_macos,
+            is_macos,
+            sandboxing,
+        }
+    }
+
+    #[test]
+    fn test_unknown_tool_has_no_guidance() {
+        assert_eq!(render("no_such_tool", &context(true, true, false)), None);
+    }
+
+    #[test]
+    fn test_fetch_guidance_gated_on_sandboxing() {
+        let sandboxed = render("fetch", &context(true, true, false))
+            .expect("fetch guidance should render when sandboxing");
+        assert!(sandboxed.contains("Fetches a URL and returns the content as Markdown."));
+        assert!(sandboxed.contains("granted network access"));
+
+        // The stable description renders unsandboxed too; only the host-grant
+        // text is omitted when the runtime paths it describes are disabled.
+        let unsandboxed = render("fetch", &context(false, true, false))
+            .expect("fetch guidance should render without sandboxing");
+        assert!(unsandboxed.contains("Fetches a URL and returns the content as Markdown."));
+        assert!(!unsandboxed.contains("granted network access"));
+    }
+
+    #[test]
+    fn test_create_directory_guidance_gated_on_sandboxing_and_platform() {
+        let linux = render("create_directory", &context(true, true, false))
+            .expect("create_directory guidance should render when sandboxing on Linux");
+        assert!(linux.contains("Creates a new directory"));
+        assert!(linux.contains("directory **outside** the project"));
+        assert!(linux.contains("`reason`"));
+        assert!(linux.contains("The only other supported path outside the project"));
+
+        let macos = render("create_directory", &context(true, false, true))
+            .expect("create_directory guidance should render when sandboxing on macOS");
+        assert!(macos.contains("directory **outside** the project"));
+
+        // Out-of-project creation grants aren't supported on Windows, so the
+        // description must not advertise them there.
+        let windows = render("create_directory", &context(true, false, false))
+            .expect("create_directory guidance should render on Windows");
+        assert!(windows.contains("Creates a new directory"));
+        assert!(!windows.contains("directory **outside** the project"));
+        assert!(windows.contains("The only supported path outside the project"));
+
+        // Unsandboxed: the stable description renders, without the
+        // out-of-project grant behavior.
+        let unsandboxed = render("create_directory", &context(false, true, false))
+            .expect("create_directory guidance should render without sandboxing");
+        assert!(unsandboxed.contains("Creates a new directory"));
+        assert!(!unsandboxed.contains("directory **outside** the project"));
+        assert!(unsandboxed.contains("The only supported path outside the project"));
+    }
+}

--- a/crates/agent/src/tool_guidance/create_directory.hbs
+++ b/crates/agent/src/tool_guidance/create_directory.hbs
@@ -1,0 +1,22 @@
+{{!-- The full model-facing description for the `create_directory` tool, rendered
+when the completion request is built and used in place of the tool's Rust doc
+comment. Out-of-project creation only exists when terminal commands are
+sandboxed, and only on platforms that can grant a not-yet-existing directory
+(Linux/macOS), so it is gated on both. The matching `reason` input is stripped
+from the schema at request-build time under the same conditions, since schemas
+aren't templates. --}}
+Creates a new directory at the specified path within the project. Returns confirmation that the directory was created.
+
+This tool creates a directory and all necessary parent directories. It should be used whenever you need to create new directories within the project.
+{{#if (and sandboxing (or is_linux is_macos))}}
+This tool can also create a directory **outside** the project. Doing so grants
+sandboxed terminal commands write access to exactly that new directory — so,
+rather than requesting write access to a broad existing parent (e.g. your home
+directory) just to create something inside it, create the specific directory
+here first and then write into it. Justify the creation with the `reason`
+parameter: it is shown to the user, attributed to you, in the approval prompt
+that grants the write access. The only other supported path outside the project
+is `~/.agents/skills` or a descendant, for global agent skills.
+{{else}}
+The only supported path outside the project is `~/.agents/skills` or a descendant, for global agent skills.
+{{/if}}

--- a/crates/agent/src/tool_guidance/fetch.hbs
+++ b/crates/agent/src/tool_guidance/fetch.hbs
@@ -1,0 +1,18 @@
+{{!-- The full model-facing description for the `fetch` tool, rendered when the
+completion request is built and used in place of the tool's Rust doc comment.
+The host-grant behavior below only exists when terminal commands are sandboxed,
+so it is gated on the same `sandboxing` context variable the system prompt
+uses. --}}
+Fetches a URL and returns the content as Markdown.
+{{#if sandboxing}}
+This tool is not run inside the terminal OS sandbox, but it still refuses to
+reach any host that hasn't been granted network access. It shares the same
+per-host grants as the `terminal` tool: approving a host for one authorizes
+it for the other, whether the grant is for this thread or saved permanently.
+HTTP redirects are followed one hop at a time, and each hop's host must be
+granted the same way, so a granted host can't redirect the request to a host
+that hasn't been approved.
+When unsandboxed access has been granted, these restrictions are lifted
+entirely, matching the terminal, which is also how loopback and IP-literal
+hosts (which can't be granted individually) become reachable.
+{{/if}}

--- a/crates/agent/src/tools/create_directory_tool.rs
+++ b/crates/agent/src/tools/create_directory_tool.rs
@@ -19,24 +19,9 @@ use crate::{
 };
 use std::path::{Path, PathBuf};
 
-/// Creates a new directory at the specified path, and all necessary parent directories. Returns confirmation that the directory was created.
-///
-/// Use this whenever you need to create new directories. Paths inside the project are created directly.
-///
-#[cfg_attr(
-    any(target_os = "linux", target_os = "macos"),
-    doc = "This tool can also create a directory **outside** the project. When agent terminal \
-    commands are sandboxed, doing so grants those commands write access to exactly that new \
-    directory — so, rather than requesting write access to a broad existing parent (e.g. your \
-    home directory) just to create something inside it, create the specific directory here \
-    first and then write into it. The only other supported path outside the project is \
-    `~/.agents/skills` or a descendant, for global agent skills."
-)]
-#[cfg_attr(
-    not(any(target_os = "linux", target_os = "macos")),
-    doc = "The only supported path outside the project is `~/.agents/skills` or a descendant, \
-    for global agent skills."
-)]
+// The model-facing description for this tool is rendered from
+// `src/tool_guidance/create_directory.hbs` at request-build time, so the
+// schema description here is intentionally empty rather than duplicating it.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CreateDirectoryToolInput {
     /// The path of the new directory.

--- a/crates/agent/src/tools/fetch_tool.rs
+++ b/crates/agent/src/tools/fetch_tool.rs
@@ -46,18 +46,9 @@ fn normalize_url(url: &str) -> Cow<'_, str> {
     }
 }
 
-/// Fetches a URL and returns the content as Markdown.
-///
-/// This tool is not run inside the terminal OS sandbox, but it still refuses to
-/// reach any host that hasn't been granted network access. It shares the same
-/// per-host grants as the `terminal` tool: approving a host for one authorizes
-/// it for the other, whether the grant is for this thread or saved permanently.
-/// HTTP redirects are followed one hop at a time, and each hop's host must be
-/// granted the same way, so a granted host can't redirect the request to a host
-/// that hasn't been approved.
-/// When unsandboxed access has been granted, these restrictions are lifted
-/// entirely, matching the terminal, which is also how loopback and IP-literal
-/// hosts (which can't be granted individually) become reachable.
+// The model-facing description for this tool is rendered from
+// `src/tool_guidance/fetch.hbs` at request-build time, so the schema
+// description here is intentionally empty rather than duplicating it.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FetchToolInput {
     /// The URL to fetch.

--- a/crates/agent_settings/Cargo.toml
+++ b/crates/agent_settings/Cargo.toml
@@ -18,6 +18,7 @@ convert_case.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
+handlebars.workspace = true
 language_model.workspace = true
 log.workspace = true
 paths.workspace = true

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -1,4 +1,5 @@
 mod agent_profile;
+mod template_engine;
 mod user_agents_md;
 
 use std::cmp::Ordering::{Equal, Greater, Less};
@@ -24,6 +25,7 @@ use settings::{
 use util::ResultExt as _;
 
 pub use crate::agent_profile::*;
+pub use crate::template_engine::{ToolGuidanceContext, render_template, template_engine};
 pub use crate::user_agents_md::{UserAgentsMd, UserAgentsMdState, init as init_user_agents_md};
 
 pub const SUMMARIZE_THREAD_PROMPT: &str = include_str!("prompts/summarize_thread_prompt.txt");

--- a/crates/agent_settings/src/template_engine.rs
+++ b/crates/agent_settings/src/template_engine.rs
@@ -1,0 +1,363 @@
+//! Shared strict-mode Handlebars engine for the agent's prompt templates.
+//!
+//! The built-in system prompt (in the `agent` crate) and the per-tool
+//! guidance tier both render through [`template_engine`], so every template
+//! sees the same strict mode and the same small helper surface. Strict mode
+//! turns a typo'd context variable into a render error instead of silent
+//! empty output.
+//!
+//! Helper surface, deliberately small and stable:
+//!
+//! - `contains`: `{{#if (contains available_tools "grep")}}`
+//! - `join`: `{{join available_tools ", "}}`
+//! - `array`: builds a list inline — `{{join (array "a" "b") ", "}}` — since
+//!   the template syntax has no array literal.
+//! - set operations over two lists, each returning a deduplicated list that
+//!   preserves the order its elements first appear in its inputs:
+//!   - `union`: elements in either list —
+//!     `{{join (union (array "a" "b") (array "b" "c")) ", "}}` → `a, b, c`
+//!   - `intersect`: elements in both lists —
+//!     `{{#if (intersect available_tools (array "grep"))}}`
+//!   - `differ`: elements of the first list absent from the second —
+//!     `{{join (differ available_tools (array "grep")) ", "}}`
+//! - the engine's built-in `and` / `or` / `not` compose as subexpressions:
+//!   `{{#if (and sandboxing (or is_linux is_macos))}}`.
+//!
+//! All helpers return typed values via `call_inner` (rather than writing to
+//! the output stream) so they keep their type when used as subexpressions —
+//! output-writing helpers degrade to strings there, where the string
+//! `"false"` would be truthy.
+
+use std::sync::LazyLock;
+
+use gpui::SharedString;
+use handlebars::{Handlebars, JsonRender as _, JsonValue, RenderError, ScopedJson};
+use serde::Serialize;
+
+/// The session context available to tool guidance templates.
+///
+/// Deliberately small and stable: it covers the axes tool guidance actually
+/// conditions on — the session's tool set, platform, sandboxing state —
+/// without exposing request-builder internals that templates would couple to.
+#[derive(Serialize)]
+pub struct ToolGuidanceContext<'a> {
+    /// Names of the tools enabled for the session.
+    pub available_tools: &'a [SharedString],
+    pub model_name: Option<&'a str>,
+    /// Today's date, `YYYY-MM-DD`.
+    pub date: &'a str,
+    pub is_linux: bool,
+    pub is_windows: bool,
+    pub is_macos: bool,
+    /// Whether agent terminal commands are sandboxed for this thread's
+    /// project — the same gate the built-in system prompt applies to its
+    /// sandbox section.
+    pub sandboxing: bool,
+}
+
+/// A strict-mode Handlebars registry with the shared helpers registered.
+pub fn template_engine() -> Handlebars<'static> {
+    let mut handlebars = Handlebars::new();
+    handlebars.set_strict_mode(true);
+    handlebars.register_helper("contains", Box::new(ContainsHelper));
+    handlebars.register_helper("join", Box::new(JoinHelper));
+    handlebars.register_helper("array", Box::new(ArrayHelper));
+    handlebars.register_helper("union", Box::new(SetOpHelper(SetOp::Union)));
+    handlebars.register_helper("intersect", Box::new(SetOpHelper(SetOp::Intersect)));
+    handlebars.register_helper("differ", Box::new(SetOpHelper(SetOp::Differ)));
+    handlebars
+}
+
+/// The shared helper-registered engine, built once and reused by
+/// [`render_template`], which renders tool guidance per-tool on every
+/// completion request and would otherwise rebuild the registry each time.
+static TEMPLATE_ENGINE: LazyLock<Handlebars<'static>> = LazyLock::new(template_engine);
+
+/// Renders a template source against the shared engine.
+pub fn render_template(source: &str, context: &impl Serialize) -> anyhow::Result<String> {
+    Ok(TEMPLATE_ENGINE.render_template(source, context)?)
+}
+
+/// Handlebars helper for checking if an item is in a list:
+/// `{{#if (contains available_tools "grep")}}`.
+#[derive(Clone, Copy)]
+pub struct ContainsHelper;
+
+impl handlebars::HelperDef for ContainsHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        _: &'reg handlebars::Handlebars<'reg>,
+        _: &'rc handlebars::Context,
+        _: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+        let list = h
+            .param(0)
+            .and_then(|value| value.value().as_array())
+            .ok_or_else(|| RenderError::new("contains: missing or invalid list parameter"))?;
+        let query = h
+            .param(1)
+            .map(|value| value.value())
+            .ok_or_else(|| RenderError::new("contains: missing or invalid query parameter"))?;
+        Ok(ScopedJson::Derived(JsonValue::Bool(list.contains(query))))
+    }
+}
+
+/// Handlebars helper for joining a list into a string with a separator:
+/// `{{join available_tools ", "}}`. Elements render like `{{this}}` would
+/// render them.
+#[derive(Clone, Copy)]
+pub struct JoinHelper;
+
+impl handlebars::HelperDef for JoinHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        _: &'reg handlebars::Handlebars<'reg>,
+        _: &'rc handlebars::Context,
+        _: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+        let list = h
+            .param(0)
+            .and_then(|value| value.value().as_array())
+            .ok_or_else(|| RenderError::new("join: missing or invalid list parameter"))?;
+        let separator = h
+            .param(1)
+            .and_then(|value| value.value().as_str())
+            .ok_or_else(|| RenderError::new("join: missing or invalid separator parameter"))?;
+        let joined = list
+            .iter()
+            .map(|value| value.render())
+            .collect::<Vec<_>>()
+            .join(separator);
+        Ok(ScopedJson::Derived(JsonValue::String(joined)))
+    }
+}
+
+/// Handlebars helper that builds a JSON array from its parameters, letting
+/// templates construct a list inline: `{{join (array "a" "b") ", "}}` or
+/// `{{#if (contains (array "a" "b") "a")}}`. The template syntax has no array
+/// literal, so this is the only way to define a list in place.
+#[derive(Clone, Copy)]
+pub struct ArrayHelper;
+
+impl handlebars::HelperDef for ArrayHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        _: &'reg handlebars::Handlebars<'reg>,
+        _: &'rc handlebars::Context,
+        _: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+        Ok(ScopedJson::Derived(JsonValue::Array(
+            h.params()
+                .iter()
+                .map(|param| param.value().clone())
+                .collect(),
+        )))
+    }
+}
+
+/// Set operation applied by [`SetOpHelper`].
+#[derive(Clone, Copy)]
+enum SetOp {
+    /// Elements in either list.
+    Union,
+    /// Elements in both lists.
+    Intersect,
+    /// Elements of the first list absent from the second.
+    Differ,
+}
+
+impl SetOp {
+    fn name(self) -> &'static str {
+        match self {
+            SetOp::Union => "union",
+            SetOp::Intersect => "intersect",
+            SetOp::Differ => "differ",
+        }
+    }
+
+    fn apply(self, first: &[JsonValue], second: &[JsonValue]) -> Vec<JsonValue> {
+        // Deduplicate while preserving first-appearance order, so the result
+        // reads naturally when joined back into a prompt list.
+        let deduped = |values: &[JsonValue]| -> Vec<JsonValue> {
+            let mut result: Vec<JsonValue> = Vec::new();
+            for value in values {
+                if !result.contains(value) {
+                    result.push(value.clone());
+                }
+            }
+            result
+        };
+        match self {
+            SetOp::Union => deduped(
+                &first
+                    .iter()
+                    .chain(second.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            SetOp::Intersect => deduped(
+                &first
+                    .iter()
+                    .filter(|value| second.contains(value))
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            SetOp::Differ => deduped(
+                &first
+                    .iter()
+                    .filter(|value| !second.contains(value))
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+        }
+    }
+}
+
+/// Handlebars helper for set operations over two lists:
+/// `{{join (union available_tools (array "grep")) ", "}}` or
+/// `{{#if (intersect available_tools (array "grep"))}}`. Returns a
+/// deduplicated list preserving first-appearance order, so it composes as a
+/// subexpression anywhere a list does.
+#[derive(Clone, Copy)]
+pub struct SetOpHelper(SetOp);
+
+impl handlebars::HelperDef for SetOpHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        _: &'reg handlebars::Handlebars<'reg>,
+        _: &'rc handlebars::Context,
+        _: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> Result<ScopedJson<'reg, 'rc>, RenderError> {
+        let name = self.0.name();
+        let list = |index: usize| -> Result<&Vec<JsonValue>, RenderError> {
+            h.param(index)
+                .and_then(|value| value.value().as_array())
+                .ok_or_else(|| {
+                    RenderError::new(format!("{name}: missing or invalid list parameter {index}"))
+                })
+        };
+        Ok(ScopedJson::Derived(JsonValue::Array(
+            self.0.apply(list(0)?, list(1)?),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(source: &str) -> anyhow::Result<String> {
+        let available_tools = vec![SharedString::from("grep"), SharedString::from("terminal")];
+        let context = ToolGuidanceContext {
+            available_tools: &available_tools,
+            model_name: Some("test-model"),
+            date: "2026-01-01",
+            is_linux: false,
+            is_windows: false,
+            is_macos: true,
+            sandboxing: true,
+        };
+        render_template(source, &context)
+    }
+
+    #[test]
+    fn test_contains_as_subexpression() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{#if (contains available_tools \"grep\")}}yes{{else}}no{{/if}}")?,
+            "yes"
+        );
+        assert_eq!(
+            render("{{#if (contains available_tools \"fetch\")}}yes{{else}}no{{/if}}")?,
+            "no"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_join() -> anyhow::Result<()> {
+        assert_eq!(render("{{join available_tools \", \"}}")?, "grep, terminal");
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_builds_inline_list() -> anyhow::Result<()> {
+        assert_eq!(render("{{join (array \"a\" \"b\") \"-\"}}")?, "a-b");
+        assert_eq!(
+            render("{{#if (contains (array \"a\" \"b\") \"b\")}}yes{{else}}no{{/if}}")?,
+            "yes"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_builtin_boolean_helpers_compose() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{#if (and sandboxing (or is_linux is_macos))}}yes{{else}}no{{/if}}")?,
+            "yes"
+        );
+        assert_eq!(
+            render("{{#if (and sandboxing (not is_macos))}}yes{{else}}no{{/if}}")?,
+            "no"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_union() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{join (union available_tools (array \"terminal\" \"fetch\")) \", \"}}")?,
+            "grep, terminal, fetch"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_intersect() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{join (intersect available_tools (array \"terminal\" \"fetch\")) \", \"}}")?,
+            "terminal"
+        );
+        assert_eq!(
+            render("{{#if (intersect available_tools (array \"grep\"))}}yes{{else}}no{{/if}}")?,
+            "yes"
+        );
+        assert_eq!(
+            render("{{#if (intersect available_tools (array \"fetch\"))}}yes{{else}}no{{/if}}")?,
+            "no"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_differ() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{join (differ available_tools (array \"grep\")) \", \"}}")?,
+            "terminal"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_ops_deduplicate_preserving_order() -> anyhow::Result<()> {
+        assert_eq!(
+            render("{{join (union (array \"b\" \"a\" \"b\") (array \"a\" \"c\")) \", \"}}")?,
+            "b, a, c"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_ops_reject_non_list_parameters() {
+        assert!(render("{{union available_tools \"grep\"}}").is_err());
+        assert!(render("{{differ \"grep\" available_tools}}").is_err());
+    }
+
+    #[test]
+    fn test_strict_mode_rejects_unknown_variables() {
+        assert!(render("{{no_such_variable}}").is_err());
+    }
+}


### PR DESCRIPTION
# Objective

- Closes #63261

## Solution

- **Shared strict-mode Handlebars engine in `agent_settings`** with a deliberately small, stable context (`available_tools`, `date`, `is_linux`/`is_macos`/`is_windows`, `model_name`, `sandboxing`) and `contains`/`join`/`array`/`union`/`intersect`/`differ` helpers.
- **Description handlebars template per tool**: embedded default guidance templates in `crates/agent/src/tool_guidance/<tool>.hbs`, rendered and replace a tool's description(if handlebars template for this tool exisits) at request-build time — so tool instructions can adapt to the session's tool set, platform, and sandboxing state. Tool descriptions are the right home for this: the system prompt starts the cached prefix (context-varying content there busts the prompt cache), while tool descriptions are per-tool and only sent when the tool is enabled.
- **TEMPORARY migration**: the sandbox-conditional text for `fetch` and `create_directory` that was hardcoded in `Thread::build_completion_request` now lives in the templates (gated on `sandboxing`). The `create_directory` schema `reason`-property strip remains as a small function of the same context value, since schemas can't be templated this way.

## Testing

- `./script/clippy`
- `cargo test -p agent_settings`
- `cargo test -p agent`

### New tests

- `agent_settings::template_engine` — 10 tests for the shared engine: `contains` as a subexpression, `join`, inline `array`, `union`, `intersect`, `differ`, `and`/`or`/`not` composition, strict-mode rejection of unknown variables, preservation of element order for mathematical set operators, rejection of non-list (json list, as handlebars works on serilized json) for mathematical set operators.
- `agent::tool_guidance` — 3 tests: unknown-tool fallback (`None`), `fetch` guidance gated on `sandboxing`, and `create_directory` guidance gated on `sandboxing` plus Linux/macOS.
- `agent::templates` — the 10 existing system-prompt tests now run through the shared engine, guarding the `contains` helper migration.

### Results

- `cargo test -p agent_settings`: 50 passed, 0 failed
- `cargo test -p agent`: 730 passed, 0 failed, 11 ignored

### Showcase
A example of part of my owned `terminal` tool description powered by same scaffold (+handlebars updated to v6.x):
```handlebars
{{#if (gt (len (intersect available_tools (array 'read_file' 'grep' 'find_path'))) 0)}}
Never use this tool to find/read/edit a file unless the native file tools cannot cover it (error or scope limitation).
Never use this tool to find/read/edit a file unless the native file tools cannot cover it (error or scope limitation) — prefer native tools over their `terminal` counterparts when searching for file contents.
{{/if}}
{{#if (contains available_tools 'skill')}}
While using this tool to run a CLI tool, load that tool's Skill if one is available.
While using this tool to run a CLI tool, load that tool's Skill if one is available.
{{/if}}
Ask the user for the path to a specific CLI tool when a call fails with `command not found` or similar.

`cat`/`grep`/`ls`/`find` via this tool can reach anywhere on the filesystem (slow on large file trees); they respect neither `gitignore` nor `.zed/settings.json`.
{{#if is_windows}}
- Never create or redirect to a file named `nul`, `con`, `prn`, `aux`, `com1`-`com9`, or `lpt1`-`lpt9` — these are Windows reserved names.
- Use `es` (Everything Search) instead of `ls` for filename/path search — it reaches anywhere, fast.{{!-- ##### why: `ls` is slow on large file trees and needs recursive calls. ##### --}} Reach for `es` first when you need to search a repo not in `$PWD`.
{{/if}}
```

This is just an example of new scaffold, It's not in this PR.
I won't touch tool descriptions not in the referenced issue, out of scope.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
