### PR TITLE
git_ui: Do not treat root commits as boundaries

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -89,7 +89,7 @@ async fn run_git_blame(
     let mut child = {
         let span = ztracing::debug_span!("spawning git-blame command", path = path.as_unix_str());
         let _enter = span.enter();
-        let mut args = vec!["blame", "--incremental"];
+        let mut args = vec!["blame", "--root", "--incremental"];
         let revision_string;
         match source {
             BlameSource::Contents(..) => args.extend(["--contents", "-"]),

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -89,7 +89,7 @@ async fn run_git_blame(
     let mut child = {
         let span = ztracing::debug_span!("spawning git-blame command", path = path.as_unix_str());
         let _enter = span.enter();
-        let mut args = vec!["blame", "--root", "--incremental"];
+        let mut args = vec!["blame", "--incremental"];
         let revision_string;
         match source {
             BlameSource::Contents(..) => args.extend(["--contents", "-"]),
@@ -111,6 +111,20 @@ async fn run_git_blame(
             .kill_on_drop(true)
             .spawn()
             .context("starting git blame process")?
+    };
+
+    let is_shallow = {
+        let output = git
+            .build_command(&["rev-parse", "--is-shallow-repository"])
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("starting git rev-parse process")?;
+
+        output.status.success()
+            && str::from_utf8(&output.stdout)
+                .map(str::trim)
+                .is_ok_and(|value| value == "true")
     };
 
     let stdin = child.stdin.take();
@@ -151,7 +165,7 @@ async fn run_git_blame(
             }
 
             let line = line_buffer.trim_end_matches(&['\r', '\n'][..]);
-            parser.push_line(line)?;
+            parser.push_line(line, is_shallow)?;
             lines_read += 1;
 
             if lines_read % BLAME_PARSE_YIELD_INTERVAL == 0 {
@@ -351,7 +365,7 @@ impl GitBlameParser {
         }
     }
 
-    fn push_line(&mut self, line: &str) -> Result<()> {
+    fn push_line(&mut self, line: &str, is_shallow: bool) -> Result<()> {
         let mut done = false;
 
         match &mut self.current_entry {
@@ -386,7 +400,7 @@ impl GitBlameParser {
                 self.current_entry.replace(new_entry);
             }
             Some(entry) => {
-                if line == "boundary" {
+                if is_shallow && line == "boundary" {
                     entry.boundary = true;
                     return Ok(());
                 }
@@ -502,7 +516,7 @@ mod tests {
         let mut parser = GitBlameParser::new();
 
         for line in output.lines() {
-            parser.push_line(line)?;
+            parser.push_line(line, true)?;
         }
 
         Ok(parser.entries)

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -1,6 +1,6 @@
 use crate::Oid;
 use crate::commit::{get_messages, get_tag_names};
-use crate::repository::{GitBinary, RepoPath};
+use crate::repository::{GitBinary, RepoPath, read_shallow_file};
 use anyhow::{Context as _, Result};
 use collections::{HashMap, HashSet};
 use futures::{AsyncWriteExt, TryFutureExt, try_join};
@@ -113,19 +113,33 @@ async fn run_git_blame(
             .context("starting git blame process")?
     };
 
-    let is_shallow = {
-        let output = git
-            .build_command(&["rev-parse", "--is-shallow-repository"])
+    let shallow_file_content = {
+        let shallow_file_path = git
+            .build_command(&[
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "shallow",
+            ])
             .kill_on_drop(true)
             .output()
             .await
-            .context("starting git rev-parse process")?;
+            .context("resolving shallow file path")?;
 
-        output.status.success()
-            && str::from_utf8(&output.stdout)
-                .map(str::trim)
-                .is_ok_and(|value| value == "true")
+        if shallow_file_path.status.success()
+            && let Ok(path) = str::from_utf8(&shallow_file_path.stdout).map(str::trim)
+            && let Ok(Some(content)) = read_shallow_file(&std::path::Path::new(path)).await
+        {
+            std::borrow::Cow::Owned(content)
+        } else {
+            std::borrow::Cow::Borrowed("")
+        }
     };
+
+    let shallow_boundaries_hash = shallow_file_content
+        .lines()
+        .map(str::trim)
+        .map(str::as_bytes);
 
     let stdin = child.stdin.take();
     let stdout = child
@@ -165,7 +179,11 @@ async fn run_git_blame(
             }
 
             let line = line_buffer.trim_end_matches(&['\r', '\n'][..]);
-            parser.push_line(line, is_shallow)?;
+            parser.push_line(line, |oid| {
+                shallow_boundaries_hash
+                    .clone()
+                    .any(|sha| sha == oid.as_bytes())
+            })?;
             lines_read += 1;
 
             if lines_read % BLAME_PARSE_YIELD_INTERVAL == 0 {
@@ -229,6 +247,8 @@ pub struct BlameEntry {
     pub previous: Option<String>,
     pub filename: String,
 
+    /// Whether this entry is a boundary entry. Not like git blame's `boundary` marker,
+    /// This `boundary` is `shallow boundary`
     #[serde(default)]
     pub boundary: bool,
 }
@@ -365,7 +385,7 @@ impl GitBlameParser {
         }
     }
 
-    fn push_line(&mut self, line: &str, is_shallow: bool) -> Result<()> {
+    fn push_line(&mut self, line: &str, check_shallow: impl FnOnce(&Oid) -> bool) -> Result<()> {
         let mut done = false;
 
         match &mut self.current_entry {
@@ -400,8 +420,8 @@ impl GitBlameParser {
                 self.current_entry.replace(new_entry);
             }
             Some(entry) => {
-                if is_shallow && line == "boundary" {
-                    entry.boundary = true;
+                if line == "boundary" {
+                    entry.boundary = check_shallow(&entry.sha);
                     return Ok(());
                 }
                 let Some((key, value)) = line.split_once(' ') else {
@@ -516,7 +536,7 @@ mod tests {
         let mut parser = GitBlameParser::new();
 
         for line in output.lines() {
-            parser.push_line(line, true)?;
+            parser.push_line(line, |_| true)?;
         }
 
         Ok(parser.entries)

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -623,7 +623,7 @@ async fn load_commit_object<R: smol::io::AsyncBufRead + Unpin>(
     }
 }
 
-async fn read_shallow_file(shallow_file_path: &Path) -> Result<Option<String>> {
+pub(crate) async fn read_shallow_file(shallow_file_path: &Path) -> Result<Option<String>> {
     match smol::fs::read_to_string(shallow_file_path).await {
         Ok(contents) => Ok(Some(contents)),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -6727,6 +6727,79 @@ mod tests {
         assert_eq!(
             remote_urls.get("upstream").unwrap(),
             "/Users/user/My Projects/upstream.git"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_blame_complete_root_in_shallow_repository(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let repository_directory = tempfile::tempdir().unwrap();
+        git_init_repo(repository_directory.path());
+        fs::write(repository_directory.path().join("a.txt"), "one\n").unwrap();
+        git_command(repository_directory.path(), ["add", "a.txt"]);
+        git_command(
+            repository_directory.path(),
+            ["commit", "-m", "complete root"],
+        );
+        let complete_root_sha =
+            git_command_output(repository_directory.path(), ["rev-parse", "HEAD"]);
+
+        let remote_directory = tempfile::tempdir().unwrap();
+        git_init_repo(remote_directory.path());
+        git_command(
+            remote_directory.path(),
+            ["commit", "--allow-empty", "-m", "first"],
+        );
+        git_command(
+            remote_directory.path(),
+            ["commit", "--allow-empty", "-m", "second"],
+        );
+        let shallow_sha = git_command_output(remote_directory.path(), ["rev-parse", "HEAD"]);
+        git_command(
+            repository_directory.path(),
+            [
+                "fetch".to_string(),
+                "--depth=1".to_string(),
+                format!("file://{}", remote_directory.path().display()),
+                "HEAD:refs/heads/shallow".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            git_command_output(
+                repository_directory.path(),
+                ["rev-parse", "--is-shallow-repository"],
+            ),
+            "true",
+        );
+        assert_eq!(
+            fs::read_to_string(repository_directory.path().join(".git/shallow"))
+                .unwrap()
+                .trim(),
+            shallow_sha,
+        );
+        assert_ne!(complete_root_sha, shallow_sha);
+
+        let repository = RealGitRepository::new(
+            &repository_directory.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+        let blame = repository
+            .blame(repo_path("a.txt"), Rope::from("one\n"), LineEnding::Unix)
+            .await
+            .unwrap();
+        assert_eq!(
+            blame
+                .entries
+                .iter()
+                .map(|entry| (entry.sha.to_string(), entry.range.clone(), entry.boundary))
+                .collect::<Vec<_>>(),
+            vec![(complete_root_sha, 0..1, false)],
         );
     }
 }


### PR DESCRIPTION
# Objective

Fixes #63838

After #63024, we introduced a fancy UI for unshallowing commits. However, Git treats root commits as boundaries, which may cause a shallow-repository warning to appear for root commits

See:
https://github.com/zed-industries/zed/blob/d84e5d4992bd445b8af8eeaf1717f4cf9c5d5a54/crates/git_ui/src/blame_ui.rs#L402-L404

## Solution

- check whether shallow-commit is 

---

Release Notes:

- Fixed blame treat root commit as `boundary`
