### PR TITLE
which_key: Add a pending key binding indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21002,6 +21002,7 @@ dependencies = [
  "util",
  "vim_mode_setting",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20998,6 +20998,7 @@ dependencies = [
  "theme_settings",
  "ui",
  "util",
+ "vim_mode_setting",
  "workspace",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20996,6 +20996,7 @@ dependencies = [
  "command_palette",
  "gpui",
  "settings",
+ "theme",
  "theme_settings",
  "ui",
  "util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20992,6 +20992,7 @@ dependencies = [
 name = "which_key"
 version = "0.1.0"
 dependencies = [
+ "collections",
  "command_palette",
  "gpui",
  "settings",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1927,6 +1927,9 @@
     "line_endings_button": false,
     // Control when to show the active encoding in the status bar.
     "active_encoding_button": "non_utf8",
+    // Whether to show an indicator with a countdown while a multi-stroke
+    // key binding is pending.
+    "pending_keystrokes_indicator": true,
   },
   // Settings specific to the terminal
   "terminal": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1927,8 +1927,8 @@
     "line_endings_button": false,
     // Control when to show the active encoding in the status bar.
     "active_encoding_button": "non_utf8",
-    // Whether to show an indicator with a countdown while a multi-stroke
-    // key binding is pending.
+    // Whether to show an indicator with a countdown while timed multi-stroke
+    // input is pending. Hovering the indicator pauses the timeout.
     "pending_keystrokes_indicator": true,
   },
   // Settings specific to the terminal

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1928,7 +1928,8 @@
     // Control when to show the active encoding in the status bar.
     "active_encoding_button": "non_utf8",
     // Whether to show an indicator with a countdown while timed multi-stroke
-    // input is pending. Hovering the indicator pauses the timeout.
+    // input is pending. Hovering the indicator pauses the timeout. Its binding
+    // preview popover is disabled when "which_key.enabled" is true.
     "pending_keystrokes_indicator": true,
   },
   // Settings specific to the terminal
@@ -2752,6 +2753,8 @@
   // Which-key popup settings
   "which_key": {
     // Whether to show the which-key popup when holding down key combinations.
+    // When enabled, the pending keystrokes indicator remains visible, but its
+    // binding preview popover is disabled.
     "enabled": false,
     // Delay in milliseconds before showing the which-key popup.
     "delay_ms": 1000,

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -650,7 +650,247 @@ mod tests {
         )
     }
 
+    struct PendingInputTestView {
+        focus_handle: FocusHandle,
+        action_count: Rc<Cell<usize>>,
+        secondary_action_count: Rc<Cell<usize>>,
+    }
+
+    #[derive(Clone)]
+    struct PendingTextInputTestView {
+        focus_handle: FocusHandle,
+        text: Rc<RefCell<String>>,
+        action_count: Rc<Cell<usize>>,
+    }
+
+    impl PendingTextInputTestView {
+        fn new(cx: &mut Context<Self>) -> Self {
+            Self {
+                focus_handle: cx.focus_handle(),
+                text: Rc::default(),
+                action_count: Rc::default(),
+            }
+        }
+    }
+
+    impl Element for PendingTextInputTestView {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            Some("pending-text-input-test".into())
+        }
+
+        fn source_location(&self) -> Option<&'static panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> (LayoutId, Self::RequestLayoutState) {
+            (window.request_layout(Style::default(), [], cx), ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            _: Bounds<Pixels>,
+            _: &mut Self::RequestLayoutState,
+            window: &mut Window,
+            cx: &mut App,
+        ) -> Self::PrepaintState {
+            window.set_focus_handle(&self.focus_handle, cx);
+        }
+
+        fn paint(
+            &mut self,
+            _: Option<&GlobalElementId>,
+            _: Option<&InspectorElementId>,
+            _: Bounds<Pixels>,
+            _: &mut Self::RequestLayoutState,
+            _: &mut Self::PrepaintState,
+            window: &mut Window,
+            cx: &mut App,
+        ) {
+            let mut key_context = KeyContext::default();
+            key_context.add("Terminal");
+            window.set_key_context(key_context);
+            window.handle_input(&self.focus_handle, self.clone(), cx);
+            let action_count = self.action_count.clone();
+            window.on_action(
+                std::any::TypeId::of::<TestAction>(),
+                move |_, phase, _, _| {
+                    if phase == DispatchPhase::Bubble {
+                        action_count.set(action_count.get() + 1);
+                    }
+                },
+            );
+        }
+    }
+
+    impl IntoElement for PendingTextInputTestView {
+        type Element = Self;
+
+        fn into_element(self) -> Self::Element {
+            self
+        }
+    }
+
+    impl InputHandler for PendingTextInputTestView {
+        fn selected_text_range(
+            &mut self,
+            _: bool,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<UTF16Selection> {
+            None
+        }
+
+        fn marked_text_range(&mut self, _: &mut Window, _: &mut App) -> Option<Range<usize>> {
+            None
+        }
+
+        fn text_for_range(
+            &mut self,
+            _: Range<usize>,
+            _: &mut Option<Range<usize>>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<String> {
+            None
+        }
+
+        fn replace_text_in_range(
+            &mut self,
+            replacement_range: Option<Range<usize>>,
+            text: &str,
+            _: &mut Window,
+            _: &mut App,
+        ) {
+            if replacement_range.is_some() {
+                unimplemented!()
+            }
+            self.text.borrow_mut().push_str(text)
+        }
+
+        fn replace_and_mark_text_in_range(
+            &mut self,
+            replacement_range: Option<Range<usize>>,
+            new_text: &str,
+            _: Option<Range<usize>>,
+            _: &mut Window,
+            _: &mut App,
+        ) {
+            if replacement_range.is_some() {
+                unimplemented!()
+            }
+            self.text.borrow_mut().push_str(new_text)
+        }
+
+        fn unmark_text(&mut self, _: &mut Window, _: &mut App) {}
+
+        fn prefers_ime_for_printable_keys(&mut self, _: &mut Window, _: &mut App) -> bool {
+            true
+        }
+
+        fn bounds_for_range(
+            &mut self,
+            _: Range<usize>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<Bounds<Pixels>> {
+            None
+        }
+
+        fn character_index_for_point(
+            &mut self,
+            _: Point<Pixels>,
+            _: &mut Window,
+            _: &mut App,
+        ) -> Option<usize> {
+            None
+        }
+    }
+
+    impl Render for PendingTextInputTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.clone()
+        }
+    }
+
     struct PendingInputTimeoutPauseOwner;
+
+    impl Render for PendingInputTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            use crate::{InteractiveElement as _, Styled as _};
+            let action_count = self.action_count.clone();
+            let secondary_action_count = self.secondary_action_count.clone();
+            crate::div()
+                .key_context("Terminal")
+                .track_focus(&self.focus_handle)
+                .size_full()
+                .on_action(move |_: &TestAction, _, _| {
+                    action_count.set(action_count.get() + 1);
+                })
+                .on_action(move |_: &SecondaryTestAction, _, _| {
+                    secondary_action_count.set(secondary_action_count.get() + 1);
+                })
+        }
+    }
+
+    fn setup_pending_input_test(
+        cx: &mut TestAppContext,
+        bindings: impl IntoIterator<Item = KeyBinding>,
+    ) -> (&mut VisualTestContext, Rc<Cell<usize>>, Rc<Cell<usize>>) {
+        cx.update(|cx| cx.bind_keys(bindings));
+
+        let action_count = Rc::new(Cell::new(0));
+        let secondary_action_count = Rc::new(Cell::new(0));
+        let (view, cx) = cx.add_window_view(|_, cx| PendingInputTestView {
+            focus_handle: cx.focus_handle(),
+            action_count: action_count.clone(),
+            secondary_action_count: secondary_action_count.clone(),
+        });
+        let focus_handle = cx.update(|_, cx| view.read(cx).focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        (cx, action_count, secondary_action_count)
+    }
+
+    fn setup_pending_input_timeout_test(
+        cx: &mut TestAppContext,
+    ) -> (&mut VisualTestContext, Rc<Cell<usize>>, Rc<Cell<usize>>) {
+        setup_pending_input_test(
+            cx,
+            [
+                KeyBinding::new("ctrl-b", TestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h j", TestAction, Some("Terminal")),
+            ],
+        )
+    }
+
+    fn query_prefers_ime_for_printable_keys(cx: &mut VisualTestContext) -> Option<bool> {
+        let mut platform_window = cx.test_window(cx.window_handle());
+        let mut input_handler = platform_window.take_input_handler()?;
+        let prefers_ime = input_handler.query_prefers_ime_for_printable_keys();
+        platform_window.set_input_handler(input_handler);
+        Some(prefers_ime)
+    }
+
+    fn simulate_pending_binding(cx: &mut VisualTestContext) {
+        cx.simulate_modifiers_change(crate::Modifiers::control());
+        cx.simulate_keystrokes("ctrl-b");
+        cx.simulate_modifiers_change(crate::Modifiers::default());
+    }
 
     #[test]
     fn test_keybinding_for_action_bounds() {
@@ -1065,53 +1305,43 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_pending_input_timeout_dispatches_shorter_binding(cx: &mut TestAppContext) {
-        struct TestView {
-            focus_handle: FocusHandle,
-            action_count: Rc<Cell<usize>>,
-            secondary_action_count: Rc<Cell<usize>>,
-        }
-
-        impl Render for TestView {
-            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-                use crate::{InteractiveElement as _, Styled as _};
-                let action_count = self.action_count.clone();
-                let secondary_action_count = self.secondary_action_count.clone();
-                crate::div()
-                    .key_context("Terminal")
-                    .track_focus(&self.focus_handle)
-                    .size_full()
-                    .on_action(move |_: &TestAction, _, _| {
-                        action_count.set(action_count.get() + 1);
-                    })
-                    .on_action(move |_: &SecondaryTestAction, _, _| {
-                        secondary_action_count.set(secondary_action_count.get() + 1);
-                    })
-            }
-        }
-
+    fn test_printable_pending_input_replays_on_timeout(cx: &mut TestAppContext) {
         cx.update(|cx| {
-            cx.bind_keys([
-                KeyBinding::new("ctrl-b", TestAction, Some("Terminal")),
-                KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
-                KeyBinding::new("ctrl-b h j", TestAction, Some("Terminal")),
-            ]);
+            cx.bind_keys([KeyBinding::new("j k", TestAction, Some("Terminal"))]);
         });
-
-        let action_count = Rc::new(Cell::new(0));
-        let secondary_action_count = Rc::new(Cell::new(0));
-        let (view, cx) = cx.add_window_view(|_, cx| TestView {
-            focus_handle: cx.focus_handle(),
-            action_count: action_count.clone(),
-            secondary_action_count: secondary_action_count.clone(),
-        });
+        let (test, cx) = cx.add_window_view(|_, cx| PendingTextInputTestView::new(cx));
+        let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
         cx.update(|window, cx| {
-            window.focus(&view.read(cx).focus_handle.clone(), cx);
+            window.focus(&focus_handle, cx);
             window.activate_window();
         });
-        cx.simulate_modifiers_change(crate::Modifiers::control());
-        cx.simulate_keystrokes("ctrl-b");
-        cx.simulate_modifiers_change(crate::Modifiers::default());
+
+        cx.simulate_keystrokes("j");
+
+        cx.update(|window, _| {
+            let pending_input = window.pending_input().expect("pending input");
+            assert_eq!(pending_input.keystrokes().len(), 1);
+            assert!(pending_input.timeout().is_some());
+        });
+        test.update(cx, |test, _| {
+            assert_eq!(test.action_count.get(), 0);
+            assert_eq!(test.text.borrow().as_str(), "");
+        });
+
+        cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        test.update(cx, |test, _| {
+            assert_eq!(test.action_count.get(), 0);
+            assert_eq!(test.text.borrow().as_str(), "j");
+        });
+    }
+
+    #[crate::test]
+    fn test_pending_input_timeout_dispatches_shorter_binding(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
         cx.update(|window, _| {
             assert_eq!(
                 window
@@ -1130,12 +1360,130 @@ mod tests {
         assert_eq!(action_count.get(), 0);
 
         // Emulate a countdown indicator re-rendering the window while waiting for the timeout.
-        for _ in 0..7 {
+        for _ in 0..10 {
             cx.executor()
                 .advance_clock(crate::PENDING_INPUT_TIMEOUT / 10);
             cx.update(|window, _| window.refresh());
             cx.run_until_parked();
         }
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 0);
+    }
+
+    #[crate::test]
+    fn test_running_pending_input_timeout_resets_when_binding_advances(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 4 / 5);
+        cx.run_until_parked();
+        cx.simulate_keystrokes("h");
+        cx.run_until_parked();
+
+        cx.update(|window, cx| {
+            let pending_input = window.pending_input().expect("pending input");
+            let timeout = pending_input.timeout().expect("pending input timeout");
+            assert_eq!(pending_input.keystrokes().len(), 2);
+            assert!(!timeout.is_paused());
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT);
+        });
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT / 5);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 0);
+        assert_eq!(secondary_action_count.get(), 0);
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 4 / 5);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 0);
+        assert_eq!(secondary_action_count.get(), 1);
+    }
+
+    #[crate::test]
+    fn test_pending_input_timeout_starts_when_binding_becomes_ambiguous(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_test(
+            cx,
+            [
+                KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h j", TestAction, Some("Terminal")),
+            ],
+        );
+        simulate_pending_binding(cx);
+
+        cx.update(|window, _| {
+            let pending_input = window.pending_input().expect("pending input");
+            assert_eq!(pending_input.keystrokes().len(), 1);
+            assert!(pending_input.timeout().is_none());
+        });
+
+        cx.simulate_keystrokes("h");
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let pending_input = window.pending_input().expect("pending input");
+            let timeout = pending_input.timeout().expect("pending input timeout");
+            assert_eq!(pending_input.keystrokes().len(), 2);
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT);
+        });
+
+        cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 0);
+        assert_eq!(secondary_action_count.get(), 1);
+    }
+
+    #[crate::test]
+    fn test_invalid_continuation_while_timeout_paused_replays_pending_input(
+        cx: &mut TestAppContext,
+    ) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_test(
+            cx,
+            [
+                KeyBinding::new("ctrl-b", TestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
+                KeyBinding::new("x", SecondaryTestAction, Some("Terminal")),
+            ],
+        );
+        simulate_pending_binding(cx);
+        let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("x");
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 1);
+
+        drop(pause_owner);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(window.pending_input_is_none()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 1);
+    }
+
+    #[crate::test]
+    fn test_pending_input_timeout_pauses_and_resumes(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 7 / 10);
+        cx.run_until_parked();
 
         let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
         let other_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
@@ -1160,23 +1508,68 @@ mod tests {
         cx.update(|window, _| assert!(window.has_pending_keystrokes()));
         assert_eq!(action_count.get(), 0);
 
-        drop(pause_owner);
-        cx.update(|_, _| {});
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, false, cx));
+        });
         cx.run_until_parked();
-        for _ in 0..3 {
-            cx.executor()
-                .advance_clock(crate::PENDING_INPUT_TIMEOUT / 10);
-            cx.update(|window, _| window.refresh());
-            cx.run_until_parked();
-        }
+        cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT * 3 / 10);
+        });
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 3 / 10);
+        cx.run_until_parked();
 
         cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
         assert_eq!(action_count.get(), 1);
         assert_eq!(secondary_action_count.get(), 0);
+    }
 
-        cx.simulate_modifiers_change(crate::Modifiers::control());
-        cx.simulate_keystrokes("ctrl-b");
-        cx.simulate_modifiers_change(crate::Modifiers::default());
+    #[crate::test]
+    fn test_pending_input_timeout_resumes_when_owner_is_released(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 7 / 10);
+        cx.run_until_parked();
+
+        let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+        });
+        cx.run_until_parked();
+
+        drop(pause_owner);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT * 3 / 10);
+        });
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 3 / 10);
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 0);
+    }
+
+    #[crate::test]
+    fn test_pending_input_timeout_resets_when_binding_advances(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
         cx.executor()
             .advance_clock(crate::PENDING_INPUT_TIMEOUT / 2);
         cx.run_until_parked();
@@ -1207,26 +1600,25 @@ mod tests {
             .advance_clock(crate::PENDING_INPUT_TIMEOUT * 2);
         cx.run_until_parked();
         cx.update(|window, _| assert!(window.has_pending_keystrokes()));
-        assert_eq!(action_count.get(), 1);
+        assert_eq!(action_count.get(), 0);
         assert_eq!(secondary_action_count.get(), 0);
 
-        drop(pause_owner);
-        cx.update(|_, _| {});
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, false, cx));
+        });
         cx.run_until_parked();
         cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
         cx.run_until_parked();
 
         cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
-        assert_eq!(action_count.get(), 1);
+        assert_eq!(action_count.get(), 0);
         assert_eq!(secondary_action_count.get(), 1);
+    }
 
-        cx.update(|window, cx| {
-            let focus_handle = view.read(cx).focus_handle.clone();
-            window.focus(&focus_handle, cx);
-        });
-        cx.simulate_modifiers_change(crate::Modifiers::control());
-        cx.simulate_keystrokes("ctrl-b");
-        cx.simulate_modifiers_change(crate::Modifiers::default());
+    #[crate::test]
+    fn test_clearing_pending_input_invalidates_timeout_pause(cx: &mut TestAppContext) {
+        let (cx, action_count, secondary_action_count) = setup_pending_input_timeout_test(cx);
+        simulate_pending_binding(cx);
         let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
         cx.update(|window, cx| {
             assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
@@ -1241,191 +1633,23 @@ mod tests {
         cx.run_until_parked();
 
         cx.update(|window, _| assert!(window.pending_input_is_none()));
-        assert_eq!(action_count.get(), 1);
-        assert_eq!(secondary_action_count.get(), 1);
+        assert_eq!(action_count.get(), 0);
+        assert_eq!(secondary_action_count.get(), 0);
     }
 
     #[crate::test]
     fn test_input_handler_pending(cx: &mut TestAppContext) {
-        #[derive(Clone)]
-        struct CustomElement {
-            focus_handle: FocusHandle,
-            text: Rc<RefCell<String>>,
-            action_count: Rc<Cell<usize>>,
-        }
-        impl CustomElement {
-            fn new(cx: &mut Context<Self>) -> Self {
-                Self {
-                    focus_handle: cx.focus_handle(),
-                    text: Rc::default(),
-                    action_count: Rc::default(),
-                }
-            }
-        }
-        impl Element for CustomElement {
-            type RequestLayoutState = ();
-
-            type PrepaintState = ();
-
-            fn id(&self) -> Option<ElementId> {
-                Some("custom".into())
-            }
-            fn source_location(&self) -> Option<&'static panic::Location<'static>> {
-                None
-            }
-            fn request_layout(
-                &mut self,
-                _: Option<&GlobalElementId>,
-                _: Option<&InspectorElementId>,
-                window: &mut Window,
-                cx: &mut App,
-            ) -> (LayoutId, Self::RequestLayoutState) {
-                (window.request_layout(Style::default(), [], cx), ())
-            }
-            fn prepaint(
-                &mut self,
-                _: Option<&GlobalElementId>,
-                _: Option<&InspectorElementId>,
-                _: Bounds<Pixels>,
-                _: &mut Self::RequestLayoutState,
-                window: &mut Window,
-                cx: &mut App,
-            ) -> Self::PrepaintState {
-                window.set_focus_handle(&self.focus_handle, cx);
-            }
-            fn paint(
-                &mut self,
-                _: Option<&GlobalElementId>,
-                _: Option<&InspectorElementId>,
-                _: Bounds<Pixels>,
-                _: &mut Self::RequestLayoutState,
-                _: &mut Self::PrepaintState,
-                window: &mut Window,
-                cx: &mut App,
-            ) {
-                let mut key_context = KeyContext::default();
-                key_context.add("Terminal");
-                window.set_key_context(key_context);
-                window.handle_input(&self.focus_handle, self.clone(), cx);
-                let action_count = self.action_count.clone();
-                window.on_action(
-                    std::any::TypeId::of::<TestAction>(),
-                    move |_, phase, _, _| {
-                        if phase == DispatchPhase::Bubble {
-                            action_count.set(action_count.get() + 1);
-                        }
-                    },
-                );
-            }
-        }
-        impl IntoElement for CustomElement {
-            type Element = Self;
-
-            fn into_element(self) -> Self::Element {
-                self
-            }
-        }
-
-        impl InputHandler for CustomElement {
-            fn selected_text_range(
-                &mut self,
-                _: bool,
-                _: &mut Window,
-                _: &mut App,
-            ) -> Option<UTF16Selection> {
-                None
-            }
-
-            fn marked_text_range(&mut self, _: &mut Window, _: &mut App) -> Option<Range<usize>> {
-                None
-            }
-
-            fn text_for_range(
-                &mut self,
-                _: Range<usize>,
-                _: &mut Option<Range<usize>>,
-                _: &mut Window,
-                _: &mut App,
-            ) -> Option<String> {
-                None
-            }
-
-            fn replace_text_in_range(
-                &mut self,
-                replacement_range: Option<Range<usize>>,
-                text: &str,
-                _: &mut Window,
-                _: &mut App,
-            ) {
-                if replacement_range.is_some() {
-                    unimplemented!()
-                }
-                self.text.borrow_mut().push_str(text)
-            }
-
-            fn replace_and_mark_text_in_range(
-                &mut self,
-                replacement_range: Option<Range<usize>>,
-                new_text: &str,
-                _: Option<Range<usize>>,
-                _: &mut Window,
-                _: &mut App,
-            ) {
-                if replacement_range.is_some() {
-                    unimplemented!()
-                }
-                self.text.borrow_mut().push_str(new_text)
-            }
-
-            fn unmark_text(&mut self, _: &mut Window, _: &mut App) {}
-
-            fn prefers_ime_for_printable_keys(&mut self, _: &mut Window, _: &mut App) -> bool {
-                true
-            }
-
-            fn bounds_for_range(
-                &mut self,
-                _: Range<usize>,
-                _: &mut Window,
-                _: &mut App,
-            ) -> Option<Bounds<Pixels>> {
-                None
-            }
-
-            fn character_index_for_point(
-                &mut self,
-                _: Point<Pixels>,
-                _: &mut Window,
-                _: &mut App,
-            ) -> Option<usize> {
-                None
-            }
-        }
-        impl Render for CustomElement {
-            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-                self.clone()
-            }
-        }
-
         cx.update(|cx| {
             cx.bind_keys([KeyBinding::new("ctrl-b", TestAction, Some("Terminal"))]);
             cx.bind_keys([KeyBinding::new("ctrl-b h", TestAction, Some("Terminal"))]);
             cx.bind_keys([KeyBinding::new("ctrl-x k", TestAction, Some("Terminal"))]);
         });
-        let (test, cx) = cx.add_window_view(|_, cx| CustomElement::new(cx));
+        let (test, cx) = cx.add_window_view(|_, cx| PendingTextInputTestView::new(cx));
         let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
         cx.update(|window, cx| {
             window.focus(&focus_handle, cx);
             window.activate_window();
         });
-
-        let query_prefers_ime_for_printable_keys = |cx: &mut VisualTestContext| {
-            let mut platform_window = cx.test_window(cx.window_handle());
-            let mut input_handler = platform_window.take_input_handler()?;
-            let prefers_ime = input_handler.query_prefers_ime_for_printable_keys();
-            platform_window.set_input_handler(input_handler);
-            Some(prefers_ime)
-        };
 
         assert_eq!(query_prefers_ime_for_printable_keys(cx), Some(true));
         cx.simulate_keystrokes("ctrl-x");

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -1104,8 +1104,18 @@ mod tests {
         cx.simulate_keystrokes("ctrl-b");
         cx.simulate_modifiers_change(crate::Modifiers::default());
         cx.update(|window, _| {
-            assert!(window.has_pending_keystrokes());
-            assert!(window.pending_input_will_timeout());
+            assert_eq!(
+                window
+                    .pending_input()
+                    .map(|pending_input| pending_input.keystrokes().len()),
+                Some(1)
+            );
+            assert_eq!(
+                window
+                    .pending_input()
+                    .and_then(|pending_input| pending_input.timeout()),
+                Some(crate::PENDING_INPUT_TIMEOUT)
+            );
         });
         assert_eq!(action_count.get(), 0);
 

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -650,6 +650,8 @@ mod tests {
         )
     }
 
+    struct PendingInputTimeoutPauseOwner;
+
     #[test]
     fn test_keybinding_for_action_bounds() {
         let tree = test_dispatch_tree(vec![KeyBinding::new(
@@ -1067,18 +1069,23 @@ mod tests {
         struct TestView {
             focus_handle: FocusHandle,
             action_count: Rc<Cell<usize>>,
+            secondary_action_count: Rc<Cell<usize>>,
         }
 
         impl Render for TestView {
             fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
                 use crate::{InteractiveElement as _, Styled as _};
                 let action_count = self.action_count.clone();
+                let secondary_action_count = self.secondary_action_count.clone();
                 crate::div()
                     .key_context("Terminal")
                     .track_focus(&self.focus_handle)
                     .size_full()
                     .on_action(move |_: &TestAction, _, _| {
                         action_count.set(action_count.get() + 1);
+                    })
+                    .on_action(move |_: &SecondaryTestAction, _, _| {
+                        secondary_action_count.set(secondary_action_count.get() + 1);
                     })
             }
         }
@@ -1087,19 +1094,21 @@ mod tests {
             cx.bind_keys([
                 KeyBinding::new("ctrl-b", TestAction, Some("Terminal")),
                 KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h j", TestAction, Some("Terminal")),
             ]);
         });
 
         let action_count = Rc::new(Cell::new(0));
+        let secondary_action_count = Rc::new(Cell::new(0));
         let (view, cx) = cx.add_window_view(|_, cx| TestView {
             focus_handle: cx.focus_handle(),
             action_count: action_count.clone(),
+            secondary_action_count: secondary_action_count.clone(),
         });
         cx.update(|window, cx| {
             window.focus(&view.read(cx).focus_handle.clone(), cx);
             window.activate_window();
         });
-
         cx.simulate_modifiers_change(crate::Modifiers::control());
         cx.simulate_keystrokes("ctrl-b");
         cx.simulate_modifiers_change(crate::Modifiers::default());
@@ -1113,14 +1122,48 @@ mod tests {
             assert_eq!(
                 window
                     .pending_input()
-                    .and_then(|pending_input| pending_input.timeout()),
+                    .and_then(|pending_input| pending_input.timeout())
+                    .map(|timeout| timeout.duration()),
                 Some(crate::PENDING_INPUT_TIMEOUT)
             );
         });
         assert_eq!(action_count.get(), 0);
 
         // Emulate a countdown indicator re-rendering the window while waiting for the timeout.
-        for _ in 0..10 {
+        for _ in 0..7 {
+            cx.executor()
+                .advance_clock(crate::PENDING_INPUT_TIMEOUT / 10);
+            cx.update(|window, _| window.refresh());
+            cx.run_until_parked();
+        }
+
+        let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        let other_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+            assert!(!window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+            assert!(!window.set_pending_input_timeout_paused(&other_owner, false, cx));
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(timeout.is_paused());
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT * 3 / 10);
+        });
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 2);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 0);
+
+        drop(pause_owner);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        for _ in 0..3 {
             cx.executor()
                 .advance_clock(crate::PENDING_INPUT_TIMEOUT / 10);
             cx.update(|window, _| window.refresh());
@@ -1129,6 +1172,77 @@ mod tests {
 
         cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
         assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 0);
+
+        cx.simulate_modifiers_change(crate::Modifiers::control());
+        cx.simulate_keystrokes("ctrl-b");
+        cx.simulate_modifiers_change(crate::Modifiers::default());
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT / 2);
+        cx.run_until_parked();
+        let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT / 2);
+        });
+
+        cx.simulate_keystrokes("h");
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let pending_input = window.pending_input().expect("pending input");
+            let timeout = pending_input.timeout().expect("pending input timeout");
+            assert_eq!(pending_input.keystrokes().len(), 2);
+            assert!(timeout.is_paused());
+            assert_eq!(timeout.remaining(cx), crate::PENDING_INPUT_TIMEOUT);
+        });
+
+        cx.executor()
+            .advance_clock(crate::PENDING_INPUT_TIMEOUT * 2);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 0);
+
+        drop(pause_owner);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 1);
+
+        cx.update(|window, cx| {
+            let focus_handle = view.read(cx).focus_handle.clone();
+            window.focus(&focus_handle, cx);
+        });
+        cx.simulate_modifiers_change(crate::Modifiers::control());
+        cx.simulate_keystrokes("ctrl-b");
+        cx.simulate_modifiers_change(crate::Modifiers::default());
+        let pause_owner = cx.update(|_, cx| cx.new(|_| PendingInputTimeoutPauseOwner));
+        cx.update(|window, cx| {
+            assert!(window.set_pending_input_timeout_paused(&pause_owner, true, cx));
+            window.focus(&cx.focus_handle(), cx);
+            assert!(!window.has_pending_keystrokes());
+        });
+
+        drop(pause_owner);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        cx.executor().advance_clock(crate::PENDING_INPUT_TIMEOUT);
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(window.pending_input_is_none()));
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(secondary_action_count.get(), 1);
     }
 
     #[crate::test]

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -1063,6 +1063,65 @@ mod tests {
     }
 
     #[crate::test]
