### PR TITLE
agent: add expand_terminal_command to clamp long commands in terminal…

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1272,6 +1272,12 @@
     //
     // Default: true
     "expand_terminal_card": true,
+    // Whether to show the full command in terminal tool call headers. When
+    // disabled, the command is clamped to a single line until the card is
+    // expanded, so long commands don't dominate the thread.
+    //
+    // Default: true
+    "expand_terminal_command": true,
     // Command to automatically run when Zed creates a Terminal Thread shell in the agent panel.
     // The command is sent to the shell as if typed, so it is interpreted by your
     // configured shell (including on Windows and remote/WSL projects).

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -599,6 +599,7 @@ mod tests {
             enable_feedback: false,
             expand_edit_card: true,
             expand_terminal_card: true,
+            expand_terminal_command: true,
             terminal_init_command: None,
             cancel_generation_on_terminal_stop: true,
             use_modifier_to_send: true,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -233,6 +233,7 @@ pub struct AgentSettings {
     pub enable_feedback: bool,
     pub expand_edit_card: bool,
     pub expand_terminal_card: bool,
+    pub expand_terminal_command: bool,
     pub terminal_init_command: Option<String>,
     pub thinking_display: ThinkingBlockDisplay,
     pub cancel_generation_on_terminal_stop: bool,
@@ -807,6 +808,7 @@ impl Settings for AgentSettings {
             enable_feedback: agent.enable_feedback.unwrap(),
             expand_edit_card: agent.expand_edit_card.unwrap(),
             expand_terminal_card: agent.expand_terminal_card.unwrap(),
+            expand_terminal_command: agent.expand_terminal_command.unwrap(),
             terminal_init_command: agent
                 .terminal_init_command
                 .filter(|command| !command.trim().is_empty()),

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -1004,6 +1004,7 @@ mod tests {
             enable_feedback: false,
             expand_edit_card: true,
             expand_terminal_card: true,
+            expand_terminal_command: true,
             terminal_init_command: None,
             cancel_generation_on_terminal_stop: true,
             use_modifier_to_send: true,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7754,6 +7754,7 @@ impl ThreadView {
         &self,
         group: SharedString,
         is_preview: bool,
+        clamp: bool,
         command: Entity<Markdown>,
         window: &Window,
         cx: &Context<Self>,
@@ -7802,6 +7803,28 @@ impl ThreadView {
                 wrap_button_visibility: markdown::WrapButtonVisibility::Hidden,
                 border: false,
             });
+        // When clamped, show only the command's first line, ellipsized, so a long
+        // command occupies one row instead of wrapping over the whole card. The
+        // full text stays available via the header's expand chevron and the copy
+        // button below.
+        let command_body = if clamp {
+            Label::new(
+                command_text
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+            )
+            .buffer_font(cx)
+            .size(LabelSize::Small)
+            .color(Color::Muted)
+            .truncate()
+            .into_any_element()
+        } else {
+            markdown_element.into_any_element()
+        };
+
         let copy_button_id = SharedString::from(format!("{group}-copy-command"));
         let copy_button = CopyButton::new(copy_button_id, command_text)
             .tooltip_label("Copy Command")
@@ -7813,7 +7836,7 @@ impl ThreadView {
             .p_1p5()
             .bg(header_bg)
             .when(is_preview, |this| this.pt_1().children(run_command_label))
-            .child(markdown_element)
+            .child(command_body)
             .child(div().absolute().top_1().right_1().child(copy_button))
     }
 
@@ -7873,18 +7896,25 @@ impl ThreadView {
             .map(|path| path.display().to_string())
             .unwrap_or_else(|| "current directory".to_string());
 
-        let command_element = self.render_collapsible_command(
-            header_group.clone(),
-            false,
-            tool_call.label.clone(),
-            window,
-            cx,
-        );
-
         let is_expanded = self
             .entry_view_state
             .read(cx)
             .is_tool_call_expanded(&tool_call.id);
+
+        // `expand_terminal_card` governs the output; this governs the command in
+        // the header, which otherwise soft-wraps over several lines and crowds
+        // out the conversation.
+        let clamp_command =
+            !AgentSettings::get_global(cx).expand_terminal_command && !is_expanded;
+
+        let command_element = self.render_collapsible_command(
+            header_group.clone(),
+            false,
+            clamp_command,
+            tool_call.label.clone(),
+            window,
+            cx,
+        );
 
         let truncated_tooltip = truncated_output.then(|| {
             if let Some(output) = output {
@@ -8458,6 +8488,7 @@ impl ThreadView {
                     this.child(self.render_collapsible_command(
                         card_header_id.clone(),
                         true,
+                        false,
                         tool_call.label.clone(),
                         window,
                         cx,

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -308,6 +308,12 @@ pub struct AgentSettingsContent {
     ///
     /// Default: true
     pub expand_terminal_card: Option<bool>,
+    /// Whether to show the full command in terminal tool call headers. When
+    /// disabled, the command is clamped to a single line until the card is
+    /// expanded, so long commands don't dominate the thread.
+    ///
+    /// Default: true
+    pub expand_terminal_command: Option<bool>,
     /// Command to automatically run when Zed creates a Terminal Thread shell in the agent panel.
     /// The command is sent to the shell as if typed, so it is interpreted by your
     /// configured shell (including on Windows and remote/WSL projects).

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8578,6 +8578,29 @@ fn ai_page(cx: &App) -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Expand Terminal Command",
+                description: "Whether to show the full command in terminal tool call headers. When disabled, the command is clamped to a single line until the card is expanded.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("agent.expand_terminal_command"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()?
+                            .expand_terminal_command
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .expand_terminal_command = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Terminal Thread Init Command",
                 description: "Command to automatically run when Zed creates a Terminal Thread shell in the agent panel. Runs in your configured shell.",
                 field: Box::new(SettingField {


### PR DESCRIPTION
## Objective

In the agent panel, `expand_terminal_card` controls whether a terminal tool
call's *output* is expanded, but the command itself always renders in full in
the card header. Long commands soft-wrap over several lines, so in a busy
thread the conversation gets pushed apart by shell invocations.

This hits external ACP agents hardest (Claude, Codex, opencode, ...) since they
render through the same `ThreadView` and tend to run long commands.

Related: #58333, #58314 (and #58313, which was converted into #58333).

## Solution

Add `agent.expand_terminal_command`, default `true`, so nothing changes unless
you opt in.

When set to `false`, the command in a terminal card header is clamped to a
single ellipsized line until the card is expanded. The full text stays
reachable through the existing expand chevron and the copy button.
