### PR TITLE
gpui_wgpu: Read instance flags from the environment

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -290,7 +290,7 @@ impl WgpuContext {
     pub fn instance(display: Box<dyn wgpu::wgt::WgpuHasDisplayHandle>) -> wgpu::Instance {
         wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::VULKAN | wgpu::Backends::GL,
-            flags: wgpu::InstanceFlags::default(),
+            flags: instance_flags(),
             backend_options: wgpu::BackendOptions::default(),
             memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
             display: Some(display),
@@ -565,6 +565,14 @@ impl WgpuContext {
     }
 }
 
+/// Instance flags, including the ones wgpu reads from the environment. Without
+/// them a driver reporting a zero conformance version, such as Mesa's PanVK on
+/// most Mali GPUs, cannot be enabled at all.
+#[cfg(not(target_family = "wasm"))]
+fn instance_flags() -> wgpu::InstanceFlags {
+    wgpu::InstanceFlags::from_env_or_default()
+}
+
 #[cfg(not(target_family = "wasm"))]
 fn parse_pci_id(id: &str) -> anyhow::Result<u32> {
     let mut id = id.trim();
@@ -584,7 +592,29 @@ fn parse_pci_id(id: &str) -> anyhow::Result<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_pci_id;
+    use super::{instance_flags, parse_pci_id};
+
+    #[test]
+    fn instance_flags_follow_the_environment() {
+        const KEY: &str = "WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER";
+        const FLAG: wgpu::InstanceFlags = wgpu::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER;
+
+        assert!(
+            !wgpu::InstanceFlags::default().contains(FLAG),
+            "the flag is already set without the environment, so this test proves nothing"
+        );
+
+        let previous = std::env::var_os(KEY);
+        // Safety: no other thread in this test binary reads wgpu's environment.
+        unsafe { std::env::set_var(KEY, "1") };
+        let flags = instance_flags();
+        match previous {
+            Some(value) => unsafe { std::env::set_var(KEY, value) },
+            None => unsafe { std::env::remove_var(KEY) },
+        }
+
+        assert!(flags.contains(FLAG));
+    }
 
     #[test]
     fn test_parse_device_id() {


### PR DESCRIPTION
`WgpuContext::instance` built its `InstanceDescriptor` with `InstanceFlags::default()`, which resolves to `from_build_config()` and never looks at the environment. The variables wgpu documents therefore did nothing in a GPUI application, while working in every other wgpu application.

`InstanceFlags::from_env_or_default()` is `default().with_env()`, so the base value is unchanged and behaviour with no variable set is identical.

This matters because wgpu-hal hides any Vulkan adapter whose driver reports a zero conformance version unless `ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` is set, special casing only MoltenVK. Mesa's PanVK reports zero on every Mali GPU except the G610, so on those boards the Vulkan adapter was silently dropped, GL was selected instead, and startup panicked in `create_bind_group_layout` with `Downlevel flags DownlevelFlags(VERTEX_STORAGE) are required but not supported`. The message names a GL limitation on a machine that has Vulkan, which is hard to trace back without reading wgpu-hal. `WGPU_BACKEND=vulkan` does not help, because the adapter is filtered before backend selection.

Verified on a Rockchip RK3326 with a Mali-G31 MC1, Mesa 26.1.3 PanVK, kernel 6.12.94 and sway. With `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER=1` the `hello_world` example renders, and a five minute soak drawing 192 animated quads per frame held 23.5 FPS with constant RSS and DRM memory and no GPU faults.

A full application built on GPUI and gpui-component, cross compiled for aarch64, was exercised on the same board. Without the change it panics as described above. With it, it reaches its main screen, renders text and images, starts its background worker and completes its network setup. Same binary, same hardware, same environment.

The flag enables nothing on its own. A user has to set a variable whose name says "noncompliant adapter".

Release Notes:

- Fixed GPUI ignoring wgpu's instance environment variables, which prevented running on GPUs whose Vulkan driver reports a zero conformance version, such as Mali under Mesa's PanVK.
