### PR TITLE
editor: Limit row highlight expansion to viewport

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1020,7 +1020,7 @@ pub struct Editor {
     show_indent_guides: Option<bool>,
     buffers_with_disabled_indent_guides: HashSet<BufferId>,
     highlight_order: usize,
-    highlighted_rows: TypeIdHashMap<RowHighlights>,
+    highlighted_rows: TypeIdHashMap<Vec<RowHighlight>>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     navigation_overlays: HashMap<NavigationOverlayKey, Arc<[NavigationTargetOverlay]>>,
     gutter_highlights: TypeIdHashMap<GutterHighlight>,
@@ -1523,12 +1523,6 @@ struct RowHighlight {
     color: fn(&App) -> Hsla,
     options: RowHighlightOptions,
     type_id: TypeId,
-}
-
-#[derive(Default)]
-struct RowHighlights {
-    ranges: Vec<RowHighlight>,
-    has_diff_base_anchors: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -9111,9 +9105,6 @@ impl Editor {
     ) {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
-        row_highlights.has_diff_base_anchors |=
-            range.start.diff_base_anchor().is_some() || range.end.diff_base_anchor().is_some();
-        let row_highlights = &mut row_highlights.ranges;
         let ix = row_highlights.binary_search_by(|highlight| {
             Ordering::Equal
                 .then_with(|| highlight.range.start.cmp(&range.start, &snapshot))
@@ -9193,7 +9184,7 @@ impl Editor {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
         let mut ranges_to_remove = ranges_to_remove.iter().peekable();
-        row_highlights.ranges.retain(|highlight| {
+        row_highlights.retain(|highlight| {
             while let Some(range_to_remove) = ranges_to_remove.peek() {
                 match range_to_remove.end.cmp(&highlight.range.start, &snapshot) {
                     Ordering::Less | Ordering::Equal => {
@@ -9226,7 +9217,7 @@ impl Editor {
     ) -> impl 'a + Iterator<Item = (Range<Anchor>, Hsla)> {
         self.highlighted_rows
             .get(&TypeId::of::<T>())
-            .map_or(&[] as &[_], |highlights| highlights.ranges.as_slice())
+            .map_or(&[] as &[_], |highlights| highlights.as_slice())
             .iter()
             .map(|highlight| (highlight.range.clone(), (highlight.color)(cx)))
     }
@@ -9265,40 +9256,34 @@ impl Editor {
         self.highlighted_rows
             .values()
             .flat_map(|highlighted_rows| {
-                let ranges = highlighted_rows.ranges.as_slice();
-                let (start_index, end_index) = if highlighted_rows.has_diff_base_anchors {
-                    (0, ranges.len())
-                } else {
-                    // Diff-base anchor ordering depends on the current diff snapshot, while regular
-                    // buffer anchors preserve their ordering across edits.
-                    let start_index = ranges.partition_point(|highlight| {
-                        highlight
-                            .range
-                            .end
-                            .cmp(&anchor_range.start, buffer_snapshot)
-                            .is_lt()
-                    });
-                    let end_index = ranges.partition_point(|highlight| {
-                        highlight
-                            .range
-                            .start
-                            .cmp(&anchor_range.end, buffer_snapshot)
-                            .is_le()
-                    });
-                    (start_index, end_index)
-                };
-                ranges[start_index..end_index].iter().filter(|highlight| {
+                let start_index = highlighted_rows.partition_point(|highlight| {
                     highlight
                         .range
                         .end
                         .cmp(&anchor_range.start, buffer_snapshot)
-                        .is_ge()
-                        && highlight
+                        .is_lt()
+                });
+                let end_index = highlighted_rows.partition_point(|highlight| {
+                    highlight
+                        .range
+                        .start
+                        .cmp(&anchor_range.end, buffer_snapshot)
+                        .is_le()
+                });
+                highlighted_rows[start_index..end_index]
+                    .iter()
+                    .filter(|highlight| {
+                        highlight
                             .range
-                            .start
-                            .cmp(&anchor_range.end, buffer_snapshot)
-                            .is_le()
-                })
+                            .end
+                            .cmp(&anchor_range.start, buffer_snapshot)
+                            .is_ge()
+                            && highlight
+                                .range
+                                .start
+                                .cmp(&anchor_range.end, buffer_snapshot)
+                                .is_le()
+                    })
             })
             .fold(
                 BTreeMap::<DisplayRow, LineHighlight>::new(),
@@ -9361,7 +9346,7 @@ impl Editor {
     ) -> Option<DisplayRow> {
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.ranges.iter())
+            .flat_map(|highlighted_rows| highlighted_rows.iter())
             .filter_map(|highlight| {
                 if highlight.options.autoscroll {
                     Some(highlight.range.start.to_display_point(snapshot).row())
@@ -9835,7 +9820,7 @@ impl Editor {
         let current_execution_position = self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .and_then(|lines| lines.ranges.last().map(|line| line.range.end));
+            .and_then(|lines| lines.last().map(|line| line.range.end));
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
             let inline_values = editor

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1020,7 +1020,7 @@ pub struct Editor {
     show_indent_guides: Option<bool>,
     buffers_with_disabled_indent_guides: HashSet<BufferId>,
     highlight_order: usize,
-    highlighted_rows: TypeIdHashMap<Vec<RowHighlight>>,
+    highlighted_rows: TypeIdHashMap<RowHighlights>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     navigation_overlays: HashMap<NavigationOverlayKey, Arc<[NavigationTargetOverlay]>>,
     gutter_highlights: TypeIdHashMap<GutterHighlight>,
@@ -1523,6 +1523,12 @@ struct RowHighlight {
     color: fn(&App) -> Hsla,
     options: RowHighlightOptions,
     type_id: TypeId,
+}
+
+#[derive(Default)]
+struct RowHighlights {
+    ranges: Vec<RowHighlight>,
+    has_diff_base_anchors: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -9105,6 +9111,9 @@ impl Editor {
     ) {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
+        row_highlights.has_diff_base_anchors |=
+            range.start.diff_base_anchor().is_some() || range.end.diff_base_anchor().is_some();
+        let row_highlights = &mut row_highlights.ranges;
         let ix = row_highlights.binary_search_by(|highlight| {
             Ordering::Equal
                 .then_with(|| highlight.range.start.cmp(&range.start, &snapshot))
@@ -9184,7 +9193,7 @@ impl Editor {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
         let mut ranges_to_remove = ranges_to_remove.iter().peekable();
-        row_highlights.retain(|highlight| {
+        row_highlights.ranges.retain(|highlight| {
             while let Some(range_to_remove) = ranges_to_remove.peek() {
                 match range_to_remove.end.cmp(&highlight.range.start, &snapshot) {
                     Ordering::Less | Ordering::Equal => {
@@ -9217,7 +9226,7 @@ impl Editor {
     ) -> impl 'a + Iterator<Item = (Range<Anchor>, Hsla)> {
         self.highlighted_rows
             .get(&TypeId::of::<T>())
-            .map_or(&[] as &[_], |vec| vec.as_slice())
+            .map_or(&[] as &[_], |highlights| highlights.ranges.as_slice())
             .iter()
             .map(|highlight| (highlight.range.clone(), (highlight.color)(cx)))
     }
@@ -9231,21 +9240,81 @@ impl Editor {
         cx: &mut App,
     ) -> BTreeMap<DisplayRow, LineHighlight> {
         let snapshot = self.snapshot(window, cx);
+        let max_row = snapshot.max_point().row();
+        self.highlighted_display_rows_in_range(
+            Anchor::Min..Anchor::Max,
+            DisplayRow(0)..max_row.next_row(),
+            &snapshot.display_snapshot,
+            cx,
+        )
+    }
+
+    pub fn highlighted_display_rows_in_range(
+        &self,
+        anchor_range: Range<Anchor>,
+        display_row_range: Range<DisplayRow>,
+        snapshot: &DisplaySnapshot,
+        cx: &App,
+    ) -> BTreeMap<DisplayRow, LineHighlight> {
+        if display_row_range.is_empty() {
+            return BTreeMap::default();
+        }
+
+        let buffer_snapshot = snapshot.buffer_snapshot();
         let mut used_highlight_orders = HashMap::default();
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.iter())
+            .flat_map(|highlighted_rows| {
+                let ranges = highlighted_rows.ranges.as_slice();
+                let (start_index, end_index) = if highlighted_rows.has_diff_base_anchors {
+                    (0, ranges.len())
+                } else {
+                    // Diff-base anchor ordering depends on the current diff snapshot, while regular
+                    // buffer anchors preserve their ordering across edits.
+                    let start_index = ranges.partition_point(|highlight| {
+                        highlight
+                            .range
+                            .end
+                            .cmp(&anchor_range.start, buffer_snapshot)
+                            .is_lt()
+                    });
+                    let end_index = ranges.partition_point(|highlight| {
+                        highlight
+                            .range
+                            .start
+                            .cmp(&anchor_range.end, buffer_snapshot)
+                            .is_le()
+                    });
+                    (start_index, end_index)
+                };
+                ranges[start_index..end_index].iter().filter(|highlight| {
+                    highlight
+                        .range
+                        .end
+                        .cmp(&anchor_range.start, buffer_snapshot)
+                        .is_ge()
+                        && highlight
+                            .range
+                            .start
+                            .cmp(&anchor_range.end, buffer_snapshot)
+                            .is_le()
+                })
+            })
             .fold(
                 BTreeMap::<DisplayRow, LineHighlight>::new(),
                 |mut unique_rows, highlight| {
-                    let start = highlight.range.start.to_display_point(&snapshot);
-                    let end = highlight.range.end.to_display_point(&snapshot);
-                    let start_row = start.row().0;
-                    let end_row = if !highlight.range.end.is_max() && end.column() == 0 {
+                    let start = highlight.range.start.to_display_point(snapshot);
+                    let end = highlight.range.end.to_display_point(snapshot);
+                    let start_row = start.row().0.max(display_row_range.start.0);
+                    let mut end_row = if !highlight.range.end.is_max() && end.column() == 0 {
                         end.row().0.saturating_sub(1)
                     } else {
                         end.row().0
                     };
+                    end_row = end_row.min(display_row_range.end.0.saturating_sub(1));
+                    if start_row > end_row {
+                        return unique_rows;
+                    }
                     let mut header_rows = snapshot
                         .blocks_in_range(
                             DisplayRow(start_row)..DisplayRow(end_row.saturating_add(1)),
@@ -9292,7 +9361,7 @@ impl Editor {
     ) -> Option<DisplayRow> {
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.iter())
+            .flat_map(|highlighted_rows| highlighted_rows.ranges.iter())
             .filter_map(|highlight| {
                 if highlight.options.autoscroll {
                     Some(highlight.range.start.to_display_point(snapshot).row())
@@ -9766,7 +9835,7 @@ impl Editor {
         let current_execution_position = self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .and_then(|lines| lines.last().map(|line| line.range.end));
+            .and_then(|lines| lines.ranges.last().map(|line| line.range.end));
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
             let inline_values = editor

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -84,6 +84,108 @@ fn display_ranges(editor: &Editor, cx: &mut Context<'_, Editor>) -> Vec<Range<Di
         .display_ranges(&editor.display_snapshot(cx))
 }
 
+#[gpui::test]
+fn test_highlighted_display_rows_in_range(cx: &mut TestAppContext) {
+    struct FirstHighlight;
+    struct SecondHighlight;
+
+    init_test(cx, |_| {});
+    let buffer = cx.new(|cx| language::Buffer::local(sample_text(8, 3, 'a'), cx));
+    let editor = cx.add_window(|window, cx| Editor::for_buffer(buffer, None, window, cx));
+
+    assert!(
+        editor
+            .update(cx, |editor, window, cx| {
+                let buffer = editor.buffer().read(cx).snapshot(cx);
+                editor.highlight_rows::<FirstHighlight>(
+                    buffer.anchor_before(Point::new(0, 0))..buffer.anchor_before(Point::new(6, 0)),
+                    |cx| cx.theme().colors().editor_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(0, 0))..buffer.anchor_before(Point::new(1, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(3, 0))..buffer.anchor_before(Point::new(4, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(6, 0))..buffer.anchor_before(Point::new(7, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+
+                let display_row_range = DisplayRow(2)..DisplayRow(5);
+                let expected = editor
+                    .highlighted_display_rows(window, cx)
+                    .into_iter()
+                    .filter(|(row, _)| display_row_range.contains(row))
+                    .collect::<BTreeMap<_, _>>();
+                let snapshot = editor.snapshot(window, cx);
+                let actual = editor.highlighted_display_rows_in_range(
+                    buffer.anchor_before(Point::new(2, 0))..buffer.anchor_before(Point::new(5, 0)),
+                    display_row_range,
+                    &snapshot.display_snapshot,
+                    cx,
+                );
+
+                assert_eq!(actual, expected);
+
+                let highlight_start = buffer.anchor_before(Point::new(2, 0));
+                let Some(block_id) = editor
+                    .insert_blocks(
+                        [BlockProperties {
+                            style: BlockStyle::Fixed,
+                            placement: BlockPlacement::Above(highlight_start),
+                            height: Some(1),
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        }],
+                        None,
+                        cx,
+                    )
+                    .into_iter()
+                    .next()
+                else {
+                    panic!("expected an inserted block");
+                };
+                editor.highlight_rows::<SecondHighlight>(
+                    highlight_start..buffer.anchor_before(Point::new(4, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                let Some(block_row) = editor.row_for_block(block_id, cx) else {
+                    panic!("expected an inserted block row");
+                };
+                let display_row_range = block_row..block_row.next_row();
+                let expected = editor
+                    .highlighted_display_rows(window, cx)
+                    .into_iter()
+                    .filter(|(row, _)| display_row_range.contains(row))
+                    .collect::<BTreeMap<_, _>>();
+                let snapshot = editor.snapshot(window, cx);
+                let actual = editor.highlighted_display_rows_in_range(
+                    buffer.anchor_before(Point::new(1, 0))..highlight_start,
+                    display_row_range,
+                    &snapshot.display_snapshot,
+                    cx,
+                );
+
+                assert!(!expected.is_empty());
+                assert_eq!(actual, expected);
+            })
+            .is_ok()
+    );
+}
+
 #[cfg(any(test, feature = "test-support"))]
 pub mod property_test;
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8215,9 +8215,13 @@ impl Element for EditorElement {
                         )
                     };
 
-                    let mut highlighted_rows = self
-                        .editor
-                        .update(cx, |editor, cx| editor.highlighted_display_rows(window, cx));
+                    let mut highlighted_rows =
+                        self.editor.read(cx).highlighted_display_rows_in_range(
+                            start_anchor..end_anchor,
+                            start_row..end_row,
+                            &snapshot.display_snapshot,
+                            cx,
+                        );
 
                     let mut highlighted_ranges = self
                         .editor_with_selections(cx)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1158,7 +1158,7 @@ impl Item for Editor {
         if self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .is_some_and(|lines| !lines.ranges.is_empty())
+            .is_some_and(|lines| !lines.is_empty())
             && let Some(breakpoint_store) = self.breakpoint_store.as_ref()
         {
             breakpoint_store.update(cx, |store, _cx| {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1158,7 +1158,7 @@ impl Item for Editor {
         if self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .is_some_and(|lines| !lines.is_empty())
+            .is_some_and(|lines| !lines.ranges.is_empty())
             && let Some(breakpoint_store) = self.breakpoint_store.as_ref()
         {
             breakpoint_store.update(cx, |store, _cx| {

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -237,25 +237,39 @@ fn conflicts_updated(
     // Add new highlights and blocks
     let editor_handle = cx.weak_entity();
     let new_conflicts = &conflict_set.conflicts[event.new_range.clone()];
+    let mut converted_ranges = snapshot
+        .ordered_buffer_anchor_ranges_to_anchor_ranges(new_conflicts.iter().flat_map(|conflict| {
+            [
+                conflict.range.start..conflict.range.start,
+                conflict.range.clone(),
+                conflict.ours.clone(),
+                conflict.theirs.clone(),
+            ]
+        }))
+        .into_iter();
     let mut blocks = Vec::new();
     for conflict in new_conflicts {
-        update_conflict_highlighting(editor, conflict, &snapshot, cx);
+        let block_anchor = converted_ranges.next().flatten().map(|range| range.start);
+        let outer = converted_ranges.next().flatten();
+        let ours = converted_ranges.next().flatten();
+        let theirs = converted_ranges.next().flatten();
+        if let (Some(outer), Some(ours), Some(theirs)) = (outer, ours, theirs) {
+            update_conflict_highlighting(editor, conflict, outer, ours, theirs, cx);
+        }
 
-        let Some(anchor) = snapshot.anchor_in_excerpt(conflict.range.start) else {
-            continue;
-        };
-
-        let editor_handle = editor_handle.clone();
-        blocks.push(BlockProperties {
-            placement: BlockPlacement::Above(anchor),
-            height: Some(1),
-            style: BlockStyle::Sticky,
-            render: Arc::new({
-                let conflict = conflict.clone();
-                move |cx| render_conflict_buttons(&conflict, editor_handle.clone(), cx)
-            }),
-            priority: 0,
-        })
+        if let Some(anchor) = block_anchor {
+            let editor_handle = editor_handle.clone();
+            blocks.push(BlockProperties {
+                placement: BlockPlacement::Above(anchor),
+                height: Some(1),
+                style: BlockStyle::Sticky,
+                render: Arc::new({
+                    let conflict = conflict.clone();
+                    move |cx| render_conflict_buttons(&conflict, editor_handle.clone(), cx)
+                }),
+                priority: 0,
+            })
+        }
     }
     let new_block_ids = editor.insert_blocks(blocks, None, cx);
 
@@ -279,14 +293,12 @@ fn conflicts_updated(
 fn update_conflict_highlighting(
     editor: &mut Editor,
     conflict: &ConflictRegion,
-    buffer: &editor::MultiBufferSnapshot,
+    outer: Range<editor::Anchor>,
+    ours: Range<editor::Anchor>,
+    theirs: Range<editor::Anchor>,
     cx: &mut Context<Editor>,
-) -> Option<()> {
+) {
     log::debug!("update conflict highlighting for {conflict:?}");
-
-    let outer = buffer.buffer_anchor_range_to_anchor_range(conflict.range.clone())?;
-    let ours = buffer.buffer_anchor_range_to_anchor_range(conflict.ours.clone())?;
-    let theirs = buffer.buffer_anchor_range_to_anchor_range(conflict.theirs.clone())?;
 
     let ours_background = |cx: &App| cx.theme().colors().version_control_conflict_marker_ours;
     let theirs_background = |cx: &App| cx.theme().colors().version_control_conflict_marker_theirs;
@@ -318,8 +330,6 @@ fn update_conflict_highlighting(
         options,
         cx,
     );
-
-    Some(())
 }
 
 fn render_conflict_buttons(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5382,6 +5382,97 @@ impl MultiBufferSnapshot {
         None
     }
 
+    /// Converts ranges from one buffer in start-anchor order without restarting the excerpt scan
+    /// for every range. Unordered or mixed-buffer input falls back to independent conversions.
+    pub fn ordered_buffer_anchor_ranges_to_anchor_ranges(
+        &self,
+        text_anchor_ranges: impl IntoIterator<Item = Range<text::Anchor>>,
+    ) -> Vec<Option<Range<Anchor>>> {
+        let text_anchor_ranges = text_anchor_ranges.into_iter().collect::<Vec<_>>();
+        let Some(first_range) = text_anchor_ranges.first() else {
+            return Vec::new();
+        };
+        let buffer_id = first_range.start.buffer_id;
+        let ranges_share_buffer = text_anchor_ranges
+            .iter()
+            .all(|range| range.start.buffer_id == buffer_id && range.end.buffer_id == buffer_id);
+        if !ranges_share_buffer {
+            return text_anchor_ranges
+                .into_iter()
+                .map(|range| self.buffer_anchor_range_to_anchor_range(range))
+                .collect();
+        }
+
+        let Some(buffer_state) = self.buffers.get(&buffer_id) else {
+            return vec![None; text_anchor_ranges.len()];
+        };
+        let buffer_snapshot = &buffer_state.buffer_snapshot;
+        let ranges_are_ordered = text_anchor_ranges.windows(2).all(|ranges| {
+            ranges[0]
+                .start
+                .cmp(&ranges[1].start, buffer_snapshot)
+                .is_le()
+        });
+        if !ranges_are_ordered {
+            return text_anchor_ranges
+                .into_iter()
+                .map(|range| self.buffer_anchor_range_to_anchor_range(range))
+                .collect();
+        }
+
+        let path_key = buffer_state.path_key.clone();
+        let mut cursor = self.excerpts.cursor::<PathKey>(());
+        cursor.seek_forward(&path_key, Bias::Left);
+        let excerpts = iter::from_fn(move || {
+            let excerpt = cursor.item()?;
+            if excerpt.path_key != path_key {
+                return None;
+            }
+            cursor.next();
+            Some(excerpt)
+        })
+        .collect::<Vec<_>>();
+        let mut first_candidate_index = 0;
+        text_anchor_ranges
+            .into_iter()
+            .map(|range| {
+                while let Some(excerpt) = excerpts.get(first_candidate_index) {
+                    let buffer_snapshot = excerpt.buffer_snapshot(self);
+                    if excerpt
+                        .range
+                        .context
+                        .end
+                        .cmp(&range.start, buffer_snapshot)
+                        .is_lt()
+                    {
+                        first_candidate_index += 1;
+                        continue;
+                    }
+                    break;
+                }
+
+                for excerpt in &excerpts[first_candidate_index..] {
+                    let buffer_snapshot = excerpt.buffer_snapshot(self);
+                    if excerpt
+                        .range
+                        .context
+                        .start
+                        .cmp(&range.start, buffer_snapshot)
+                        .is_gt()
+                    {
+                        break;
+                    }
+                    if excerpt.range.contains(&range.start, buffer_snapshot)
+                        && excerpt.range.contains(&range.end, buffer_snapshot)
+                    {
+                        return Some(Anchor::range_in_buffer(excerpt.path_key_index, range));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
     /// Returns a buffer anchor and its buffer snapshot for the given anchor, if it is in the multibuffer.
     pub fn anchor_to_buffer_anchor(
         &self,

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1166,6 +1166,76 @@ fn test_remove_excerpts_for_paths(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_ordered_buffer_anchor_ranges_to_anchor_ranges(cx: &mut App) {
+    let buffer = cx.new(|cx| Buffer::local(sample_text(12, 3, 'a'), cx));
+    let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));
+    multibuffer.update(cx, |multibuffer, cx| {
+        multibuffer.set_excerpts_for_path(
+            PathKey::for_buffer(&buffer, cx),
+            buffer.clone(),
+            [
+                Point::new(1, 0)..Point::new(1, 3),
+                Point::new(5, 0)..Point::new(5, 3),
+                Point::new(9, 0)..Point::new(9, 3),
+            ],
+            0,
+            cx,
+        );
+    });
+
+    let buffer_snapshot = buffer.read(cx).snapshot();
+    let ranges = [
+        buffer_snapshot.anchor_before(Point::new(1, 0))
+            ..buffer_snapshot.anchor_before(Point::new(1, 0)),
+        buffer_snapshot.anchor_before(Point::new(1, 1))
+            ..buffer_snapshot.anchor_after(Point::new(1, 2)),
+        buffer_snapshot.anchor_before(Point::new(3, 0))
+            ..buffer_snapshot.anchor_after(Point::new(3, 2)),
+        buffer_snapshot.anchor_before(Point::new(5, 0))
+            ..buffer_snapshot.anchor_after(Point::new(5, 3)),
+        buffer_snapshot.anchor_before(Point::new(9, 1))
+            ..buffer_snapshot.anchor_after(Point::new(9, 2)),
+    ];
+    let snapshot = multibuffer.read(cx).snapshot(cx);
+    let expected = ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(ranges.clone()),
+        expected
+    );
+
+    let unordered_ranges = ranges.clone().into_iter().rev().collect::<Vec<_>>();
+    let expected = unordered_ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(unordered_ranges),
+        expected
+    );
+
+    let other_buffer = cx.new(|cx| Buffer::local("other", cx));
+    let other_snapshot = other_buffer.read(cx).snapshot();
+    let mixed_buffer_ranges = vec![
+        other_snapshot.anchor_before(Point::zero())..other_snapshot.anchor_after(Point::new(0, 5)),
+        ranges[0].clone(),
+    ];
+    let expected = mixed_buffer_ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(mixed_buffer_ranges),
+        expected
+    );
+}
+
+#[gpui::test]
 fn test_expand_excerpts(cx: &mut App) {
     let buffer = cx.new(|cx| Buffer::local(sample_text(20, 3, 'a'), cx));
     let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));

--- a/script/generate-merge-conflict-benchmark
+++ b/script/generate-merge-conflict-benchmark
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+PRESETS = {
+    "small": (2, 8, 16 * 1024),
+    "medium": (32, 64, 128 * 1024),
+    "severe": (128, 256, 512 * 1024),
+}
+
+
+def run_git(
+    repository: Path, *arguments: str, expect_failure: bool = False
+) -> subprocess.CompletedProcess:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_AUTHOR_NAME": "Zed Benchmark",
+            "GIT_AUTHOR_EMAIL": "benchmark@zed.dev",
+            "GIT_COMMITTER_NAME": "Zed Benchmark",
+            "GIT_COMMITTER_EMAIL": "benchmark@zed.dev",
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", repository, *arguments],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if expect_failure:
+        if result.returncode == 0:
+            raise RuntimeError(f"git {' '.join(arguments)} unexpectedly succeeded")
+    elif result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {stderr}")
+    return result
+
+
+def unchanged_separator(region_index: int) -> str:
+    return "".join(
+        f"// unchanged separator {region_index:04d} {line_index:02d}\n"
+        for line_index in range(10)
+    )
+
+
+def conflict_file(
+    file_index: int, region_count: int, variant: str, padding: int
+) -> str:
+    chunks = [
+        f"// Synthetic merge-conflict workload: file {file_index:04d}, variant {variant}\n"
+    ]
+    for region_index in range(region_count):
+        value = f"{variant}-file-{file_index:04d}-region-{region_index:04d}-"
+        chunks.append(
+            f'pub const VALUE_{region_index:04d}: &str = "{value}{"x" * padding}";\n'
+        )
+        chunks.append(unchanged_separator(region_index))
+    return "".join(chunks)
+
+
+def padding_for_target_size(file_index: int, region_count: int, target_size: int) -> int:
+    unpadded_ours = conflict_file(file_index, region_count, "ours", 0)
+    unpadded_theirs = conflict_file(file_index, region_count, "theirs", 0)
+    marker_overhead = region_count * len(
+        "<<<<<<< HEAD\n=======\n>>>>>>> conflict-side\n"
+    )
+    shared_separator_size = sum(
+        len(unchanged_separator(region_index))
+        for region_index in range(region_count)
+    )
+    minimum_size = (
+        len(unpadded_ours)
+        + len(unpadded_theirs)
+        - shared_separator_size
+        + marker_overhead
+    )
+    if target_size < minimum_size:
+        raise ValueError(
+            f"target size {target_size} is too small for {region_count} regions; "
+            f"minimum is approximately {minimum_size} bytes"
+        )
+    return (target_size - minimum_size) // (2 * region_count)
+
+
+def write_variant(
+    repository: Path,
+    file_count: int,
+    region_count: int,
+    target_size: int,
+    variant: str,
+) -> None:
+    for file_index in range(file_count):
+        path = (
+            repository
+            / "conflicts"
+            / f"module_{file_index:04d}"
+            / f"generated_conflict_{file_index:04d}.rs"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        padding = padding_for_target_size(file_index, region_count, target_size)
+        path.write_text(
+            conflict_file(file_index, region_count, variant, padding),
+            encoding="utf-8",
+        )
+
+
+def validate(repository: Path, file_count: int, region_count: int) -> tuple[int, int]:
+    merge_head = run_git(repository, "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    if not merge_head.stdout.strip():
+        raise RuntimeError("MERGE_HEAD is missing")
+
+    unresolved_output = run_git(
+        repository, "diff", "--name-only", "--diff-filter=U", "-z"
+    ).stdout
+    unresolved_paths = [
+        Path(path.decode()) for path in unresolved_output.split(b"\0") if path
+    ]
+    if len(unresolved_paths) != file_count:
+        raise RuntimeError(
+            f"expected {file_count} unresolved paths, found {len(unresolved_paths)}"
+        )
+
+    total_bytes = 0
+    for relative_path in unresolved_paths:
+        contents = (repository / relative_path).read_bytes()
+        total_bytes += len(contents)
+        marker_counts = (
+            contents.count(b"<<<<<<< "),
+            contents.count(b"======="),
+            contents.count(b">>>>>>> "),
+        )
+        if marker_counts != (region_count, region_count, region_count):
+            raise RuntimeError(
+                f"{relative_path} has marker counts {marker_counts}, "
+                f"expected {(region_count, region_count, region_count)}"
+            )
+
+    status_entries = [
+        entry
+        for entry in run_git(
+            repository, "status", "--porcelain=v1", "-z"
+        ).stdout.split(b"\0")
+        if entry
+    ]
+    if len(status_entries) != file_count or any(
+        not entry.startswith(b"UU ") for entry in status_entries
+    ):
+        raise RuntimeError("the repository contains unexpected status entries")
+
+    return len(unresolved_paths), total_bytes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a deterministic unresolved Git merge for Zed performance testing."
+    )
+    parser.add_argument("destination", type=Path)
+    parser.add_argument(
+        "--preset", choices=PRESETS, default="medium", help="workload size"
+    )
+    arguments = parser.parse_args()
+
+    file_count, region_count, target_size = PRESETS[arguments.preset]
+    destination = arguments.destination.expanduser().resolve()
+    try:
+        destination.mkdir(parents=True, exist_ok=False)
+        run_git(destination, "init", "-b", "main")
+
+        write_variant(destination, file_count, region_count, target_size, "base")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "base")
+
+        run_git(destination, "switch", "-c", "conflict-side")
+        write_variant(destination, file_count, region_count, target_size, "theirs")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "theirs")
+
+        run_git(destination, "switch", "main")
+        write_variant(destination, file_count, region_count, target_size, "ours")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "ours")
+
+        run_git(destination, "merge", "conflict-side", expect_failure=True)
+        unresolved_count, total_bytes = validate(
+            destination, file_count, region_count
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"repository: {destination}")
+    print(f"preset: {arguments.preset}")
+    print(f"unresolved files: {unresolved_count}")
+    print(f"conflict regions per file: {region_count}")
+    print(f"total conflict regions: {unresolved_count * region_count}")
+    print(f"working tree bytes: {total_bytes}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Limit row-highlight expansion during editor rendering to ranges that intersect the visible viewport.
- Use the stable multibuffer anchor ordering established by #62636 to binary-prune every highlight group, including ranges with diff-base anchors.
- Preserve exact-boundary highlights for custom blocks and add regression coverage comparing viewport results with the full-editor result.

This is stacked on #63394 so the benchmark fixture and batched conflict anchor conversion are available independently.

## Performance

The severe synthetic workload contains 128 conflicted files, 256 conflict regions per file, and 163,840 accumulated row-highlight ranges.

In the initial paired measurement, viewport filtering reduced:

- project-diff refresh from 67.6–87.8 seconds to 13.47–13.53 seconds;
- cumulative row-highlight expansion from 53–74 seconds to about 7.7 milliseconds;
- the longest individual expansion from 817–875 milliseconds to 0.063–0.071 milliseconds;
- examined highlight ranges from 10.7–15.6 million to about 2,500.

After isolating this commit from the separate block-insertion experiment and hardening the anchor-boundary behavior, two severe-workload runs completed in 17.75 and 20.51 seconds. Those isolated runs are not a direct A/B comparison with the initial numbers because they intentionally omit the block-insertion fast path.

## Validation

- `cargo test -p editor test_highlighted_display_rows_in_range`
- `./script/clippy -p editor`
- `git diff --check`
- Two independent code reviews focused on viewport boundaries and anchor ordering

Release Notes:

- Improved project diff performance for repositories with many merge conflicts.
