### PR TITLE
ai: Add DeepSeek V4 Flash Vision Experimental model

### DIFF
--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -55,6 +55,8 @@ pub enum Model {
     #[serde(rename = "deepseek-v4-pro")]
     #[default]
     V4Pro,
+    #[serde(rename = "deepseek-v4-flash-vision-exp")]
+    V4FlashVisionExp,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -74,6 +76,7 @@ impl Model {
         match id {
             "deepseek-v4-flash" => Ok(Self::V4Flash),
             "deepseek-v4-pro" => Ok(Self::V4Pro),
+            "deepseek-v4-flash-vision-exp" => Ok(Self::V4FlashVisionExp),
             _ => anyhow::bail!("invalid model id {id}"),
         }
     }
@@ -82,6 +85,7 @@ impl Model {
         match self {
             Self::V4Flash => "deepseek-v4-flash",
             Self::V4Pro => "deepseek-v4-pro",
+            Self::V4FlashVisionExp => "deepseek-v4-flash-vision-exp",
             Self::Custom { name, .. } => name,
         }
     }
@@ -90,6 +94,7 @@ impl Model {
         match self {
             Self::V4Flash => "DeepSeek V4 Flash",
             Self::V4Pro => "DeepSeek V4 Pro",
+            Self::V4FlashVisionExp => "DeepSeek V4 Flash Vision Experimental",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name).as_str(),
@@ -98,14 +103,14 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::V4Flash | Self::V4Pro => 1_000_000,
+            Self::V4Flash | Self::V4Pro | Self::V4FlashVisionExp => 1_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
 
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
-            Self::V4Flash | Self::V4Pro => Some(384_000),
+            Self::V4Flash | Self::V4Pro | Self::V4FlashVisionExp => Some(384_000),
             Self::Custom {
                 max_output_tokens, ..
             } => *max_output_tokens,
@@ -195,7 +200,7 @@ pub enum RequestMessage {
         reasoning_content: Option<String>,
     },
     User {
-        content: String,
+        content: UserContent,
     },
     System {
         content: String,
@@ -204,6 +209,29 @@ pub enum RequestMessage {
         content: String,
         tool_call_id: String,
     },
+}
+
+/// The content of a user message. Plain text serializes as a bare string;
+/// multimodal content (e.g. images) serializes as an array of parts.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum UserContent {
+    Text(String),
+    Parts(Vec<UserContentPart>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum UserContentPart {
+    Text { text: String },
+    ImageUrl { image_url: ImageUrl },
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct ImageUrl {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -338,5 +366,44 @@ pub async fn stream_completion(
             response.status(),
             body,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_content_serializes_text_as_plain_string() {
+        let content = UserContent::Text("hello".to_string());
+        assert_eq!(serde_json::to_string(&content).unwrap(), r#""hello""#);
+    }
+
+    #[test]
+    fn user_content_serializes_parts_as_array() {
+        let content = UserContent::Parts(vec![
+            UserContentPart::Text {
+                text: "What is in this image?".to_string(),
+            },
+            UserContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "data:image/jpeg;base64,AAAA".to_string(),
+                    detail: None,
+                },
+            },
+        ]);
+        assert_eq!(
+            serde_json::to_string(&content).unwrap(),
+            r#"[{"type":"text","text":"What is in this image?"},{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,AAAA"}}]"#
+        );
+    }
+
+    #[test]
+    fn vision_model_id_round_trips() {
+        assert_eq!(
+            Model::from_id("deepseek-v4-flash-vision-exp").unwrap(),
+            Model::V4FlashVisionExp
+        );
+        assert_eq!(Model::V4FlashVisionExp.id(), "deepseek-v4-flash-vision-exp");
     }
 }

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use collections::{HashMap, IndexMap};
 use credentials_provider::CredentialsProvider;
-use deepseek::DEEPSEEK_API_URL;
+use deepseek::{DEEPSEEK_API_URL, ImageUrl, UserContent, UserContentPart};
 
 use futures::Stream;
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
@@ -168,6 +168,10 @@ impl LanguageModelProvider for DeepSeekLanguageModelProvider {
 
         models.insert("deepseek-v4-flash", deepseek::Model::V4Flash);
         models.insert("deepseek-v4-pro", deepseek::Model::V4Pro);
+        models.insert(
+            "deepseek-v4-flash-vision-exp",
+            deepseek::Model::V4FlashVisionExp,
+        );
 
         for available_model in &Self::settings(cx).available_models {
             models.insert(
@@ -284,7 +288,7 @@ impl LanguageModel for DeepSeekLanguageModel {
     fn supports_thinking(&self) -> bool {
         matches!(
             self.model,
-            deepseek::Model::V4Flash | deepseek::Model::V4Pro
+            deepseek::Model::V4Flash | deepseek::Model::V4Pro | deepseek::Model::V4FlashVisionExp
         )
     }
 
@@ -317,7 +321,7 @@ impl LanguageModel for DeepSeekLanguageModel {
     }
 
     fn supports_images(&self) -> bool {
-        false
+        matches!(self.model, deepseek::Model::V4FlashVisionExp)
     }
 
     fn telemetry_id(&self) -> String {
@@ -379,6 +383,39 @@ pub fn into_deepseek(
     let mut current_reasoning: Option<String> = None;
 
     for message in request.messages {
+        // User messages containing images are sent as a single multimodal
+        // message, with text and image parts in order.
+        let send_images = message.role == Role::User
+            && matches!(model, deepseek::Model::V4FlashVisionExp)
+            && message
+                .content
+                .iter()
+                .any(|content| matches!(content, MessageContent::Image(_)));
+
+        if send_images {
+            let mut parts = Vec::new();
+            for content in message.content {
+                match content {
+                    MessageContent::Text(text) if !text.trim().is_empty() => {
+                        parts.push(UserContentPart::Text { text });
+                    }
+                    MessageContent::Image(image) => {
+                        parts.push(UserContentPart::ImageUrl {
+                            image_url: ImageUrl {
+                                url: image.to_base64_url(),
+                                detail: None,
+                            },
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            messages.push(deepseek::RequestMessage::User {
+                content: UserContent::Parts(parts),
+            });
+            continue;
+        }
+
         for content in message.content {
             match content {
                 MessageContent::Text(text) => {
@@ -390,7 +427,9 @@ pub fn into_deepseek(
 
                     if should_add {
                         messages.push(match message.role {
-                            Role::User => deepseek::RequestMessage::User { content: text },
+                            Role::User => deepseek::RequestMessage::User {
+                                content: UserContent::Text(text),
+                            },
                             Role::Assistant => deepseek::RequestMessage::Assistant {
                                 content: Some(text),
                                 tool_calls: Vec::new(),
@@ -512,7 +551,7 @@ fn deepseek_thinking(
     thinking_allowed: bool,
 ) -> Option<deepseek::Thinking> {
     let kind = match model {
-        deepseek::Model::V4Flash | deepseek::Model::V4Pro => {
+        deepseek::Model::V4Flash | deepseek::Model::V4Pro | deepseek::Model::V4FlashVisionExp => {
             if thinking_allowed {
                 deepseek::ThinkingType::Enabled
             } else {


### PR DESCRIPTION
Closes #<issue> (if applicable)

## Summary

Adds DeepSeek's experimental vision model, `deepseek-v4-flash-vision-exp`, to the DeepSeek provider alongside `deepseek-v4-flash` and `deepseek-v4-pro`.

The model has the same 1M context window and 384K max output tokens as the existing V4 models, and additionally accepts image input in user messages (per [DeepSeek's vision guide](https://api-docs.deepseek.com/guides/vision)).

## Changes

- `crates/deepseek`: add `Model::V4FlashVisionExp` with id, display name, and token limits
- `crates/deepseek`: user message content is now an untagged `UserContent` enum — plain text still serializes as a bare string (wire-compatible with before), multimodal content serializes as an OpenAI-style parts array
- `crates/language_models`: register the model in `provided_models`, enable thinking and image support for it
- `into_deepseek` now sends user messages containing images as a single multimodal message with text and image parts in order; non-vision models keep ignoring images as before

## Tests

- `cargo test -p deepseek` — 3 new serde/model tests, all pass
- `cargo check -p language_models` and `cargo clippy -p deepseek -p language_models` — clean

---

Release Notes:

- Added DeepSeek V4 Flash Vision Experimental (experimental vision model) to the DeepSeek provider

Human in the loop: all changes reviewed and verified locally by a human before opening this PR.
