### PR TITLE
gpui_wgpu: Allocate path render targets lazily

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -572,7 +572,7 @@ impl WgpuRenderer {
             globals_bind_group,
             path_globals_bind_group,
             instance_data,
-            // Defer intermediate texture creation to first draw call via ensure_intermediate_textures().
+            // Allocated by ensure_intermediate_textures() on the first frame that draws paths.
             // This avoids panics when the device/surface is in an invalid state during initialization.
             path_intermediate_texture: None,
             path_intermediate_view: None,
@@ -1338,8 +1338,11 @@ impl WgpuRenderer {
             }
         };
 
-        // Now that we know the surface is healthy, ensure intermediate textures exist
-        self.ensure_intermediate_textures();
+        // Only scenes with paths need the intermediate targets, and the surface
+        // has to be known healthy before allocating them.
+        if !scene.paths.is_empty() {
+            self.ensure_intermediate_textures();
+        }
 
         let frame_view = frame
             .texture


### PR DESCRIPTION
`ensure_intermediate_textures()` ran before knowing whether the scene had any paths, so every window allocated `path_intermediate` and `path_msaa` even when nothing drew a path. Both scale with the window area, and `path_msaa` also with the sample count of 4.

The call is now guarded by `scene.paths.is_empty()`. Both path draw functions already return early when the textures are absent.

`hello_world` on an Intel iGPU under Wayland, 500x500 window, no paths in the scene:

| | before | after |
| --- | --- | --- |
| allocated by wgpu | 19,275,272 B | 6,840,072 B |
| reserved by gpu-allocator | 29,360,128 B | 12,582,912 B |
| GPU memory (i915 fdinfo) | 95.8 MB | 79.4 MB |

Dropping the 9.6 MB `path_msaa` also frees the 16 MiB allocator block, so the reserved figure falls by more than the allocated one. `paths_bench`, which does draw paths, reports identical allocator totals before and after.

Release Notes:

- Improved GPU memory usage by allocating path rendering targets only when a frame draws paths.
