### PR TITLE
docs: Update documentation for YARA

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -182,7 +182,7 @@
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md)
-- [Yara](./languages/yara.md)
+- [YARA](./languages/yara.md)
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -77,8 +77,7 @@ Some work out-of-the-box and others rely on 3rd party extensions.
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md) \*
-- [Yara](./languages/yarn.md)
-- [Yarn](./languages/yarn.md)
+- [Yara](./languages/yara.md)
 - [Zig](./languages/zig.md)
 
 ## Additional Community Language Extensions

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -77,7 +77,7 @@ Some work out-of-the-box and others rely on 3rd party extensions.
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md) \*
-- [Yara](./languages/yara.md)
+- [YARA](./languages/yara.md)
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -78,6 +78,7 @@ Some work out-of-the-box and others rely on 3rd party extensions.
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md) \*
 - [Yara](./languages/yara.md)
+- [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 
 ## Additional Community Language Extensions

--- a/docs/src/languages/yara.md
+++ b/docs/src/languages/yara.md
@@ -1,11 +1,16 @@
 ---
-title: Yara
-description: "Configure Yara language support in Zed, including language servers, formatting, and debugging."
+title: YARA
+description: "Configure YARA language support in Zed, including language servers, formatting, and debugging."
 ---
 
-# Yara
+# YARA
 
-`Yara` language support in Zed is provided by the [Yara language extension](https://github.com/egibs/yara.zed). Please report issues to [https://github.com/egibs/yara.zed/issues](https://github.com/egibs/yara.zed/issues).
+[YARA](https://virustotal.github.io/yara/) support is available through the [YARA extension](https://github.com/egibs/yara.zed).
 
 - Tree-sitter: [egibs/tree-sitter-yara](https://github.com/egibs/tree-sitter-yara)
 - Language Server: [avast/yls](https://github.com/avast/yls)
+
+## Setup
+
+1. Follow instructions to [Install YLS](https://github.com/avast/yls/wiki/How-to-setup) from the YARA Language Server website.
+2. Ensure `yls` is in your PATH.


### PR DESCRIPTION
## Description
Fixed documentation bug in \docs/src/languages.md\:

- **Issue**: \Yara\ was incorrectly linked to \./languages/yarn.md\ and there was a duplicate \Yarn\ entry
- **Fix**: Changed \Yara\ link to \./languages/yara.md\ and removed the duplicate \Yarn\ entry

## Testing
- Verified both \yara.md\ and \yarn.md\ files exist in \docs/src/languages/\
- Applied Prettier formatting to the file

---

Release Notes:

- N/A