+    fn test_pending_input_timeout_dispatches_shorter_binding(cx: &mut TestAppContext) {
+        struct TestView {
+            focus_handle: FocusHandle,
+            action_count: Rc<Cell<usize>>,
+        }
+
+        impl Render for TestView {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                use crate::{InteractiveElement as _, Styled as _};
+                let action_count = self.action_count.clone();
+                crate::div()
+                    .key_context("Terminal")
+                    .track_focus(&self.focus_handle)
+                    .size_full()
+                    .on_action(move |_: &TestAction, _, _| {
+                        action_count.set(action_count.get() + 1);
+                    })
+            }
+        }
+
+        cx.update(|cx| {
+            cx.bind_keys([
+                KeyBinding::new("ctrl-b", TestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-b h", SecondaryTestAction, Some("Terminal")),
+            ]);
+        });
+
+        let action_count = Rc::new(Cell::new(0));
+        let (view, cx) = cx.add_window_view(|_, cx| TestView {
+            focus_handle: cx.focus_handle(),
+            action_count: action_count.clone(),
+        });
+        cx.update(|window, cx| {
+            window.focus(&view.read(cx).focus_handle.clone(), cx);
+            window.activate_window();
+        });
+
+        cx.simulate_modifiers_change(crate::Modifiers::control());
+        cx.simulate_keystrokes("ctrl-b");
+        cx.simulate_modifiers_change(crate::Modifiers::default());
+        cx.update(|window, _| {
+            assert!(window.has_pending_keystrokes());
+            assert!(window.pending_input_will_timeout());
+        });
+        assert_eq!(action_count.get(), 0);
+
+        // Emulate a countdown indicator re-rendering the window while waiting for the timeout.
+        for _ in 0..10 {
+            cx.executor()
+                .advance_clock(crate::PENDING_INPUT_TIMEOUT / 10);
+            cx.update(|window, _| window.refresh());
+            cx.run_until_parked();
+        }
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(action_count.get(), 1);
+    }
+
+    #[crate::test]
     fn test_input_handler_pending(cx: &mut TestAppContext) {
         #[derive(Clone)]
         struct CustomElement {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1283,7 +1283,7 @@ pub(crate) const PENDING_INPUT_TIMEOUT: Duration = Duration::from_secs(1);
 /// Pending input for a potential multi-stroke key binding.
 pub struct PendingInputStatus<'a> {
     keystrokes: &'a [Keystroke],
-    timeout: Option<Duration>,
+    timeout: Option<PendingInputTimeoutStatus>,
 }
 
 impl<'a> PendingInputStatus<'a> {
@@ -1292,9 +1292,117 @@ impl<'a> PendingInputStatus<'a> {
         self.keystrokes
     }
 
-    /// Returns how long GPUI waits before flushing this input, if it needs a timeout.
-    pub fn timeout(&self) -> Option<Duration> {
+    /// Returns the timeout state for flushing this input, if it needs a timeout.
+    pub fn timeout(&self) -> Option<PendingInputTimeoutStatus> {
         self.timeout
+    }
+}
+
+/// The timeout state for pending input.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PendingInputTimeoutStatus {
+    duration: Duration,
+    remaining: Duration,
+    started_at: Option<Instant>,
+    paused: bool,
+}
+
+impl PendingInputTimeoutStatus {
+    /// Returns the full timeout duration.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns the duration remaining before pending input is flushed.
+    pub fn remaining(&self, cx: &App) -> Duration {
+        self.started_at
+            .map(|started_at| {
+                self.remaining
+                    .saturating_sub(cx.background_executor().now() - started_at)
+            })
+            .unwrap_or(self.remaining)
+    }
+
+    /// Returns whether the timeout is paused.
+    pub fn is_paused(&self) -> bool {
+        self.paused
+    }
+}
+
+#[derive(Debug)]
+struct PendingInputTimeout {
+    duration: Duration,
+    remaining: Duration,
+    state: PendingInputTimeoutState,
+}
+
+#[derive(Debug)]
+enum PendingInputTimeoutState {
+    Running { started_at: Instant, task: Task<()> },
+    Paused { pause: PendingInputTimeoutPause },
+}
+
+#[derive(Debug)]
+struct PendingInputTimeoutPause {
+    owner_id: EntityId,
+    _release_subscription: Subscription,
+}
+
+impl PendingInputTimeout {
+    fn is_paused(&self) -> bool {
+        matches!(&self.state, PendingInputTimeoutState::Paused { .. })
+    }
+
+    fn pause(&mut self, pause: PendingInputTimeoutPause, now: Instant) -> bool {
+        match std::mem::replace(&mut self.state, PendingInputTimeoutState::Paused { pause }) {
+            PendingInputTimeoutState::Running { started_at, task } => {
+                self.remaining = self.remaining.saturating_sub(now - started_at);
+                drop(task);
+                true
+            }
+            previous_state @ PendingInputTimeoutState::Paused { .. } => {
+                self.state = previous_state;
+                false
+            }
+        }
+    }
+
+    fn pause_owner_id(&self) -> Option<EntityId> {
+        match &self.state {
+            PendingInputTimeoutState::Running { .. } => None,
+            PendingInputTimeoutState::Paused { pause } => Some(pause.owner_id),
+        }
+    }
+
+    fn resume(&mut self, owner_id: EntityId, started_at: Instant, task: Task<()>) -> bool {
+        match std::mem::replace(
+            &mut self.state,
+            PendingInputTimeoutState::Running { started_at, task },
+        ) {
+            PendingInputTimeoutState::Paused { pause } if pause.owner_id == owner_id => true,
+            previous_state => {
+                self.state = previous_state;
+                false
+            }
+        }
+    }
+
+    fn reset_duration(&mut self, duration: Duration) {
+        self.duration = duration;
+        self.remaining = duration;
+    }
+
+    fn status(&self) -> PendingInputTimeoutStatus {
+        let (started_at, paused) = match &self.state {
+            PendingInputTimeoutState::Running { started_at, .. } => (Some(*started_at), false),
+            PendingInputTimeoutState::Paused { .. } => (None, true),
+        };
+        PendingInputTimeoutStatus {
+            duration: self.duration,
+            remaining: self.remaining,
+            started_at,
+            paused,
+        }
     }
 }
 
@@ -1302,8 +1410,7 @@ impl<'a> PendingInputStatus<'a> {
 struct PendingInput {
     keystrokes: SmallVec<[Keystroke; 1]>,
     focus: Option<FocusId>,
-    timer: Option<Task<()>>,
-    timeout: Option<Duration>,
+    timeout: Option<PendingInputTimeout>,
 }
 
 pub(crate) struct ElementStateBox {
@@ -5567,7 +5674,7 @@ impl Window {
         }
 
         if !match_result.pending.is_empty() {
-            currently_pending.timer.take();
+            let previous_timeout = currently_pending.timeout.take();
             currently_pending.keystrokes = match_result.pending;
             currently_pending.focus = self.focus;
 
@@ -5581,39 +5688,23 @@ impl Window {
                     accepts
                 });
 
-            if match_result.pending_has_binding || text_input_requires_timeout {
-                currently_pending.timeout = Some(PENDING_INPUT_TIMEOUT);
-            }
-
-            if let Some(timeout) = currently_pending.timeout {
-                currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(timeout).await;
-                    cx.update(move |window, cx| {
-                        let Some(currently_pending) = window
-                            .pending_input
-                            .take()
-                            .filter(|pending| pending.focus == window.focus)
-                        else {
-                            return;
-                        };
-
-                        let node_id = window.focus_node_id_in_rendered_frame(window.focus);
-                        let dispatch_path =
-                            window.rendered_frame.dispatch_tree.dispatch_path(node_id);
-
-                        let to_replay = window
-                            .rendered_frame
-                            .dispatch_tree
-                            .flush_dispatch(currently_pending.keystrokes, &dispatch_path);
-
-                        window.pending_input_changed(cx);
-                        window.replay_pending_input(to_replay, cx)
-                    })
-                    .log_err();
-                }));
+            let needs_timeout = previous_timeout.is_some()
+                || match_result.pending_has_binding
+                || text_input_requires_timeout;
+            currently_pending.timeout = if needs_timeout {
+                match previous_timeout {
+                    Some(mut timeout) if timeout.is_paused() => {
+                        timeout.reset_duration(PENDING_INPUT_TIMEOUT);
+                        Some(timeout)
+                    }
+                    previous_timeout => {
+                        drop(previous_timeout);
+                        Some(self.new_pending_input_timeout(PENDING_INPUT_TIMEOUT, cx))
+                    }
+                }
             } else {
-                currently_pending.timer = None;
-            }
+                None
+            };
             self.pending_input = Some(currently_pending);
             self.pending_input_changed(cx);
             cx.propagate_event = false;
@@ -5654,6 +5745,44 @@ impl Window {
 
         self.finish_dispatch_key_event(event, dispatch_path, match_result.context_stack, cx);
         self.pending_input_changed(cx);
+    }
+
+    fn new_pending_input_timeout(&self, duration: Duration, cx: &App) -> PendingInputTimeout {
+        let (started_at, task) = self.start_pending_input_timeout(duration, cx);
+        PendingInputTimeout {
+            duration,
+            remaining: duration,
+            state: PendingInputTimeoutState::Running { started_at, task },
+        }
+    }
+
+    fn start_pending_input_timeout(&self, remaining: Duration, cx: &App) -> (Instant, Task<()>) {
+        let started_at = cx.background_executor().now();
+        let task = self.spawn(cx, async move |cx| {
+            cx.background_executor.timer(remaining).await;
+            cx.update(move |window, cx| {
+                let Some(currently_pending) = window
+                    .pending_input
+                    .take()
+                    .filter(|pending| pending.focus == window.focus)
+                else {
+                    return;
+                };
+
+                let node_id = window.focus_node_id_in_rendered_frame(window.focus);
+                let dispatch_path = window.rendered_frame.dispatch_tree.dispatch_path(node_id);
+
+                let to_replay = window
+                    .rendered_frame
+                    .dispatch_tree
+                    .flush_dispatch(currently_pending.keystrokes, &dispatch_path);
+
+                window.pending_input_changed(cx);
+                window.replay_pending_input(to_replay, cx)
+            })
+            .log_err();
+        });
+        (started_at, task)
     }
 
     fn finish_dispatch_key_event(
@@ -5770,8 +5899,87 @@ impl Window {
             .filter(|pending_input| pending_input.focus == self.focus)
             .map(|pending_input| PendingInputStatus {
                 keystrokes: pending_input.keystrokes.as_slice(),
-                timeout: pending_input.timeout,
+                timeout: pending_input
+                    .timeout
+                    .as_ref()
+                    .map(PendingInputTimeout::status),
             })
+    }
+
+    /// Pauses or resumes the current pending input timeout on behalf of `owner`.
+    ///
+    /// A paused timeout resumes automatically if `owner` is released. Returns whether the timeout
+    /// state changed. A timeout paused by one owner cannot be resumed by another.
+    pub fn set_pending_input_timeout_paused<T: 'static>(
+        &mut self,
+        owner: &Entity<T>,
+        paused: bool,
+        cx: &mut App,
+    ) -> bool {
+        let owner_id = owner.entity_id();
+        if !paused {
+            return self.resume_pending_input_timeout(owner_id, cx);
+        }
+
+        let timeout = self
+            .pending_input
+            .as_ref()
+            .filter(|pending_input| pending_input.focus == self.focus)
+            .and_then(|pending_input| pending_input.timeout.as_ref());
+        let Some(timeout) = timeout else {
+            return false;
+        };
+        if timeout.is_paused() {
+            return false;
+        }
+
+        let release_subscription = self.observe_release(owner, cx, move |_, window, cx| {
+            window.resume_pending_input_timeout(owner_id, cx);
+        });
+        let now = cx.background_executor().now();
+        let changed = self
+            .pending_input
+            .as_mut()
+            .filter(|pending_input| pending_input.focus == self.focus)
+            .and_then(|pending_input| pending_input.timeout.as_mut())
+            .is_some_and(|timeout| {
+                timeout.pause(
+                    PendingInputTimeoutPause {
+                        owner_id,
+                        _release_subscription: release_subscription,
+                    },
+                    now,
+                )
+            });
+
+        if changed {
+            self.defer_pending_input_changed(cx);
+        }
+        changed
+    }
+
+    fn resume_pending_input_timeout(&mut self, owner_id: EntityId, cx: &mut App) -> bool {
+        let Some(remaining) = self
+            .pending_input
+            .as_ref()
+            .and_then(|pending_input| pending_input.timeout.as_ref())
+            .filter(|timeout| timeout.pause_owner_id() == Some(owner_id))
+            .map(|timeout| timeout.remaining)
+        else {
+            return false;
+        };
+
+        let (started_at, task) = self.start_pending_input_timeout(remaining, cx);
+        let changed = self
+            .pending_input
+            .as_mut()
+            .and_then(|pending_input| pending_input.timeout.as_mut())
+            .is_some_and(|timeout| timeout.resume(owner_id, started_at, task));
+
+        if changed {
+            self.defer_pending_input_changed(cx);
+        }
+        changed
     }
 
     /// Returns the currently pending input keystrokes that might result in a multi-stroke key binding.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1278,6 +1278,10 @@ pub(crate) enum DrawPhase {
     Focus,
 }
 
