### PR TITLE
task: Tolerate trailing commas in unmodeled VS Code launch.json/tasks.json fields

### DIFF
--- a/crates/task/src/serde_helpers.rs
+++ b/crates/task/src/serde_helpers.rs
@@ -1,5 +1,26 @@
-use serde::de::{self, Deserializer, Visitor};
+use serde::Deserialize;
+use serde::de::{self, DeserializeOwned, Deserializer, Visitor};
 use std::fmt;
+
+/// Deserializes `T` after first materializing the input into an owned
+/// [`serde_json_lenient::Value`].
+///
+/// `serde_json_lenient` tolerates trailing commas in the values it actually
+/// deserializes, but its value-skipping codepath (used for object fields the
+/// target type does not model) rejects them. VS Code's `tasks.json` and
+/// `launch.json` regularly contain fields Zed doesn't model — such as
+/// `compounds` or `inputs` — and editors happily leave trailing commas inside
+/// them, which would otherwise abort the entire parse. Building a `Value`
+/// first tolerates those trailing commas, and the subsequent `from_value` has
+/// nothing to skip mid-stream.
+pub fn ignore_unknown_fields_lenient<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    let value = serde_json_lenient::Value::deserialize(deserializer)?;
+    serde_json_lenient::from_value(value).map_err(de::Error::custom)
+}
 
 /// Deserializes a non-empty string array.
 pub fn non_empty_string_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>

--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -46,12 +46,37 @@ impl VsCodeDebugTaskDefinition {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VsCodeDebugTaskFile {
-    #[serde(default)]
     version: Option<String>,
     configurations: Vec<VsCodeDebugTaskDefinition>,
+}
+
+impl<'de> Deserialize<'de> for VsCodeDebugTaskFile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize via `ignore_unknown_fields_lenient` so that trailing
+        // commas inside fields we don't model (e.g. `compounds`, `inputs`)
+        // don't abort the parse of the configurations we do care about.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct VsCodeDebugTaskFileContents {
+            #[serde(default)]
+            version: Option<String>,
+            configurations: Vec<VsCodeDebugTaskDefinition>,
+        }
+
+        let VsCodeDebugTaskFileContents {
+            version,
+            configurations,
+        } = crate::serde_helpers::ignore_unknown_fields_lenient(deserializer)?;
+        Ok(Self {
+            version,
+            configurations,
+        })
+    }
 }
 
 impl TryFrom<VsCodeDebugTaskFile> for DebugTaskFile {
@@ -190,5 +215,37 @@ mod tests {
                 build: None
             }])
         );
+    }
+
+    #[test]
+    fn test_parsing_launch_json_with_compounds_and_trailing_commas() {
+        // Regression test: an editor-formatted `launch.json` with trailing
+        // commas and a `compounds` section (which Zed does not model) must not
+        // cause the modeled `configurations` to be dropped.
+        let raw = r#"
+            {
+                "version": "0.2.0",
+                "configurations": [
+                    { "name": "Server", "type": "node", "request": "launch" },
+                    { "name": "Client", "type": "node", "request": "launch" },
+                ],
+                "compounds": [
+                    {
+                        "name": "Full Stack",
+                        "configurations": ["Server", "Client"],
+                    },
+                ],
+            }
+        "#;
+        let parsed: VsCodeDebugTaskFile =
+            serde_json_lenient::from_str(raw).expect("deserializing launch.json");
+        let zed = DebugTaskFile::try_from(parsed).expect("converting to Zed debug templates");
+
+        let labels = zed
+            .0
+            .iter()
+            .map(|scenario| scenario.label.to_string())
+            .collect::<Vec<_>>();
+        pretty_assertions::assert_eq!(labels, vec!["Server", "Client"]);
     }
 }

--- a/crates/task/src/vscode_format.rs
+++ b/crates/task/src/vscode_format.rs
@@ -138,9 +138,28 @@ impl VsCodeTaskDefinition {
 }
 
 /// [`VsCodeTaskFile`] is a superset of Code's task definition format.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct VsCodeTaskFile {
     tasks: Vec<VsCodeTaskDefinition>,
