### PR TITLE
claude_code_ide: Make Zed a recognised Claude Code IDE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,6 +3077,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "claude_code_ide"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-tungstenite",
+ "collections",
+ "db",
+ "editor",
+ "futures 0.3.32",
+ "gpui",
+ "language",
+ "libc",
+ "log",
+ "net",
+ "paths",
+ "project",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "settings",
+ "smol",
+ "tempfile",
+ "theme",
+ "theme_settings",
+ "workspace",
+]
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
@@ -22724,6 +22752,7 @@ dependencies = [
  "channel",
  "chrono",
  "clap",
+ "claude_code_ide",
  "cli",
  "client",
  "clock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/buffer_diff",
     "crates/call",
     "crates/channel",
+    "crates/claude_code_ide",
     "crates/cli",
     "crates/client",
     "crates/clock",
@@ -296,6 +297,7 @@ breadcrumbs = { path = "crates/breadcrumbs" }
 buffer_diff = { path = "crates/buffer_diff" }
 call = { path = "crates/call" }
 channel = { path = "crates/channel" }
+claude_code_ide = { path = "crates/claude_code_ide" }
 cli = { path = "crates/cli" }
 client = { path = "crates/client" }
 clock = { path = "crates/clock" }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -164,6 +164,7 @@
       "cmd-alt-l": ["buffer_search::Deploy", { "selection_search_enabled": true }],
       "cmd-e": "buffer_search::UseSelectionForFind",
       "cmd->": "agent::AddSelectionToThread",
+      "cmd-alt-x": "claude_code_ide::SendSelectionToClaudeCode",
       "cmd-alt-e": "editor::SelectEnclosingSymbol",
       "alt-enter": "editor::OpenSelectionsInMultibuffer",
       "alt-cmd-f": "text_finder::Toggle",

--- a/crates/claude_code_ide/Cargo.toml
+++ b/crates/claude_code_ide/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "claude_code_ide"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/claude_code_ide.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+async-tungstenite.workspace = true
+collections.workspace = true
+editor.workspace = true
+futures.workspace = true
+gpui.workspace = true
+language.workspace = true
+log.workspace = true
+net.workspace = true
+paths.workspace = true
+project.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+smol.workspace = true
+workspace.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
+db = { workspace = true, features = ["test-support"] }
+tempfile.workspace = true
+theme.workspace = true
+theme_settings.workspace = true

--- a/crates/claude_code_ide/src/bridge.rs
+++ b/crates/claude_code_ide/src/bridge.rs
@@ -1,0 +1,411 @@
+//! Per-workspace lifecycle for the Claude Code IDE bridge.
+//!
+//! On workspace open: generate an auth token, start the server, write the lockfile,
+//! inject the discovery env vars, and subscribe to editor selection changes. All of
+//! it is torn down when the workspace closes.
+//!
+//! The bridge entity is tracked in a GPUI global keyed by workspace `EntityId` (see
+//! [`BridgeRegistry`]) so handlers can find it without forking `Workspace`.
+
+use collections::HashMap;
+use editor::{Editor, EditorEvent};
+use gpui::{
+    Action, App, AppContext as _, Context, Entity, EntityId, Global, Subscription, Task,
+    WeakEntity,
+};
+use std::path::PathBuf;
+use std::time::Duration;
+use workspace::Workspace;
+
+use crate::lockfile::{self, LockData};
+use crate::selection::{self, SharedSelection};
+use crate::selection_socket;
+use crate::server::{self, BridgeServer};
+
+/// Debounce window for coalescing rapid selection changes before pushing a
+/// `selection_changed` notification.
+const SELECTION_DEBOUNCE: Duration = Duration::from_millis(50);
+
+/// Editor→Claude-Code notification names (wire contract).
+const SELECTION_CHANGED: &str = "selection_changed";
+const AT_MENTIONED: &str = "at_mentioned";
+
+gpui::actions!(
+    claude_code_ide,
+    [
+        /// Send the active editor selection to the connected Claude Code session.
+        SendSelectionToClaudeCode
+    ]
+);
+
+/// Maps a workspace to its bridge so handlers can find it without a `Workspace`
+/// field.
+#[derive(Default)]
+struct BridgeRegistry {
+    bridges: HashMap<EntityId, WeakEntity<ClaudeCodeIde>>,
+}
+
+impl Global for BridgeRegistry {}
+
+fn register_bridge(workspace: EntityId, bridge: &Entity<ClaudeCodeIde>, cx: &mut App) {
+    cx.default_global::<BridgeRegistry>()
+        .bridges
+        .insert(workspace, bridge.downgrade());
+}
+
+fn bridge_for(workspace: EntityId, cx: &App) -> Option<Entity<ClaudeCodeIde>> {
+    cx.try_global::<BridgeRegistry>()?
+        .bridges
+        .get(&workspace)
+        .and_then(WeakEntity::upgrade)
+}
+
+/// Feed in a selection captured outside the Zed editor, keyed by `source`.
+///
+/// The broadcast is the AGGREGATE across every source, so an editor and two other
+/// editors send all three regions together rather than only the newest.
+pub(crate) fn push_external_selection(
+    workspace_id: EntityId,
+    source: String,
+    payload: crate::protocol::SelectionPayload,
+    owner_pid: Option<u32>,
+    cx: &mut App,
+) {
+    with_bridge(workspace_id, cx, |bridge| {
+        bridge.push_external_selection(source, payload, owner_pid)
+    });
+}
+
+/// Drop one source's selection, for a client whose selection has gone away. Without
+/// it the region would ride in every later broadcast for the life of the workspace.
+pub(crate) fn clear_external_selection(workspace_id: EntityId, source: String, cx: &mut App) {
+    with_bridge(workspace_id, cx, |bridge| {
+        bridge.clear_external_selection(&source)
+    });
+}
+
+/// Drop every source's selection. The escape hatch for a region whose owner died
+/// leaving no pid to reap by, so nothing can address its key.
+pub(crate) fn clear_all_external_selections(workspace_id: EntityId, cx: &mut App) {
+    with_bridge(workspace_id, cx, |bridge| {
+        bridge.clear_all_external_selections()
+    });
+}
+
+fn with_bridge(
+    workspace_id: EntityId,
+    cx: &mut App,
+    update: impl FnOnce(&mut ClaudeCodeIde),
+) {
+    let Some(bridge) = bridge_for(workspace_id, cx) else {
+        log::debug!("claude_code_ide: no live bridge for workspace {workspace_id}");
+        return;
+    };
+    bridge.update(cx, |bridge, _cx| update(bridge));
+}
+
+/// Owns the bridge for one workspace. Dropped when the workspace closes, which
+/// stops the server (via the contained task handles) and unlinks the lockfile
+/// (via the release observer registered in [`start_for_workspace`]).
+pub struct ClaudeCodeIde {
+    selection: SharedSelection,
+    /// `None` until the async server bind completes.
+    server: Option<BridgeServer>,
+    lock_path: Option<PathBuf>,
+    /// Bound path of the selection socket, kept so it can be unlinked on
+    /// release. `None` when the socket could not be bound.
+    selection_socket_path: Option<PathBuf>,
+    /// Accept loop for the selection socket. Dropping it stops accepting.
+    selection_socket: Option<Task<()>>,
+    /// Subscription to the active editor's events; replaced whenever the active
+    /// item changes.
+    editor_subscription: Option<Subscription>,
+    /// Pending debounce task for the next selection push.
+    pending_push: Option<Task<()>>,
+    workspace: WeakEntity<Workspace>,
+    _startup: Task<()>,
+    _workspace_subscription: Subscription,
+}
+
+/// Register the bridge to start for every workspace.
+pub fn init(cx: &mut App) {
+    cx.observe_new(|workspace: &mut Workspace, window, cx| {
+        let Some(window) = window else {
+            return;
+        };
+        start_for_workspace(workspace, window.window_handle(), cx);
+    })
+    .detach();
+
+    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
+        workspace.register_action(
+            |workspace, _: &SendSelectionToClaudeCode, _window, cx| {
+                let workspace_id = cx.entity_id();
+                if let Some(bridge) = bridge_for(workspace_id, cx) {
+                    bridge.update(cx, |bridge, cx| bridge.send_at_mention(cx));
+                }
+                let _ = workspace;
+            },
+        );
+    })
+    .detach();
+}
+
+/// Start the bridge for a single workspace.
+pub fn start_for_workspace(
+    workspace: &mut Workspace,
+    window: gpui::AnyWindowHandle,
+    cx: &mut Context<Workspace>,
+) {
+    let selection = SharedSelection::new();
+    selection.set_workspace(cx.weak_entity());
+    selection.set_window(window);
+
+    let auth_token = lockfile::generate_auth_token();
+    let workspace_folders = workspace
+        .project()
+        .read(cx)
+        .visible_worktrees(cx)
+        .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let workspace_id = cx.entity_id();
+
+    // Bind the server and, once bound, write the lockfile + inject env vars.
+    let startup = cx.spawn({
+        let selection = selection.clone();
+        async move |workspace_handle, cx| {
+            let server = match server::start(auth_token.clone(), selection.clone(), cx).await {
+                Ok(server) => server,
+                Err(err) => {
+                    log::error!("claude_code_ide: failed to start server: {err}");
+                    return;
+                }
+            };
+            let port = server.port();
+
+            let lock_data = LockData::new(workspace_folders, auth_token);
+            let lock_path = match lockfile::write_lock(port, &lock_data) {
+                Ok(path) => Some(path),
+                Err(err) => {
+                    log::error!("claude_code_ide: failed to write lockfile: {err}");
+                    None
+                }
+            };
+
+            // A selection socket lets programs running in this workspace's
+            // terminals (an nvim, a shell script) contribute selections the Zed
+            // editor path cannot see. Failing to bind costs only that extra
+            // source, so the bridge carries on without it.
+            let (socket_path, socket_task) = match selection_socket::start(workspace_id, port, cx) {
+                Ok((path, task)) => (Some(path), Some(task)),
+                Err(err) => {
+                    log::warn!(
+                        "claude_code_ide: selection socket unavailable, external \
+                         selection sources disabled: {err:#}"
+                    );
+                    (None, None)
+                }
+            };
+
+            let _ = workspace_handle.update(cx, |workspace, cx| {
+                // Inject discovery env vars so `claude` in this workspace's
+                // terminals auto-connects, plus the selection socket path for any
+                // relay running there. Only affects terminals spawned after this
+                // point, so it has to happen during workspace startup.
+                workspace.project().update(cx, |project, _| {
+                    project.set_terminal_env_var(
+                        "CLAUDE_CODE_SSE_PORT".to_string(),
+                        port.to_string(),
+                    );
+                    project.set_terminal_env_var(
+                        "ENABLE_IDE_INTEGRATION".to_string(),
+                        "true".to_string(),
+                    );
+                    if let Some(socket_path) = &socket_path {
+                        project.set_terminal_env_var(
+                            selection_socket::SELECTION_SOCK_ENV.to_string(),
+                            socket_path.to_string_lossy().to_string(),
+                        );
+                    }
+                });
+            });
+
+            if let Some(bridge) = cx.update(|cx| bridge_for(workspace_id, cx)) {
+                let _ = bridge.update(cx, |bridge, _| {
+                    bridge.server = Some(server);
+                    bridge.lock_path = lock_path;
+                    bridge.selection_socket_path = socket_path;
+                    bridge.selection_socket = socket_task;
+                });
+            }
+        }
+    });
+
+    let workspace_entity = cx.entity();
+    let workspace_subscription = cx.subscribe(
+        &workspace_entity,
+        move |workspace, _emitter, event, cx| {
+            if matches!(event, workspace::Event::ActiveItemChanged) {
+                let workspace_id = cx.entity_id();
+                let workspace_entity = cx.entity();
+                // Defer: this fires while the Workspace is mid-update, so reading
+                // it now (on_active_item_changed reads active_item) would double-
+                // lease and panic. Run once the current update unwinds.
+                cx.defer(move |cx| {
+                    if let Some(bridge) = bridge_for(workspace_id, cx) {
+                        bridge.update(cx, |bridge, cx| {
+                            bridge.on_active_item_changed(&workspace_entity, cx);
+                        });
+                    }
+                });
+                let _ = workspace;
+            }
+        },
+    );
+
+    let workspace_handle = cx.weak_entity();
+    let bridge = cx.new(|_cx| ClaudeCodeIde {
+        selection,
+        server: None,
+        lock_path: None,
+        selection_socket_path: None,
+        selection_socket: None,
+        editor_subscription: None,
+        pending_push: None,
+        workspace: workspace_handle,
+        _startup: startup,
+        _workspace_subscription: workspace_subscription,
+    });
+
+    register_bridge(workspace_id, &bridge, cx);
+
+    // Unlink the lockfile and the selection socket when the bridge is released.
+    cx.observe_release(&bridge, |_workspace, bridge, _cx| {
+        if let Some(path) = bridge.lock_path.take() {
+            lockfile::unlink_lock(&path);
+        }
+        // Drop the accept loop before unlinking so nothing is still listening on
+        // a path that no longer exists.
+        bridge.selection_socket.take();
+        if let Some(path) = bridge.selection_socket_path.take() {
+            selection_socket::unlink_socket(&path);
+        }
+    })
+    .detach();
+
+    // Keep the bridge alive for the workspace's life; dropping this strong
+    // handle on workspace release fires the release observer above.
+    cx.on_release(move |_workspace, _cx| drop(bridge)).detach();
+
+    log::info!("claude_code_ide: started for workspace");
+}
+
+impl ClaudeCodeIde {
+    /// Re-subscribe to the newly-active editor and push its selection.
+    fn on_active_item_changed(&mut self, workspace: &Entity<Workspace>, cx: &mut Context<Self>) {
+        let editor = workspace.read(cx).active_item_as::<Editor>(cx);
+        let Some(editor) = editor else {
+            self.editor_subscription = None;
+            return;
+        };
+
+        self.editor_subscription =
+            Some(cx.subscribe(&editor, |bridge, _editor, event, cx| {
+                if let EditorEvent::SelectionsChanged { .. } = event {
+                    bridge.schedule_selection_push(cx);
+                }
+            }));
+
+        // Push the current selection for the freshly-focused editor immediately.
+        self.push_selection_now(cx);
+    }
+
+    /// Debounce a selection push so a burst of changes coalesces into one
+    /// notification.
+    fn schedule_selection_push(&mut self, cx: &mut Context<Self>) {
+        self.pending_push = Some(cx.spawn(async move |bridge, cx| {
+            cx.background_executor().timer(SELECTION_DEBOUNCE).await;
+            let _ = bridge.update(cx, |bridge, cx| {
+                bridge.push_selection_now(cx);
+            });
+        }));
+    }
+
+    /// Compute the current selection, cache it, and push `selection_changed`.
+    fn push_selection_now(&mut self, cx: &mut App) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let payload = selection::capture(&self.selection, &workspace, cx);
+        if let (Some(server), Some(payload)) = (self.server.as_ref(), payload) {
+            server.notify(SELECTION_CHANGED, payload);
+        }
+    }
+
+    /// Broadcast what is currently selected across every source.
+    ///
+    /// When nothing is left the aggregate is `None`, and sending nothing would leave
+    /// the client showing the selection just removed, so an explicitly empty payload
+    /// goes out instead: `selection: null` with empty text says "nothing selected".
+    fn broadcast_selection(&self) {
+        let Some(server) = self.server.as_ref() else {
+            return;
+        };
+        match self.selection.latest() {
+            Some(aggregate) => server.notify(SELECTION_CHANGED, aggregate),
+            None => server.notify(SELECTION_CHANGED, crate::protocol::cleared_selection()),
+        }
+    }
+
+    /// Store one source's selection, supplied by the caller rather than read from the
+    /// active editor, replacing only that source's region.
+    fn push_external_selection(
+        &mut self,
+        source: String,
+        payload: crate::protocol::SelectionPayload,
+        owner_pid: Option<u32>,
+    ) {
+        self.selection.upsert_external(source, payload, owner_pid);
+        self.broadcast_selection();
+    }
+
+    fn clear_external_selection(&mut self, source: &str) {
+        if self.selection.remove_external(source) {
+            self.broadcast_selection();
+        }
+    }
+
+    fn clear_all_external_selections(&mut self) {
+        let removed = self.selection.remove_all_external();
+        if removed > 0 {
+            log::info!("claude_code_ide: cleared {removed} external selection region(s)");
+            self.broadcast_selection();
+        }
+    }
+
+    /// Push `at_mentioned` for the current selection (explicit user action).
+    fn send_at_mention(&mut self, cx: &mut App) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let Some(payload) = selection::capture(&self.selection, &workspace, cx) else {
+            log::info!("claude_code_ide: no selection to send");
+            return;
+        };
+        if let Some(server) = self.server.as_ref() {
+            server.notify(
+                AT_MENTIONED,
+                serde_json::json!({
+                    "filePath": payload.file_path,
+                    "lineStart": payload.selection.start.line,
+                    "lineEnd": payload.selection.end.line,
+                }),
+            );
+        }
+    }
+}
+
+/// Boxed action, so callers outside this crate can dispatch it.
+pub fn send_selection_action() -> Box<dyn Action> {
+    SendSelectionToClaudeCode.boxed_clone()
+}

