### PR TITLE
Avoid redundant string allocations

### DIFF
--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -335,10 +335,7 @@ impl Editor {
                 );
 
                 // Remove shortcode from buffer
-                edits.push((
-                    emoji_shortcode_start..selection.start,
-                    "".to_string().into(),
-                ));
+                edits.push((emoji_shortcode_start..selection.start, Arc::from("")));
                 new_selections.push((
                     Selection {
                         id: selection.id,

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -1092,7 +1092,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                 let label = format!("Create new worktree based on {branch_label}");
 
                 let item = create_new_list_item(
-                    "create-from-current".to_string().into(),
+                    SharedString::new_static("create-from-current"),
                     label.into(),
                     self.creation_blocked_reason(cx),
                     selected,
@@ -1109,7 +1109,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                 let label = format!("Create new worktree based on {branch_label}");
 
                 let item = create_new_list_item(
-                    "create-from-main".to_string().into(),
+                    SharedString::new_static("create-from-main"),
                     label.into(),
                     self.creation_blocked_reason(cx),
                     selected,

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -864,7 +864,7 @@ impl ToolchainSelectorDelegate {
                 Some(())
             }
         });
-        let placeholder_text = "Select a toolchain…".to_string().into();
+        let placeholder_text = Arc::from("Select a toolchain…");
         Self {
             toolchain_selector,
             candidates: Default::default(),


### PR DESCRIPTION
Remove unnecessary intermediate `String` allocations when constructing `Arc<str>` and `SharedString` values. Use static `SharedString` storage for fixed worktree picker identifiers.

Validation:

- `cargo fmt --all -- --check`
- `tooling/lints/single-lint owned_string_into_shared -p editor -p git_ui_core -p toolchain_selector`
- `cargo test -p editor -p git_ui_core -p toolchain_selector`

Release Notes:

- N/A