### PR TITLE
Feature/open running container

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -49,7 +49,7 @@ use workspace::{
     SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceId,
     notifications::DetachAndPromptErr, with_active_or_new_workspace,
 };
-use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote};
+use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote, OpenRunningContainer};
 
 actions!(
     recent_projects,
@@ -502,6 +502,25 @@ pub fn init(cx: &mut App) {
     });
 
     cx.observe_new(DisconnectedOverlay::register).detach();
+
+    cx.on_action(|_: &OpenRunningContainer, cx| {
+        let create_new_window = default_open_in_new_window(cx);
+        let use_podman = dev_container::use_podman(cx);
+        with_active_or_new_workspace(cx, move |workspace, window, cx| {
+            let fs = workspace.project().read(cx).fs().clone();
+            let handle = cx.entity().downgrade();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                RemoteServerProjects::new_running_container(
+                    create_new_window,
+                    use_podman,
+                    fs,
+                    window,
+                    handle,
+                    cx,
+                )
+            });
+        });
+    });
 
     cx.on_action(|_: &OpenDevContainer, cx| {
         with_active_or_new_workspace(cx, move |workspace, window, cx| {

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -25,8 +25,9 @@ use paths::{global_ssh_config_file, user_ssh_config_file};
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
 use project::{Fs, Project};
 use remote::{
-    RemoteClient, RemoteConnectionOptions, SshConnectionOptions, WslConnectionOptions,
-    remote_client::ConnectionIdentifier,
+    DockerConnectionOptions, RemoteClient, RemoteConnectionOptions, RunningContainer,
+    SshConnectionOptions, WslConnectionOptions, remote_client::ConnectionIdentifier,
+    running_container_defaults, running_containers,
 };
 use settings::{
     RemoteProject, RemoteSettingsContent, Settings as _, SettingsStore, update_settings_file,
@@ -165,6 +166,9 @@ enum ProjectPickerData {
     Wsl {
         distro_name: SharedString,
     },
+    Container {
+        name: SharedString,
+    },
 }
 
 struct ProjectPicker {
@@ -176,6 +180,226 @@ struct ProjectPicker {
 struct EditNicknameState {
     index: SshServerIndex,
     editor: Entity<Editor>,
+}
+
+struct RunningContainerPickerDelegate {
+    selected_index: usize,
+    containers: Vec<RunningContainer>,
+    matching_containers: Vec<RunningContainer>,
+    parent_modal: WeakEntity<RemoteServerProjects>,
+    use_podman: bool,
+    loading: bool,
+    inspecting: bool,
+}
+
+impl RunningContainerPickerDelegate {
+    fn new(parent_modal: WeakEntity<RemoteServerProjects>, use_podman: bool) -> Self {
+        Self {
+            selected_index: 0,
+            containers: Vec::new(),
+            matching_containers: Vec::new(),
+            parent_modal,
+            use_podman,
+            loading: true,
+            inspecting: false,
+        }
+    }
+
+    fn set_containers(&mut self, containers: Vec<RunningContainer>) {
+        self.containers = containers;
+        self.loading = false;
+    }
+}
+
+fn running_container_matches_query(container: &RunningContainer, query: &str) -> bool {
+    let query = query.to_lowercase();
+    [
+        container.names.as_str(),
+        container.image.as_str(),
+        container.id.as_str(),
+    ]
+    .into_iter()
+    .any(|field| field.to_lowercase().contains(&query))
+}
+
+impl PickerDelegate for RunningContainerPickerDelegate {
+    type ListItem = AnyElement;
+
+    fn name() -> &'static str {
+        "running container picker"
+    }
+
+    fn match_count(&self) -> usize {
+        self.matching_containers.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        index: usize,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = index;
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Select a Running Container".into()
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some(
+            if self.loading {
+                "Loading running containers…"
+            } else {
+                "No running containers found"
+            }
+            .into(),
+        )
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        self.matching_containers = self
+            .containers
+            .iter()
+            .filter(|container| running_container_matches_query(container, &query))
+            .cloned()
+            .collect();
+        self.selected_index = self
+            .selected_index
+            .min(self.matching_containers.len().saturating_sub(1));
+        Task::ready(())
+    }
+
+    fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        if self.inspecting {
+            return;
+        }
+        let Some(container) = self.matching_containers.get(self.selected_index).cloned() else {
+            return;
+        };
+        self.inspecting = true;
+        let picker = cx.entity().downgrade();
+        let parent_modal = self.parent_modal.clone();
+        let use_podman = self.use_podman;
+        cx.spawn_in(window, async move |_, cx| match running_container_defaults(
+            &container.id,
+            use_podman,
+        )
+        .await
+        {
+            Ok(defaults) => {
+                if picker.read_with(cx, |_, _| ()).is_err() {
+                    return;
+                }
+                let initial_directory =
+                    (defaults.working_directory != "/").then_some(defaults.working_directory);
+                parent_modal
+                    .update_in(cx, |modal, window, cx| {
+                        modal.create_remote_project(
+                            None,
+                            RemoteConnectionOptions::Docker(DockerConnectionOptions {
+                                name: container.names,
+                                container_id: container.id,
+                                remote_user: defaults.remote_user,
+                                upload_binary_over_docker_exec: false,
+                                use_podman,
+                                remote_env: Default::default(),
+                            }),
+                            initial_directory,
+                            Some(use_podman),
+                            window,
+                            cx,
+                        );
+                    })
+                    .ok();
+            }
+            Err(error) => {
+                if picker
+                    .update(cx, |picker, cx| {
+                        picker.delegate.inspecting = false;
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+                cx.prompt(
+                    PromptLevel::Critical,
+                    "Failed to inspect running container",
+                    Some(&error.to_string()),
+                    &["OK"],
+                )
+                .await
+                .ok();
+            }
+        })
+        .detach();
+    }
+
+    fn dismissed(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.parent_modal
+            .update(cx, |modal, cx| {
+                modal.cancel(&menu::Cancel, window, cx);
+            })
+            .ok();
+    }
+
+    fn render_match(
+        &self,
+        index: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let container = self.matching_containers.get(index)?;
+        let short_id = container.id.chars().take(12).collect::<String>();
+        let details = [
+            container.names.as_str(),
+            container.image.as_str(),
+            container.id.as_str(),
+        ]
+        .join("\n");
+
+        Some(
+            ListItem::new(SharedString::from(format!("li-running-container-{index}")))
+                .inset(true)
+                .spacing(ui::ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .start_slot(Icon::new(IconName::Box).color(Color::Muted))
+                .child(
+                    v_flex()
+                        .gap_0p5()
+                        .child(
+                            h_flex()
+                                .w_full()
+                                .justify_between()
+                                .gap_2()
+                                .child(Label::new(container.names.clone()))
+                                .child(
+                                    Label::new(container.image.clone())
+                                        .size(ui::LabelSize::Small)
+                                        .color(Color::Muted),
+                                ),
+                        )
+                        .child(
+                            Label::new(short_id)
+                                .size(ui::LabelSize::Small)
+                                .color(Color::Muted),
+                        ),
+                )
+                .tooltip(Tooltip::text(details))
+                .into_any_element(),
+        )
+    }
 }
 
 struct DevContainerPickerDelegate {
@@ -408,10 +632,8 @@ impl ProjectPicker {
             RemoteConnectionOptions::Wsl(connection) => ProjectPickerData::Wsl {
                 distro_name: connection.distro_name.clone().into(),
             },
-            RemoteConnectionOptions::Docker(_) => ProjectPickerData::Ssh {
-                // Not implemented as a project picker at this time
-                connection_string: "".into(),
-                nickname: None,
+            RemoteConnectionOptions::Docker(connection) => ProjectPickerData::Container {
+                name: connection.name.clone().into(),
             },
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionOptions::Mock(options) => ProjectPickerData::Ssh {
@@ -576,6 +798,14 @@ impl gpui::Render for ProjectPicker {
                     nickname: None,
                     is_wsl: true,
                     is_devcontainer: false,
+                }
+                .render(window, cx),
+                ProjectPickerData::Container { name } => SshConnectionHeader {
+                    connection_string: name.clone(),
+                    paths: Default::default(),
+                    nickname: None,
+                    is_wsl: false,
+                    is_devcontainer: true,
                 }
                 .render(window, cx),
             })
@@ -794,6 +1024,7 @@ enum Mode {
     ViewServerOptions(ViewServerOptionsState),
     EditNickname(EditNicknameState),
     ProjectPicker(Entity<ProjectPicker>),
+    RunningContainerPicker(Entity<Picker<RunningContainerPickerDelegate>>),
     CreateRemoteServer(CreateRemoteServer),
     CreateRemoteDevContainer(CreateRemoteDevContainer),
     #[cfg(target_os = "windows")]
@@ -811,6 +1042,7 @@ impl Mode {
 
 enum RemoteMatch {
     AddServer,
+    AddRunningContainer,
     AddDevContainer,
     AddWsl,
     Separator,
@@ -898,6 +1130,9 @@ impl RemoteServerPickerDelegate {
         let mut matches = Vec::new();
         if self.query.trim().is_empty() {
             matches.push(RemoteMatch::AddServer);
+            if is_local {
+                matches.push(RemoteMatch::AddRunningContainer);
+            }
             if has_open_project && is_local {
                 matches.push(RemoteMatch::AddDevContainer);
             }
@@ -1152,6 +1387,14 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                     })
                     .ok();
             }
+            RemoteMatch::AddRunningContainer => {
+                let use_podman = dev_container::use_podman(cx);
+                remote_server_projects
+                    .update(cx, |this, cx| {
+                        this.init_running_container_mode(use_podman, window, cx);
+                    })
+                    .ok();
+            }
             RemoteMatch::AddDevContainer => {
                 remote_server_projects
                     .update(cx, |this, cx| {
@@ -1210,6 +1453,7 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                                     Some(index),
                                     connection.into(),
                                     None,
+                                    None,
                                     window,
                                     cx,
                                 );
@@ -1225,6 +1469,7 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                                 this.create_remote_project(
                                     Some(new_ix.into()),
                                     connection.into(),
+                                    None,
                                     None,
                                     window,
                                     cx,
@@ -1271,6 +1516,12 @@ impl PickerDelegate for RemoteServerPickerDelegate {
             RemoteMatch::AddServer => {
                 Some(self.render_action_item(ix, IconName::Plus, "Connect SSH Server", selected))
             }
+            RemoteMatch::AddRunningContainer => Some(self.render_action_item(
+                ix,
+                IconName::Plus,
+                "Connect Running Container",
+                selected,
+            )),
             RemoteMatch::AddDevContainer => {
                 Some(self.render_action_item(ix, IconName::Plus, "Connect Dev Container", selected))
             }
@@ -1426,6 +1677,81 @@ impl RemoteServerProjects {
             workspace,
             cx,
         )
+    }
+
+    pub fn new_running_container(
+        create_new_window: bool,
+        use_podman: bool,
+        fs: Arc<dyn Fs>,
+        window: &mut Window,
+        workspace: WeakEntity<Workspace>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut this = Self::new_inner(
+            Mode::default_mode(&BTreeSet::new(), cx),
+            create_new_window,
+            fs,
+            window,
+            workspace,
+            cx,
+        );
+        this.init_running_container_mode(use_podman, window, cx);
+        this
+    }
+
+    fn init_running_container_mode(
+        &mut self,
+        use_podman: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let parent_modal = cx.weak_entity();
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(
+                RunningContainerPickerDelegate::new(parent_modal, use_podman),
+                window,
+                cx,
+            )
+            .embedded()
+        });
+        self.mode = Mode::RunningContainerPicker(picker.clone());
+        picker.focus_handle(cx).focus(window, cx);
+        let picker = picker.downgrade();
+
+        cx.spawn_in(window, async move |_, cx| {
+            match running_containers(use_podman).await {
+                Ok(containers) => {
+                    picker
+                        .update_in(cx, |picker, window, cx| {
+                            picker.delegate.set_containers(containers);
+                            let query = picker.query(cx);
+                            picker.update_matches(query, window, cx);
+                            cx.notify();
+                        })
+                        .ok();
+                }
+                Err(error) => {
+                    if picker
+                        .update(cx, |picker, cx| {
+                            picker.delegate.loading = false;
+                            cx.notify();
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+                    cx.prompt(
+                        PromptLevel::Critical,
+                        "Failed to list running containers",
+                        Some(&error.to_string()),
+                        &["OK"],
+                    )
+                    .await
+                    .ok();
+                }
+            }
+        })
+        .detach();
     }
 
     /// Creates a new RemoteServerProjects modal that opens directly in dev container creation mode.
@@ -1784,6 +2110,7 @@ impl RemoteServerProjects {
         index: Option<ServerIndex>,
         connection_options: RemoteConnectionOptions,
         initial_directory: Option<String>,
+        return_to_running_containers: Option<bool>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1827,7 +2154,24 @@ impl RemoteServerProjects {
                             let weak = cx.entity().downgrade();
                             let fs = workspace.project().read(cx).fs().clone();
                             workspace.toggle_modal(window, cx, |window, cx| {
-                                RemoteServerProjects::new(create_new_window, fs, window, weak, cx)
+                                if let Some(use_podman) = return_to_running_containers {
+                                    RemoteServerProjects::new_running_container(
+                                        create_new_window,
+                                        use_podman,
+                                        fs,
+                                        window,
+                                        weak,
+                                        cx,
+                                    )
+                                } else {
+                                    RemoteServerProjects::new(
+                                        create_new_window,
+                                        fs,
+                                        window,
+                                        weak,
+                                        cx,
+                                    )
+                                }
                             });
                         });
                     };
@@ -1891,7 +2235,7 @@ impl RemoteServerProjects {
     fn confirm(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
         match &self.mode {
             Mode::Default | Mode::ViewServerOptions(_) => {}
-            Mode::ProjectPicker(_) => {}
+            Mode::ProjectPicker(_) | Mode::RunningContainerPicker(_) => {}
             Mode::CreateRemoteServer(state) => {
                 if let Some(prompt) = state.ssh_prompt.as_ref() {
                     prompt.update(cx, |prompt, cx| {
@@ -3079,6 +3423,7 @@ impl Focusable for RemoteServerProjects {
         match &self.mode {
             Mode::Default => self.default_picker.focus_handle(cx),
             Mode::ProjectPicker(picker) => picker.focus_handle(cx),
+            Mode::RunningContainerPicker(picker) => picker.focus_handle(cx),
             _ => self.focus_handle.clone(),
         }
     }
@@ -3108,6 +3453,7 @@ impl Render for RemoteServerProjects {
                     .render_view_options(state.clone(), window, cx)
                     .into_any_element(),
                 Mode::ProjectPicker(element) => element.clone().into_any_element(),
+                Mode::RunningContainerPicker(element) => element.clone().into_any_element(),
                 Mode::CreateRemoteServer(state) => self
                     .render_create_remote_server(state, window, cx)
                     .into_any_element(),
@@ -3133,6 +3479,20 @@ mod filter_tests {
         RemoteEntry::SshConfig {
             host: SharedString::from(host),
         }
+    }
+
+    #[test]
+    fn running_container_matches_name_image_and_full_id() {
+        let container = RunningContainer {
+            id: "0123456789abcdef0123456789abcdef".to_string(),
+            image: "example/My-API:latest".to_string(),
+            names: "my-api-container".to_string(),
+        };
+
+        assert!(running_container_matches_query(&container, "api-container"));
+        assert!(running_container_matches_query(&container, "my-api:latest"));
+        assert!(running_container_matches_query(&container, "abcdef012345"));
+        assert!(!running_container_matches_query(&container, "postgres"));
     }
 
     #[test]

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -382,10 +382,10 @@ impl Focusable for ProjectPicker {
 impl ProjectPicker {
     fn new(
         create_new_window: bool,
-        index: ServerIndex,
+        index: Option<ServerIndex>,
         connection: RemoteConnectionOptions,
         project: Entity<Project>,
-        home_dir: RemotePathBuf,
+        initial_directory: RemotePathBuf,
         workspace: WeakEntity<Workspace>,
         window: &mut Window,
         cx: &mut Context<RemoteServerProjects>,
@@ -396,7 +396,7 @@ impl ProjectPicker {
 
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list(delegate, window, cx).embedded();
-            picker.set_query(&home_dir.to_string(), window, cx);
+            picker.set_query(&initial_directory.to_string(), window, cx);
             picker
         });
 
@@ -453,38 +453,38 @@ impl ProjectPicker {
                     let (paths, paths_with_positions) =
                         determine_paths_with_positions(&remote_connection, paths).await;
 
-                    cx.update(|_, cx| {
-                        let fs = app_state.fs.clone();
-                        update_settings_file(fs, cx, {
-                            let paths = paths
-                                .iter()
-                                .map(|path| path.to_string_lossy().into_owned())
-                                .collect();
-                            move |settings, _| match index {
-                                ServerIndex::Ssh(index) => {
-                                    if let Some(server) = settings
-                                        .remote
-                                        .ssh_connections
-                                        .as_mut()
-                                        .and_then(|connections| connections.get_mut(index.0))
-                                    {
-                                        server.projects.insert(RemoteProject { paths });
-                                    };
+                    if let Some(index) = index {
+                        cx.update(|_, cx| {
+                            let fs = app_state.fs.clone();
+                            update_settings_file(fs, cx, {
+                                let paths = paths
+                                    .iter()
+                                    .map(|path| path.to_string_lossy().into_owned())
+                                    .collect();
+                                move |settings, _| match index {
+                                    ServerIndex::Ssh(index) => {
+                                        if let Some(server) =
+                                            settings.remote.ssh_connections.as_mut().and_then(
+                                                |connections| connections.get_mut(index.0),
+                                            )
+                                        {
+                                            server.projects.insert(RemoteProject { paths });
+                                        };
+                                    }
+                                    ServerIndex::Wsl(index) => {
+                                        if let Some(server) =
+                                            settings.remote.wsl_connections.as_mut().and_then(
+                                                |connections| connections.get_mut(index.0),
+                                            )
+                                        {
+                                            server.projects.insert(RemoteProject { paths });
+                                        };
+                                    }
                                 }
-                                ServerIndex::Wsl(index) => {
-                                    if let Some(server) = settings
-                                        .remote
-                                        .wsl_connections
-                                        .as_mut()
-                                        .and_then(|connections| connections.get_mut(index.0))
-                                    {
-                                        server.projects.insert(RemoteProject { paths });
-                                    };
-                                }
-                            }
-                        });
-                    })
-                    .log_err();
+                            });
+                        })
+                        .log_err();
+                    }
 
                     let window = if create_new_window {
                         let options = cx
@@ -1206,7 +1206,13 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                         let index = *index;
                         remote_server_projects
                             .update(cx, |this, cx| {
-                                this.create_remote_project(index, connection.into(), window, cx);
+                                this.create_remote_project(
+                                    Some(index),
+                                    connection.into(),
+                                    None,
+                                    window,
+                                    cx,
+                                );
                             })
                             .ok();
                     }
@@ -1217,8 +1223,9 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                             .update(cx, |this, cx| {
                                 let new_ix = this.create_host_from_ssh_config(&host, cx);
                                 this.create_remote_project(
-                                    new_ix.into(),
+                                    Some(new_ix.into()),
                                     connection.into(),
+                                    None,
                                     window,
                                     cx,
                                 );
@@ -1548,10 +1555,10 @@ impl RemoteServerProjects {
 
     fn project_picker(
         create_new_window: bool,
-        index: ServerIndex,
+        index: Option<ServerIndex>,
         connection_options: remote::RemoteConnectionOptions,
         project: Entity<Project>,
-        home_dir: RemotePathBuf,
+        initial_directory: RemotePathBuf,
         window: &mut Window,
         cx: &mut Context<Self>,
         workspace: WeakEntity<Workspace>,
@@ -1563,7 +1570,7 @@ impl RemoteServerProjects {
             index,
             connection_options,
             project,
-            home_dir,
+            initial_directory,
             workspace,
             window,
             cx,
@@ -1774,8 +1781,9 @@ impl RemoteServerProjects {
 
     fn create_remote_project(
         &mut self,
-        index: ServerIndex,
+        index: Option<ServerIndex>,
         connection_options: RemoteConnectionOptions,
+        initial_directory: Option<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1840,17 +1848,21 @@ impl RemoteServerProjects {
                         )
                     })?;
 
-                    let home_dir = project
-                        .read_with(cx, |project, cx| project.resolve_abs_path("~", cx))
-                        .await
-                        .and_then(|path| path.into_abs_path())
-                        .map(|path| RemotePathBuf::new(path, path_style))
-                        .unwrap_or_else(|| match path_style {
-                            PathStyle::Unix => RemotePathBuf::from_str("/", PathStyle::Unix),
-                            PathStyle::Windows => {
-                                RemotePathBuf::from_str("C:\\", PathStyle::Windows)
-                            }
-                        });
+                    let initial_directory = if let Some(initial_directory) = initial_directory {
+                        RemotePathBuf::new(initial_directory, path_style)
+                    } else {
+                        project
+                            .read_with(cx, |project, cx| project.resolve_abs_path("~", cx))
+                            .await
+                            .and_then(|path| path.into_abs_path())
+                            .map(|path| RemotePathBuf::new(path, path_style))
+                            .unwrap_or_else(|| match path_style {
+                                PathStyle::Unix => RemotePathBuf::from_str("/", PathStyle::Unix),
+                                PathStyle::Windows => {
+                                    RemotePathBuf::from_str("C:\\", PathStyle::Windows)
+                                }
+                            })
+                    };
 
                     workspace
                         .update_in(cx, |workspace, window, cx| {
@@ -1861,7 +1873,7 @@ impl RemoteServerProjects {
                                     index,
                                     connection_options,
                                     project,
-                                    home_dir,
+                                    initial_directory,
                                     window,
                                     cx,
                                     weak,

--- a/crates/remote/src/remote.rs
+++ b/crates/remote/src/remote.rs
@@ -15,7 +15,10 @@ pub use remote_client::{
 pub use remote_identity::{
     RemoteConnectionIdentity, remote_connection_identity, same_remote_connection_identity,
 };
-pub use transport::docker::DockerConnectionOptions;
+pub use transport::docker::{
+    DockerConnectionOptions, RunningContainer, RunningContainerDefaults,
+    running_container_defaults, running_containers,
+};
 pub use transport::ssh::{SshConnectionOptions, SshPortForwardOption};
 pub use transport::wsl::WslConnectionOptions;
 #[cfg(target_os = "windows")]

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -7,13 +7,14 @@ use parking_lot::Mutex;
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
 use semver::Version as SemanticVersion;
 use std::collections::BTreeMap;
+use std::process::Output;
 use std::time::Instant;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
 use util::ResultExt;
-use util::command::Stdio;
+use util::command::{Command, Stdio};
 use util::shell::ShellKind;
 use util::{
     paths::{PathStyle, RemotePathBuf},
@@ -50,6 +51,101 @@ pub struct DockerConnectionOptions {
     pub upload_binary_over_docker_exec: bool,
     pub use_podman: bool,
     pub remote_env: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RunningContainer {
+    #[serde(rename = "ID", alias = "Id")]
+    pub id: String,
+    pub image: String,
+    pub names: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunningContainerDefaults {
+    pub remote_user: String,
+    pub working_directory: String,
+}
+
+const CONTAINER_DEFAULTS_MARKER: &str = "=====ZED_CONTAINER_DEFAULTS_7f3a9c=====";
+
+fn container_cli(use_podman: bool) -> &'static str {
+    if use_podman { "podman" } else { "docker" }
+}
+
+fn parse_running_containers(output: &str) -> Result<Vec<RunningContainer>> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .with_context(|| format!("failed to parse container list entry: {line}"))
+        })
+        .collect()
+}
+
+fn command_output(command: &Command, output: Output) -> Result<String> {
+    anyhow::ensure!(
+        output.status.success(),
+        "failed to run command {command:?}: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub async fn running_containers(use_podman: bool) -> Result<Vec<RunningContainer>> {
+    let mut command = util::command::new_command(container_cli(use_podman));
+    command.args([
+        "ps",
+        "--no-trunc",
+        r#"--format={"ID":{{json .ID}},"Image":{{json .Image}},"Names":{{json .Names}}}"#,
+    ]);
+    let output = command
+        .output()
+        .await
+        .with_context(|| format!("failed to run {command:?}"))?;
+    let output = command_output(&command, output)?;
+    parse_running_containers(&output)
+}
+
+fn parse_running_container_defaults(output: &str) -> Result<RunningContainerDefaults> {
+    let Some((_, after_start)) = output.split_once(CONTAINER_DEFAULTS_MARKER) else {
+        anyhow::bail!("container defaults output did not contain the opening marker");
+    };
+    let Some((defaults, _)) = after_start.split_once(CONTAINER_DEFAULTS_MARKER) else {
+        anyhow::bail!("container defaults output did not contain the closing marker");
+    };
+    let mut lines = defaults.trim_matches(['\r', '\n']).lines();
+    let remote_user = lines.next().unwrap_or_default().trim().to_string();
+    let working_directory = lines.collect::<Vec<_>>().join("\n").trim().to_string();
+    anyhow::ensure!(!remote_user.is_empty(), "container user was empty");
+    anyhow::ensure!(
+        !working_directory.is_empty(),
+        "container working directory was empty"
+    );
+    Ok(RunningContainerDefaults {
+        remote_user,
+        working_directory,
+    })
+}
+
+pub async fn running_container_defaults(
+    container_id: &str,
+    use_podman: bool,
+) -> Result<RunningContainerDefaults> {
+    let script = format!(
+        "user=\"$(id -un 2>/dev/null || id -u)\" || exit 1; printf '{CONTAINER_DEFAULTS_MARKER}\\n%s\\n' \"$user\"; pwd; printf '{CONTAINER_DEFAULTS_MARKER}\\n'"
+    );
+    let mut command = util::command::new_command(container_cli(use_podman));
+    command.args(["exec", container_id, "sh", "-c", &script]);
+    let output = command
+        .output()
+        .await
+        .with_context(|| format!("failed to inspect running container {container_id}"))?;
+    let output = command_output(&command, output)
+        .with_context(|| format!("failed to inspect running container {container_id}"))?;
+    parse_running_container_defaults(&output)
 }
 
 pub(crate) struct DockerExecConnection {
@@ -120,11 +216,7 @@ impl DockerExecConnection {
     }
 
     fn docker_cli(&self) -> &str {
-        if self.connection_options.use_podman {
-            "podman"
-        } else {
-            "docker"
-        }
+        container_cli(self.connection_options.use_podman)
     }
 
     /// Run a shell command inside the container and reliably extract its output
@@ -875,5 +967,44 @@ impl RemoteConnection for DockerExecConnection {
 
     fn default_system_shell(&self) -> String {
         String::from("/bin/sh")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_running_containers() {
+        let output = concat!(
+            r#"{"ID":"0123456789abcdef","Image":"example/api:latest","Names":"api"}"#,
+            "\n",
+            r#"{"Id":"fedcba9876543210","Image":"postgres:17","Names":"database"}"#,
+            "\n"
+        );
+
+        let containers = parse_running_containers(output).expect("container output should parse");
+
+        assert_eq!(containers.len(), 2);
+        assert_eq!(containers[0].id, "0123456789abcdef");
+        assert_eq!(containers[0].names, "api");
+        assert_eq!(containers[0].image, "example/api:latest");
+        assert_eq!(containers[1].id, "fedcba9876543210");
+        assert_eq!(containers[1].names, "database");
+    }
+
+    #[test]
+    fn parses_running_container_defaults_with_surrounding_output() {
+        let output = format!(
+            "shell noise\n{CONTAINER_DEFAULTS_MARKER}\n1001\n/workspaces/project with spaces\n{CONTAINER_DEFAULTS_MARKER}\nmore noise"
+        );
+
+        assert_eq!(
+            parse_running_container_defaults(&output).expect("container defaults should parse"),
+            RunningContainerDefaults {
+                remote_user: "1001".to_string(),
+                working_directory: "/workspaces/project with spaces".to_string(),
+            }
+        );
     }
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -717,6 +717,12 @@ pub struct OpenRemote {
 #[serde(deny_unknown_fields)]
 pub struct OpenDevContainer;
 
+/// Opens a picker for connecting to a running container.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = projects)]
+#[serde(deny_unknown_fields)]
+pub struct OpenRunningContainer;
+
 /// Where to spawn the task in the UI.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
# Objective

VSCode has the option to not only open containers with a devcontainer.json setup but any regular docker or podman container. I implemented this feature in zed as well.

## Solution

I added a field to the Open Remote Folder and the command palette to open a running container. It will then ask you to enter the container (it can't derive it from the current folder, you will need to select it using the already built in fuzzy findiner). Once you do that, you will need to enter a folder, it uses the default container folder by default but there are many usecases where you don't want the default folder.

## Testing

I tested both release builds and debug builds. Note I only tested Docker support as I don't have podman installed on my pc.

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
 
A bit, but I am no expert in the zed codebase, this is my first PR after all.

- [ ] Unsafe blocks (if any) have justifying comments

There are none.

- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior

There are a few tests.

- [ ] Performance impact has been considered and is acceptable

Should be negligable.

## Showcase

Here are some screenshots:

<img width="680" height="205" alt="Screenshot_20260827_234133" src="https://github.com/user-attachments/assets/bb84dd10-dde4-4d7c-89ed-b4fc11058b80" />
<img width="1473" height="1034" alt="Screenshot_20260827_235358" src="https://github.com/user-attachments/assets/00ae01af-50da-4916-a0f7-69dcc7ef1768" />
<img width="1473" height="1034" alt="Screenshot_20260827_235418" src="https://github.com/user-attachments/assets/f14654a9-9cec-4873-bc81-90182d993865" />
<img width="1460" height="1017" alt="Screenshot_20260827_235438" src="https://github.com/user-attachments/assets/c256b5e0-8cef-454a-b00b-ae5d8c5513ec" />
<img width="1461" height="1019" alt="Screenshot_20260827_235511" src="https://github.com/user-attachments/assets/506a08de-998e-49dc-8a7c-87cb5916f670" />
<img width="1462" height="1021" alt="Screenshot_20260827_235527" src="https://github.com/user-attachments/assets/8e1aa622-033b-456e-bac0-d033d87f82cf" />


---

Release Notes:

- Add open in running container option