### PR TITLE
Fix Keymap Editor "Search by Keystrokes" shortcut shadowed by the text finder

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1387,6 +1387,12 @@
     },
   },
   {
+    "context": "KeymapEditor > BufferSearchBar",
+    "bindings": {
+      "alt-ctrl-f": "keymap_editor::ToggleKeystrokeSearch",
+    },
+  },
+  {
     "context": "KeystrokeInput",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1471,6 +1471,13 @@
     },
   },
   {
+    "context": "KeymapEditor > BufferSearchBar",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-alt-f": "keymap_editor::ToggleKeystrokeSearch",
+    },
+  },
+  {
     "context": "KeystrokeInput",
     "use_key_equivalents": true,
     "bindings": {


### PR DESCRIPTION
# Objective

Fixes #62361.

In the Keymap Editor, focus lands on the "Filter action names" input, which is wrapped in a `BufferSearchBar` key context (`crates/keymap_editor/src/keymap_editor.rs`). Its `cmd-alt-f → text_finder::Toggle` binding (added in #60677) shadows the `KeymapEditor` context's `cmd-alt-f → keymap_editor::ToggleKeystrokeSearch`, because `BufferSearchBar` sits deeper in the focus stack — so `cmd-alt-f` in the filter opens the file finder instead of toggling "Search by Keystrokes". Same collision on Linux (`ctrl-alt-f`); Windows is unaffected (it uses `alt-f`).

## Solution

Add a `KeymapEditor > BufferSearchBar` binding mapping the chord back to `keymap_editor::ToggleKeystrokeSearch`, in `default-macos.json` and `default-linux.json`. It's more specific than the plain `BufferSearchBar` binding and placed after the `KeymapEditor` block, so it wins the same-depth tie-break (gpui precedence: depth, then definition order) — restoring the shortcut inside the Keymap Editor without affecting the global text finder.

I gave the `KeymapEditor` binding precedence rather than rebinding "Search by Keystrokes" to a non-conflicting default (e.g. `cmd-alt-k`), since it's less invasive and doesn't change a documented default. Happy to switch to the rebind if the team prefers.

## Testing

Built and ran locally on macOS: opened the Keymap Editor (`cmd-k cmd-s`), pressed `cmd-alt-f` with focus in the filter → "Search by Keystrokes" toggles instead of opening the file finder; confirmed the file finder still works normally in a regular editor. `cargo test -p zed keymap` passes (validates the bundled keymaps parse and all actions resolve).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Tests cover the new/changed behavior (bundled-keymap validation exercises the new binding; runtime behavior manually verified — no logic to unit-test in a default-keymap change)

_Unsafe blocks / UI standards / performance: N/A for a keymap default change._


Release Notes:

- Fixed the Keymap Editor's "Search by Keystrokes" shortcut (`cmd-alt-f` / `ctrl-alt-f`) being shadowed by the file finder.
