### PR TITLE
theme: Show bundled Docker icon for `.dockerignore` files

### DIFF
--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -66,7 +66,7 @@ pub struct IconDefinition {
 }
 
 const FILE_STEMS_BY_ICON_KEY: &[(&str, &[&str])] = &[
-    ("docker", &["Containerfile", "Dockerfile"]),
+    ("docker", &["Containerfile", "Dockerfile", ".dockerignore"]),
     ("ruby", &["Podfile"]),
     ("heroku", &["Procfile"]),
 ];


### PR DESCRIPTION
## Objective

Fixes #63227 — `.dockerignore` files display a generic icon instead of the Docker icon.

## Solution

Added `.dockerignore` to the list of filenames mapped to the Docker icon in `crates/theme/src/icon_theme.rs`.

## Testing

- No automated tests added; the change is a static mapping.
- Manually verified by opening a project with a `.dockerignore` file in Zed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments (none)
- [x] The content adheres to Zed's UI standards (single icon mapping)
- [ ] Tests cover the new/changed behavior (not required for static mapping)
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

- `.dockerignore` now shows the Docker icon for the bundled icon theme.
