### PR TITLE
gpui_linux: Support rigid floating windows (fixes resize on Hyprland)

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -271,7 +271,21 @@ impl WaylandSurfaceState {
             None
         };
 
-        if let Some(size) = params.window_min_size {
+        let rigid = !params.is_resizable
+            && matches!(params.kind, WindowKind::Dialog | WindowKind::Floating)
+            && (params.window_min_size.is_none()
+                || params.window_min_size == Some(params.bounds.size));
+
+        if rigid {
+            toplevel.set_min_size(
+                f32::from(params.bounds.size.width) as i32,
+                f32::from(params.bounds.size.height) as i32,
+            );
+            toplevel.set_max_size(
+                f32::from(params.bounds.size.width) as i32,
+                f32::from(params.bounds.size.height) as i32,
+            );
+        } else if let Some(size) = params.window_min_size {
             toplevel.set_min_size(f32::from(size.width) as i32, f32::from(size.height) as i32);
         }
 
@@ -288,6 +302,7 @@ impl WaylandSurfaceState {
             toplevel,
             decoration,
             dialog,
+            rigid,
         }))
     }
 }
@@ -297,6 +312,7 @@ pub struct WaylandXdgSurfaceState {
     toplevel: xdg_toplevel::XdgToplevel,
     decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
     dialog: Option<XdgDialogV1>,
+    rigid: bool,
 }
 
 pub struct WaylandLayerSurfaceState {
@@ -418,8 +434,17 @@ impl WaylandSurfaceState {
 
     fn set_geometry(&self, x: i32, y: i32, width: i32, height: i32) {
         match self {
-            WaylandSurfaceState::Xdg(WaylandXdgSurfaceState { xdg_surface, .. }) => {
+            WaylandSurfaceState::Xdg(WaylandXdgSurfaceState {
+                xdg_surface,
+                toplevel,
+                rigid,
+                ..
+            }) => {
                 xdg_surface.set_window_geometry(x, y, width, height);
+                if *rigid {
+                    toplevel.set_min_size(width, height);
+                    toplevel.set_max_size(width, height);
+                }
             }
             WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface, .. }) => {
                 // cannot set window position of a layer surface
@@ -506,6 +531,7 @@ impl WaylandSurfaceState {
                 toplevel,
                 decoration: _decoration,
                 dialog,
+                ..
             }) => {
                 // drop the dialog before toplevel so compositor can explicitly unapply it's effects
                 if let Some(dialog) = dialog {
@@ -586,12 +612,14 @@ impl WaylandWindowState {
                 xdg_state.toplevel.set_app_id(app_id.clone());
             }
 
-            // Set max window size based on the GPU's maximum texture dimension.
-            // This prevents the window from being resized larger than what the GPU can render.
-            let max_texture_size = renderer.max_texture_size() as i32;
-            xdg_state
-                .toplevel
-                .set_max_size(max_texture_size, max_texture_size);
+            if !xdg_state.rigid {
+                // Set max window size based on the GPU's maximum texture dimension.
+                // This prevents the window from being resized larger than what the GPU can render.
+                let max_texture_size = renderer.max_texture_size() as i32;
+                xdg_state
+                    .toplevel
+                    .set_max_size(max_texture_size, max_texture_size);
+            }
         }
 
         Ok(Self {


### PR DESCRIPTION
# Objective

- Support rigid floating windows on Wayland
- Fix resizes not working on Hyprland

## Solution

- If the window is non-resizeable and Floating/Dialog, we set the min size and max size to the window size

This turns the window into a "rigid" window, one where the only valid size is the size we set.
This is good because for a couple reasons:
1. Many wayland compositors allow the user to initiate a resize with a keybind, bypassing gpui's is_resizeable window flag. By making the window rigid, it can no longer be resized by the user
2. Hyprland doesn't even support resizing a floating window with xdg_surface::set_window_geometry, it *only* supports resizing via setting min/max size. See https://github.com/hyprwm/Hyprland/discussions/16030

## Testing

- Yes, with my own application, as you can see below, it fixes the box not resizing under Hyprland. Additionally, the box can no longer be manually resized with Mod+Right Click+Drag

Before change
https://github.com/user-attachments/assets/058e679f-c97e-4cd2-ae74-9e064a133a98

After change
https://github.com/user-attachments/assets/396990aa-d773-4ae0-9f7f-5b6e4fab6cdd

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

---

Release Notes:

- gpui_linux: Support rigid floating windows (fixes resize on Hyprland)
