### PR TITLE
vim: Fix panic serializing marks whose anchors are unsorted

### DIFF
--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -398,6 +398,64 @@ mod test {
         cx.shared_state().await.assert_eq("Hello, worldˇ!");
     }
 
+    /// Regression test for a crash family (ZED-APE, ZED-AR0, ZED-APW): a
+    /// mark's anchors are stored in caller order, which multi-cursor callers
+    /// do not guarantee to be sorted, but serializing marks summarized them
+    /// with an API that requires sorted input and panics with "cannot
+    /// summarize backward" otherwise. Sorting at storage time is not an
+    /// option, because paired marks like `[` and `]` correspond by index.
+    #[gpui::test]
+    async fn test_mark_serialization_with_unsorted_anchors(cx: &mut TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        let path = Path::new(path!("/unsorted.rs"));
+        let fs = cx.workspace(|workspace, _, cx| workspace.project().read(cx).fs().clone());
+        fs.as_fake()
+            .insert_file(path, "alpha\nbeta\ngamma\n".into())
+            .await;
+        let _ = cx
+            .workspace(|workspace, window, cx| {
+                workspace.open_abs_path(
+                    path!("/unsorted.rs").into(),
+                    OpenOptions::default(),
+                    window,
+                    cx,
+                )
+            })
+            .await;
+        cx.run_until_parked();
+
+        let editor = cx.workspace(|workspace, _, cx| {
+            workspace
+                .active_item(cx)
+                .unwrap()
+                .downcast::<Editor>()
+                .unwrap()
+        });
+        let (multibuffer, anchors) = cx.update(|_, cx| {
+            editor.update(cx, |editor, cx| {
+                let multibuffer = editor.buffer().clone();
+                let snapshot = multibuffer.read(cx).snapshot(cx);
+                let anchors = vec![
+                    snapshot.anchor_before(editor::MultiBufferOffset(10)),
+                    snapshot.anchor_before(editor::MultiBufferOffset(2)),
+                ];
+                (multibuffer, anchors)
+            })
+        });
+
+        let workspace_entity_id = cx.workspace(|_, _, cx| cx.entity_id());
+        cx.update(|_, cx| {
+            crate::Vim::update_globals(cx, |globals, cx| {
+                let marks_state = globals.marks.get(&workspace_entity_id).unwrap().clone();
+                marks_state.update(cx, |marks_state, cx| {
+                    marks_state.set_mark("[".to_string(), &multibuffer, anchors, cx);
+                });
+            });
+        });
+        cx.run_until_parked();
+    }
+
     #[gpui::test]
     async fn test_global_mark_overwrite(cx: &mut TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -451,14 +451,20 @@ impl MarksState {
     ) {
         let new_points: HashMap<String, Vec<Point>> =
             if let Some(anchors) = self.buffer_marks.get(&buffer.read(cx).remote_id()) {
+                let buffer = buffer.read(cx);
                 anchors
                     .iter()
                     .map(|(name, anchors)| {
                         (
                             name.clone(),
-                            buffer
-                                .read(cx)
-                                .summaries_for_anchors::<Point, _>(anchors.iter().copied())
+                            // A mark's anchors are in caller order, which is not
+                            // necessarily sorted (paired marks like `[` and `]`
+                            // correspond by index across marks), so they cannot
+                            // be summarized with the sorted-input-only
+                            // `summaries_for_anchors`.
+                            anchors
+                                .iter()
+                                .map(|anchor| buffer.summary_for_anchor::<Point>(anchor))
                                 .collect(),
                         )
                     })


### PR DESCRIPTION
A mark's anchors are stored in caller order: paired marks like [ and ]
correspond by index, so storage cannot sort them, and multi-cursor callers
do not guarantee sorted order. Serializing marks summarized them with
summaries_for_anchors, which requires sorted input and panics with "cannot
summarize backward" otherwise (ZED-APE, ZED-AR0, ZED-APW). Summarize each
anchor independently instead.

Release Notes:

- Fixed a crash that could occur when setting vim marks with multiple
  cursors.

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, use "Fixes #X" for each issue as [described in the GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- N/A or Added/Fixed/Improved ...