+/// How long the window waits for more keystrokes before flushing pending input, when the
+/// keystrokes typed so far both match a binding and are a prefix of longer bindings.
+pub const PENDING_INPUT_TIMEOUT: Duration = Duration::from_secs(1);
+
 #[derive(Default, Debug)]
 struct PendingInput {
     keystrokes: SmallVec<[Keystroke; 1]>,
@@ -5566,7 +5570,7 @@ impl Window {
 
             if currently_pending.needs_timeout {
                 currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(Duration::from_secs(1)).await;
+                    cx.background_executor.timer(PENDING_INPUT_TIMEOUT).await;
                     cx.update(move |window, cx| {
                         let Some(currently_pending) = window
                             .pending_input
@@ -5747,6 +5751,13 @@ impl Window {
         if self.pending_input.take().is_some() {
             self.defer_pending_input_changed(cx);
         }
+    }
+
+    /// Whether the currently pending input keystrokes will be flushed after
+    /// [`PENDING_INPUT_TIMEOUT`], because they also match a shorter binding or text input.
+    pub fn pending_input_will_timeout(&self) -> bool {
+        self.active_pending_input()
+            .is_some_and(|pending_input| pending_input.timer.is_some())
     }
 
     /// Returns the currently pending input keystrokes that might result in a multi-stroke key binding.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1278,16 +1278,32 @@ pub(crate) enum DrawPhase {
     Focus,
 }
 
-/// How long the window waits for more keystrokes before flushing pending input, when the
-/// keystrokes typed so far both match a binding and are a prefix of longer bindings.
-pub const PENDING_INPUT_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const PENDING_INPUT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Pending input for a potential multi-stroke key binding.
+pub struct PendingInputStatus<'a> {
+    keystrokes: &'a [Keystroke],
+    timeout: Option<Duration>,
+}
+
+impl<'a> PendingInputStatus<'a> {
+    /// Returns the keystrokes entered so far.
+    pub fn keystrokes(&self) -> &'a [Keystroke] {
+        self.keystrokes
+    }
+
+    /// Returns how long GPUI waits before flushing this input, if it needs a timeout.
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+}
 
 #[derive(Default, Debug)]
 struct PendingInput {
     keystrokes: SmallVec<[Keystroke; 1]>,
     focus: Option<FocusId>,
     timer: Option<Task<()>>,
-    needs_timeout: bool,
+    timeout: Option<Duration>,
 }
 
 pub(crate) struct ElementStateBox {
@@ -5565,12 +5581,13 @@ impl Window {
                     accepts
                 });
 
-            currently_pending.needs_timeout |=
-                match_result.pending_has_binding || text_input_requires_timeout;
+            if match_result.pending_has_binding || text_input_requires_timeout {
+                currently_pending.timeout = Some(PENDING_INPUT_TIMEOUT);
+            }
 
-            if currently_pending.needs_timeout {
+            if let Some(timeout) = currently_pending.timeout {
                 currently_pending.timer = Some(self.spawn(cx, async move |cx| {
-                    cx.background_executor.timer(PENDING_INPUT_TIMEOUT).await;
+                    cx.background_executor.timer(timeout).await;
                     cx.update(move |window, cx| {
                         let Some(currently_pending) = window
                             .pending_input
@@ -5729,17 +5746,9 @@ impl Window {
         }
     }
 
-    /// Pending input that can still complete a binding. Input left over from a previous focus can
-    /// never complete one.
-    fn active_pending_input(&self) -> Option<&PendingInput> {
-        self.pending_input
-            .as_ref()
-            .filter(|pending_input| pending_input.focus == self.focus)
-    }
-
     /// Determine whether a potential multi-stroke key binding is in progress on this window.
     pub fn has_pending_keystrokes(&self) -> bool {
-        self.active_pending_input().is_some()
+        self.pending_input().is_some()
     }
 
     #[cfg(test)]
@@ -5753,17 +5762,22 @@ impl Window {
         }
     }
 
-    /// Whether the currently pending input keystrokes will be flushed after
-    /// [`PENDING_INPUT_TIMEOUT`], because they also match a shorter binding or text input.
-    pub fn pending_input_will_timeout(&self) -> bool {
-        self.active_pending_input()
-            .is_some_and(|pending_input| pending_input.timer.is_some())
+    /// Returns pending input that can still complete a multi-stroke key binding. Input left over
+    /// from a previous focus can never complete one.
+    pub fn pending_input(&self) -> Option<PendingInputStatus<'_>> {
+        self.pending_input
+            .as_ref()
+            .filter(|pending_input| pending_input.focus == self.focus)
+            .map(|pending_input| PendingInputStatus {
+                keystrokes: pending_input.keystrokes.as_slice(),
+                timeout: pending_input.timeout,
+            })
     }
 
     /// Returns the currently pending input keystrokes that might result in a multi-stroke key binding.
     pub fn pending_input_keystrokes(&self) -> Option<&[Keystroke]> {
-        self.active_pending_input()
-            .map(|pending_input| pending_input.keystrokes.as_slice())
+        self.pending_input()
+            .map(|pending_input| pending_input.keystrokes())
     }
 
     fn replay_pending_input(&mut self, replays: SmallVec<[Replay; 1]>, cx: &mut App) {

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -1,7 +1,6 @@
 use gpui::{
     Action, App, AppContext as _, Entity, EventEmitter, FocusHandle, Focusable,
     KeyBindingContextPredicate, KeyContext, Keystroke, MouseButton, Render, Subscription, Task,
-    actions,
 };
 use itertools::Itertools;
 use serde_json::json;
@@ -12,14 +11,7 @@ use ui::{
     h_flex, px, v_flex,
 };
 use workspace::{Item, SplitDirection, Workspace};
-
-actions!(
-    dev,
-    [
-        /// Opens the key context view for debugging keybindings.
-        OpenKeyContextView
-    ]
-);
+use zed_actions::dev::OpenKeyContextView;
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -816,6 +816,7 @@ impl VsCodeSettings {
             cursor_position_button: None,
             line_endings_button: None,
             active_encoding_button: None,
+            pending_keystrokes_indicator: None,
         })
     }
 

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1439,13 +1439,15 @@ pub struct ReplSettingsContent {
 /// Settings for configuring the which-key popup behaviour.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct WhichKeySettingsContent {
-    /// Whether to show the which-key popup when holding down key combinations
+    /// Whether to show the which-key popup when holding down key combinations.
+    /// When enabled, the pending keystrokes indicator remains visible, but its binding preview
+    /// popover is disabled.
     ///
     /// Default: false
     pub enabled: Option<bool>,
     /// Delay in milliseconds before showing the which-key popup.
     ///
-    /// Default: 700
+    /// Default: 1000
     pub delay_ms: Option<u64>,
 }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -561,6 +561,10 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: non_utf8
     pub active_encoding_button: Option<EncodingDisplayOptions>,
+    /// Whether to show an indicator with a countdown while a multi-stroke key binding is pending.
+    ///
+    /// Default: true
+    pub pending_keystrokes_indicator: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -561,7 +561,8 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: non_utf8
     pub active_encoding_button: Option<EncodingDisplayOptions>,
-    /// Whether to show an indicator with a countdown while a multi-stroke key binding is pending.
+    /// Whether to show an indicator with a countdown while timed multi-stroke input is pending.
+    /// Hovering the indicator pauses the timeout.
     ///
     /// Default: true
     pub pending_keystrokes_indicator: Option<bool>,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -563,6 +563,7 @@ pub struct StatusBarSettingsContent {
     pub active_encoding_button: Option<EncodingDisplayOptions>,
     /// Whether to show an indicator with a countdown while timed multi-stroke input is pending.
     /// Hovering the indicator pauses the timeout.
+    /// Its binding preview popover is disabled when the which-key popup is enabled.
     ///
     /// Default: true
     pub pending_keystrokes_indicator: Option<bool>,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1760,7 +1760,7 @@ fn editor_page() -> SettingsPage {
             SettingsPageItem::SectionHeader("Which-key Menu"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Show Which-key Menu",
-                description: "Display the which-key menu with matching bindings while a multi-stroke binding is pending.",
+                description: "Display the which-key menu with matching bindings while a multi-stroke binding is pending. The pending keystrokes indicator remains visible, but its binding preview popover is disabled.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("which_key.enabled"),
@@ -4104,7 +4104,7 @@ fn window_and_layout_page() -> SettingsPage {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Pending Keystrokes Indicator",
-                description: "Show an indicator with a countdown while a multi-stroke key binding is pending.",
+                description: "Show an indicator with a countdown while a multi-stroke key binding is pending. Its binding preview popover is disabled when the which-key menu is enabled.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("status_bar.pending_keystrokes_indicator"),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3988,7 +3988,7 @@ fn search_and_files_page() -> SettingsPage {
 }
 
 fn window_and_layout_page() -> SettingsPage {
-    fn status_bar_section() -> [SettingsPageItem; 11] {
+    fn status_bar_section() -> [SettingsPageItem; 12] {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4097,6 +4097,29 @@ fn window_and_layout_page() -> SettingsPage {
                             .status_bar
                             .get_or_insert_default()
                             .line_endings_button = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Pending Keystrokes Indicator",
+                description: "Show an indicator with a countdown while a multi-stroke key binding is pending.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("status_bar.pending_keystrokes_indicator"),
+                    pick: |settings_content| {
+                        settings_content
+                            .status_bar
+                            .as_ref()?
+                            .pending_keystrokes_indicator
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .status_bar
+                            .get_or_insert_default()
+                            .pending_keystrokes_indicator = value;
                     },
                 }),
                 metadata: None,

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -47,6 +47,7 @@ pub struct KeyBinding {
     source: Source,
     size: Option<AbsoluteLength>,
     style: KeyBindingStyle,
+    color: Option<Color>,
     /// The [`PlatformStyle`] to use when displaying this keybinding.
     platform_style: PlatformStyle,
     /// Determines whether the keybinding is meant for vim mode.
@@ -127,6 +128,7 @@ impl KeyBinding {
             },
             size: None,
             style: KeyBindingStyle::Default,
+            color: None,
             vim_mode: KeyBinding::is_vim_mode(cx),
             platform_style: PlatformStyle::platform(),
             disabled: false,
@@ -138,6 +140,7 @@ impl KeyBinding {
             source: Source::Keystrokes { keystrokes },
             size: None,
             style: KeyBindingStyle::Default,
+            color: None,
             vim_mode,
             platform_style: PlatformStyle::platform(),
             disabled: false,
@@ -159,6 +162,12 @@ impl KeyBinding {
     /// Sets how this keybinding is presented.
     pub fn style(mut self, style: KeyBindingStyle) -> Self {
         self.style = style;
+        self
+    }
+
+    /// Sets the color used to render the keybinding.
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
         self
     }
 
@@ -249,10 +258,10 @@ impl RenderOnce for KeyBinding {
             let color = if self.disabled {
                 Some(Color::Disabled)
             } else {
-                match self.style {
+                self.color.or(match self.style {
                     KeyBindingStyle::Default => None,
                     KeyBindingStyle::Label => Some(Color::Default),
-                }
+                })
             };
 
             h_flex()

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -46,12 +46,23 @@ impl Clone for Source {
 pub struct KeyBinding {
     source: Source,
     size: Option<AbsoluteLength>,
+    style: KeyBindingStyle,
     /// The [`PlatformStyle`] to use when displaying this keybinding.
     platform_style: PlatformStyle,
     /// Determines whether the keybinding is meant for vim mode.
     vim_mode: bool,
     /// Indicates whether the keybinding is currently disabled.
     disabled: bool,
+}
+
+/// Controls how a [`KeyBinding`] is presented.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum KeyBindingStyle {
+    /// Render each key using compact key dimensions and muted colors.
+    #[default]
+    Default,
+    /// Render keys and modifier symbols using the same metrics and colors as a [`Label`].
+    Label,
 }
 
 struct VimStyle(bool);
@@ -115,6 +126,7 @@ impl KeyBinding {
                 focus_handle,
             },
             size: None,
+            style: KeyBindingStyle::Default,
             vim_mode: KeyBinding::is_vim_mode(cx),
             platform_style: PlatformStyle::platform(),
             disabled: false,
@@ -125,6 +137,7 @@ impl KeyBinding {
         Self {
             source: Source::Keystrokes { keystrokes },
             size: None,
+            style: KeyBindingStyle::Default,
             vim_mode,
             platform_style: PlatformStyle::platform(),
             disabled: false,
@@ -140,6 +153,12 @@ impl KeyBinding {
     /// Sets the size for this [`KeyBinding`].
     pub fn size(mut self, size: impl Into<AbsoluteLength>) -> Self {
         self.size = Some(size.into());
+        self
+    }
+
+    /// Sets how this keybinding is presented.
+    pub fn style(mut self, style: KeyBindingStyle) -> Self {
+        self.style = style;
         self
     }
 
@@ -205,13 +224,17 @@ fn render_key(
     color: Option<Color>,
     platform_style: PlatformStyle,
     size: impl Into<Option<AbsoluteLength>>,
+    style: KeyBindingStyle,
 ) -> AnyElement {
     let key_icon = icon_for_key(key, platform_style);
     match key_icon {
         Some(icon) => KeyIcon::new(icon, color).size(size).into_any_element(),
         None => {
             let key = capitalize(key);
-            Key::new(&key, color).size(size).into_any_element()
+            match style {
+                KeyBindingStyle::Default => Key::new(&key, color).size(size).into_any_element(),
+                KeyBindingStyle::Label => LabelKey::new(&key, color).size(size).into_any_element(),
+            }
         }
     }
 }
@@ -223,7 +246,14 @@ impl RenderOnce for KeyBinding {
         }
 
         let render_keybinding = |keystrokes: &[KeybindingKeystroke]| {
-            let color = self.disabled.then_some(Color::Disabled);
+            let color = if self.disabled {
+                Some(Color::Disabled)
+            } else {
+                match self.style {
+                    KeyBindingStyle::Default => None,
+                    KeyBindingStyle::Label => Some(Color::Default),
+                }
+            };
 
             h_flex()
                 .debug_selector(|| {
@@ -241,15 +271,16 @@ impl RenderOnce for KeyBinding {
                 .children(keystrokes.iter().map(|keystroke| {
                     h_flex()
                         .flex_none()
-                        .py_0p5()
+                        .when(self.style == KeyBindingStyle::Default, |this| this.py_0p5())
                         .rounded_xs()
-                        .text_color(cx.theme().colors().text_muted)
-                        .children(render_keybinding_keystroke(
+                        .text_color(color.unwrap_or(Color::Muted).color(cx))
+                        .children(render_keybinding_keystroke_with_style(
                             keystroke,
                             color,
                             self.size,
                             PlatformStyle::platform(),
                             self.vim_mode,
+                            self.style,
                         ))
                 }))
                 .into_any_element()
@@ -279,6 +310,24 @@ pub fn render_keybinding_keystroke(
     platform_style: PlatformStyle,
     vim_mode: bool,
 ) -> Vec<AnyElement> {
+    render_keybinding_keystroke_with_style(
+        keystroke,
+        color,
+        size,
+        platform_style,
+        vim_mode,
+        KeyBindingStyle::Default,
+    )
+}
+
+fn render_keybinding_keystroke_with_style(
+    keystroke: &KeybindingKeystroke,
+    color: Option<Color>,
+    size: impl Into<Option<AbsoluteLength>>,
+    platform_style: PlatformStyle,
+    vim_mode: bool,
+    style: KeyBindingStyle,
+) -> Vec<AnyElement> {
     let use_text = vim_mode
         || matches!(
             platform_style,
@@ -287,28 +336,40 @@ pub fn render_keybinding_keystroke(
     let size = size.into();
 
     if use_text {
-        let element = Key::new(
-            keystroke_text(
-                keystroke.modifiers(),
-                keystroke.key(),
-                platform_style,
-                vim_mode,
-            ),
-            color,
-        )
-        .size(size)
-        .into_any_element();
+        let text = keystroke_text(
+            keystroke.modifiers(),
+            keystroke.key(),
+            platform_style,
+            vim_mode,
+        );
+        let element = match style {
+            KeyBindingStyle::Default => Key::new(text, color).size(size).into_any_element(),
+            KeyBindingStyle::Label => LabelKey::new(text, color).size(size).into_any_element(),
+        };
         vec![element]
     } else {
         let mut elements = Vec::new();
-        elements.extend(render_modifiers(
+        let modifiers = render_modifiers_with_style(
             keystroke.modifiers(),
             platform_style,
             color,
             size,
             true,
+            style,
+        )
+        .collect::<Vec<_>>();
+        if style == KeyBindingStyle::Label && !modifiers.is_empty() {
+            elements.push(h_flex().children(modifiers).mr_0p5().into_any_element());
+        } else {
+            elements.extend(modifiers);
+        }
+        elements.push(render_key(
+            keystroke.key(),
+            color,
+            platform_style,
+            size,
+            style,
         ));
-        elements.push(render_key(keystroke.key(), color, platform_style, size));
         elements
     }
 }
@@ -344,6 +405,24 @@ pub fn render_modifiers(
     size: Option<AbsoluteLength>,
     trailing_separator: bool,
 ) -> impl Iterator<Item = AnyElement> {
+    render_modifiers_with_style(
+        modifiers,
+        platform_style,
+        color,
+        size,
+        trailing_separator,
+        KeyBindingStyle::Default,
+    )
+}
+
+fn render_modifiers_with_style(
+    modifiers: &Modifiers,
+    platform_style: PlatformStyle,
+    color: Option<Color>,
+    size: Option<AbsoluteLength>,
+    trailing_separator: bool,
+    style: KeyBindingStyle,
+) -> impl Iterator<Item = AnyElement> {
     #[derive(Clone)]
     enum KeyOrIcon {
         Key(&'static str),
@@ -358,37 +437,42 @@ pub fn render_modifiers(
         windows: KeyOrIcon,
     }
 
+    let mac_modifier = |icon, label| match style {
+        KeyBindingStyle::Default => KeyOrIcon::Icon(icon),
+        KeyBindingStyle::Label => KeyOrIcon::Key(label),
+    };
+
     let table = {
         use KeyOrIcon::*;
 
         [
             Modifier {
                 enabled: modifiers.function,
-                mac: Icon(IconName::Control),
+                mac: mac_modifier(IconName::Control, "Fn"),
                 linux: Key("Fn"),
                 windows: Key("Fn"),
             },
             Modifier {
                 enabled: modifiers.control,
-                mac: Icon(IconName::Control),
+                mac: mac_modifier(IconName::Control, "⌃"),
                 linux: Key("Ctrl"),
                 windows: Key("Ctrl"),
             },
             Modifier {
                 enabled: modifiers.alt,
-                mac: Icon(IconName::Option),
+                mac: mac_modifier(IconName::Option, "⌥"),
                 linux: Key("Alt"),
                 windows: Key("Alt"),
             },
             Modifier {
                 enabled: modifiers.platform,
-                mac: Icon(IconName::Command),
+                mac: mac_modifier(IconName::Command, "⌘"),
                 linux: Key("Super"),
                 windows: Key("Win"),
             },
             Modifier {
                 enabled: modifiers.shift,
-                mac: Icon(IconName::Shift),
+                mac: mac_modifier(IconName::Shift, "⇧"),
                 linux: Key("Shift"),
                 windows: Key("Shift"),
             },
@@ -424,9 +508,15 @@ pub fn render_modifiers(
         })
         .flatten()
         .map(move |key_or_icon| match key_or_icon {
-            KeyOrIcon::Key(key) => Key::new(key, color).size(size).into_any_element(),
+            KeyOrIcon::Key(key) => match style {
+                KeyBindingStyle::Default => Key::new(key, color).size(size).into_any_element(),
+                KeyBindingStyle::Label => LabelKey::new(key, color).size(size).into_any_element(),
+            },
             KeyOrIcon::Icon(icon) => KeyIcon::new(icon, color).size(size).into_any_element(),
-            KeyOrIcon::Plus => "+".into_any_element(),
+            KeyOrIcon::Plus => match style {
+                KeyBindingStyle::Default => "+".into_any_element(),
+                KeyBindingStyle::Label => LabelKey::new("+", color).size(size).into_any_element(),
+            },
         })
 }
 
@@ -471,6 +561,41 @@ impl Key {
     }
 
     pub fn size(mut self, size: impl Into<Option<AbsoluteLength>>) -> Self {
+        self.size = size.into();
+        self
+    }
+}
+
+#[derive(IntoElement)]
+struct LabelKey {
+    key: SharedString,
+    color: Option<Color>,
+    size: Option<AbsoluteLength>,
+}
+
+impl RenderOnce for LabelKey {
+    fn render(self, window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let size = self
+            .size
+            .map(|size| LabelSize::Custom(size.to_rems(window.rem_size())))
+            .unwrap_or_default();
+
+        Label::new(self.key)
+            .size(size)
+            .color(self.color.unwrap_or(Color::Default))
+    }
+}
+
+impl LabelKey {
+    fn new(key: impl Into<SharedString>, color: Option<Color>) -> Self {
+        Self {
+            key: key.into(),
+            color,
+            size: None,
+        }
+    }
+
+    fn size(mut self, size: impl Into<Option<AbsoluteLength>>) -> Self {
         self.size = size.into();
         self
     }

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -146,11 +146,12 @@ impl Render for ModeIndicator {
             (pending.into(), Some(mode))
         };
         h_flex()
+            .h(ButtonSize::Default.rems())
             .gap_1()
             .when(!label.is_empty(), |el| {
                 el.child(
                     Label::new(label)
-                        .line_height_style(LineHeightStyle::UiLabel)
+                        .size(LabelSize::Small)
                         .weight(FontWeight::MEDIUM),
                 )
             })
@@ -166,7 +167,6 @@ impl Render for ModeIndicator {
                         .child(
                             Label::new(mode)
                                 .size(LabelSize::Small)
-                                .line_height_style(LineHeightStyle::UiLabel)
                                 .weight(FontWeight::MEDIUM)
                                 .when(
                                     bg_color != system_transparent

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -20,3 +20,6 @@ theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -23,4 +23,5 @@ vim_mode_setting.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
+collections.workspace = true
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -21,6 +21,7 @@ ui.workspace = true
 util.workspace = true
 vim_mode_setting.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 collections.workspace = true

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -19,6 +19,7 @@ settings.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true
+vim_mode_setting.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -25,3 +25,4 @@ workspace.workspace = true
 [dev-dependencies]
 collections.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
+theme.workspace = true

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -171,6 +171,7 @@ impl Render for PendingKeystrokesIndicator {
                     })
                     .into_any_element()
             }))
+            .tooltip_show_delay(Duration::ZERO)
             .into_any_element()
     }
 }

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,4 +1,3 @@
-use command_palette::humanize_action_name;
 use gpui::{
     Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Subscription, Window,
 };
@@ -8,7 +7,7 @@ use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes}
 use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
-use crate::FILTERED_KEYSTROKES;
+use crate::bindings_for_pending_input;
 
 const MAX_TOOLTIP_BINDINGS: usize = 10;
 
@@ -81,37 +80,22 @@ impl PendingKeystrokesIndicator {
         };
         let keystrokes = pending_input.keystrokes();
 
-        let pending_len = keystrokes.len();
-        let mut bindings = window
-            .possible_bindings_for_input(keystrokes)
-            .iter()
-            .filter_map(|binding| {
-                let binding_keystrokes = binding.keystrokes();
-                if binding_keystrokes.len() <= pending_len {
-                    return None;
-                }
-                if FILTERED_KEYSTROKES.iter().any(|filtered| {
-                    binding_keystrokes.len() >= filtered.len()
-                        && binding_keystrokes[..filtered.len()]
-                            .iter()
-                            .map(|keystroke| keystroke.inner())
-                            .eq(filtered.iter())
-                }) {
-                    return None;
-                }
-                let remaining = &binding_keystrokes[pending_len..];
+        let mut bindings = bindings_for_pending_input(window, keystrokes)
+            .into_iter()
+            .map(|binding| {
                 let remaining_text = text_for_keystrokes(
-                    &remaining
+                    &binding
+                        .remaining_keystrokes
                         .iter()
                         .map(|keystroke| keystroke.inner().clone())
                         .collect::<Vec<_>>(),
                     cx,
                 );
-                Some((
+                (
                     remaining_text,
-                    remaining.to_vec(),
-                    SharedString::from(humanize_action_name(binding.action().name())),
-                ))
+                    binding.remaining_keystrokes,
+                    binding.action_name,
+                )
             })
             .collect::<Vec<_>>();
         bindings.sort_by(|(text_a, keys_a, action_a), (text_b, keys_b, action_b)| {
@@ -271,6 +255,7 @@ impl StatusItemView for PendingKeystrokesIndicator {
 mod tests {
     use std::cell::Cell;
 
+    use command_palette::humanize_action_name;
     use gpui::{
         Action as _, Entity, FocusHandle, KeyBinding, TestAppContext, VisualTestContext, actions,
     };

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -258,19 +258,50 @@ mod tests {
         [ShorterBinding, LongerBinding, LongestBinding]
     );
 
-    struct TestView {
-        focus_handle: FocusHandle,
-        shorter_binding_count: Rc<Cell<usize>>,
-        longer_binding_count: Rc<Cell<usize>>,
+    fn timed_bindings() -> [KeyBinding; 2] {
+        [
+            KeyBinding::new(
+                "ctrl-b",
+                ShorterBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            ),
+            KeyBinding::new(
+                "ctrl-b h",
+                LongerBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            ),
+        ]
     }
 
-    #[derive(Debug, Default, PartialEq)]
+    fn nested_timed_bindings() -> [KeyBinding; 3] {
+        [
+            KeyBinding::new(
+                "ctrl-b",
+                ShorterBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            ),
+            KeyBinding::new(
+                "ctrl-b h",
+                LongerBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            ),
+            KeyBinding::new(
+                "ctrl-b h j",
+                LongestBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            ),
+        ]
+    }
+
+    struct TestView {
+        focus_handle: FocusHandle,
+    }
+
+    #[derive(Debug, PartialEq)]
     struct PendingSnapshot {
         keystrokes: Vec<String>,
         generation: u64,
         bindings: Vec<(Vec<String>, String)>,
-        timeout_duration: Duration,
-        remaining_duration: Duration,
         timeout_paused: bool,
     }
 
@@ -295,8 +326,6 @@ mod tests {
                     )
                 })
                 .collect(),
-            timeout_duration: pending.timeout_duration,
-            remaining_duration: pending.remaining_duration,
             timeout_paused: pending.timeout_paused,
         })
     }
@@ -313,52 +342,17 @@ mod tests {
         });
     }
 
-    impl Render for TestView {
-        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-            let shorter_binding_count = self.shorter_binding_count.clone();
-            let longer_binding_count = self.longer_binding_count.clone();
-            div()
-                .key_context("PendingKeystrokesIndicatorTest")
-                .track_focus(&self.focus_handle)
-                .on_action(move |_: &ShorterBinding, _, _| {
-                    shorter_binding_count.set(shorter_binding_count.get() + 1);
-                })
-                .on_action(move |_: &LongerBinding, _, _| {
-                    longer_binding_count.set(longer_binding_count.get() + 1);
-                })
-                .on_action(|_: &LongestBinding, _, _| {})
-        }
-    }
-
-    #[gpui::test]
-    fn test_indicator_tracks_pending_input_lifecycle(cx: &mut TestAppContext) {
+    fn setup_indicator_test(
+        cx: &mut TestAppContext,
+        bindings: impl IntoIterator<Item = KeyBinding>,
+    ) -> (Entity<PendingKeystrokesIndicator>, &mut VisualTestContext) {
         cx.update(|cx| {
             settings::init(cx);
-            cx.bind_keys([
-                KeyBinding::new(
-                    "ctrl-b",
-                    ShorterBinding,
-                    Some("PendingKeystrokesIndicatorTest"),
-                ),
-                KeyBinding::new(
-                    "ctrl-b h",
-                    LongerBinding,
-                    Some("PendingKeystrokesIndicatorTest"),
-                ),
-                KeyBinding::new(
-                    "ctrl-b h j",
-                    LongestBinding,
-                    Some("PendingKeystrokesIndicatorTest"),
-                ),
-            ]);
+            cx.bind_keys(bindings);
         });
 
-        let shorter_binding_count = Rc::new(Cell::new(0));
-        let longer_binding_count = Rc::new(Cell::new(0));
         let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
             focus_handle: cx.focus_handle(),
-            shorter_binding_count: shorter_binding_count.clone(),
-            longer_binding_count: longer_binding_count.clone(),
         });
         let indicator =
             cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
@@ -368,12 +362,30 @@ mod tests {
             window.activate_window();
         });
 
+        (indicator, cx)
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .key_context("PendingKeystrokesIndicatorTest")
+                .track_focus(&self.focus_handle)
+                .on_action(|_: &ShorterBinding, _, _| {})
+                .on_action(|_: &LongerBinding, _, _| {})
+                .on_action(|_: &LongestBinding, _, _| {})
+        }
+    }
+
+    #[gpui::test]
+    fn test_indicator_tracks_pending_input(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
 
-        let first_pending = indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
-        assert!(first_pending.is_some(), "expected pending input snapshot");
-        let first_pending = first_pending.unwrap_or_default();
+        let first_pending = indicator
+            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+            .expect("pending input snapshot");
         assert_eq!(first_pending.keystrokes, vec!["ctrl-b"]);
         assert_eq!(
             first_pending.bindings,
@@ -389,63 +401,14 @@ mod tests {
             ]
         );
 
-        let pending_before_unrelated_settings_update = indicator
-            .read_with(cx, |indicator, _| indicator.pending().cloned())
-            .expect("pending input");
-        cx.update(|_, cx| {
-            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
-                store
-                    .set_user_settings(r#"{"ui_font_size":15}"#, cx)
-                    .expect("valid test settings");
-            });
-        });
-        cx.run_until_parked();
-        let pending_after_unrelated_settings_update = indicator
-            .read_with(cx, |indicator, _| indicator.pending().cloned())
-            .expect("pending input");
-        assert!(Rc::ptr_eq(
-            &pending_before_unrelated_settings_update,
-            &pending_after_unrelated_settings_update
-        ));
-
-        cx.executor()
-            .advance_clock(first_pending.timeout_duration / 2);
-        cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
-
-        set_indicator_hovered(&indicator, true, cx);
-        cx.run_until_parked();
-        let hovered_pending = indicator
-            .read_with(cx, |indicator, _| pending_snapshot(indicator))
-            .unwrap_or_default();
-        assert!(hovered_pending.timeout_paused);
-        assert_eq!(
-            hovered_pending.remaining_duration,
-            first_pending.timeout_duration / 2
-        );
-
-        cx.executor()
-            .advance_clock(first_pending.timeout_duration * 2);
-        cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
-        assert_eq!(shorter_binding_count.get(), 0);
-
         cx.simulate_keystrokes("h");
         cx.run_until_parked();
 
-        let second_pending = indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
-        assert!(
-            second_pending.is_some(),
-            "expected updated pending input snapshot"
-        );
-        let second_pending = second_pending.unwrap_or_default();
+        let second_pending = indicator
+            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+            .expect("updated pending input snapshot");
         assert_eq!(second_pending.keystrokes, vec!["ctrl-b", "h"]);
         assert!(second_pending.generation > first_pending.generation);
-        assert!(second_pending.timeout_paused);
-        assert_eq!(
-            second_pending.remaining_duration,
-            second_pending.timeout_duration
-        );
         assert_eq!(
             second_pending.bindings,
             vec![(
@@ -454,226 +417,79 @@ mod tests {
             )]
         );
 
-        cx.executor()
-            .advance_clock(second_pending.timeout_duration * 2);
+        cx.simulate_keystrokes("j");
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
-        assert_eq!(longer_binding_count.get(), 0);
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+    }
+
+    #[gpui::test]
+    fn test_hover_pauses_and_resumes_timeout(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        set_indicator_hovered(&indicator, true, cx);
+        cx.run_until_parked();
+        let paused_pending = indicator
+            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+            .expect("paused pending input");
+        assert!(paused_pending.timeout_paused);
 
         set_indicator_hovered(&indicator, false, cx);
         cx.run_until_parked();
         let resumed_pending = indicator
             .read_with(cx, |indicator, _| pending_snapshot(indicator))
-            .unwrap_or_default();
+            .expect("resumed pending input");
         assert!(!resumed_pending.timeout_paused);
-        assert_eq!(
-            resumed_pending.remaining_duration,
-            resumed_pending.timeout_duration
-        );
 
-        cx.executor()
-            .advance_clock(resumed_pending.remaining_duration);
+        cx.simulate_keystrokes("h");
         cx.run_until_parked();
-
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
-        assert_eq!(shorter_binding_count.get(), 0);
-        assert_eq!(longer_binding_count.get(), 1);
-
-        cx.simulate_keystrokes("ctrl-b");
-        cx.run_until_parked();
-        set_indicator_hovered(&indicator, true, cx);
-        cx.run_until_parked();
-
-        cx.update(|_, cx| {
-            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
-                store
-                    .set_user_settings(r#"{"status_bar":{"experimental.show":false}}"#, cx)
-                    .expect("valid test settings");
-            });
-        });
-        cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
-        let remaining_after_disabling = cx.update(|window, cx| {
-            let timeout = window
-                .pending_input()
-                .and_then(|pending_input| pending_input.timeout())
-                .expect("pending input timeout");
-            assert!(!timeout.is_paused());
-            timeout.remaining(cx)
-        });
-        cx.executor().advance_clock(remaining_after_disabling);
-        cx.run_until_parked();
-        assert_eq!(shorter_binding_count.get(), 1);
-
-        cx.simulate_keystrokes("ctrl-b");
-        cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
-
-        cx.update(|_, cx| {
-            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
-                store
-                    .set_user_settings(r#"{"status_bar":{"experimental.show":true}}"#, cx)
-                    .expect("valid test settings");
-            });
-        });
-        cx.run_until_parked();
-        let pending_after_reenabling =
-            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
-        assert!(
-            pending_after_reenabling.is_some(),
-            "expected the current pending input after re-enabling the indicator"
-        );
-
-        cx.update(|_, cx| {
-            VimModeSetting::override_global(VimModeSetting(true), cx);
-        });
-        cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
-
-        cx.update(|_, cx| {
-            VimModeSetting::override_global(VimModeSetting(false), cx);
-        });
-        cx.run_until_parked();
-        let pending_after_disabling_vim =
-            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
-        assert!(
-            pending_after_disabling_vim.is_some(),
-            "expected the current pending input after disabling Vim mode"
-        );
-        set_indicator_hovered(&indicator, true, cx);
-        cx.run_until_parked();
-        let remaining_before_release = cx.update(|window, cx| {
-            window
-                .pending_input()
-                .and_then(|pending_input| pending_input.timeout())
-                .map(|timeout| timeout.remaining(cx))
-                .expect("pending input timeout")
-        });
-
-        let weak_indicator = indicator.downgrade();
-        drop(indicator);
-        cx.update(|_, _| {});
-        cx.run_until_parked();
-        weak_indicator.assert_released();
-
-        let remaining_after_release = cx.update(|window, cx| {
-            let timeout = window
-                .pending_input()
-                .and_then(|pending_input| pending_input.timeout())
-                .expect("pending input timeout");
-            assert!(!timeout.is_paused());
-            timeout.remaining(cx)
-        });
-        assert_eq!(remaining_after_release, remaining_before_release);
-        cx.executor().advance_clock(remaining_after_release);
-        cx.run_until_parked();
-        assert_eq!(shorter_binding_count.get(), 2);
     }
 
     #[gpui::test]
-    fn test_indicator_tracks_status_bar_and_helix_modes(cx: &mut TestAppContext) {
-        cx.update(|cx| {
-            settings::init(cx);
-            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
-                store
-                    .set_user_settings(
-                        r#"{"status_bar":{"experimental.show":false,"pending_keystrokes_indicator":true}}"#,
-                        cx,
-                    )
-                    .expect("valid test settings");
-            });
-            cx.bind_keys([
-                KeyBinding::new(
-                    "ctrl-b",
-                    ShorterBinding,
-                    Some("PendingKeystrokesIndicatorTest"),
-                ),
-                KeyBinding::new(
-                    "ctrl-b h",
-                    LongerBinding,
-                    Some("PendingKeystrokesIndicatorTest"),
-                ),
-            ]);
-        });
-
-        let shorter_binding_count = Rc::new(Cell::new(0));
-        let longer_binding_count = Rc::new(Cell::new(0));
-        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
-            focus_handle: cx.focus_handle(),
-            shorter_binding_count,
-            longer_binding_count,
-        });
-        let indicator =
-            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
-        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
-        cx.update(|window, cx| {
-            window.focus(&focus_handle, cx);
-            window.activate_window();
-        });
+    fn test_disabling_indicator_releases_timeout_pause(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        set_indicator_hovered(&indicator, true, cx);
+        cx.run_until_parked();
 
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {
                 store
                     .set_user_settings(
-                        r#"{"status_bar":{"experimental.show":true,"pending_keystrokes_indicator":true}}"#,
+                        r#"{"status_bar":{"pending_keystrokes_indicator":false}}"#,
                         cx,
                     )
                     .expect("valid test settings");
             });
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
-
-        cx.update(|_, cx| {
-            HelixModeSetting::override_global(HelixModeSetting(true), cx);
-        });
-        cx.run_until_parked();
         assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
-
-        cx.update(|_, cx| {
-            HelixModeSetting::override_global(HelixModeSetting(false), cx);
+        cx.update(|window, _| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
         });
-        cx.run_until_parked();
-        let pending_after_disabling_helix =
-            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
-        assert!(pending_after_disabling_helix.is_some());
-        cx.executor().advance_clock(
-            pending_after_disabling_helix
-                .unwrap_or_default()
-                .timeout_duration,
-        );
+
+        cx.simulate_keystrokes("h");
         cx.run_until_parked();
     }
 
     #[gpui::test]
     fn test_indicator_ignores_pending_input_without_timeout(cx: &mut TestAppContext) {
-        cx.update(|cx| {
-            settings::init(cx);
-            cx.bind_keys([KeyBinding::new(
+        let (indicator, cx) = setup_indicator_test(
+            cx,
+            [KeyBinding::new(
                 "ctrl-b h",
                 LongerBinding,
                 Some("PendingKeystrokesIndicatorTest"),
-            )]);
-        });
-
-        let shorter_binding_count = Rc::new(Cell::new(0));
-        let longer_binding_count = Rc::new(Cell::new(0));
-        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
-            focus_handle: cx.focus_handle(),
-            shorter_binding_count,
-            longer_binding_count,
-        });
-        let indicator =
-            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
-        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
-        cx.update(|window, cx| {
-            window.focus(&focus_handle, cx);
-            window.activate_window();
-        });
+            )],
+        );
 
         let notification_count = Rc::new(Cell::new(0));
         let _notification_subscription = cx.update({

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -576,6 +576,38 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_indicator_does_not_apply_which_key_binding_filter(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(
+            cx,
+            [
+                KeyBinding::new("g", ShorterBinding, Some("PendingKeystrokesIndicatorTest")),
+                KeyBinding::new("g j", LongerBinding, Some("PendingKeystrokesIndicatorTest")),
+            ],
+        );
+
+        cx.simulate_keystrokes("g");
+        cx.run_until_parked();
+
+        cx.update(|window, _| {
+            let pending_keystrokes = window
+                .pending_input_keystrokes()
+                .expect("pending input keystrokes");
+            assert!(crate::bindings_for_which_key(window, pending_keystrokes).is_empty());
+        });
+
+        let render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("pending input snapshot");
+        assert_eq!(
+            render_state.bindings,
+            vec![(
+                vec!["j".to_string()],
+                humanize_action_name(LongerBinding.name()),
+            )]
+        );
+    }
+
+    #[gpui::test]
     fn test_hovering_indicator_opens_popover_and_pauses_timeout(cx: &mut TestAppContext) {
         let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,22 +1,43 @@
 use gpui::{
-    Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Subscription, Window,
+    Anchor, Animation, AnimationExt, App, Context, HoverListenerMode, KeybindingKeystroke, Render,
+    Subscription, Task, Window, anchored, deferred,
 };
 use settings::{Settings, SettingsStore};
 use std::{rc::Rc, time::Duration};
-use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keybinding_keystrokes};
+use ui::{
+    ButtonLike, CircularProgress, KeyBinding, KeyBindingStyle, prelude::*,
+    text_for_keybinding_keystrokes, tooltip_container,
+};
+use util::ResultExt;
 use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
 use crate::{bindings_for_pending_input, map_pending_keystrokes};
 
 const MAX_TOOLTIP_BINDINGS: usize = 10;
+const POPOVER_HIDE_DELAY: Duration = Duration::from_millis(300);
 
 /// A status bar item shown while timed pending input can complete a multi-stroke key binding.
 pub struct PendingKeystrokesIndicator {
     render_state: Option<Rc<IndicatorRenderState>>,
     pending_input_generation: u64,
+    popover: PopoverState,
     _pending_input_subscription: Subscription,
     _settings_subscription: Subscription,
+}
+
+#[derive(Default)]
+struct PopoverState {
+    indicator_pointer_over: bool,
+    pointer_over: bool,
+    visible: bool,
+    hide_task: Option<Task<()>>,
+}
+
+impl PopoverState {
+    fn is_pointer_over(&self) -> bool {
+        self.indicator_pointer_over || self.pointer_over
+    }
 }
 
 struct IndicatorRenderState {
@@ -54,6 +75,7 @@ impl PendingKeystrokesIndicator {
         Self {
             render_state: None,
             pending_input_generation: 0,
+            popover: PopoverState::default(),
             _pending_input_subscription: pending_input_subscription,
             _settings_subscription: settings_subscription,
         }
@@ -119,6 +141,7 @@ impl PendingKeystrokesIndicator {
     }
 
     fn clear_render_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        self.popover = PopoverState::default();
         window.set_pending_input_timeout_paused(&cx.entity(), false, cx);
         self.render_state.take().is_some()
     }
@@ -127,12 +150,56 @@ impl PendingKeystrokesIndicator {
         self.render_state.as_ref()
     }
 
-    fn set_hovered(&mut self, hovered: bool, window: &mut Window, cx: &mut Context<Self>) {
+    fn set_indicator_pointer_over(
+        &mut self,
+        pointer_over: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.popover.indicator_pointer_over = pointer_over;
+        self.update_pointer_over_state(window, cx);
+    }
+
+    fn set_popover_pointer_over(
+        &mut self,
+        pointer_over: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.popover.pointer_over = pointer_over;
+        self.update_pointer_over_state(window, cx);
+    }
+
+    fn update_pointer_over_state(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.render_state.is_none() {
             return;
         }
 
-        window.set_pending_input_timeout_paused(&cx.entity(), hovered, cx);
+        if self.popover.is_pointer_over() {
+            self.popover.hide_task.take();
+            let was_visible = self.popover.visible;
+            self.popover.visible = true;
+            window.set_pending_input_timeout_paused(&cx.entity(), true, cx);
+            if !was_visible {
+                cx.notify();
+            }
+        } else if self.popover.visible && self.popover.hide_task.is_none() {
+            window.set_pending_input_timeout_paused(&cx.entity(), true, cx);
+            self.popover.hide_task = Some(cx.spawn_in(window, async move |this, cx| {
+                cx.background_executor().timer(POPOVER_HIDE_DELAY).await;
+                this.update_in(cx, |this, window, cx| {
+                    this.popover.hide_task.take();
+                    if this.popover.is_pointer_over() {
+                        return;
+                    }
+
+                    this.popover.visible = false;
+                    window.set_pending_input_timeout_paused(&cx.entity(), false, cx);
+                    cx.notify();
+                })
+                .log_err();
+            }));
+        }
     }
 }
 
@@ -149,10 +216,7 @@ impl Render for PendingKeystrokesIndicator {
             .clamp(0.0, 1.0)
         };
 
-        h_flex()
-            .id("pending-keystrokes-indicator")
-            .gap_1()
-            .px_1()
+        let button = ButtonLike::new("pending-keystrokes-indicator")
             .child(if cx.reduce_motion() {
                 Icon::new(IconName::CountdownTimer)
                     .size(IconSize::XSmall)
@@ -186,45 +250,100 @@ impl Render for PendingKeystrokesIndicator {
             })
             .child(
                 KeyBinding::from_keystrokes(render_state.keystrokes.clone(), false)
-                    .size(rems_from_px(12_f32)),
-            )
-            .tooltip(Tooltip::element(move |_, _| {
-                let render_state = &render_state;
-                v_flex()
-                    .gap_1()
+                    .size(rems_from_px(12_f32))
+                    .style(KeyBindingStyle::Label),
+            );
+
+        let popover = self.popover.visible.then(|| {
+            let popover_render_state = render_state.clone();
+            let anchored_popover = deferred(
+                anchored()
+                    .anchor(Anchor::BottomRight)
+                    .snap_to_window_with_margin(px(8.))
                     .child(
-                        h_flex()
-                            .gap_1()
-                            .child(KeyBinding::from_keystrokes(
-                                render_state.keystrokes.clone(),
-                                false,
-                            ))
-                            .child(Label::new("is waiting for more keys").color(Color::Muted)),
-                    )
-                    .children(render_state.bindings.iter().take(MAX_TOOLTIP_BINDINGS).map(
-                        |(keystrokes, action)| {
-                            h_flex()
-                                .gap_2()
-                                .child(KeyBinding::from_keystrokes(keystrokes.clone(), false))
-                                .child(Label::new(action.clone()).size(LabelSize::Small))
-                        },
-                    ))
-                    .when(render_state.bindings.len() > MAX_TOOLTIP_BINDINGS, |el| {
-                        el.child(
-                            Label::new(format!(
-                                "…and {} more",
-                                render_state.bindings.len() - MAX_TOOLTIP_BINDINGS
-                            ))
-                            .size(LabelSize::Small)
-                            .color(Color::Muted),
-                        )
-                    })
-                    .into_any_element()
+                        div()
+                            .id("pending-keystrokes-popover")
+                            .debug_selector(|| "PENDING_KEYSTROKES_POPOVER".into())
+                            .pb_2()
+                            .occlude()
+                            .on_hover(cx.listener(|this, pointer_over: &bool, window, cx| {
+                                this.set_popover_pointer_over(*pointer_over, window, cx);
+                            }))
+                            .hover_listener_mode(HoverListenerMode::InputModalityIndependent)
+                            .child(tooltip_container(cx, |el, _| {
+                                el.child(
+                                    v_flex()
+                                        .gap_1()
+                                        .child(
+                                            h_flex()
+                                                .gap_1()
+                                                .child(KeyBinding::from_keystrokes(
+                                                    popover_render_state.keystrokes.clone(),
+                                                    false,
+                                                ))
+                                                .child(
+                                                    Label::new("is waiting for more keys")
+                                                        .color(Color::Muted),
+                                                ),
+                                        )
+                                        .children(
+                                            popover_render_state
+                                                .bindings
+                                                .iter()
+                                                .take(MAX_TOOLTIP_BINDINGS)
+                                                .map(|(keystrokes, action)| {
+                                                    h_flex()
+                                                        .gap_2()
+                                                        .child(KeyBinding::from_keystrokes(
+                                                            keystrokes.clone(),
+                                                            false,
+                                                        ))
+                                                        .child(
+                                                            Label::new(action.clone())
+                                                                .size(LabelSize::Small),
+                                                        )
+                                                }),
+                                        )
+                                        .when(
+                                            popover_render_state.bindings.len()
+                                                > MAX_TOOLTIP_BINDINGS,
+                                            |el| {
+                                                el.child(
+                                                    Label::new(format!(
+                                                        "…and {} more",
+                                                        popover_render_state.bindings.len()
+                                                            - MAX_TOOLTIP_BINDINGS
+                                                    ))
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                                )
+                                            },
+                                        ),
+                                )
+                            })),
+                    ),
+            )
+            .with_priority(1);
+
+            div()
+                .absolute()
+                .top_0()
+                .right_0()
+                .w_0()
+                .h_0()
+                .child(anchored_popover)
+        });
+
+        div()
+            .id("pending-keystrokes-indicator-wrapper")
+            .debug_selector(|| "PENDING_KEYSTROKES_INDICATOR".into())
+            .relative()
+            .child(button)
+            .when_some(popover, |this, popover| this.child(popover))
+            .on_hover(cx.listener(|this, pointer_over: &bool, window, cx| {
+                this.set_indicator_pointer_over(*pointer_over, window, cx);
             }))
-            .tooltip_show_delay(Duration::ZERO)
-            .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
-                this.set_hovered(*hovered, window, cx);
-            }))
+            .hover_listener_mode(HoverListenerMode::InputModalityIndependent)
             .into_any_element()
     }
 }
@@ -254,7 +373,8 @@ mod tests {
 
     use command_palette::humanize_action_name;
     use gpui::{
-        Action as _, Entity, FocusHandle, KeyBinding, TestAppContext, VisualTestContext, actions,
+        Action as _, Entity, FocusHandle, KeyBinding, Modifiers, TestAppContext, VisualTestContext,
+        actions, point,
     };
 
     use super::*;
@@ -301,6 +421,7 @@ mod tests {
 
     struct TestView {
         focus_handle: FocusHandle,
+        indicator: Entity<PendingKeystrokesIndicator>,
     }
 
     #[derive(Debug, PartialEq)]
@@ -309,6 +430,8 @@ mod tests {
         generation: u64,
         bindings: Vec<(Vec<String>, String)>,
         timeout_paused: bool,
+        popover_visible: bool,
+        popover_pointer_over: bool,
     }
 
     fn indicator_snapshot(indicator: &PendingKeystrokesIndicator) -> Option<IndicatorSnapshot> {
@@ -335,19 +458,9 @@ mod tests {
                     })
                     .collect(),
                 timeout_paused: render_state.timeout_paused,
+                popover_visible: indicator.popover.visible,
+                popover_pointer_over: indicator.popover.pointer_over,
             })
-    }
-
-    fn set_indicator_hovered(
-        indicator: &Entity<PendingKeystrokesIndicator>,
-        hovered: bool,
-        cx: &mut VisualTestContext,
-    ) {
-        cx.update(|window, cx| {
-            indicator.update(cx, |indicator, cx| {
-                indicator.set_hovered(hovered, window, cx);
-            });
-        });
     }
 
     fn setup_indicator_test(
@@ -356,15 +469,17 @@ mod tests {
     ) -> (Entity<PendingKeystrokesIndicator>, &mut VisualTestContext) {
         cx.update(|cx| {
             settings::init(cx);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
             cx.bind_keys(bindings);
         });
 
-        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
+        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
             focus_handle: cx.focus_handle(),
+            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
         });
-        let indicator =
-            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
-        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
+        let (focus_handle, indicator) = test_view.read_with(cx, |test_view, _| {
+            (test_view.focus_handle.clone(), test_view.indicator.clone())
+        });
         cx.update(|window, cx| {
             window.focus(&focus_handle, cx);
             window.activate_window();
@@ -373,14 +488,44 @@ mod tests {
         (indicator, cx)
     }
 
+    fn start_pending_input_and_hover_indicator(cx: &mut VisualTestContext) {
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        let indicator_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_INDICATOR")
+            .expect("rendered pending keystrokes indicator");
+        cx.simulate_mouse_move(indicator_bounds.center(), None, Modifiers::none());
+    }
+
+    fn move_pointer_over_popover(cx: &mut VisualTestContext) {
+        let popover_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_POPOVER")
+            .expect("rendered pending keystrokes popover");
+        cx.simulate_mouse_move(popover_bounds.center(), None, Modifiers::none());
+    }
+
+    fn move_pointer_outside(cx: &mut VisualTestContext) {
+        let outside = cx.update(|window, _| point(window.viewport_size().width - px(1.), px(1.)));
+        cx.simulate_mouse_move(outside, None, Modifiers::none());
+    }
+
     impl Render for TestView {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
             div()
+                .size_full()
                 .key_context("PendingKeystrokesIndicatorTest")
                 .track_focus(&self.focus_handle)
                 .on_action(|_: &ShorterBinding, _, _| {})
                 .on_action(|_: &LongerBinding, _, _| {})
                 .on_action(|_: &LongestBinding, _, _| {})
+                .child(
+                    v_flex()
+                        .size_full()
+                        .justify_end()
+                        .items_end()
+                        .child(self.indicator.clone()),
+                )
         }
     }
 
@@ -431,28 +576,102 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_hover_pauses_and_resumes_timeout(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
+    fn test_hovering_indicator_opens_popover_and_pauses_timeout(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        start_pending_input_and_hover_indicator(cx);
 
-        cx.simulate_keystrokes("ctrl-b");
-        cx.run_until_parked();
-
-        set_indicator_hovered(&indicator, true, cx);
-        cx.run_until_parked();
         let paused_render_state = indicator
             .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("paused pending input");
         assert!(paused_render_state.timeout_paused);
+        assert!(paused_render_state.popover_visible);
+    }
 
-        set_indicator_hovered(&indicator, false, cx);
+    #[gpui::test]
+    fn test_popover_is_positioned_above_indicator(cx: &mut TestAppContext) {
+        let (_, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        start_pending_input_and_hover_indicator(cx);
+
+        let indicator_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_INDICATOR")
+            .expect("rendered pending keystrokes indicator");
+        let popover_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_POPOVER")
+            .expect("rendered pending keystrokes popover");
+        assert!(
+            popover_bounds.bottom() <= indicator_bounds.top(),
+            "popover {popover_bounds:?} should render above indicator {indicator_bounds:?}"
+        );
+        assert_eq!(popover_bounds.right(), indicator_bounds.right());
+    }
+
+    #[gpui::test]
+    fn test_pointer_handoff_keeps_popover_open_and_timeout_paused(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        start_pending_input_and_hover_indicator(cx);
+        move_pointer_over_popover(cx);
+
+        let handoff_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("pending input during popover handoff");
+        assert!(handoff_render_state.timeout_paused);
+        assert!(handoff_render_state.popover_visible);
+        assert!(handoff_render_state.popover_pointer_over);
+
+        cx.executor().advance_clock(POPOVER_HIDE_DELAY);
+        cx.run_until_parked();
+        let stationary_popover_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("pending input while pointer remains over popover");
+        assert!(stationary_popover_render_state.timeout_paused);
+        assert!(stationary_popover_render_state.popover_visible);
+        assert!(stationary_popover_render_state.popover_pointer_over);
+    }
+
+    #[gpui::test]
+    fn test_open_popover_updates_with_pending_input(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        start_pending_input_and_hover_indicator(cx);
+        let initial_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("initial pending input");
+        move_pointer_over_popover(cx);
+
+        cx.simulate_keystrokes("h");
+        cx.run_until_parked();
+        let updated_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("updated pending input while popover is open");
+        assert_eq!(updated_render_state.keystrokes, vec!["ctrl-b", "h"]);
+        assert!(updated_render_state.generation > initial_render_state.generation);
+        assert!(updated_render_state.timeout_paused);
+        assert!(updated_render_state.popover_visible);
+        assert!(cx.debug_bounds("PENDING_KEYSTROKES_POPOVER").is_some());
+    }
+
+    #[gpui::test]
+    fn test_popover_hides_and_timeout_resumes_after_delay(cx: &mut TestAppContext) {
+        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        start_pending_input_and_hover_indicator(cx);
+        move_pointer_over_popover(cx);
+        move_pointer_outside(cx);
+
+        cx.executor()
+            .advance_clock(POPOVER_HIDE_DELAY - Duration::from_millis(1));
+        cx.run_until_parked();
+        let grace_period_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
+            .expect("pending input during popover dismissal grace period");
+        assert!(grace_period_render_state.timeout_paused);
+        assert!(grace_period_render_state.popover_visible);
+
+        cx.executor().advance_clock(Duration::from_millis(1));
         cx.run_until_parked();
         let resumed_render_state = indicator
             .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("resumed pending input");
         assert!(!resumed_render_state.timeout_paused);
-
-        cx.simulate_keystrokes("h");
-        cx.run_until_parked();
+        assert!(!resumed_render_state.popover_visible);
     }
 
     #[gpui::test]
@@ -461,8 +680,10 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
-        set_indicator_hovered(&indicator, true, cx);
-        cx.run_until_parked();
+        let indicator_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_INDICATOR")
+            .expect("rendered pending keystrokes indicator");
+        cx.simulate_mouse_move(indicator_bounds.center(), None, Modifiers::none());
 
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,8 +1,11 @@
 use command_palette::humanize_action_name;
-use gpui::{Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Window};
-use settings::Settings;
+use gpui::{
+    Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Subscription, Window,
+};
+use settings::{Settings, SettingsStore};
 use std::{rc::Rc, time::Duration};
 use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
+use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
 use crate::FILTERED_KEYSTROKES;
@@ -14,6 +17,8 @@ const MAX_TOOLTIP_BINDINGS: usize = 10;
 pub struct PendingKeystrokesIndicator {
     pending: Option<Rc<PendingKeystrokes>>,
     pending_input_generation: u64,
+    _pending_input_subscription: Subscription,
+    _settings_subscription: Subscription,
 }
 
 struct PendingKeystrokes {
@@ -25,26 +30,53 @@ struct PendingKeystrokes {
 
 impl PendingKeystrokesIndicator {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        cx.observe_pending_input(window, |this: &mut Self, window, cx| {
-            this.update_pending(window, cx);
-            cx.notify();
-        })
-        .detach();
+        let pending_input_subscription =
+            cx.observe_pending_input(window, |this: &mut Self, window, cx| {
+                if this.update_pending(window, cx) {
+                    cx.notify();
+                }
+            });
+
+        let mut enabled = Self::enabled(cx);
+        let settings_subscription =
+            cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
+                let new_enabled = Self::enabled(cx);
+                if new_enabled == enabled {
+                    return;
+                }
+
+                enabled = new_enabled;
+                if this.update_pending(window, cx) {
+                    cx.notify();
+                }
+            });
 
         Self {
             pending: None,
             pending_input_generation: 0,
+            _pending_input_subscription: pending_input_subscription,
+            _settings_subscription: settings_subscription,
         }
     }
 
-    fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn enabled(cx: &App) -> bool {
+        let status_bar_settings = StatusBarSettings::get_global(cx);
+        status_bar_settings.show
+            && status_bar_settings.pending_keystrokes_indicator
+            && !VimModeSetting::is_enabled(cx)
+            && !HelixModeSetting::is_enabled(cx)
+    }
+
+    fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if !Self::enabled(cx) {
+            return self.clear_pending();
+        }
+
         let Some(pending_input) = window.pending_input() else {
-            self.pending = None;
-            return;
+            return self.clear_pending();
         };
         let Some(timeout) = pending_input.timeout() else {
-            self.pending = None;
-            return;
+            return self.clear_pending();
         };
         let keystrokes = pending_input.keystrokes();
 
@@ -105,12 +137,17 @@ impl PendingKeystrokesIndicator {
                 .collect(),
             timeout,
         }));
+        true
+    }
+
+    fn clear_pending(&mut self) -> bool {
+        self.pending.take().is_some()
     }
 }
 
 impl Render for PendingKeystrokesIndicator {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if !StatusBarSettings::get_global(cx).pending_keystrokes_indicator {
+        if !Self::enabled(cx) {
             return div().hidden().into_any_element();
         }
         let Some(pending) = self.pending.clone() else {
@@ -274,6 +311,7 @@ mod tests {
     #[gpui::test]
     fn test_indicator_tracks_pending_input_lifecycle(cx: &mut TestAppContext) {
         cx.update(|cx| {
+            settings::init(cx);
             cx.bind_keys([
                 KeyBinding::new(
                     "ctrl-b",
@@ -330,6 +368,25 @@ mod tests {
             ]
         );
 
+        let pending_before_unrelated_settings_update = indicator
+            .read_with(cx, |indicator, _| indicator.pending.clone())
+            .expect("pending input");
+        cx.update(|_, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(r#"{"ui_font_size":15}"#, cx)
+                    .expect("valid test settings");
+            });
+        });
+        cx.run_until_parked();
+        let pending_after_unrelated_settings_update = indicator
+            .read_with(cx, |indicator, _| indicator.pending.clone())
+            .expect("pending input");
+        assert!(Rc::ptr_eq(
+            &pending_before_unrelated_settings_update,
+            &pending_after_unrelated_settings_update
+        ));
+
         cx.executor().advance_clock(first_pending.timeout / 2);
         cx.run_until_parked();
         assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_some()));
@@ -359,5 +416,137 @@ mod tests {
         assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
         assert_eq!(shorter_binding_count.get(), 0);
         assert_eq!(longer_binding_count.get(), 1);
+
+        cx.update(|_, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(
+                        r#"{"status_bar":{"pending_keystrokes_indicator":false}}"#,
+                        cx,
+                    )
+                    .expect("valid test settings");
+            });
+        });
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+
+        cx.update(|_, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(
+                        r#"{"status_bar":{"pending_keystrokes_indicator":true}}"#,
+                        cx,
+                    )
+                    .expect("valid test settings");
+            });
+        });
+        cx.run_until_parked();
+        let pending_after_reenabling =
+            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
+        assert!(
+            pending_after_reenabling.is_some(),
+            "expected the current pending input after re-enabling the indicator"
+        );
+
+        cx.update(|_, cx| {
+            VimModeSetting::override_global(VimModeSetting(true), cx);
+        });
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+
+        cx.update(|_, cx| {
+            VimModeSetting::override_global(VimModeSetting(false), cx);
+        });
+        cx.run_until_parked();
+        let pending_after_disabling_vim =
+            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
+        assert!(
+            pending_after_disabling_vim.is_some(),
+            "expected the current pending input after disabling Vim mode"
+        );
+        cx.executor()
+            .advance_clock(pending_after_disabling_vim.unwrap_or_default().timeout);
+        cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn test_indicator_tracks_status_bar_and_helix_modes(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            settings::init(cx);
+            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(
+                        r#"{"status_bar":{"experimental.show":false,"pending_keystrokes_indicator":true}}"#,
+                        cx,
+                    )
+                    .expect("valid test settings");
+            });
+            cx.bind_keys([
+                KeyBinding::new(
+                    "ctrl-b",
+                    ShorterBinding,
+                    Some("PendingKeystrokesIndicatorTest"),
+                ),
+                KeyBinding::new(
+                    "ctrl-b h",
+                    LongerBinding,
+                    Some("PendingKeystrokesIndicatorTest"),
+                ),
+            ]);
+        });
+
+        let shorter_binding_count = Rc::new(Cell::new(0));
+        let longer_binding_count = Rc::new(Cell::new(0));
+        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
+            focus_handle: cx.focus_handle(),
+            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
+            shorter_binding_count,
+            longer_binding_count,
+        });
+        let (indicator, focus_handle) = test_view.read_with(cx, |test_view, _| {
+            (test_view.indicator.clone(), test_view.focus_handle.clone())
+        });
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+
+        cx.update(|_, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(
+                        r#"{"status_bar":{"experimental.show":true,"pending_keystrokes_indicator":true}}"#,
+                        cx,
+                    )
+                    .expect("valid test settings");
+            });
+        });
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_some()));
+
+        cx.update(|_, cx| {
+            HelixModeSetting::override_global(HelixModeSetting(true), cx);
+        });
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+
+        cx.update(|_, cx| {
+            HelixModeSetting::override_global(HelixModeSetting(false), cx);
+        });
+        cx.run_until_parked();
+        let pending_after_disabling_helix =
+            indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
+        assert!(pending_after_disabling_helix.is_some());
+        cx.executor()
+            .advance_clock(pending_after_disabling_helix.unwrap_or_default().timeout);
+        cx.run_until_parked();
     }
 }

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    Anchor, Animation, AnimationExt, App, Context, HoverListenerMode, KeybindingKeystroke, Render,
-    Subscription, Task, Window, anchored, deferred,
+    Action as _, Anchor, Animation, AnimationExt, App, Context, HoverListenerMode,
+    KeybindingKeystroke, Render, Subscription, Task, Window, anchored, deferred,
 };
 use settings::{Settings, SettingsStore};
 use std::{rc::Rc, time::Duration};
@@ -234,6 +234,9 @@ impl Render for PendingKeystrokesIndicator {
         };
 
         let button = ButtonLike::new("pending-keystrokes-indicator")
+            .on_click(|_, window, cx| {
+                window.dispatch_action(zed_actions::dev::OpenKeyContextView.boxed_clone(), cx);
+            })
             .child(if cx.reduce_motion() {
                 Icon::new(IconName::CountdownTimer)
                     .size(IconSize::XSmall)
@@ -391,8 +394,8 @@ mod tests {
     use super::*;
     use command_palette::humanize_action_name;
     use gpui::{
-        Action as _, Entity, FocusHandle, KeyBinding, Modifiers, TestAppContext, VisualTestContext,
-        actions, point,
+        Entity, FocusHandle, KeyBinding, Modifiers, TestAppContext, VisualTestContext, actions,
+        point,
     };
 
     actions!(
@@ -438,6 +441,7 @@ mod tests {
     struct TestView {
         focus_handle: FocusHandle,
         indicator: Entity<PendingKeystrokesIndicator>,
+        open_key_context_view_count: Rc<Cell<usize>>,
     }
 
     #[derive(Debug, PartialEq)]
@@ -482,7 +486,11 @@ mod tests {
     fn setup_indicator_test(
         cx: &mut TestAppContext,
         bindings: impl IntoIterator<Item = KeyBinding>,
-    ) -> (Entity<PendingKeystrokesIndicator>, &mut VisualTestContext) {
+    ) -> (
+        Entity<PendingKeystrokesIndicator>,
+        Rc<Cell<usize>>,
+        &mut VisualTestContext,
+    ) {
         cx.update(|cx| {
             settings::init(cx);
             WhichKeySettings::register(cx);
@@ -490,9 +498,14 @@ mod tests {
             cx.bind_keys(bindings);
         });
 
-        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
-            focus_handle: cx.focus_handle(),
-            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
+        let open_key_context_view_count = Rc::new(Cell::new(0));
+        let (test_view, cx) = cx.add_window_view({
+            let open_key_context_view_count = open_key_context_view_count.clone();
+            |window, cx| TestView {
+                focus_handle: cx.focus_handle(),
+                indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
+                open_key_context_view_count,
+            }
         });
         let (focus_handle, indicator) = test_view.read_with(cx, |test_view, _| {
             (test_view.focus_handle.clone(), test_view.indicator.clone())
@@ -502,7 +515,7 @@ mod tests {
             window.activate_window();
         });
 
-        (indicator, cx)
+        (indicator, open_key_context_view_count, cx)
     }
 
     fn start_pending_input_and_hover_indicator(cx: &mut VisualTestContext) {
@@ -528,7 +541,7 @@ mod tests {
     }
 
     impl Render for TestView {
-        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             div()
                 .size_full()
                 .key_context("PendingKeystrokesIndicatorTest")
@@ -536,6 +549,12 @@ mod tests {
                 .on_action(|_: &ShorterBinding, _, _| {})
                 .on_action(|_: &LongerBinding, _, _| {})
                 .on_action(|_: &LongestBinding, _, _| {})
+                .on_action(
+                    cx.listener(|this, _: &zed_actions::dev::OpenKeyContextView, _, _| {
+                        this.open_key_context_view_count
+                            .set(this.open_key_context_view_count.get() + 1);
+                    }),
+                )
                 .child(
                     v_flex()
                         .size_full()
@@ -548,7 +567,7 @@ mod tests {
 
     #[gpui::test]
     fn test_indicator_tracks_pending_input(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
@@ -594,7 +613,7 @@ mod tests {
 
     #[gpui::test]
     fn test_indicator_does_not_apply_which_key_binding_filter(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(
+        let (indicator, _, cx) = setup_indicator_test(
             cx,
             [
                 KeyBinding::new("g", ShorterBinding, Some("PendingKeystrokesIndicatorTest")),
@@ -628,7 +647,7 @@ mod tests {
     fn test_which_key_disables_popover_but_keeps_indicator_and_hover_pause(
         cx: &mut TestAppContext,
     ) {
-        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, timed_bindings());
 
         cx.update(|_, cx| {
             cx.update_global::<SettingsStore, _>(|store, cx| {
@@ -680,8 +699,23 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_clicking_indicator_opens_key_context_view(cx: &mut TestAppContext) {
+        let (_, open_key_context_view_count, cx) = setup_indicator_test(cx, timed_bindings());
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        let indicator_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_INDICATOR")
+            .expect("rendered pending keystrokes indicator");
+        cx.simulate_click(indicator_bounds.center(), Modifiers::none());
+
+        assert_eq!(open_key_context_view_count.get(), 1);
+    }
+
+    #[gpui::test]
     fn test_hovering_indicator_opens_popover_and_pauses_timeout(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
 
         let paused_render_state = indicator
@@ -693,7 +727,7 @@ mod tests {
 
     #[gpui::test]
     fn test_popover_is_positioned_above_indicator(cx: &mut TestAppContext) {
-        let (_, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (_, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
 
         let indicator_bounds = cx
@@ -711,7 +745,7 @@ mod tests {
 
     #[gpui::test]
     fn test_pointer_handoff_keeps_popover_open_and_timeout_paused(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
         move_pointer_over_popover(cx);
 
@@ -734,7 +768,7 @@ mod tests {
 
     #[gpui::test]
     fn test_open_popover_updates_with_pending_input(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
         let initial_render_state = indicator
             .read_with(cx, |indicator, _| indicator_snapshot(indicator))
@@ -755,7 +789,7 @@ mod tests {
 
     #[gpui::test]
     fn test_popover_hides_and_timeout_resumes_after_delay(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, nested_timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
         move_pointer_over_popover(cx);
         move_pointer_outside(cx);
@@ -780,7 +814,7 @@ mod tests {
 
     #[gpui::test]
     fn test_disabling_indicator_releases_timeout_pause(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
+        let (indicator, _, cx) = setup_indicator_test(cx, timed_bindings());
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
@@ -815,7 +849,7 @@ mod tests {
 
     #[gpui::test]
     fn test_indicator_ignores_pending_input_without_timeout(cx: &mut TestAppContext) {
-        let (indicator, cx) = setup_indicator_test(
+        let (indicator, _, cx) = setup_indicator_test(
             cx,
             [KeyBinding::new(
                 "ctrl-b h",

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,7 +1,7 @@
 use command_palette::humanize_action_name;
-use gpui::{App, Context, KeybindingKeystroke, PENDING_INPUT_TIMEOUT, Render, Task, Window};
+use gpui::{Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Window};
 use settings::Settings;
-use std::{rc::Rc, time::Instant};
+use std::{rc::Rc, time::Duration};
 use ui::{ButtonLike, CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
 use util::ResultExt;
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
@@ -14,14 +14,15 @@ const MAX_TOOLTIP_BINDINGS: usize = 10;
 /// longer bindings, counting down until the shorter binding is applied.
 pub struct PendingKeystrokesIndicator {
     pending: Option<PendingKeystrokes>,
-    _countdown_task: Option<Task<()>>,
+    pending_input_generation: u64,
 }
 
 #[derive(Clone)]
 struct PendingKeystrokes {
     keystrokes: Rc<[KeybindingKeystroke]>,
-    started_at: Instant,
+    pending_input_generation: u64,
     bindings: Vec<(Rc<[KeybindingKeystroke]>, SharedString)>,
+    timeout: Duration,
 }
 
 impl PendingKeystrokesIndicator {
@@ -34,19 +35,20 @@ impl PendingKeystrokesIndicator {
 
         Self {
             pending: None,
-            _countdown_task: None,
+            pending_input_generation: 0,
         }
     }
 
     fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(keystrokes) = window
-            .pending_input_keystrokes()
-            .filter(|_| window.pending_input_will_timeout())
-        else {
+        let Some(pending_input) = window.pending_input() else {
             self.pending = None;
-            self._countdown_task = None;
             return;
         };
+        let Some(timeout) = pending_input.timeout() else {
+            self.pending = None;
+            return;
+        };
+        let keystrokes = pending_input.keystrokes();
 
         let pending_len = keystrokes.len();
         let mut bindings = window
@@ -92,33 +94,19 @@ impl PendingKeystrokesIndicator {
             text_a == text_b && action_a == action_b
         });
 
+        self.pending_input_generation = self.pending_input_generation.wrapping_add(1);
         self.pending = Some(PendingKeystrokes {
             keystrokes: keystrokes
                 .iter()
                 .map(|keystroke| KeybindingKeystroke::from_keystroke(keystroke.clone()))
                 .collect(),
-            started_at: Instant::now(),
+            pending_input_generation: self.pending_input_generation,
             bindings: bindings
                 .into_iter()
                 .map(|(_, keystrokes, action)| (Rc::from(keystrokes), action))
                 .collect(),
+            timeout,
         });
-        self._countdown_task = Some(cx.spawn(async move |this, cx| {
-            loop {
-                cx.background_executor()
-                    .timer(PENDING_INPUT_TIMEOUT / 30)
-                    .await;
-                let done = this
-                    .update(cx, |this, cx| {
-                        cx.notify();
-                        this.pending.is_none()
-                    })
-                    .unwrap_or(true);
-                if done {
-                    break;
-                }
-            }
-        }));
     }
 }
 
@@ -131,22 +119,26 @@ impl Render for PendingKeystrokesIndicator {
             return div().hidden().into_any_element();
         };
 
-        let remaining = 1.0
-            - (pending.started_at.elapsed().as_secs_f32() / PENDING_INPUT_TIMEOUT.as_secs_f32())
-                .clamp(0.0, 1.0);
-
         ButtonLike::new("pending-keystrokes-indicator")
             .child(
                 h_flex()
                     .gap_1()
                     .child(
-                        CircularProgress::new(remaining, 1.0, px(13.), cx)
+                        CircularProgress::new(1.0, 1.0, px(13.), cx)
                             .stroke_width(px(2.))
-                            .progress_color(cx.theme().colors().text_muted),
+                            .progress_color(cx.theme().colors().text_muted)
+                            .with_animation(
+                                (
+                                    "pending-keystrokes-countdown",
+                                    pending.pending_input_generation,
+                                ),
+                                Animation::new(pending.timeout).with_max_fps(30.0),
+                                |progress, delta| progress.value(1.0 - delta),
+                            ),
                     )
                     .child(
                         KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
-                            .size(rems_from_px(12.)),
+                            .size(rems_from_px(12_f32)),
                     ),
             )
             .tooltip(Tooltip::element(move |_, _| {

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -1,0 +1,216 @@
+use command_palette::humanize_action_name;
+use gpui::{App, Context, KeybindingKeystroke, PENDING_INPUT_TIMEOUT, Render, Task, Window};
+use settings::Settings;
+use std::{rc::Rc, time::Instant};
+use ui::{ButtonLike, CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
+use util::ResultExt;
+use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
+
+use crate::FILTERED_KEYSTROKES;
+
+const MAX_TOOLTIP_BINDINGS: usize = 10;
+
+/// A status bar item shown while pending keystrokes both match a key binding and are a prefix of
+/// longer bindings, counting down until the shorter binding is applied.
+pub struct PendingKeystrokesIndicator {
+    pending: Option<PendingKeystrokes>,
+    _countdown_task: Option<Task<()>>,
+}
+
+#[derive(Clone)]
+struct PendingKeystrokes {
+    keystrokes: Rc<[KeybindingKeystroke]>,
+    started_at: Instant,
+    bindings: Vec<(Rc<[KeybindingKeystroke]>, SharedString)>,
+}
+
+impl PendingKeystrokesIndicator {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        cx.observe_pending_input(window, |this: &mut Self, window, cx| {
+            this.update_pending(window, cx);
+            cx.notify();
+        })
+        .detach();
+
+        Self {
+            pending: None,
+            _countdown_task: None,
+        }
+    }
+
+    fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(keystrokes) = window
+            .pending_input_keystrokes()
+            .filter(|_| window.pending_input_will_timeout())
+        else {
+            self.pending = None;
+            self._countdown_task = None;
+            return;
+        };
+
+        let pending_len = keystrokes.len();
+        let mut bindings = window
+            .possible_bindings_for_input(keystrokes)
+            .iter()
+            .filter_map(|binding| {
+                let binding_keystrokes = binding.keystrokes();
+                if binding_keystrokes.len() <= pending_len {
+                    return None;
+                }
+                if FILTERED_KEYSTROKES.iter().any(|filtered| {
+                    binding_keystrokes.len() >= filtered.len()
+                        && binding_keystrokes[..filtered.len()]
+                            .iter()
+                            .map(|keystroke| keystroke.inner())
+                            .eq(filtered.iter())
+                }) {
+                    return None;
+                }
+                let remaining = &binding_keystrokes[pending_len..];
+                let remaining_text = text_for_keystrokes(
+                    &remaining
+                        .iter()
+                        .map(|keystroke| keystroke.inner().clone())
+                        .collect::<Vec<_>>(),
+                    cx,
+                );
+                Some((
+                    remaining_text,
+                    remaining.to_vec(),
+                    SharedString::from(humanize_action_name(binding.action().name())),
+                ))
+            })
+            .collect::<Vec<_>>();
+        bindings.sort_by(|(text_a, keys_a, action_a), (text_b, keys_b, action_b)| {
+            keys_a
+                .len()
+                .cmp(&keys_b.len())
+                .then_with(|| text_a.cmp(text_b))
+                .then_with(|| action_a.cmp(action_b))
+        });
+        bindings.dedup_by(|(text_a, _, action_a), (text_b, _, action_b)| {
+            text_a == text_b && action_a == action_b
+        });
+
+        self.pending = Some(PendingKeystrokes {
+            keystrokes: keystrokes
+                .iter()
+                .map(|keystroke| KeybindingKeystroke::from_keystroke(keystroke.clone()))
+                .collect(),
+            started_at: Instant::now(),
+            bindings: bindings
+                .into_iter()
+                .map(|(_, keystrokes, action)| (Rc::from(keystrokes), action))
+                .collect(),
+        });
+        self._countdown_task = Some(cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(PENDING_INPUT_TIMEOUT / 30)
+                    .await;
+                let done = this
+                    .update(cx, |this, cx| {
+                        cx.notify();
+                        this.pending.is_none()
+                    })
+                    .unwrap_or(true);
+                if done {
+                    break;
+                }
+            }
+        }));
+    }
+}
+
+impl Render for PendingKeystrokesIndicator {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !StatusBarSettings::get_global(cx).pending_keystrokes_indicator {
+            return div().hidden().into_any_element();
+        }
+        let Some(pending) = self.pending.clone() else {
+            return div().hidden().into_any_element();
+        };
+
+        let remaining = 1.0
+            - (pending.started_at.elapsed().as_secs_f32() / PENDING_INPUT_TIMEOUT.as_secs_f32())
+                .clamp(0.0, 1.0);
+
+        ButtonLike::new("pending-keystrokes-indicator")
+            .child(
+                h_flex()
+                    .gap_1()
+                    .child(
+                        CircularProgress::new(remaining, 1.0, px(13.), cx)
+                            .stroke_width(px(2.))
+                            .progress_color(cx.theme().colors().text_muted),
+                    )
+                    .child(
+                        KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
+                            .size(rems_from_px(12.)),
+                    ),
+            )
+            .tooltip(Tooltip::element(move |_, _| {
+                let pending = &pending;
+                v_flex()
+                    .gap_1()
+                    .child(
+                        h_flex()
+                            .gap_1()
+                            .child(KeyBinding::from_keystrokes(
+                                pending.keystrokes.clone(),
+                                false,
+                            ))
+                            .child(Label::new("is waiting for more keys").color(Color::Muted)),
+                    )
+                    .children(pending.bindings.iter().take(MAX_TOOLTIP_BINDINGS).map(
+                        |(keystrokes, action)| {
+                            h_flex()
+                                .gap_2()
+                                .child(KeyBinding::from_keystrokes(keystrokes.clone(), false))
+                                .child(Label::new(action.clone()).size(LabelSize::Small))
+                        },
+                    ))
+                    .when(pending.bindings.len() > MAX_TOOLTIP_BINDINGS, |el| {
+                        el.child(
+                            Label::new(format!(
+                                "…and {} more",
+                                pending.bindings.len() - MAX_TOOLTIP_BINDINGS
+                            ))
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                        )
+                    })
+                    .child(
+                        Label::new("Click to open the key context view")
+                            .size(LabelSize::XSmall)
+                            .color(Color::Muted),
+                    )
+                    .into_any_element()
+            }))
+            .on_click(|_, window, cx| {
+                if let Some(action) = cx.build_action("dev::OpenKeyContextView", None).log_err() {
+                    window.dispatch_action(action, cx);
+                }
+            })
+            .into_any_element()
+    }
+}
+
+impl StatusItemView for PendingKeystrokesIndicator {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn hide_setting(&self, _: &App) -> Option<HideStatusItem> {
+        Some(HideStatusItem::new(|settings| {
+            settings
+                .status_bar
+                .get_or_insert_default()
+                .pending_keystrokes_indicator = Some(false);
+        }))
+    }
+}

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -137,7 +137,7 @@ impl PendingKeystrokesIndicator {
 }
 
 impl Render for PendingKeystrokesIndicator {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let Some(render_state) = self.render_state().cloned() else {
             return div().hidden().into_any_element();
         };
@@ -159,9 +159,14 @@ impl Render for PendingKeystrokesIndicator {
                     .color(Color::Muted)
                     .into_any_element()
             } else {
-                let progress = CircularProgress::new(remaining_fraction, 1.0, px(13.), cx)
-                    .stroke_width(px(2.))
-                    .progress_color(cx.theme().colors().text_muted);
+                let progress = CircularProgress::new(
+                    remaining_fraction,
+                    1.0,
+                    rems_from_px(13_f32).to_pixels(window.rem_size()),
+                    cx,
+                )
+                .stroke_width(rems_from_px(2_f32).to_pixels(window.rem_size()))
+                .progress_color(cx.theme().colors().text_muted);
                 if render_state.timeout_paused || render_state.remaining_duration.is_zero() {
                     progress.into_any_element()
                 } else {

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -2,8 +2,7 @@ use command_palette::humanize_action_name;
 use gpui::{Animation, AnimationExt, App, Context, KeybindingKeystroke, Render, Window};
 use settings::Settings;
 use std::{rc::Rc, time::Duration};
-use ui::{ButtonLike, CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
-use util::ResultExt;
+use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
 use crate::FILTERED_KEYSTROKES;
@@ -119,27 +118,26 @@ impl Render for PendingKeystrokesIndicator {
             return div().hidden().into_any_element();
         };
 
-        ButtonLike::new("pending-keystrokes-indicator")
+        h_flex()
+            .id("pending-keystrokes-indicator")
+            .gap_1()
+            .px_1()
             .child(
-                h_flex()
-                    .gap_1()
-                    .child(
-                        CircularProgress::new(1.0, 1.0, px(13.), cx)
-                            .stroke_width(px(2.))
-                            .progress_color(cx.theme().colors().text_muted)
-                            .with_animation(
-                                (
-                                    "pending-keystrokes-countdown",
-                                    pending.pending_input_generation,
-                                ),
-                                Animation::new(pending.timeout).with_max_fps(30.0),
-                                |progress, delta| progress.value(1.0 - delta),
-                            ),
-                    )
-                    .child(
-                        KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
-                            .size(rems_from_px(12_f32)),
+                CircularProgress::new(1.0, 1.0, px(13.), cx)
+                    .stroke_width(px(2.))
+                    .progress_color(cx.theme().colors().text_muted)
+                    .with_animation(
+                        (
+                            "pending-keystrokes-countdown",
+                            pending.pending_input_generation,
+                        ),
+                        Animation::new(pending.timeout).with_max_fps(30.0),
+                        |progress, delta| progress.value(1.0 - delta),
                     ),
+            )
+            .child(
+                KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
+                    .size(rems_from_px(12_f32)),
             )
             .tooltip(Tooltip::element(move |_, _| {
                 let pending = &pending;
@@ -172,18 +170,8 @@ impl Render for PendingKeystrokesIndicator {
                             .color(Color::Muted),
                         )
                     })
-                    .child(
-                        Label::new("Click to open the key context view")
-                            .size(LabelSize::XSmall)
-                            .color(Color::Muted),
-                    )
                     .into_any_element()
             }))
-            .on_click(|_, window, cx| {
-                if let Some(action) = cx.build_action("dev::OpenKeyContextView", None).log_err() {
-                    window.dispatch_action(action, cx);
-                }
-            })
             .into_any_element()
     }
 }

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -12,11 +12,10 @@ const MAX_TOOLTIP_BINDINGS: usize = 10;
 /// A status bar item shown while pending keystrokes both match a key binding and are a prefix of
 /// longer bindings, counting down until the shorter binding is applied.
 pub struct PendingKeystrokesIndicator {
-    pending: Option<PendingKeystrokes>,
+    pending: Option<Rc<PendingKeystrokes>>,
     pending_input_generation: u64,
 }
 
-#[derive(Clone)]
 struct PendingKeystrokes {
     keystrokes: Rc<[KeybindingKeystroke]>,
     pending_input_generation: u64,
@@ -94,7 +93,7 @@ impl PendingKeystrokesIndicator {
         });
 
         self.pending_input_generation = self.pending_input_generation.wrapping_add(1);
-        self.pending = Some(PendingKeystrokes {
+        self.pending = Some(Rc::new(PendingKeystrokes {
             keystrokes: keystrokes
                 .iter()
                 .map(|keystroke| KeybindingKeystroke::from_keystroke(keystroke.clone()))
@@ -105,7 +104,7 @@ impl PendingKeystrokesIndicator {
                 .map(|(_, keystrokes, action)| (Rc::from(keystrokes), action))
                 .collect(),
             timeout,
-        });
+        }));
     }
 }
 

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -3,11 +3,11 @@ use gpui::{
 };
 use settings::{Settings, SettingsStore};
 use std::{rc::Rc, time::Duration};
-use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keystrokes};
+use ui::{CircularProgress, KeyBinding, Tooltip, prelude::*, text_for_keybinding_keystrokes};
 use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
-use crate::bindings_for_pending_input;
+use crate::{bindings_for_pending_input, map_pending_keystrokes};
 
 const MAX_TOOLTIP_BINDINGS: usize = 10;
 
@@ -83,14 +83,8 @@ impl PendingKeystrokesIndicator {
         let mut bindings = bindings_for_pending_input(window, keystrokes)
             .into_iter()
             .map(|binding| {
-                let remaining_text = text_for_keystrokes(
-                    &binding
-                        .remaining_keystrokes
-                        .iter()
-                        .map(|keystroke| keystroke.inner().clone())
-                        .collect::<Vec<_>>(),
-                    cx,
-                );
+                let remaining_text =
+                    text_for_keybinding_keystrokes(&binding.remaining_keystrokes, cx);
                 (
                     remaining_text,
                     binding.remaining_keystrokes,
@@ -111,10 +105,7 @@ impl PendingKeystrokesIndicator {
 
         self.pending_input_generation = self.pending_input_generation.wrapping_add(1);
         self.pending = Some(Rc::new(PendingKeystrokes {
-            keystrokes: keystrokes
-                .iter()
-                .map(|keystroke| KeybindingKeystroke::from_keystroke(keystroke.clone()))
-                .collect(),
+            keystrokes: map_pending_keystrokes(keystrokes, cx.keyboard_mapper().as_ref()).into(),
             pending_input_generation: self.pending_input_generation,
             bindings: bindings
                 .into_iter()

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -193,3 +193,164 @@ impl StatusItemView for PendingKeystrokesIndicator {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use gpui::{Action as _, Entity, FocusHandle, KeyBinding, TestAppContext, actions};
+
+    use super::*;
+
+    actions!(
+        pending_keystrokes_indicator_test,
+        [ShorterBinding, LongerBinding, LongestBinding]
+    );
+
+    struct TestView {
+        focus_handle: FocusHandle,
+        indicator: Entity<PendingKeystrokesIndicator>,
+        shorter_binding_count: Rc<Cell<usize>>,
+        longer_binding_count: Rc<Cell<usize>>,
+    }
+
+    #[derive(Debug, Default, PartialEq)]
+    struct PendingSnapshot {
+        keystrokes: Vec<String>,
+        generation: u64,
+        bindings: Vec<(Vec<String>, String)>,
+        timeout: Duration,
+    }
+
+    fn pending_snapshot(indicator: &PendingKeystrokesIndicator) -> Option<PendingSnapshot> {
+        indicator.pending.as_ref().map(|pending| PendingSnapshot {
+            keystrokes: pending
+                .keystrokes
+                .iter()
+                .map(|keystroke| keystroke.inner().unparse())
+                .collect(),
+            generation: pending.pending_input_generation,
+            bindings: pending
+                .bindings
+                .iter()
+                .map(|(keystrokes, action)| {
+                    (
+                        keystrokes
+                            .iter()
+                            .map(|keystroke| keystroke.inner().unparse())
+                            .collect(),
+                        action.to_string(),
+                    )
+                })
+                .collect(),
+            timeout: pending.timeout,
+        })
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let shorter_binding_count = self.shorter_binding_count.clone();
+            let longer_binding_count = self.longer_binding_count.clone();
+            div()
+                .key_context("PendingKeystrokesIndicatorTest")
+                .track_focus(&self.focus_handle)
+                .on_action(move |_: &ShorterBinding, _, _| {
+                    shorter_binding_count.set(shorter_binding_count.get() + 1);
+                })
+                .on_action(move |_: &LongerBinding, _, _| {
+                    longer_binding_count.set(longer_binding_count.get() + 1);
+                })
+                .on_action(|_: &LongestBinding, _, _| {})
+        }
+    }
+
+    #[gpui::test]
+    fn test_indicator_tracks_pending_input_lifecycle(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([
+                KeyBinding::new(
+                    "ctrl-b",
+                    ShorterBinding,
+                    Some("PendingKeystrokesIndicatorTest"),
+                ),
+                KeyBinding::new(
+                    "ctrl-b h",
+                    LongerBinding,
+                    Some("PendingKeystrokesIndicatorTest"),
+                ),
+                KeyBinding::new(
+                    "ctrl-b h j",
+                    LongestBinding,
+                    Some("PendingKeystrokesIndicatorTest"),
+                ),
+            ]);
+        });
+
+        let shorter_binding_count = Rc::new(Cell::new(0));
+        let longer_binding_count = Rc::new(Cell::new(0));
+        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
+            focus_handle: cx.focus_handle(),
+            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
+            shorter_binding_count: shorter_binding_count.clone(),
+            longer_binding_count: longer_binding_count.clone(),
+        });
+        let (indicator, focus_handle) = test_view.read_with(cx, |test_view, _| {
+            (test_view.indicator.clone(), test_view.focus_handle.clone())
+        });
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        let first_pending = indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
+        assert!(first_pending.is_some(), "expected pending input snapshot");
+        let first_pending = first_pending.unwrap_or_default();
+        assert_eq!(first_pending.keystrokes, vec!["ctrl-b"]);
+        assert_eq!(
+            first_pending.bindings,
+            vec![
+                (
+                    vec!["h".to_string()],
+                    humanize_action_name(LongerBinding.name()),
+                ),
+                (
+                    vec!["h".to_string(), "j".to_string()],
+                    humanize_action_name(LongestBinding.name()),
+                ),
+            ]
+        );
+
+        cx.executor().advance_clock(first_pending.timeout / 2);
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_some()));
+
+        cx.simulate_keystrokes("h");
+        cx.run_until_parked();
+
+        let second_pending = indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
+        assert!(
+            second_pending.is_some(),
+            "expected updated pending input snapshot"
+        );
+        let second_pending = second_pending.unwrap_or_default();
+        assert_eq!(second_pending.keystrokes, vec!["ctrl-b", "h"]);
+        assert!(second_pending.generation > first_pending.generation);
+        assert_eq!(
+            second_pending.bindings,
+            vec![(
+                vec!["j".to_string()],
+                humanize_action_name(LongestBinding.name()),
+            )]
+        );
+
+        cx.executor().advance_clock(second_pending.timeout);
+        cx.run_until_parked();
+
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert_eq!(shorter_binding_count.get(), 0);
+        assert_eq!(longer_binding_count.get(), 1);
+    }
+}

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -773,7 +773,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_open_popover_updates_with_pending_input(cx: &mut TestAppContext) {
+    fn test_open_popover_tracks_pending_input_lifecycle(cx: &mut TestAppContext) {
         let (indicator, _, cx) = setup_indicator_test(cx, nested_timed_bindings());
         start_pending_input_and_hover_indicator(cx);
         let initial_render_state = indicator
@@ -791,6 +791,13 @@ mod tests {
         assert!(updated_render_state.timeout_paused);
         assert!(updated_render_state.popover_visible);
         assert!(cx.debug_bounds("PENDING_KEYSTROKES_POPOVER").is_some());
+
+        cx.simulate_keystrokes("j");
+        cx.run_until_parked();
+
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.render_state().is_none()));
+        assert!(cx.debug_bounds("PENDING_KEYSTROKES_POPOVER").is_none());
     }
 
     #[gpui::test]
@@ -851,6 +858,7 @@ mod tests {
 
         cx.simulate_keystrokes("h");
         cx.run_until_parked();
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
     }
 
     #[gpui::test]

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -121,7 +121,12 @@ impl Render for PendingKeystrokesIndicator {
             .id("pending-keystrokes-indicator")
             .gap_1()
             .px_1()
-            .child(
+            .child(if cx.reduce_motion() {
+                Icon::new(IconName::CountdownTimer)
+                    .size(IconSize::XSmall)
+                    .color(Color::Muted)
+                    .into_any_element()
+            } else {
                 CircularProgress::new(1.0, 1.0, px(13.), cx)
                     .stroke_width(px(2.))
                     .progress_color(cx.theme().colors().text_muted)
@@ -132,8 +137,9 @@ impl Render for PendingKeystrokesIndicator {
                         ),
                         Animation::new(pending.timeout).with_max_fps(30.0),
                         |progress, delta| progress.value(1.0 - delta),
-                    ),
-            )
+                    )
+                    .into_any_element()
+            })
             .child(
                 KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
                     .size(rems_from_px(12_f32)),

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -297,10 +297,13 @@ impl Render for PendingKeystrokesIndicator {
                                         .child(
                                             h_flex()
                                                 .gap_1()
-                                                .child(KeyBinding::from_keystrokes(
-                                                    popover_render_state.keystrokes.clone(),
-                                                    false,
-                                                ))
+                                                .child(
+                                                    KeyBinding::from_keystrokes(
+                                                        popover_render_state.keystrokes.clone(),
+                                                        false,
+                                                    )
+                                                    .color(Color::Accent),
+                                                )
                                                 .child(
                                                     Label::new("is waiting for more keys")
                                                         .color(Color::Muted),
@@ -314,10 +317,13 @@ impl Render for PendingKeystrokesIndicator {
                                                 .map(|(keystrokes, action)| {
                                                     h_flex()
                                                         .gap_2()
-                                                        .child(KeyBinding::from_keystrokes(
-                                                            keystrokes.clone(),
-                                                            false,
-                                                        ))
+                                                        .child(
+                                                            KeyBinding::from_keystrokes(
+                                                                keystrokes.clone(),
+                                                                false,
+                                                            )
+                                                            .color(Color::Accent),
+                                                        )
                                                         .child(
                                                             Label::new(action.clone())
                                                                 .size(LabelSize::Small),

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -13,13 +13,13 @@ const MAX_TOOLTIP_BINDINGS: usize = 10;
 
 /// A status bar item shown while timed pending input can complete a multi-stroke key binding.
 pub struct PendingKeystrokesIndicator {
-    pending: Option<Rc<PendingKeystrokes>>,
+    render_state: Option<Rc<IndicatorRenderState>>,
     pending_input_generation: u64,
     _pending_input_subscription: Subscription,
     _settings_subscription: Subscription,
 }
 
-struct PendingKeystrokes {
+struct IndicatorRenderState {
     keystrokes: Rc<[KeybindingKeystroke]>,
     pending_input_generation: u64,
     bindings: Vec<(Rc<[KeybindingKeystroke]>, SharedString)>,
@@ -32,7 +32,7 @@ impl PendingKeystrokesIndicator {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let pending_input_subscription =
             cx.observe_pending_input(window, |this: &mut Self, window, cx| {
-                if this.update_pending(window, cx) {
+                if this.refresh_render_state(window, cx) {
                     cx.notify();
                 }
             });
@@ -46,13 +46,13 @@ impl PendingKeystrokesIndicator {
                 }
 
                 enabled = new_enabled;
-                if this.update_pending(window, cx) {
+                if this.refresh_render_state(window, cx) {
                     cx.notify();
                 }
             });
 
         Self {
-            pending: None,
+            render_state: None,
             pending_input_generation: 0,
             _pending_input_subscription: pending_input_subscription,
             _settings_subscription: settings_subscription,
@@ -67,16 +67,16 @@ impl PendingKeystrokesIndicator {
             && !HelixModeSetting::is_enabled(cx)
     }
 
-    fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+    fn refresh_render_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if !Self::enabled(cx) {
-            return self.clear_pending(window, cx);
+            return self.clear_render_state(window, cx);
         }
 
         let Some(pending_input) = window.pending_input() else {
-            return self.clear_pending(window, cx);
+            return self.clear_render_state(window, cx);
         };
         let Some(timeout) = pending_input.timeout() else {
-            return self.clear_pending(window, cx);
+            return self.clear_render_state(window, cx);
         };
         let keystrokes = pending_input.keystrokes();
 
@@ -104,7 +104,7 @@ impl PendingKeystrokesIndicator {
         });
 
         self.pending_input_generation = self.pending_input_generation.wrapping_add(1);
-        self.pending = Some(Rc::new(PendingKeystrokes {
+        self.render_state = Some(Rc::new(IndicatorRenderState {
             keystrokes: map_pending_keystrokes(keystrokes, cx.keyboard_mapper().as_ref()).into(),
             pending_input_generation: self.pending_input_generation,
             bindings: bindings
@@ -118,17 +118,17 @@ impl PendingKeystrokesIndicator {
         true
     }
 
-    fn clear_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+    fn clear_render_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         window.set_pending_input_timeout_paused(&cx.entity(), false, cx);
-        self.pending.take().is_some()
+        self.render_state.take().is_some()
     }
 
-    fn pending(&self) -> Option<&Rc<PendingKeystrokes>> {
-        self.pending.as_ref()
+    fn render_state(&self) -> Option<&Rc<IndicatorRenderState>> {
+        self.render_state.as_ref()
     }
 
     fn set_hovered(&mut self, hovered: bool, window: &mut Window, cx: &mut Context<Self>) {
-        if self.pending.is_none() {
+        if self.render_state.is_none() {
             return;
         }
 
@@ -138,14 +138,15 @@ impl PendingKeystrokesIndicator {
 
 impl Render for PendingKeystrokesIndicator {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let Some(pending) = self.pending().cloned() else {
+        let Some(render_state) = self.render_state().cloned() else {
             return div().hidden().into_any_element();
         };
-        let remaining_fraction = if pending.timeout_duration.is_zero() {
+        let remaining_fraction = if render_state.timeout_duration.is_zero() {
             0.0
         } else {
-            (pending.remaining_duration.as_secs_f32() / pending.timeout_duration.as_secs_f32())
-                .clamp(0.0, 1.0)
+            (render_state.remaining_duration.as_secs_f32()
+                / render_state.timeout_duration.as_secs_f32())
+            .clamp(0.0, 1.0)
         };
 
         h_flex()
@@ -161,16 +162,16 @@ impl Render for PendingKeystrokesIndicator {
                 let progress = CircularProgress::new(remaining_fraction, 1.0, px(13.), cx)
                     .stroke_width(px(2.))
                     .progress_color(cx.theme().colors().text_muted);
-                if pending.timeout_paused || pending.remaining_duration.is_zero() {
+                if render_state.timeout_paused || render_state.remaining_duration.is_zero() {
                     progress.into_any_element()
                 } else {
                     progress
                         .with_animation(
                             (
                                 "pending-keystrokes-countdown",
-                                pending.pending_input_generation,
+                                render_state.pending_input_generation,
                             ),
-                            Animation::new(pending.remaining_duration).with_max_fps(30.0),
+                            Animation::new(render_state.remaining_duration).with_max_fps(30.0),
                             move |progress, delta| {
                                 progress.value(remaining_fraction * (1.0 - delta))
                             },
@@ -179,23 +180,23 @@ impl Render for PendingKeystrokesIndicator {
                 }
             })
             .child(
-                KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
+                KeyBinding::from_keystrokes(render_state.keystrokes.clone(), false)
                     .size(rems_from_px(12_f32)),
             )
             .tooltip(Tooltip::element(move |_, _| {
-                let pending = &pending;
+                let render_state = &render_state;
                 v_flex()
                     .gap_1()
                     .child(
                         h_flex()
                             .gap_1()
                             .child(KeyBinding::from_keystrokes(
-                                pending.keystrokes.clone(),
+                                render_state.keystrokes.clone(),
                                 false,
                             ))
                             .child(Label::new("is waiting for more keys").color(Color::Muted)),
                     )
-                    .children(pending.bindings.iter().take(MAX_TOOLTIP_BINDINGS).map(
+                    .children(render_state.bindings.iter().take(MAX_TOOLTIP_BINDINGS).map(
                         |(keystrokes, action)| {
                             h_flex()
                                 .gap_2()
@@ -203,11 +204,11 @@ impl Render for PendingKeystrokesIndicator {
                                 .child(Label::new(action.clone()).size(LabelSize::Small))
                         },
                     ))
-                    .when(pending.bindings.len() > MAX_TOOLTIP_BINDINGS, |el| {
+                    .when(render_state.bindings.len() > MAX_TOOLTIP_BINDINGS, |el| {
                         el.child(
                             Label::new(format!(
                                 "…and {} more",
-                                pending.bindings.len() - MAX_TOOLTIP_BINDINGS
+                                render_state.bindings.len() - MAX_TOOLTIP_BINDINGS
                             ))
                             .size(LabelSize::Small)
                             .color(Color::Muted),
@@ -298,36 +299,38 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq)]
-    struct PendingSnapshot {
+    struct IndicatorSnapshot {
         keystrokes: Vec<String>,
         generation: u64,
         bindings: Vec<(Vec<String>, String)>,
         timeout_paused: bool,
     }
 
-    fn pending_snapshot(indicator: &PendingKeystrokesIndicator) -> Option<PendingSnapshot> {
-        indicator.pending().map(|pending| PendingSnapshot {
-            keystrokes: pending
-                .keystrokes
-                .iter()
-                .map(|keystroke| keystroke.inner().unparse())
-                .collect(),
-            generation: pending.pending_input_generation,
-            bindings: pending
-                .bindings
-                .iter()
-                .map(|(keystrokes, action)| {
-                    (
-                        keystrokes
-                            .iter()
-                            .map(|keystroke| keystroke.inner().unparse())
-                            .collect(),
-                        action.to_string(),
-                    )
-                })
-                .collect(),
-            timeout_paused: pending.timeout_paused,
-        })
+    fn indicator_snapshot(indicator: &PendingKeystrokesIndicator) -> Option<IndicatorSnapshot> {
+        indicator
+            .render_state()
+            .map(|render_state| IndicatorSnapshot {
+                keystrokes: render_state
+                    .keystrokes
+                    .iter()
+                    .map(|keystroke| keystroke.inner().unparse())
+                    .collect(),
+                generation: render_state.pending_input_generation,
+                bindings: render_state
+                    .bindings
+                    .iter()
+                    .map(|(keystrokes, action)| {
+                        (
+                            keystrokes
+                                .iter()
+                                .map(|keystroke| keystroke.inner().unparse())
+                                .collect(),
+                            action.to_string(),
+                        )
+                    })
+                    .collect(),
+                timeout_paused: render_state.timeout_paused,
+            })
     }
 
     fn set_indicator_hovered(
@@ -383,12 +386,12 @@ mod tests {
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
 
-        let first_pending = indicator
-            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+        let first_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("pending input snapshot");
-        assert_eq!(first_pending.keystrokes, vec!["ctrl-b"]);
+        assert_eq!(first_render_state.keystrokes, vec!["ctrl-b"]);
         assert_eq!(
-            first_pending.bindings,
+            first_render_state.bindings,
             vec![
                 (
                     vec!["h".to_string()],
@@ -404,13 +407,13 @@ mod tests {
         cx.simulate_keystrokes("h");
         cx.run_until_parked();
 
-        let second_pending = indicator
-            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+        let second_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("updated pending input snapshot");
-        assert_eq!(second_pending.keystrokes, vec!["ctrl-b", "h"]);
-        assert!(second_pending.generation > first_pending.generation);
+        assert_eq!(second_render_state.keystrokes, vec!["ctrl-b", "h"]);
+        assert!(second_render_state.generation > first_render_state.generation);
         assert_eq!(
-            second_pending.bindings,
+            second_render_state.bindings,
             vec![(
                 vec!["j".to_string()],
                 humanize_action_name(LongestBinding.name()),
@@ -419,7 +422,7 @@ mod tests {
 
         cx.simulate_keystrokes("j");
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.render_state().is_none()));
     }
 
     #[gpui::test]
@@ -431,17 +434,17 @@ mod tests {
 
         set_indicator_hovered(&indicator, true, cx);
         cx.run_until_parked();
-        let paused_pending = indicator
-            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+        let paused_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("paused pending input");
-        assert!(paused_pending.timeout_paused);
+        assert!(paused_render_state.timeout_paused);
 
         set_indicator_hovered(&indicator, false, cx);
         cx.run_until_parked();
-        let resumed_pending = indicator
-            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+        let resumed_render_state = indicator
+            .read_with(cx, |indicator, _| indicator_snapshot(indicator))
             .expect("resumed pending input");
-        assert!(!resumed_pending.timeout_paused);
+        assert!(!resumed_render_state.timeout_paused);
 
         cx.simulate_keystrokes("h");
         cx.run_until_parked();
@@ -467,7 +470,7 @@ mod tests {
             });
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.render_state().is_none()));
         cx.update(|window, _| {
             let timeout = window
                 .pending_input()
@@ -509,7 +512,7 @@ mod tests {
             let pending_input = window.pending_input().expect("pending input");
             assert!(pending_input.timeout().is_none());
         });
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.render_state().is_none()));
         assert_eq!(notification_count.get(), 0);
     }
 }

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -12,7 +12,9 @@ use util::ResultExt;
 use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, item::ItemHandle};
 
-use crate::{bindings_for_pending_input, map_pending_keystrokes};
+use crate::{
+    bindings_for_pending_input, map_pending_keystrokes, which_key_settings::WhichKeySettings,
+};
 
 const MAX_TOOLTIP_BINDINGS: usize = 10;
 const POPOVER_HIDE_DELAY: Duration = Duration::from_millis(300);
@@ -59,17 +61,26 @@ impl PendingKeystrokesIndicator {
             });
 
         let mut enabled = Self::enabled(cx);
+        let mut popover_enabled = Self::popover_enabled(cx);
         let settings_subscription =
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
                 let new_enabled = Self::enabled(cx);
-                if new_enabled == enabled {
+                let new_popover_enabled = Self::popover_enabled(cx);
+                if new_enabled == enabled && new_popover_enabled == popover_enabled {
                     return;
                 }
 
                 enabled = new_enabled;
+                popover_enabled = new_popover_enabled;
+                if !new_popover_enabled {
+                    this.popover.pointer_over = false;
+                    this.popover.visible = false;
+                    this.popover.hide_task.take();
+                }
                 if this.refresh_render_state(window, cx) {
                     cx.notify();
                 }
+                this.update_pointer_over_state(window, cx);
             });
 
         Self {
@@ -87,6 +98,10 @@ impl PendingKeystrokesIndicator {
             && status_bar_settings.pending_keystrokes_indicator
             && !VimModeSetting::is_enabled(cx)
             && !HelixModeSetting::is_enabled(cx)
+    }
+
+    fn popover_enabled(cx: &App) -> bool {
+        !WhichKeySettings::get_global(cx).enabled
     }
 
     fn refresh_render_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
@@ -178,9 +193,9 @@ impl PendingKeystrokesIndicator {
         if self.popover.is_pointer_over() {
             self.popover.hide_task.take();
             let was_visible = self.popover.visible;
-            self.popover.visible = true;
+            self.popover.visible = Self::popover_enabled(cx);
             window.set_pending_input_timeout_paused(&cx.entity(), true, cx);
-            if !was_visible {
+            if was_visible != self.popover.visible {
                 cx.notify();
             }
         } else if self.popover.visible && self.popover.hide_task.is_none() {
@@ -199,6 +214,8 @@ impl PendingKeystrokesIndicator {
                 })
                 .log_err();
             }));
+        } else if !self.popover.visible {
+            window.set_pending_input_timeout_paused(&cx.entity(), false, cx);
         }
     }
 }
@@ -371,13 +388,12 @@ impl StatusItemView for PendingKeystrokesIndicator {
 mod tests {
     use std::cell::Cell;
 
+    use super::*;
     use command_palette::humanize_action_name;
     use gpui::{
         Action as _, Entity, FocusHandle, KeyBinding, Modifiers, TestAppContext, VisualTestContext,
         actions, point,
     };
-
-    use super::*;
 
     actions!(
         pending_keystrokes_indicator_test,
@@ -469,6 +485,7 @@ mod tests {
     ) -> (Entity<PendingKeystrokesIndicator>, &mut VisualTestContext) {
         cx.update(|cx| {
             settings::init(cx);
+            WhichKeySettings::register(cx);
             theme_settings::init(theme::LoadThemes::JustBase, cx);
             cx.bind_keys(bindings);
         });
@@ -605,6 +622,61 @@ mod tests {
                 humanize_action_name(LongerBinding.name()),
             )]
         );
+    }
+
+    #[gpui::test]
+    fn test_which_key_disables_popover_but_keeps_indicator_and_hover_pause(
+        cx: &mut TestAppContext,
+    ) {
+        let (indicator, cx) = setup_indicator_test(cx, timed_bindings());
+
+        cx.update(|_, cx| {
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store
+                    .set_user_settings(
+                        r#"{
+                            "status_bar": {"pending_keystrokes_indicator": true},
+                            "which_key": {"enabled": true}
+                        }"#,
+                        cx,
+                    )
+                    .expect("valid test settings");
+            });
+        });
+        cx.run_until_parked();
+        cx.update(|_, cx| {
+            assert!(StatusBarSettings::get_global(cx).pending_keystrokes_indicator);
+            assert!(WhichKeySettings::get_global(cx).enabled);
+        });
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        assert!(indicator.read_with(cx, |indicator, _| indicator.render_state().is_some()));
+        let indicator_bounds = cx
+            .debug_bounds("PENDING_KEYSTROKES_INDICATOR")
+            .expect("rendered pending keystrokes indicator");
+        cx.simulate_mouse_move(indicator_bounds.center(), None, Modifiers::none());
+        cx.run_until_parked();
+
+        assert!(cx.debug_bounds("PENDING_KEYSTROKES_POPOVER").is_none());
+        cx.update(|window, _| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(timeout.is_paused());
+        });
+
+        move_pointer_outside(cx);
+        cx.run_until_parked();
+        cx.update(|window, _| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
+        });
     }
 
     #[gpui::test]

--- a/crates/which_key/src/pending_keystrokes_indicator.rs
+++ b/crates/which_key/src/pending_keystrokes_indicator.rs
@@ -12,8 +12,7 @@ use crate::FILTERED_KEYSTROKES;
 
 const MAX_TOOLTIP_BINDINGS: usize = 10;
 
-/// A status bar item shown while pending keystrokes both match a key binding and are a prefix of
-/// longer bindings, counting down until the shorter binding is applied.
+/// A status bar item shown while timed pending input can complete a multi-stroke key binding.
 pub struct PendingKeystrokesIndicator {
     pending: Option<Rc<PendingKeystrokes>>,
     pending_input_generation: u64,
@@ -25,7 +24,9 @@ struct PendingKeystrokes {
     keystrokes: Rc<[KeybindingKeystroke]>,
     pending_input_generation: u64,
     bindings: Vec<(Rc<[KeybindingKeystroke]>, SharedString)>,
-    timeout: Duration,
+    timeout_duration: Duration,
+    remaining_duration: Duration,
+    timeout_paused: bool,
 }
 
 impl PendingKeystrokesIndicator {
@@ -69,14 +70,14 @@ impl PendingKeystrokesIndicator {
 
     fn update_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if !Self::enabled(cx) {
-            return self.clear_pending();
+            return self.clear_pending(window, cx);
         }
 
         let Some(pending_input) = window.pending_input() else {
-            return self.clear_pending();
+            return self.clear_pending(window, cx);
         };
         let Some(timeout) = pending_input.timeout() else {
-            return self.clear_pending();
+            return self.clear_pending(window, cx);
         };
         let keystrokes = pending_input.keystrokes();
 
@@ -135,23 +136,41 @@ impl PendingKeystrokesIndicator {
                 .into_iter()
                 .map(|(_, keystrokes, action)| (Rc::from(keystrokes), action))
                 .collect(),
-            timeout,
+            timeout_duration: timeout.duration(),
+            remaining_duration: timeout.remaining(cx),
+            timeout_paused: timeout.is_paused(),
         }));
         true
     }
 
-    fn clear_pending(&mut self) -> bool {
+    fn clear_pending(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        window.set_pending_input_timeout_paused(&cx.entity(), false, cx);
         self.pending.take().is_some()
+    }
+
+    fn pending(&self) -> Option<&Rc<PendingKeystrokes>> {
+        self.pending.as_ref()
+    }
+
+    fn set_hovered(&mut self, hovered: bool, window: &mut Window, cx: &mut Context<Self>) {
+        if self.pending.is_none() {
+            return;
+        }
+
+        window.set_pending_input_timeout_paused(&cx.entity(), hovered, cx);
     }
 }
 
 impl Render for PendingKeystrokesIndicator {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if !Self::enabled(cx) {
+        let Some(pending) = self.pending().cloned() else {
             return div().hidden().into_any_element();
-        }
-        let Some(pending) = self.pending.clone() else {
-            return div().hidden().into_any_element();
+        };
+        let remaining_fraction = if pending.timeout_duration.is_zero() {
+            0.0
+        } else {
+            (pending.remaining_duration.as_secs_f32() / pending.timeout_duration.as_secs_f32())
+                .clamp(0.0, 1.0)
         };
 
         h_flex()
@@ -164,18 +183,25 @@ impl Render for PendingKeystrokesIndicator {
                     .color(Color::Muted)
                     .into_any_element()
             } else {
-                CircularProgress::new(1.0, 1.0, px(13.), cx)
+                let progress = CircularProgress::new(remaining_fraction, 1.0, px(13.), cx)
                     .stroke_width(px(2.))
-                    .progress_color(cx.theme().colors().text_muted)
-                    .with_animation(
-                        (
-                            "pending-keystrokes-countdown",
-                            pending.pending_input_generation,
-                        ),
-                        Animation::new(pending.timeout).with_max_fps(30.0),
-                        |progress, delta| progress.value(1.0 - delta),
-                    )
-                    .into_any_element()
+                    .progress_color(cx.theme().colors().text_muted);
+                if pending.timeout_paused || pending.remaining_duration.is_zero() {
+                    progress.into_any_element()
+                } else {
+                    progress
+                        .with_animation(
+                            (
+                                "pending-keystrokes-countdown",
+                                pending.pending_input_generation,
+                            ),
+                            Animation::new(pending.remaining_duration).with_max_fps(30.0),
+                            move |progress, delta| {
+                                progress.value(remaining_fraction * (1.0 - delta))
+                            },
+                        )
+                        .into_any_element()
+                }
             })
             .child(
                 KeyBinding::from_keystrokes(pending.keystrokes.clone(), false)
@@ -215,6 +241,9 @@ impl Render for PendingKeystrokesIndicator {
                     .into_any_element()
             }))
             .tooltip_show_delay(Duration::ZERO)
+            .on_hover(cx.listener(|this, hovered: &bool, window, cx| {
+                this.set_hovered(*hovered, window, cx);
+            }))
             .into_any_element()
     }
 }
@@ -242,7 +271,9 @@ impl StatusItemView for PendingKeystrokesIndicator {
 mod tests {
     use std::cell::Cell;
 
-    use gpui::{Action as _, Entity, FocusHandle, KeyBinding, TestAppContext, actions};
+    use gpui::{
+        Action as _, Entity, FocusHandle, KeyBinding, TestAppContext, VisualTestContext, actions,
+    };
 
     use super::*;
 
@@ -253,7 +284,6 @@ mod tests {
 
     struct TestView {
         focus_handle: FocusHandle,
-        indicator: Entity<PendingKeystrokesIndicator>,
         shorter_binding_count: Rc<Cell<usize>>,
         longer_binding_count: Rc<Cell<usize>>,
     }
@@ -263,11 +293,13 @@ mod tests {
         keystrokes: Vec<String>,
         generation: u64,
         bindings: Vec<(Vec<String>, String)>,
-        timeout: Duration,
+        timeout_duration: Duration,
+        remaining_duration: Duration,
+        timeout_paused: bool,
     }
 
     fn pending_snapshot(indicator: &PendingKeystrokesIndicator) -> Option<PendingSnapshot> {
-        indicator.pending.as_ref().map(|pending| PendingSnapshot {
+        indicator.pending().map(|pending| PendingSnapshot {
             keystrokes: pending
                 .keystrokes
                 .iter()
@@ -287,8 +319,22 @@ mod tests {
                     )
                 })
                 .collect(),
-            timeout: pending.timeout,
+            timeout_duration: pending.timeout_duration,
+            remaining_duration: pending.remaining_duration,
+            timeout_paused: pending.timeout_paused,
         })
+    }
+
+    fn set_indicator_hovered(
+        indicator: &Entity<PendingKeystrokesIndicator>,
+        hovered: bool,
+        cx: &mut VisualTestContext,
+    ) {
+        cx.update(|window, cx| {
+            indicator.update(cx, |indicator, cx| {
+                indicator.set_hovered(hovered, window, cx);
+            });
+        });
     }
 
     impl Render for TestView {
@@ -333,15 +379,14 @@ mod tests {
 
         let shorter_binding_count = Rc::new(Cell::new(0));
         let longer_binding_count = Rc::new(Cell::new(0));
-        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
+        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
             focus_handle: cx.focus_handle(),
-            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
             shorter_binding_count: shorter_binding_count.clone(),
             longer_binding_count: longer_binding_count.clone(),
         });
-        let (indicator, focus_handle) = test_view.read_with(cx, |test_view, _| {
-            (test_view.indicator.clone(), test_view.focus_handle.clone())
-        });
+        let indicator =
+            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
+        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
         cx.update(|window, cx| {
             window.focus(&focus_handle, cx);
             window.activate_window();
@@ -369,7 +414,7 @@ mod tests {
         );
 
         let pending_before_unrelated_settings_update = indicator
-            .read_with(cx, |indicator, _| indicator.pending.clone())
+            .read_with(cx, |indicator, _| indicator.pending().cloned())
             .expect("pending input");
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {
@@ -380,16 +425,34 @@ mod tests {
         });
         cx.run_until_parked();
         let pending_after_unrelated_settings_update = indicator
-            .read_with(cx, |indicator, _| indicator.pending.clone())
+            .read_with(cx, |indicator, _| indicator.pending().cloned())
             .expect("pending input");
         assert!(Rc::ptr_eq(
             &pending_before_unrelated_settings_update,
             &pending_after_unrelated_settings_update
         ));
 
-        cx.executor().advance_clock(first_pending.timeout / 2);
+        cx.executor()
+            .advance_clock(first_pending.timeout_duration / 2);
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_some()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
+
+        set_indicator_hovered(&indicator, true, cx);
+        cx.run_until_parked();
+        let hovered_pending = indicator
+            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+            .unwrap_or_default();
+        assert!(hovered_pending.timeout_paused);
+        assert_eq!(
+            hovered_pending.remaining_duration,
+            first_pending.timeout_duration / 2
+        );
+
+        cx.executor()
+            .advance_clock(first_pending.timeout_duration * 2);
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
+        assert_eq!(shorter_binding_count.get(), 0);
 
         cx.simulate_keystrokes("h");
         cx.run_until_parked();
@@ -402,6 +465,11 @@ mod tests {
         let second_pending = second_pending.unwrap_or_default();
         assert_eq!(second_pending.keystrokes, vec!["ctrl-b", "h"]);
         assert!(second_pending.generation > first_pending.generation);
+        assert!(second_pending.timeout_paused);
+        assert_eq!(
+            second_pending.remaining_duration,
+            second_pending.timeout_duration
+        );
         assert_eq!(
             second_pending.bindings,
             vec![(
@@ -410,37 +478,65 @@ mod tests {
             )]
         );
 
-        cx.executor().advance_clock(second_pending.timeout);
+        cx.executor()
+            .advance_clock(second_pending.timeout_duration * 2);
+        cx.run_until_parked();
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
+        assert_eq!(longer_binding_count.get(), 0);
+
+        set_indicator_hovered(&indicator, false, cx);
+        cx.run_until_parked();
+        let resumed_pending = indicator
+            .read_with(cx, |indicator, _| pending_snapshot(indicator))
+            .unwrap_or_default();
+        assert!(!resumed_pending.timeout_paused);
+        assert_eq!(
+            resumed_pending.remaining_duration,
+            resumed_pending.timeout_duration
+        );
+
+        cx.executor()
+            .advance_clock(resumed_pending.remaining_duration);
         cx.run_until_parked();
 
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
         assert_eq!(shorter_binding_count.get(), 0);
         assert_eq!(longer_binding_count.get(), 1);
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+        set_indicator_hovered(&indicator, true, cx);
+        cx.run_until_parked();
 
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {
                 store
-                    .set_user_settings(
-                        r#"{"status_bar":{"pending_keystrokes_indicator":false}}"#,
-                        cx,
-                    )
+                    .set_user_settings(r#"{"status_bar":{"experimental.show":false}}"#, cx)
                     .expect("valid test settings");
             });
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        let remaining_after_disabling = cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
+            timeout.remaining(cx)
+        });
+        cx.executor().advance_clock(remaining_after_disabling);
+        cx.run_until_parked();
+        assert_eq!(shorter_binding_count.get(), 1);
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
 
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {
                 store
-                    .set_user_settings(
-                        r#"{"status_bar":{"pending_keystrokes_indicator":true}}"#,
-                        cx,
-                    )
+                    .set_user_settings(r#"{"status_bar":{"experimental.show":true}}"#, cx)
                     .expect("valid test settings");
             });
         });
@@ -456,7 +552,7 @@ mod tests {
             VimModeSetting::override_global(VimModeSetting(true), cx);
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
 
         cx.update(|_, cx| {
             VimModeSetting::override_global(VimModeSetting(false), cx);
@@ -468,9 +564,34 @@ mod tests {
             pending_after_disabling_vim.is_some(),
             "expected the current pending input after disabling Vim mode"
         );
-        cx.executor()
-            .advance_clock(pending_after_disabling_vim.unwrap_or_default().timeout);
+        set_indicator_hovered(&indicator, true, cx);
         cx.run_until_parked();
+        let remaining_before_release = cx.update(|window, cx| {
+            window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .map(|timeout| timeout.remaining(cx))
+                .expect("pending input timeout")
+        });
+
+        let weak_indicator = indicator.downgrade();
+        drop(indicator);
+        cx.update(|_, _| {});
+        cx.run_until_parked();
+        weak_indicator.assert_released();
+
+        let remaining_after_release = cx.update(|window, cx| {
+            let timeout = window
+                .pending_input()
+                .and_then(|pending_input| pending_input.timeout())
+                .expect("pending input timeout");
+            assert!(!timeout.is_paused());
+            timeout.remaining(cx)
+        });
+        assert_eq!(remaining_after_release, remaining_before_release);
+        cx.executor().advance_clock(remaining_after_release);
+        cx.run_until_parked();
+        assert_eq!(shorter_binding_count.get(), 2);
     }
 
     #[gpui::test]
@@ -501,15 +622,14 @@ mod tests {
 
         let shorter_binding_count = Rc::new(Cell::new(0));
         let longer_binding_count = Rc::new(Cell::new(0));
-        let (test_view, cx) = cx.add_window_view(|window, cx| TestView {
+        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
             focus_handle: cx.focus_handle(),
-            indicator: cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)),
             shorter_binding_count,
             longer_binding_count,
         });
-        let (indicator, focus_handle) = test_view.read_with(cx, |test_view, _| {
-            (test_view.indicator.clone(), test_view.focus_handle.clone())
-        });
+        let indicator =
+            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
+        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
         cx.update(|window, cx| {
             window.focus(&focus_handle, cx);
             window.activate_window();
@@ -517,7 +637,7 @@ mod tests {
 
         cx.simulate_keystrokes("ctrl-b");
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
 
         cx.update(|_, cx| {
             cx.update_global::<settings::SettingsStore, _>(|store, cx| {
@@ -530,13 +650,13 @@ mod tests {
             });
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_some()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_some()));
 
         cx.update(|_, cx| {
             HelixModeSetting::override_global(HelixModeSetting(true), cx);
         });
         cx.run_until_parked();
-        assert!(indicator.read_with(cx, |indicator, _| indicator.pending.is_none()));
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
 
         cx.update(|_, cx| {
             HelixModeSetting::override_global(HelixModeSetting(false), cx);
@@ -545,8 +665,59 @@ mod tests {
         let pending_after_disabling_helix =
             indicator.read_with(cx, |indicator, _| pending_snapshot(indicator));
         assert!(pending_after_disabling_helix.is_some());
-        cx.executor()
-            .advance_clock(pending_after_disabling_helix.unwrap_or_default().timeout);
+        cx.executor().advance_clock(
+            pending_after_disabling_helix
+                .unwrap_or_default()
+                .timeout_duration,
+        );
         cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    fn test_indicator_ignores_pending_input_without_timeout(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            settings::init(cx);
+            cx.bind_keys([KeyBinding::new(
+                "ctrl-b h",
+                LongerBinding,
+                Some("PendingKeystrokesIndicatorTest"),
+            )]);
+        });
+
+        let shorter_binding_count = Rc::new(Cell::new(0));
+        let longer_binding_count = Rc::new(Cell::new(0));
+        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
+            focus_handle: cx.focus_handle(),
+            shorter_binding_count,
+            longer_binding_count,
+        });
+        let indicator =
+            cx.update(|window, cx| cx.new(|cx| PendingKeystrokesIndicator::new(window, cx)));
+        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        let notification_count = Rc::new(Cell::new(0));
+        let _notification_subscription = cx.update({
+            let indicator = indicator.clone();
+            let notification_count = notification_count.clone();
+            move |_, cx| {
+                cx.observe(&indicator, move |_, _| {
+                    notification_count.set(notification_count.get() + 1);
+                })
+            }
+        });
+
+        cx.simulate_keystrokes("ctrl-b");
+        cx.run_until_parked();
+
+        cx.update(|window, _| {
+            let pending_input = window.pending_input().expect("pending input");
+            assert!(pending_input.timeout().is_none());
+        });
+        assert!(indicator.read_with(cx, |indicator, _| indicator.pending().is_none()));
+        assert_eq!(notification_count.get(), 0);
     }
 }

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -148,7 +148,7 @@ mod tests {
     use std::cell::Cell;
 
     use collections::HashMap;
-    use gpui::{InvalidKeystrokeError, PlatformKeyboardMapper};
+    use gpui::PlatformKeyboardMapper;
 
     use super::*;
 
@@ -184,25 +184,39 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_map_pending_keystrokes_uses_platform_mapper() -> Result<(), InvalidKeystrokeError> {
+    #[gpui::test]
+    fn test_map_pending_keystrokes_uses_platform_mapper(cx: &mut App) {
         let keyboard_mapper = TestKeyboardMapper {
             call_count: Cell::new(0),
         };
-        let keystroke = Keystroke::parse("ctrl-@")?;
+        let keystroke = Keystroke::parse("ctrl-@").expect("valid test keystroke");
 
         let mapped = map_pending_keystrokes(std::slice::from_ref(&keystroke), &keyboard_mapper);
 
         assert_eq!(keyboard_mapper.call_count.get(), 1);
-        let Some(mapped) = mapped.first() else {
+        let Some(mapped_keystroke) = mapped.first() else {
             panic!("expected mapped pending keystroke");
         };
-        assert_eq!(mapped.inner(), &keystroke);
+        assert_eq!(mapped_keystroke.inner(), &keystroke);
         #[cfg(target_os = "windows")]
         {
-            assert_eq!(mapped.modifiers(), &gpui::Modifiers::control_shift());
-            assert_eq!(mapped.key(), "2");
+            assert_eq!(
+                mapped_keystroke.modifiers(),
+                &gpui::Modifiers::control_shift()
+            );
+            assert_eq!(mapped_keystroke.key(), "2");
         }
-        Ok(())
+
+        let expected_display_text = if cfg!(target_os = "windows") {
+            "Ctrl-Shift-2"
+        } else if cfg!(any(target_os = "linux", target_os = "freebsd")) {
+            "Ctrl-@"
+        } else {
+            "Control-@"
+        };
+        assert_eq!(
+            ui::text_for_keybinding_keystrokes(&mapped, cx),
+            expected_display_text
+        );
     }
 }

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -1,9 +1,11 @@
 //! Which-key support for Zed.
 
+mod pending_keystrokes_indicator;
 mod which_key_modal;
 mod which_key_settings;
 
 use gpui::{App, Keystroke};
+pub use pending_keystrokes_indicator::PendingKeystrokesIndicator;
 use settings::Settings;
 use std::{sync::LazyLock, time::Duration};
 use util::ResultExt;

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -33,19 +33,34 @@ pub(crate) fn bindings_for_pending_input(
     window: &Window,
     pending_keystrokes: &[Keystroke],
 ) -> Vec<PendingBinding> {
+    collect_bindings_for_pending_input(window, pending_keystrokes, |_| true)
+}
+
+pub(crate) fn bindings_for_which_key(
+    window: &Window,
+    pending_keystrokes: &[Keystroke],
+) -> Vec<PendingBinding> {
+    collect_bindings_for_pending_input(window, pending_keystrokes, |binding| {
+        let binding_keystrokes = binding.keystrokes();
+        !FILTERED_KEYSTROKES.iter().any(|filtered| {
+            binding_keystrokes.len() >= filtered.len()
+                && binding_keystrokes[..filtered.len()]
+                    .iter()
+                    .map(|keystroke| keystroke.inner())
+                    .eq(filtered.iter())
+        })
+    })
+}
+
+fn collect_bindings_for_pending_input(
+    window: &Window,
+    pending_keystrokes: &[Keystroke],
+    mut include_binding: impl FnMut(&gpui::KeyBinding) -> bool,
+) -> Vec<PendingBinding> {
     window
         .possible_bindings_for_input(pending_keystrokes)
         .into_iter()
-        .filter(|binding| {
-            let binding_keystrokes = binding.keystrokes();
-            !FILTERED_KEYSTROKES.iter().any(|filtered| {
-                binding_keystrokes.len() >= filtered.len()
-                    && binding_keystrokes[..filtered.len()]
-                        .iter()
-                        .map(|keystroke| keystroke.inner())
-                        .eq(filtered.iter())
-            })
-        })
+        .filter(|binding| include_binding(binding))
         .filter_map(|binding| {
             let remaining_keystrokes = binding.keystrokes().get(pending_keystrokes.len()..)?;
             if remaining_keystrokes.is_empty() {

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -4,7 +4,7 @@ mod pending_keystrokes_indicator;
 mod which_key_modal;
 mod which_key_settings;
 
-use gpui::{App, Keystroke};
+use gpui::{App, KeybindingKeystroke, Keystroke, SharedString, Window};
 pub use pending_keystrokes_indicator::PendingKeystrokesIndicator;
 use settings::Settings;
 use std::{sync::LazyLock, time::Duration};
@@ -12,6 +12,43 @@ use util::ResultExt;
 use which_key_modal::WhichKeyModal;
 use which_key_settings::WhichKeySettings;
 use workspace::Workspace;
+
+pub(crate) struct PendingBinding {
+    pub(crate) remaining_keystrokes: Vec<KeybindingKeystroke>,
+    pub(crate) action_name: SharedString,
+}
+
+pub(crate) fn bindings_for_pending_input(
+    window: &Window,
+    pending_keystrokes: &[Keystroke],
+) -> Vec<PendingBinding> {
+    window
+        .possible_bindings_for_input(pending_keystrokes)
+        .into_iter()
+        .filter(|binding| {
+            let binding_keystrokes = binding.keystrokes();
+            !FILTERED_KEYSTROKES.iter().any(|filtered| {
+                binding_keystrokes.len() >= filtered.len()
+                    && binding_keystrokes[..filtered.len()]
+                        .iter()
+                        .map(|keystroke| keystroke.inner())
+                        .eq(filtered.iter())
+            })
+        })
+        .filter_map(|binding| {
+            let remaining_keystrokes = binding.keystrokes().get(pending_keystrokes.len()..)?;
+            if remaining_keystrokes.is_empty() {
+                return None;
+            }
+            let remaining_keystrokes = remaining_keystrokes.to_vec();
+            let action_name = command_palette::humanize_action_name(binding.action().name()).into();
+            Some(PendingBinding {
+                remaining_keystrokes,
+                action_name,
+            })
+        })
+        .collect()
+}
 
 pub fn init(cx: &mut App) {
     WhichKeySettings::register(cx);

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -4,7 +4,7 @@ mod pending_keystrokes_indicator;
 mod which_key_modal;
 mod which_key_settings;
 
-use gpui::{App, KeybindingKeystroke, Keystroke, SharedString, Window};
+use gpui::{App, KeybindingKeystroke, Keystroke, PlatformKeyboardMapper, SharedString, Window};
 pub use pending_keystrokes_indicator::PendingKeystrokesIndicator;
 use settings::Settings;
 use std::{sync::LazyLock, time::Duration};
@@ -16,6 +16,17 @@ use workspace::Workspace;
 pub(crate) struct PendingBinding {
     pub(crate) remaining_keystrokes: Vec<KeybindingKeystroke>,
     pub(crate) action_name: SharedString,
+}
+
+pub(crate) fn map_pending_keystrokes(
+    keystrokes: &[Keystroke],
+    keyboard_mapper: &dyn PlatformKeyboardMapper,
+) -> Vec<KeybindingKeystroke> {
+    keystrokes
+        .iter()
+        .cloned()
+        .map(|keystroke| KeybindingKeystroke::new_with_mapper(keystroke, false, keyboard_mapper))
+        .collect()
 }
 
 pub(crate) fn bindings_for_pending_input(
@@ -131,3 +142,67 @@ pub static FILTERED_KEYSTROKES: LazyLock<Vec<Vec<Keystroke>>> = LazyLock::new(||
     })
     .collect()
 });
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use collections::HashMap;
+    use gpui::{InvalidKeystrokeError, PlatformKeyboardMapper};
+
+    use super::*;
+
+    struct TestKeyboardMapper {
+        call_count: Cell<usize>,
+    }
+
+    impl PlatformKeyboardMapper for TestKeyboardMapper {
+        fn map_key_equivalent(
+            &self,
+            keystroke: Keystroke,
+            use_key_equivalents: bool,
+        ) -> KeybindingKeystroke {
+            assert!(!use_key_equivalents);
+            self.call_count.set(self.call_count.get() + 1);
+
+            #[cfg(target_os = "windows")]
+            {
+                KeybindingKeystroke::new(
+                    keystroke,
+                    gpui::Modifiers::control_shift(),
+                    "2".to_owned(),
+                )
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                KeybindingKeystroke::from_keystroke(keystroke)
+            }
+        }
+
+        fn get_key_equivalents(&self) -> Option<&HashMap<char, char>> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_map_pending_keystrokes_uses_platform_mapper() -> Result<(), InvalidKeystrokeError> {
+        let keyboard_mapper = TestKeyboardMapper {
+            call_count: Cell::new(0),
+        };
+        let keystroke = Keystroke::parse("ctrl-@")?;
+
+        let mapped = map_pending_keystrokes(std::slice::from_ref(&keystroke), &keyboard_mapper);
+
+        assert_eq!(keyboard_mapper.call_count.get(), 1);
+        let Some(mapped) = mapped.first() else {
+            panic!("expected mapped pending keystroke");
+        };
+        assert_eq!(mapped.inner(), &keystroke);
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(mapped.modifiers(), &gpui::Modifiers::control_shift());
+            assert_eq!(mapped.key(), "2");
+        }
+        Ok(())
+    }
+}

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -14,7 +14,7 @@ use ui::{
 };
 use workspace::{ModalView, Workspace};
 
-use crate::FILTERED_KEYSTROKES;
+use crate::bindings_for_pending_input;
 
 pub struct WhichKeyModal {
     _workspace: WeakEntity<Workspace>,
@@ -65,27 +65,9 @@ impl WhichKeyModal {
             cx.emit(DismissEvent);
             return;
         };
-        let bindings = window.possible_bindings_for_input(pending_keys);
-
-        let mut binding_data = bindings
-            .iter()
-            .map(|binding| (binding.keystrokes().to_vec(), binding.action()))
-            .filter(|(keystrokes, _action)| {
-                // Check if this binding matches any filtered keystroke pattern
-                !FILTERED_KEYSTROKES.iter().any(|filtered| {
-                    keystrokes.len() >= filtered.len()
-                        && keystrokes[..filtered.len()]
-                            .iter()
-                            .map(|keystroke| keystroke.inner())
-                            .eq(filtered.iter())
-                })
-            })
-            .filter_map(|(keystrokes, action)| {
-                let remaining_keystrokes = keystrokes.get(pending_keys.len()..)?.to_vec();
-                let action_name: SharedString =
-                    command_palette::humanize_action_name(action.name()).into();
-                Some((remaining_keystrokes, action_name))
-            })
+        let mut binding_data = bindings_for_pending_input(window, pending_keys)
+            .into_iter()
+            .map(|binding| (binding.remaining_keystrokes, binding.action_name))
             .collect();
 
         binding_data = group_bindings(binding_data);

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -10,11 +10,11 @@ use std::collections::HashMap;
 use theme_settings::ThemeSettings;
 use ui::{
     Divider, DividerColor, DynamicSpacing, LabelSize, WithScrollbar, prelude::*,
-    text_for_keybinding_keystrokes, text_for_keystrokes,
+    text_for_keybinding_keystrokes,
 };
 use workspace::{ModalView, Workspace};
 
-use crate::bindings_for_pending_input;
+use crate::{bindings_for_pending_input, map_pending_keystrokes};
 
 pub struct WhichKeyModal {
     _workspace: WeakEntity<Workspace>,
@@ -101,7 +101,8 @@ impl WhichKeyModal {
             text_a.cmp(&text_b)
         });
         binding_data.dedup();
-        self.pending_keys = text_for_keystrokes(&pending_keys, cx).into();
+        let pending_keys = map_pending_keystrokes(pending_keys, cx.keyboard_mapper().as_ref());
+        self.pending_keys = text_for_keybinding_keystrokes(&pending_keys, cx).into();
         self.bindings = binding_data
             .into_iter()
             .map(|(keystrokes, action)| {

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -14,7 +14,7 @@ use ui::{
 };
 use workspace::{ModalView, Workspace};
 
-use crate::{bindings_for_pending_input, map_pending_keystrokes};
+use crate::{bindings_for_which_key, map_pending_keystrokes};
 
 pub struct WhichKeyModal {
     _workspace: WeakEntity<Workspace>,
@@ -65,7 +65,7 @@ impl WhichKeyModal {
             cx.emit(DismissEvent);
             return;
         };
-        let mut binding_data = bindings_for_pending_input(window, pending_keys)
+        let mut binding_data = bindings_for_which_key(window, pending_keys)
             .into_iter()
             .map(|binding| (binding.remaining_keystrokes, binding.action_name))
             .collect();

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -293,9 +293,56 @@ fn group_bindings(
 mod tests {
     #[cfg(target_os = "windows")]
     use gpui::Modifiers;
-    use gpui::{InvalidKeystrokeError, Keystroke};
+    use gpui::{
+        Action as _, Entity, FocusHandle, InvalidKeystrokeError, KeyBinding, Keystroke,
+        TestAppContext, VisualTestContext, actions,
+    };
 
     use super::*;
+
+    actions!(
+        which_key_modal_test,
+        [FirstBinding, SecondBinding, ThirdBinding]
+    );
+
+    struct TestView {
+        focus_handle: FocusHandle,
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .key_context("WhichKeyModalTest")
+                .track_focus(&self.focus_handle)
+                .on_action(|_: &FirstBinding, _, _| {})
+                .on_action(|_: &SecondBinding, _, _| {})
+                .on_action(|_: &ThirdBinding, _, _| {})
+        }
+    }
+
+    fn setup_modal_test<'a>(
+        cx: &'a mut TestAppContext,
+        bindings: impl IntoIterator<Item = KeyBinding>,
+        pending_keystrokes: &str,
+    ) -> (Entity<WhichKeyModal>, &'a mut VisualTestContext) {
+        cx.update(|cx| cx.bind_keys(bindings));
+        let (test_view, cx) = cx.add_window_view(|_, cx| TestView {
+            focus_handle: cx.focus_handle(),
+        });
+        let focus_handle = test_view.read_with(cx, |test_view, _| test_view.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+        cx.simulate_keystrokes(pending_keystrokes);
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+
+        let modal = cx.update(|window, cx| {
+            cx.new(|cx| WhichKeyModal::new(WeakEntity::new_invalid(), window, cx))
+        });
+        (modal, cx)
+    }
 
     #[test]
     fn test_group_bindings_preserves_keybinding_keystrokes() -> Result<(), InvalidKeystrokeError> {
@@ -316,5 +363,39 @@ mod tests {
             vec![(vec![keystroke], SharedString::from("test action"))]
         );
         Ok(())
+    }
+
+    #[gpui::test]
+    fn test_which_key_modal_groups_and_orders_pending_bindings(cx: &mut TestAppContext) {
+        let (modal, cx) = setup_modal_test(
+            cx,
+            [
+                KeyBinding::new("ctrl-b h", FirstBinding, Some("WhichKeyModalTest")),
+                KeyBinding::new("ctrl-b h j", SecondBinding, Some("WhichKeyModalTest")),
+                KeyBinding::new("ctrl-b k", ThirdBinding, Some("WhichKeyModalTest")),
+            ],
+            "ctrl-b",
+        );
+
+        let h = KeybindingKeystroke::from_keystroke(
+            Keystroke::parse("h").expect("valid test keystroke"),
+        );
+        let k = KeybindingKeystroke::from_keystroke(
+            Keystroke::parse("k").expect("valid test keystroke"),
+        );
+        let h_text = cx.update(|_, cx| text_for_keybinding_keystrokes(&[h], cx));
+        let k_text = cx.update(|_, cx| text_for_keybinding_keystrokes(&[k], cx));
+        let expected_bindings = vec![
+            (
+                k_text.into(),
+                command_palette::humanize_action_name(ThirdBinding.name()).into(),
+            ),
+            (h_text.into(), SharedString::from("+2 keybinds")),
+        ];
+
+        assert_eq!(
+            modal.read_with(cx, |modal, _| modal.bindings.clone()),
+            expected_bindings
+        );
     }
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -217,6 +217,7 @@ pub struct StatusBarSettings {
     pub cursor_position_button: bool,
     pub line_endings_button: bool,
     pub active_encoding_button: EncodingDisplayOptions,
+    pub pending_keystrokes_indicator: bool,
 }
 
 impl Settings for StatusBarSettings {
@@ -229,6 +230,7 @@ impl Settings for StatusBarSettings {
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
             active_encoding_button: status_bar.active_encoding_button.unwrap(),
+            pending_keystrokes_indicator: status_bar.pending_keystrokes_indicator.unwrap(),
         }
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -610,6 +610,8 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         let active_toolchain_language =
             cx.new(|cx| toolchain_selector::ActiveToolchain::new(workspace, window, cx));
         let vim_mode_indicator = cx.new(|cx| vim::ModeIndicator::new(window, cx));
+        let pending_keystrokes_indicator =
+            cx.new(|cx| which_key::PendingKeystrokesIndicator::new(window, cx));
         let image_info = cx.new(|_cx| ImageInfo::new(workspace));
 
         let lsp_button_menu_handle = PopoverMenuHandle::default();
@@ -644,6 +646,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_right_item(vim_mode_indicator, window, cx);
             status_bar.add_right_item(cursor_position, window, cx);
             status_bar.add_right_item(image_info, window, cx);
+            status_bar.add_right_item(pending_keystrokes_indicator, window, cx);
         });
 
         let panels_task = initialize_panels(window, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -643,9 +643,10 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_right_item(active_buffer_language, window, cx);
             status_bar.add_right_item(active_toolchain_language, window, cx);
             status_bar.add_right_item(line_ending_indicator, window, cx);
-            status_bar.add_right_item(vim_mode_indicator, window, cx);
             status_bar.add_right_item(cursor_position, window, cx);
             status_bar.add_right_item(image_info, window, cx);
+            // Keep these last so they stay leftmost and can change without moving the other items.
+            status_bar.add_right_item(vim_mode_indicator, window, cx);
             status_bar.add_right_item(pending_keystrokes_indicator, window, cx);
         });
 

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -254,7 +254,9 @@ pub mod dev {
             ToggleFpsOverlay,
             /// Resets the debug frame-time overlay's statistics, except for the
             /// total frame count.
-            ResetFrameOverlayStats
+            ResetFrameOverlayStats,
+            /// Opens the key context view for debugging keybindings.
+            OpenKeyContextView
         ]
     );
 }

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -179,6 +179,21 @@ Zed can also wait before inserting printable text when it might begin a multi-st
 
 Whenever pending input has a timeout, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match and pauses the timeout so you can read them. The timeout resumes with the same remaining duration when the pointer leaves. The indicator can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`. Vim and Helix modes continue to use their existing pending-key indicator instead.
 
+To also use the larger which-key menu, open the Settings Editor and search for
+`Show Which-key Menu`. The pending keystrokes indicator remains visible when the
+menu is enabled, and hovering it still pauses the timeout, but its binding list
+popover is disabled. Or add this to your settings.json:
+
+```json [settings]
+{
+  "which_key": {
+    "enabled": true
+  }
+}
+```
+
+Set `which_key.delay_ms` to change how long Zed waits before opening the menu.
+
 ### Non-QWERTY keyboards
 
 Zed's support for non-QWERTY keyboards is still a work in progress.

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -175,6 +175,8 @@ The other kind of conflict that arises is when you have two bindings, one of whi
 
 When this happens, and both bindings are active in the current context, Zed will wait for 1 second after you type `ctrl-w` to see if you're about to type `left`. If you don't type anything, or if you type a different key, then `DeleteToNextWordEnd` will be triggered. If you do, then `DeleteToEndOfLine` will be triggered.
 
+While Zed is waiting, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match, and clicking it opens the key context view. It can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`.
+
 ### Non-QWERTY keyboards
 
 Zed's support for non-QWERTY keyboards is still a work in progress.

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -175,7 +175,9 @@ The other kind of conflict that arises is when you have two bindings, one of whi
 
 When this happens, and both bindings are active in the current context, Zed will wait for 1 second after you type `ctrl-w` to see if you're about to type `left`. If you don't type anything, or if you type a different key, then `DeleteToNextWordEnd` will be triggered. If you do, then `DeleteToEndOfLine` will be triggered.
 
-While Zed is waiting, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match. It can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`.
+Zed can also wait before inserting printable text when it might begin a multi-stroke binding. For example, with a `j k` binding, typing `j` waits briefly for `k`; otherwise, `j` is inserted after the timeout.
+
+Whenever pending input has a timeout, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match and pauses the timeout so you can read them. The timeout resumes with the same remaining duration when the pointer leaves. The indicator can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`. Vim and Helix modes continue to use their existing pending-key indicator instead.
 
 ### Non-QWERTY keyboards
 

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -175,7 +175,7 @@ The other kind of conflict that arises is when you have two bindings, one of whi
 
 When this happens, and both bindings are active in the current context, Zed will wait for 1 second after you type `ctrl-w` to see if you're about to type `left`. If you don't type anything, or if you type a different key, then `DeleteToNextWordEnd` will be triggered. If you do, then `DeleteToEndOfLine` will be triggered.
 
-While Zed is waiting, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match, and clicking it opens the key context view. It can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`.
+While Zed is waiting, a countdown indicator with the pending keystrokes is shown in the status bar. Hovering it lists the bindings that could still match. It can be hidden with `{"status_bar": {"pending_keystrokes_indicator": false}}`.
 
 ### Non-QWERTY keyboards
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1859,12 +1859,24 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 ```json [settings]
 {
   "status_bar": {
+    "show_active_file": false,
     "active_language_button": true,
     "cursor_position_button": true,
-    "line_endings_button": false
+    "line_endings_button": false,
+    "active_encoding_button": "non_utf8",
+    "pending_keystrokes_indicator": true
   }
 }
 ```
+
+**Options**
+
+- `show_active_file`: Whether to show the name of the active file in the status bar
+- `active_language_button`: Whether to show the active language button (clicking it opens the language selector)
+- `cursor_position_button`: Whether to show the cursor position button (clicking it opens the go-to-line/column input)
+- `line_endings_button`: Whether to show the active line endings button (clicking it opens the line-ending selector)
+- `active_encoding_button`: When to show the active encoding button: `"enabled"`, `"disabled"`, or `"non_utf8"` (only for encodings other than UTF-8 without BOM)
+- `pending_keystrokes_indicator`: Whether to show an indicator with a countdown while pending keystrokes conflict with a shorter key binding (see [key bindings](../key-bindings.md#precedence))
 
 There is an experimental setting that completely hides the status bar. This causes major usability problems (you will be unable to use many of Zed's features), but is provided for those who value screen real-estate above all else.
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1876,7 +1876,7 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 - `cursor_position_button`: Whether to show the cursor position button (clicking it opens the go-to-line/column input)
 - `line_endings_button`: Whether to show the active line endings button (clicking it opens the line-ending selector)
 - `active_encoding_button`: When to show the active encoding button: `"enabled"`, `"disabled"`, or `"non_utf8"` (only for encodings other than UTF-8 without BOM)
-- `pending_keystrokes_indicator`: Whether to show an indicator with a countdown while pending keystrokes conflict with a shorter key binding (see [key bindings](../key-bindings.md#precedence))
+- `pending_keystrokes_indicator`: Whether to show an indicator with a countdown while timed multi-stroke input is pending. Hovering the indicator pauses the timeout (see [key bindings](../key-bindings.md#precedence))
 
 There is an experimental setting that completely hides the status bar. This causes major usability problems (you will be unable to use many of Zed's features), but is provided for those who value screen real-estate above all else.
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1876,7 +1876,7 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 - `cursor_position_button`: Whether to show the cursor position button (clicking it opens the go-to-line/column input)
 - `line_endings_button`: Whether to show the active line endings button (clicking it opens the line-ending selector)
 - `active_encoding_button`: When to show the active encoding button: `"enabled"`, `"disabled"`, or `"non_utf8"` (only for encodings other than UTF-8 without BOM)
-- `pending_keystrokes_indicator`: Whether to show an indicator with a countdown while timed multi-stroke input is pending. Hovering the indicator pauses the timeout (see [key bindings](../key-bindings.md#precedence))
+- `pending_keystrokes_indicator`: Whether to show an indicator with a countdown while timed multi-stroke input is pending. Hovering the indicator pauses the timeout. Its binding preview popover is disabled when the which-key popup is enabled (see [key bindings](../key-bindings.md#precedence))
 
 There is an experimental setting that completely hides the status bar. This causes major usability problems (you will be unable to use many of Zed's features), but is provided for those who value screen real-estate above all else.
 
@@ -5304,6 +5304,26 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 - Description: Whether or not to enable vim mode.
 - Setting: `vim_mode`
 - Default: `false`
+
+## Which-key Menu
+
+- Description: Show matching bindings while a multi-stroke binding is pending.
+- Setting: `which_key`
+- Default:
+
+```json [settings]
+{
+  "which_key": {
+    "enabled": false,
+    "delay_ms": 1000
+  }
+}
+```
+
+**Options**
+
+- `enabled`: Whether to show the which-key menu. When enabled, the pending keystrokes indicator remains visible, but its binding preview popover is disabled.
+- `delay_ms`: How long Zed waits before showing the menu, in milliseconds.
 
 ## When Closing With No Tabs
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -359,9 +359,9 @@ TBD: Centered layout related settings
     // If set to "non_utf8", the button is hidden only for UTF-8 without BOM.
     // Defaults to "non_utf8".
     "active_encoding_button": "non_utf8",
-    // Show/hide an indicator with a countdown while a multi-stroke
-    // key binding is pending.
-    // Hovering it lists the bindings that could still match.
+    // Show/hide an indicator with a countdown while timed multi-stroke
+    // input is pending. Hovering it lists the bindings that could still match
+    // and pauses the timeout.
     // Defaults to true.
     "pending_keystrokes_indicator": true
   },

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -360,8 +360,8 @@ TBD: Centered layout related settings
     // Defaults to "non_utf8".
     "active_encoding_button": "non_utf8",
     // Show/hide an indicator with a countdown while timed multi-stroke
-    // input is pending. Hovering it lists the bindings that could still match
-    // and pauses the timeout.
+    // input is pending. Hovering it pauses the timeout. Unless the which-key
+    // menu is enabled, hovering also lists the bindings that could still match.
     // Defaults to true.
     "pending_keystrokes_indicator": true
   },

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -361,8 +361,7 @@ TBD: Centered layout related settings
     "active_encoding_button": "non_utf8",
     // Show/hide an indicator with a countdown while a multi-stroke
     // key binding is pending.
-    // Hovering it lists the bindings that could still match;
-    // clicking it opens the key context view.
+    // Hovering it lists the bindings that could still match.
     // Defaults to true.
     "pending_keystrokes_indicator": true
   },

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -358,7 +358,13 @@ TBD: Centered layout related settings
     // Show/hide a button that displays the buffer's character encoding.
     // If set to "non_utf8", the button is hidden only for UTF-8 without BOM.
     // Defaults to "non_utf8".
-    "active_encoding_button": "non_utf8"
+    "active_encoding_button": "non_utf8",
+    // Show/hide an indicator with a countdown while a multi-stroke
+    // key binding is pending.
+    // Hovering it lists the bindings that could still match;
+    // clicking it opens the key context view.
+    // Defaults to true.
+    "pending_keystrokes_indicator": true
   },
   "global_lsp_settings": {
     // Show/hide the LSP button in the status bar.


### PR DESCRIPTION
This PR makes Zed's one-second key binding delay visible.

Say both ctrl-w and ctrl-w left have bindings. After you press ctrl-w, Zed waits to see whether left follows. The PR shows that wait in the status bar with a countdown. Hovering the indicator shows which bindings can still match.

It also adds a setting to hide the indicator. It does not change how Zed resolves key bindings.

<img height="100" alt="dyn-db84a840272e2f6250a3f527a59b1efd" src="https://github.com/user-attachments/assets/e42c6a6c-4677-499f-a1d3-835960ebb21a" />
<br/>
<img height="100" alt="dyn-8012278d030b41bc8ebfae1540504eff" src="https://github.com/user-attachments/assets/250928d5-f913-40f0-9068-00ccb5cdf59f" />
<br/>
<img height="100" alt="file-5e6ffa90944faa294e7870f471b4e65b" src="https://github.com/user-attachments/assets/c250e6eb-a269-4e2c-a5a0-0be9b5006f99" />

Release Notes:

- Added a status bar countdown for pending multi-stroke key bindings.