--- a/crates/claude_code_ide/src/bridge_tests.rs
+++ b/crates/claude_code_ide/src/bridge_tests.rs
@@ -1,0 +1,392 @@
+//! Product-path tests: drive the bridge against a real (test) `Workspace` and
+//! assert both the discovery lockfile and the real editor→selection payload
+//! path, which the transport tests (no workspace) never exercise.
+
+use crate::bridge;
+use crate::selection::SharedSelection;
+use async_tungstenite::tungstenite::Message;
+use futures::AsyncWriteExt as _;
+use gpui::{AppContext as _, TestAppContext};
+use project::{FakeFs, Project};
+use serde_json::json;
+use workspace::{AppState, Workspace};
+
+fn init_test(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let settings_store = settings::SettingsStore::test(cx);
+        cx.set_global(settings_store);
+        cx.set_global(db::AppDatabase::test_new());
+        theme_settings::init(theme::LoadThemes::JustBase, cx);
+    });
+}
+
+/// Heavier init that brings up editor + workspace so a real `Editor` can be
+/// opened and driven (needed for the selection-path test).
+fn init_test_with_editor(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let app_state = AppState::test(cx);
+        theme_settings::init(theme::LoadThemes::JustBase, cx);
+        editor::init(cx);
+        workspace::init(app_state, cx);
+    });
+}
+
+#[gpui::test]
+async fn start_for_workspace_writes_lockfile(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    init_test(cx);
+
+    // Point the lockfile dir at a throwaway location so we don't touch the real
+    // ~/.claude/ide. SAFETY: single-threaded test setup.
+    let lock_dir = tempfile::tempdir().expect("temp lock dir");
+    unsafe {
+        std::env::set_var("CLAUDE_CONFIG_DIR", lock_dir.path());
+    }
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window =
+        cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+    // Start the bridge for this workspace.
+    window
+        .update(cx, |workspace, window, cx| {
+            bridge::start_for_workspace(workspace, window.window_handle(), cx);
+        })
+        .expect("update workspace");
+
+    // Let the async server bind and the lockfile get written.
+    cx.run_until_parked();
+
+    // Exactly one lockfile should exist under CLAUDE_CONFIG_DIR/ide.
+    let ide_dir = lock_dir.path().join("ide");
+    let entries: Vec<_> = std::fs::read_dir(&ide_dir)
+        .expect("ide dir exists")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_some_and(|ext| ext == "lock")
+        })
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one lockfile, found {entries:?}"
+    );
+
+    let lock_path = entries[0].path();
+    let port_from_name: u16 = lock_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.parse().ok())
+        .expect("lockfile name is <port>.lock");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&lock_path).expect("read lockfile"))
+            .expect("lockfile is valid JSON");
+    assert_eq!(json["ideName"], "Zed");
+    assert_eq!(json["transport"], "ws");
+    assert!(json["pid"].is_number());
+    let token = json["authToken"].as_str().expect("authToken is a string");
+    assert_eq!(token.len(), 32, "token should be 32 hex chars");
+    assert!(
+        token.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "token should be lowercase hex"
+    );
+    // workspaceFolders is present (empty for a project with no worktrees).
+    assert!(json["workspaceFolders"].is_array());
+
+    // The port in the filename is a real bound port (non-zero).
+    assert!(port_from_name > 0, "port should be a real bound port");
+
+    unsafe {
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+}
+
+#[gpui::test]
+async fn selection_capture_reads_real_editor(cx: &mut TestAppContext) {
+    init_test_with_editor(cx);
+
+    // A project with one file whose line 2 (0-based) is a known string.
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        json!({ "main.rs": "fn main() {}\nlet x = 1;\nlet answer = 42;\n" }),
+    )
+    .await;
+    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let (workspace, cx) =
+        cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+    // Open the file as a real editor in the active pane.
+    let buffer = project
+        .update(cx, |project, cx| {
+            let path = project
+                .find_project_path("main.rs", cx)
+                .expect("find main.rs");
+            project.open_buffer(path, cx)
+        })
+        .await
+        .expect("open buffer");
+    let editor = workspace.update_in(cx, |workspace, window, cx| {
+        let editor =
+            cx.new(|cx| editor::Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx));
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+        editor
+    });
+
+    // Select "answer = 42" on line 2 (row 2, cols 4..15).
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(editor::SelectionEffects::default(), window, cx, |selections| {
+            selections.select_ranges([language::Point::new(2, 4)..language::Point::new(2, 15)]);
+        });
+    });
+
+    // Capture the selection through the bridge's real payload path.
+    let selection = SharedSelection::new();
+    selection.set_workspace(workspace.downgrade());
+    let payload = cx
+        .update(|_window, cx| crate::selection::capture(&selection, &workspace, cx))
+        .expect("capture should produce a selection payload");
+
+    assert!(
+        payload.file_path.ends_with("main.rs"),
+        "file path should point at main.rs, got {}",
+        payload.file_path
+    );
+    assert_eq!(payload.file_url, format!("file://{}", payload.file_path));
+    assert_eq!(payload.selection.start.line, 2);
+    assert_eq!(payload.selection.start.character, 4);
+    assert_eq!(payload.selection.end.line, 2);
+    assert_eq!(payload.selection.end.character, 15);
+    assert_eq!(payload.text, "answer = 42");
+}
+
+#[gpui::test]
+async fn selection_capture_concats_multiple_regions(cx: &mut TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        json!({ "main.rs": "fn main() {}\nlet x = 1;\nlet answer = 42;\n" }),
+    )
+    .await;
+    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let (workspace, cx) =
+        cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            let path = project
+                .find_project_path("main.rs", cx)
+                .expect("find main.rs");
+            project.open_buffer(path, cx)
+        })
+        .await
+        .expect("open buffer");
+    let editor = workspace.update_in(cx, |workspace, window, cx| {
+        let editor =
+            cx.new(|cx| editor::Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx));
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+        editor
+    });
+
+    // Two disjoint selections: "x = 1" on line 1 and "answer = 42" on line 2.
+    // select_ranges makes the LAST range the newest => the primary region.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(editor::SelectionEffects::default(), window, cx, |selections| {
+            selections.select_ranges([
+                language::Point::new(1, 4)..language::Point::new(1, 9),
+                language::Point::new(2, 4)..language::Point::new(2, 15),
+            ]);
+        });
+    });
+
+    let selection = SharedSelection::new();
+    selection.set_workspace(workspace.downgrade());
+    let payload = cx
+        .update(|_window, cx| crate::selection::capture(&selection, &workspace, cx))
+        .expect("capture should produce a selection payload");
+
+    // Top-level selection/filePath stay TRUTHFUL to the primary (newest) region
+    // so the CLI's single-region banner never lies.
+    assert!(payload.file_path.ends_with("main.rs"));
+    assert_eq!(payload.selection.start.line, 2);
+    assert_eq!(payload.selection.start.character, 4);
+    assert_eq!(payload.selection.end.line, 2);
+    assert_eq!(payload.selection.end.character, 15);
+
+    // text carries BOTH regions under `# <path>:<startLine>-<endLine>` headers,
+    // in document order (1-based line numbers).
+    assert!(
+        payload.text.contains("x = 1"),
+        "text should include the first region, got:\n{}",
+        payload.text
+    );
+    assert!(
+        payload.text.contains("answer = 42"),
+        "text should include the primary region, got:\n{}",
+        payload.text
+    );
+    assert!(
+        payload.text.contains(":2-2\n"),
+        "text should carry a 1-based header for line 2, got:\n{}",
+        payload.text
+    );
+    assert!(
+        payload.text.contains(":3-3\n"),
+        "text should carry a 1-based header for line 3, got:\n{}",
+        payload.text
+    );
+}
+
+/// Start a bridge on a test workspace, discover it the way Claude Code does (read
+/// the lockfile for port and token), and return the selection socket plus a
+/// connected, handshaken client.
+async fn bridge_with_client(
+    cx: &mut TestAppContext,
+    lock_dir: &std::path::Path,
+) -> (std::path::PathBuf, crate::server_tests::ClientWs) {
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    window
+        .update(cx, |workspace, window, cx| {
+            bridge::start_for_workspace(workspace, window.window_handle(), cx);
+        })
+        .expect("update workspace");
+    cx.run_until_parked();
+
+    let entry = std::fs::read_dir(lock_dir.join("ide"))
+        .expect("ide dir exists")
+        .next()
+        .expect("one lockfile was written")
+        .expect("lockfile is readable");
+    let port: u16 = entry
+        .path()
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.parse().ok())
+        .expect("lockfile is named <port>.lock");
+    let lock: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(entry.path()).expect("read lockfile"))
+            .expect("lockfile holds JSON");
+    let token = lock["authToken"].as_str().expect("authToken").to_string();
+
+    let socket = crate::selection_socket::socket_path_for_port(port);
+    assert!(socket.exists(), "bridge should have bound {socket:?}");
+
+    // Handshake so the client's outgoing sender is registered before any push.
+    let connect = cx.background_executor.spawn(async move {
+        let mut ws = crate::server_tests::connect(port, Some(&token))
+            .await
+            .expect("client connects");
+        ws.send(Message::text(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+        ))
+        .await
+        .expect("send initialize");
+        let _ = crate::server_tests::next_json(&mut ws).await;
+        ws
+    });
+    cx.run_until_parked();
+    (socket, connect.await)
+}
+
+/// Write one newline-terminated line to the selection socket, as a client does, and
+/// let the bridge process it.
+async fn push_line(cx: &mut TestAppContext, socket: &std::path::Path, line: &str) {
+    let task = cx.background_executor.spawn({
+        let socket = socket.to_path_buf();
+        let line = format!("{line}\n");
+        async move {
+            let mut stream = net::async_net::UnixStream::connect(&socket)
+                .await
+                .expect("connect to the selection socket");
+            stream.write_all(line.as_bytes()).await.expect("write line");
+            stream.flush().await.ok();
+        }
+    });
+    cx.run_until_parked();
+    task.await;
+    cx.run_until_parked();
+}
+
+/// Read the next frame, handing the client back so later phases reuse it.
+async fn next_frame(
+    cx: &mut TestAppContext,
+    mut ws: crate::server_tests::ClientWs,
+) -> (serde_json::Value, crate::server_tests::ClientWs) {
+    let task = cx
+        .background_executor
+        .spawn(async move { (crate::server_tests::next_json(&mut ws).await, ws) });
+    cx.run_until_parked();
+    let (frame, ws) = task.await;
+    log::info!("observed frame: {frame}");
+    (frame, ws)
+}
+
+/// The whole external-selection chain, headless: a client payload written to the
+/// socket travels parse -> aggregate -> `selection_changed` to a connected Claude
+/// Code client. Then a second push under the same source must REPLACE the first
+/// region rather than add one, and a clear must announce that nothing is selected.
+/// The one test crossing every seam at once.
+#[gpui::test]
+async fn client_payload_over_the_socket_reaches_a_connected_client(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    init_test(cx);
+
+    // Keep the real ~/.claude/ide untouched. SAFETY: single-threaded test setup.
+    let lock_dir = tempfile::tempdir().expect("temp lock dir");
+    unsafe {
+        std::env::set_var("CLAUDE_CONFIG_DIR", lock_dir.path());
+    }
+    let (socket, ws) = bridge_with_client(cx, lock_dir.path()).await;
+
+    // Byte-for-byte what zed-claude-selection.nvim builds, including the escaped
+    // newline, the zero-based span and the `nvim:<pid>` source it states for itself.
+    push_line(
+        cx,
+        &socket,
+        concat!(
+            r#"{"op":"push_selection","text":"line two\nline three","#,
+            r#""filePath":"/repo/a.rs","fileUrl":"file:///repo/a.rs","#,
+            r#""source":"nvim:4242","#,
+            r#""selection":{"start":{"line":1,"character":0},"end":{"line":2,"character":0}}}"#
+        ),
+    )
+    .await;
+    let (frame, ws) = next_frame(cx, ws).await;
+    assert_eq!(frame["method"], "selection_changed", "got {frame}");
+    assert_eq!(frame["params"]["text"], "line two\nline three", "got {frame}");
+    assert_eq!(frame["params"]["filePath"], "/repo/a.rs", "got {frame}");
+    assert_eq!(frame["params"]["selection"]["start"]["line"], 1, "got {frame}");
+    assert_eq!(frame["params"]["selection"]["end"]["line"], 2, "got {frame}");
+
+    // Same source, different file: replaces rather than appends. Were the key
+    // derived per file, this would be two regions with both files under headers.
+    push_line(
+        cx,
+        &socket,
+        concat!(
+            r#"{"op":"push_selection","text":"other file","#,
+            r#""filePath":"/repo/b.rs","source":"nvim:4242","#,
+            r#""selection":{"start":{"line":0,"character":0},"end":{"line":1,"character":0}}}"#
+        ),
+    )
+    .await;
+    let (frame, ws) = next_frame(cx, ws).await;
+    assert_eq!(frame["params"]["text"], "other file", "should replace, got {frame}");
+
+    // With no regions left the bridge must say so, or the client keeps showing the
+    // selection we just dropped.
+    push_line(cx, &socket, r#"{"op":"clear_selection","source":"nvim:4242"}"#).await;
+    let (frame, _ws) = next_frame(cx, ws).await;
+    assert_eq!(frame["method"], "selection_changed", "got {frame}");
+    assert!(frame["params"]["selection"].is_null(), "got {frame}");
+    assert_eq!(frame["params"]["text"], "", "got {frame}");
+}

--- a/crates/claude_code_ide/src/claude_code_ide.rs
+++ b/crates/claude_code_ide/src/claude_code_ide.rs
@@ -1,0 +1,32 @@
+//! Makes Zed a recognised Claude Code "IDE", per workspace.
+//!
+//! The CLI finds its host editor by scanning `~/.claude/ide/` for a `<port>.lock`
+//! file, then opening a loopback WebSocket to that port and speaking MCP. The VS
+//! Code and JetBrains integrations implement the same contract. [`lockfile`] writes
+//! the discovery file, [`server`] serves the protocol, [`selection`] answers the
+//! selection tools and turns editor selection changes into notifications,
+//! [`selection_socket`] takes selections from programs in the workspace's terminals,
+//! and [`bridge`] owns the lifecycle.
+//!
+//! Anthropic documents what the integrations do, including the lock file, but not the
+//! wire protocol. This implements it as reverse-engineered by the Neovim port,
+//! corrected where the real CLI disagreed with that write-up.
+//!
+//! See:
+//! - <https://code.claude.com/docs/en/ide-integrations>
+//! - <https://github.com/coder/claudecode.nvim/blob/main/PROTOCOL.md>
+
+pub mod bridge;
+pub mod lockfile;
+pub mod peer_cred;
+pub mod protocol;
+pub mod selection;
+pub mod selection_socket;
+pub mod server;
+
+pub use bridge::init;
+
+#[cfg(test)]
+mod bridge_tests;
+#[cfg(test)]
+mod server_tests;

--- a/crates/claude_code_ide/src/lockfile.rs
+++ b/crates/claude_code_ide/src/lockfile.rs
@@ -1,0 +1,180 @@
+//! The `~/.claude/ide/<port>.lock` discovery file.
+//!
+//! Claude Code scans `~/.claude/ide/` (or `$CLAUDE_CONFIG_DIR/ide/`) for
+//! `<port>.lock` files and connects to the port named by the file. The JSON holds
+//! the connection metadata and the shared secret the CLI must send back on the
+//! WebSocket upgrade.
+//!
+//! Lifecycle: a private `0700` directory, remove any stale file before writing,
+//! best-effort unlink on release.
+
+use anyhow::{Context as _, Result};
+use rand::RngCore as _;
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Name Claude Code shows for the connected editor.
+pub const IDE_NAME: &str = "Zed";
+
+/// The lockfile JSON. Field names are the wire contract; do not rename without
+/// matching Claude Code.
+#[derive(Debug, Serialize)]
+pub struct LockData {
+    pub pid: u32,
+    #[serde(rename = "workspaceFolders")]
+    pub workspace_folders: Vec<String>,
+    #[serde(rename = "ideName")]
+    pub ide_name: String,
+    pub transport: String,
+    #[serde(rename = "authToken")]
+    pub auth_token: String,
+}
+
+impl LockData {
+    pub fn new(workspace_folders: Vec<String>, auth_token: String) -> Self {
+        Self {
+            pid: std::process::id(),
+            workspace_folders,
+            ide_name: IDE_NAME.to_string(),
+            transport: "ws".to_string(),
+            auth_token,
+        }
+    }
+}
+
+/// The directory Claude Code scans. Honours `CLAUDE_CONFIG_DIR` when set, else
+/// `~/.claude/ide`.
+pub fn ide_lock_dir() -> PathBuf {
+    if let Some(config_dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        PathBuf::from(config_dir).join("ide")
+    } else {
+        paths::home_dir().join(".claude").join("ide")
+    }
+}
+
+/// Path of the lockfile for a bound port.
+pub fn lock_path_for_port(port: u16) -> PathBuf {
+    ide_lock_dir().join(format!("{port}.lock"))
+}
+
+/// A 32-character lowercase hex token (128 bits) from the OS CSPRNG, matching
+/// the token width Claude Code's other IDE integrations use.
+pub fn generate_auth_token() -> String {
+    let mut bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut bytes);
+    let mut token = String::with_capacity(32);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        // Infallible: writing to a String never errors.
+        let _ = write!(token, "{byte:02x}");
+    }
+    token
+}
+
+/// Write the lockfile with `0600` permissions inside a `0700` directory,
+/// removing any stale file at that port first.
+pub fn write_lock(port: u16, data: &LockData) -> Result<PathBuf> {
+    let dir = ide_lock_dir();
+    create_private_dir(&dir).with_context(|| format!("creating ide lock dir {}", dir.display()))?;
+
+    let path = lock_path_for_port(port);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .with_context(|| format!("removing stale ide lock {}", path.display()))?;
+        log::info!("claude_code_ide: removed stale lock {}", path.display());
+    }
+
+    let json = serde_json::to_vec(data).context("serializing ide lock data")?;
+    std::fs::write(&path, &json)
+        .with_context(|| format!("writing ide lock {}", path.display()))?;
+    restrict_file(&path)
+        .with_context(|| format!("restricting ide lock permissions {}", path.display()))?;
+    log::info!(
+        "claude_code_ide: wrote lock {} (port {port})",
+        path.display()
+    );
+    Ok(path)
+}
+
+/// Remove the lockfile; a missing file is not an error (the workspace may have
+/// been torn down more than once).
+pub fn unlink_lock(path: &PathBuf) {
+    match std::fs::remove_file(path) {
+        Ok(()) => log::info!("claude_code_ide: unlinked lock {}", path.display()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => log::warn!(
+            "claude_code_ide: failed to unlink lock {}: {err}",
+            path.display()
+        ),
+    }
+}
+
+fn create_private_dir(dir: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let perms = std::fs::Permissions::from_mode(0o700);
+        std::fs::set_permissions(dir, perms)?;
+    }
+    Ok(())
+}
+
+fn restrict_file(path: &std::path::Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The token is the shared secret the CLI must present back, so its shape is a
+    /// wire contract: 32 lowercase hex chars, and never the same twice.
+    #[test]
+    fn auth_token_is_unique_lowercase_hex() {
+        let token = generate_auth_token();
+        assert_eq!(token.len(), 32, "got {token:?}");
+        assert!(
+            token
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "should be lowercase hex, got {token:?}"
+        );
+        assert_ne!(token, generate_auth_token(), "tokens must differ");
+    }
+
+    /// The field names are the wire contract, so assert the serialised shape and
+    /// that a written file round-trips and unlinks.
+    #[test]
+    fn lock_data_shape_survives_a_write_and_unlink() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Keep the real ~/.claude untouched. SAFETY: single-threaded test setup.
+        unsafe {
+            std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
+        }
+
+        let data = LockData::new(vec!["/tmp/project".to_string()], "deadbeef".to_string());
+        let path = write_lock(12345, &data).expect("write lock");
+        let json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).expect("read back")).expect("json");
+        assert_eq!(json["ideName"], "Zed");
+        assert_eq!(json["transport"], "ws");
+        assert_eq!(json["authToken"], "deadbeef");
+        assert_eq!(json["workspaceFolders"][0], "/tmp/project");
+        assert!(json["pid"].is_number());
+
+        unlink_lock(&path);
+        assert!(!path.exists(), "unlink should remove it");
+        unsafe {
+            std::env::remove_var("CLAUDE_CONFIG_DIR");
+        }
+    }
+}

