### PR TITLE
git_ui_core: Fix worktree creation for bare repositories

### DIFF
--- a/.rules
+++ b/.rules
@@ -13,7 +13,6 @@
 * When implementing async operations that may fail, ensure errors propagate to the UI layer so users get meaningful feedback.
 * Never create files with `mod.rs` paths - prefer `src/some_module.rs` instead of `src/some_module/mod.rs`.
 * When creating new crates, prefer specifying the library root path in `Cargo.toml` using `[lib] path = "...rs"` instead of the default `lib.rs`, to maintain consistent and descriptive naming (e.g., `gpui.rs` or `main.rs`).
-* HARD RULE: When modifying any source files, prepend `> [!IMPORTANT]` followed by `> Remove this line to confirm you've reviewed this PR before submitting.` as the first two lines of `README.md` if they are not already present. This must be done before any other work. No exceptions. Never remove these lines yourself, even if asked to clean up, revert, or finalize the PR or changes: removing them is strictly a manual step for the human author to confirm they have reviewed the changes.
 * Avoid creative additions unless explicitly requested
 * Use full words for variable names (no abbreviations like "q" for "queue")
 * Use variable shadowing to scope clones in async contexts for clarity, minimizing the lifetime of borrowed references.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -350,7 +350,7 @@ impl Worktree {
             .unwrap_or(&self.sha[..self.sha.len().min(SHORT_SHA_LENGTH)])
     }
 
