### PR TITLE
language: Keep touching ranges when splicing combined injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1752,34 +1752,27 @@ pub(crate) fn splice_included_ranges(
             ),
         };
 
-        let mut start_ix = ranges_ix
-            + match ranges[ranges_ix..].binary_search_by_key(&remove.start, |r| r.end_byte) {
-                Ok(ix) => ix,
-                Err(ix) => ix,
-            };
-        let mut end_ix = ranges_ix
-            + match ranges[ranges_ix..].binary_search_by_key(&remove.end, |r| r.start_byte) {
-                Ok(ix) => ix + 1,
-                Err(ix) => ix,
-            };
+        // Splice out the ranges that the change actually overlaps. A non-empty range
+        // that merely *touches* the change - it ends where the change begins, or
+        // begins where the change ends - is unaffected by it and must be preserved:
+        // the injection query is only re-run over the changed ranges, so a range that
+        // is removed here but not re-reported by the query is lost for good. Combined
+        // injections routinely produce such touching ranges; the Go template lexer,
+        // for example, splits `podSelector: {}` into three adjacent `(text)` nodes.
+        //
+        // Empty ranges are the exception: several of them can share a start or end
+        // byte, so touching empty ranges are included in the splice.
+        let start_ix = ranges_ix
+            + ranges[ranges_ix..].partition_point(|range| {
+                range.end_byte < remove.start
+                    || (range.end_byte == remove.start && range.start_byte < range.end_byte)
+            });
+        let end_ix = ranges_ix
+            + ranges[ranges_ix..].partition_point(|range| {
+                range.start_byte < remove.end
+                    || (range.start_byte == remove.end && range.start_byte == range.end_byte)
+            });
 
-        // If there are empty ranges, then there may be multiple ranges with the same
-        // start or end. Expand the splice to include any adjacent ranges that touch
-        // the changed range.
-        while start_ix > 0 {
-            if ranges[start_ix - 1].end_byte == remove.start {
-                start_ix -= 1;
-            } else {
-                break;
-            }
-        }
-        while let Some(range) = ranges.get(end_ix) {
-            if range.start_byte == remove.end {
-                end_ix += 1;
-            } else {
-                break;
-            }
-        }
         let changed_start = changed_portion
             .as_ref()
             .map_or(usize::MAX, |range| range.start)

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -67,6 +67,51 @@ fn test_splice_included_ranges() {
     );
     assert_eq!(change, 0..1);
 