+}
+
+impl<'de> Deserialize<'de> for VsCodeTaskFile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize via `ignore_unknown_fields_lenient` so that trailing
+        // commas inside fields we don't model (e.g. `version`, `inputs`) don't
+        // abort the parse of the tasks we do care about.
+        #[derive(Deserialize)]
+        struct VsCodeTaskFileContents {
+            tasks: Vec<VsCodeTaskDefinition>,
+        }
+
+        let VsCodeTaskFileContents { tasks } =
+            crate::serde_helpers::ignore_unknown_fields_lenient(deserializer)?;
+        Ok(Self { tasks })
+    }
 }
 
 impl TryFrom<VsCodeTaskFile> for TaskTemplates {
@@ -529,6 +548,34 @@ mod tests {
         assert_eq!(vscode_definitions.tasks[1].label, "Explicit Label");
         assert_eq!(vscode_definitions.tasks[2].label, "gulp: build");
         assert_eq!(vscode_definitions.tasks[3].label, "echo hello");
+    }
+
+    #[test]
+    fn can_deserialize_tasks_with_unknown_fields_and_trailing_commas() {
+        // Regression test: an editor-formatted `tasks.json` with trailing
+        // commas and fields Zed does not model (`version`, `inputs`) must not
+        // cause the modeled `tasks` to be dropped.
+        let raw = r#"
+            {
+                "version": "2.0.0",
+                "tasks": [
+                    { "label": "build", "type": "shell", "command": "make" },
+                    { "label": "test", "type": "shell", "command": "make test" },
+                ],
+                "inputs": [
+                    { "id": "target", "type": "promptString", "description": "Target" },
+                ],
+            }
+        "#;
+        let vscode_definitions: VsCodeTaskFile =
+            serde_json_lenient::from_str(raw).unwrap();
+
+        let labels = vscode_definitions
+            .tasks
+            .iter()
+            .map(|task| task.label.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(labels, vec!["build", "test"]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #60081

## What this solves

A `.vscode/launch.json` that contains a `compounds` section **and** trailing commas causes Zed to silently drop *all* debug configurations, with only a log line:

```
ERROR [crates/project/src/project_settings.rs] parsing VSCode debug tasks, file "...launch.json": compounds: expected value at line ... column ...
```

This is easy to hit because VS Code's own JSON formatter adds trailing commas, and `compounds` is a standard VS Code feature.

## Root cause

`VsCodeDebugTaskFile` / `VsCodeTaskFile` don't model every VS Code field (`compounds`, `inputs`, top-level `version`, ...), so serde skips them. These files are parsed with `serde_json_lenient`, which tolerates trailing commas in the values it *deserializes*, but **not** in the values it *skips* (its `ignore_value` codepath). So a trailing comma anywhere inside an unmodeled field aborts the whole parse.

The codebase already documents this exact quirk and works around it in `crates/dev_container/src/devcontainer_json.rs` by materializing the input into a `serde_json_lenient::Value` first (which tolerates trailing commas) and then deserializing from that value.

## Fix

Apply the same established workaround to the two VS Code config types:
- Add `ignore_unknown_fields_lenient` to `crates/task/src/serde_helpers.rs`.
- Give `VsCodeDebugTaskFile` (launch.json) and `VsCodeTaskFile` (tasks.json) a custom `Deserialize` that routes through it.

Both files shared the identical latent bug, so both are fixed. The fix lives on the types themselves, so every caller (and the existing tests) benefit.

## Tests

- `task::vscode_debug_format::tests::test_parsing_launch_json_with_compounds_and_trailing_commas` — the exact repro from the issue; asserts both configurations survive. Reverting the fix makes this fail with `Error("key must be a string")` at the trailing comma.
- `task::vscode_format::tests::can_deserialize_tasks_with_unknown_fields_and_trailing_commas` — tasks.json counterpart with `version`/`inputs` + trailing commas.

`cargo test -p task` and `cargo clippy -p task --tests` both pass.

Release Notes:

- Fixed VS Code `launch.json`/`tasks.json` files failing to import when an unmodeled field (such as `compounds`) contained trailing commas.