--- a/crates/claude_code_ide/src/peer_cred.rs
+++ b/crates/claude_code_ide/src/peer_cred.rs
@@ -1,0 +1,134 @@
+//! The pid of a connected Unix-socket client, read from the kernel
+//! (`LOCAL_PEERPID` on macOS, `SO_PEERCRED` on Linux) so a client cannot forge it.
+//!
+//! Used only to know whether the process that pushed a selection is still alive, so
+//! its region can be reaped when it dies. It is deliberately NOT used to key
+//! regions: it resolves only while the peer is alive, and these clients close the
+//! socket the moment they have written, so it is not reliable enough to name things
+//! by.
+//!
+//! The socket already sits under a `0700` directory, so only the owning user can
+//! connect. [`peer_pid`] also checks the peer's effective uid against ours, keeping
+//! that property explicit at the read boundary rather than resting on the mode.
+
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd as _;
+
+/// The connected client's pid, or `None` when it cannot be read or the peer belongs
+/// to another user. Always `None` on non-unix, where the caller keeps every region.
+#[cfg(unix)]
+pub fn peer_pid(stream: &net::async_net::UnixStream) -> Option<u32> {
+    peer_pid_for_fd(stream.as_raw_fd())
+}
+
+/// The fd-level half, split out so a test can drive it with a plain std socket pair
+/// rather than building an async stream.
+#[cfg(unix)]
+fn peer_pid_for_fd(fd: std::os::unix::io::RawFd) -> Option<u32> {
+    let Some((euid, pid)) = peer_euid_and_pid(fd) else {
+        log::warn!("claude_code_ide: could not read selection socket peer credentials");
+        return None;
+    };
+    // SAFETY: `geteuid` reads this process's own id and cannot fail.
+    let ours = unsafe { libc::geteuid() };
+    if euid != ours {
+        log::warn!("claude_code_ide: selection socket peer euid {euid} != ours {ours}, refusing");
+        return None;
+    }
+    Some(pid)
+}
+
+#[cfg(not(unix))]
+pub fn peer_pid(_stream: &net::async_net::UnixStream) -> Option<u32> {
+    None
+}
+
+/// The peer's (euid, pid) as one read, so the two platform paths appear once each.
+///
+/// macOS needs two calls (`getpeereid` for the uid, `LOCAL_PEERPID` for the pid).
+/// Linux gets both from one `SO_PEERCRED`, and the libc crate does not declare
+/// `getpeereid` for linux-gnu. Other unix targets have no mechanism wired, so they
+/// report nothing and every region is kept.
+#[cfg(target_os = "macos")]
+fn peer_euid_and_pid(fd: std::os::unix::io::RawFd) -> Option<(u32, u32)> {
+    let mut euid: libc::uid_t = 0;
+    let mut egid: libc::gid_t = 0;
+    let mut pid: libc::pid_t = 0;
+    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    // SAFETY: `fd` is a live connected Unix-socket fd owned by the caller's stream
+    // for the duration of these calls, and every out-param is valid and correctly
+    // sized. Neither call transfers ownership of the fd.
+    let (uid_ret, pid_ret) = unsafe {
+        (
+            libc::getpeereid(fd, &mut euid, &mut egid),
+            libc::getsockopt(
+                fd,
+                libc::SOL_LOCAL,
+                libc::LOCAL_PEERPID,
+                &mut pid as *mut libc::pid_t as *mut libc::c_void,
+                &mut len,
+            ),
+        )
+    };
+    (uid_ret == 0 && pid_ret == 0 && pid > 0).then_some((euid, pid as u32))
+}
+
+#[cfg(target_os = "linux")]
+fn peer_euid_and_pid(fd: std::os::unix::io::RawFd) -> Option<(u32, u32)> {
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: as above; `cred`/`len` are valid out-params sized for a `ucred`.
+    let ret = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut libc::ucred as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    (ret == 0 && cred.pid > 0).then_some((cred.uid, cred.pid as u32))
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "linux")))]
+fn peer_euid_and_pid(_fd: std::os::unix::io::RawFd) -> Option<(u32, u32)> {
+    None
+}
+
+/// Other unix targets (BSDs) that are neither macOS nor Linux.
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "linux")))]
+fn peer_pid_raw(_fd: std::os::unix::io::RawFd) -> Option<u32> {
+    None
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    /// The kernel must report the connecting process's pid for an accepted
+    /// connection. The selection socket's region key depends on this, and a
+    /// `None` here silently downgrades it to per-file keying, so it is worth
+    /// asserting against the real syscall rather than trusting it.
+    #[test]
+    fn reports_the_connecting_process_pid() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("peer.sock");
+
+        let listener = std::os::unix::net::UnixListener::bind(&path).expect("bind");
+        // Keep the client alive: the pid is only readable while the peer exists.
+        let _client = std::os::unix::net::UnixStream::connect(&path).expect("connect");
+        let (accepted, _addr) = listener.accept().expect("accept");
+
+        let observed = peer_pid_for_fd(accepted.as_raw_fd());
+        log::info!("observed peer pid: {observed:?}, ours: {}", std::process::id());
+        assert_eq!(
+            observed,
+            Some(std::process::id()),
+            "the peer of a self-connection is this process"
+        );
+    }
+}

