### PR TITLE
gpui_windows: Support WindowKind::Floating

### DIFF
--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -440,22 +440,23 @@ impl WindowsWindow {
             draw_coordinator,
         } = creation_info;
         register_window_class(icon);
-        let parent_hwnd = if params.kind == WindowKind::Dialog || params.kind == WindowKind::Floating {
-            let parent_window = unsafe { GetActiveWindow() };
-            if parent_window.is_invalid() {
-                None
-            } else {
-                // Disable the parent window to make this dialog modal
-                if params.kind == WindowKind::Dialog {
-                    unsafe {
-                        EnableWindow(parent_window, false).as_bool();
-                    };
+        let parent_hwnd =
+            if params.kind == WindowKind::Dialog || params.kind == WindowKind::Floating {
+                let parent_window = unsafe { GetActiveWindow() };
+                if parent_window.is_invalid() {
+                    None
+                } else {
+                    // Disable the parent window to make this dialog modal
+                    if params.kind == WindowKind::Dialog {
+                        unsafe {
+                            EnableWindow(parent_window, false).as_bool();
+                        };
+                    }
+                    Some(parent_window)
                 }
-                Some(parent_window)
-            }
-        } else {
-            None
-        };
+            } else {
+                None
+            };
         let hide_title_bar = params
             .titlebar
             .as_ref()

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -440,15 +440,17 @@ impl WindowsWindow {
             draw_coordinator,
         } = creation_info;
         register_window_class(icon);
-        let parent_hwnd = if params.kind == WindowKind::Dialog {
+        let parent_hwnd = if params.kind == WindowKind::Dialog || params.kind == WindowKind::Floating {
             let parent_window = unsafe { GetActiveWindow() };
             if parent_window.is_invalid() {
                 None
             } else {
                 // Disable the parent window to make this dialog modal
-                unsafe {
-                    EnableWindow(parent_window, false).as_bool();
-                };
+                if params.kind == WindowKind::Dialog {
+                    unsafe {
+                        EnableWindow(parent_window, false).as_bool();
+                    };
+                }
                 Some(parent_window)
             }
         } else {
@@ -483,6 +485,12 @@ impl WindowsWindow {
             let dwexstyle = if params.kind == WindowKind::Dialog {
                 dwstyle |= WS_POPUP | WS_CAPTION;
                 WS_EX_DLGMODALFRAME
+            } else if params.kind == WindowKind::Floating && parent_hwnd.is_some() {
+                dwstyle |= WS_POPUPWINDOW;
+                if !hide_title_bar {
+                    dwstyle |= WS_CAPTION;
+                }
+                WS_EX_APPWINDOW
             } else {
                 WS_EX_APPWINDOW
             };
@@ -628,6 +636,8 @@ impl PlatformWindow for WindowsWindow {
     fn resize(&mut self, size: Size<Pixels>) {
         let hwnd = self.0.hwnd;
         let bounds = gpui::bounds(self.bounds().origin, size).to_device_pixels(self.scale_factor());
+
+        _ = self.state.border_offset.update(hwnd);
         let rect = calculate_window_rect(bounds, &self.state.border_offset);
 
         self.0


### PR DESCRIPTION
# Objective

- WindowKind::Floating did nothing on Windows

## Solution

- Sets WS_POPUPWINDOW flag and parent_hwnd for WindowKind::Floating

## Testing

Tested locally with my project https://github.com/Moulberry/PandoraLauncher on Windows

`_ = self.state.border_offset.update(hwnd);` was added to resize() because the initial call to GetWindowRect/GetClientRect is broken for popups, causing resizes to break

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

Window floats even though parent window was clicked
<img width="484" height="304" alt="image" src="https://github.com/user-attachments/assets/2d090f52-64f8-4d33-9d05-728d96b190cc" />

Release Notes:

- gpui_windows: Support WindowKind::Floating
