### PR TITLE
Use permission bits

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -6,7 +6,6 @@ use parking_lot::Mutex;
 use slotmap::{KeyData, SlotMap};
 use std::ffi::OsString;
 use std::fs::Permissions;
-use std::os::unix::fs::PermissionsExt;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::Instant;
 use util::maybe;
@@ -29,6 +28,12 @@ use std::os::unix::ffi::OsStrExt;
 
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(windows)]
+use std::os::windows::fs::PermissionsExt;
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 use std::mem::MaybeUninit;
@@ -1467,6 +1472,7 @@ impl FakeFsState {
                 len: 0,
                 content: Vec::new(),
                 git_dir_path: None,
+                permission_bits: 0o644,
             });
             Ok(())
         })?;
@@ -1485,6 +1491,7 @@ enum FakeFsEntry {
         content: Vec<u8>,
         // The path to the repository state directory, if this is a gitfile.
         git_dir_path: Option<PathBuf>,
+        permission_bits: u32,
     },
     Dir {
         inode: u64,
@@ -1492,6 +1499,7 @@ enum FakeFsEntry {
         len: u64,
         entries: BTreeMap<String, FakeFsEntry>,
         git_repo_state: Option<Arc<Mutex<FakeGitRepositoryState>>>,
+        permission_bits: u32,
     },
     Symlink {
         target: PathBuf,
@@ -1509,6 +1517,7 @@ impl PartialEq for FakeFsEntry {
                     len: l_len,
                     content: l_content,
                     git_dir_path: l_git_dir_path,
+                    permission_bits: l_permission_bits,
                 },
                 Self::File {
                     inode: r_inode,
@@ -1516,6 +1525,7 @@ impl PartialEq for FakeFsEntry {
                     len: r_len,
                     content: r_content,
                     git_dir_path: r_git_dir_path,
+                    permission_bits: r_permission_bits,
                 },
             ) => {
                 l_inode == r_inode
@@ -1523,6 +1533,7 @@ impl PartialEq for FakeFsEntry {
                     && l_len == r_len
                     && l_content == r_content
                     && l_git_dir_path == r_git_dir_path
+                    && l_permission_bits == r_permission_bits
             }
             (
                 Self::Dir {
@@ -1531,6 +1542,7 @@ impl PartialEq for FakeFsEntry {
                     len: l_len,
                     entries: l_entries,
                     git_repo_state: l_git_repo_state,
+                    permission_bits: l_permission_bits,
                 },
                 Self::Dir {
                     inode: r_inode,
@@ -1538,6 +1550,7 @@ impl PartialEq for FakeFsEntry {
                     len: r_len,
                     entries: r_entries,
                     git_repo_state: r_git_repo_state,
+                    permission_bits: r_permission_bits,
                 },
             ) => {
                 let same_repo_state = match (l_git_repo_state.as_ref(), r_git_repo_state.as_ref()) {
@@ -1550,6 +1563,7 @@ impl PartialEq for FakeFsEntry {
                     && l_len == r_len
                     && l_entries == r_entries
                     && same_repo_state
+                    && l_permission_bits == r_permission_bits
             }
             (Self::Symlink { target: l_target }, Self::Symlink { target: r_target }) => {
                 l_target == r_target
@@ -1759,6 +1773,7 @@ impl FakeFs {
                     len: 0,
                     entries: Default::default(),
                     git_repo_state: None,
+                    permission_bits: 0o755,
                 },
                 git_event_tx: tx,
                 next_mtime: UNIX_EPOCH + Self::SYSTEMTIME_INTERVAL,
@@ -1824,6 +1839,7 @@ impl FakeFs {
                             content: Vec::new(),
                             len: 0,
                             git_dir_path: None,
+                            permission_bits: 0o644,
                         });
                     }
                     btree_map::Entry::Occupied(mut e) => match &mut *e.get_mut() {
@@ -1836,6 +1852,32 @@ impl FakeFs {
             })
             .unwrap();
         state.emit_event([(path.to_path_buf(), Some(PathEventKind::Changed))]);
+    }
+
+    pub async fn set_permissions(&self, path: impl AsRef<Path>, new_permission_bits: u32) -> &Self {
+        let mut state = self.state.lock();
+        let path = path.as_ref();
+        let _ = state
+            .write_path(path, move |entry| match entry {
+                btree_map::Entry::Occupied(mut e) => {
+                    match e.get_mut() {
+                        FakeFsEntry::File {
+                            permission_bits, ..
+                        } => *permission_bits = new_permission_bits,
+                        FakeFsEntry::Dir {
+                            permission_bits, ..
+                        } => *permission_bits = new_permission_bits,
+                        FakeFsEntry::Symlink { .. } => {}
+                    }
+                    Ok(())
+                }
+                btree_map::Entry::Vacant(_) => Err(anyhow::anyhow!(
+                    "cannot set permissions: path does not exist"
+                )),
+            })
+            .unwrap();
+        state.emit_event([(path, Some(PathEventKind::Changed))]);
+        self
     }
 
     pub async fn insert_file(&self, path: impl AsRef<Path>, content: Vec<u8>) {
@@ -1890,6 +1932,7 @@ impl FakeFs {
                             len: new_len,
                             content: new_content,
                             git_dir_path: None,
+                            permission_bits: 0o644,
                         });
                     }
                     btree_map::Entry::Occupied(mut e) => {
@@ -2905,6 +2948,7 @@ impl Fs for FakeFs {
                         len: 0,
                         entries: Default::default(),
                         git_repo_state: None,
+                        permission_bits: 0o755,
                     }
                 });
                 Ok(())
@@ -2926,6 +2970,7 @@ impl Fs for FakeFs {
             len: 0,
             content: Vec::new(),
             git_dir_path: None,
+            permission_bits: 0o644,
         };
         let mut kind = Some(PathEventKind::Created);
         state.write_path(path, |entry| {
@@ -3086,7 +3131,7 @@ impl Fs for FakeFs {
         let mut state = self.state.lock();
         let mtime = state.get_and_increment_mtime();
         let inode = state.get_and_increment_inode();
-        let source_entry = state.entry(&source)?;
+        let source_entry = state.entry(&source)?.clone();
         let content = source_entry.file_content(&source)?.clone();
         let mut kind = Some(PathEventKind::Created);
         state.write_path(&target, |e| match e {
@@ -3107,6 +3152,17 @@ impl Fs for FakeFs {
                     len: content.len() as u64,
                     content,
                     git_dir_path: None,
+                    permission_bits: match source_entry {
+                        FakeFsEntry::File {
+                            permission_bits, ..
+                        } => permission_bits,
+                        FakeFsEntry::Dir {
+                            permission_bits, ..
+                        } => permission_bits,
+                        FakeFsEntry::Symlink { .. } => {
+                            anyhow::bail!("Symlink cannot be copied to a file")
+                        }
+                    },
                 })
                 .clone(),
             )),
@@ -3254,7 +3310,11 @@ impl Fs for FakeFs {
 
             Ok(Some(match &*entry {
                 FakeFsEntry::File {
-                    inode, mtime, len, ..
+                    inode,
+                    mtime,
+                    len,
+                    permission_bits,
+                    ..
                 } => Metadata {
                     inode: *inode,
                     mtime: *mtime,

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -5,6 +5,7 @@ pub use fs_watcher::requires_poll_watcher;
 use parking_lot::Mutex;
 use slotmap::{KeyData, SlotMap};
 use std::ffi::OsString;
+use std::os::unix::fs::PermissionsExt;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::Instant;
 use util::maybe;
@@ -302,6 +303,11 @@ pub struct Metadata {
     pub is_fifo: bool,
     pub is_executable: bool,
     pub is_writable: bool,
+    // Currently this is being used for comparison of crates/worktree/src:Entry
+    // and should not be considered the source of truth for is_executable, and
+    // is_writable
+    // TODO: Remove is_executable, and is_writable and derive them from permission_bits
+    pub permission_bits: u32,
 }
 
 /// Filesystem modification time. The purpose of this newtype is to discourage use of operations
@@ -1087,6 +1093,12 @@ impl Fs for RealFs {
         #[cfg(unix)]
         let is_fifo = metadata.file_type().is_fifo();
 
+        #[cfg(unix)]
+        let permission_bits = metadata.permissions().mode();
+
+        #[cfg(windows)]
+        let permission_bits = metadata.permissions().file_attributes();
+
         let path_buf = path.to_path_buf();
         let is_executable = self
             .executor
@@ -1102,6 +1114,7 @@ impl Fs for RealFs {
             is_fifo,
             is_executable,
             is_writable: !metadata.permissions().readonly(),
+            permission_bits: permission_bits.into(),
         }))
     }
 
@@ -3243,6 +3256,7 @@ impl Fs for FakeFs {
                     is_fifo: false,
                     is_executable: false,
                     is_writable: true,
+                    permission_bits: 0o644,
                 },
                 FakeFsEntry::Dir {
                     inode, mtime, len, ..
@@ -3255,6 +3269,7 @@ impl Fs for FakeFs {
                     is_fifo: false,
                     is_executable: false,
                     is_writable: true,
+                    permission_bits: 0o755,
                 },
                 FakeFsEntry::Symlink { .. } => unreachable!(),
             }))

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -5,6 +5,7 @@ pub use fs_watcher::requires_poll_watcher;
 use parking_lot::Mutex;
 use slotmap::{KeyData, SlotMap};
 use std::ffi::OsString;
+use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::time::Instant;
@@ -302,12 +303,20 @@ pub struct Metadata {
     pub len: u64,
     pub is_fifo: bool,
     pub is_executable: bool,
-    pub is_writable: bool,
-    // Currently this is being used for comparison of crates/worktree/src:Entry
-    // and should not be considered the source of truth for is_executable, and
-    // is_writable
-    // TODO: Remove is_executable, and is_writable and derive them from permission_bits
+    // permission_bits should not be used to derive `is_executable`
     pub permission_bits: u32,
+}
+
+impl Metadata {
+    pub fn is_writable(&self) -> bool {
+        #[cfg(unix)]
+        let permissions = Permissions::from_mode(self.permission_bits);
+
+        #[cfg(windows)]
+        let permissions = Permissions::from_mode(self.permission_bits);
+
+        return !permissions.readonly();
+    }
 }
 
 /// Filesystem modification time. The purpose of this newtype is to discourage use of operations
@@ -1113,8 +1122,7 @@ impl Fs for RealFs {
             is_dir: metadata.file_type().is_dir(),
             is_fifo,
             is_executable,
-            is_writable: !metadata.permissions().readonly(),
-            permission_bits: permission_bits.into(),
+            permission_bits: permission_bits,
         }))
     }
 
@@ -3254,12 +3262,15 @@ impl Fs for FakeFs {
                     is_dir: false,
                     is_symlink,
                     is_fifo: false,
-                    is_executable: false,
-                    is_writable: true,
-                    permission_bits: 0o644,
+                    is_executable: permission_bits & 0o111 != 0,
+                    permission_bits: *permission_bits,
                 },
                 FakeFsEntry::Dir {
-                    inode, mtime, len, ..
+                    inode,
+                    mtime,
+                    len,
+                    permission_bits,
+                    ..
                 } => Metadata {
                     inode: *inode,
                     mtime: *mtime,
@@ -3267,9 +3278,8 @@ impl Fs for FakeFs {
                     is_dir: true,
                     is_symlink,
                     is_fifo: false,
-                    is_executable: false,
-                    is_writable: true,
-                    permission_bits: 0o755,
+                    is_executable: permission_bits & 0o111 != 0,
+                    permission_bits: *permission_bits,
                 },
                 FakeFsEntry::Symlink { .. } => unreachable!(),
             }))

--- a/crates/project/tests/integration/project_search.rs
+++ b/crates/project/tests/integration/project_search.rs
@@ -60,6 +60,7 @@ async fn test_path_inclusion_matcher(cx: &mut gpui::TestAppContext) {
         size: 0,
         char_bag: Default::default(),
         is_fifo: false,
+        permission_bits: None,
     };
 
     // 1. Test searching for `field`, including ignored files without any

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -34,6 +34,7 @@ fn load_linux_repo_snapshot() -> Vec<GitEntry> {
                 is_hidden: false,
                 char_bag: Default::default(),
                 is_fifo: false,
+                permission_bits: None,
             };
             Some(GitEntry {
                 entry,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4338,6 +4338,7 @@ impl ProjectPanel {
                 canonical_path: parent_entry.canonical_path.clone(),
                 char_bag: parent_entry.char_bag,
                 is_fifo: parent_entry.is_fifo,
+                permission_bits: parent_entry.permission_bits,
             },
             git_summary,
         }

--- a/crates/proto/proto/worktree.proto
+++ b/crates/proto/proto/worktree.proto
@@ -30,6 +30,7 @@ message Entry {
   optional string canonical_path = 12;
   bool is_hidden = 13;
   bool is_unloaded = 14;
+  optional uint32 permission_bits = 15;
 }
 
 message AddWorktree {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -7016,6 +7016,7 @@ impl<'a> From<&'a Entry> for proto::Entry {
                 .as_ref()
                 .map(|path| path.to_string_lossy().into_owned()),
             is_unloaded: entry.kind == EntryKind::UnloadedDir,
+            permission_bits: entry.permission_bits,
         }
     }
 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3987,6 +3987,10 @@ pub struct Entry {
     pub is_private: bool,
     /// The entry's size on disk, in bytes.
     pub size: u64,
+
+    // The entry's permission bits on the fs
+    pub permission_bits: Option<u32>,
+
     pub char_bag: CharBag,
     pub is_fifo: bool,
 }
@@ -4148,6 +4152,7 @@ impl Entry {
             is_private: false,
             char_bag,
             is_fifo: metadata.is_fifo,
+            permission_bits: Some(metadata.permission_bits),
         }
     }
 
@@ -7052,6 +7057,7 @@ impl TryFrom<(&CharBag, &PathMatcher, proto::Entry)> for Entry {
             is_private: false,
             char_bag,
             is_fifo: entry.is_fifo,
+            permission_bits: entry.permission_bits,
         })
     }
 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1720,7 +1720,7 @@ impl LocalWorktree {
             }
             let (text, line_ending, encoding, has_bom) =
                 decode_file_text_to_rope(fs.as_ref(), &abs_path).await?;
