### PR TITLE
Add `on_new_window` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -207,6 +207,13 @@
   //  3. Never close the window
   //         "when_closing_with_no_tabs": "keep_window_open",
   "when_closing_with_no_tabs": "platform_default",
+  // What to show when opening a new window.
+  // May take 2 values:
+  //  1. Show an empty untitled buffer
+  //         "on_new_window": "empty_tab"
+  //  2. Show the launchpad with recent projects
+  //         "on_new_window": "launchpad"
+  "on_new_window": "empty_tab",
   // What to do when the last window is closed.
   // May take 2 values:
   //  1. Use the current platform's convention

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1054,6 +1054,7 @@ impl VsCodeSettings {
             } else {
                 None
             },
+            on_new_window: None,
             on_last_window_closed: None,
             pane_split_direction_horizontal: None,
             pane_split_direction_vertical: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -105,6 +105,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: none
     pub max_tabs: Option<NonZeroUsize>,
+    /// What to show when opening a new window.
+    /// Values: empty_tab, launchpad
+    /// Default: empty_tab
+    pub on_new_window: Option<OnNewWindow>,
     /// What to do when the last window is closed
     ///
     /// Default: auto (nothing on macOS, "app quit" otherwise)
@@ -676,6 +680,28 @@ pub struct CenteredLayoutSettings {
     ///
     /// Default: 0.2
     pub right_padding: Option<CenteredPaddingSettings>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Debug,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnNewWindow {
+    /// Show an empty untitled buffer when opening a new window
+    #[default]
+    EmptyTab,
+    /// Show the launchpad with recent projects when opening a new window
+    Launchpad,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -173,6 +173,20 @@ fn general_page(cx: &App) -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "On New Window",
+                description: "What to show when opening a new window.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("on_new_window"),
+                    pick: |settings_content| settings_content.workspace.on_new_window.as_ref(),
+                    write: |settings_content, value, _| {
+                        settings_content.workspace.on_new_window = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "On Last Window Closed",
                 description: "What to do when the last window is closed.",
                 field: Box::new(SettingField {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -535,6 +535,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::SaturatingBool>(render_toggle_button)
         .add_basic_renderer::<settings::CursorShape>(render_dropdown)
         .add_basic_renderer::<settings::RestoreOnStartupBehavior>(render_dropdown)
+        .add_basic_renderer::<settings::OnNewWindow>(render_dropdown)
         .add_basic_renderer::<settings::BottomDockLayout>(render_dropdown)
         .add_basic_renderer::<settings::OnLastWindowClosed>(render_dropdown)
         .add_basic_renderer::<settings::CliDefaultOpenBehavior>(render_dropdown)

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -32,6 +32,7 @@ pub struct WorkspaceSettings {
     pub command_aliases: HashMap<String, CommandAliasTarget>,
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
+    pub on_new_window: settings::OnNewWindow,
     pub on_last_window_closed: settings::OnLastWindowClosed,
     pub text_rendering_mode: settings::TextRenderingMode,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
@@ -127,6 +128,7 @@ impl Settings for WorkspaceSettings {
             command_aliases: workspace.command_aliases.clone(),
             max_tabs: workspace.max_tabs,
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
+            on_new_window: workspace.on_new_window.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
             text_rendering_mode: workspace.text_rendering_mode.unwrap(),
             resize_all_panels_in_dock: workspace

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1340,6 +1340,12 @@ fn register_actions(
                     cx,
                     |workspace, window, cx| {
                         cx.activate(true);
+                        if matches!(
+                            WorkspaceSettings::get_global(cx).on_new_window,
+                            settings::OnNewWindow::Launchpad
+                        ) {
+                            return;
+                        }
                         // Create buffer synchronously to avoid flicker
                         let project = workspace.project().clone();
                         let buffer = project.update(cx, |project, cx| {

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3418,6 +3418,17 @@ If you wish to exclude certain hosts from using the proxy, set the `NO_PROXY` en
 }
 ```
 
+## On New Window
+
+- Description: What to show when opening a new window.
+- Setting: `on_new_window`
+- Default: `"empty_tab"`
+
+**Options**
+
+1. `"empty_tab"`: Show an empty untitled buffer
+2. `"launchpad"`: Show the launchpad
+
 ## Instrumentation
 
 - Description: Configuration for developer-oriented instrumentation tools (profilers, tracers, etc.) that can be toggled at runtime.


### PR DESCRIPTION
# Objective

There currently exists no way to configure the behavior of new windows; Zed always creates an empty tab. As per advice from https://github.com/zed-industries/zed/issues/60720#issuecomment-4936162420, adding a this as a separate setting instead of reading the value of `restore_on_startup` is more ideal.

Allows for two values: `empty_tab` and `launchpad`, the default being `empty_tab`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

https://github.com/user-attachments/assets/bf339bd1-8c62-4243-ac9d-1045d1a14865

</details>

---

Release Notes:

- Added `on_new_window` setting to configure the behavior of new windows.
