### PR TITLE
git_ui: Add configurable entry spacing

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1019,6 +1019,8 @@
     "dock": "right",
     // Default width of the git panel.
     "default_width": 360,
+    // Spacing between entries in the git panel. Can be 'comfortable' or 'standard'.
+    "entry_spacing": "comfortable",
     // Style of the git status indicator in the panel.
     //
     // Choices: label_color, icon

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -75,8 +75,8 @@ use prompt_store::RULES_FILE_NAMES;
 
 use serde::{Deserialize, Serialize};
 use settings::{
-    GitPanelClickBehavior, GitPanelGroupBy, GitPanelSortBy, Settings, SettingsStore, StatusStyle,
-    update_settings_file,
+    GitPanelClickBehavior, GitPanelGroupBy, GitPanelSortBy, PanelEntrySpacing, Settings,
+    SettingsStore, StatusStyle, update_settings_file,
 };
 use smallvec::SmallVec;
 use std::cell::Cell;
@@ -1230,6 +1230,7 @@ impl GitPanel {
             let mut was_file_icons = GitPanelSettings::get_global(cx).file_icons;
             let mut was_folder_indicator = GitPanelSettings::get_global(cx).folder_indicator;
             let mut was_diff_stats = GitPanelSettings::get_global(cx).diff_stats;
+            let mut was_entry_spacing = GitPanelSettings::get_global(cx).entry_spacing;
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
                 let settings = GitPanelSettings::get_global(cx);
                 let sort_by = settings.sort_by;
@@ -1238,6 +1239,7 @@ impl GitPanel {
                 let file_icons = settings.file_icons;
                 let folder_indicator = settings.folder_indicator;
                 let diff_stats = settings.diff_stats;
+                let entry_spacing = settings.entry_spacing;
                 if tree_view != was_tree_view {
                     match (&mut this.view_mode, tree_view) {
                         (GitPanelViewMode::Tree(state), false) => {
@@ -1263,7 +1265,10 @@ impl GitPanel {
                 if (diff_stats != was_diff_stats) || update_entries {
                     this.update_visible_entries(window, cx);
                 }
-                if file_icons != was_file_icons || folder_indicator != was_folder_indicator {
+                if file_icons != was_file_icons
+                    || folder_indicator != was_folder_indicator
+                    || entry_spacing != was_entry_spacing
+                {
                     cx.notify();
                 }
                 was_sort_by = sort_by;
@@ -1272,6 +1277,7 @@ impl GitPanel {
                 was_file_icons = file_icons;
                 was_folder_indicator = folder_indicator;
                 was_diff_stats = diff_stats;
+                was_entry_spacing = entry_spacing;
             })
             .detach();
 
@@ -7429,7 +7435,9 @@ impl GitPanel {
                                             ));
                                         }
                                         Some(GitListEntry::EmptySection(section)) => {
-                                            items.push(this.render_empty_section(*section));
+                                            items.push(
+                                                this.render_empty_section(*section, window, cx),
+                                            );
                                         }
                                         None => {}
                                     }
@@ -7479,8 +7487,12 @@ impl GitPanel {
         Label::new(label.into()).single_line().color(color)
     }
 
-    fn list_item_height(&self) -> Rems {
-        rems(1.75)
+    fn list_item_height(entry_spacing: PanelEntrySpacing, rem_size: Pixels) -> Pixels {
+        let comfortable_height = rems(1.75).to_pixels(rem_size);
+        match entry_spacing {
+            PanelEntrySpacing::Comfortable => comfortable_height,
+            PanelEntrySpacing::Standard => comfortable_height - px(2.),
+        }
     }
 
     fn render_list_header(
@@ -7488,7 +7500,7 @@ impl GitPanel {
         ix: usize,
         header: &GitHeaderEntry,
         has_write_access: bool,
-        _window: &Window,
+        window: &Window,
         cx: &Context<Self>,
     ) -> AnyElement {
         let id: ElementId = ElementId::Name(format!("header_{}", ix).into());
@@ -7513,7 +7525,10 @@ impl GitPanel {
         h_flex()
             .id(id)
             .group(group_name)
-            .h(self.list_item_height())
+            .h(Self::list_item_height(
+                GitPanelSettings::get_global(cx).entry_spacing,
+                window.rem_size(),
+            ))
             .w_full()
             .pl_2p5()
             .pr_1()
@@ -7591,14 +7606,17 @@ impl GitPanel {
             .into_any_element()
     }
 
-    fn render_empty_section(&self, section: Section) -> AnyElement {
+    fn render_empty_section(&self, section: Section, window: &Window, cx: &App) -> AnyElement {
         let message = match section {
             Section::Staged => "No staged changes yet",
             Section::Unstaged => "No unstaged changes",
             _ => "No changes",
         };
         h_flex()
-            .h(self.list_item_height())
+            .h(Self::list_item_height(
+                GitPanelSettings::get_global(cx).entry_spacing,
+                window.rem_size(),
+            ))
             .w_full()
             .pl_2p5()
             .pr_1()
@@ -7931,7 +7949,10 @@ impl GitPanel {
 
         h_flex()
             .id(id)
-            .h(self.list_item_height())
+            .h(Self::list_item_height(
+                settings.entry_spacing,
+                window.rem_size(),
+            ))
             .w_full()
             .pl_2p5()
             .pr_1()
@@ -8145,7 +8166,10 @@ impl GitPanel {
 
         h_flex()
             .id(id)
-            .h(self.list_item_height())
+            .h(Self::list_item_height(
+                settings.entry_spacing,
+                window.rem_size(),
+            ))
             .min_w_0()
             .w_full()
             .pl_2p5()
@@ -9302,6 +9326,29 @@ mod tests {
             language_model::init(cx);
             editor::init(cx);
             crate::init(cx);
+        });
+    }
+
+    #[gpui::test]
+    fn test_entry_spacing_changes_list_item_height(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            assert_eq!(
+                GitPanel::list_item_height(GitPanelSettings::get_global(cx).entry_spacing, px(16.)),
+                px(28.)
+            );
+
+            let result = SettingsStore::update_global(cx, |store, cx| {
+                store.set_user_settings(r#"{"git_panel":{"entry_spacing":"standard"}}"#, cx)
+            })
+            .result();
+            assert!(result.is_ok(), "failed to update settings: {result:?}");
+
+            assert_eq!(
+                GitPanel::list_item_height(GitPanelSettings::get_global(cx).entry_spacing, px(16.)),
+                px(26.)
+            );
         });
     }
 

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
     FolderIndicator, GitPanelClickBehavior, GitPanelGroupBy, GitPanelSortBy, IntoGpui,
-    RegisterSetting, Settings, StatusStyle,
+    PanelEntrySpacing, RegisterSetting, Settings, StatusStyle,
 };
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 use workspace::dock::DockPosition;
@@ -19,6 +19,7 @@ pub struct GitPanelSettings {
     pub button: bool,
     pub dock: DockPosition,
     pub default_width: Pixels,
+    pub entry_spacing: PanelEntrySpacing,
     pub status_style: StatusStyle,
     pub file_icons: bool,
     pub folder_indicator: FolderIndicator,
@@ -62,6 +63,7 @@ impl Settings for GitPanelSettings {
             button: git_panel.button.unwrap(),
             dock: git_panel.dock.unwrap().into(),
             default_width: git_panel.default_width.unwrap().into_gpui(),
+            entry_spacing: git_panel.entry_spacing.unwrap(),
             status_style: git_panel.status_style.unwrap(),
             file_icons: git_panel.file_icons.unwrap(),
             folder_indicator: git_panel.folder_indicator.unwrap(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -43,7 +43,7 @@ use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics, ShowIndentGuides,
+    DockSide, PanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics, ShowIndentGuides,
     update_settings_file,
 };
 use smallvec::SmallVec;
@@ -6231,8 +6231,8 @@ impl ProjectPanel {
                     .indent_level(depth)
                     .indent_step_size(px(settings.indent_size))
                     .spacing(match settings.entry_spacing {
-                        ProjectPanelEntrySpacing::Comfortable => ListItemSpacing::Dense,
-                        ProjectPanelEntrySpacing::Standard => ListItemSpacing::ExtraDense,
+                        PanelEntrySpacing::Comfortable => ListItemSpacing::Dense,
+                        PanelEntrySpacing::Standard => ListItemSpacing::ExtraDense,
                     })
                     .selectable(false)
                     .when(

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,7 +3,7 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, FolderIndicator, IntoGpui, ProjectPanelEntrySpacing, ProjectPanelSortMode,
+    DockSide, FolderIndicator, IntoGpui, PanelEntrySpacing, ProjectPanelSortMode,
     ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
@@ -14,7 +14,7 @@ pub struct ProjectPanelSettings {
     pub hide_gitignore: bool,
     pub default_width: Pixels,
     pub dock: DockSide,
-    pub entry_spacing: ProjectPanelEntrySpacing,
+    pub entry_spacing: PanelEntrySpacing,
     pub file_icons: bool,
     pub folder_indicator: FolderIndicator,
     pub git_status: bool,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -737,6 +737,10 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: 360
     pub default_width: Option<PixelSetting>,
+    /// Spacing between entries in the git panel.
+    ///
+    /// Default: comfortable
+    pub entry_spacing: Option<PanelEntrySpacing>,
     /// How entry statuses are displayed.
     ///
     /// Default: icon
@@ -1229,6 +1233,29 @@ pub struct OutlinePanelSettingsContent {
 pub enum DockSide {
     Left,
     Right,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelEntrySpacing {
+    /// Comfortable spacing of entries.
+    #[default]
+    Comfortable,
+    /// The standard spacing of entries.
+    Standard,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -7,7 +7,8 @@ use settings_macros::{MergeFrom, with_fallible_options};
 
 use crate::{
     CenteredPaddingSettings, CommandAliasTarget, DelayMs, DockPosition, DockSide, InactiveOpacity,
-    ShowIndentGuides, ShowScrollbar, serialize_optional_f32_with_two_decimal_places,
+    PanelEntrySpacing, ShowIndentGuides, ShowScrollbar,
+    serialize_optional_f32_with_two_decimal_places,
 };
 
 #[with_fallible_options]
@@ -773,7 +774,7 @@ pub struct ProjectPanelSettingsContent {
     /// Spacing between worktree entries in the project panel.
     ///
     /// Default: comfortable
-    pub entry_spacing: Option<ProjectPanelEntrySpacing>,
+    pub entry_spacing: Option<PanelEntrySpacing>,
     /// Whether to show file icons in the project panel.
     ///
     /// Default: true
@@ -853,29 +854,6 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
-}
-
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-    MergeFrom,
-    PartialEq,
-    Eq,
-    strum::VariantArray,
-    strum::VariantNames,
-)]
-#[serde(rename_all = "snake_case")]
-pub enum ProjectPanelEntrySpacing {
-    /// Comfortable spacing of entries.
-    #[default]
-    Comfortable,
-    /// The standard spacing of entries.
-    Standard,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6097,7 +6097,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 18] {
+    fn git_panel_section() -> [SettingsPageItem; 19] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6161,6 +6161,25 @@ fn panels_page() -> SettingsPage {
                             .git_panel
                             .get_or_insert_default()
                             .default_width = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Entry Spacing",
+                description: "Spacing between entries in the Git panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git_panel.entry_spacing"),
+                    pick: |settings_content| {
+                        settings_content.git_panel.as_ref()?.entry_spacing.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .entry_spacing = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -572,7 +572,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ShowDiagnostics>(render_dropdown)
         .add_basic_renderer::<settings::ShowCloseButton>(render_dropdown)
         .add_basic_renderer::<settings::FolderIndicator>(render_dropdown)
-        .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
+        .add_basic_renderer::<settings::PanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortOrder>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5704,6 +5704,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
     "button": true,
     "dock": "left",
     "default_width": 360,
+    "entry_spacing": "comfortable",
     "status_style": "icon",
     "fallback_branch_name": "main",
     "sort_by": "path",
@@ -5722,6 +5723,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `button`: Whether to show the git panel button in the status bar
 - `dock`: Where to dock the git panel. Can be `left` or `right`
 - `default_width`: Default width of the git panel
+- `entry_spacing`: Spacing between entries in the git panel. Can be `comfortable` or `standard`
 - `status_style`: How to display git status. Can be `label_color` or `icon`
 - `fallback_branch_name`: What branch name to use if `init.defaultBranch` is not set
 - `sort_by`: How to sort entries in the git panel. Can be `path` or `name`


### PR DESCRIPTION
Adds a `git_panel.entry_spacing` setting with `comfortable` and `standard` options, matching the existing Project Panel customization.

`comfortable` preserves the current Git Panel row height. `standard` applies the same 2px reduction used by the Project Panel's extra-dense spacing. Changes apply to file, directory, section header, and empty-section rows without requiring a restart.

The Project Panel and Git Panel settings remain independently configurable while sharing the `PanelEntrySpacing` option type.

```json
{
  "git_panel": {
    "entry_spacing": "standard"
  }
}
```

Testing:

- Manually tested both spacing options.
- Verified that changing the setting rerenders the Git Panel without restarting Zed.
- `cargo test -p git_ui test_entry_spacing_changes_list_item_height --lib`

Release Notes:

- Added configurable entry spacing to the Git Panel.
