### PR TITLE
Bump more dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,12 +14,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fd8203e6dfcf531d24f5bac792088edfba7d6b35844fead191603fb32a260"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.35.0",
+ "accesskit_consumer",
  "atspi-common",
  "phf 0.13.1",
  "serde",
@@ -28,19 +28,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
-dependencies = [
- "accesskit",
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
@@ -48,12 +38,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.26.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534bc3fdc89a64a1db3c46b33c198fde2b7c3c7d094e5809c8c8bf2970c18243"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.35.0",
+ "accesskit_consumer",
  "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -62,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e549dd7c6562b6a2ea807b44726e6241707db054a817dc4c7e2b8d3b39bfac"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -80,12 +70,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.33.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e93ac7bf50b964f1cbb75f741629a4e950571baa1ef1274457ab5a80d9bcc2"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.37.0",
+ "accesskit_consumer",
  "hashbrown 0.16.1",
  "static_assertions",
  "windows 0.62.2",
@@ -293,7 +283,7 @@ dependencies = [
  "project",
  "prompt_store",
  "proptest",
- "quick-xml 0.38.3",
+ "quick-xml 0.41.0",
  "rand 0.9.4",
  "regex",
  "release_channel",
@@ -517,7 +507,7 @@ dependencies = [
  "menu",
  "multi_buffer",
  "notifications",
- "ordered-float 2.10.1",
+ "ordered-float 5.5.0",
  "parking_lot",
  "paths",
  "picker",
@@ -936,7 +926,7 @@ dependencies = [
  "tempfile",
  "util",
  "which",
- "windows 0.61.3",
+ "windows 0.62.2",
  "zeroize",
 ]
 
@@ -1387,7 +1377,7 @@ dependencies = [
  "ctor",
  "db",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "http_client",
  "log",
@@ -1415,7 +1405,7 @@ dependencies = [
  "scopeguard",
  "simplelog",
  "tempfile",
- "windows 0.61.3",
+ "windows 0.62.2",
  "windows_resources",
 ]
 
@@ -2188,26 +2178,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.13.1",
- "cexpr",
- "clang-sys",
- "itertools 0.11.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex 1.3.0",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -2216,6 +2186,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.11.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -2377,7 +2349,7 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3138,7 +3110,7 @@ dependencies = [
  "tempfile",
  "util",
  "walkdir",
- "windows 0.61.3",
+ "windows 0.62.2",
  "windows_resources",
 ]
 
@@ -3193,7 +3165,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "url",
  "util",
- "windows 0.61.3",
+ "windows 0.62.2",
  "worktree",
  "zed_credentials_provider",
 ]
@@ -3752,7 +3724,7 @@ dependencies = [
  "base64 0.22.1",
  "collections",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "http_client",
  "log",
@@ -4048,7 +4020,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -4316,7 +4288,7 @@ dependencies = [
  "serde",
  "serde_json",
  "system_specs",
- "windows 0.61.3",
+ "windows 0.62.2",
  "zstd",
 ]
 
@@ -4921,7 +4893,7 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "settings",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "task",
  "tasks_ui",
  "terminal",
@@ -5083,7 +5055,7 @@ dependencies = [
  "collections",
  "ctor",
  "editor",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "indoc",
  "itertools 0.14.0",
@@ -5604,7 +5576,7 @@ dependencies = [
  "file_icons",
  "fs",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "fuzzy",
  "git",
  "gpui",
@@ -5619,7 +5591,7 @@ dependencies = [
  "markdown",
  "menu",
  "multi_buffer",
- "ordered-float 2.10.1",
+ "ordered-float 5.5.0",
  "parking_lot",
  "pretty_assertions",
  "project",
@@ -6109,9 +6081,9 @@ dependencies = [
 name = "explorer_command_injector"
 version = "0.1.0"
 dependencies = [
- "windows 0.61.3",
- "windows-core 0.61.2",
- "windows-registry 0.5.3",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -6166,8 +6138,8 @@ dependencies = [
  "tracing",
  "url",
  "util",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "which",
  "ztracing",
 ]
@@ -6248,7 +6220,7 @@ dependencies = [
  "tracing",
  "url",
  "util",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
  "wasmtime",
  "wasmtime-wasi",
  "zlog",
@@ -6730,7 +6702,7 @@ dependencies = [
  "trash",
  "unicode-normalization",
  "util",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6986,16 +6958,17 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.61.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -7207,7 +7180,7 @@ dependencies = [
  "file_icons",
  "fs",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "fuzzy",
  "fuzzy_nucleo",
  "git",
@@ -7237,7 +7210,7 @@ dependencies = [
  "settings",
  "smallvec",
  "strum 0.28.0",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "task",
  "telemetry",
  "terminal",
@@ -7508,7 +7481,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-task",
  "backtrace",
- "bindgen 0.71.1",
+ "bindgen",
  "bitflags 2.13.1",
  "chrono",
  "collections",
@@ -7573,7 +7546,7 @@ dependencies = [
  "waker-fn",
  "wasm-bindgen",
  "web-time",
- "windows 0.61.3",
+ "windows 0.62.2",
  "zed-font-kit",
  "zed-scap",
  "ztracing",
@@ -7813,10 +7786,10 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "uuid",
- "windows 0.61.3",
- "windows-core 0.61.2",
- "windows-numerics 0.2.0",
- "windows-registry 0.5.3",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-numerics 0.3.1",
+ "windows-registry 0.6.1",
  "zed-scap",
 ]
 
@@ -8483,7 +8456,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -8501,7 +8474,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -9512,7 +9485,7 @@ dependencies = [
  "encoding_rs",
  "fs",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "fuzzy_nucleo",
  "globset",
  "gpui",
@@ -9799,7 +9772,7 @@ dependencies = [
  "semver",
  "serde_json",
  "settings",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "telemetry",
  "theme",
  "theme_settings",
@@ -10408,7 +10381,7 @@ dependencies = [
  "collections",
  "ctor",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "gpui_util",
  "log",
@@ -10742,7 +10715,7 @@ name = "media"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bindgen 0.71.1",
+ "bindgen",
  "core-foundation 0.10.0",
  "core-video",
  "foreign-types 0.5.0",
@@ -10820,7 +10793,7 @@ dependencies = [
  "gpui",
  "mermaid_render",
  "merman",
- "quick-xml 0.38.3",
+ "quick-xml 0.41.0",
  "serde_json",
  "tracing",
  "usvg",
@@ -11163,7 +11136,7 @@ dependencies = [
  "clock",
  "collections",
  "ctor",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "indoc",
  "itertools 0.14.0",
@@ -11296,7 +11269,7 @@ dependencies = [
  "async-io",
  "smol",
  "tempfile",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -11319,19 +11292,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -11340,6 +11300,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -11407,7 +11368,7 @@ dependencies = [
  "channel",
  "client",
  "component",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "rpc",
  "sum_tree",
@@ -11981,6 +11942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12378,18 +12350,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -13514,20 +13486,20 @@ dependencies = [
  "theme",
  "theme_settings",
  "ui",
- "windows 0.61.3",
+ "windows 0.62.2",
  "workspace",
  "zed_actions",
 ]
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.3",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -14037,7 +14009,7 @@ dependencies = [
  "gpui",
  "language",
  "lsp",
- "ordered-float 2.10.1",
+ "ordered-float 5.5.0",
  "picker",
  "picker_preview",
  "project",
@@ -14413,15 +14385,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
@@ -14452,7 +14415,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -14490,7 +14453,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14838,7 +14801,7 @@ dependencies = [
  "menu",
  "node_runtime",
  "open_path_prompt",
- "ordered-float 2.10.1",
+ "ordered-float 5.5.0",
  "paths",
  "picker",
  "project",
@@ -15101,7 +15064,7 @@ dependencies = [
  "settings",
  "shellexpand",
  "smol",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "task",
  "telemetry",
  "tempfile",
@@ -15113,7 +15076,7 @@ dependencies = [
  "util",
  "uuid",
  "watch",
- "windows 0.61.3",
+ "windows 0.62.2",
  "workspace",
  "worktree",
  "zlog",
@@ -15848,7 +15811,7 @@ dependencies = [
  "http_proxy",
  "libc",
  "log",
- "nix 0.29.0",
+ "nix 0.30.1",
  "seccompiler",
  "serde",
  "serde_json",
@@ -17067,9 +17030,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -17434,7 +17397,7 @@ name = "streaming_diff"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "ordered-float 2.10.1",
+ "ordered-float 5.5.0",
  "rand 0.9.4",
  "rope",
  "util",
@@ -17918,16 +17881,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -17996,7 +17960,7 @@ dependencies = [
  "release_channel",
  "semver",
  "serde",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
 ]
 
 [[package]]
@@ -18168,12 +18132,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -18206,7 +18170,7 @@ dependencies = [
  "async-channel 2.5.0",
  "collections",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "gpui",
  "itertools 0.14.0",
  "libc",
@@ -18219,7 +18183,7 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "settings",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "task",
  "theme",
  "theme_settings",
@@ -18229,7 +18193,7 @@ dependencies = [
  "util",
  "util_macros",
  "vte",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -18502,7 +18466,7 @@ dependencies = [
  "core-foundation-sys",
  "sys-locale",
  "time",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -18639,7 +18603,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -19736,14 +19700,14 @@ dependencies = [
  "dirs",
  "dunce",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "globset",
  "gpui_util",
  "itertools 0.14.0",
  "libc",
  "log",
  "mach2 0.5.0",
- "nix 0.29.0",
+ "nix 0.30.1",
  "path",
  "percent-encoding",
  "rand 0.9.4",
@@ -19763,7 +19727,7 @@ dependencies = [
  "util_macros",
  "walkdir",
  "which",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -20158,16 +20122,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.252.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
@@ -20292,19 +20246,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
-dependencies = [
- "bitflags 2.13.1",
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
 ]
 
 [[package]]
@@ -20981,7 +20922,7 @@ dependencies = [
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",
  "once_cell",
- "ordered-float 4.6.0",
+ "ordered-float 5.5.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -21441,17 +21382,6 @@ dependencies = [
  "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -22298,7 +22228,7 @@ dependencies = [
  "dirs",
  "fs",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "git",
  "gpui",
  "http_client",
@@ -22349,7 +22279,7 @@ dependencies = [
  "encoding_rs",
  "fs",
  "futures 0.3.32",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.1",
  "fuzzy",
  "git",
  "gpui",
@@ -22912,7 +22842,7 @@ dependencies = [
  "snippets_ui",
  "spin 0.10.0",
  "svg_preview",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "system_specs",
  "tab_switcher",
  "tabular_data_preview",
@@ -22942,7 +22872,7 @@ dependencies = [
  "web_search",
  "web_search_providers",
  "which_key",
- "windows 0.61.3",
+ "windows 0.62.2",
  "windows_resources",
  "workspace",
  "zed-reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,7 +2377,7 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -6973,7 +6973,7 @@ dependencies = [
  "itertools 0.10.5",
  "num-traits",
  "rand 0.8.6",
- "rand_pcg",
+ "rand_pcg 0.3.1",
  "random_choice",
  "rayon",
  "seahash",
@@ -7052,11 +7052,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8499,7 +8501,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -9103,10 +9105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9118,6 +9122,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -14442,14 +14461,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes 1.11.1",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls 0.23.40",
@@ -14627,6 +14647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -16357,9 +16386,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -16367,6 +16396,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde_core",
@@ -16377,9 +16407,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -19057,7 +19087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb391ac70462b3097a755618fbf9c8f95ecc1eb379a414f7b46f202ed10db1f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,8 +516,8 @@ ztracing_macro = { path = "crates/ztracing_macro" }
 
 accesskit = { version = "0.24.0", features = ["enumn"] }
 accesskit_macos = "0.26.0"
-accesskit_unix = "0.21.0"
-accesskit_windows = "0.33.1"
+accesskit_unix = "0.22"
+accesskit_windows = "0.34"
 agent-client-protocol = { version = "=2.0.0", features = ["unstable"] }
 aho-corasick = "1.1"
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "4c129667ce56611becdc82de6e28218c80e2e88f" }
@@ -624,7 +624,7 @@ foreign-types = "0.5"
 fork = "0.4.0"
 futures = "0.3.32"
 futures-concurrency = "7.7.1"
-futures-lite = "1.13"
+futures-lite = "2"
 gh-workflow = { git = "https://github.com/zed-industries/gh-workflow", rev = "37f3c0575d379c218a9c455ee67585184e40d43f" }
 globset = "0.4"
 handlebars = "4.3"
@@ -686,7 +686,7 @@ minidumper = "0.11"
 moka = { version = "0.12.10", features = ["sync"] }
 nanoid = "0.4"
 nbformat = "1.2.0"
-nix = "0.29"
+nix = "0.30"
 notify-rust = "4"
 nucleo = "0.5"
 num-format = "0.4.4"
@@ -729,7 +729,7 @@ objc2-foundation = { version = "=0.3.2", default-features = false, features = [
 ] }
 objc2-user-notifications = "0.3"
 open = "5.0.0"
-ordered-float = "2.1.1"
+ordered-float = "5"
 palette = { version = "0.7.5", default-features = false, features = ["std"] }
 parking_lot = "0.12.1"
 parse_int = "0.9"
@@ -760,7 +760,7 @@ prost-types = "0.14"
 protox = "0.9"
 proxyvars = "0.2"
 pulldown-cmark = { version = "0.13.0", default-features = false }
-quick-xml = "0.38"
+quick-xml = "0.41"
 quote = "1.0.9"
 rand = "0.9"
 raw-window-handle = "0.6"
@@ -821,7 +821,7 @@ strum = { version = "0.28", features = ["derive"] }
 swash = "0.2.6"
 syn = { version = "2.0.101", features = ["full", "extra-traits", "visit-mut"] }
 sys-locale = "0.3.1"
-sysinfo = "0.37.0"
+sysinfo = "0.39"
 take-until = "0.2.0"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
@@ -880,8 +880,8 @@ usvg = { version = "0.46.0", default-features = false }
 uuid = { version = "1.1.2", features = ["v4", "v5", "v7", "serde"] }
 vte = { version = "0.15.0", features = ["ansi"] }
 walkdir = "2.5"
-wasm-encoder = "0.252"
-wasmparser = "0.252"
+wasm-encoder = "0.254"
+wasmparser = "0.254"
 wasmtime = { version = "48", default-features = false, features = [
     "anyhow",
     "async",
@@ -901,7 +901,7 @@ webpki-roots = "1.0.8"
 webrtc-sys = "0.3.23"
 wgpu = "29.0.4"
 which = "8"
-windows-core = "0.61"
+windows-core = "0.62"
 windows-registry = "0.6.0"
 yaml-rust2 = "0.8"
 yawc = { git = "https://github.com/zed-industries/yawc", rev = "71a452f551cac178367eaac5d7418a09afa1f3a2", version = "0.3.3" }
@@ -909,7 +909,7 @@ zeroize = "1.8"
 zstd = "0.11"
 
 [workspace.dependencies.windows]
-version = "0.61"
+version = "0.62"
 features = [
     "Data_Xml_Dom",
     "Foundation_Numerics",

--- a/crates/etw_tracing/Cargo.toml
+++ b/crates/etw_tracing/Cargo.toml
@@ -20,4 +20,9 @@ workspace.workspace = true
 [target.'cfg(target_os = "windows")'.dependencies]
 wprcontrol = { git = "https://github.com/zed-industries/wprcontrol", rev = "cd811f7" }
 windows-core = "0.61"
-windows.workspace = true
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }

--- a/crates/explorer_command_injector/Cargo.toml
+++ b/crates/explorer_command_injector/Cargo.toml
@@ -22,6 +22,6 @@ nightly = []
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
 windows-core.workspace = true
-windows-registry = "0.5"
+windows-registry.workspace = true
 
 [dependencies]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -154,7 +154,7 @@ wasm-bindgen = { workspace = true }
 embed-resource = { version = "3.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"
 
 [package.metadata.cargo-shear]
 ignored = [

--- a/crates/gpui_windows/Cargo.toml
+++ b/crates/gpui_windows/Cargo.toml
@@ -38,15 +38,15 @@ smallvec.workspace = true
 uuid.workspace = true
 windows.workspace = true
 windows-core.workspace = true
-windows-numerics = "0.2"
-windows-registry = "0.5"
+windows-numerics = "0.3"
+windows-registry.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies.scap]
 workspace = true
 optional = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-windows-registry = "0.5"
+windows-registry.workspace = true
 
 [package.metadata.cargo-shear]
 ignored = ["scap"]

--- a/crates/media/Cargo.toml
+++ b/crates/media/Cargo.toml
@@ -24,4 +24,4 @@ core-video.workspace = true
 objc.workspace = true
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"

--- a/crates/mermaid_render/src/postprocess.rs
+++ b/crates/mermaid_render/src/postprocess.rs
@@ -18,8 +18,8 @@ mod strip_foreignobject;
 pub(crate) mod util;
 
 use anyhow::{Context as _, Result};
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::{Reader, XmlVersion};
 
 use crate::MermaidTheme;
 
@@ -60,7 +60,7 @@ fn extract_svg_id(svg: &str) -> String {
                 .try_get_attribute("id")
                 .ok()
                 .flatten()
-                .and_then(|a| a.unescape_value().ok())
+                .and_then(|a| a.normalized_value(XmlVersion::Implicit1_0).ok())
                 .map(|v| v.into_owned())
                 .unwrap_or_default();
         }

--- a/crates/mermaid_render/src/postprocess/accent_colors.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors.rs
@@ -10,6 +10,7 @@ mod mindmap;
 mod sequence_diagram;
 
 use anyhow::Result;
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 
 use crate::MermaidTheme;
@@ -59,7 +60,7 @@ impl NodeTracker {
 
 pub(crate) fn parse_translate(e: &BytesStart<'_>) -> Option<(f64, f64)> {
     let attr = e.try_get_attribute("transform").ok()??;
-    let val = attr.unescape_value().ok()?;
+    let val = attr.normalized_value(XmlVersion::Implicit1_0).ok()?;
     let inner = val.strip_prefix("translate(")?.strip_suffix(')')?;
     let (x_str, y_str) = inner.split_once(',')?;
     Some((x_str.trim().parse().ok()?, y_str.trim().parse().ok()?))
@@ -67,7 +68,7 @@ pub(crate) fn parse_translate(e: &BytesStart<'_>) -> Option<(f64, f64)> {
 
 pub(crate) fn parse_path_half_height(e: &BytesStart<'_>) -> Option<f64> {
     let attr = e.try_get_attribute("d").ok()??;
-    let d = attr.unescape_value().ok()?;
+    let d = attr.normalized_value(XmlVersion::Implicit1_0).ok()?;
     let rest = d.strip_prefix('M')?.trim_start();
     // The path data starts with `M x,y ...`; the y coordinate is the second
     // whitespace/comma-separated token.
@@ -129,7 +130,7 @@ pub(crate) fn add_class<'a>(e: &BytesStart<'_>, class_to_add: &str) -> Result<By
     for attr in e.attributes() {
         let attr = attr?;
         if attr.key.local_name().as_ref() == b"class" {
-            let existing = attr.unescape_value()?;
+            let existing = attr.normalized_value(XmlVersion::Implicit1_0)?;
             let new_class = format!("{existing} {class_to_add}");
             new_elem.push_attribute(("class", new_class.as_str()));
             class_found = true;
@@ -191,7 +192,7 @@ pub(crate) fn lookup_position_accent(node_rects: &[NodeRect], e: &BytesStart<'_>
     let parse_attr = |name| -> Option<f64> {
         e.try_get_attribute(name)
             .ok()??
-            .unescape_value()
+            .normalized_value(XmlVersion::Implicit1_0)
             .ok()?
             .parse()
             .ok()
@@ -221,7 +222,7 @@ fn detect_diagram_type(e: &BytesStart<'_>) -> DiagramType {
         .try_get_attribute("class")
         .ok()
         .flatten()
-        .and_then(|a| a.unescape_value().ok())
+        .and_then(|a| a.normalized_value(XmlVersion::Implicit1_0).ok())
     {
         Some(c) => c,
         None => return DiagramType::SequenceDiagram,
@@ -279,7 +280,7 @@ impl<'a, 'theme, I: Iterator<Item = Result<Event<'a>>>> AccentColors<'theme, I> 
                     self.plot_depth += 1;
                 }
                 if let Some(class_attr) = e.try_get_attribute("class")? {
-                    let class = class_attr.unescape_value()?;
+                    let class = class_attr.normalized_value(XmlVersion::Implicit1_0)?;
                     if class.as_ref() == "plot" {
                         if is_start && !self.in_plot {
                             self.in_plot = true;
@@ -326,7 +327,7 @@ impl<'a, 'theme, I: Iterator<Item = Result<Event<'a>>>> AccentColors<'theme, I> 
             Event::Start(e) | Event::Empty(e) if e.name().as_ref() == b"path" => {
                 let class_val = e
                     .try_get_attribute("class")?
-                    .map(|a| a.unescape_value())
+                    .map(|a| a.normalized_value(XmlVersion::Implicit1_0))
                     .transpose()?;
 
                 if class_val.as_deref() == Some("pieCircle") {

--- a/crates/mermaid_render/src/postprocess/accent_colors/class_diagram.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors/class_diagram.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use quick_xml::XmlVersion;
 use quick_xml::events::Event;
 
 use super::{
@@ -38,7 +39,7 @@ impl ClassDiagramAccents {
                 }
 
                 let is_node = if let Some(class_attr) = e.try_get_attribute("class")? {
-                    let class = class_attr.unescape_value()?;
+                    let class = class_attr.normalized_value(XmlVersion::Implicit1_0)?;
                     class
                         .split_whitespace()
                         .any(|token| token == "node" || token == "stateGroup")

--- a/crates/mermaid_render/src/postprocess/accent_colors/mindmap.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors/mindmap.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 
 use super::{AccentStackEntry, NodeTracker};
@@ -105,7 +106,7 @@ impl MindmapAccents {
             Some(attr) => attr,
             None => return Ok(None),
         };
-        let class = class_attr.unescape_value()?;
+        let class = class_attr.normalized_value(XmlVersion::Implicit1_0)?;
         let is_root = class.split_whitespace().any(|t| t == "section-root");
 
         for token in class.split_whitespace() {

--- a/crates/mermaid_render/src/postprocess/accent_colors/sequence_diagram.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors/sequence_diagram.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 
 use super::{accent_class_name, add_to_event};
@@ -67,7 +68,7 @@ impl SequenceDiagramAccents {
             Some(a) => a,
             None => return Ok(None),
         };
-        let class_val = class_attr.unescape_value()?;
+        let class_val = class_attr.normalized_value(XmlVersion::Implicit1_0)?;
         if class_val.contains("actor-bottom") {
             let idx = self.actor_bottom_counter % self.accent_count;
             self.actor_bottom_counter += 1;
@@ -88,7 +89,7 @@ impl SequenceDiagramAccents {
             Some(a) => a,
             None => return Ok(None),
         };
-        let class_val = class_attr.unescape_value()?;
+        let class_val = class_attr.normalized_value(XmlVersion::Implicit1_0)?;
         if class_val.contains("actor") && class_val.contains("actor-box") {
             Ok(self.last_actor_accent.take())
         } else {

--- a/crates/mermaid_render/src/postprocess/element_fixup.rs
+++ b/crates/mermaid_render/src/postprocess/element_fixup.rs
@@ -22,6 +22,7 @@ use std::borrow::Cow;
 use std::fmt::Write as _;
 
 use anyhow::Result;
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 
 use crate::MermaidTheme;
@@ -68,7 +69,7 @@ fn is_bad_rect(e: &BytesStart) -> Result<bool> {
         match e.try_get_attribute(attr_name)? {
             None => return Ok(true),
             Some(attr) => {
-                let val = attr.unescape_value()?;
+                let val = attr.normalized_value(XmlVersion::Implicit1_0)?;
                 let trimmed = val.trim();
                 if trimmed.is_empty() {
                     return Ok(true);
@@ -183,7 +184,7 @@ impl<'a, I: Iterator<Item = Result<Event<'a>>>> ElementFixup<I> {
     fn rewrite_svg_style(&self, e: &BytesStart<'_>) -> Result<Option<BytesStart<'a>>> {
         let Some(style) = e
             .try_get_attribute("style")?
-            .map(|a| a.unescape_value())
+            .map(|a| a.normalized_value(XmlVersion::Implicit1_0))
             .transpose()?
         else {
             return Ok(None);
@@ -207,7 +208,7 @@ impl<'a, I: Iterator<Item = Result<Event<'a>>>> ElementFixup<I> {
             let attr = attr?;
             match attr.key.local_name().as_ref() {
                 b"fill" if fix_fill => {
-                    let val = attr.unescape_value()?;
+                    let val = attr.normalized_value(XmlVersion::Implicit1_0)?;
                     if is_hardcoded_text_fill(&val) {
                         new_elem.push_attribute(("fill", self.text_color_css.as_str()));
                     } else {
@@ -220,7 +221,7 @@ impl<'a, I: Iterator<Item = Result<Event<'a>>>> ElementFixup<I> {
                 }
                 b"style" => {
                     has_style = true;
-                    let style = attr.unescape_value()?;
+                    let style = attr.normalized_value(XmlVersion::Implicit1_0)?;
                     let style = rewrite_font_style(&style, &self.font_family_css);
                     new_elem.push_attribute(("style", style.as_ref()));
                 }

--- a/crates/mermaid_render/src/postprocess/strip_foreignobject.rs
+++ b/crates/mermaid_render/src/postprocess/strip_foreignobject.rs
@@ -26,8 +26,8 @@
 use std::collections::{HashSet, VecDeque};
 
 use anyhow::Result;
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::{Reader, XmlVersion};
 
 use super::ReaderIter;
 
@@ -72,7 +72,7 @@ fn is_fallback_text(e: &quick_xml::events::BytesStart<'_>) -> bool {
     e.try_get_attribute("class")
         .ok()
         .flatten()
-        .and_then(|a| a.unescape_value().ok())
+        .and_then(|a| a.normalized_value(XmlVersion::Implicit1_0).ok())
         .is_some_and(|v| v.split_whitespace().any(|c| c == FALLBACK_TEXT_CLASS))
 }
 

--- a/crates/mermaid_render/tests/check_invalid_attrs.rs
+++ b/crates/mermaid_render/tests/check_invalid_attrs.rs
@@ -174,6 +174,7 @@ fn check_svg_issues(name: &str, svg: &str) -> Vec<String> {
     }
 
     // Parse with quick-xml to find ANY empty attribute values on visual elements
+    use quick_xml::XmlVersion;
     use quick_xml::events::Event;
     let mut reader = quick_xml::Reader::from_str(svg);
     loop {
@@ -183,7 +184,9 @@ fn check_svg_issues(name: &str, svg: &str) -> Vec<String> {
                 let tag = String::from_utf8_lossy(e.name().local_name().as_ref()).to_string();
                 for attr in e.attributes().flatten() {
                     let key = String::from_utf8_lossy(attr.key.local_name().as_ref()).to_string();
-                    let val = attr.unescape_value().unwrap_or_default();
+                    let val = attr
+                        .normalized_value(XmlVersion::Implicit1_0)
+                        .unwrap_or_default();
                     let visual_attr = matches!(
                         key.as_str(),
                         "fill"
@@ -283,6 +286,7 @@ fn class_diagram_label_text_uses_accent_classes() {
 
     let svg = mermaid_render::render_to_svg(source, &theme).expect("render failed");
 
+    use quick_xml::XmlVersion;
     use quick_xml::events::Event;
     let mut reader = quick_xml::Reader::from_str(&svg);
     let mut accent_classes: Vec<String> = Vec::new();
@@ -291,7 +295,10 @@ fn class_diagram_label_text_uses_accent_classes() {
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) if e.name().as_ref() == b"text" => {
                 if let Ok(Some(class_attr)) = e.try_get_attribute("class") {
-                    let class = class_attr.unescape_value().unwrap_or_default().to_string();
+                    let class = class_attr
+                        .normalized_value(XmlVersion::Implicit1_0)
+                        .unwrap_or_default()
+                        .to_string();
                     for token in class.split_whitespace() {
                         if token.starts_with("zed-accent-") {
                             accent_classes.push(token.to_string());
@@ -315,6 +322,7 @@ fn sequence_diagram_tspan_uses_accent_classes() {
     let source = "sequenceDiagram\n    participant Database";
     let svg = mermaid_render::render_to_svg(source, &theme).expect("render failed");
 
+    use quick_xml::XmlVersion;
     use quick_xml::events::Event;
     let mut reader = quick_xml::Reader::from_str(&svg);
     let mut accent_classes: Vec<String> = Vec::new();
@@ -323,7 +331,10 @@ fn sequence_diagram_tspan_uses_accent_classes() {
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) if e.name().as_ref() == b"tspan" => {
                 if let Ok(Some(class_attr)) = e.try_get_attribute("class") {
-                    let class = class_attr.unescape_value().unwrap_or_default().to_string();
+                    let class = class_attr
+                        .normalized_value(XmlVersion::Implicit1_0)
+                        .unwrap_or_default()
+                        .to_string();
                     for token in class.split_whitespace() {
                         if token.starts_with("zed-accent-") {
                             accent_classes.push(token.to_string());

--- a/crates/sandbox/src/linux_bubblewrap.rs
+++ b/crates/sandbox/src/linux_bubblewrap.rs
@@ -26,7 +26,7 @@ use anyhow::{Context as _, Result, anyhow, bail};
 use std::ffi::{OsStr, OsString};
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
-use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd, RawFd};
+use std::os::fd::{AsFd as _, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd, RawFd};
 use std::os::unix::fs::MetadataExt as _;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
@@ -848,7 +848,7 @@ fn validate_binds(socket_path: &Path, paths: &[PathBuf]) -> Result<()> {
         );
     }
     for (fd, path) in fds.iter().zip(paths) {
-        let expected = fd_dev_ino(fd.as_raw_fd())
+        let expected = fd_dev_ino(fd.as_fd())
             .with_context(|| format!("fstat of captured descriptor for {}", path.display()))?;
         let mounted = lstat_dev_ino(path)
             .with_context(|| format!("lstat of mounted bind {}", path.display()))?;
@@ -1121,7 +1121,7 @@ fn recv_fds(stream: &UnixStream) -> std::io::Result<Vec<OwnedFd>> {
 }
 
 /// `(device, inode)` of the object an already-open descriptor refers to.
-fn fd_dev_ino(fd: RawFd) -> std::io::Result<(u64, u64)> {
+fn fd_dev_ino(fd: BorrowedFd<'_>) -> std::io::Result<(u64, u64)> {
     let stat = nix::sys::stat::fstat(fd).map_err(std::io::Error::from)?;
     Ok((stat.st_dev as u64, stat.st_ino as u64))
 }

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -246,7 +246,7 @@ fn linux_location_is_equal_or_descendant(
     location: &HostFilesystemLocation,
     ancestor: &HostFilesystemLocation,
 ) -> bool {
-    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+    use std::os::fd::{AsFd as _, AsRawFd as _, FromRawFd as _, OwnedFd};
 
     if location == ancestor {
         return true;
@@ -270,15 +270,15 @@ fn linux_location_is_equal_or_descendant(
             OwnedFd::from_raw_fd(fd)
         };
 
-        let Some(parent_identity) = linux_fd_identity(parent.as_raw_fd()) else {
+        let Some(parent_identity) = linux_fd_identity(parent.as_fd()) else {
             log::warn!("failed to fstat parent fd while checking protected path overlap");
             return false;
         };
-        let Some(current_identity) = linux_fd_identity(current.as_raw_fd()) else {
+        let Some(current_identity) = linux_fd_identity(current.as_fd()) else {
             log::warn!("failed to fstat current fd while checking protected path overlap");
             return false;
         };
-        let Some(ancestor_identity) = linux_fd_identity(ancestor.linux_fd().as_raw_fd()) else {
+        let Some(ancestor_identity) = linux_fd_identity(ancestor.linux_fd().as_fd()) else {
             log::warn!("failed to fstat protected fd while checking protected path overlap");
             return false;
         };

--- a/crates/sandbox/src/util/canonical_path.rs
+++ b/crates/sandbox/src/util/canonical_path.rs
@@ -145,7 +145,7 @@ impl CanonicalPathBuf {
             // and `readlink` of an `O_PATH|O_NOFOLLOW` fd on a symlink returns
             // the symlink's *own* path (equal to `path`), so the comparison
             // below wouldn't catch it.
-            let stat = nix::sys::stat::fstat(fd.as_raw_fd()).map_err(io::Error::from)?;
+            let stat = nix::sys::stat::fstat(&fd).map_err(io::Error::from)?;
             if stat.st_mode & libc::S_IFMT == libc::S_IFLNK {
                 return Err(io::Error::new(
                     io::ErrorKind::PermissionDenied,
@@ -266,8 +266,8 @@ impl PartialEq for CanonicalPathBuf {
         #[cfg(target_os = "linux")]
         {
             match (
-                linux_fd_identity(self.fd.as_raw_fd()),
-                linux_fd_identity(other.fd.as_raw_fd()),
+                linux_fd_identity(self.fd.as_fd()),
+                linux_fd_identity(other.fd.as_fd()),
             ) {
                 (Some(a), Some(b)) => a == b,
                 // An `fstat` on an `O_PATH` fd we own should never fail; if it
@@ -296,7 +296,7 @@ impl Eq for CanonicalPathBuf {}
 /// whether two [`CanonicalPathBuf`]s (or their parents) refer to the same
 /// filesystem object.
 #[cfg(target_os = "linux")]
-pub(crate) fn linux_fd_identity(fd: std::os::fd::RawFd) -> Option<(u64, u64)> {
+pub(crate) fn linux_fd_identity(fd: BorrowedFd<'_>) -> Option<(u64, u64)> {
     let stat = nix::sys::stat::fstat(fd).ok()?;
     Some((stat.st_dev as u64, stat.st_ino as u64))
 }


### PR DESCRIPTION
* 1st commit fixes bumps `quinn-proto` and `serde_with` to fix the dependabot alerts

* 2nd commit deduplicates more dependencies

`cargo tree -d` listing: 194 -> 187 top-level entries on the host target, 298 -> 287 unique duplicated crate-versions across all targets.

<details>
<summary>Deduplicated list</summary>

```
accesskit_consumer (v0.35.0, v0.37.0 -> v0.38.0)
bindgen (v0.71.1, v0.72.1 -> v0.72.1)
nix (v0.28.0, v0.29.0, v0.30.1 -> v0.28.0, v0.30.1)
ordered-float (v2.10.1, v4.6.0 -> v5.5.0)
quick-xml (v0.30.0, v0.37.5, v0.38.3, v0.39.3, v0.41.0 -> v0.30.0, v0.37.5, v0.39.3, v0.41.0)
sysinfo (v0.31.4, v0.37.2 -> v0.31.4, v0.39.6)
wasm-encoder (v0.252.0, v0.254.0 -> v0.254.0)
wasmparser (v0.252.0, v0.254.0 -> v0.254.0)
windows-registry (v0.4.0, v0.5.3, v0.6.1 -> v0.4.0, v0.6.1)
```

`ordered-float v4.6.0` remains in the lockfile only as an inactive optional dependency of `sea-query`; the compiled graph is fully deduplicated to v5.5.0.

</details>

Release Notes:

- N/A
