### PR TITLE
Fix extensions_ui.rs: Prevent initial fetch from overwriting search results

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -459,12 +459,13 @@ impl ExtensionsPage {
                 query_editor,
                 upsells: BTreeSet::default(),
             };
-            this.fetch_extensions(
+            let fetch_task = this.fetch_extensions(
                 this.search_query(cx),
                 Some(BTreeSet::from_iter(this.provides_filter)),
                 None,
                 cx,
             );
+            this.extension_fetch_task = Some(fetch_task);
             this
         })
     }
@@ -572,7 +573,7 @@ impl ExtensionsPage {
         provides_filter: Option<BTreeSet<ExtensionProvides>>,
         on_complete: Option<Box<dyn FnOnce(&mut Self, &mut Context<Self>) + Send>>,
         cx: &mut Context<Self>,
-    ) {
+    ) -> Task<()> {
         self.is_fetching_extensions = true;
         self.fetch_failed = false;
         cx.notify();
@@ -654,9 +655,8 @@ impl ExtensionsPage {
                 }
             });
 
-            result?
+            result.and_then(|result| result).log_err();
         })
-        .detach_and_log_err(cx);
     }
 
     fn render_extensions(
@@ -890,15 +890,18 @@ impl ExtensionsPage {
                     .await;
             };
 
-            this.update(cx, |this, cx| {
+            let fetch_task = this.update(cx, |this, cx| {
                 this.fetch_extensions(
                     search,
                     Some(BTreeSet::from_iter(this.provides_filter)),
                     on_complete,
                     cx,
-                );
-            })
-            .ok();
+                )
+            });
+
+            if let Ok(fetch_task) = fetch_task {
+                fetch_task.await;
+            }
         }));
     }
 


### PR DESCRIPTION
# Objective

Fixes #63318

## Solution

Save the initial loading task to `extension_fetch_task` so that subsequent searches can cancel and replace it, eliminating the race condition where an older request overwrites the results of a newer search.

## Testing

To reproduce the bug: press the shortcut to bring up the Extensions panel and **immediately** start typing or pasting a search query.

https://github.com/user-attachments/assets/0cd23746-c6de-4f8e-96ec-312cfa71c396

https://github.com/user-attachments/assets/e4ddf3a9-a8ff-4c37-b4fb-ef75e5aaec71

This bug should (theoretically) be platform-independent.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Extension panel initial fetch overwriting search results (#63318)