### PR TITLE
editor: Stop coloring synthetic LSP outline labels with unrelated buffer words

### DIFF
--- a/crates/editor/src/document_symbols.rs
+++ b/crates/editor/src/document_symbols.rs
@@ -13,7 +13,6 @@ use multi_buffer::{
 };
 use text::BufferId;
 use theme::{ActiveTheme as _, SyntaxTheme};
-use unicode_segmentation::UnicodeSegmentation as _;
 use util::maybe;
 
 use crate::display_map::DisplaySnapshot;
@@ -254,10 +253,11 @@ fn lsp_symbols_enabled(buffer: &Buffer, cx: &App) -> bool {
 /// Finds where the symbol name appears in the buffer and returns combined
 /// (tree-sitter + semantic token) highlights for those positions.
 ///
-/// First tries to find the name verbatim near the selection range so that
-/// complex names (`impl Trait for Type`) get full highlighting. Falls back
-/// to word-by-word matching for cases like `impl<T> Trait<T> for Type`
-/// where the LSP name doesn't appear verbatim in the buffer.
+/// The name is only matched verbatim near the selection range, so that
+/// complex names (`impl Trait for Type`) get full highlighting. A name that
+/// does not appear verbatim is not a slice of the source, so no buffer
+/// position describes it; `None` is returned and the caller falls back to
+/// re-parsing the label with the buffer's language.
 fn highlights_from_buffer(
     display_snapshot: &DisplaySnapshot,
     item: &OutlineItem<text::Anchor>,
@@ -294,37 +294,11 @@ fn highlights_from_buffer(
         .text_for_range(search_start..search_end)
         .collect::<String>();
 
-    let mut outline_text_highlights = Vec::new();
-    match search_text.find(outline_text.as_str()) {
-        Some(start_index) => {
-            let multibuffer_start = search_start_offset + MultiBufferOffset(start_index);
-            let multibuffer_end = multibuffer_start + MultiBufferOffset(outline_text.len());
-            outline_text_highlights.extend(
-                display_snapshot
-                    .combined_highlights(multibuffer_start..multibuffer_end, syntax_theme),
-            );
-        }
-        None => {
-            for (outline_text_word_start, outline_word) in outline_text.split_word_bound_indices() {
-                if let Some(start_index) = search_text.find(outline_word) {
-                    let multibuffer_start = search_start_offset + MultiBufferOffset(start_index);
-                    let multibuffer_end = multibuffer_start + MultiBufferOffset(outline_word.len());
-                    outline_text_highlights.extend(
-                        display_snapshot
-                            .combined_highlights(multibuffer_start..multibuffer_end, syntax_theme)
-                            .into_iter()
-                            .map(|(range_in_word, style)| {
-                                (
-                                    outline_text_word_start + range_in_word.start
-                                        ..outline_text_word_start + range_in_word.end,
-                                    style,
-                                )
-                            }),
-                    );
-                }
-            }
-        }
-    }
+    let start_index = search_text.find(outline_text.as_str())?;
+    let multibuffer_start = search_start_offset + MultiBufferOffset(start_index);
+    let multibuffer_end = multibuffer_start + MultiBufferOffset(outline_text.len());
+    let outline_text_highlights =
+        display_snapshot.combined_highlights(multibuffer_start..multibuffer_end, syntax_theme);
 
     if outline_text_highlights.is_empty() {
         None
@@ -895,6 +869,87 @@ mod tests {
                 "reparsing the symbol text should highlight the `impl` keyword"
             );
             assert_eq!(symbol.highlight_ranges, expected);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_lsp_document_symbols_synthetic_label_ignores_buffer_words(
+        cx: &mut TestAppContext,
+    ) {
+        use ui::ActiveTheme as _;
+
+        init_test(cx, |_| {});
+
+        update_test_language_settings(cx, &|settings| {
+            settings.defaults.document_symbols = Some(DocumentSymbols::On);
+        });
+
+        let mut cx = EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                document_symbol_provider: Some(lsp::OneOf::Left(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            cx,
+        )
+        .await;
+        cx.update_editor(|editor, _window, cx| {
+            editor
+                .project
+                .as_ref()
+                .expect("editor should have a project")
+                .read(cx)
+                .languages()
+                .set_theme(cx.theme().clone());
+        });
+
+        // A synthesized label: it describes the symbol rather than slicing it,
+        // but it shares words (`/`, `security`, `answers`) with the string
+        // literal on the same line. The word-by-word fallback used to match
+        // those words inside that literal and paint them `@string`, striping a
+        // label that is not source text at all.
+        let mut symbol_request = cx
+            .set_request_handler::<lsp::request::DocumentSymbolRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
+                        nested_symbol(
+                            "GET /security/answers",
+                            lsp::SymbolKind::FUNCTION,
+                            lsp_range(0, 0, 0, 12),
+                            lsp_range(0, 3, 0, 7),
+                            Vec::new(),
+                        ),
+                    ])))
+                },
+            );
+
+        cx.set_state("fn maˇin() { let route = \"/security/answers\"; }\n");
+        assert!(symbol_request.next().await.is_some());
+        cx.run_until_parked();
+
+        cx.update_editor(|editor, _window, cx| {
+            let (_, symbols) = editor
+                .outline_symbols_at_cursor
+                .as_ref()
+                .expect("Should have outline symbols");
+            assert_eq!(symbols.len(), 1);
+            let symbol = &symbols[0];
+            assert_eq!(symbol.text, "GET /security/answers");
+
+            let language = editor
+                .buffer
+                .read(cx)
+                .as_singleton()
+                .expect("singleton buffer")
+                .read(cx)
+                .language()
+                .cloned()
+                .expect("buffer language");
+            let expected = highlight_ranges_from_text(&symbol.text, &language, cx.theme().syntax());
+            assert_eq!(
+                symbol.highlight_ranges, expected,
+                "a label that is not a verbatim source slice must not inherit \
+                 highlights from unrelated words on the same line"
+            );
         });
     }
 