+    // preserves non-empty ranges that merely touch the changed range.
+    //
+    // Combined injections can produce adjacent content ranges - the Go template
+    // lexer splits `podSelector: {}` into the three touching `(text)` nodes
+    // `"podSelector: "`, `"{"` and `"}"`. Editing the text after them re-runs the
+    // injection query over the edited range only, so splicing out the untouched
+    // `"}"` would drop it from the combined layer for good.
+    let adjacent = vec![
+        ts_range(0..7),
+        ts_range(7..8),
+        ts_range(8..9),
+        ts_range(9..20),
+    ];
+    let (new_ranges, change) =
+        splice_included_ranges(adjacent.clone(), &[15..16], &[ts_range(9..21)]);
+    assert_eq!(
+        new_ranges,
+        &[
+            ts_range(0..7),
+            ts_range(7..8),
+            ts_range(8..9),
+            ts_range(9..21)
+        ]
+    );
+    assert_eq!(change, 3..4);
+
+    // the same edit still replaces any touching range that the query re-reported.
+    let (new_ranges, change) =
+        splice_included_ranges(adjacent, &[9..10], &[ts_range(8..9), ts_range(9..21)]);
+    assert_eq!(
+        new_ranges,
+        &[
+            ts_range(0..7),
+            ts_range(7..8),
+            ts_range(8..9),
+            ts_range(9..21)
+        ]
+    );
+    assert_eq!(change, 2..4);
+
+    // empty ranges that touch the changed range are still spliced out.
+    let with_empty_ranges = vec![ts_range(0..7), ts_range(7..7), ts_range(7..20)];
+    let (new_ranges, _) = splice_included_ranges(with_empty_ranges, &[7..7], &[ts_range(7..20)]);
+    assert_eq!(new_ranges, &[ts_range(0..7), ts_range(7..20)]);
+
     fn ts_range(range: Range<usize>) -> tree_sitter::Range {
         tree_sitter::Range {
             start_byte: range.start,
@@ -819,6 +864,28 @@ fn test_combined_injections_editing_after_last_injection(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_combined_injections_with_adjacent_ranges(cx: &mut App) {
+    // Editing inside one content range must not drop the ranges that merely
+    // touch it. The injection query is only re-run over the edited range, so a
+    // neighbor that is spliced out here is never re-reported, and the combined
+    // layer silently loses everything it contributed. See
+    // zed-industries/zed#57341, where typing in a Helm chart dropped the `}` of
+    // `podSelector: {}` and broke YAML highlighting for the rest of the file.
+    test_edit_sequence(
+        "Adjacent",
+        &[
+            "
+                int aaa;int bbb;int ccc;
+            ",
+            "
+                int aaa;int bbb;int cc«c»c;
+            ",
+        ],
+        cx,
+    );
+}
+
+#[gpui::test]
 fn test_combined_injections_inside_injections(cx: &mut App) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Markdown",
@@ -1404,6 +1471,7 @@ fn test_edit_sequence(language_name: &str, steps: &[&str], cx: &mut App) -> (Buf
     registry.add(Arc::new(ruby_lang()));
     registry.add(Arc::new(html_lang()));
     registry.add(Arc::new(erb_lang()));
+    registry.add(Arc::new(adjacent_injections_lang()));
     registry.add(markdown_lang());
     registry.add(Arc::new(markdown_inline_lang()));
 
@@ -1534,6 +1602,37 @@ fn erb_lang() -> Language {
             (
                 (content) @injection.content
                 (#set! injection.language "html")
+                (#set! injection.combined)
+            )
+        "#,
+    )
+    .unwrap()
+}
+
+/// A language whose injection query produces *adjacent* combined content
+/// ranges, like the Go template grammar does: because its lexer stops at `{`,
+/// `podSelector: {}` becomes the three touching `(text)` nodes
+/// `"podSelector: "`, `"{"` and `"}"`, which are then combined into one YAML
+/// layer. Consecutive C declarations written without whitespace between them
+/// have the same shape.
+fn adjacent_injections_lang() -> Language {
+    Language::new(
+        LanguageConfig {
+            name: "Adjacent".into(),
+            matcher: (LanguageMatcher {
+                path_suffixes: vec!["adjacent".into()],
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_c::LANGUAGE.into()),
+    )
+    .with_injection_query(
+        r#"
+            (
+                (declaration) @injection.content
+                (#set! injection.language "ruby")
                 (#set! injection.combined)
             )
         "#,


### PR DESCRIPTION
# Objective

Fixes #57341

Helm/go-template combined injections lose YAML highlighting after an edit. A fresh parse of the same buffer is fine; the incremental path is not.

The Go template lexer stops at `{`, so `podSelector: {}` becomes three touching `(text)` nodes (`"podSelector: "`, `"{"`, `"}"`). The Helm `injections.scm` combines those into one YAML layer. On edit, `splice_included_ranges` treated a range that only *touches* the change as part of the splice. The injection query is re-run only over the changed span, so the neighbour was removed and never put back. YAML then saw an unmatched `{` and highlighting died for the rest of the file.

## Solution

Splice by overlap, not touch.

Non-empty ranges that only share a boundary with the change stay in the combined layer. Empty ranges that share a start or end byte are still spliced — several of them can sit on the same byte, which is why the old expansion loops existed.

## Testing

- New unit cases in `test_splice_included_ranges` for adjacent content ranges and for empty ranges that still need to be spliced.
- New `test_combined_injections_with_adjacent_ranges`: C declarations with no whitespace between them, combined into one Ruby layer. Incremental parse is compared to a fresh parse after typing in the last range.
- Confirmed the new tests fail on the old splice logic (the unit test drops the touching `8..9` range; the GPUI test's incremental layer has 1 Ruby call vs 3 on a fresh parse).
- Full `syntax_map::syntax_map_tests` (28 tests, including randomized ERB / HEEx / Rust-macro edits) passes with the fix.

Reviewers can rerun:

```
cargo test -p language syntax_map::syntax_map_tests
```

I did not re-test with the Helm extension in the editor. The C+Ruby fixture produces the same adjacent combined ranges as the go-template `{}` split.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Helm/go-template files losing YAML syntax highlighting after edits near adjacent `{}` ranges
