### PR TITLE
Git Panel Multi-Select

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2578,8 +2578,7 @@ impl GitPanel {
     fn add_created_entries_to_exclude_list(
         &mut self,
         action_label: &'static str,
-        add_path: impl Fn(&mut Repository, &RepoPath) -> oneshot::Receiver<anyhow::Result<()>>
-        + 'static,
+        add_path: impl Fn(&mut Repository, &RepoPath) -> oneshot::Receiver<anyhow::Result<()>> + 'static,
         cx: &mut Context<Self>,
     ) {
         maybe!({
@@ -2592,8 +2591,7 @@ impl GitPanel {
                 }
 
                 let repo_path = entry.repo_path;
-                let receiver =
-                    active_repository.update(cx, |repo, _| add_path(repo, &repo_path));
+                let receiver = active_repository.update(cx, |repo, _| add_path(repo, &repo_path));
                 let workspace = workspace.clone();
 
                 cx.spawn(async move |_, cx| {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -710,6 +710,13 @@ enum GitListEntry {
     EmptySection(Section),
 }
 
+/// Stable key used to re-resolve a marked entry's index across list rebuilds,
+/// since raw indices only stay valid for the render pass that produced them.
+enum MarkedEntryKey {
+    File(RepoPath, Option<Section>),
+    Directory(TreeKey),
+}
+
 impl GitListEntry {
     fn status_entry(&self) -> Option<&GitStatusEntry> {
         match self {
@@ -2058,12 +2065,83 @@ impl GitPanel {
         self.selected_entry.and_then(|i| self.entries.get(i))
     }
 
+    /// Extends `marked_entries` to cover every row between the current
+    /// selection (the anchor) and `target`, then moves the anchor to
+    /// `target`. Used by shift-click range selection.
+    fn mark_range(&mut self, target: usize) {
+        let Some(anchor) = self.selected_entry else {
+            return;
+        };
+        for ix in anchor.min(target)..=anchor.max(target) {
+            if !self.marked_entries.contains(&ix) {
+                self.marked_entries.push(ix);
+            }
+        }
+        self.selected_entry = Some(target);
+    }
+
     fn change_entries_by_path(&self) -> impl Iterator<Item = &GitStatusEntry> {
         // A grouping can project one changed file into multiple list rows.
         self.entries
             .iter()
             .filter_map(GitListEntry::status_entry)
             .unique_by(|entry| entry.repo_path.clone())
+    }
+
+    /// Returns the file entries a selection-scoped action should act on:
+    /// the marked set when one exists, otherwise just the current selection.
+    /// Marked directories are expanded to their descendant files. Mirrors
+    /// project_panel's `effective_entries`: a lone mark that isn't the current
+    /// selection still yields just the selection, so one-off actions work
+    /// without requiring the mark to be cleared first.
+    fn effective_status_entries(&self) -> Vec<GitStatusEntry> {
+        let selected = self
+            .selected_entry
+            .and_then(|ix| self.entries.get(ix))
+            .and_then(GitListEntry::status_entry)
+            .cloned();
+
+        if self.marked_entries.is_empty() {
+            return selected.into_iter().collect();
+        }
+
+        let single_mark_excludes_selection = self.selected_entry.is_some_and(
+            |selected_ix| matches!(self.marked_entries.as_slice(), [ix] if *ix != selected_ix),
+        );
+        if single_mark_excludes_selection {
+            return selected.into_iter().collect();
+        }
+
+        self.marked_entries
+            .iter()
+            .flat_map(|&ix| match self.entries.get(ix) {
+                Some(GitListEntry::Directory(_)) => self
+                    .directory_descendants(ix)
+                    .map(<[GitStatusEntry]>::to_vec)
+                    .unwrap_or_default(),
+                Some(entry) => entry.status_entry().cloned().into_iter().collect(),
+                None => Vec::new(),
+            })
+            .unique_by(|entry| entry.repo_path.clone())
+            .collect()
+    }
+
+    /// Like `effective_status_entries`, but falls back to a lone selected
+    /// directory's own path rather than treating it as empty: unlike
+    /// stage/discard, copying a path is meaningful for a directory itself.
+    fn effective_repo_paths(&self) -> Vec<RepoPath> {
+        if self.marked_entries.is_empty() {
+            return self
+                .get_selected_entry()
+                .and_then(GitListEntry::repo_path)
+                .cloned()
+                .into_iter()
+                .collect();
+        }
+        self.effective_status_entries()
+            .into_iter()
+            .map(|entry| entry.repo_path)
+            .collect()
     }
 
     fn directory_descendants(&self, entry_index: usize) -> Option<&[GitStatusEntry]> {
@@ -2202,28 +2280,38 @@ impl GitPanel {
     }
 
     fn copy_path(&mut self, _: &CopyPath, _: &mut Window, cx: &mut Context<Self>) {
-        if let Some((repo_path, repo)) = self
-            .get_selected_entry()
-            .and_then(GitListEntry::repo_path)
-            .zip(self.active_repository.as_ref())
-        {
-            let path = repo.read(cx).repo_path_to_abs_path(repo_path);
-            cx.write_to_clipboard(ClipboardItem::new_string(
-                path.to_string_lossy().into_owned(),
-            ));
-        } else {
+        let Some(repo) = self.active_repository.clone() else {
             cx.propagate();
+            return;
+        };
+        let repo = repo.read(cx);
+        let paths = self
+            .effective_repo_paths()
+            .iter()
+            .map(|repo_path| {
+                repo.repo_path_to_abs_path(repo_path)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
+            cx.propagate();
+        } else {
+            cx.write_to_clipboard(ClipboardItem::new_string(paths.join("\n")));
         }
     }
 
     fn copy_relative_path(&mut self, _: &CopyRelativePath, _: &mut Window, cx: &mut Context<Self>) {
-        if let Some(repo_path) = self.get_selected_entry().and_then(GitListEntry::repo_path) {
-            let path_style = self.project.read(cx).path_style(cx);
-            cx.write_to_clipboard(ClipboardItem::new_string(
-                repo_path.display(path_style).into_owned(),
-            ));
-        } else {
+        let path_style = self.project.read(cx).path_style(cx);
+        let paths = self
+            .effective_repo_paths()
+            .iter()
+            .map(|repo_path| repo_path.display(path_style).into_owned())
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
             cx.propagate();
+        } else {
+            cx.write_to_clipboard(ClipboardItem::new_string(paths.join("\n")));
         }
     }
 
@@ -2264,56 +2352,143 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         let path_style = self.project.read(cx).path_style(cx);
-        maybe!({
-            let list_entry = self.entries.get(self.selected_entry?)?.clone();
-            let entry = list_entry.status_entry()?.to_owned();
-            let skip_prompt = action.skip_prompt || entry.status.is_created();
+        let entries = self.effective_status_entries();
 
-            let prompt = if skip_prompt {
-                Task::ready(Ok(0))
-            } else {
-                let (message, confirm_text) = if entry.status.is_deleted() {
-                    ("Are you sure you want to restore ", "Restore File")
+        if entries.len() <= 1 {
+            maybe!({
+                let entry = entries.into_iter().next()?;
+                let skip_prompt = action.skip_prompt || entry.status.is_created();
+
+                let prompt = if skip_prompt {
+                    Task::ready(Ok(0))
                 } else {
-                    (
-                        "Are you sure you want to discard changes to ",
-                        "Discard Changes",
-                    )
-                };
-                let prompt = window.prompt(
-                    PromptLevel::Warning,
-                    &format!(
-                        "{}{}?",
-                        message,
-                        MarkdownInlineCode(
-                            entry
-                                .repo_path
-                                .file_name()
-                                .unwrap_or(entry.repo_path.display(path_style).as_ref())
+                    let (message, confirm_text) = if entry.status.is_deleted() {
+                        ("Are you sure you want to restore ", "Restore File")
+                    } else {
+                        (
+                            "Are you sure you want to discard changes to ",
+                            "Discard Changes",
+                        )
+                    };
+                    let prompt = window.prompt(
+                        PromptLevel::Warning,
+                        &format!(
+                            "{}{}?",
+                            message,
+                            MarkdownInlineCode(
+                                entry
+                                    .repo_path
+                                    .file_name()
+                                    .unwrap_or(entry.repo_path.display(path_style).as_ref())
+                            ),
                         ),
-                    ),
-                    None,
-                    &[confirm_text, "Cancel"],
-                    cx,
-                );
-                cx.background_spawn(prompt)
-            };
+                        None,
+                        &[confirm_text, "Cancel"],
+                        cx,
+                    );
+                    cx.background_spawn(prompt)
+                };
 
-            let this = cx.weak_entity();
-            window
-                .spawn(cx, async move |cx| {
-                    if prompt.await? != 0 {
-                        return anyhow::Ok(());
-                    }
+                let this = cx.weak_entity();
+                window
+                    .spawn(cx, async move |cx| {
+                        if prompt.await? != 0 {
+                            return anyhow::Ok(());
+                        }
 
-                    this.update_in(cx, |this, window, cx| {
-                        this.revert_entry(&entry, window, cx);
-                    })?;
+                        this.update_in(cx, |this, window, cx| {
+                            this.revert_entry(&entry, window, cx);
+                        })?;
 
-                    Ok(())
-                })
-                .detach();
-            Some(())
+                        Ok(())
+                    })
+                    .detach();
+                Some(())
+            });
+            return;
+        }
+
+        // Multiple marked entries: one combined confirmation instead of a
+        // prompt-per-file, then trash/checkout each group in a single batch.
+        let Some(active_repo) = self.active_repository.clone() else {
+            return;
+        };
+        let workspace = self.workspace.clone();
+
+        let all_created = entries.iter().all(|entry| entry.status.is_created());
+        let mut details = entries
+            .iter()
+            .filter_map(|entry| entry.repo_path.as_ref().file_name())
+            .map(|filename| filename.to_string())
+            .take(5)
+            .join("\n");
+        if entries.len() > 5 {
+            details.push_str(&format!("\nand {} more…", entries.len() - 5));
+        }
+        let message = if all_created {
+            "Trash these files?"
+        } else {
+            "Discard changes to these files?"
+        };
+
+        let prompt_task = if action.skip_prompt {
+            Task::ready(Ok(TrashCancel::Trash))
+        } else {
+            prompt(message, Some(&details), window, cx)
+        };
+
+        cx.spawn_in(window, async move |this, cx| {
+            match prompt_task.await? {
+                TrashCancel::Trash => {}
+                TrashCancel::Cancel => return Ok(()),
+            }
+
+            let (created_entries, tracked_entries): (Vec<_>, Vec<_>) = entries
+                .into_iter()
+                .partition(|entry| entry.status.is_created());
+
+            if !tracked_entries.is_empty() {
+                this.update_in(cx, |this, window, cx| {
+                    this.perform_checkout(tracked_entries, window, cx);
+                })?;
+            }
+
+            if !created_entries.is_empty() {
+                let tasks = workspace.update(cx, |workspace, cx| {
+                    created_entries
+                        .iter()
+                        .filter_map(|entry| {
+                            workspace.project().update(cx, |project, cx| {
+                                let project_path = active_repo
+                                    .read(cx)
+                                    .repo_path_to_project_path(&entry.repo_path, cx)?;
+                                project.trash_file(project_path, cx)
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                })?;
+                let total_count = tasks.len();
+                let to_unstage = created_entries
+                    .into_iter()
+                    .filter(|entry| !entry.status.staging().is_fully_unstaged())
+                    .collect();
+                this.update(cx, |this, cx| this.change_file_stage(false, to_unstage, cx))?;
+
+                let results = futures::future::join_all(tasks).await;
+                let errors: Vec<anyhow::Error> =
+                    results.into_iter().filter_map(|r| r.err()).collect();
+                let failed_count = errors.len();
+                if let Some(first_error) = errors.into_iter().next() {
+                    return Err(anyhow::anyhow!(
+                        "Failed to trash {failed_count} of {total_count} files: {first_error:#}"
+                    ));
+                }
+            }
+
+            Ok(())
+        })
+        .detach_and_prompt_err("Failed to discard changes", window, cx, |e, _, _| {
+            Some(format!("{e}"))
         });
     }
 
@@ -2324,31 +2499,31 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         maybe!({
-            let list_entry = self.entries.get(self.selected_entry?)?.clone();
-            let entry = list_entry.status_entry()?.to_owned();
-
-            if !entry.status.is_created() {
-                return Some(());
-            }
-
             let active_repository = self.active_repository.clone()?;
             let workspace = self.workspace.clone();
-            let repo_path = entry.repo_path;
 
-            let receiver = active_repository
-                .update(cx, |repo, _| repo.add_path_to_gitignore(&repo_path, false));
-
-            cx.spawn(async move |_, cx| {
-                if let Err(e) = receiver.await? {
-                    if let Some(workspace) = workspace.upgrade() {
-                        cx.update(|cx| {
-                            show_error_toast(workspace, "add to .gitignore", e, cx);
-                        });
-                    }
+            for entry in self.effective_status_entries() {
+                if !entry.status.is_created() {
+                    continue;
                 }
-                anyhow::Ok(())
-            })
-            .detach_and_log_err(cx);
+
+                let repo_path = entry.repo_path;
+                let receiver = active_repository
+                    .update(cx, |repo, _| repo.add_path_to_gitignore(&repo_path, false));
+                let workspace = workspace.clone();
+
+                cx.spawn(async move |_, cx| {
+                    if let Err(e) = receiver.await? {
+                        if let Some(workspace) = workspace.upgrade() {
+                            cx.update(|cx| {
+                                show_error_toast(workspace, "add to .gitignore", e, cx);
+                            });
+                        }
+                    }
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            }
 
             Some(())
         });
@@ -2361,32 +2536,32 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         maybe!({
-            let list_entry = self.entries.get(self.selected_entry?)?.clone();
-            let entry = list_entry.status_entry()?.to_owned();
-
-            if !entry.status.is_created() {
-                return Some(());
-            }
-
             let active_repository = self.active_repository.clone()?;
             let workspace = self.workspace.clone();
-            let repo_path = entry.repo_path;
 
-            let receiver = active_repository.update(cx, |repo, _| {
-                repo.add_path_to_git_info_exclude(&repo_path, false)
-            });
-
-            cx.spawn(async move |_, cx| {
-                if let Err(e) = receiver.await? {
-                    if let Some(workspace) = workspace.upgrade() {
-                        cx.update(|cx| {
-                            show_error_toast(workspace, "add to .git/info/exclude", e, cx);
-                        });
-                    }
+            for entry in self.effective_status_entries() {
+                if !entry.status.is_created() {
+                    continue;
                 }
-                anyhow::Ok(())
-            })
-            .detach_and_log_err(cx);
+
+                let repo_path = entry.repo_path;
+                let receiver = active_repository.update(cx, |repo, _| {
+                    repo.add_path_to_git_info_exclude(&repo_path, false)
+                });
+                let workspace = workspace.clone();
+
+                cx.spawn(async move |_, cx| {
+                    if let Err(e) = receiver.await? {
+                        if let Some(workspace) = workspace.upgrade() {
+                            cx.update(|cx| {
+                                show_error_toast(workspace, "add to .git/info/exclude", e, cx);
+                            });
+                        }
+                    }
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            }
 
             Some(())
         });
@@ -3020,16 +3195,36 @@ impl GitPanel {
         let Some(selected_index) = self.selected_entry else {
             return;
         };
-        let Some(selected_entry) = self.entries.get(selected_index).cloned() else {
-            return;
-        };
 
-        if self.is_resolved_conflict(selected_index, cx) {
+        let entries = self.effective_status_entries();
+        if entries.len() <= 1 {
+            let Some(selected_entry) = self.entries.get(selected_index).cloned() else {
+                return;
+            };
+            if self.is_resolved_conflict(selected_index, cx) {
+                return;
+            }
+            let intent = self.stage_intent_for_entry_index(selected_index);
+            self.toggle_staged_for_entry(&selected_entry, intent, window, cx);
             return;
         }
 
+        let Some(active_repository) = self.active_repository.clone() else {
+            return;
+        };
         let intent = self.stage_intent_for_entry_index(selected_index);
-        self.toggle_staged_for_entry(&selected_entry, intent, window, cx);
+        let repo = active_repository.read(cx);
+        let entries = entries
+            .into_iter()
+            .filter(|entry| {
+                !(entry.status.is_conflicted()
+                    && GitPanel::stage_status_for_entry(entry, repo) == StageStatus::Staged)
+            })
+            .collect::<Vec<_>>();
+        let stage = entries
+            .iter()
+            .any(|entry| intent.resolve_with(|| GitPanel::stage_status_for_entry(entry, repo)));
+        self.change_file_stage(stage, entries, cx);
     }
 
     fn stage_range(&mut self, _: &git::StageRange, _window: &mut Window, cx: &mut Context<Self>) {
@@ -3041,14 +3236,13 @@ impl GitPanel {
     }
 
     fn stage_selected(&mut self, _: &git::StageFile, _window: &mut Window, cx: &mut Context<Self>) {
-        let Some(selected_entry) = self.get_selected_entry() else {
-            return;
-        };
-        let Some(status_entry) = selected_entry.status_entry() else {
-            return;
-        };
-        if status_entry.staging != StageStatus::Staged {
-            self.change_file_stage(true, vec![status_entry.clone()], cx);
+        let entries = self
+            .effective_status_entries()
+            .into_iter()
+            .filter(|entry| entry.staging != StageStatus::Staged)
+            .collect::<Vec<_>>();
+        if !entries.is_empty() {
+            self.change_file_stage(true, entries, cx);
         }
     }
 
@@ -3058,14 +3252,13 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(selected_entry) = self.get_selected_entry() else {
-            return;
-        };
-        let Some(status_entry) = selected_entry.status_entry() else {
-            return;
-        };
-        if status_entry.staging != StageStatus::Unstaged {
-            self.change_file_stage(false, vec![status_entry.clone()], cx);
+        let entries = self
+            .effective_status_entries()
+            .into_iter()
+            .filter(|entry| entry.staging != StageStatus::Unstaged)
+            .collect::<Vec<_>>();
+        if !entries.is_empty() {
+            self.change_file_stage(false, entries, cx);
         }
     }
 
@@ -4855,6 +5048,26 @@ impl GitPanel {
             let entry = self.entries.get(index)?.status_entry()?;
             Some((entry.repo_path.clone(), self.section_for_entry_index(index)))
         });
+        // Raw indices only stay valid for the render pass that produced them, so
+        // marks are captured by the same stable key used to re-resolve `selected_entry`
+        // (path+section for files, `TreeKey` for directories) and remapped after rebuild.
+        let marked_change = self
+            .marked_entries
+            .iter()
+            .filter_map(|&index| {
+                let entry = self.entries.get(index)?;
+                if let Some(status_entry) = entry.status_entry() {
+                    Some(MarkedEntryKey::File(
+                        status_entry.repo_path.clone(),
+                        self.section_for_entry_index(index),
+                    ))
+                } else {
+                    entry
+                        .directory_entry()
+                        .map(|directory| MarkedEntryKey::Directory(directory.key.clone()))
+                }
+            })
+            .collect::<Vec<_>>();
         let bulk_staging = self.bulk_staging.take();
         let last_staged_path_prev_index = bulk_staging
             .as_ref()
@@ -5206,6 +5419,15 @@ impl GitPanel {
                 .and_then(|section| self.entry_by_path_in_section(&path, section))
                 .or_else(|| self.entry_by_path(&path));
         }
+        self.marked_entries = marked_change
+            .into_iter()
+            .filter_map(|key| match key {
+                MarkedEntryKey::File(path, section) => section
+                    .and_then(|section| self.entry_by_path_in_section(&path, section))
+                    .or_else(|| self.entry_by_path(&path)),
+                MarkedEntryKey::Directory(key) => self.directory_entry_index(&key),
+            })
+            .collect();
         self.select_first_entry_if_none(window, cx);
         self.select_last_entry_if_out_of_bounds(window, cx);
 
@@ -7632,6 +7854,13 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Right-clicking a row outside the current mark set clears the marks first, so
+        // a stray right-click doesn't silently apply a bulk action to files the user
+        // forgot were marked.
+        if !self.marked_entries.contains(&ix) {
+            self.marked_entries.clear();
+        }
+
         if matches!(self.entries.get(ix), Some(GitListEntry::Directory(_))) {
             self.selected_entry = Some(ix);
             self.deploy_panel_context_menu(position, Some(ix), true, window, cx);
@@ -7639,29 +7868,51 @@ impl GitPanel {
         }
 
         let stage_intent = self.stage_intent_for_entry_index(ix);
-        let Some(entry) = self.entries.get(ix).and_then(|e| e.status_entry()) else {
+        if self
+            .entries
+            .get(ix)
+            .and_then(|e| e.status_entry())
+            .is_none()
+        {
             return;
-        };
+        }
+        self.selected_entry = Some(ix);
+        let effective_entries = self.effective_status_entries();
+        let count = effective_entries.len();
+
         // Resolve against the pending-op-aware status (like the checkboxes do)
         // so the menu label can't lag behind a just-clicked checkbox.
         let repo = self.active_repository.as_ref().map(|repo| repo.read(cx));
-        let stage_title = if stage_intent.resolve_with(|| match repo {
-            Some(repo) => GitPanel::stage_status_for_entry(entry, repo),
-            None => entry.status.staging(),
-        }) {
-            "Stage File"
-        } else {
-            "Unstage File"
+        let goal_to_stage = effective_entries.iter().any(|entry| {
+            stage_intent.resolve_with(|| match repo {
+                Some(repo) => GitPanel::stage_status_for_entry(entry, repo),
+                None => entry.status.staging(),
+            })
+        });
+        let stage_title = match (goal_to_stage, count) {
+            (true, 1) => "Stage File".to_string(),
+            (false, 1) => "Unstage File".to_string(),
+            (true, n) => format!("Stage {n} Files"),
+            (false, n) => format!("Unstage {n} Files"),
         };
-        let restore_title = if entry.status.is_created() {
-            "Trash File"
-        } else if entry.status.is_deleted() {
-            "Restore File"
-        } else {
-            "Discard Changes"
+        let all_created = effective_entries
+            .iter()
+            .all(|entry| entry.status.is_created());
+        let all_deleted = effective_entries
+            .iter()
+            .all(|entry| entry.status.is_deleted());
+        let any_created = effective_entries
+            .iter()
+            .any(|entry| entry.status.is_created());
+        let restore_title = match (count, all_created, all_deleted) {
+            (1, true, _) => "Trash File".to_string(),
+            (1, _, true) => "Restore File".to_string(),
+            (1, false, false) => "Discard Changes".to_string(),
+            (n, true, _) => format!("Trash {n} Files"),
+            (n, _, true) => format!("Restore {n} Files"),
+            (n, false, false) => format!("Discard {n} Changes"),
         };
         let context_menu = ContextMenu::build(window, cx, |context_menu, _, _| {
-            let is_created = entry.status.is_created();
             context_menu
                 .context(self.focus_handle.clone())
                 .action(stage_title, ToggleStaged.boxed_clone())
@@ -7674,26 +7925,31 @@ impl GitPanel {
                 .action("Copy Relative Path", CopyRelativePath.boxed_clone())
                 .separator()
                 .action_disabled_when(
-                    !is_created,
+                    !any_created,
                     "Add to .gitignore",
                     git::AddToGitignore.boxed_clone(),
                 )
                 .action_disabled_when(
-                    !is_created,
+                    !any_created,
                     "Add to .git/info/exclude",
                     git::AddToGitInfoExclude.boxed_clone(),
                 )
                 .separator()
-                .action("Open Diff", menu::Confirm.boxed_clone())
-                .action("Open File Diff", menu::SecondaryConfirm.boxed_clone())
-                .action("View File", ViewFile.boxed_clone())
-                .when(!is_created, |context_menu| {
-                    context_menu
-                        .separator()
-                        .action("View File History", Box::new(git::FileHistory))
+                .action_disabled_when(count > 1, "Open Diff", menu::Confirm.boxed_clone())
+                .action_disabled_when(
+                    count > 1,
+                    "Open File Diff",
+                    menu::SecondaryConfirm.boxed_clone(),
+                )
+                .action_disabled_when(count > 1, "View File", ViewFile.boxed_clone())
+                .when(!all_created, |context_menu| {
+                    context_menu.separator().action_disabled_when(
+                        count > 1,
+                        "View File History",
+                        Box::new(git::FileHistory),
+                    )
                 })
         });
-        self.selected_entry = Some(ix);
         self.set_context_menu(context_menu, position, None, window, cx);
     }
 
@@ -8014,6 +8270,12 @@ impl GitPanel {
             )
             .on_click({
                 cx.listener(move |this, event: &ClickEvent, window, cx| {
+                    if event.modifiers().shift && this.selected_entry.is_some() {
+                        this.mark_range(ix);
+                        cx.notify();
+                        return;
+                    }
+                    this.marked_entries.clear();
                     this.selected_entry = Some(ix);
                     cx.notify();
                     this.open_selected_entry_on_click(event.modifiers().secondary(), window, cx);
@@ -8047,8 +8309,8 @@ impl GitPanel {
         window: &Window,
         cx: &Context<Self>,
     ) -> AnyElement {
-        // TODO: Have not yet plugged in self.marked_entries. Not sure when and why we need that
         let selected = self.selected_entry == Some(ix);
+        let marked = self.marked_entries.contains(&ix);
         let label_color = Color::Muted;
 
         let id: ElementId = ElementId::Name(format!("dir_{}_{}", entry.name, ix).into());
@@ -8058,23 +8320,26 @@ impl GitPanel {
             ElementId::Name(format!("dir_checkbox_wrapper_{}_{}", entry.name, ix).into());
 
         let selected_bg_alpha = 0.08;
+        let marked_bg_alpha = 0.12;
         let state_opacity_step = 0.04;
 
         let info_color = cx.theme().status().info;
         let colors = cx.theme().colors();
 
-        let (base_bg, hover_bg, active_bg) = if selected {
+        let base_bg = match (selected, marked) {
+            (true, true) => info_color.alpha(selected_bg_alpha + marked_bg_alpha),
+            (true, false) => info_color.alpha(selected_bg_alpha),
+            (false, true) => info_color.alpha(marked_bg_alpha),
+            (false, false) => colors.ghost_element_background,
+        };
+
+        let (hover_bg, active_bg) = if selected {
             (
-                info_color.alpha(selected_bg_alpha),
                 info_color.alpha(selected_bg_alpha + state_opacity_step),
                 info_color.alpha(selected_bg_alpha + state_opacity_step * 2.0),
             )
         } else {
-            (
-                colors.ghost_element_background,
-                colors.ghost_element_hover,
-                colors.ghost_element_active,
-            )
+            (colors.ghost_element_hover, colors.ghost_element_active)
         };
 
         let settings = GitPanelSettings::get_global(cx);
@@ -8203,7 +8468,13 @@ impl GitPanel {
             )
             .on_click({
                 let key = entry.key.clone();
-                cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                cx.listener(move |this, event: &ClickEvent, window, cx| {
+                    if event.modifiers().shift && this.selected_entry.is_some() {
+                        this.mark_range(ix);
+                        cx.notify();
+                        return;
+                    }
+                    this.marked_entries.clear();
                     this.selected_entry = Some(ix);
                     this.toggle_directory(&key, window, cx);
                 })
@@ -9807,6 +10078,175 @@ mod tests {
         assert_eq!(
             cx.read_from_clipboard().and_then(|item| item.text()),
             Some(path!("/project/src").to_owned())
+        );
+    }
+
+    #[gpui::test]
+    async fn test_mark_range_extends_and_moves_anchor(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+                "d.rs": "d",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+                ("d.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b, ix_c, ix_d) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("c.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("d.rs")).unwrap(),
+            )
+        });
+
+        panel.update(&mut cx, |panel, _| {
+            panel.selected_entry = Some(ix_a);
+            panel.mark_range(ix_c);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_c));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b, ix_c]);
+        });
+
+        // Shift-clicking again from the new anchor (c) extends further, without
+        // dropping entries already marked on the other side of the anchor.
+        panel.update(&mut cx, |panel, _| {
+            panel.mark_range(ix_d);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_d));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b, ix_c, ix_d]);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_marked_entries_remap_across_rebuild(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let ix_a = panel
+            .read_with(&cx, |panel, _| {
+                entry_index_for_repo_path(panel, &repo_path("a.rs"))
+            })
+            .unwrap();
+        let ix_c = panel
+            .read_with(&cx, |panel, _| {
+                entry_index_for_repo_path(panel, &repo_path("c.rs"))
+            })
+            .unwrap();
+
+        panel.update(&mut cx, |panel, _| {
+            panel.marked_entries = vec![ix_a, ix_c];
+        });
+
+        // Staging b.rs moves it into the Staged section, reshuffling every
+        // index after it — marks must follow their files, not their old slots.
+        let status_entry_b = panel
+            .read_with(&cx, |panel, _| {
+                let ix = entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap();
+                panel.entries[ix].status_entry().cloned()
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.toggle_staged_for_entry(
+                &GitListEntry::Status(status_entry_b),
+                StageIntent::Stage,
+                window,
+                cx,
+            );
+        });
+        await_git_panel_entries(&panel, &mut cx).await;
+
+        panel.read_with(&cx, |panel, _| {
+            let marked_paths = panel
+                .marked_entries
+                .iter()
+                .filter_map(|&ix| panel.entries.get(ix)?.status_entry())
+                .map(|entry| entry.repo_path.clone())
+                .collect::<std::collections::HashSet<_>>();
+            assert_eq!(
+                marked_paths,
+                std::collections::HashSet::from([repo_path("a.rs"), repo_path("c.rs")])
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_discard_multiple_marked_entries_shows_combined_prompt(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+            )
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.selected_entry = Some(ix_a);
+            panel.mark_range(ix_b);
+            panel.revert_selected(&git::RestoreFile::default(), window, cx);
+        });
+
+        let (message, detail) = cx
+            .pending_prompt()
+            .expect("discarding multiple marked files should show one combined prompt");
+        assert_eq!(message, "Discard changes to these files?");
+        assert!(
+            detail.contains("a.rs") && detail.contains("b.rs"),
+            "prompt should list both marked files, got: {detail}"
+        );
+        assert!(
+            !detail.contains("c.rs"),
+            "prompt should not list the unmarked file, got: {detail}"
         );
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -10378,6 +10378,93 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_toggle_mark_builds_disjoint_selection(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b, ix_c) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("c.rs")).unwrap(),
+            )
+        });
+
+        panel.update(&mut cx, |panel, _| {
+            panel.select_single_entry(ix_a);
+        });
+
+        // Cmd/Ctrl-clicking a second, non-adjacent row seeds the mark set with
+        // the current selection (a) before adding the clicked row (c), so the
+        // first toggle adds to the existing selection instead of replacing it.
+        panel.update(&mut cx, |panel, _| {
+            panel.toggle_mark(ix_c);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_c));
+            assert_eq!(panel.range_selection_anchor, Some(ix_c));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_c]);
+        });
+
+        // Toggling a third, disjoint row just adds it, without touching the
+        // rows already marked (which wouldn't be possible with range selection
+        // alone, since a and c aren't adjacent to b).
+        panel.update(&mut cx, |panel, _| {
+            panel.toggle_mark(ix_b);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_b));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b, ix_c]);
+        });
+
+        // Toggling the currently-selected row (b) back off removes it from the
+        // marked set and falls back to re-selecting the last remaining mark,
+        // rather than leaving a stale selection pointing at an unmarked row.
+        panel.update(&mut cx, |panel, _| {
+            panel.toggle_mark(ix_b);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_c));
+            assert_eq!(panel.range_selection_anchor, Some(ix_c));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_c]);
+        });
+
+        // Toggling off every remaining mark clears the selection entirely.
+        panel.update(&mut cx, |panel, _| {
+            panel.toggle_mark(ix_c);
+        });
+        panel.update(&mut cx, |panel, _| {
+            panel.toggle_mark(ix_a);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, None);
+            assert_eq!(panel.range_selection_anchor, None);
+            assert!(panel.marked_entries.is_empty());
+        });
+    }
+
+    #[gpui::test]
     async fn test_checkbox_click_stages_whole_marked_set(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2105,6 +2105,31 @@ impl GitPanel {
         self.range_selection_anchor = Some(ix);
     }
 
+    /// Toggles `ix`'s membership in `marked_entries`, seeding the mark set with
+    /// the current selection first if it's empty, so cmd/ctrl-click adds to the
+    /// existing selection rather than replacing it. Used by cmd/ctrl-click.
+    fn toggle_mark(&mut self, ix: usize) {
+        if self.marked_entries.is_empty()
+            && let Some(selected) = self.selected_entry
+        {
+            self.marked_entries.push(selected);
+        }
+
+        if let Some(position) = self.marked_entries.iter().position(|&marked| marked == ix) {
+            self.marked_entries.remove(position);
+            if self.marked_entries.is_empty() {
+                self.selected_entry = None;
+            } else if self.selected_entry == Some(ix) {
+                self.selected_entry = self.marked_entries.last().copied();
+            }
+        } else {
+            self.marked_entries.push(ix);
+            self.selected_entry = Some(ix);
+        }
+
+        self.range_selection_anchor = self.selected_entry;
+    }
+
     fn change_entries_by_path(&self) -> impl Iterator<Item = &GitStatusEntry> {
         // A grouping can project one changed file into multiple list rows.
         self.entries
@@ -8363,7 +8388,11 @@ impl GitPanel {
                         cx.notify();
                         return;
                     }
-                    this.select_single_entry(ix);
+                    if event.modifiers().secondary() {
+                        this.toggle_mark(ix);
+                    } else {
+                        this.select_single_entry(ix);
+                    }
                     cx.notify();
                     this.open_selected_entry_on_click(event.modifiers().secondary(), window, cx);
                 })
@@ -8562,7 +8591,11 @@ impl GitPanel {
                         cx.notify();
                         return;
                     }
-                    this.select_single_entry(ix);
+                    if event.modifiers().secondary() {
+                        this.toggle_mark(ix);
+                    } else {
+                        this.select_single_entry(ix);
+                    }
                     this.toggle_directory(&key, window, cx);
                 })
             })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -712,6 +712,7 @@ enum GitListEntry {
 
 /// Stable key used to re-resolve a marked entry's index across list rebuilds,
 /// since raw indices only stay valid for the render pass that produced them.
+#[derive(Clone)]
 enum MarkedEntryKey {
     File(RepoPath, Option<Section>),
     Directory(TreeKey),
@@ -2463,7 +2464,10 @@ impl GitPanel {
         };
         let workspace = self.workspace.clone();
 
-        let created_count = entries.iter().filter(|entry| entry.status.is_created()).count();
+        let created_count = entries
+            .iter()
+            .filter(|entry| entry.status.is_created())
+            .count();
         let mut details = entries
             .iter()
             .filter_map(|entry| entry.repo_path.as_ref().file_name())
@@ -2507,39 +2511,7 @@ impl GitPanel {
                 })?;
             }
 
-            if !created_entries.is_empty() {
-                let tasks = workspace.update(cx, |workspace, cx| {
-                    created_entries
-                        .iter()
-                        .filter_map(|entry| {
-                            workspace.project().update(cx, |project, cx| {
-                                let project_path = active_repo
-                                    .read(cx)
-                                    .repo_path_to_project_path(&entry.repo_path, cx)?;
-                                project.trash_file(project_path, cx)
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                })?;
-                let total_count = tasks.len();
-                let to_unstage = created_entries
-                    .into_iter()
-                    .filter(|entry| !entry.status.staging().is_fully_unstaged())
-                    .collect();
-                this.update(cx, |this, cx| this.change_file_stage(false, to_unstage, cx))?;
-
-                let results = futures::future::join_all(tasks).await;
-                let errors: Vec<anyhow::Error> =
-                    results.into_iter().filter_map(|r| r.err()).collect();
-                let failed_count = errors.len();
-                if let Some(first_error) = errors.into_iter().next() {
-                    return Err(anyhow::anyhow!(
-                        "Failed to trash {failed_count} of {total_count} files: {first_error:#}"
-                    ));
-                }
-            }
-
-            Ok(())
+            GitPanel::trash_created_entries(this, workspace, active_repo, created_entries, cx).await
         })
         .detach_and_prompt_err("Failed to discard changes", window, cx, |e, _, _| {
             Some(format!("{e}"))
@@ -2667,6 +2639,51 @@ impl GitPanel {
             }
             Some(())
         });
+    }
+
+    /// Trashes each of `created_entries` (unstaging any that are staged first)
+    /// and reports how many, if any, failed. Shared by `revert_selected` and
+    /// `clean_all`, which both need to trash a batch of untracked files.
+    async fn trash_created_entries(
+        this: WeakEntity<Self>,
+        workspace: WeakEntity<Workspace>,
+        active_repo: Entity<Repository>,
+        created_entries: Vec<GitStatusEntry>,
+        cx: &mut AsyncWindowContext,
+    ) -> anyhow::Result<()> {
+        if created_entries.is_empty() {
+            return Ok(());
+        }
+
+        let tasks = workspace.update(cx, |workspace, cx| {
+            created_entries
+                .iter()
+                .filter_map(|entry| {
+                    workspace.project().update(cx, |project, cx| {
+                        let project_path = active_repo
+                            .read(cx)
+                            .repo_path_to_project_path(&entry.repo_path, cx)?;
+                        project.trash_file(project_path, cx)
+                    })
+                })
+                .collect::<Vec<_>>()
+        })?;
+        let total_count = tasks.len();
+        let to_unstage = created_entries
+            .into_iter()
+            .filter(|entry| !entry.status.staging().is_fully_unstaged())
+            .collect();
+        this.update(cx, |this, cx| this.change_file_stage(false, to_unstage, cx))?;
+
+        let results = futures::future::join_all(tasks).await;
+        let errors: Vec<anyhow::Error> = results.into_iter().filter_map(|r| r.err()).collect();
+        let failed_count = errors.len();
+        if let Some(first_error) = errors.into_iter().next() {
+            return Err(anyhow::anyhow!(
+                "Failed to trash {failed_count} of {total_count} files: {first_error:#}"
+            ));
+        }
+        Ok(())
     }
 
     fn perform_checkout(
@@ -2833,35 +2850,7 @@ impl GitPanel {
                 TrashCancel::Trash => {}
                 TrashCancel::Cancel => return Ok(()),
             }
-            let tasks = workspace.update(cx, |workspace, cx| {
-                to_delete
-                    .iter()
-                    .filter_map(|entry| {
-                        workspace.project().update(cx, |project, cx| {
-                            let project_path = active_repo
-                                .read(cx)
-                                .repo_path_to_project_path(&entry.repo_path, cx)?;
-                            project.trash_file(project_path, cx)
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            })?;
-            let total_count = tasks.len();
-            let to_unstage = to_delete
-                .into_iter()
-                .filter(|entry| !entry.status.staging().is_fully_unstaged())
-                .collect();
-            this.update(cx, |this, cx| this.change_file_stage(false, to_unstage, cx))?;
-
-            let results = futures::future::join_all(tasks).await;
-            let errors: Vec<anyhow::Error> = results.into_iter().filter_map(|r| r.err()).collect();
-            let failed_count = errors.len();
-            if let Some(first_error) = errors.into_iter().next() {
-                return Err(anyhow::anyhow!(
-                    "Failed to trash {failed_count} of {total_count} files: {first_error:#}"
-                ));
-            }
-            Ok(())
+            GitPanel::trash_created_entries(this, workspace, active_repo, to_delete, cx).await
         })
         .detach_and_prompt_err("Failed to trash files", window, cx, |e, _, _| {
             Some(format!("{e}"))
@@ -3092,12 +3081,26 @@ impl GitPanel {
             self.toggle_staged_for_entry(entry, intent, window, cx);
             return;
         }
+        let entries = self.effective_status_entries();
+        self.stage_batch(entries, intent, cx);
+    }
+
+    /// Excludes already-staged conflicted entries (staging those needs an explicit,
+    /// single-entry action since it can't be undone by toggling), resolves whether
+    /// the batch should stage or unstage from `intent`, and applies it. Shared by
+    /// the checkbox (`toggle_staged_for_entry_or_marked`) and keyboard/menu
+    /// (`toggle_staged_for_selected`) bulk-staging paths so they can't diverge.
+    fn stage_batch(
+        &mut self,
+        entries: Vec<GitStatusEntry>,
+        intent: StageIntent,
+        cx: &mut Context<Self>,
+    ) {
         let Some(active_repository) = self.active_repository.clone() else {
             return;
         };
         let repo = active_repository.read(cx);
-        let entries = self
-            .effective_status_entries()
+        let entries = entries
             .into_iter()
             .filter(|entry| {
                 !(entry.status.is_conflicted()
@@ -3297,22 +3300,8 @@ impl GitPanel {
             return;
         }
 
-        let Some(active_repository) = self.active_repository.clone() else {
-            return;
-        };
         let intent = self.stage_intent_for_entry_index(selected_index);
-        let repo = active_repository.read(cx);
-        let entries = entries
-            .into_iter()
-            .filter(|entry| {
-                !(entry.status.is_conflicted()
-                    && GitPanel::stage_status_for_entry(entry, repo) == StageStatus::Staged)
-            })
-            .collect::<Vec<_>>();
-        let stage = entries
-            .iter()
-            .any(|entry| intent.resolve_with(|| GitPanel::stage_status_for_entry(entry, repo)));
-        self.change_file_stage(stage, entries, cx);
+        self.stage_batch(entries, intent, cx);
     }
 
     fn stage_range(&mut self, _: &git::StageRange, _window: &mut Window, cx: &mut Context<Self>) {
@@ -5130,31 +5119,46 @@ impl GitPanel {
         });
     }
 
+    /// Stable key for the entry at `index`, used to re-resolve a selected or
+    /// marked row's position after a rebuild reorders raw indices.
+    fn marked_entry_key(&self, index: usize) -> Option<MarkedEntryKey> {
+        let entry = self.entries.get(index)?;
+        if let Some(status_entry) = entry.status_entry() {
+            Some(MarkedEntryKey::File(
+                status_entry.repo_path.clone(),
+                self.section_for_entry_index(index),
+            ))
+        } else {
+            entry
+                .directory_entry()
+                .map(|directory| MarkedEntryKey::Directory(directory.key.clone()))
+        }
+    }
+
+    /// Resolves a `MarkedEntryKey` captured before a rebuild back to its new index.
+    fn resolve_marked_entry_key(&self, key: &MarkedEntryKey) -> Option<usize> {
+        match key.clone() {
+            MarkedEntryKey::File(path, section) => section
+                .and_then(|section| self.entry_by_path_in_section(&path, section))
+                .or_else(|| self.entry_by_path(&path)),
+            MarkedEntryKey::Directory(key) => self.directory_entry_index(&key),
+        }
+    }
+
     fn update_visible_entries(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let path_style = self.project.read(cx).path_style(cx);
-        let selected_change = self.selected_entry.and_then(|index| {
-            let entry = self.entries.get(index)?.status_entry()?;
-            Some((entry.repo_path.clone(), self.section_for_entry_index(index)))
-        });
         // Raw indices only stay valid for the render pass that produced them, so
-        // marks are captured by the same stable key used to re-resolve `selected_entry`
-        // (path+section for files, `TreeKey` for directories) and remapped after rebuild.
+        // both `selected_entry` and `marked_entries` are captured by the same stable
+        // key (path+section for files, `TreeKey` for directories) and remapped after
+        // rebuild. A selected directory must be captured the same way as a marked one,
+        // otherwise it keeps a stale index across a rebuild that reorders rows.
+        let selected_change = self
+            .selected_entry
+            .and_then(|index| self.marked_entry_key(index));
         let marked_change = self
             .marked_entries
             .iter()
-            .filter_map(|&index| {
-                let entry = self.entries.get(index)?;
-                if let Some(status_entry) = entry.status_entry() {
-                    Some(MarkedEntryKey::File(
-                        status_entry.repo_path.clone(),
-                        self.section_for_entry_index(index),
-                    ))
-                } else {
-                    entry
-                        .directory_entry()
-                        .map(|directory| MarkedEntryKey::Directory(directory.key.clone()))
-                }
-            })
+            .filter_map(|&index| self.marked_entry_key(index))
             .collect::<Vec<_>>();
         let bulk_staging = self.bulk_staging.take();
         let last_staged_path_prev_index = bulk_staging
@@ -5502,19 +5506,12 @@ impl GitPanel {
             self.bulk_staging = bulk_staging;
         }
 
-        if let Some((path, section)) = selected_change {
-            self.selected_entry = section
-                .and_then(|section| self.entry_by_path_in_section(&path, section))
-                .or_else(|| self.entry_by_path(&path));
+        if let Some(key) = selected_change {
+            self.selected_entry = self.resolve_marked_entry_key(&key);
         }
         self.marked_entries = marked_change
-            .into_iter()
-            .filter_map(|key| match key {
-                MarkedEntryKey::File(path, section) => section
-                    .and_then(|section| self.entry_by_path_in_section(&path, section))
-                    .or_else(|| self.entry_by_path(&path)),
-                MarkedEntryKey::Directory(key) => self.directory_entry_index(&key),
-            })
+            .iter()
+            .filter_map(|key| self.resolve_marked_entry_key(key))
             .collect();
         self.select_first_entry_if_none(window, cx);
         self.select_last_entry_if_out_of_bounds(window, cx);
@@ -10480,6 +10477,87 @@ mod tests {
                 marked_paths,
                 std::collections::HashSet::from([repo_path("a.rs"), repo_path("c.rs")])
             );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_selected_directory_remaps_across_rebuild(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let git_panel = settings.git_panel.get_or_insert_default();
+                    git_panel.tree_view = Some(true);
+                    // Group by staging state so that fully staging "aaa/a.rs" moves
+                    // its whole directory into a separate Staged section, actually
+                    // reordering `self.entries` rather than just relabeling rows.
+                    git_panel.group_by = Some(GitPanelGroupBy::Staging);
+                })
+            });
+        });
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "aaa": {
+                    "a.rs": "a",
+                },
+                "zzz": {
+                    "b.rs": "b",
+                },
+            }),
+            &[
+                ("aaa/a.rs", StatusCode::Modified),
+                ("zzz/b.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let dir_ix = panel
+            .read_with(&cx, |panel, _| {
+                panel.entries.iter().position(|entry| {
+                    matches!(entry, GitListEntry::Directory(dir) if dir.key.path == repo_path("zzz"))
+                })
+            })
+            .unwrap();
+
+        // Select the "zzz" directory without marking it, matching the
+        // checkbox/keyboard selection path (marks are a separate, opt-in set).
+        panel.update(&mut cx, |panel, _| {
+            panel.selected_entry = Some(dir_ix);
+            panel.marked_entries.clear();
+        });
+
+        // Fully staging "aaa/a.rs" moves the whole "aaa" directory into the Staged
+        // section, ahead of "zzz", shifting every index after it — the selected
+        // directory must follow by its stable key, not its old raw index.
+        let status_entry_a = panel
+            .read_with(&cx, |panel, _| {
+                let ix = entry_index_for_repo_path(panel, &repo_path("aaa/a.rs")).unwrap();
+                panel.entries[ix].status_entry().cloned()
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.toggle_staged_for_entry(
+                &GitListEntry::Status(status_entry_a),
+                StageIntent::Stage,
+                window,
+                cx,
+            );
+        });
+        cx.executor().run_until_parked();
+        await_git_panel_entries(&panel, &mut cx).await;
+
+        panel.read_with(&cx, |panel, _| {
+            let selected_ix = panel
+                .selected_entry
+                .expect("selection should remain set across the rebuild");
+            let directory = panel.entries[selected_ix]
+                .directory_entry()
+                .expect("selection should still point at the \"zzz\" directory");
+            assert_eq!(directory.key.path, repo_path("zzz"));
         });
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1084,6 +1084,13 @@ pub struct GitPanel {
     max_width_item_index: Option<usize>,
     selected_entry: Option<usize>,
     marked_entries: Vec<usize>,
+    /// The fixed endpoint for shift-click/shift-arrow range selection. Set on every
+    /// non-extending selection (plain click, plain arrow move) and left untouched
+    /// while a range is being extended, so a chain of shift-clicks or shift-arrows
+    /// always measures from the same origin, matching platform file-manager
+    /// convention (Finder, Explorer): the range can grow or shrink back, rather
+    /// than only ever accumulating.
+    range_selection_anchor: Option<usize>,
     tracked_count: usize,
     tracked_staged_count: usize,
     update_visible_entries_task: Task<()>,
@@ -1386,6 +1393,7 @@ impl GitPanel {
                 max_width_item_index: None,
                 selected_entry: None,
                 marked_entries: Vec::new(),
+                range_selection_anchor: None,
                 tracked_count: 0,
                 tracked_staged_count: 0,
                 update_visible_entries_task: Task::ready(()),
@@ -1797,7 +1805,7 @@ impl GitPanel {
     fn select_previous(
         &mut self,
         _: &menu::SelectPrevious,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.active_tab == GitPanelTab::History {
@@ -1868,11 +1876,15 @@ impl GitPanel {
             return;
         };
 
-        self.selected_entry = Some(candidate);
+        if window.modifiers().shift {
+            self.mark_range(candidate);
+        } else {
+            self.select_single_entry(candidate);
+        }
         self.scroll_to_selected_entry(cx);
     }
 
-    fn select_next(&mut self, _: &menu::SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+    fn select_next(&mut self, _: &menu::SelectNext, window: &mut Window, cx: &mut Context<Self>) {
         if self.active_tab == GitPanelTab::History {
             self.select_next_history_entry(cx);
             return;
@@ -1946,7 +1958,11 @@ impl GitPanel {
             return;
         };
 
-        self.selected_entry = Some(candidate);
+        if window.modifiers().shift {
+            self.mark_range(candidate);
+        } else {
+            self.select_single_entry(candidate);
+        }
         self.scroll_to_selected_entry(cx);
     }
 
@@ -2065,19 +2081,27 @@ impl GitPanel {
         self.selected_entry.and_then(|i| self.entries.get(i))
     }
 
-    /// Extends `marked_entries` to cover every row between the current
-    /// selection (the anchor) and `target`, then moves the anchor to
-    /// `target`. Used by shift-click range selection.
+    /// Sets `marked_entries` to exactly the rows between `range_selection_anchor`
+    /// and `target` (replacing any previous marks), then moves the selection
+    /// cursor to `target` without disturbing the anchor. Used by shift-click and
+    /// shift-arrow range selection, so a chain of shift-selections always measures
+    /// from the same fixed point and can shrink a range back, not just grow it.
     fn mark_range(&mut self, target: usize) {
-        let Some(anchor) = self.selected_entry else {
+        let Some(anchor) = self.range_selection_anchor.or(self.selected_entry) else {
             return;
         };
-        for ix in anchor.min(target)..=anchor.max(target) {
-            if !self.marked_entries.contains(&ix) {
-                self.marked_entries.push(ix);
-            }
-        }
+        self.range_selection_anchor = Some(anchor);
+        self.marked_entries = (anchor.min(target)..=anchor.max(target)).collect();
         self.selected_entry = Some(target);
+    }
+
+    /// Resets range selection to a single row: clears any marks and sets both the
+    /// selection and the range anchor to `ix`. Used by plain clicks and plain
+    /// arrow moves, so the next shift-selection starts fresh from here.
+    fn select_single_entry(&mut self, ix: usize) {
+        self.marked_entries.clear();
+        self.selected_entry = Some(ix);
+        self.range_selection_anchor = Some(ix);
     }
 
     fn change_entries_by_path(&self) -> impl Iterator<Item = &GitStatusEntry> {
@@ -2137,6 +2161,15 @@ impl GitPanel {
                 .cloned()
                 .into_iter()
                 .collect();
+        }
+        // A lone mark on the currently selected directory (e.g. a shift-click on
+        // the already-selected row) still means "this directory", not "expand it
+        // to its descendants" the way effective_status_entries would.
+        if let [ix] = self.marked_entries.as_slice()
+            && Some(*ix) == self.selected_entry
+            && let Some(entry @ GitListEntry::Directory(_)) = self.entries.get(*ix)
+        {
+            return entry.repo_path().cloned().into_iter().collect();
         }
         self.effective_status_entries()
             .into_iter()
@@ -3020,6 +3053,40 @@ impl GitPanel {
         }
 
         self.change_file_stage(stage, repo_paths, cx);
+    }
+
+    /// Like `toggle_staged_for_entry`, but when `ix` is part of a multi-row
+    /// mark, applies the toggle to the whole marked set instead of just the
+    /// clicked row, so the checkbox stays consistent with the keyboard and
+    /// context-menu actions (which already go through `effective_status_entries`).
+    fn toggle_staged_for_entry_or_marked(
+        &mut self,
+        ix: usize,
+        entry: &GitListEntry,
+        intent: StageIntent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.marked_entries.len() <= 1 || !self.marked_entries.contains(&ix) {
+            self.toggle_staged_for_entry(entry, intent, window, cx);
+            return;
+        }
+        let Some(active_repository) = self.active_repository.clone() else {
+            return;
+        };
+        let repo = active_repository.read(cx);
+        let entries = self
+            .effective_status_entries()
+            .into_iter()
+            .filter(|entry| {
+                !(entry.status.is_conflicted()
+                    && GitPanel::stage_status_for_entry(entry, repo) == StageStatus::Staged)
+            })
+            .collect::<Vec<_>>();
+        let stage = entries
+            .iter()
+            .any(|entry| intent.resolve_with(|| GitPanel::stage_status_for_entry(entry, repo)));
+        self.change_file_stage(stage, entries, cx);
     }
 
     fn change_file_stage(
@@ -7856,9 +7923,11 @@ impl GitPanel {
     ) {
         // Right-clicking a row outside the current mark set clears the marks first, so
         // a stray right-click doesn't silently apply a bulk action to files the user
-        // forgot were marked.
+        // forgot were marked. This also re-anchors range selection at `ix`, so a
+        // follow-up shift-click ranges from the row that was actually right-clicked.
         if !self.marked_entries.contains(&ix) {
             self.marked_entries.clear();
+            self.range_selection_anchor = Some(ix);
         }
 
         if matches!(self.entries.get(ix), Some(GitListEntry::Directory(_))) {
@@ -8246,7 +8315,8 @@ impl GitPanel {
                                                 } else {
                                                     GitListEntry::Status(entry.clone())
                                                 };
-                                            this.toggle_staged_for_entry(
+                                            this.toggle_staged_for_entry_or_marked(
+                                                ix,
                                                 &list_entry,
                                                 stage_intent,
                                                 window,
@@ -8275,8 +8345,7 @@ impl GitPanel {
                         cx.notify();
                         return;
                     }
-                    this.marked_entries.clear();
-                    this.selected_entry = Some(ix);
+                    this.select_single_entry(ix);
                     cx.notify();
                     this.open_selected_entry_on_click(event.modifiers().secondary(), window, cx);
                 })
@@ -8445,7 +8514,8 @@ impl GitPanel {
                                         if !has_write_access || resolved_conflict {
                                             return;
                                         }
-                                        this.toggle_staged_for_entry(
+                                        this.toggle_staged_for_entry_or_marked(
+                                            ix,
                                             &GitListEntry::Directory(entry.clone()),
                                             stage_intent,
                                             window,
@@ -8474,8 +8544,7 @@ impl GitPanel {
                         cx.notify();
                         return;
                     }
-                    this.marked_entries.clear();
-                    this.selected_entry = Some(ix);
+                    this.select_single_entry(ix);
                     this.toggle_directory(&key, window, cx);
                 })
             })
@@ -9545,7 +9614,7 @@ mod tests {
         repository::repo_path,
         status::{StatusCode, TrackedStatus, UnmergedStatus, UnmergedStatusCode},
     };
-    use gpui::{TestAppContext, UpdateGlobal, VisualTestContext, px};
+    use gpui::{Modifiers, TestAppContext, UpdateGlobal, VisualTestContext, px};
     use indoc::indoc;
     use project::FakeFs;
     use search::{BufferSearchBar, buffer_search::Deploy};
@@ -10079,10 +10148,37 @@ mod tests {
             cx.read_from_clipboard().and_then(|item| item.text()),
             Some(path!("/project/src").to_owned())
         );
+
+        // A directory that is both selected and (trivially) marked, e.g. via a
+        // shift-click on the already-selected row, must still copy its own path
+        // rather than expanding to its descendant files.
+        panel.update(&mut cx, |panel, _| {
+            let entry_index = panel
+                .entries
+                .iter()
+                .position(|entry| {
+                    matches!(entry, GitListEntry::Directory(dir) if dir.key.path == repo_path("src"))
+                })
+                .expect("src directory should exist in the changes list");
+            panel.selected_entry = Some(entry_index);
+            panel.mark_range(entry_index);
+        });
+
+        cx.dispatch_action(CopyRelativePath);
+        assert_eq!(
+            cx.read_from_clipboard().and_then(|item| item.text()),
+            Some(path!("src").to_owned())
+        );
+
+        cx.dispatch_action(CopyPath);
+        assert_eq!(
+            cx.read_from_clipboard().and_then(|item| item.text()),
+            Some(path!("/project/src").to_owned())
+        );
     }
 
     #[gpui::test]
-    async fn test_mark_range_extends_and_moves_anchor(cx: &mut TestAppContext) {
+    async fn test_mark_range_keeps_fixed_anchor(cx: &mut TestAppContext) {
         init_test(cx);
 
         let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
@@ -10123,8 +10219,8 @@ mod tests {
             assert_eq!(marked, vec![ix_a, ix_b, ix_c]);
         });
 
-        // Shift-clicking again from the new anchor (c) extends further, without
-        // dropping entries already marked on the other side of the anchor.
+        // Shift-clicking again extends further from the same fixed anchor (a),
+        // not from the row that was last shift-clicked (c).
         panel.update(&mut cx, |panel, _| {
             panel.mark_range(ix_d);
         });
@@ -10134,6 +10230,169 @@ mod tests {
             marked.sort();
             assert_eq!(marked, vec![ix_a, ix_b, ix_c, ix_d]);
         });
+
+        // Shift-clicking back toward the anchor shrinks the range instead of only
+        // ever growing it, matching platform (Finder/Explorer) convention.
+        panel.update(&mut cx, |panel, _| {
+            panel.mark_range(ix_b);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_b));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b]);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_shift_arrow_extends_and_shrinks_range(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b, ix_c) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("c.rs")).unwrap(),
+            )
+        });
+
+        panel.update(&mut cx, |panel, _| {
+            panel.select_single_entry(ix_a);
+        });
+
+        // Shift-Down extends the range from the fixed anchor (a) without requiring
+        // a mouse gesture, mirroring shift-click.
+        cx.simulate_modifiers_change(Modifiers {
+            shift: true,
+            ..Default::default()
+        });
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.select_next(&menu::SelectNext, window, cx);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_b));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b]);
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.select_next(&menu::SelectNext, window, cx);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_c));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b, ix_c]);
+        });
+
+        // Shift-Up shrinks the range back toward the anchor instead of only
+        // ever growing it.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.select_previous(&menu::SelectPrevious, window, cx);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_b));
+            let mut marked = panel.marked_entries.clone();
+            marked.sort();
+            assert_eq!(marked, vec![ix_a, ix_b]);
+        });
+
+        // Releasing shift and moving again collapses the selection to a single
+        // row and re-anchors it there, so a later shift-move starts fresh.
+        cx.simulate_modifiers_change(Default::default());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.select_next(&menu::SelectNext, window, cx);
+        });
+        panel.read_with(&cx, |panel, _| {
+            assert_eq!(panel.selected_entry, Some(ix_c));
+            assert!(panel.marked_entries.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_checkbox_click_stages_whole_marked_set(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+                "c.rs": "c",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+                ("c.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+            )
+        });
+
+        // Mark a.rs and b.rs (as a shift-click range would), leaving c.rs unmarked.
+        panel.update(&mut cx, |panel, _| {
+            panel.selected_entry = Some(ix_a);
+            panel.mark_range(ix_b);
+        });
+
+        // Clicking the checkbox on one of the marked rows (b.rs) must stage the
+        // whole marked set, not just the clicked row, to stay consistent with
+        // the keyboard/menu stage actions.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            let entry = panel.entries[ix_b].status_entry().cloned().unwrap();
+            panel.toggle_staged_for_entry_or_marked(
+                ix_b,
+                &GitListEntry::Status(entry),
+                StageIntent::Stage,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let stage_status_of = |panel: &Entity<GitPanel>, cx: &VisualTestContext, path: &str| {
+            panel.read_with(cx, |panel, cx| {
+                let repo = panel
+                    .active_repository
+                    .as_ref()
+                    .expect("active repository should exist")
+                    .read(cx);
+                let entry = panel
+                    .change_entries_by_path()
+                    .find(|entry| entry.repo_path == repo_path(path))
+                    .expect("entry should exist")
+                    .clone();
+                GitPanel::stage_status_for_entry(&entry, repo)
+            })
+        };
+
+        assert_eq!(stage_status_of(&panel, &cx, "a.rs"), StageStatus::Staged);
+        assert_eq!(stage_status_of(&panel, &cx, "b.rs"), StageStatus::Staged);
+        assert_eq!(stage_status_of(&panel, &cx, "c.rs"), StageStatus::Unstaged);
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -27,7 +27,7 @@ use editor::{Editor, EditorElement, EditorMode, MultiBuffer, MultiBufferOffset, 
 use editor::{EditorStyle, RewrapOptions};
 use file_icons::FileIcons;
 use futures::StreamExt as _;
-use futures::channel::oneshot::Canceled;
+use futures::channel::oneshot::{self, Canceled};
 use git::Oid;
 use git::commit::ParsedCommitMessage;
 use git::repository::{
@@ -2368,11 +2368,7 @@ impl GitPanel {
                     .into_owned()
             })
             .collect::<Vec<_>>();
-        if paths.is_empty() {
-            cx.propagate();
-        } else {
-            cx.write_to_clipboard(ClipboardItem::new_string(paths.join("\n")));
-        }
+        Self::write_paths_to_clipboard(paths, cx);
     }
 
     fn copy_relative_path(&mut self, _: &CopyRelativePath, _: &mut Window, cx: &mut Context<Self>) {
@@ -2382,6 +2378,13 @@ impl GitPanel {
             .iter()
             .map(|repo_path| repo_path.display(path_style).into_owned())
             .collect::<Vec<_>>();
+        Self::write_paths_to_clipboard(paths, cx);
+    }
+
+    /// Writes `paths` newline-joined to the clipboard, or propagates the action if
+    /// there's nothing to copy. Shared by `copy_path` and `copy_relative_path`, which
+    /// differ only in how each path is formatted before reaching this point.
+    fn write_paths_to_clipboard(paths: Vec<String>, cx: &mut Context<Self>) {
         if paths.is_empty() {
             cx.propagate();
         } else {
@@ -2549,41 +2552,34 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        maybe!({
-            let active_repository = self.active_repository.clone()?;
-            let workspace = self.workspace.clone();
-
-            for entry in self.effective_status_entries() {
-                if !entry.status.is_created() {
-                    continue;
-                }
-
-                let repo_path = entry.repo_path;
-                let receiver = active_repository
-                    .update(cx, |repo, _| repo.add_path_to_gitignore(&repo_path, false));
-                let workspace = workspace.clone();
-
-                cx.spawn(async move |_, cx| {
-                    if let Err(e) = receiver.await? {
-                        if let Some(workspace) = workspace.upgrade() {
-                            cx.update(|cx| {
-                                show_error_toast(workspace, "add to .gitignore", e, cx);
-                            });
-                        }
-                    }
-                    anyhow::Ok(())
-                })
-                .detach_and_log_err(cx);
-            }
-
-            Some(())
-        });
+        self.add_created_entries_to_exclude_list(
+            "add to .gitignore",
+            |repo, repo_path| repo.add_path_to_gitignore(repo_path, false),
+            cx,
+        );
     }
 
     fn add_to_git_info_exclude(
         &mut self,
         _: &git::AddToGitInfoExclude,
         _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.add_created_entries_to_exclude_list(
+            "add to .git/info/exclude",
+            |repo, repo_path| repo.add_path_to_git_info_exclude(repo_path, false),
+            cx,
+        );
+    }
+
+    /// Applies `add_path` to every untracked entry in the effective selection, toasting
+    /// `action_label` on failure. Shared by `add_to_gitignore` and `add_to_git_info_exclude`,
+    /// which differ only in which repository method they call and how to describe it.
+    fn add_created_entries_to_exclude_list(
+        &mut self,
+        action_label: &'static str,
+        add_path: impl Fn(&mut Repository, &RepoPath) -> oneshot::Receiver<anyhow::Result<()>>
+        + 'static,
         cx: &mut Context<Self>,
     ) {
         maybe!({
@@ -2596,16 +2592,15 @@ impl GitPanel {
                 }
 
                 let repo_path = entry.repo_path;
-                let receiver = active_repository.update(cx, |repo, _| {
-                    repo.add_path_to_git_info_exclude(&repo_path, false)
-                });
+                let receiver =
+                    active_repository.update(cx, |repo, _| add_path(repo, &repo_path));
                 let workspace = workspace.clone();
 
                 cx.spawn(async move |_, cx| {
                     if let Err(e) = receiver.await? {
                         if let Some(workspace) = workspace.upgrade() {
                             cx.update(|cx| {
-                                show_error_toast(workspace, "add to .git/info/exclude", e, cx);
+                                show_error_toast(workspace, action_label, e, cx);
                             });
                         }
                     }
@@ -10327,36 +10322,15 @@ mod tests {
             panel.select_single_entry(ix_a);
         });
 
-        // Shift-Down extends the range from the fixed anchor (a) without requiring
-        // a mouse gesture, mirroring shift-click.
+        // Shift-Down routes into `mark_range` (whose grow/shrink-from-anchor logic
+        // is covered by `test_mark_range_keeps_fixed_anchor`) without requiring a
+        // mouse gesture, mirroring shift-click.
         cx.simulate_modifiers_change(Modifiers {
             shift: true,
             ..Default::default()
         });
         panel.update_in(&mut cx, |panel, window, cx| {
             panel.select_next(&menu::SelectNext, window, cx);
-        });
-        panel.read_with(&cx, |panel, _| {
-            assert_eq!(panel.selected_entry, Some(ix_b));
-            let mut marked = panel.marked_entries.clone();
-            marked.sort();
-            assert_eq!(marked, vec![ix_a, ix_b]);
-        });
-
-        panel.update_in(&mut cx, |panel, window, cx| {
-            panel.select_next(&menu::SelectNext, window, cx);
-        });
-        panel.read_with(&cx, |panel, _| {
-            assert_eq!(panel.selected_entry, Some(ix_c));
-            let mut marked = panel.marked_entries.clone();
-            marked.sort();
-            assert_eq!(marked, vec![ix_a, ix_b, ix_c]);
-        });
-
-        // Shift-Up shrinks the range back toward the anchor instead of only
-        // ever growing it.
-        panel.update_in(&mut cx, |panel, window, cx| {
-            panel.select_previous(&menu::SelectPrevious, window, cx);
         });
         panel.read_with(&cx, |panel, _| {
             assert_eq!(panel.selected_entry, Some(ix_b));
@@ -10685,64 +10659,20 @@ mod tests {
     async fn test_discard_multiple_marked_entries_shows_combined_prompt(cx: &mut TestAppContext) {
         init_test(cx);
 
-        let (_, _, _, panel, mut cx) = setup_git_panel_with_changes(
-            cx,
-            json!({
-                ".git": {},
-                "a.rs": "a",
-                "b.rs": "b",
-                "c.rs": "c",
-            }),
-            &[
-                ("a.rs", StatusCode::Modified),
-                ("b.rs", StatusCode::Modified),
-                ("c.rs", StatusCode::Modified),
-            ],
-        )
-        .await;
-
-        let (ix_a, ix_b) = panel.read_with(&cx, |panel, _| {
-            (
-                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
-                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
-            )
-        });
-
-        panel.update_in(&mut cx, |panel, window, cx| {
-            panel.selected_entry = Some(ix_a);
-            panel.mark_range(ix_b);
-            panel.revert_selected(&git::RestoreFile::default(), window, cx);
-        });
-
-        let (message, detail) = cx
-            .pending_prompt()
-            .expect("discarding multiple marked files should show one combined prompt");
-        assert_eq!(message, "Discard changes to these files?");
-        assert!(
-            detail.contains("a.rs") && detail.contains("b.rs"),
-            "prompt should list both marked files, got: {detail}"
-        );
-        assert!(
-            !detail.contains("c.rs"),
-            "prompt should not list the unmarked file, got: {detail}"
-        );
-    }
-
-    #[gpui::test]
-    async fn test_discard_mixed_marked_entries_warns_about_permanent_deletion(
-        cx: &mut TestAppContext,
-    ) {
-        init_test(cx);
-
-        // a.rs is a tracked modification (discarding it just reverts the working
-        // copy); new.rs is untracked (discarding it permanently trashes the file).
-        // Marking both together must not silently pick one wording over the other.
+        // a.rs/b.rs are tracked modifications (discarding just reverts the working
+        // copy); new.rs has no head/index entry at all, so it's untracked/created
+        // (discarding it permanently trashes the file). Built by hand rather than
+        // via `setup_git_panel_with_changes`, since that helper's `set_status_for_repo`
+        // can't express "some files tracked, one file untracked" in a single call:
+        // once any status is set, files left out of the list become tracked-clean
+        // rather than untracked.
         let fs = FakeFs::new(cx.background_executor.clone());
         fs.insert_tree(
             path!("/project"),
             json!({
                 ".git": {},
                 "a.rs": "changed a\n",
+                "b.rs": "changed b\n",
                 "new.rs": "new\n",
             }),
         )
@@ -10750,7 +10680,10 @@ mod tests {
 
         fs.set_head_and_index_for_repo(
             path!("/project/.git").as_ref(),
-            &[("a.rs", "original a\n".into())],
+            &[
+                ("a.rs", "original a\n".into()),
+                ("b.rs", "original b\n".into()),
+            ],
         );
 
         let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
@@ -10777,15 +10710,41 @@ mod tests {
         let panel = workspace.update_in(&mut cx, GitPanel::new);
         await_git_panel_entries(&panel, &mut cx).await;
 
-        let (ix_a, ix_new) = panel.read_with(&cx, |panel, _| {
+        let (ix_a, ix_b, ix_new) = panel.read_with(&cx, |panel, _| {
             (
                 entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
                 entry_index_for_repo_path(panel, &repo_path("new.rs")).unwrap(),
             )
         });
 
+        // A pair of tracked-only marks gets the plain "discard" wording, listing
+        // only the marked files.
         panel.update_in(&mut cx, |panel, window, cx| {
             panel.selected_entry = Some(ix_a);
+            panel.mark_range(ix_b);
+            panel.revert_selected(&git::RestoreFile::default(), window, cx);
+        });
+
+        let (message, detail) = cx
+            .pending_prompt()
+            .expect("discarding multiple marked files should show one combined prompt");
+        assert_eq!(message, "Discard changes to these files?");
+        assert!(
+            detail.contains("a.rs") && detail.contains("b.rs"),
+            "prompt should list both marked files, got: {detail}"
+        );
+        assert!(
+            !detail.contains("new.rs"),
+            "prompt should not list the unmarked file, got: {detail}"
+        );
+        cx.simulate_prompt_answer("Cancel");
+        cx.run_until_parked();
+
+        // Extending the mark to include a created file must not silently pick
+        // one wording over the other: mixing tracked and untracked changes needs
+        // its own "permanently deleted" warning.
+        panel.update_in(&mut cx, |panel, window, cx| {
             panel.marked_entries = vec![ix_a, ix_new];
             panel.revert_selected(&git::RestoreFile::default(), window, cx);
         });

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2229,6 +2229,11 @@ impl GitPanel {
             self.toggle_directory(&dir_entry.key, window, cx);
             return;
         }
+        // Opening a diff only makes sense for a single file; when more than one
+        // is marked this is a no-op, mirroring the disabled "Open Diff" menu item.
+        if self.effective_status_entries().len() > 1 {
+            return;
+        }
         maybe!({
             let selected_index = self.selected_entry?;
             let entry = self.entries.get(selected_index)?.status_entry()?;
@@ -2276,6 +2281,11 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Opening a diff only makes sense for a single file; when more than one
+        // is marked this is a no-op, mirroring the disabled "Open File Diff" menu item.
+        if self.effective_status_entries().len() > 1 {
+            return;
+        }
         maybe!({
             let entry = self
                 .entries
@@ -2292,6 +2302,11 @@ impl GitPanel {
     }
 
     fn view_file(&mut self, _: &ViewFile, window: &mut Window, cx: &mut Context<Self>) {
+        // Viewing a file only makes sense for a single file; when more than one
+        // is marked this is a no-op, mirroring the disabled "View File" menu item.
+        if self.effective_status_entries().len() > 1 {
+            return;
+        }
         maybe!({
             let entry = self.entries.get(self.selected_entry?)?.status_entry()?;
             let project_path = self
@@ -2448,7 +2463,7 @@ impl GitPanel {
         };
         let workspace = self.workspace.clone();
 
-        let all_created = entries.iter().all(|entry| entry.status.is_created());
+        let created_count = entries.iter().filter(|entry| entry.status.is_created()).count();
         let mut details = entries
             .iter()
             .filter_map(|entry| entry.repo_path.as_ref().file_name())
@@ -2458,10 +2473,16 @@ impl GitPanel {
         if entries.len() > 5 {
             details.push_str(&format!("\nand {} more…", entries.len() - 5));
         }
-        let message = if all_created {
+        // Trashing an untracked file is a permanent deletion, unlike discarding
+        // changes to a tracked file (which just reverts the working copy), so a
+        // marked set that mixes the two must say so rather than picking whichever
+        // wording matches the majority of the set.
+        let message = if created_count == entries.len() {
             "Trash these files?"
-        } else {
+        } else if created_count == 0 {
             "Discard changes to these files?"
+        } else {
+            "Discard changes to these files? Untracked files will be permanently deleted."
         };
 
         let prompt_task = if action.skip_prompt {
@@ -10507,6 +10528,171 @@ mod tests {
             !detail.contains("c.rs"),
             "prompt should not list the unmarked file, got: {detail}"
         );
+    }
+
+    #[gpui::test]
+    async fn test_discard_mixed_marked_entries_warns_about_permanent_deletion(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        // a.rs is a tracked modification (discarding it just reverts the working
+        // copy); new.rs is untracked (discarding it permanently trashes the file).
+        // Marking both together must not silently pick one wording over the other.
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.rs": "changed a\n",
+                "new.rs": "new\n",
+            }),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("a.rs", "original a\n".into())],
+        );
+
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        let panel = workspace.update_in(&mut cx, GitPanel::new);
+        await_git_panel_entries(&panel, &mut cx).await;
+
+        let (ix_a, ix_new) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("new.rs")).unwrap(),
+            )
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.selected_entry = Some(ix_a);
+            panel.marked_entries = vec![ix_a, ix_new];
+            panel.revert_selected(&git::RestoreFile::default(), window, cx);
+        });
+
+        let (message, detail) = cx
+            .pending_prompt()
+            .expect("discarding a mixed marked set should show one combined prompt");
+        assert_eq!(
+            message,
+            "Discard changes to these files? Untracked files will be permanently deleted."
+        );
+        assert!(
+            detail.contains("a.rs") && detail.contains("new.rs"),
+            "prompt should list both marked files, got: {detail}"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_discard_multiple_marked_untracked_files_trashes_them(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        // No status entries are set up, so both files are untracked by default
+        // (there is no head/index content for them at all).
+        let (fs, _, _, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "new_a.rs": "a",
+                "new_b.rs": "b",
+            }),
+            &[],
+        )
+        .await;
+
+        let (ix_a, ix_b) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("new_a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("new_b.rs")).unwrap(),
+            )
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.selected_entry = Some(ix_a);
+            panel.marked_entries = vec![ix_a, ix_b];
+            panel.revert_selected(&git::RestoreFile::default(), window, cx);
+        });
+
+        let (message, _detail) = cx
+            .pending_prompt()
+            .expect("discarding untracked marked files should show a trash confirmation");
+        assert_eq!(message, "Trash these files?");
+
+        cx.simulate_prompt_answer("Trash");
+        cx.run_until_parked();
+
+        assert!(!fs.is_file(Path::new(path!("/project/new_a.rs"))).await);
+        assert!(!fs.is_file(Path::new(path!("/project/new_b.rs"))).await);
+    }
+
+    #[gpui::test]
+    async fn test_single_file_actions_are_noop_with_multiple_marked_entries(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        // Open Diff / Open File Diff / View File are single-file actions and are
+        // shown disabled in the context menu once more than one entry is marked;
+        // the underlying Confirm/SecondaryConfirm/ViewFile keybindings must agree
+        // and no-op too, rather than silently acting on whichever row happens to
+        // be `selected_entry`.
+        let (_, _, workspace, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "a.rs": "a",
+                "b.rs": "b",
+            }),
+            &[
+                ("a.rs", StatusCode::Modified),
+                ("b.rs", StatusCode::Modified),
+            ],
+        )
+        .await;
+
+        let (ix_a, ix_b) = panel.read_with(&cx, |panel, _| {
+            (
+                entry_index_for_repo_path(panel, &repo_path("a.rs")).unwrap(),
+                entry_index_for_repo_path(panel, &repo_path("b.rs")).unwrap(),
+            )
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.selected_entry = Some(ix_a);
+            panel.marked_entries = vec![ix_a, ix_b];
+            panel.open_diff(&menu::Confirm, window, cx);
+            panel.open_solo_diff(&menu::SecondaryConfirm, window, cx);
+            panel.view_file(&ViewFile, window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update(&mut cx, |workspace, cx| {
+            assert!(workspace.item_of_type::<ProjectDiff>(cx).is_none());
+            assert!(workspace.item_of_type::<SoloDiffView>(cx).is_none());
+            assert!(workspace.item_of_type::<Editor>(cx).is_none());
+        });
     }
 
     async fn history_panel_for_project(


### PR DESCRIPTION
# Objective

The git panel only ever operated on the single selected entry, so staging, discarding, or copying paths for several files at once meant repeating the action file by file. This PR fixes that.

`marked_entries` already existed as a field on `GitPanel` but was unused.

## Solution

- **Disjoint selection.** Cmd/Ctrl+Click toggles a row in or out of the marked set, seeding it from the current selection first.
- **Range selection.** Shift+Click or Shift+Arrow extends the marked set from a fixed anchor. The anchor only moves on a plain click or arrow move, so a chain of shift selections can shrink back towards it instead of only growing. This matches the conventions in the Finder/Explorer.
- **Effective selection resolution.** `effective_status_entries`/`effective_repo_paths`, mirroring `project_panel`'s `effective_entries`, resolve which files an action targets: the marked set when one exists, with directories expanding to their files, otherwise the current selection. Wired into stage/unstage, `RevertFile`, `Copy Path`/`Copy Relative Path`, and `Add to .gitignore`/`Add to .git/info/exclude`.
- **Combined discard prompt.** Discarding multiple marked files shows one confirmation instead of one per file, listing up to five filenames then "…and N more", and batches the checkout/trash. The wording distinguishes untracked-only, tracked-only, and mixed sets ("Trash these files?" versus "Discard changes to these files? Untracked files will be permanently deleted.")
- **Consistent menu and keybindings.** The right-click menu and the `Confirm`/`SecondaryConfirm`/`ViewFile` keybindings now agree on the marked set: menu labels pluralize as in "Stage 3 Files", single-file-only actions like Open Diff and View File History are disabled or no-op once more than one entry is marked, right-clicking outside the current mark clears it first, and marked/selected rows get a distinct background tint.
- **Stable remapping.** Marked entries are captured by a stable key before each list rebuild, then remapped afterward: repo path plus section for files, `TreeKey` for directories. This is the same approach already used for `selected_entry`.

**Known limitation: Shift+Click on the stage checkbox**

Shift-clicking the stage checkbox itself already had range-staging behaviour on `main`, via `stage_bulk`, anchored on a separate `bulk_staging` field unrelated to `marked_entries`. This PR leaves that untouched. A plain click on a checkbox belonging to a marked row does stage the whole marked set, via `toggle_staged_for_entry_or_marked`, so the two mechanisms coexist rather than being unified.

## Testing

Added unit tests in `crates/git_ui/src/git_panel.rs`:

- **`test_mark_range_keeps_fixed_anchor`**: range selection extends from a fixed anchor and can shrink back without moving it.
- **`test_shift_arrow_extends_and_shrinks_range`**: Shift+Down/Shift+Up route through the same `mark_range` logic as Shift+Click and releasing Shift collapses the selection to a single re-anchored row.
- **`test_toggle_mark_builds_disjoint_selection`**: Cmd/Ctrl+Click seeds the mark set from the current selection, adds disjoint rows, falls back to the last remaining mark when the selected row is toggled off, and clears once every mark is off.
- **`test_checkbox_click_stages_whole_marked_set`**: clicking the stage checkbox on one row of a marked range stages the whole set.
- **`test_marked_entries_remap_across_rebuild`**: marks follow their files, not their old slot indices, after a status change reshuffles the list.
- **`test_selected_directory_remaps_across_rebuild`**: same guarantee for a selected but unmarked directory.
- **`test_discard_multiple_marked_entries_shows_combined_prompt`**: covers the prompt wording for a tracked-only marked pair and, in the same test, for extending the mark to include a created file, so both scenarios share one panel/fs setup instead of two.
- **`test_discard_multiple_marked_untracked_files_trashes_them`**: an all-untracked marked set trashes both files from disk. A mixed or all-tracked set can't run to completion in this harness, since `FakeGitRepository::checkout_files` is `unimplemented!()`; this is a pre-existing test-infra gap that every other discard test in this file works around the same way.
- **`test_single_file_actions_are_noop_with_multiple_marked_entries`**: `Confirm`/`SecondaryConfirm`/`ViewFile` don't open anything when more than one entry is marked.

Ran the existing `git_panel` test suite: 57 passed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

- Shift+Click or Shift+Arrow across a range of files or directories to mark them, or Cmd/Ctrl+Click individual rows to build a disjoint set, then stage, unstage, discard, or copy paths for the whole set via the context menu or keybindings.

---

Release Notes:

- Added multi-select (Shift+Click, Shift+Arrow, Cmd/Ctrl+Click) to the git panel, allowing stage, unstage, discard, and copy path actions to apply to several files at once
