### PR TITLE
Show sticky scroll context rows inside multibuffer excerpts

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1888,11 +1888,15 @@ impl Editor {
             .scroll_manager
             .native_anchor(display_snapshot, cx)
             .anchor;
-        let Some(buffer_snapshot) = multi_buffer.as_singleton() else {
+        let scroll_offset = scroll_anchor.to_offset(&multi_buffer);
+        let Some((buffer_snapshot, excerpt_range)) =
+            multi_buffer.excerpt_containing(scroll_offset..scroll_offset)
+        else {
             return;
         };
 
         let buffer = buffer_snapshot.clone();
+        let excerpt_end = excerpt_range.context.end;
         let Some((buffer_visible_start, _)) = multi_buffer.anchor_to_buffer_anchor(scroll_anchor)
         else {
             return;
@@ -1904,6 +1908,18 @@ impl Editor {
 
         let syntax = self.style(cx).syntax.clone();
         let background_task = cx.background_spawn(async move {
+            let anchor_range = |range: Range<text::Anchor>| -> Option<Range<Anchor>> {
+                let start = multi_buffer.anchor_in_excerpt(range.start)?;
+                let end = multi_buffer
+                    .anchor_in_excerpt(range.end)
+                    .or_else(|| multi_buffer.anchor_in_excerpt(excerpt_end))?;
+                if end.cmp(&start, &multi_buffer).is_lt() {
+                    return None;
+                }
+
+                Some(start..end)
+            };
+
             buffer
                 .outline_items_containing(
                     Point::new(start_row, 0)..Point::new(end_row, 0),
@@ -1914,22 +1930,14 @@ impl Editor {
                 .filter_map(|outline_item| {
                     Some(OutlineItem {
                         depth: outline_item.depth,
-                        range: multi_buffer
-                            .buffer_anchor_range_to_anchor_range(outline_item.range)?,
-                        selection_range: multi_buffer
-                            .buffer_anchor_range_to_anchor_range(outline_item.selection_range)?,
-                        source_range_for_text: multi_buffer.buffer_anchor_range_to_anchor_range(
-                            outline_item.source_range_for_text,
-                        )?,
+                        range: anchor_range(outline_item.range)?,
+                        selection_range: anchor_range(outline_item.selection_range)?,
+                        source_range_for_text: anchor_range(outline_item.source_range_for_text)?,
                         text: outline_item.text,
                         highlight_ranges: outline_item.highlight_ranges,
                         name_ranges: outline_item.name_ranges,
-                        body_range: outline_item.body_range.and_then(|range| {
-                            multi_buffer.buffer_anchor_range_to_anchor_range(range)
-                        }),
-                        annotation_range: outline_item.annotation_range.and_then(|range| {
-                            multi_buffer.buffer_anchor_range_to_anchor_range(range)
-                        }),
+                        body_range: outline_item.body_range.and_then(&anchor_range),
+                        annotation_range: outline_item.annotation_range.and_then(&anchor_range),
                     })
                 })
                 .collect()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -40293,7 +40293,7 @@ async fn test_sticky_scroll(cx: &mut TestAppContext) {
         });
         cx.run_until_parked();
         cx.update_editor(|e, window, cx| {
-            EditorElement::sticky_headers(&e, &e.snapshot(window, cx))
+            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), 0.0)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -40382,7 +40382,7 @@ async fn test_sticky_scroll_with_decoration_prefix_in_item(cx: &mut TestAppConte
         });
         cx.run_until_parked();
         cx.update_editor(|e, window, cx| {
-            EditorElement::sticky_headers(&e, &e.snapshot(window, cx))
+            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), 0.0)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -40445,7 +40445,7 @@ async fn test_sticky_scroll_anchors_multiline_c_signature_on_name_row(cx: &mut T
         });
         cx.run_until_parked();
         cx.update_editor(|editor, window, cx| {
-            EditorElement::sticky_headers(&editor, &editor.snapshot(window, cx))
+            EditorElement::sticky_headers(&editor, &editor.snapshot(window, cx), 0.0)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -40528,7 +40528,7 @@ async fn test_sticky_scroll_with_expanded_deleted_diff_hunks(
         });
         cx.run_until_parked();
         cx.update_editor(|e, window, cx| {
-            EditorElement::sticky_headers(&e, &e.snapshot(window, cx))
+            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), 0.0)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -40584,7 +40584,7 @@ async fn test_no_duplicated_sticky_headers(cx: &mut TestAppContext) {
         });
         cx.run_until_parked();
         cx.update_editor(|e, window, cx| {
-            EditorElement::sticky_headers(&e, &e.snapshot(window, cx))
+            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), 0.0)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -40611,6 +40611,104 @@ async fn test_no_duplicated_sticky_headers(cx: &mut TestAppContext) {
     assert_eq!(sticky_headers(4.0), vec![(struct_foo, 0.0)]);
     assert_eq!(sticky_headers(4.5), vec![(struct_foo, -0.5)]);
     assert_eq!(sticky_headers(5.0), vec![]);
+}
+
+#[gpui::test]
+async fn test_sticky_headers_in_multibuffer(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let text = indoc! {"
+        fn foo() {
+            let a = 1;
+            let b = 2;
+            let c = 3;
+            let d = 4;
+        }
+        fn bar() {
+            let x = 1;
+            let y = 2;
+            let z = 3;
+        }
+    "};
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        let multi_buffer = MultiBuffer::build_multi(
+            [(text, vec![Point::row_range(0..4), Point::row_range(8..10)])],
+            cx,
+        );
+        let buffer_id = multi_buffer
+            .read(cx)
+            .snapshot(cx)
+            .all_buffer_ids()
+            .next()
+            .unwrap();
+        let buffer = multi_buffer.read(cx).buffer(buffer_id).unwrap();
+        buffer.update(cx, |buffer, cx| {
+            buffer.set_language(Some(rust_lang()), cx);
+        });
+
+        Editor::new(EditorMode::full(), multi_buffer, None, window, cx)
+    });
+    let mut cx = EditorTestContext::for_editor_in(editor.clone(), cx).await;
+    cx.run_until_parked();
+
+    let multibuffer_row = |cx: &mut EditorTestContext, needle: &str| {
+        let text = cx.update_editor(|e, _, cx| e.buffer().read(cx).snapshot(cx).text());
+        text.lines().position(|line| line.contains(needle)).unwrap() as u32
+    };
+    let display_row = |cx: &mut EditorTestContext, point: Point| {
+        cx.update_editor(|e, window, cx| {
+            e.snapshot(window, cx)
+                .display_snapshot
+                .point_to_display_point(point, text::Bias::Left)
+                .row()
+                .as_f64()
+        })
+    };
+    let mut sticky_headers =
+        |cx: &mut EditorTestContext, scroll_top: ScrollOffset, top_offset_rows: ScrollOffset| {
+            cx.update_editor(|e, window, cx| {
+                e.scroll(
+                    gpui::Point {
+                        x: 0.,
+                        y: scroll_top,
+                    },
+                    window,
+                    cx,
+                );
+            });
+            cx.run_until_parked();
+            cx.update_editor(|e, window, cx| {
+                EditorElement::sticky_headers(&e, &e.snapshot(window, cx), top_offset_rows)
+                    .into_iter()
+                    .map(
+                        |StickyHeader {
+                             start_point,
+                             offset,
+                             ..
+                         }| { (start_point, offset) },
+                    )
+                    .collect::<Vec<_>>()
+            })
+        };
+
+    let fn_foo = Point::new(multibuffer_row(&mut cx, "fn foo"), 0);
+    let let_a = Point::new(multibuffer_row(&mut cx, "let a"), 0);
+    let inside_foo = display_row(&mut cx, let_a);
+
+    assert_eq!(
+        sticky_headers(&mut cx, inside_foo, 0.0),
+        vec![(fn_foo, 0.0)]
+    );
+
+    assert_eq!(
+        sticky_headers(&mut cx, inside_foo, 2.0),
+        vec![(fn_foo, 2.0)]
+    );
+
+    let let_y = Point::new(multibuffer_row(&mut cx, "let y"), 0);
+    let inside_bar = display_row(&mut cx, let_y);
+    assert_eq!(sticky_headers(&mut cx, inside_bar, 0.0), vec![]);
 }
 
 #[gpui::test]
@@ -40658,7 +40756,7 @@ async fn test_autoscroll_keeps_cursor_visible_below_sticky_headers(cx: &mut Test
         cx.update_editor(|editor, window, cx| {
             let snapshot = editor.snapshot(window, cx);
             let scroll_top = snapshot.scroll_position().y;
-            let sticky_header_count = EditorElement::sticky_headers(editor, &snapshot).len();
+            let sticky_header_count = EditorElement::sticky_headers(editor, &snapshot, 0.0).len();
             let cursor_row = editor
                 .selections
                 .newest_display(&snapshot.display_snapshot)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8006,7 +8006,6 @@ impl Element for EditorElement {
         };
 
         let is_minimap = self.editor.read(cx).mode.is_minimap();
-        let is_singleton = self.editor.read(cx).buffer_kind(cx) == ItemBufferKind::Singleton;
 
         if !is_minimap {
             let focus_handle = self.editor.focus_handle(cx);
@@ -8825,29 +8824,56 @@ impl Element for EditorElement {
                         scroll_position.x * f64::from(em_layout_width),
                         scroll_position.y * f64::from(line_height),
                     );
-                    let sticky_headers = if !is_minimap
-                        && is_singleton
-                        && EditorSettings::get_global(cx).sticky_scroll.enabled
-                    {
-                        let relative = self.editor.read(cx).relative_line_numbers(cx);
-                        self.layout_sticky_headers(
-                            &snapshot,
-                            editor_width,
-                            is_row_soft_wrapped,
-                            line_height,
-                            scroll_pixel_position,
-                            content_origin,
-                            &gutter_dimensions,
-                            &gutter_hitbox,
-                            &text_hitbox,
-                            relative,
-                            current_selection_head,
-                            window,
-                            cx,
-                        )
+                    let sticky_buffer_header_height = if sticky_header_excerpt_id.is_some() {
+                        let full_height = FILE_HEADER_HEIGHT as f32 * line_height;
+                        let display_row = blocks
+                            .iter()
+                            .filter(|block| block.is_buffer_header)
+                            .find_map(|block| {
+                                block.row.filter(|row| row.0 > scroll_position.y as u32)
+                            });
+                        match display_row {
+                            Some(display_row) => {
+                                let max_row = display_row.0.saturating_sub(FILE_HEADER_HEIGHT);
+                                let offset = (scroll_position.y - max_row as f64).max(0.0);
+                                let slide_up =
+                                    Pixels::from(offset * ScrollPixelOffset::from(line_height));
+
+                                (full_height - slide_up).max(Pixels::ZERO)
+                            }
+                            None => full_height,
+                        }
                     } else {
-                        None
+                        Pixels::ZERO
                     };
+
+                    let sticky_headers =
+                        if !is_minimap && EditorSettings::get_global(cx).sticky_scroll.enabled {
+                            let relative = self.editor.read(cx).relative_line_numbers(cx);
+                            let top_offset_rows = if sticky_buffer_header.is_some() {
+                                ScrollOffset::from(sticky_buffer_header_height / line_height)
+                            } else {
+                                ScrollOffset::default()
+                            };
+                            self.layout_sticky_headers(
+                                &snapshot,
+                                editor_width,
+                                is_row_soft_wrapped,
+                                line_height,
+                                scroll_pixel_position,
+                                content_origin,
+                                &gutter_dimensions,
+                                &gutter_hitbox,
+                                &text_hitbox,
+                                relative,
+                                current_selection_head,
+                                top_offset_rows,
+                                window,
+                                cx,
+                            )
+                        } else {
+                            None
+                        };
                     let indent_guides =
                         if scroll_pixel_position != preliminary_scroll_pixel_position {
                             self.layout_indent_guides(
@@ -9372,27 +9398,10 @@ impl Element for EditorElement {
                     let has_sticky_buffer_header =
                         sticky_buffer_header.is_some() || sticky_header_excerpt_id.is_some();
                     let sticky_header_height = if has_sticky_buffer_header {
-                        let full_height = FILE_HEADER_HEIGHT as f32 * line_height;
-                        let display_row = blocks
-                            .iter()
-                            .filter(|block| block.is_buffer_header)
-                            .find_map(|block| {
-                                block.row.filter(|row| row.0 > scroll_position.y as u32)
-                            });
-                        let offset = match display_row {
-                            Some(display_row) => {
-                                let max_row = display_row.0.saturating_sub(FILE_HEADER_HEIGHT);
-                                let offset = (scroll_position.y - max_row as f64).max(0.0);
-                                let slide_up =
-                                    Pixels::from(offset * ScrollPixelOffset::from(line_height));
-
-                                (full_height - slide_up).max(Pixels::ZERO)
-                            }
-                            None => full_height,
-                        };
                         let header_bottom_padding =
                             BUFFER_HEADER_PADDING.to_pixels(window.rem_size());
-                        sticky_scroll_header_height + offset - header_bottom_padding
+                        sticky_scroll_header_height
+                            .max(sticky_buffer_header_height - header_bottom_padding)
                     } else {
                         sticky_scroll_header_height
                     };
@@ -9592,13 +9601,13 @@ impl Element for EditorElement {
                         }
                     });
 
+                    self.paint_sticky_headers(layout, window, cx);
+
                     window.with_element_namespace("blocks", |window| {
                         if let Some(mut sticky_header) = layout.sticky_buffer_header.take() {
                             sticky_header.paint(window, cx)
                         }
                     });
-
-                    self.paint_sticky_headers(layout, window, cx);
                     self.paint_minimap(layout, window, cx);
                     self.paint_scrollbars(layout, window, cx);
                     self.paint_edit_prediction_popover(layout, window, cx);

--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -62,7 +62,11 @@ pub(super) struct StickyHeaderLine {
 }
 
 impl EditorElement {
-    pub(crate) fn sticky_headers(editor: &Editor, snapshot: &EditorSnapshot) -> Vec<StickyHeader> {
+    pub(crate) fn sticky_headers(
+        editor: &Editor,
+        snapshot: &EditorSnapshot,
+        top_offset_rows: ScrollOffset,
+    ) -> Vec<StickyHeader> {
         let scroll_top = snapshot.scroll_position().y;
 
         let mut end_rows = Vec::<DisplayRow>::new();
@@ -112,7 +116,7 @@ impl EditorElement {
                 end_rows.pop();
             }
             let depth = end_rows.len();
-            let adjusted_scroll_top = scroll_top + depth as f64;
+            let adjusted_scroll_top = scroll_top + top_offset_rows + depth as f64;
 
             if sticky_row.as_f64() >= adjusted_scroll_top || end_row.as_f64() <= adjusted_scroll_top
             {
@@ -120,7 +124,7 @@ impl EditorElement {
             }
 
             let max_scroll_offset = max_sticky_row.as_f64() - scroll_top;
-            let offset = (depth as f64).min(max_scroll_offset);
+            let offset = (top_offset_rows + depth as f64).min(max_scroll_offset);
 
             end_rows.push(end_row);
             rows.push(StickyHeader {
@@ -238,6 +242,7 @@ impl EditorElement {
         text_hitbox: &Hitbox,
         relative_line_numbers: RelativeLineNumbers,
         relative_to: Option<DisplayRow>,
+        top_offset_rows: ScrollOffset,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<StickyHeaders> {
@@ -245,7 +250,7 @@ impl EditorElement {
             .show_line_numbers
             .unwrap_or_else(|| EditorSettings::get_global(cx).gutter.line_numbers);
 
-        let rows = Self::sticky_headers(self.editor.read(cx), snapshot);
+        let rows = Self::sticky_headers(self.editor.read(cx), snapshot, top_offset_rows);
 
         let mut lines = Vec::<StickyHeaderLine>::new();
 


### PR DESCRIPTION
# Objective

Show sticky scroll context rows (the enclosing scope) inside multibuffer excerpts, most notably the diff views. Today `sticky_scroll` only works in singleton buffers; in multibuffers only the sticky file header is shown, so a hunk far below its `fn` line gives no hint which scope it belongs to.

Requested in the discussion: https://github.com/zed-industries/zed/discussions/63380

## Solution

- `Editor::refresh_sticky_headers` no longer bails on multibuffers: it computes outline items for the excerpt at the top of the viewport, keeps items whose declaration line is part of an excerpt, and clamps ranges extending past the visible excerpt to the excerpt boundary.
- Pinned rows stack below the sticky buffer header: `EditorElement::sticky_headers` takes a `top_offset_rows`, and `sticky_header_height` now combines the buffer header and the scope rows as a max instead of a sum.
- Declarations that are not part of any excerpt are not pinned — rendering scope rows for lines outside the excerpts needs a separate rendering path and is intentionally left for a follow-up.

## Testing

- `cargo test -p editor sticky`: 12 tests pass, including a new `test_sticky_headers_in_multibuffer` covering the in-excerpt pin, boundary clamping, the buffer-header offset, and the declaration-outside-excerpt case; all pre-existing singleton sticky tests are unchanged and green.
- Verified manually in a diff multibuffer with expanded hunks: the enclosing declaration pins below the sticky buffer header while the hunk sits ~2800 lines further down. I don't have a shareable screenshot (the capture is from a private codebase) — happy to iterate on the stacking behavior.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added sticky scroll context rows inside multibuffer excerpts (e.g. diff views) when the scope's declaration line is part of an excerpt.