### PR DESCRIPTION
Closes #57576.

## Problem

`highlights_from_buffer` colors an LSP-supplied outline label by locating it in the buffer. When the label is **not** a verbatim slice of the source, it falls through to `outline_text.split_word_bound_indices()` and looks each word up independently in the surrounding lines. Every word inherits whichever tree-sitter/semantic highlight its *first incidental match* happens to carry.

For a label like `GET /security/answers` emitted by a framework-aware LSP over `Route::get('/security/answers', ...)`:

| Word | Match in source | Applied color |
|---|---|---|
| `GET` | none (source has lowercase `get`) | default |
| `security` | inside the `'/security/answers'` string literal | `@string` |
| `answers` | inside the same literal | `@string` |

The result is visibly striped, and the colors describe *string literal contents* rather than the symbol. It gets worse for multi-segment URIs: `/file-builder-attribute-search` splits into four words, each resolved independently.

An LSP server cannot opt out. `flatten_document_symbols` hard-codes `highlight_ranges: Vec::new()`, and this pass unconditionally overwrites it whenever `highlights_from_buffer` returns `Some`.

## Fix

Return `None` when the verbatim search fails, instead of falling through to word-by-word matching.

This routes such labels into the reparse fallback that already exists one level up:

```rust
} else if let Some(language) = &language {
    item.highlight_ranges = highlight_ranges_from_text(&item.text, language, &syntax);
}
```

That path parses the label text with the buffer's own language and is already covered by `test_lsp_document_symbols_fall_back_to_reparsed_text_highlights` — it just was not reachable for any label sharing a highlighted word with the surrounding lines, which is nearly all of them.

Tree-sitter outlines (`outline.scm`-derived) are unaffected: they do not go through `highlights_from_buffer`.

## Behavior change worth reviewing

The removed fallback was documented as serving `impl<T> Trait<T> for Type` — a rust-analyzer label that is *near*-verbatim, its words genuinely drawn from the line beneath it. Word matching does a reasonable job there, and those labels now get grammar-reparsed instead. Since such a label is itself valid Rust, the reparse should highlight `impl`, `for`, and the type names correctly — but I have not verified that against a live rust-analyzer, only reasoned it from the fallback's behavior. Either way it trades buffer-accurate semantic-token colors for grammar-only colors in that case, and that is the part of this change most worth your judgement.

If you would rather keep word matching for near-verbatim labels, a narrower variant is to require the whole label be reconstructible from contiguous source before falling back. Happy to reshape it that way, or to close this if the tradeoff is not one you want — the issue mainly needed a concrete illustration.

## Tests

Added `test_lsp_document_symbols_synthetic_label_ignores_buffer_words`: a `GET /security/answers` label over `fn main() { let route = "/security/answers"; }`.

`cargo test -p editor --lib document_symbols` — 14 passed, 0 failed.

Reverting only the production change and keeping the test reproduces the bug exactly. Actual, on `main`:

```
[(4..5,  color: hsla(0.264, 0.38, 0.62)),   //  /
 (5..13, color: hsla(0.264, 0.38, 0.62)),   //  security
 (13..14,color: hsla(0.264, 0.38, 0.62)),   //  /
 (14..21,color: hsla(0.264, 0.38, 0.62))]   //  answers
```

Every segment painted with the `@string` color lifted out of the `"/security/answers"` literal, and `GET` (0..3) left with no highlight at all — because the buffer has no `GET`, only `main`.

Expected, with this change:

```
[(0..3,  color: hsla(0.108, 0.67, 0.69)),   //  GET
 (4..5,  color: None), (5..13, color: None),
 (13..14,color: None), (14..21,color: None)]
```

The reparse recognizes `GET` as an identifier and leaves the path segments as plain text. Not merely "less wrong" — it is the first time the label's own structure drives its color rather than an unrelated literal's.


---

Release Notes:

- Fixed outline and breadcrumb labels from language servers being colored using unrelated words found elsewhere on the same line.