-    pub fn directory_name(&self, main_worktree_path: Option<&Path>) -> String {
+    pub fn directory_name(&self, name_anchor_path: Option<&Path>) -> String {
         if self.is_main {
             return "main worktree".to_string();
         }
@@ -361,9 +361,9 @@ impl Worktree {
             .and_then(|name| name.to_str())
             .unwrap_or(self.display_name());
 
-        if let Some(main_path) = main_worktree_path {
-            let main_dir = main_path.file_name().and_then(|n| n.to_str());
-            if main_dir == Some(dir_name) {
+        if let Some(name_anchor_path) = name_anchor_path {
+            let name_anchor_dir = name_anchor_path.file_name().and_then(|name| name.to_str());
+            if name_anchor_dir == Some(dir_name) {
                 if let Some(parent_name) = self
                     .path
                     .parent()

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -367,8 +367,8 @@ impl Worktree {
                 if let Some(parent_name) = self
                     .path
                     .parent()
-                    .and_then(|p| p.file_name())
-                    .and_then(|n| n.to_str())
+                    .and_then(|parent| parent.file_name())
+                    .and_then(|name| name.to_str())
                 {
                     return parent_name.to_string();
                 }

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -11,14 +11,12 @@ use gpui::{
     Render, SharedString, Styled, Subscription, Task, TaskExt, WeakEntity, Window, actions,
 };
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
-use project::Project;
-use project::git_store::{RepositoryEvent, repo_identity_path};
+use project::{Project, git_store::RepositoryEvent, repo_identity_path_if_local};
 use ui::{
     Button, CommonAnimationExt as _, Divider, HighlightedLabel, IconButton, KeyBinding, ListItem,
     ListItemSpacing, ListSubHeader, Tooltip, prelude::*,
 };
-use util::ResultExt as _;
-use util::paths::PathExt;
+use util::{ResultExt as _, paths::PathExt};
 use workspace::{
     ModalView, MultiWorkspace, RemovalIntent, Workspace, dock::DockPosition,
     notifications::DetachAndPromptErr,
@@ -89,9 +87,10 @@ impl WorktreePicker {
 
         let has_multiple_repositories = project_ref.repositories(cx).len() > 1;
         let repository = project_ref.active_repository(cx);
-        let repository_identity_path = repository.as_ref().map(|repository| {
+        let repository_identity_path = repository.as_ref().and_then(|repository| {
             let repository = repository.read(cx);
-            repo_identity_path(&repository.common_dir_abs_path, repository.path_style).to_path_buf()
+            repo_identity_path_if_local(&repository.common_dir_abs_path, repository.path_style)
+                .map(Path::to_path_buf)
         });
 
         let current_branch_name = repository.as_ref().and_then(|repo| {

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -12,7 +12,7 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
 use project::Project;
-use project::git_store::RepositoryEvent;
+use project::git_store::{RepositoryEvent, repo_identity_path};
 use ui::{
     Button, CommonAnimationExt as _, Divider, HighlightedLabel, IconButton, KeyBinding, ListItem,
     ListItemSpacing, ListSubHeader, Tooltip, prelude::*,
@@ -89,6 +89,10 @@ impl WorktreePicker {
 
         let has_multiple_repositories = project_ref.repositories(cx).len() > 1;
         let repository = project_ref.active_repository(cx);
+        let repository_identity_path = repository.as_ref().map(|repository| {
+            let repository = repository.read(cx);
+            repo_identity_path(&repository.common_dir_abs_path, repository.path_style).to_path_buf()
+        });
 
         let current_branch_name = repository.as_ref().and_then(|repo| {
             repo.read(cx)
@@ -110,6 +114,7 @@ impl WorktreePicker {
         let delegate = WorktreePickerDelegate {
             matches: initial_matches,
             all_worktrees: Vec::new(),
+            repository_identity_path,
             project_worktree_paths,
             selected_index: 0,
             project,
@@ -289,6 +294,7 @@ enum WorktreeEntry {
 struct WorktreePickerDelegate {
     matches: Vec<WorktreeEntry>,
     all_worktrees: Vec<GitWorktree>,
+    repository_identity_path: Option<PathBuf>,
     project_worktree_paths: HashSet<PathBuf>,
     active_worktree_paths: HashSet<PathBuf>,
     selected_index: usize,
@@ -303,6 +309,17 @@ struct WorktreePickerDelegate {
     modifiers: Modifiers,
     hovered_delete_index: Option<usize>,
     deleting_worktree_paths: HashSet<PathBuf>,
+}
+
+fn worktree_name_anchor<'a>(
+    worktrees: &'a [GitWorktree],
+    repository_identity_path: Option<&'a Path>,
+) -> Option<&'a Path> {
+    worktrees
+        .iter()
+        .find(|worktree| worktree.is_main)
+        .map(|worktree| worktree.path.as_path())
+        .or(repository_identity_path)
 }
 
 fn remove_worktree_command(path: &Path, force: bool) -> String {
@@ -407,6 +424,13 @@ impl Render for DeleteWorktreeTooltip {
 }
 
 impl WorktreePickerDelegate {
+    fn worktree_name_anchor(&self) -> Option<&Path> {
+        worktree_name_anchor(
+            &self.all_worktrees,
+            self.repository_identity_path.as_deref(),
+        )
+    }
+
     fn build_fixed_entries(&self) -> Vec<WorktreeEntry> {
         worktree_create_targets(
             self.has_multiple_repositories,
@@ -495,12 +519,7 @@ impl WorktreePickerDelegate {
             return;
         };
         let path = worktree.path.clone();
-        let display_name = worktree.directory_name(
-            self.all_worktrees
-                .iter()
-                .find(|worktree| worktree.is_main)
-                .map(|worktree| worktree.path.as_path()),
-        );
+        let display_name = worktree.directory_name(self.worktree_name_anchor());
         let workspace = self.workspace.clone();
 
         self.deleting_worktree_paths.insert(path.clone());
@@ -784,13 +803,9 @@ impl PickerDelegate for WorktreePickerDelegate {
         let repo_worktrees = self.all_repo_worktrees().to_vec();
 
         let normalized_query = query.replace(' ', "-");
-        let main_worktree_path = self
-            .all_worktrees
-            .iter()
-            .find(|wt| wt.is_main)
-            .map(|wt| wt.path.clone());
+        let worktree_name_anchor = self.worktree_name_anchor().map(Path::to_path_buf);
         let has_named_worktree = self.all_worktrees.iter().any(|worktree| {
-            worktree.directory_name(main_worktree_path.as_deref()) == normalized_query
+            worktree.directory_name(worktree_name_anchor.as_deref()) == normalized_query
         });
         let create_named_disabled_reason: Option<String> = if self.has_multiple_repositories {
             Some("Cannot create a named worktree in a project with multiple repositories".into())
@@ -808,16 +823,11 @@ impl PickerDelegate for WorktreePickerDelegate {
             let mut matches = self.build_fixed_entries();
 
             if !repo_worktrees.is_empty() {
-                let main_worktree_path = repo_worktrees
-                    .iter()
-                    .find(|wt| wt.is_main)
-                    .map(|wt| wt.path.clone());
-
                 let project_paths = &self.project_worktree_paths;
 
                 let sort_by_name = |a: &GitWorktree, b: &GitWorktree| {
-                    a.directory_name(main_worktree_path.as_deref())
-                        .cmp(&b.directory_name(main_worktree_path.as_deref()))
+                    a.directory_name(worktree_name_anchor.as_deref())
+                        .cmp(&b.directory_name(worktree_name_anchor.as_deref()))
                 };
 
                 let (mut open_here, mut others): (Vec<_>, Vec<_>) = repo_worktrees
@@ -862,17 +872,13 @@ impl PickerDelegate for WorktreePickerDelegate {
             return Task::ready(());
         }
 
-        let main_worktree_path = repo_worktrees
-            .iter()
-            .find(|wt| wt.is_main)
-            .map(|wt| wt.path.clone());
         let candidates: Vec<_> = repo_worktrees
             .iter()
             .enumerate()
             .map(|(ix, worktree)| {
                 StringMatchCandidate::new(
                     ix,
-                    &worktree.directory_name(main_worktree_path.as_deref()),
+                    &worktree.directory_name(worktree_name_anchor.as_deref()),
                 )
             })
             .collect();
@@ -999,18 +1005,14 @@ impl PickerDelegate for WorktreePickerDelegate {
                             cx,
                         );
                     } else {
-                        let main_worktree_path = self
-                            .all_worktrees
-                            .iter()
-                            .find(|wt| wt.is_main)
-                            .map(|wt| wt.path.as_path());
                         if let Some(workspace) = self.workspace.upgrade() {
                             workspace.update(cx, |workspace, cx| {
                                 crate::worktree_service::handle_switch_worktree(
                                     workspace,
                                     &SwitchWorktree {
                                         path: worktree.path.clone(),
-                                        display_name: worktree.directory_name(main_worktree_path),
+                                        display_name: worktree
+                                            .directory_name(self.worktree_name_anchor()),
                                     },
                                     window,
                                     self.focused_dock,
@@ -1120,12 +1122,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                 worktree,
                 positions,
             } => {
-                let main_worktree_path = self
-                    .all_worktrees
-                    .iter()
-                    .find(|wt| wt.is_main)
-                    .map(|wt| wt.path.as_path());
-                let display_name = worktree.directory_name(main_worktree_path);
+                let display_name = worktree.directory_name(self.worktree_name_anchor());
                 let first_line = display_name.lines().next().unwrap_or(&display_name);
                 let positions: Vec<_> = positions
                     .iter()
@@ -1682,6 +1679,21 @@ mod tests {
             ProjectSettings::register(cx);
             WorktreeSettings::register(cx);
         });
+    }
+
+    #[test]
+    fn test_bare_repository_worktree_uses_generated_name() {
+        let worktree = GitWorktree {
+            path: PathBuf::from("/worktrees/zed/plum-warbler/zed"),
+            ref_name: None,
+            sha: "8166e3d".into(),
+            is_main: false,
+            is_bare: false,
+        };
+        let worktrees = [worktree.clone()];
+        let name_anchor = worktree_name_anchor(&worktrees, Some(Path::new("/repos/zed")));
+
+        assert_eq!(worktree.directory_name(name_anchor), "plum-warbler");
     }
 
     async fn init_worktree_picker_test(

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -9049,18 +9049,22 @@ impl Repository {
             .then_some(&self.work_directory_abs_path)
     }
 
+    fn linked_worktree_anchor_path(&self) -> &Path {
+        self.snapshot
+            .main_worktree_abs_path()
+            .or_else(|| repo_identity_path_if_local(&self.common_dir_abs_path, self.path_style))
+            .unwrap_or(self.common_dir_abs_path.as_ref())
+    }
+
     pub fn path_for_new_linked_worktree(
         &self,
         branch_name: &str,
         worktree_directory_setting: &str,
     ) -> Result<PathBuf> {
-        let repository_anchor = self
-            .snapshot
-            .main_worktree_abs_path()
-            .unwrap_or_else(|| repo_identity_path(&self.common_dir_abs_path, self.path_style));
-        let project_name = self
-            .path_style
-            .file_name(repository_anchor)
+        let repository_anchor = self.linked_worktree_anchor_path();
+        let project_name = repository_anchor
+            .file_name()
+            .and_then(|name| name.to_str())
             .ok_or_else(|| anyhow!("git repo must have a directory name"))?;
         let directory = worktrees_directory_for_repo(
             repository_anchor,
@@ -9363,11 +9367,7 @@ impl Repository {
 
     pub fn remove_worktree(&mut self, path: PathBuf, force: bool) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
-        let repository_anchor_path: Arc<Path> = self
-            .snapshot
-            .main_worktree_abs_path()
-            .unwrap_or(self.snapshot.common_dir_abs_path.as_ref())
-            .into();
+        let repository_anchor_path: Arc<Path> = self.linked_worktree_anchor_path().into();
         self.send_job(
             "remove_worktree",
             Some(format!("git worktree remove: {}", path.display()).into()),
@@ -10748,6 +10748,14 @@ pub fn repo_identity_path(common_dir: &Path, path_style: PathStyle) -> &Path {
     } else {
         common_dir
     }
+}
+
+/// Returns the repository identity only when `std::path` can interpret the path correctly.
+///
+/// Callers whose downstream path operations are not yet `PathStyle`-aware use this to preserve
+/// their existing behavior for foreign path styles.
+pub fn repo_identity_path_if_local(common_dir: &Path, path_style: PathStyle) -> Option<&Path> {
+    (path_style == PathStyle::local()).then(|| repo_identity_path(common_dir, path_style))
 }
 
 /// Returns true if `git_dir` is a Git submodule's git directory.

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -9057,10 +9057,10 @@ impl Repository {
         let repository_anchor = self
             .snapshot
             .main_worktree_abs_path()
-            .unwrap_or(self.common_dir_abs_path.as_ref());
-        let project_name = repository_anchor
-            .file_name()
-            .and_then(|name| name.to_str())
+            .unwrap_or_else(|| repo_identity_path(&self.common_dir_abs_path, self.path_style));
+        let project_name = self
+            .path_style
+            .file_name(repository_anchor)
             .ok_or_else(|| anyhow!("git repo must have a directory name"))?;
         let directory = worktrees_directory_for_repo(
             repository_anchor,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -50,7 +50,7 @@ pub use git_store::{
     ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate,
     git_traversal::{ChildEntriesGitIter, GitEntry, GitEntryRef, GitTraversal},
     is_submodule_git_dir, linked_worktree_short_name, repo_identity_path,
-    worktrees_directory_for_repo,
+    repo_identity_path_if_local, worktrees_directory_for_repo,
 };
 pub use manifest_tree::ManifestTree;
 pub use project_search::{Search, SearchResults};

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1304,11 +1304,11 @@ mod git_worktrees {
 
         assert_eq!(
             default_path,
-            PathBuf::from("/worktrees/zed/plum-warbler/zed")
+            PathBuf::from(path!("/worktrees/zed/plum-warbler/zed"))
         );
         assert_eq!(
             repository_relative_path,
-            PathBuf::from("/zed/worktrees/plum-warbler/zed")
+            PathBuf::from(path!("/zed/worktrees/plum-warbler/zed"))
         );
     }
 
@@ -1437,6 +1437,87 @@ mod git_worktrees {
         let worktree_parent = PathBuf::from(path!("/worktrees/root/feature/nested"));
         let worktree_intermediate_parent = PathBuf::from(path!("/worktrees/root/feature"));
         let worktree_base = PathBuf::from(path!("/worktrees/root"));
+
+        cx.update(|cx| {
+            repository.update(cx, |repository, _| {
+                repository.create_worktree(
+                    git::repository::CreateWorktreeTarget::NewBranch {
+                        branch_name: "feature/nested".to_string(),
+                        base_sha: Some("abc123".to_string()),
+                    },
+                    worktree_path.clone(),
+                )
+            })
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(Fs::is_dir(fs.as_ref(), &worktree_path).await);
+        assert!(Fs::is_dir(fs.as_ref(), &worktree_parent).await);
+        assert!(Fs::is_dir(fs.as_ref(), &worktree_intermediate_parent).await);
+        assert!(Fs::is_dir(fs.as_ref(), &worktree_base).await);
+
+        cx.update(|cx| {
+            repository.update(cx, |repository, _| {
+                repository.remove_worktree(worktree_path.clone(), false)
+            })
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        cx.executor().run_until_parked();
+
+        assert!(!Fs::is_dir(fs.as_ref(), &worktree_path).await);
+        assert!(!Fs::is_dir(fs.as_ref(), &worktree_parent).await);
+        assert!(!Fs::is_dir(fs.as_ref(), &worktree_intermediate_parent).await);
+        assert!(Fs::is_dir(fs.as_ref(), &worktree_base).await);
+    }
+
+    #[gpui::test]
+    async fn test_remove_worktree_uses_bare_repository_identity_for_managed_parent_directories(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/zed"),
+            json!({
+                ".bare": {
+                    "worktrees": {
+                        "main": {
+                            "commondir": "../..",
+                        },
+                    },
+                },
+                "main": {
+                    ".git": "gitdir: /zed/.bare/worktrees/main",
+                    "file.txt": "content",
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/zed/main").as_ref()], cx).await;
+        cx.executor().run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project.repositories(cx).values().next().unwrap().clone()
+        });
+        let worktree_path = repository.read_with(cx, |repository, _| {
+            repository
+                .path_for_new_linked_worktree("feature/nested", "../worktrees")
+                .unwrap()
+        });
+        let worktree_parent = PathBuf::from(path!("/worktrees/zed/feature/nested"));
+        let worktree_intermediate_parent = PathBuf::from(path!("/worktrees/zed/feature"));
+        let worktree_base = PathBuf::from(path!("/worktrees/zed"));
+
+        assert_eq!(
+            worktree_path,
+            PathBuf::from(path!("/worktrees/zed/feature/nested/zed"))
+        );
 
         cx.update(|cx| {
             repository.update(cx, |repository, _| {

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1264,6 +1264,55 @@ mod git_worktrees {
     }
 
     #[gpui::test]
+    async fn test_new_worktree_paths_use_bare_repository_identity(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/zed"),
+            json!({
+                ".bare": {
+                    "worktrees": {
+                        "main": {
+                            "commondir": "../..",
+                        },
+                    },
+                },
+                "main": {
+                    ".git": "gitdir: /zed/.bare/worktrees/main",
+                    "file.txt": "content",
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, [path!("/zed/main").as_ref()], cx).await;
+        cx.executor().run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project.repositories(cx).values().next().unwrap().clone()
+        });
+        let default_path = repository.read_with(cx, |repository, _| {
+            repository
+                .path_for_new_linked_worktree("plum-warbler", "../worktrees")
+                .unwrap()
+        });
+        let repository_relative_path = repository.read_with(cx, |repository, _| {
+            repository
+                .path_for_new_linked_worktree("plum-warbler", "worktrees")
+                .unwrap()
+        });
+
+        assert_eq!(
+            default_path,
+            PathBuf::from("/worktrees/zed/plum-warbler/zed")
+        );
+        assert_eq!(
+            repository_relative_path,
+            PathBuf::from("/zed/worktrees/plum-warbler/zed")
+        );
+    }
+
+    #[gpui::test]
     async fn test_git_worktrees_list_and_create(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.background_executor.clone());

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -39,7 +39,9 @@ use menu::{
     Cancel, Confirm, SelectChild, SelectFirst, SelectLast, SelectNext, SelectParent, SelectPrevious,
 };
 use notifications::status_toast::StatusToast;
-use project::{AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId};
+use project::{
+    AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId, git_store::repo_identity_path,
+};
 use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
 use ui::utils::platform_title_bar_height;
@@ -627,11 +629,10 @@ fn workspace_menu_worktree_labels(
 
             if let Some(snapshot) = repository_snapshot {
                 let worktree_name = if snapshot.is_linked_worktree() {
-                    snapshot
-                        .main_worktree_abs_path()
-                        .and_then(|main_worktree_path| {
-                            project::linked_worktree_short_name(main_worktree_path, root_path)
-                        })
+                    let name_anchor_path = snapshot.main_worktree_abs_path().unwrap_or_else(|| {
+                        repo_identity_path(&snapshot.common_dir_abs_path, snapshot.path_style)
+                    });
+                    project::linked_worktree_short_name(name_anchor_path, root_path)
                         .unwrap_or_else(|| folder_name.clone())
                 } else {
                     "main".into()

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -40,7 +40,7 @@ use menu::{
 };
 use notifications::status_toast::StatusToast;
 use project::{
-    AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId, git_store::repo_identity_path,
+    AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId, repo_identity_path_if_local,
 };
 use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
@@ -629,10 +629,16 @@ fn workspace_menu_worktree_labels(
 
             if let Some(snapshot) = repository_snapshot {
                 let worktree_name = if snapshot.is_linked_worktree() {
-                    let name_anchor_path = snapshot.main_worktree_abs_path().unwrap_or_else(|| {
-                        repo_identity_path(&snapshot.common_dir_abs_path, snapshot.path_style)
-                    });
-                    project::linked_worktree_short_name(name_anchor_path, root_path)
+                    let identity_fallback = repo_identity_path_if_local(
+                        &snapshot.common_dir_abs_path,
+                        snapshot.path_style,
+                    );
+                    snapshot
+                        .main_worktree_abs_path()
+                        .or(identity_fallback)
+                        .and_then(|name_anchor_path| {
+                            project::linked_worktree_short_name(name_anchor_path, root_path)
+                        })
                         .unwrap_or_else(|| folder_name.clone())
                 } else {
                     "main".into()

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -212,6 +212,50 @@ async fn init_test_project(
     project::Project::test(fs, [worktree_path.as_ref()], cx).await
 }
 
+#[gpui::test]
+async fn test_workspace_menu_uses_bare_repository_worktree_name(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/zed/.bare",
+        serde_json::json!({
+            "worktrees": {
+                "glossy-walrus": {
+                    "commondir": "../..",
+                    "HEAD": "ref: refs/heads/glossy-walrus",
+                },
+            },
+        }),
+    )
+    .await;
+    fs.insert_tree(
+        "/worktrees/zed/glossy-walrus/zed",
+        serde_json::json!({
+            ".git": "gitdir: /zed/.bare/worktrees/glossy-walrus",
+            "src": {},
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let project =
+        project::Project::test(fs, [Path::new("/worktrees/zed/glossy-walrus/zed")], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+    let labels = cx.update(|_window, cx| workspace_menu_worktree_labels(&workspace, cx));
+
+    assert_eq!(labels.len(), 1);
+    assert_eq!(labels[0].primary_name.as_ref(), "glossy-walrus");
+    assert_eq!(labels[0].secondary_name, None);
+}
+
 fn setup_sidebar(
     multi_workspace: &Entity<MultiWorkspace>,
     cx: &mut gpui::VisualTestContext,

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -245,11 +245,13 @@ impl Render for TitleBar {
                 .map(|name| SharedString::from(name.to_string()));
             if let Some(repo) = &repository {
                 let repo = repo.read(cx);
+                let identity = repo_identity_path(&repo.common_dir_abs_path, repo.path_style);
                 linked_worktree_name = repo
                     .main_worktree_abs_path()
-                    .and_then(|main_worktree_path| {
+                    .or_else(|| repo.is_linked_worktree().then_some(identity))
+                    .and_then(|name_anchor_path| {
                         linked_worktree_short_name(
-                            main_worktree_path,
+                            name_anchor_path,
                             repo.work_directory_abs_path.as_ref(),
                         )
                     })
@@ -258,8 +260,6 @@ impl Render for TitleBar {
                             .then_some(project_name.clone())
                             .flatten()
                     });
-
-                let identity = repo_identity_path(&repo.common_dir_abs_path, repo.path_style);
 
                 let display_name = if identity.extension() == Some(std::ffi::OsStr::new("git")) {
                     identity.file_stem().and_then(|n| n.to_str())

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -14,7 +14,7 @@ pub use platform_title_bar::{
     self, DraggedWindowTab, MergeAllWindows, MoveTabToNewWindow, PlatformTitleBar,
     ShowNextWindowTab, ShowPreviousWindowTab,
 };
-use project::{linked_worktree_short_name, repo_identity_path};
+use project::{linked_worktree_short_name, repo_identity_path, repo_identity_path_if_local};
 
 #[cfg(not(target_os = "macos"))]
 use crate::application_menu::{
@@ -41,6 +41,7 @@ use remote::RemoteConnectionOptions;
 use settings::{Settings as _, SettingsStore};
 
 use std::any::TypeId;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use theme::ActiveTheme;
@@ -63,6 +64,18 @@ pub use onboarding_banner::restore_banner;
 const MAX_PROJECT_NAME_LENGTH: usize = 40;
 const MAX_BRANCH_NAME_LENGTH: usize = 40;
 const MAX_SHORT_SHA_LENGTH: usize = 8;
+
+fn linked_worktree_name_anchor<'a>(
+    main_worktree_path: Option<&'a Path>,
+    repository_identity_path: Option<&'a Path>,
+    is_linked_worktree: bool,
+) -> Option<&'a Path> {
+    main_worktree_path.or_else(|| {
+        is_linked_worktree
+            .then_some(repository_identity_path)
+            .flatten()
+    })
+}
 
 actions!(
     collab,
@@ -246,20 +259,24 @@ impl Render for TitleBar {
             if let Some(repo) = &repository {
                 let repo = repo.read(cx);
                 let identity = repo_identity_path(&repo.common_dir_abs_path, repo.path_style);
-                linked_worktree_name = repo
-                    .main_worktree_abs_path()
-                    .or_else(|| repo.is_linked_worktree().then_some(identity))
-                    .and_then(|name_anchor_path| {
-                        linked_worktree_short_name(
-                            name_anchor_path,
-                            repo.work_directory_abs_path.as_ref(),
-                        )
-                    })
-                    .or_else(|| {
-                        repo.is_linked_worktree()
-                            .then_some(project_name.clone())
-                            .flatten()
-                    });
+                let identity_fallback =
+                    repo_identity_path_if_local(&repo.common_dir_abs_path, repo.path_style);
+                linked_worktree_name = linked_worktree_name_anchor(
+                    repo.main_worktree_abs_path(),
+                    identity_fallback,
+                    repo.is_linked_worktree(),
+                )
+                .and_then(|name_anchor_path| {
+                    linked_worktree_short_name(
+                        name_anchor_path,
+                        repo.work_directory_abs_path.as_ref(),
+                    )
+                })
+                .or_else(|| {
+                    repo.is_linked_worktree()
+                        .then_some(project_name.clone())
+                        .flatten()
+                });
 
                 let display_name = if identity.extension() == Some(std::ffi::OsStr::new("git")) {
                     identity.file_stem().and_then(|n| n.to_str())
@@ -1420,5 +1437,50 @@ impl TitleBar {
                 .into()
             })
             .anchor(Anchor::TopRight)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::paths::PathStyle;
+
+    #[test]
+    fn test_foreign_path_style_does_not_use_repository_identity_as_name_anchor() {
+        let (common_dir, foreign_path_style) = match PathStyle::local() {
+            PathStyle::Unix => (Path::new(r"C:\repos\zed"), PathStyle::Windows),
+            PathStyle::Windows => (Path::new("/repos/zed"), PathStyle::Unix),
+        };
+        let repository_identity_path = repo_identity_path_if_local(common_dir, foreign_path_style);
+
+        assert_eq!(
+            linked_worktree_name_anchor(None, repository_identity_path, true),
+            None
+        );
+    }
+
+    #[test]
+    fn test_local_path_style_uses_bare_repository_worktree_name() {
+        let (repository_identity_path, work_directory_path) = match PathStyle::local() {
+            PathStyle::Unix => (
+                Path::new("/repos/zed"),
+                Path::new("/worktrees/zed/plum-warbler/zed"),
+            ),
+            PathStyle::Windows => (
+                Path::new(r"C:\repos\zed"),
+                Path::new(r"C:\worktrees\zed\plum-warbler\zed"),
+            ),
+        };
+
+        let repository_identity_path =
+            repo_identity_path_if_local(repository_identity_path, PathStyle::local());
+        let name_anchor_path = linked_worktree_name_anchor(None, repository_identity_path, true);
+
+        assert_eq!(
+            name_anchor_path.and_then(|name_anchor_path| {
+                linked_worktree_short_name(name_anchor_path, work_directory_path)
+            }),
+            Some("plum-warbler".into())
+        );
     }
 }


### PR DESCRIPTION
Follow-up https://github.com/zed-industries/zed/pull/55153
Fixes https://github.com/zed-industries/zed/discussions/54553#discussioncomment-17091833

When a repository stores its Git data in `~/work/zed/.bare`, creating a linked worktree from Zed is broken in two visible ways:

- Zed creates `random-code` at:
```
~/work/worktrees/.bare/random-code/.bare
```
instead of:
```
~/work/worktrees/zed/random-code/zed
```

- Because the checkout ends in `.bare`, Zed displays `.bare` as its worktree name in the title bar, worktree picker, and agent thread sidebar. Every worktree Zed creates from that repository gets the same `.bare` label instead of its generated name.

This problem is specific to the path Zed creates. Worktrees using either of these layouts are not malformed:
```
~/work/worktrees/zed/random-code/zed
~/work/zed/some-worktree
```

https://github.com/zed-industries/zed/pull/55153 introduced repository identities for bare repositories. This PR uses that identity in the remaining worktree naming and creation paths.

There are three repository layouts to account for:

- In a normal repository, the common Git directory is `~/work/zed/.git`, so Zed derives the main worktree at `~/work/zed`. Existing behavior remains unchanged.

- With `~/work/zed/.bare`, Git has no main worktree. A checkout named main is still a linked worktree. Zed now treats `~/work/zed` as the repository identity, creates new worktrees under `~/work/worktrees/zed`, and displays their generated names.

- With a bare repository named `~/work/foo.git`, `foo.git` is the repository identity. Its worktree path remains `~/work/worktrees/foo.git/random-code/foo.git`. Zed uses foo.git to derive the worktree name random-code, while displaying the repository itself as foo.

Existing malformed worktrees such as `~/work/worktrees/.bare/random-code/.bare` are not moved and may continue to display `.bare`.

Broken:

<p>
<img width="238" height="58" alt="image" src="https://github.com/user-attachments/assets/1504e4d0-c34a-471f-8e76-c5ec062b1d77" />
</p>
<p>
<img width="274" height="49" alt="image" src="https://github.com/user-attachments/assets/13266ca9-4e64-426c-b03c-e23c924a3597" />
</p>
<p>
<img width="574" height="85" alt="image" src="https://github.com/user-attachments/assets/0fca58c7-5be7-4d36-9067-066d0b80caf8" />
</p>

Release Notes:

- Fixed linked worktree names and creation paths for bare Git repositories.