--- a/crates/claude_code_ide/src/protocol.rs
+++ b/crates/claude_code_ide/src/protocol.rs
@@ -1,0 +1,114 @@
+//! Wire types for the Claude Code IDE bridge: JSON-RPC 2.0 framing plus the MCP
+//! payload shapes Claude Code expects.
+//!
+//! `context_server` already models MCP, but its request/response structs are
+//! `pub(crate)` and shaped for its Unix-socket + stdio transport, so we define the
+//! small subset we need here rather than reach into its internals.
+//!
+//! Only shapes that are deserialised, or built in more than one place, are structs.
+//! One-shot responses are built with `json!` at the point of use, which keeps the
+//! wire text next to the code that decides it.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use serde_json::value::RawValue;
+
+pub const JSON_RPC_VERSION: &str = "2.0";
+
+/// An inbound JSON-RPC message. A request carries an `id`, a notification does not.
+/// `params` stays raw so each method can deserialize its own shape.
+#[derive(Debug, Deserialize)]
+pub struct IncomingMessage {
+    #[allow(dead_code)]
+    pub jsonrpc: Option<String>,
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Box<RawValue>>,
+}
+
+impl IncomingMessage {
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+pub mod error_code {
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    #[allow(dead_code)]
+    pub const INTERNAL_ERROR: i32 = -32603;
+}
+
+pub fn ok_response<T: Serialize>(id: Value, result: T) -> Value {
+    json!({ "jsonrpc": JSON_RPC_VERSION, "id": id, "result": result })
+}
+
+pub fn err_response(id: Value, code: i32, message: impl Into<String>) -> Value {
+    let message: String = message.into();
+    json!({
+        "jsonrpc": JSON_RPC_VERSION,
+        "id": id,
+        "error": { "code": code, "message": message },
+    })
+}
+
+pub fn notification<T: Serialize>(method: &str, params: T) -> Value {
+    json!({ "jsonrpc": JSON_RPC_VERSION, "method": method, "params": params })
+}
+
+/// Parameters of a `tools/call` request.
+#[derive(Debug, Deserialize)]
+pub struct CallToolParams {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Value,
+}
+
+/// A tool result. Claude Code reads `content[].text`, so every result we produce is
+/// a single text block whose body is the JSON the CLI parses.
+pub fn tool_ok(text: impl Into<String>) -> Value {
+    let text: String = text.into();
+    json!({ "content": [{ "type": "text", "text": text }] })
+}
+
+/// A tool-level error, distinct from a JSON-RPC transport error.
+pub fn tool_error(text: impl Into<String>) -> Value {
+    let text: String = text.into();
+    json!({ "content": [{ "type": "text", "text": text }], "isError": true })
+}
+
+/// A zero-based line/character position, matching the protocol's coordinates.
+#[derive(Debug, Serialize, Clone, Copy)]
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+pub struct SelectionRange {
+    pub start: Position,
+    pub end: Position,
+}
+
+/// Payload for the selection tools and for `selection_changed`.
+#[derive(Debug, Serialize, Clone)]
+pub struct SelectionPayload {
+    pub text: String,
+    #[serde(rename = "filePath")]
+    pub file_path: String,
+    #[serde(rename = "fileUrl")]
+    pub file_url: String,
+    pub selection: SelectionRange,
+}
+
+/// A `selection_changed` payload saying there is no selection any more.
+///
+/// A `Value` rather than a [`SelectionPayload`] because that struct's `selection` is
+/// not optional, and making it optional would add a `None` case to every read path
+/// that currently cannot have one.
+pub fn cleared_selection() -> Value {
+    json!({ "text": "", "filePath": "", "fileUrl": "", "selection": Value::Null })
+}
+

--- a/crates/claude_code_ide/src/selection.rs
+++ b/crates/claude_code_ide/src/selection.rs
@@ -1,0 +1,637 @@
+//! Editor selection: the MCP tools that read it and the shared state behind them.
+//!
+//! Tool handlers could read the active editor live, but `selection_changed` needs
+//! the same computation on every change anyway, so [`capture`] computes it once and
+//! both paths read the cached value.
+
+use gpui::{App, AsyncApp, Entity, WeakEntity};
+use language::LocalFile as _;
+use std::cell::RefCell;
+use std::rc::Rc;
+use workspace::Workspace;
+
+use crate::protocol::{Position, SelectionPayload, SelectionRange, tool_error, tool_ok};
+use serde_json::{Value, json};
+
+/// State shared between the bridge (which updates it) and the server dispatch
+/// loop (which reads it). Single-threaded: only touched on the foreground.
+#[derive(Clone)]
+pub struct SharedSelection(Rc<RefCell<SelectionState>>);
+
+#[derive(Default)]
+struct SelectionState {
+    editor: Option<SelectionPayload>,
+    /// One region per external source. A `Vec` rather than a map so the aggregate
+    /// text keeps a stable order across pushes.
+    external: Vec<ExternalRegion>,
+    /// The most recently set region, used as the aggregate's top-level `selection`
+    /// and `filePath` so the CLI's single-region banner names your latest action
+    /// rather than a synthesised range spanning files.
+    last_primary: Option<SelectionPayload>,
+    workspace: Option<WeakEntity<Workspace>>,
+    /// For tools that drive UI (openFile/openDiff).
+    window: Option<gpui::AnyWindowHandle>,
+}
+
+/// One external source's contribution, plus the process that pushed it.
+///
+/// `owner_pid` exists so a region can be reaped when its owner dies: a client that
+/// is killed never gets to retract, and because keys are per-process nothing would
+/// replace it either. `None` when the pid could not be read, and then the region is
+/// kept, because an unknown owner is not evidence of a dead one.
+struct ExternalRegion {
+    source: String,
+    payload: SelectionPayload,
+    owner_pid: Option<u32>,
+}
+
+/// Whether a process still exists. `kill(pid, 0)` performs the permission and
+/// existence checks without sending a signal, which is the standard liveness test.
+/// Reports `true` on any non-unix target, so a region is never reaped on a platform
+/// where we cannot ask.
+fn process_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // `kill` treats 0 as "every process in my group" and negatives as a group
+        // id, so those must never reach it: pid 0 would answer "alive" for the
+        // caller's own group, and a pid that casts negative would ask about the
+        // wrong thing entirely. Neither is a real owner, so both read as dead.
+        let Ok(raw) = i32::try_from(pid) else {
+            return false;
+        };
+        if raw <= 0 {
+            return false;
+        }
+        // SAFETY: `kill` with signal 0 sends nothing; it only performs the
+        // existence and permission checks. No memory is touched.
+        let result = unsafe { libc::kill(raw as libc::pid_t, 0) };
+        if result == 0 {
+            return true;
+        }
+        // EPERM means it exists but belongs to someone else, which still counts as
+        // alive. Only ESRCH means "no such process".
+        std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
+impl SharedSelection {
+    pub fn new() -> Self {
+        Self(Rc::new(RefCell::new(SelectionState::default())))
+    }
+
+    pub fn set_workspace(&self, workspace: WeakEntity<Workspace>) {
+        self.0.borrow_mut().workspace = Some(workspace);
+    }
+
+    pub fn set_window(&self, window: gpui::AnyWindowHandle) {
+        self.0.borrow_mut().window = Some(window);
+    }
+
+    pub fn window(&self) -> Option<gpui::AnyWindowHandle> {
+        self.0.borrow().window
+    }
+
+    /// Record the Zed editor's current selection (or clear it with `None`).
+    /// When present it also becomes the primary (most-recent) region.
+    pub fn set_editor(&self, payload: Option<SelectionPayload>) {
+        let mut state = self.0.borrow_mut();
+        if let Some(payload) = &payload {
+            state.last_primary = Some(payload.clone());
+        }
+        state.editor = payload;
+    }
+
+    /// Upsert one external source's current selection, keyed by `source`.
+    /// Replaces that source's previous entry (re-selecting in the same nvim),
+    /// and makes it the primary (most-recent) region.
+    pub fn upsert_external(
+        &self,
+        source: String,
+        payload: SelectionPayload,
+        owner_pid: Option<u32>,
+    ) {
+        let mut state = self.0.borrow_mut();
+        state.last_primary = Some(payload.clone());
+        if let Some(entry) = state.external.iter_mut().find(|entry| entry.source == source) {
+            entry.payload = payload;
+            // Trust the newest sighting: the same logical source may reconnect from
+            // a different process (a restarted editor reusing an explicit key).
+            entry.owner_pid = owner_pid;
+        } else {
+            state.external.push(ExternalRegion {
+                source,
+                payload,
+                owner_pid,
+            });
+        }
+        state.reap_dead_owners();
+    }
+
+    /// Drop one source's region, reporting whether there was one to drop.
+    ///
+    /// `last_primary` is left alone deliberately: the remaining regions still need a
+    /// truthful top-level range. A caller that removes the final region should
+    /// broadcast a cleared payload, not an aggregate.
+    pub fn remove_external(&self, source: &str) -> bool {
+        let mut state = self.0.borrow_mut();
+        let before = state.external.len();
+        state.external.retain(|entry| entry.source != source);
+        before != state.external.len()
+    }
+
+    /// Drop every external region. The escape hatch for one whose key nothing can
+    /// address any more, so neither a retraction nor a replacement can reach it.
+    pub fn remove_all_external(&self) -> usize {
+        let mut state = self.0.borrow_mut();
+        let removed = state.external.len();
+        state.external.clear();
+        removed
+    }
+
+    /// The aggregate across every source, or `None` when nothing is selected. What
+    /// `getCurrentSelection` returns and what every `selection_changed` broadcasts.
+    ///
+    /// Reaps dead owners first. Reaping on read as well as on write matters because
+    /// editor selection changes drive most broadcasts and never touch the write path.
+    pub fn latest(&self) -> Option<SelectionPayload> {
+        let mut state = self.0.borrow_mut();
+        state.reap_dead_owners();
+        state.aggregate()
+    }
+
+    pub fn workspace(&self) -> Option<WeakEntity<Workspace>> {
+        self.0.borrow().workspace.clone()
+    }
+}
+
+impl SelectionState {
+    /// Drop regions whose owning process no longer exists. Without this, a client
+    /// that was killed leaves a region nothing can retract or replace. An unknown
+    /// owner is kept, because it is not evidence of a dead one.
+    fn reap_dead_owners(&mut self) {
+        self.external.retain(|entry| match entry.owner_pid {
+            Some(pid) => {
+                let alive = process_is_alive(pid);
+                if !alive {
+                    log::info!(
+                        "claude_code_ide: reaping selection from {} (owner pid {pid} is gone)",
+                        entry.source
+                    );
+                }
+                alive
+            }
+            None => true,
+        });
+    }
+
+    /// Combine every source into one payload. None for zero regions, the payload
+    /// verbatim for one, and for several a `text` concatenating each under a
+    /// `# <path>:<start>-<end>` header while the top-level fields stay truthful to
+    /// the primary region, so the CLI's single-region banner never lies.
+    fn aggregate(&self) -> Option<SelectionPayload> {
+        let mut regions: Vec<&SelectionPayload> = Vec::new();
+        if let Some(editor) = &self.editor {
+            regions.push(editor);
+        }
+        regions.extend(self.external.iter().map(|entry| &entry.payload));
+
+        match regions.as_slice() {
+            [] => None,
+            [only] => Some((*only).clone()),
+            many => {
+                let text = many
+                    .iter()
+                    .map(|region| {
+                        format!(
+                            "# {}:{}-{}\n{}",
+                            region.file_path,
+                            region.selection.start.line + 1,
+                            region.selection.end.line + 1,
+                            region.text,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
+                // Top-level fields stay truthful to the primary region; only
+                // `text` carries every region. Fall back to the first region if
+                // no primary was recorded (should not happen once any source
+                // has been set).
+                let primary = self.last_primary.clone().unwrap_or_else(|| many[0].clone());
+                Some(SelectionPayload {
+                    text,
+                    file_path: primary.file_path,
+                    file_url: primary.file_url,
+                    selection: primary.selection,
+                })
+            }
+        }
+    }
+}
+
+impl Default for SharedSelection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The tools advertised in `tools/list`. The names are the wire contract: Claude
+/// Code surfaces each one to the model as `mcp__ide__<name>`.
+pub fn tools() -> Value {
+    let none = json!({ "type": "object", "properties": {} });
+    let tool = |name: &str, description: &str, input_schema: Value| {
+        json!({ "name": name, "description": description, "inputSchema": input_schema })
+    };
+    json!([
+        tool("getCurrentSelection", "Get the active editor's current text selection.", none.clone()),
+        tool("getLatestSelection", "Get the most recent text selection across editors.", none.clone()),
+        tool("getWorkspaceFolders", "Get the workspace's root folders.", none.clone()),
+        tool("openDiff", "Open a diff for review.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "old_file_path": { "type": "string" },
+                    "new_file_path": { "type": "string" },
+                    "new_file_contents": { "type": "string" },
+                    "tab_name": { "type": "string" },
+                },
+            })),
+        tool("closeAllDiffTabs", "Close all diff tabs.", none),
+        tool("executeCode", "Execute Python in a Jupyter kernel (requires an open notebook).",
+            json!({
+                "type": "object",
+                "properties": { "code": { "type": "string" } },
+                "required": ["code"],
+            })),
+    ])
+}
+
+/// Build the `getCurrentSelection` / `getLatestSelection` tool result from the
+/// cached selection. Recomputes live from the active editor first so a tool
+/// call reflects the very latest cursor, then falls back to the cache.
+pub async fn current_selection_result(
+    selection: &SharedSelection,
+    cx: &mut AsyncApp,
+) -> serde_json::Value {
+    // Refresh the editor slot from the live active editor so a tool call
+    // reflects the very latest cursor, then return the AGGREGATE across the
+    // editor and every external source (so `claude` sees all selected text in
+    // all files, not just the editor's).
+    if let Some(workspace) = selection.workspace() {
+        let live = cx.update(|cx| compute_active_selection(&workspace, cx));
+        selection.set_editor(live);
+    }
+
+    match selection.latest() {
+        Some(payload) => payload_result(&payload),
+        None => tool_ok("{}"),
+    }
+}
+
+fn payload_result(payload: &SelectionPayload) -> serde_json::Value {
+    match serde_json::to_string(payload) {
+        Ok(text) => tool_ok(text),
+        Err(err) => tool_error(format!("failed to encode selection: {err}")),
+    }
+}
+
+/// Build the `getWorkspaceFolders` tool result from the project's worktrees.
+pub async fn workspace_folders_result(
+    selection: &SharedSelection,
+    cx: &mut AsyncApp,
+) -> serde_json::Value {
+    let Some(workspace) = selection.workspace() else {
+        return tool_error("no workspace bound");
+    };
+    let folders = cx.update(|cx| compute_workspace_folders(&workspace, cx));
+    match folders {
+        Some(result) => match serde_json::to_string(&result) {
+            Ok(text) => tool_ok(text),
+            Err(err) => tool_error(format!("failed to encode folders: {err}")),
+        },
+        None => tool_ok(r#"{"folders":[],"rootPath":null}"#),
+    }
+}
+
+/// Read the active editor's newest selection into a payload, or `None` when no
+/// editor is active or it has no backing file.
+pub fn compute_active_selection(
+    workspace: &WeakEntity<Workspace>,
+    cx: &mut App,
+) -> Option<SelectionPayload> {
+    let workspace = workspace.upgrade()?;
+    let editor = workspace
+        .read(cx)
+        .active_item_as::<editor::Editor>(cx)?;
+    editor.update(cx, |editor, cx| selection_payload(editor, cx))
+}
+
+/// One resolved selection region: its file, range, and selected text.
+struct SelectionRegion {
+    file_path: String,
+    start: language::Point,
+    end: language::Point,
+    text: String,
+}
+
+fn selection_payload(editor: &mut editor::Editor, cx: &mut App) -> Option<SelectionPayload> {
+    let display_snapshot = editor.display_snapshot(cx);
+    let buffer_snapshot = display_snapshot.buffer_snapshot();
+    let multi_buffer = editor.buffer().clone();
+
+    // The newest selection is the PRIMARY region: the top-level `selection` /
+    // `filePath` / `fileUrl` stay truthful to it, so the CLI's single-region
+    // banner ("N lines from <file>") never lies. Additional regions are carried
+    // in `text` only (see below) - the protocol has no `selections[]` array, so
+    // multi-selection has nowhere else to go.
+    let newest = editor.selections.newest::<language::Point>(&display_snapshot);
+    let (primary_buffer, _) = multi_buffer
+        .read(cx)
+        .point_to_buffer_offset(newest.head(), cx)?;
+    let primary_path = project::File::from_dyn(primary_buffer.read(cx).file())
+        .map(|file| file.abs_path(cx))?;
+    let file_path = primary_path.to_string_lossy().to_string();
+    let file_url = format!("file://{file_path}");
+
+    // Resolve every disjoint selection to (path, range, text). A region whose
+    // buffer has no backing file (scratch/untitled) can't be attributed, so it
+    // is dropped rather than mislabelled.
+    let regions: Vec<SelectionRegion> = editor
+        .selections
+        .all::<language::Point>(&display_snapshot)
+        .into_iter()
+        .filter_map(|selection| {
+            let text = buffer_snapshot
+                .text_for_range(selection.start..selection.end)
+                .collect::<String>();
+            let (buffer, _) = multi_buffer
+                .read(cx)
+                .point_to_buffer_offset(selection.head(), cx)?;
+            let abs_path = project::File::from_dyn(buffer.read(cx).file())
+                .map(|file| file.abs_path(cx))?;
+            Some(SelectionRegion {
+                file_path: abs_path.to_string_lossy().to_string(),
+                start: selection.start,
+                end: selection.end,
+                text,
+            })
+        })
+        .collect();
+
+    // Single region: send its text verbatim (the proven single-select shape, so
+    // the banner label from `filePath` is clean). Multiple regions: concatenate
+    // all of them into `text` under `# <path>:<startLine>-<endLine>` headers so
+    // the model can attribute each block to its file and lines. `text_for_range`
+    // over the primary range covers the fallback where no region is file-backed.
+    let text = if regions.len() > 1 {
+        regions
+            .iter()
+            .map(|region| {
+                format!(
+                    "# {}:{}-{}\n{}",
+                    region.file_path,
+                    region.start.row + 1,
+                    region.end.row + 1,
+                    region.text,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    } else {
+        buffer_snapshot
+            .text_for_range(newest.start..newest.end)
+            .collect::<String>()
+    };
+
+    Some(SelectionPayload {
+        text,
+        file_path,
+        file_url,
+        selection: SelectionRange {
+            start: Position {
+                line: newest.start.row,
+                character: newest.start.column,
+            },
+            end: Position {
+                line: newest.end.row,
+                character: newest.end.column,
+            },
+        },
+    })
+}
+
+fn compute_workspace_folders(workspace: &WeakEntity<Workspace>, cx: &mut App) -> Option<Value> {
+    let workspace = workspace.upgrade()?;
+    let project = workspace.read(cx).project().clone();
+    let paths: Vec<(String, String)> = project
+        .read(cx)
+        .visible_worktrees(cx)
+        .map(|worktree| {
+            let worktree = worktree.read(cx);
+            (
+                worktree.root_name().as_unix_str().to_string(),
+                worktree.abs_path().to_string_lossy().to_string(),
+            )
+        })
+        .collect();
+    let root_path = paths.first().map(|(_, path)| path.clone());
+    let folders: Vec<Value> = paths
+        .iter()
+        .map(|(name, path)| json!({ "name": name, "uri": format!("file://{path}"), "path": path }))
+        .collect();
+    Some(json!({ "folders": folders, "rootPath": root_path }))
+}
+
+/// Convenience for the bridge subscription: recompute the editor selection,
+/// update the editor slot, and return the AGGREGATE (editor plus every external
+/// source) to broadcast. So an editor selection change re-broadcasts every
+/// source's current selection together, not the editor's in isolation.
+pub fn capture(
+    selection: &SharedSelection,
+    workspace: &Entity<Workspace>,
+    cx: &mut App,
+) -> Option<SelectionPayload> {
+    let payload = compute_active_selection(&workspace.downgrade(), cx);
+    selection.set_editor(payload);
+    selection.latest()
+}
+
+#[cfg(test)]
+mod aggregate_tests {
+    use super::*;
+
+    /// Upsert with no known owner. These tests are about aggregation, so they opt
+    /// out of liveness: an unknown owner is never reaped.
+    fn upsert(selection: &SharedSelection, source: &str, payload: SelectionPayload) {
+        selection.upsert_external(source.to_string(), payload, None);
+    }
+
+    fn payload(path: &str, start: u32, end: u32, text: &str) -> SelectionPayload {
+        SelectionPayload {
+            text: text.to_string(),
+            file_path: path.to_string(),
+            file_url: format!("file://{path}"),
+            selection: SelectionRange {
+                start: Position {
+                    line: start,
+                    character: 0,
+                },
+                end: Position {
+                    line: end,
+                    character: 0,
+                },
+            },
+        }
+    }
+
+    /// Removing one source leaves the others, removing an absent one reports false,
+    /// and removing the last empties the aggregate so the caller knows to send a
+    /// cleared notification rather than nothing. The sweep drops everything at once.
+    #[test]
+    fn removal_drops_one_source_or_all_and_can_empty_the_aggregate() {
+        let selection = SharedSelection::new();
+        upsert(&selection, "pid:1", payload("/a.rs", 0, 0, "alpha"));
+        upsert(&selection, "pid:2", payload("/b.rs", 4, 5, "bravo"));
+
+        assert!(selection.remove_external("pid:1"), "removing a present source");
+        let text = selection.latest().expect("one source remains").text;
+        log::info!("observed remaining text: {text}");
+        assert!(text.contains("bravo") && !text.contains("alpha"), "got {text}");
+        assert!(!selection.remove_external("pid:1"), "removing an absent source");
+
+        assert!(selection.remove_external("pid:2"), "removes the last source");
+        assert!(selection.latest().is_none(), "aggregate must be empty");
+
+        upsert(&selection, "a", payload("/a.rs", 0, 0, "alpha"));
+        upsert(&selection, "b", payload("/b.rs", 0, 0, "bravo"));
+        assert_eq!(selection.remove_all_external(), 2, "sweep drops both");
+        assert!(selection.latest().is_none(), "everything should be gone");
+        assert_eq!(selection.remove_all_external(), 0, "a second sweep finds nothing");
+    }
+
+    /// A region whose owner has died disappears on the next read, while a live owner
+    /// survives and an unknown owner is kept (not knowing who owns a region is not
+    /// evidence that it is stale). This is the fix for a client killed without
+    /// retracting: its key names a dead process, so nothing would ever replace it.
+    #[test]
+    fn regions_are_reaped_only_when_their_owner_is_known_dead() {
+        let selection = SharedSelection::new();
+
+        // A genuinely dead pid: spawn, reap, reuse its id. More honest than picking a
+        // number and hoping. smol's Command because the tree disallows the blocking one.
+        let dead_pid = smol::block_on(async {
+            let mut child = smol::process::Command::new("true")
+                .spawn()
+                .expect("spawn a short-lived child");
+            let pid = child.id();
+            child.status().await.expect("reap the child");
+            pid
+        });
+
+        let region = |name: &str, text: &str| payload(&format!("/{name}.rs"), 0, 0, text);
+        selection.upsert_external("dead".into(), region("gone", "from a dead"), Some(dead_pid));
+        selection.upsert_external(
+            "live".into(),
+            region("live", "from a live"),
+            Some(std::process::id()),
+        );
+        upsert(&selection, "unknown", region("x", "from an unknown"));
+
+        let text = selection.latest().expect("survivors remain").text;
+        log::info!("observed aggregate after reaping: {text}");
+        assert!(text.contains("from a live"), "live owner survives, got {text}");
+        assert!(text.contains("from an unknown"), "unknown owner kept, got {text}");
+        assert!(!text.contains("from a dead"), "dead owner reaped, got {text}");
+    }
+
+    /// `kill` reads 0 as "my process group" and negatives as a group id, so an owner
+    /// pid of 0 must never reach it: it would answer "alive" for our own group and
+    /// pin a region forever.
+    #[test]
+    fn pid_zero_is_never_treated_as_alive() {
+        assert!(!process_is_alive(0), "pid 0 must not read as a live owner");
+        assert!(process_is_alive(std::process::id()), "our own pid is alive");
+    }
+
+    #[test]
+    fn no_sources_is_empty() {
+        let selection = SharedSelection::new();
+        assert!(selection.latest().is_none(), "nothing selected -> None");
+    }
+
+    #[test]
+    fn single_source_passes_through_verbatim() {
+        // One region: the payload is returned unchanged, so the CLI's
+        // single-region banner ("N lines from <file>") stays clean.
+        let selection = SharedSelection::new();
+        upsert(&selection, "terminal:1", payload("/repo/a.rs", 0, 2, "fn a() {}"));
+        let got = selection.latest().expect("one source -> Some");
+        assert_eq!(got.file_path, "/repo/a.rs");
+        assert_eq!(got.text, "fn a() {}");
+        assert_eq!(got.selection.start.line, 0);
+        assert_eq!(got.selection.end.line, 2);
+    }
+
+    #[test]
+    fn two_sources_aggregate_with_headers_and_truthful_primary() {
+        // Two nvims in two terminals: BOTH selections ride in `text` under
+        // `# path:startLine-endLine` headers, and the top-level fields stay
+        // truthful to the most-recently-updated (primary) region.
+        let selection = SharedSelection::new();
+        upsert(&selection, "terminal:1", payload("/repo/a.rs", 0, 0, "alpha"));
+        upsert(&selection, "terminal:2", payload("/repo/b.rs", 4, 5, "bravo"));
+
+        let got = selection.latest().expect("two sources -> Some");
+        // Primary = the last upsert (b.rs), so the banner names it truthfully.
+        assert_eq!(got.file_path, "/repo/b.rs", "primary is the latest source");
+        assert_eq!(got.selection.start.line, 4);
+        // `text` carries BOTH regions, each under its own header (1-based lines).
+        assert!(got.text.contains("# /repo/a.rs:1-1\nalpha"), "text: {}", got.text);
+        assert!(got.text.contains("# /repo/b.rs:5-6\nbravo"), "text: {}", got.text);
+    }
+
+    #[test]
+    fn reselecting_same_source_replaces_not_accumulates() {
+        // Re-selecting in the SAME nvim (same source key) replaces its region;
+        // the aggregate stays a single region, not two stale copies.
+        let selection = SharedSelection::new();
+        upsert(&selection, "terminal:1", payload("/repo/a.rs", 0, 0, "first"));
+        upsert(&selection, "terminal:1", payload("/repo/a.rs", 9, 9, "second"));
+
+        let got = selection.latest().expect("still Some");
+        assert_eq!(got.text, "second", "same source replaces its own region");
+        assert_eq!(got.selection.start.line, 9);
+    }
+
+    #[test]
+    fn editor_and_external_aggregate_together() {
+        // The Zed editor selection and an external nvim selection combine: both
+        // appear, editor first (it is pushed into the region list first).
+        let selection = SharedSelection::new();
+        selection.set_editor(Some(payload("/repo/editor.rs", 1, 1, "in-editor")));
+        upsert(&selection, "terminal:7", payload("/repo/nvim.rs", 3, 3, "in-nvim"));
+
+        let got = selection.latest().expect("two regions -> Some");
+        assert!(got.text.contains("# /repo/editor.rs:2-2\nin-editor"), "text: {}", got.text);
+        assert!(got.text.contains("# /repo/nvim.rs:4-4\nin-nvim"), "text: {}", got.text);
+        // Primary is the external source (set last).
+        assert_eq!(got.file_path, "/repo/nvim.rs");
+    }
+
+    #[test]
+    fn clearing_editor_leaves_external_sources() {
+        // Setting the editor to None must not wipe external nvim selections.
+        let selection = SharedSelection::new();
+        selection.set_editor(Some(payload("/repo/editor.rs", 0, 0, "e")));
+        upsert(&selection, "terminal:1", payload("/repo/n.rs", 0, 0, "n"));
+        selection.set_editor(None);
+
+        let got = selection.latest().expect("external survives editor clear");
+        assert_eq!(got.file_path, "/repo/n.rs");
+        assert_eq!(got.text, "n", "only the external region remains");
+    }
+}

--- a/crates/claude_code_ide/src/selection_socket.rs
+++ b/crates/claude_code_ide/src/selection_socket.rs
@@ -1,0 +1,497 @@
+//! A Unix socket letting programs in a workspace's terminals feed selections to
+//! this workspace's bridge, which the editor path cannot see.
+//!
+//! The bridge advertises the socket to its terminals as `$ZED_SELECTION_SOCK`, so
+//! connecting to the inherited path is itself the proof the caller belongs to this
+//! workspace: no port matching, no lockfile hunt.
+//!
+//! One newline-terminated JSON object per connection, one reply line, then close:
+//!
+//! ```text
+//! {"op":"push_selection","text":"...","filePath":"/abs/path",
+//!  "fileUrl":"file:///abs/path","source":"cli:42",
+//!  "selection":{"start":{"line":0,"character":0},"end":{"line":3,"character":0}}}
+//! ```
+//!
+//! `text` and `filePath` are required, `fileUrl` defaults to `file://<filePath>`,
+//! `selection` defaults to a zero span, and coordinates are zero-based. `source`
+//! keys the region (see [`key_for`]). `clear_selection` retracts one source, or all
+//! of them with `"all": true`.
+//!
+//! Clients live in separate repositories: `zed-claude-selection.nvim` and
+//! `cc-ide-sel`. `bridge_tests` holds a client payload verbatim, so it doubles as
+//! the contract.
+
+use anyhow::{Context as _, Result};
+use futures::{
+    AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, StreamExt as _, io::BufReader,
+};
+use gpui::{AsyncApp, EntityId, Task};
+use net::async_net::{UnixListener, UnixStream};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::protocol::{Position, SelectionPayload, SelectionRange};
+
+/// The variable naming this socket in the environment of every terminal the
+/// workspace spawns. A client finds the socket by reading it, so the name is part
+/// of the contract.
+pub const SELECTION_SOCK_ENV: &str = "ZED_SELECTION_SOCK";
+
+/// Refuse absurd requests rather than buffering them. A selection is text a
+/// human chose, so a megabyte is already far past anything meaningful.
+const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+
+/// The directory holding every workspace's selection socket.
+pub fn socket_dir() -> PathBuf {
+    paths::temp_dir().join("zed-cc-ide")
+}
+
+/// The socket path for a bridge, keyed by the loopback port it already owns.
+/// That port is unique per workspace and lives exactly as long as the bridge, so
+/// the socket needs no separate identity and no workspace database id.
+pub fn socket_path_for_port(port: u16) -> PathBuf {
+    socket_dir().join(format!("{port}.sock"))
+}
+
+/// Create the parent directory private (0700) and clear any stale socket file,
+/// which would otherwise make `bind` fail with `EADDRINUSE`.
+fn prepare_socket_path(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating selection socket dir {}", parent.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("restricting {}", parent.display()))?;
+        }
+    }
+    if path.exists() {
+        std::fs::remove_file(path)
+            .with_context(|| format!("removing stale selection socket {}", path.display()))?;
+        log::info!(
+            "claude_code_ide: removed stale selection socket {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Remove the socket file when the bridge goes away. A missing file is normal.
+pub fn unlink_socket(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => log::info!(
+            "claude_code_ide: unlinked selection socket {}",
+            path.display()
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => log::warn!(
+            "claude_code_ide: failed to unlink selection socket {}: {err}",
+            path.display()
+        ),
+    }
+}
+
+/// One inbound request. Every field past `op` is optional on the wire, so a
+/// malformed request is answered with an error rather than dropping the connection.
+#[derive(Debug, Deserialize)]
+struct Request {
+    op: String,
+    text: Option<String>,
+    #[serde(rename = "filePath")]
+    file_path: Option<String>,
+    #[serde(rename = "fileUrl")]
+    file_url: Option<String>,
+    /// Stable per-caller key, and the field a client should set. Re-pushing under
+    /// the same key replaces that caller's region instead of adding another, so a
+    /// long-lived editor holds exactly one region however many files it visits.
+    /// Absent, the file path keys it, and regions accumulate as the caller moves
+    /// between files.
+    source: Option<String>,
+    selection: Option<Span>,
+    /// On `clear_selection`, drop EVERY external region rather than just this
+    /// caller's. The escape hatch for a region whose owner died leaving no pid to
+    /// reap by, so nothing can address its key any more.
+    #[serde(default)]
+    all: bool,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Span {
+    #[serde(default)]
+    start: Point,
+    #[serde(default)]
+    end: Point,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, Copy)]
+struct Point {
+    #[serde(default)]
+    line: u32,
+    #[serde(default)]
+    character: u32,
+}
+
+/// What a validated request asks the bridge to do.
+enum Action {
+    /// Set this source's region, replacing whatever it held before.
+    Push {
+        source: String,
+        payload: SelectionPayload,
+    },
+    /// Drop this source's region, because its selection has gone away.
+    Clear { source: String },
+    /// Drop every external region.
+    ClearAll,
+}
+
+/// The key a caller's region is held under: its stated `source`, else the file path.
+///
+/// The peer's pid is deliberately not a key, though it is still read for reaping. It
+/// resolves only while the peer is alive, and these clients close the socket as soon
+/// as they have written, so keying by it gave `pid:` on one push and `file:` on the
+/// next with nothing to explain why.
+fn key_for(explicit: Option<String>, file_path: Option<&str>) -> Option<String> {
+    if let Some(source) = explicit {
+        return Some(source);
+    }
+    log::info!(
+        "claude_code_ide: selection caller stated no source, keying by file path; \
+         state a `source` to hold exactly one region"
+    );
+    file_path.map(|path| format!("file:{path}"))
+}
+
+/// Validate a request and decide what it asks for. Returns the reason on
+/// rejection so the caller can be told what was wrong.
+fn parse(request: Request) -> std::result::Result<Action, String> {
+    match request.op.as_str() {
+        "push_selection" => {
+            let (Some(text), Some(file_path)) = (request.text, request.file_path) else {
+                return Err("push_selection requires both text and filePath".to_string());
+            };
+            let source = key_for(request.source, Some(&file_path))
+                .ok_or_else(|| "cannot identify the calling source".to_string())?;
+
+            // An empty selection is a retraction: broadcasting an empty region
+            // would show `claude` a selection with no content in it.
+            if text.is_empty() {
+                return Ok(Action::Clear { source });
+            }
+
+            let file_url = request
+                .file_url
+                .unwrap_or_else(|| format!("file://{file_path}"));
+            let span = request.selection.unwrap_or_default();
+            Ok(Action::Push {
+                source,
+                payload: SelectionPayload {
+                    text,
+                    file_path,
+                    file_url,
+                    selection: SelectionRange {
+                        start: Position {
+                            line: span.start.line,
+                            character: span.start.character,
+                        },
+                        end: Position {
+                            line: span.end.line,
+                            character: span.end.character,
+                        },
+                    },
+                },
+            })
+        }
+        "clear_selection" if request.all => Ok(Action::ClearAll),
+        // `filePath` is optional here: it only matters as the fallback key, which a
+        // caller that states a `source` never needs. A clear naming neither says
+        // nothing about what to drop, so it is refused rather than guessed at.
+        "clear_selection" => {
+            let source = key_for(request.source, request.file_path.as_deref()).ok_or_else(|| {
+                "clear_selection needs a source or a filePath to say what to clear; \
+                 pass `all: true` to clear every region"
+                    .to_string()
+            })?;
+            Ok(Action::Clear { source })
+        }
+        other => Err(format!("unknown op: {other}")),
+    }
+}
+
+/// Bind the socket and start accepting. Returns the bound path (to advertise and
+/// later unlink) and the accept task, which stops when dropped.
+///
+/// Accept and dispatch both run on the foreground executor, so pushing into the
+/// bridge needs no thread hand-off and nothing has to be `Send`.
+pub fn start(
+    workspace_id: EntityId,
+    port: u16,
+    cx: &mut AsyncApp,
+) -> Result<(PathBuf, Task<()>)> {
+    let path = socket_path_for_port(port);
+    prepare_socket_path(&path)?;
+    let listener = UnixListener::bind(&path)
+        .with_context(|| format!("binding selection socket {}", path.display()))?;
+    log::info!(
+        "claude_code_ide: selection socket listening on {}",
+        path.display()
+    );
+
+    let task = cx.spawn(async move |cx| {
+        let mut incoming = listener.incoming();
+        while let Some(stream) = incoming.next().await {
+            match stream {
+                Ok(stream) => serve(stream, workspace_id, cx).await,
+                Err(err) => {
+                    log::warn!("claude_code_ide: selection socket accept error: {err}");
+                    break;
+                }
+            }
+        }
+        log::info!("claude_code_ide: selection socket accept loop ended");
+    });
+
+    Ok((path, task))
+}
+
+/// Handle one connection: read a single line, push it, answer one line.
+async fn serve(mut stream: UnixStream, workspace_id: EntityId, cx: &mut AsyncApp) {
+    // Identify the caller from the kernel before reading a byte it sent, so the
+    // region key cannot be forged by the request body.
+    let peer_pid = crate::peer_cred::peer_pid(&stream);
+
+    let mut line = String::new();
+    // Cap the stream before buffering it: `Take` is `AsyncRead` but not
+    // `AsyncBufRead`, so capping the reader instead would lose `read_line`. The
+    // borrow ends with this block, freeing the stream for the reply below.
+    let read = {
+        let mut reader = BufReader::new((&mut stream).take(MAX_REQUEST_BYTES));
+        reader.read_line(&mut line).await
+    };
+    if let Err(err) = read {
+        log::warn!("claude_code_ide: selection socket read failed: {err}");
+        return;
+    }
+    if line.trim().is_empty() {
+        return;
+    }
+
+    let reply = match serde_json::from_str::<Request>(line.trim()) {
+        Ok(request) => match parse(request) {
+            Ok(Action::Push { source, payload }) => {
+                let file_path = payload.file_path.clone();
+                let logged_source = source.clone();
+                cx.update(|cx| {
+                    crate::bridge::push_external_selection(
+                        workspace_id,
+                        source,
+                        payload,
+                        peer_pid,
+                        cx,
+                    );
+                });
+                log::info!(
+                    "claude_code_ide: relayed selection from {logged_source} ({file_path}) \
+                     to the bridge"
+                );
+                serde_json::json!({ "ok": true })
+            }
+            Ok(Action::Clear { source }) => {
+                let logged_source = source.clone();
+                cx.update(|cx| {
+                    crate::bridge::clear_external_selection(workspace_id, source, cx);
+                });
+                log::info!("claude_code_ide: cleared the selection held for {logged_source}");
+                serde_json::json!({ "ok": true })
+            }
+            Ok(Action::ClearAll) => {
+                cx.update(|cx| {
+                    crate::bridge::clear_all_external_selections(workspace_id, cx);
+                });
+                log::info!("claude_code_ide: cleared every external selection region");
+                serde_json::json!({ "ok": true })
+            }
+            Err(reason) => {
+                log::info!("claude_code_ide: rejected selection request: {reason}");
+                serde_json::json!({ "ok": false, "error": reason })
+            }
+        },
+        Err(err) => {
+            log::warn!("claude_code_ide: malformed selection request: {err}");
+            serde_json::json!({ "ok": false, "error": format!("malformed request: {err}") })
+        }
+    };
+
+    // The caller is fire-and-forget (the Neovim shim closes without reading), so
+    // a failed write is expected and only worth a debug line.
+    let encoded = format!("{reply}\n");
+    if let Err(err) = stream.write_all(encoded.as_bytes()).await {
+        log::debug!("claude_code_ide: selection socket reply not delivered: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse a raw line the way `serve` does.
+    fn parse_raw(raw: &str) -> std::result::Result<Action, String> {
+        let request = serde_json::from_str::<Request>(raw).expect("request parses as JSON");
+        parse(request)
+    }
+
+    fn expect_push(action: Action) -> (String, SelectionPayload) {
+        match action {
+            Action::Push { source, payload } => (source, payload),
+            Action::Clear { source } => panic!("expected a push, got a clear for {source}"),
+            Action::ClearAll => panic!("expected a push, got a clear-all"),
+        }
+    }
+
+    fn expect_clear(action: Action) -> String {
+        match action {
+            Action::Clear { source } => source,
+            Action::Push { source, .. } => panic!("expected a clear, got a push for {source}"),
+            Action::ClearAll => panic!("expected a scoped clear, got a clear-all"),
+        }
+    }
+
+    /// `all: true` sweeps every region and needs no identity, since it is the
+    /// escape hatch for a key nothing can address any more.
+    #[test]
+    fn clear_all_needs_no_source() {
+        let action = parse_raw(r#"{"op":"clear_selection","all":true}"#)
+            .expect("clear-all is valid with nothing naming a source");
+        assert!(
+            matches!(action, Action::ClearAll),
+            "expected ClearAll, got something else"
+        );
+    }
+
+    /// A client that states its own `source` is keyed by it, whatever file the
+    /// selection came from, which is how one editor holds exactly one region
+    /// however many files it visits.
+    #[test]
+    fn parses_a_client_payload_keyed_by_its_stated_source() {
+        let raw = r#"{"op":"push_selection","text":"line two\nline three",
+                      "filePath":"/repo/a.rs","fileUrl":"file:///repo/a.rs",
+                      "source":"nvim:4242",
+                      "selection":{"start":{"line":1,"character":0},
+                                   "end":{"line":2,"character":0}}}"#;
+        let (source, payload) = expect_push(parse_raw(raw).expect("payload is valid"));
+        log::info!("observed source: {source}");
+        assert_eq!(source, "nvim:4242");
+        assert_eq!(payload.text, "line two\nline three");
+        assert_eq!(payload.file_url, "file:///repo/a.rs");
+        assert_eq!(payload.selection.start.line, 1);
+        assert_eq!(payload.selection.end.line, 2);
+    }
+
+    /// `fileUrl` and `selection` are optional: the URL is derived from the path
+    /// and the span defaults to zero.
+    #[test]
+    fn derives_file_url_and_defaults_span() {
+        let raw = r#"{"op":"push_selection","text":"hi","filePath":"/a/b.txt"}"#;
+        let (_source, payload) = expect_push(parse_raw(raw).expect("minimal payload is valid"));
+        log::info!("observed derived url: {}", payload.file_url);
+        assert_eq!(payload.file_url, "file:///a/b.txt");
+        assert_eq!(payload.selection.start.line, 0);
+        assert_eq!(payload.selection.end.character, 0);
+    }
+
+    /// The key is the stated `source`, else the file path. There is no third rule, so
+    /// the same request always yields the same key. The consequences that matter: one
+    /// source holds ONE region across several files (so a push replaces rather than
+    /// accumulates), and two sources stay independent.
+    #[test]
+    fn key_is_the_stated_source_else_the_file_path() {
+        let key = |raw: &str| expect_push(parse_raw(raw).expect("valid")).0;
+
+        assert_eq!(
+            key(r#"{"op":"push_selection","text":"x","filePath":"/a.rs","source":"cli"}"#),
+            "cli",
+            "a stated source is used verbatim"
+        );
+        assert_eq!(
+            key(r#"{"op":"push_selection","text":"x","filePath":"/a.rs"}"#),
+            "file:/a.rs",
+            "without a source the path keys it"
+        );
+        assert_eq!(
+            key(r#"{"op":"push_selection","text":"a","filePath":"/one.rs","source":"nvim:7"}"#),
+            key(r#"{"op":"push_selection","text":"b","filePath":"/two.rs","source":"nvim:7"}"#),
+            "one source reuses its key across files, so its region is replaced"
+        );
+        assert_ne!(
+            key(r#"{"op":"push_selection","text":"x","filePath":"/a.rs","source":"nvim:11"}"#),
+            key(r#"{"op":"push_selection","text":"x","filePath":"/a.rs","source":"nvim:12"}"#),
+            "distinct sources must not collide"
+        );
+    }
+
+    /// A retraction arrives two ways: the explicit op, or a push whose text is
+    /// empty (which is what an editor with nothing selected has to say). Both key
+    /// the same way as a push, so a client retracts exactly its own region.
+    #[test]
+    fn clears_via_the_op_and_via_empty_text() {
+        let explicit = r#"{"op":"clear_selection","source":"nvim:5"}"#;
+        assert_eq!(
+            expect_clear(parse_raw(explicit).expect("valid")),
+            "nvim:5",
+            "clear_selection needs no filePath when a source is stated"
+        );
+
+        let empty_push =
+            r#"{"op":"push_selection","text":"","filePath":"/a.rs","source":"nvim:5"}"#;
+        assert_eq!(
+            expect_clear(parse_raw(empty_push).expect("valid")),
+            "nvim:5",
+            "an empty selection is a retraction, not a region"
+        );
+    }
+
+    /// Missing `text` or `filePath` is rejected with a reason, and an unknown op
+    /// is named in the error rather than silently ignored.
+    #[test]
+    fn rejects_incomplete_and_unknown_requests() {
+        for raw in [
+            r#"{"op":"push_selection","filePath":"/a.rs"}"#,
+            r#"{"op":"push_selection","text":"hi"}"#,
+            r#"{"op":"push_selection"}"#,
+        ] {
+            let observed = parse_raw(raw).err();
+            log::info!("observed rejection for {raw}: {observed:?}");
+            assert!(observed.is_some(), "{raw} must be rejected");
+        }
+
+        let observed = parse_raw(r#"{"op":"send_input","text":"x"}"#)
+            .err()
+            .expect("unknown op is rejected");
+        assert!(
+            observed.contains("send_input"),
+            "error should name the op, observed {observed}"
+        );
+
+        // A clear naming neither a source nor a file says nothing about what to
+        // drop, and the error points at the sweep instead of guessing.
+        let observed = parse_raw(r#"{"op":"clear_selection"}"#)
+            .err()
+            .expect("an unaddressed clear is rejected");
+        log::info!("observed unaddressed-clear rejection: {observed}");
+        assert!(observed.contains("all"), "observed {observed}");
+    }
+
+    /// The socket path is keyed by port, so two workspaces never collide and the
+    /// path is stable for a given bridge.
+    #[test]
+    fn socket_path_is_per_port() {
+        let a = socket_path_for_port(41234);
+        let b = socket_path_for_port(41235);
+        log::info!("observed paths a={a:?} b={b:?}");
+        assert_ne!(a, b);
+        assert_eq!(a, socket_path_for_port(41234));
+        assert!(a.to_string_lossy().ends_with("41234.sock"));
+        assert!(a.starts_with(socket_dir()));
+    }
+}

--- a/crates/claude_code_ide/src/server.rs
+++ b/crates/claude_code_ide/src/server.rs
@@ -1,0 +1,467 @@
+//! The loopback WebSocket + MCP server Claude Code connects back into.
+//!
+//! Concurrency mirrors `context_server::listener::McpServer`: socket I/O on a
+//! background task, dispatch on the foreground so tool handlers can `cx.update`
+//! GPUI entities. Transport is a `smol` TCP listener upgraded by
+//! `async_tungstenite` (the `typst_viewer` precedent) rather than the Unix socket
+//! `context_server` uses.
+
+use anyhow::{Context as _, Result};
+use async_tungstenite::tungstenite::Message;
+use async_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HandshakeRequest, Response as HandshakeResponse,
+};
+use collections::HashMap;
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded};
+use futures::{FutureExt, StreamExt, select_biased};
+use gpui::{AppContext as _, AsyncApp, Task};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::protocol::{self, CallToolParams, IncomingMessage, error_code, tool_error, tool_ok};
+use crate::selection::{self, SharedSelection};
+use serde_json::{Value, json};
+
+/// The header Claude Code sends on the WebSocket upgrade carrying the token
+/// from the lockfile.
+const AUTH_HEADER: &str = "x-claude-code-ide-authorization";
+
+/// Fallback MCP protocol version if the client's `initialize` omits one. In
+/// practice we echo the client's version; this is only the default. Observed
+/// value from claude-code 2.1.212 was "2025-11-25".
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Live client connections, keyed by a monotonic id.
+///
+/// One workspace injects one `CLAUDE_CODE_SSE_PORT` into every terminal, so every
+/// `claude` in it connects to this one server. Hence a set rather than a slot:
+/// notifications go to all of them, and a connection closing removes only its own
+/// entry so one client exiting never silences the rest.
+type Connections = Rc<RefCell<ConnectionSet>>;
+
+#[derive(Default)]
+struct ConnectionSet {
+    /// Monotonic id handed to the next accepted connection. Never reused, so a
+    /// closing connection can remove exactly its own slot with no ABA race.
+    next_id: u64,
+    senders: HashMap<u64, UnboundedSender<String>>,
+}
+
+impl ConnectionSet {
+    /// Register a new connection's sender, returning the id it must present when
+    /// it later removes itself.
+    fn insert(&mut self, sender: UnboundedSender<String>) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.senders.insert(id, sender);
+        id
+    }
+
+    fn remove(&mut self, id: u64) {
+        self.senders.remove(&id);
+    }
+}
+
+/// A running bridge server. Dropping it stops the accept loop and closes the
+/// listener; connected clients see the socket close.
+pub struct BridgeServer {
+    port: u16,
+    /// Live senders to every connected client. Used to push `selection_changed`
+    /// / `at_mentioned` notifications. Empty until the first client connects.
+    connections: Connections,
+    _accept_task: Task<()>,
+}
+
+impl BridgeServer {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Broadcast a JSON-RPC notification to every connected client. Silently
+    /// no-ops when no client is connected. Encoded once, sent to all.
+    pub fn notify<T: serde::Serialize>(&self, method: &'static str, params: T) {
+        let connections = self.connections.borrow();
+        if connections.senders.is_empty() {
+            log::debug!("claude_code_ide: no clients connected; dropping {method}");
+            return;
+        }
+        let text = match serde_json::to_string(&protocol::notification(method, params)) {
+            Ok(text) => text,
+            Err(err) => {
+                log::warn!("claude_code_ide: failed to encode {method}: {err}");
+                return;
+            }
+        };
+        for sender in connections.senders.values() {
+            sender.unbounded_send(text.clone()).ok();
+        }
+    }
+}
+
+/// Bind a loopback listener on an ephemeral port and start accepting Claude Code
+/// connections. `auth_token` must match what we write to the lockfile.
+/// `selection` is the shared handle the selection tools read.
+pub fn start(
+    auth_token: String,
+    selection: SharedSelection,
+    cx: &mut AsyncApp,
+) -> Task<Result<BridgeServer>> {
+    let bind = cx.background_spawn(async move {
+        let listener = smol::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("binding claude_code_ide listener")?;
+        let port = listener.local_addr()?.port();
+        anyhow::Ok((listener, port))
+    });
+
+    cx.spawn(async move |cx| {
+        let (listener, port) = bind.await?;
+        let connections: Connections = Rc::new(RefCell::new(ConnectionSet::default()));
+
+        let accept_task = cx.spawn({
+            let connections = connections.clone();
+            async move |cx| {
+                loop {
+                    match listener.accept().await {
+                        Ok((stream, peer)) => {
+                            log::info!("claude_code_ide: connection from {peer}");
+                            serve_connection(
+                                stream,
+                                auth_token.clone(),
+                                selection.clone(),
+                                connections.clone(),
+                                cx,
+                            );
+                        }
+                        Err(err) => {
+                            log::warn!("claude_code_ide: accept error: {err}");
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        log::info!("claude_code_ide: listening on 127.0.0.1:{port}");
+        Ok(BridgeServer {
+            port,
+            connections,
+            _accept_task: accept_task,
+        })
+    })
+}
+
+/// Handle one client connection: perform the authenticated WebSocket handshake,
+/// then split into an I/O task and a dispatch loop.
+fn serve_connection(
+    stream: smol::net::TcpStream,
+    auth_token: String,
+    selection: SharedSelection,
+    connections: Connections,
+    cx: &mut AsyncApp,
+) {
+    let (incoming_tx, mut incoming_rx) = unbounded::<IncomingMessage>();
+    let (outgoing_tx, outgoing_rx) = unbounded::<String>();
+
+    // Register this client's sender in the connection set and remember its id so
+    // we remove exactly this connection (not whichever connected last) on close.
+    let connection_id = connections.borrow_mut().insert(outgoing_tx.clone());
+
+    // The socket I/O runs on a background thread, so it may only capture `Send`
+    // values (the channel endpoints), never the `Rc`-based connection set.
+    cx.background_spawn(async move {
+        if let Err(err) = handle_io(stream, auth_token, incoming_tx, outgoing_rx).await {
+            log::info!("claude_code_ide: connection closed: {err}");
+        }
+    })
+    .detach();
+
+    // The dispatch loop runs on the foreground, where touching `connections`
+    // (an `Rc`) is fine. When `incoming_rx` closes (client gone / I/O task
+    // finished), remove only THIS connection's sender so the remaining clients
+    // keep receiving notifications.
+    cx.spawn(async move |cx| {
+        while let Some(message) = incoming_rx.next().await {
+            dispatch(message, &selection, &outgoing_tx, cx).await;
+        }
+        connections.borrow_mut().remove(connection_id);
+    })
+    .detach();
+}
+
+/// Run the WebSocket handshake (validating the auth header), then pump messages
+/// between the socket and the mpsc channels until either side closes.
+///
+/// The handshake callback's error type is fixed by `accept_hdr_async`: it must
+/// return `Result<HandshakeResponse, ErrorResponse>`, and that error is 136 bytes.
+/// Boxing it is not open to us, so the size lint is allowed here rather than
+/// worked around.
+#[allow(clippy::result_large_err)]
+async fn handle_io(
+    stream: smol::net::TcpStream,
+    auth_token: String,
+    incoming_tx: UnboundedSender<IncomingMessage>,
+    mut outgoing_rx: UnboundedReceiver<String>,
+) -> Result<()> {
+    let mut authorized = false;
+    let ws = async_tungstenite::accept_hdr_async(stream, |req: &HandshakeRequest, mut response: HandshakeResponse| {
+        let presented = req
+            .headers()
+            .get(AUTH_HEADER)
+            .and_then(|value| value.to_str().ok());
+        match presented {
+            Some(token) if token == auth_token => {
+                authorized = true;
+                // Claude Code requests the `mcp` subprotocol on the upgrade; echo
+                // it back so the negotiation is well-formed (it connects without
+                // this too, but a correct server confirms the subprotocol).
+                if req
+                    .headers()
+                    .get("sec-websocket-protocol")
+                    .and_then(|value| value.to_str().ok())
+                    .is_some_and(|protocols| {
+                        protocols.split(',').any(|p| p.trim() == "mcp")
+                    })
+                {
+                    if let Ok(value) = "mcp".parse() {
+                        response.headers_mut().insert("sec-websocket-protocol", value);
+                    }
+                }
+                Ok(response)
+            }
+            _ => {
+                let mut error = ErrorResponse::new(Some("invalid or missing authorization".into()));
+                *error.status_mut() =
+                    async_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
+                Err(error)
+            }
+        }
+    })
+    .await
+    .context("websocket handshake")?;
+
+    if !authorized {
+        anyhow::bail!("connection was not authorized");
+    }
+    log::info!("claude_code_ide: client authorized");
+
+    let (mut write, mut read) = ws.split();
+    loop {
+        select_biased! {
+            outgoing = outgoing_rx.next().fuse() => {
+                match outgoing {
+                    Some(text) => {
+                        log::trace!("claude_code_ide send: {text}");
+                        write.send(Message::text(text)).await.context("ws send")?;
+                    }
+                    None => break,
+                }
+            }
+            incoming = read.next().fuse() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        log::trace!("claude_code_ide recv: {text}");
+                        match serde_json::from_str::<IncomingMessage>(&text) {
+                            Ok(message) => { incoming_tx.unbounded_send(message).ok(); }
+                            Err(err) => log::warn!("claude_code_ide: bad message: {err}; raw: {text}"),
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Ping(payload))) => {
+                        write.send(Message::Pong(payload)).await.ok();
+                    }
+                    Some(Ok(_)) => {} // ignore binary/pong/frame
+                    Some(Err(err)) => {
+                        log::info!("claude_code_ide: read error: {err}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Route one inbound JSON-RPC message to its handler and send the response.
+async fn dispatch(
+    message: IncomingMessage,
+    selection: &SharedSelection,
+    outgoing_tx: &UnboundedSender<String>,
+    cx: &mut AsyncApp,
+) {
+    // Notifications (no id) get no response. We currently expect none inbound,
+    // but the client may send `notifications/initialized`.
+    if message.is_notification() {
+        log::debug!("claude_code_ide: notification {} (ignored)", message.method);
+        return;
+    }
+    let id = message.id.clone().unwrap_or(serde_json::Value::Null);
+
+    match message.method.as_str() {
+        "initialize" => {
+            // Echo the client's protocolVersion (MCP negotiation): the real
+            // Claude Code CLI sends a newer version than any we'd hardcode, and
+            // reflecting it avoids a version-mismatch rejection. Fall back to our
+            // default if the client omitted it.
+            let protocol_version = message
+                .params
+                .as_ref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw.get()).ok())
+                .and_then(|params| {
+                    params
+                        .get("protocolVersion")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_owned)
+                })
+                .unwrap_or_else(|| MCP_PROTOCOL_VERSION.to_string());
+            send_ok(
+                outgoing_tx,
+                id,
+                json!({
+                    "protocolVersion": protocol_version,
+                    // The tool set is static per session, so we never push
+                    // tools/list_changed.
+                    "capabilities": { "tools": { "listChanged": false } },
+                    "serverInfo": {
+                        "name": "zed-claude-code-ide",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                }),
+            );
+        }
+        "tools/list" => send_ok(outgoing_tx, id, json!({ "tools": selection::tools() })),
+        "tools/call" => {
+            let params: CallToolParams = match message
+                .params
+                .as_ref()
+                .map(|raw| serde_json::from_str(raw.get()))
+                .transpose()
+            {
+                Ok(Some(params)) => params,
+                Ok(None) => {
+                    send_err(outgoing_tx, id, error_code::INVALID_PARAMS, "missing params");
+                    return;
+                }
+                Err(err) => {
+                    send_err(
+                        outgoing_tx,
+                        id,
+                        error_code::INVALID_PARAMS,
+                        format!("bad params: {err}"),
+                    );
+                    return;
+                }
+            };
+            let result = call_tool(&params, selection, cx).await;
+            send_ok(outgoing_tx, id, result);
+        }
+        other => {
+            send_err(
+                outgoing_tx,
+                id,
+                error_code::METHOD_NOT_FOUND,
+                format!("unhandled method {other}"),
+            );
+        }
+    }
+}
+
+/// Execute a named MCP tool. Unknown tools return a tool-level error rather than
+/// a transport error, matching how Claude Code's other IDE servers behave.
+async fn call_tool(
+    params: &CallToolParams,
+    selection: &SharedSelection,
+    cx: &mut AsyncApp,
+) -> serde_json::Value {
+    match params.name.as_str() {
+        "getCurrentSelection" | "getLatestSelection" => {
+            selection::current_selection_result(selection, cx).await
+        }
+        "getWorkspaceFolders" => selection::workspace_folders_result(selection, cx).await,
+        // Claude Code calls closeAllDiffTabs unprompted on connect, and drives
+        // openDiff from its edit flow, so both must answer or every connection and
+        // every edit reports an error. Acknowledging is not implementing: an
+        // interactive keep/reject surface, and Jupyter execution, are separate work.
+        "closeAllDiffTabs" => tool_ok("0"),
+        "openDiff" => tool_ok("DIFF_REJECTED"),
+        "executeCode" => tool_error("Jupyter code execution is not available in Zed"),
+        other => tool_error(format!("unknown tool: {other}")),
+    }
+}
+
+fn send_ok<T: serde::Serialize>(tx: &UnboundedSender<String>, id: Value, result: T) {
+    send(tx, protocol::ok_response(id, result));
+}
+
+fn send_err(tx: &UnboundedSender<String>, id: Value, code: i32, message: impl Into<String>) {
+    send(tx, protocol::err_response(id, code, message));
+}
+
+fn send(tx: &UnboundedSender<String>, message: Value) {
+    match serde_json::to_string(&message) {
+        Ok(text) => {
+            tx.unbounded_send(text).ok();
+        }
+        Err(err) => log::warn!("claude_code_ide: failed to encode response: {err}"),
+    }
+}
+
+#[cfg(test)]
+mod connection_set_tests {
+    use super::*;
+
+    /// A broadcast reaches every registered connection, and closing one
+    /// connection (removing its slot) leaves the others receiving. This is the
+    /// heart of the multi-`claude` fix: N sessions share one server, so a
+    /// notification must fan out to all of them and one session exiting must not
+    /// silence the rest.
+    #[test]
+    fn broadcast_reaches_all_and_remove_is_scoped_to_one() {
+        let mut set = ConnectionSet::default();
+
+        let (tx_a, mut rx_a) = unbounded::<String>();
+        let (tx_b, mut rx_b) = unbounded::<String>();
+        let id_a = set.insert(tx_a);
+        let id_b = set.insert(tx_b);
+        assert_ne!(id_a, id_b, "each connection gets a distinct id");
+
+        // A "broadcast" writes the same text to every sender in the set.
+        // `try_recv()` yields `Ok(msg)` for a delivered message.
+        for sender in set.senders.values() {
+            sender.unbounded_send("first".to_string()).ok();
+        }
+        assert_eq!(rx_a.try_recv().ok(), Some("first".to_string()));
+        assert_eq!(rx_b.try_recv().ok(), Some("first".to_string()));
+
+        // Remove only connection A; B's slot must survive.
+        set.remove(id_a);
+        assert!(!set.senders.contains_key(&id_a), "A's slot is gone");
+        assert!(set.senders.contains_key(&id_b), "B's slot survives A closing");
+
+        for sender in set.senders.values() {
+            sender.unbounded_send("second".to_string()).ok();
+        }
+        // B still receives; A's sender was dropped by remove(), so A's channel is
+        // closed: `try_recv()` returns `Err(TryRecvError::Closed)`, never
+        // "second".
+        assert_eq!(rx_b.try_recv().ok(), Some("second".to_string()));
+        assert!(
+            rx_a.try_recv().is_err(),
+            "a removed connection must receive no further broadcasts"
+        );
+    }
+
+    /// Ids are monotonic and never reused, so a late close removing an old id
+    /// cannot evict a newer connection that happened to reuse a slot (there is no
+    /// slot reuse: the ABA hazard the monotonic counter exists to prevent).
+    #[test]
+    fn ids_are_monotonic_and_not_reused() {
+        let mut set = ConnectionSet::default();
+        let (tx0, _rx0) = unbounded::<String>();
+        let (tx1, _rx1) = unbounded::<String>();
+        let id0 = set.insert(tx0);
+        set.remove(id0);
+        let id1 = set.insert(tx1);
+        assert!(id1 > id0, "a fresh connection never reuses a closed id");
+    }
+}

--- a/crates/claude_code_ide/src/server_tests.rs
+++ b/crates/claude_code_ide/src/server_tests.rs
@@ -1,0 +1,238 @@
+//! Transport-level integration tests: drive the real WebSocket + MCP server as
+//! a Claude Code client would, over a loopback socket.
+//!
+//! Dispatch runs on the foreground executor while socket I/O runs on the background
+//! reactor, so these run the *client* on `cx.background_executor` (a real thread) and
+//! drive the server with `run_until_parked`. `allow_parking` is required because the
+//! client blocks on real socket reads.
+
+use crate::selection::SharedSelection;
+use crate::server;
+use async_tungstenite::tungstenite::Message;
+use async_tungstenite::tungstenite::client::IntoClientRequest;
+use futures::StreamExt as _;
+use gpui::TestAppContext;
+
+pub(crate) type ClientWs = async_tungstenite::WebSocketStream<smol::net::TcpStream>;
+
+/// Connect a WebSocket client to the bridge, optionally presenting an auth
+/// token. Runs on the background reactor.
+pub(crate) async fn connect(port: u16, token: Option<&str>) -> anyhow::Result<ClientWs> {
+    let url = format!("ws://127.0.0.1:{port}");
+    let addr = format!("127.0.0.1:{port}");
+    let tcp = smol::net::TcpStream::connect(&addr).await?;
+    let mut request = url.as_str().into_client_request()?;
+    if let Some(token) = token {
+        request
+            .headers_mut()
+            .insert("x-claude-code-ide-authorization", token.parse()?);
+    }
+    let (ws, _response) = async_tungstenite::client_async(request, tcp).await?;
+    Ok(ws)
+}
+
+/// Read the next text frame and parse it as JSON.
+pub(crate) async fn next_json(ws: &mut ClientWs) -> serde_json::Value {
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(text))) => {
+                return serde_json::from_str(&text).expect("valid JSON response");
+            }
+            Some(Ok(_)) => continue,
+            other => panic!("expected a text frame, got {other:?}"),
+        }
+    }
+}
+
+#[gpui::test]
+async fn rejects_missing_or_wrong_token(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    let token = "0123456789abcdef0123456789abcdef".to_string();
+    let selection = SharedSelection::new();
+    let mut async_cx = cx.to_async();
+    let server = server::start(token.clone(), selection, &mut async_cx)
+        .await
+        .expect("server should start");
+    let port = server.port();
+
+    // Run all three handshake attempts on the background reactor; drive the
+    // server's accept loop with run_until_parked.
+    let token_clone = token.clone();
+    let client = cx.background_executor.spawn(async move {
+        let no_token = connect(port, None).await.is_ok();
+        let wrong = connect(port, Some("ffffffffffffffffffffffffffffffff"))
+            .await
+            .is_ok();
+        let correct = connect(port, Some(&token_clone)).await.is_ok();
+        (no_token, wrong, correct)
+    });
+    cx.run_until_parked();
+    let (no_token_ok, wrong_ok, correct_ok) = client.await;
+
+    assert!(!no_token_ok, "connection without a token should be rejected");
+    assert!(!wrong_ok, "connection with a wrong token should be rejected");
+    assert!(correct_ok, "connection with the correct token should succeed");
+}
+
+#[gpui::test]
+async fn initialize_and_list_tools_round_trip(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    let token = "abcdef0123456789abcdef0123456789".to_string();
+    let selection = SharedSelection::new();
+    let mut async_cx = cx.to_async();
+    let server = server::start(token.clone(), selection, &mut async_cx)
+        .await
+        .expect("server should start");
+    let port = server.port();
+
+    // The whole client conversation runs on the background reactor and reports
+    // the three responses back; run_until_parked drives the server between the
+    // client's socket operations.
+    let token_clone = token.clone();
+    let client = cx.background_executor.spawn(async move {
+        let mut ws = connect(port, Some(&token_clone))
+            .await
+            .expect("authorized connection");
+        ws.send(Message::text(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+        ))
+        .await
+        .expect("send initialize");
+        let init = next_json(&mut ws).await;
+
+        ws.send(Message::text(
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+        ))
+        .await
+        .expect("send tools/list");
+        let list = next_json(&mut ws).await;
+
+        ws.send(Message::text(
+            r#"{"jsonrpc":"2.0","id":3,"method":"no/such/method","params":{}}"#,
+        ))
+        .await
+        .expect("send bogus");
+        let err = next_json(&mut ws).await;
+
+        (init, list, err)
+    });
+    cx.run_until_parked();
+    let (init, list, err) = client.await;
+
+    assert_eq!(init["id"], 1);
+    assert_eq!(init["result"]["serverInfo"]["name"], "zed-claude-code-ide");
+    assert_eq!(init["result"]["capabilities"]["tools"]["listChanged"], false);
+
+    assert_eq!(list["id"], 2);
+    let names: Vec<String> = list["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(names.contains(&"getCurrentSelection".to_string()));
+    assert!(names.contains(&"getWorkspaceFolders".to_string()));
+    assert!(names.contains(&"executeCode".to_string()));
+
+    assert_eq!(err["id"], 3);
+    assert!(err["error"]["code"].is_number());
+}
+
+#[gpui::test]
+async fn notify_broadcasts_to_all_connected_clients(cx: &mut TestAppContext) {
+    // Two `claude` sessions in one workspace both connect to the single server.
+    // A selection_changed broadcast must reach BOTH: the multi-connection fix.
+    cx.executor().allow_parking();
+    let token = "abcabcabcabcabcabcabcabcabcabcab".to_string();
+    let selection = SharedSelection::new();
+    let mut async_cx = cx.to_async();
+    let server = server::start(token.clone(), selection, &mut async_cx)
+        .await
+        .expect("server should start");
+    let port = server.port();
+
+    // Connect two clients on the background reactor and complete their MCP
+    // handshakes so their dispatch loops register the outgoing senders.
+    let token_a = token.clone();
+    let connect_both = cx.background_executor.spawn(async move {
+        let mut a = connect(port, Some(&token_a)).await.expect("client A connects");
+        let mut b = connect(port, Some(&token_a)).await.expect("client B connects");
+        for ws in [&mut a, &mut b] {
+            ws.send(Message::text(
+                r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+            ))
+            .await
+            .expect("send initialize");
+            let _ = next_json(ws).await;
+        }
+        (a, b)
+    });
+    cx.run_until_parked();
+    let (mut a, mut b) = connect_both.await;
+
+    // Fire the broadcast from the foreground, then let the I/O tasks flush it.
+    server.notify(
+        "selection_changed",
+        serde_json::json!({ "text": "hello", "filePath": "/x" }),
+    );
+    cx.run_until_parked();
+
+    // Both clients must receive the same notification frame.
+    let received = cx.background_executor.spawn(async move {
+        let first = next_json(&mut a).await;
+        let second = next_json(&mut b).await;
+        (first, second)
+    });
+    cx.run_until_parked();
+    let (first, second) = received.await;
+
+    for (label, frame) in [("A", &first), ("B", &second)] {
+        assert_eq!(
+            frame["method"], "selection_changed",
+            "client {label} should receive selection_changed, got {frame}"
+        );
+        assert_eq!(
+            frame["params"]["text"], "hello",
+            "client {label} should receive the broadcast payload, got {frame}"
+        );
+        assert!(
+            frame["id"].is_null(),
+            "a notification carries no id, got {frame}"
+        );
+    }
+}
+
+#[gpui::test]
+async fn call_tool_without_selection_is_empty(cx: &mut TestAppContext) {
+    cx.executor().allow_parking();
+    let token = "1111111111111111aaaaaaaaaaaaaaaa".to_string();
+    let selection = SharedSelection::new();
+    let mut async_cx = cx.to_async();
+    let server = server::start(token.clone(), selection, &mut async_cx)
+        .await
+        .expect("server should start");
+    let port = server.port();
+
+    let token_clone = token.clone();
+    let client = cx.background_executor.spawn(async move {
+        let mut ws = connect(port, Some(&token_clone))
+            .await
+            .expect("authorized connection");
+        // No workspace bound and no cached selection: getCurrentSelection
+        // returns an empty object rather than erroring.
+        ws.send(Message::text(
+            r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"getCurrentSelection","arguments":{}}}"#,
+        ))
+        .await
+        .expect("send tools/call");
+        next_json(&mut ws).await
+    });
+    cx.run_until_parked();
+    let response = client.await;
+
+    assert_eq!(response["id"], 7);
+    let text = response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text content");
+    assert_eq!(text, "{}");
+}

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1388,9 +1388,7 @@ impl Project {
 
                 buffers_needing_diff: Default::default(),
                 git_diff_debouncer: DebouncedDelay::new(),
-                terminals: Terminals {
-                    local_handles: Vec::new(),
-                },
+                terminals: Terminals::default(),
                 node: Some(node),
                 search_history: Self::new_search_history(),
                 environment,
@@ -1631,9 +1629,7 @@ impl Project {
                 remote_client: Some(remote.clone()),
                 buffers_needing_diff: Default::default(),
                 git_diff_debouncer: DebouncedDelay::new(),
-                terminals: Terminals {
-                    local_handles: Vec::new(),
-                },
+                terminals: Terminals::default(),
                 node: Some(node),
                 search_history: Self::new_search_history(),
                 environment,
@@ -1921,9 +1917,7 @@ impl Project {
                 agent_server_store,
                 buffers_needing_diff: Default::default(),
                 git_diff_debouncer: DebouncedDelay::new(),
-                terminals: Terminals {
-                    local_handles: Vec::new(),
-                },
+                terminals: Terminals::default(),
                 node: None,
                 search_history: Self::new_search_history(),
                 search_included_history: Self::new_search_history(),

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -24,8 +24,13 @@ use util::{
 
 use crate::{Project, ProjectPath};
 
+#[derive(Default)]
 pub struct Terminals {
     pub(crate) local_handles: Vec<WeakEntity<terminal::Terminal>>,
+    /// Extra environment variables handed to every terminal this project
+    /// subsequently spawns, layered over the resolved directory environment and
+    /// the `terminal.env` setting. See [`Project::set_terminal_env_var`].
+    pub(crate) extra_env: HashMap<String, String>,
 }
 
 impl Project {
@@ -131,9 +136,13 @@ impl Project {
             .map(|p| self.active_toolchain(p, LanguageName::new_static("Python"), cx))
             .collect::<Vec<_>>();
         let lang_registry = self.languages.clone();
+        let extra_env = self.terminals.extra_env.clone();
         cx.spawn(async move |project, cx| {
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
+            // Project-injected vars win over the setting, so a caller that must
+            // be seen (a discovery port) is not silently shadowed by user config.
+            env.extend(extra_env);
 
             let activation_script = maybe!(async {
                 for toolchain in toolchains {
@@ -372,10 +381,12 @@ impl Project {
             self.resolve_directory_environment(&env_shell, path.clone(), remote_client.clone(), cx);
 
         let lang_registry = self.languages.clone();
+        let extra_env = self.terminals.extra_env.clone();
         cx.spawn(async move |project, cx| {
             let shell_kind = ShellKind::new(&shell, path_style.is_windows());
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
+            env.extend(extra_env);
 
             let activation_script = maybe!(async {
                 for toolchain in toolchains {
@@ -538,9 +549,11 @@ impl Project {
             cx,
         );
 
+        let extra_env = self.terminals.extra_env.clone();
         cx.spawn(async move |project, cx| {
             let mut env = env_task.await.unwrap_or_default();
             env.extend(settings.env);
+            env.extend(extra_env);
 
             project.update(cx, move |_, cx| {
                 match remote_client {
@@ -578,6 +591,19 @@ impl Project {
 
     pub fn local_terminal_handles(&self) -> &Vec<WeakEntity<terminal::Terminal>> {
         &self.terminals.local_handles
+    }
+
+    /// Inject (or overwrite) an environment variable that every terminal
+    /// subsequently spawned by this project inherits, layered on top of the
+    /// resolved directory environment and the `terminal.env` setting. Only
+    /// affects terminals created after this call. Idempotent: setting the same
+    /// key again replaces the value.
+    pub fn set_terminal_env_var(&mut self, key: String, value: String) {
+        log::info!(
+            "project: injecting terminal env var {key}=<{} bytes>",
+            value.len()
+        );
+        self.terminals.extra_env.insert(key, value);
     }
 
     fn resolve_directory_environment(

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -89,6 +89,7 @@ call.workspace = true
 channel.workspace = true
 chrono.workspace = true
 clap.workspace = true
+claude_code_ide.workspace = true
 cli.workspace = true
 client.workspace = true
 clock = { workspace = true, optional = true }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -767,6 +767,7 @@ fn main() {
         });
         vim::init(cx);
         terminal_view::init(cx);
+        claude_code_ide::init(cx);
         journal::init(app_state.clone(), cx);
         encoding_selector::init(cx);
         language_selector::init(cx);


### PR DESCRIPTION
Claude Code discovers its host editor by scanning `~/.claude/ide/` for a `<port>.lock` file, then opening a loopback WebSocket to that port and speaking MCP. The VS Code and JetBrains integrations implement that contract, which gives them selection sharing, diagnostics and diff review. Zed does not, so a `claude` running in a Zed terminal cannot see what you have selected, and you end up pasting code into the prompt that the editor already knows about.

This PR adds the bridge, which runs per workspace. The bridge writes the discovery lockfile, binds an authenticated loopback WebSocket, answers the selection and workspace-folder tools, and pushes `selection_changed` as the editor selection moves. The discovery environment variables go into the terminals the workspace spawns, so `claude` connects with no `/ide` step.

Anthropic documents what the integrations do, including the lock file, but does not publish the wire protocol. This implements it as reverse-engineered by the Neovim port, corrected in the places where the real CLI disagreed with that write-up.

### References

- Claude Code IDE integrations, the behaviour this reproduces: <https://code.claude.com/docs/en/ide-integrations>
- `claudecode.nvim`, the Neovim port: <https://github.com/coder/claudecode.nvim>
- Its reverse-engineered protocol write-up, which this crate follows: <https://github.com/coder/claudecode.nvim/blob/main/PROTOCOL.md>

### What is in it

- `crates/claude_code_ide`, a new crate holding the lockfile, the server, the selection state and the per-workspace lifecycle.
- `Project::set_terminal_env_var` in `crates/project`, so the bridge can hand the discovery port to terminals the project spawns. Applied after `terminal.env`, so a variable a caller must have seen is not silently shadowed by user config.
- A unix socket per workspace, advertised to its terminals as `$ZED_SELECTION_SOCK`, which accepts selections from programs running there. An editor running inside a Zed terminal is invisible to the editor path, so this is how it contributes. A Neovim client exists separately and is not part of this change.
- `cmd-alt-x` sends the current selection as an `at_mentioned`.

Selections from every source combine rather than overwrite, so an editor selection and two terminal editors send all three regions together. A region goes away when its source retracts it or when the process that pushed it exits.

### Deliberately acknowledged rather than implemented

`closeAllDiffTabs` and `openDiff` answer without doing the work. Claude Code calls the first unprompted on every connect and drives the second from its edit flow, so a bridge that ignored them would report an error on every connection and every edit. `executeCode` refuses for the same reason. An interactive diff review surface and Jupyter execution are each a separate piece of work.

### Trying it

1. Open a folder in Zed. A projectless window advertises no workspace folders, and the CLI filters IDEs whose folders do not intersect the session cwd.
2. Check the lockfile and socket appeared:

   ```sh
   ls ~/.claude/ide/*.lock
   ls ~/Library/Caches/Zed/zed-cc-ide/     # macOS; $TMPDIR/zed-cc-ide elsewhere
   ```

3. Open a terminal **after** the workspace has loaded, since the environment is injected into terminals spawned from then on, and confirm:

   ```sh
   echo "$CLAUDE_CODE_SSE_PORT $ENABLE_IDE_INTEGRATION $ZED_SELECTION_SOCK"
   ```

4. Run `claude` there. It should report a connected IDE with no `/ide` step. Select text in an editor and ask what it can see.

`ZED_LOG=warn,claude_code_ide=trace` logs every JSON-RPC frame in both directions, which is the quickest way to see a `selection_changed` payload as the CLI receives it.


### Notes

- One workspace injects one port into every terminal it spawns, so every `claude` in that workspace shares one server and every one of them receives the broadcast. That is intended, and it is why the connection set is a set rather than a slot.
- Peer credentials are read on unix only. Elsewhere a region is kept until its source retracts it, rather than being reaped when its owner exits.
- The retraction payload sends `selection: null` with empty text. The notification's `selection` field is nullable, and this was confirmed by hand against the CLI, but it is not covered by an automated test against a real CLI because none exists here.

Release Notes:

- Added support for Zed as a Claude Code IDE, so a `claude` session running in a Zed terminal can see the editor selection.