-            let is_writable = metadata.is_some_and(|metadata| metadata.is_writable);
+            let is_writable = metadata.is_some_and(|metadata| metadata.is_writable());
 
             let worktree = this.upgrade().context("worktree was dropped")?;
             let file = match entry.await? {

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -6022,6 +6022,7 @@ async fn test_remote_worktree_without_git_emits_root_repo_event_after_first_upda
                     size: None,
                     canonical_path: None,
                     is_unloaded: false,
+                    permission_bits: Some(0o755),
                 }],
                 removed_entries: vec![],
                 scan_id: 1,
@@ -6117,6 +6118,7 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
                     size: None,
                     canonical_path: None,
                     is_unloaded: false,
+                    permission_bits: Some(0o755),
                 }],
                 removed_entries: vec![],
                 scan_id: 1,
@@ -7032,6 +7034,89 @@ async fn test_file_scan_depth_git_init_above_deferred_dirs(cx: &mut TestAppConte
         );
         assert_eq!(tree.deferred_scan_dir_count(), 0);
     });
+}
+
+#[gpui::test]
+#[cfg(unix)]
+async fn test_chmod_updates_permission_bits(cx: &mut TestAppContext) {
+    init_test(cx);
+    set_file_scan_depth(cx, Some(2));
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "project": {
+                "demo.py": "#!/usr/bin/env python3"
+            }
+        }),
+    )
+    .await;
+    fs.set_permissions(path!("/root/project/demo.py"), 0o644)
+        .await;
+
+    use settings::Settings;
+    cx.update(|cx| {
+        let settings_store = SettingsStore::test(cx);
+        cx.set_global(settings_store);
+        worktree::WorktreeSettings::register(cx);
+    });
+
+    let tree = build_worktree(fs.clone(), path!("/root"), cx).await;
+    cx.run_until_parked();
+
+    let demo_py = rel_path("project/demo.py");
+    let initial_permission_bits = tree.read_with(cx, |tree, _| {
+        tree.entry_for_path(demo_py)
+            .and_then(|entry| entry.permission_bits)
+            .expect("demo.py should have permission bits recorded")
+    });
+    assert_eq!(
+        initial_permission_bits & 0o111,
+        0,
+        "file should not be executable yet"
+    );
+
+    let updated_paths: Rc<Cell<Vec<PathChange>>> = Rc::new(Cell::new(Vec::new()));
+    tree.update(cx, {
+        let updated_paths = updated_paths.clone();
+        |_, cx| {
+            cx.subscribe(&cx.entity(), move |_, _, event, _| {
+                if let Event::UpdatedEntries(changes) = event {
+                    for (path, _, change_type) in changes.iter() {
+                        if path.as_ref() == demo_py {
+                            let mut paths = updated_paths.take();
+                            paths.push(*change_type);
+                            updated_paths.set(paths);
+                        }
+                    }
+                }
+            })
+            .detach();
+        }
+    });
+
+    // Change the file permissions without touching its contents.
+    fs.set_permissions(path!("/root/project/demo.py"), 0o755)
+        .await;
+    cx.run_until_parked();
+
+    let new_permission_bits = tree.read_with(cx, |tree, _| {
+        tree.entry_for_path(demo_py)
+            .and_then(|entry| entry.permission_bits)
+            .expect("demo.py should still have permission bits recorded")
+    });
+    assert_eq!(
+        new_permission_bits & 0o111,
+        0o111,
+        "entry's permission bits should reflect the file becoming executable"
+    );
+
+    assert!(
+        updated_paths.take().contains(&PathChange::Updated),
+        "chmod should fire Event::UpdatedEntries for demo.py, \
+         since language servers are notified of such changes"
+    );
 }
 
 async fn build_worktree(fs: Arc<FakeFs>, root: &str, cx: &mut TestAppContext) -> Entity<Worktree> {


### PR DESCRIPTION
# Objective

- Fixes #62268 

## Solution

- Added permission bits to `fs::Metadata` and thus `Entity`. Now, on permission change, the Entity is updated accordingly and `Event::UpdatedEntries(changes)` is fired, which thus triggers a LSP request.

## Testing

- Manual testing by replicating the steps of the linked issue. The error squiggles are refreshed as I update file permissions.
- Add automated tests for checking the emission of `Event::UpdatedEntries(changes)` event on file's permission change.
- You can test the changes by replicating the above manual testing steps/running automated tests.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixes 'Language server diagnostics do not update after file-permission change' issue.
