### PR TITLE
gpui_wgpu: Skip software Vulkan ICDs and GL on Linux startup

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -62,6 +62,27 @@ pub struct CompositorGpuHint {
     pub device_id: u32,
 }
 
+/// True when [`WgpuContext::instance`] set `VK_LOADER_DRIVERS_DISABLE`, so the
+/// fallback can unset it before creating the unrestricted instance.
+static ICD_FILTER_APPLIED: AtomicBool = AtomicBool::new(false);
+
+const SOFTWARE_RENDERER_HINTS: &[&str] = &[
+    "lvp",
+    "lavapipe",
+    "llvmpipe",
+    "dzn",
+    "swrast",
+    "swiftshader",
+];
+
+const DRIVER_OVERRIDE_VARS: &[&str] = &[
+    "VK_ICD_FILENAMES",
+    "VK_DRIVER_FILES",
+    "VK_ADD_DRIVER_FILES",
+    "VK_LOADER_DRIVERS_DISABLE",
+    "VK_LOADER_DRIVERS_SELECT",
+];
+
 impl WgpuContext {
     #[cfg(not(target_family = "wasm"))]
     pub fn new(
@@ -286,15 +307,74 @@ impl WgpuContext {
         ))
     }
 
+    /// Vulkan-only instance with software ICDs denied. Falls back to
+    /// [`Self::instance_unrestricted`] on failure.
     #[cfg(not(target_family = "wasm"))]
     pub fn instance(display: Box<dyn wgpu::wgt::WgpuHasDisplayHandle>) -> wgpu::Instance {
+        #[cfg(target_os = "linux")]
+        {
+            Self::apply_software_driver_filter();
+            Self::make_instance(display, wgpu::Backends::VULKAN)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Self::instance_unrestricted(display)
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn instance_unrestricted(
+        display: Box<dyn wgpu::wgt::WgpuHasDisplayHandle>,
+    ) -> wgpu::Instance {
+        Self::make_instance(display, wgpu::Backends::VULKAN | wgpu::Backends::GL)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn make_instance(
+        display: Box<dyn wgpu::wgt::WgpuHasDisplayHandle>,
+        backends: wgpu::Backends,
+    ) -> wgpu::Instance {
         wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::VULKAN | wgpu::Backends::GL,
+            backends,
             flags: wgpu::InstanceFlags::default(),
             backend_options: wgpu::BackendOptions::default(),
             memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
             display: Some(display),
         })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn software_driver_deny_list() -> String {
+        SOFTWARE_RENDERER_HINTS
+            .iter()
+            .map(|token| format!("*{token}*"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_software_driver_filter() {
+        if DRIVER_OVERRIDE_VARS
+            .iter()
+            .any(|var| std::env::var_os(var).is_some())
+        {
+            return;
+        }
+
+        let deny_list = Self::software_driver_deny_list();
+        // SAFETY: GPU startup is on the main thread; the loader reads this
+        // during the vkCreateInstance that follows.
+        unsafe { std::env::set_var("VK_LOADER_DRIVERS_DISABLE", &deny_list) };
+        ICD_FILTER_APPLIED.store(true, Ordering::Relaxed);
+        log::debug!("Vulkan loader will skip software ICDs ({deny_list})");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn restore_full_icd_selection() {
+        if ICD_FILTER_APPLIED.swap(false, Ordering::Relaxed) {
+            // SAFETY: same startup thread, immediately before the fallback instance.
+            unsafe { std::env::remove_var("VK_LOADER_DRIVERS_DISABLE") };
+        }
     }
 
     pub fn check_compatible_with_surface(&self, surface: &wgpu::Surface<'_>) -> anyhow::Result<()> {
@@ -584,7 +664,7 @@ fn parse_pci_id(id: &str) -> anyhow::Result<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_pci_id;
+    use super::{SOFTWARE_RENDERER_HINTS, WgpuContext, parse_pci_id};
 
     #[test]
     fn test_parse_device_id() {
@@ -602,5 +682,38 @@ mod tests {
             parse_pci_id(&format!("{:#x}", 0x1234)).unwrap(),
             parse_pci_id(&format!("{:#X}", 0x1234)).unwrap(),
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn software_driver_deny_list_only_matches_software_manifests() {
+        assert_eq!(
+            WgpuContext::software_driver_deny_list(),
+            "*lvp*,*lavapipe*,*llvmpipe*,*dzn*,*swrast*,*swiftshader*"
+        );
+
+        let is_denied = |name: &str| {
+            SOFTWARE_RENDERER_HINTS
+                .iter()
+                .any(|token| name.contains(token))
+        };
+
+        for name in [
+            "lvp_icd.x86_64.json",
+            "llvmpipe_icd.x86_64.json",
+            "dzn_icd.x86_64.json",
+            "vk_swiftshader_icd.json",
+        ] {
+            assert!(is_denied(name), "{name} must be denied");
+        }
+        for name in [
+            "intel_icd.x86_64.json",
+            "amd_icd.x86_64.json",
+            "radeon_icd.x86_64.json",
+            "virtio_icd.x86_64.json",
+            "nvidia_icd.json",
+        ] {
+            assert!(!is_denied(name), "{name} must stay enabled");
+        }
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -294,12 +294,41 @@ impl WgpuRenderer {
         };
 
         let mut ctx_ref = gpu_context.borrow_mut();
-        let context = match ctx_ref.as_mut() {
+        let (context, surface) = match ctx_ref.as_mut() {
             Some(context) => {
                 context.check_compatible_with_surface(&surface)?;
-                context
+                (context, surface)
             }
-            None => ctx_ref.insert(WgpuContext::new(instance, &surface, compositor_gpu)?),
+            None => match WgpuContext::new(instance, &surface, compositor_gpu) {
+                Ok(context) => (ctx_ref.insert(context), surface),
+                Err(lean_error) => {
+                    log::warn!(
+                        "Lean GPU context creation failed ({lean_error}); retrying with a \
+                         full (unfiltered Vulkan + GL) instance"
+                    );
+                    // Drop the lean probe surface so the full instance can open
+                    // the same window handle (one compositor surface per window).
+                    drop(surface);
+                    WgpuContext::restore_full_icd_selection();
+                    let full_instance =
+                        WgpuContext::instance_unrestricted(Box::new(window.clone()));
+                    let full_target = wgpu::SurfaceTargetUnsafe::RawHandle {
+                        // Fall back to the display handle already provided via InstanceDescriptor::display.
+                        raw_display_handle: None,
+                        raw_window_handle: window_handle.as_raw(),
+                    };
+                    // Safety: The caller guarantees that the window handle is valid
+                    // for the lifetime of this renderer (see the first surface).
+                    let full_surface = unsafe {
+                        full_instance
+                            .create_surface_unsafe(full_target)
+                            .map_err(|e| anyhow::anyhow!("Failed to create surface: {e}"))?
+                    };
+                    let context = WgpuContext::new(full_instance, &full_surface, compositor_gpu)
+                        .context("No usable GPU adapter on this system")?;
+                    (ctx_ref.insert(context), full_surface)
+                }
+            },
         };
 
         let atlas = Arc::new(WgpuAtlas::from_context(context));


### PR DESCRIPTION
# Objective

On Linux, `WgpuContext::instance()` created a wgpu instance withc`VULKAN | GL` and enumerated every adapter. The Vulkan loader then mapped every ICD under `icd.d`, including lavapipe (and LLVM) and Dozen, and the GL backend pulled in EGL/gallium even when a hardware Vulkan adapter was selected and used for the rest of the process. fixes #63327

## Solution
Linux-only, fail open:

If the user already set `VK_DRIVER_FILES` / `VK_ICD_FILENAMES` / `VK_ADD_DRIVER_FILES` / `VK_LOADER_DRIVERS_DISABLE` / `VK_LOADER_DRIVERS_SELECT`, do nothing.  Otherwise set `VK_LOADER_DRIVERS_DISABLE` to `*lvp*,*lavapipe*,*llvmpipe*,*dzn*,*swrast*,*swiftshader*` so software/translated ICDs are not loaded at `vkCreateInstance`. Hardware ICDs stay loader-default. Loaders older than 1.3.234 ignore the variable and create the instance as **Vulkan-only** so the GL/EGL/gallium  stack is not initialized just to list adapters.
If context creation fails, unset the deny list, drop the probe

## Testing
in #63327

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A or Added/Fixed/Improved ...
