### PR TITLE
git_ui: Fixed bulk restore for unstaged tracked changes

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -300,7 +300,6 @@ impl Render for StashMessageModal {
 
 fn git_panel_context_menu(
     has_tracked_changes: bool,
-    has_staged_tracked_changes: bool,
     has_staged_changes: bool,
     has_unstaged_changes: bool,
     has_new_changes: bool,
@@ -317,7 +316,7 @@ fn git_panel_context_menu(
             .action_disabled_when(!has_unstaged_changes, "Stage All", StageAll.boxed_clone())
             .action_disabled_when(!has_staged_changes, "Unstage All", UnstageAll.boxed_clone())
             .action_disabled_when(
-                !has_staged_tracked_changes,
+                !has_tracked_changes,
                 "Restore All Changes",
                 RestoreTrackedFiles.boxed_clone(),
             )
@@ -353,7 +352,7 @@ fn git_panel_context_menu(
             })
             .separator()
             .action_disabled_when(
-                !has_staged_tracked_changes,
+                !has_tracked_changes,
                 "Discard Tracked Changes",
                 RestoreTrackedFiles.boxed_clone(),
             )
@@ -2085,22 +2084,20 @@ impl GitPanel {
         self.directory_descendants(entry_index)
     }
 
-    fn is_staged_tracked(entry: &GitStatusEntry) -> bool {
-        !entry.status.is_created() && entry.staging.has_staged()
+    fn is_tracked(entry: &GitStatusEntry) -> bool {
+        !entry.status.is_created()
     }
 
-    fn contains_staged_tracked_entry<'a>(
-        entries: impl IntoIterator<Item = &'a GitStatusEntry>,
-    ) -> bool {
-        entries.into_iter().any(Self::is_staged_tracked)
+    fn contains_tracked_entry<'a>(entries: impl IntoIterator<Item = &'a GitStatusEntry>) -> bool {
+        entries.into_iter().any(Self::is_tracked)
     }
 
-    fn staged_tracked_entries<'a>(
+    fn tracked_entries<'a>(
         entries: impl IntoIterator<Item = &'a GitStatusEntry>,
     ) -> Vec<GitStatusEntry> {
         entries
             .into_iter()
-            .filter(|entry| Self::is_staged_tracked(entry))
+            .filter(|entry| Self::is_tracked(entry))
             .cloned()
             .collect()
     }
@@ -2523,8 +2520,8 @@ impl GitPanel {
     ) {
         let entries = self
             .directory_context_descendants()
-            .map(Self::staged_tracked_entries)
-            .unwrap_or_else(|| Self::staged_tracked_entries(self.change_entries_by_path()));
+            .map(Self::tracked_entries)
+            .unwrap_or_else(|| Self::tracked_entries(self.change_entries_by_path()));
 
         match entries.len() {
             0 => return,
@@ -5380,10 +5377,6 @@ impl GitPanel {
         self.tracked_count > 0
     }
 
-    fn has_staged_tracked_changes(&self) -> bool {
-        Self::contains_staged_tracked_entry(self.change_entries_by_path())
-    }
-
     pub fn has_unstaged_conflicts(&self) -> bool {
         self.change_entries_by_path()
             .any(|entry| entry.status.is_conflicted() && entry.staging.has_unstaged())
@@ -5923,7 +5916,6 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let has_tracked_changes = self.has_tracked_changes();
-        let has_staged_tracked_changes = self.has_staged_tracked_changes();
         let has_staged_changes = self.has_staged_changes();
         let has_unstaged_changes = self.has_unstaged_changes();
         let has_new_changes = self.new_count > 0;
@@ -5942,7 +5934,6 @@ impl GitPanel {
             .menu(move |window, cx| {
                 Some(git_panel_context_menu(
                     has_tracked_changes,
-                    has_staged_tracked_changes,
                     has_staged_changes,
                     has_unstaged_changes,
                     has_new_changes,
@@ -7706,20 +7697,18 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         let has_stash_items = self.stash_entries.entries.len() > 0;
-        let has_tracked_changes = self.has_tracked_changes();
+        let has_tracked_changes = target_entry_index
+            .and_then(|entry_index| self.directory_descendants(entry_index))
+            .map_or_else(
+                || self.has_tracked_changes(),
+                |entries| Self::contains_tracked_entry(entries),
+            );
         let has_staged_changes = self.has_staged_changes();
         let has_unstaged_changes = self.has_unstaged_changes();
         let has_new_changes = self.new_count > 0;
-        let has_staged_tracked_changes = target_entry_index
-            .and_then(|entry_index| self.directory_descendants(entry_index))
-            .map_or_else(
-                || self.has_staged_tracked_changes(),
-                |entries| Self::contains_staged_tracked_entry(entries),
-            );
 
         let context_menu = git_panel_context_menu(
             has_tracked_changes,
-            has_staged_tracked_changes,
             has_staged_changes,
             has_unstaged_changes,
             has_new_changes,
@@ -13127,33 +13116,33 @@ mod tests {
             "directory/tracked.rs",
             FileStatus::index(StatusCode::Modified),
         )];
-        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
-        assert!(has_staged_tracked_changes);
-        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
+        let has_tracked_changes = GitPanel::contains_tracked_entry(&entries);
+        assert!(has_tracked_changes);
+        assert_eq!(GitPanel::tracked_entries(&entries).len(), 1);
 
         // 2. Single untracked file that is staged.
         let entries = vec![entry(
             "directory/new.rs",
             FileStatus::index(StatusCode::Added),
         )];
-        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
-        assert!(!has_staged_tracked_changes);
-        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+        let has_tracked_changes = GitPanel::contains_tracked_entry(&entries);
+        assert!(!has_tracked_changes);
+        assert_eq!(GitPanel::tracked_entries(&entries).len(), 0);
 
         // 3. Single tracked file that is unstaged.
         let entries = vec![entry(
             "directory/tracked.rs",
             StatusCode::Modified.worktree(),
         )];
-        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
-        assert!(!has_staged_tracked_changes);
-        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+        let has_tracked_changes = GitPanel::contains_tracked_entry(&entries);
+        assert!(has_tracked_changes);
+        assert_eq!(GitPanel::tracked_entries(&entries).len(), 1);
 
         // 4. Single untracked file that is unstaged.
         let entries = vec![entry("directory/new.rs", FileStatus::Untracked)];
-        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
-        assert!(!has_staged_tracked_changes);
-        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 0);
+        let has_tracked_changes = GitPanel::contains_tracked_entry(&entries);
+        assert!(!has_tracked_changes);
+        assert_eq!(GitPanel::tracked_entries(&entries).len(), 0);
 
         // 5. Mixed tracked and untracked files that are both staged and
         // unstaged.
@@ -13172,13 +13161,13 @@ mod tests {
             ),
             entry("directory/unstaged_new.rs", FileStatus::Untracked),
         ];
-        let has_staged_tracked_changes = GitPanel::contains_staged_tracked_entry(&entries);
-        assert!(has_staged_tracked_changes);
-        assert_eq!(GitPanel::staged_tracked_entries(&entries).len(), 1);
+        let has_tracked_changes = GitPanel::contains_tracked_entry(&entries);
+        assert!(has_tracked_changes);
+        assert_eq!(GitPanel::tracked_entries(&entries).len(), 2);
     }
 
     #[gpui::test]
-    async fn test_discard_tracked_changes_respects_staging(cx: &mut TestAppContext) {
+    async fn test_discard_tracked_changes(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.background_executor.clone());
         fs.insert_tree(
@@ -13252,8 +13241,8 @@ mod tests {
             "prompt should list staged_b.rs, got: {detail}"
         );
         assert!(
-            !detail.contains("unstaged.rs"),
-            "prompt should NOT list unstaged.rs, got: {detail}"
+            detail.contains("unstaged.rs"),
+            "prompt should list unstaged.rs, got: {detail}"
         );
     }
 


### PR DESCRIPTION
Fixed Restore All Changes and Discard Tracked Changes doing nothing
when a repository only contained unstaged tracked changes.

# Objective

Fix https://github.com/zed-industries/zed/issues/63255

## Solution

The old code required files to be both tracked and staged. Any unstaged changes were filtered out entirely, and when no entries were present (`entries.len() == 0`), the process would immediately return, rendering both batch operations unresponsive.

The new code at `crates/git_ui/src/git_panel.rs:2087` was changed to select all non-created files, which will include unstaged tracked modifications.


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed unstaged tracked changes in bulk
