### PR TITLE
tabular_data_preview: Add shortcut to open tabular data preview

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -615,6 +615,14 @@
     },
   },
   {
+    "context": "Editor && (extension == csv || extension == tsv || extension == ssv || extension == psv)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-k v": "tabular_data::OpenPreviewToTheSide",
+      "ctrl-shift-v": "tabular_data::OpenPreview",
+    },
+  },
+  {
     "context": "Editor && mode == full",
     "bindings": {
       "ctrl-shift-o": "outline::Toggle",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -653,6 +653,14 @@
     },
   },
   {
+    "context": "Editor && (extension == csv || extension == tsv || extension == ssv || extension == psv)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-k v": "tabular_data::OpenPreviewToTheSide",
+      "cmd-shift-v": "tabular_data::OpenPreview",
+    },
+  },
+  {
     "context": "Editor && mode == full",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -612,6 +612,14 @@
     },
   },
   {
+    "context": "Editor && (extension == csv || extension == tsv || extension == ssv || extension == psv)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-k v": "tabular_data::OpenPreviewToTheSide",
+      "ctrl-shift-v": "tabular_data::OpenPreview",
+    },
+  },
+  {
     "context": "Editor && mode == full",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/tabular_data_preview/src/tabular_data_preview.rs
+++ b/crates/tabular_data_preview/src/tabular_data_preview.rs
@@ -120,7 +120,8 @@ impl TabularDataPreviewPane {
         cx: &mut Context<Workspace>,
     ) {
         let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
-        Self::activate_or_add_preview(editor, target_pane, false, window, cx);
+        Self::activate_or_add_preview(editor.clone(), target_pane, false, window, cx);
+        editor.focus_handle(cx).focus(window, cx);
     }
 
     fn activate_or_add_preview(


### PR DESCRIPTION
## TL;DR

Adds `cmd-shift-v` / `cmd-k v` (ctrl on linux/windows) to open the tabular data preview for `csv`/`tsv`/`ssv`/`psv` files, mirroring the existing `markdown::OpenPreview(ToTheSide)` and `svg::OpenPreview(ToTheSide)` bindings/context pattern already in the default keymaps.

Extension check kept explicit (not just `"Editor"`) so it doesn't compete with the `md`/`svg` blocks bound to the same keys on their own extensions.

## Testing

- Manually verified `cmd-shift-v` / `cmd-k v` open tabular data preview on `.csv`/`.tsv`/`.ssv`/`.psv` files, no-op on other extensions.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] UI standards followed
- [ ] Tests cover the new/changed behavior
- [x] Performance impact considered, acceptable

Release Notes:

- Added shortcuts to open the tabular data preview for CSV/TSV/SSV/PSV files (similar to md/svg preview)
