### PR TITLE
Fix paste line range In agent

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -836,14 +836,19 @@ fn single_query_param(url: &Url, name: &'static str) -> Result<Option<String>> {
 }
 
 pub fn selection_name(path: Option<&Path>, line_range: &RangeInclusive<u32>) -> String {
-    format!(
-        "{} ({}:{})",
-        path.and_then(|path| path.file_name())
-            .unwrap_or("Untitled".as_ref())
-            .display(),
-        *line_range.start() + 1,
-        *line_range.end() + 1
-    )
+    let start = *line_range.start() + 1;
+    let end = *line_range.end() + 1;
+
+    let file_name = path
+        .and_then(|path| path.file_name())
+        .unwrap_or("Untitled".as_ref())
+        .display();
+
+    if start == end {
+        format!("{file_name} ({start})")
+    } else {
+        format!("{file_name} ({start}:{end})")
+    }
 }
 
 /// Formats a 0-based, inclusive line range as a 1-based path suffix: `:5` for a

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1080,7 +1080,7 @@ impl MessageEditor {
         // Insert creases for pasted clipboard selections that:
         // 1. Contain exactly one selection
         // 2. Have an associated file path
-        // 3. Span multiple lines (not single-line selections)
+        // 3. Span multiple lines, or cover a whole line (not partial single-line selections)
         // 4. Belong to a file that exists in the current project
         let should_insert_creases = util::maybe!({
             let selections = editor_clipboard_selections.as_ref()?;
@@ -1091,7 +1091,7 @@ impl MessageEditor {
             let file_path = selection.file_path.as_ref()?;
             let line_range = selection.line_range.as_ref()?;
 
-            if line_range.start() == line_range.end() {
+            if line_range.start() == line_range.end() && !selection.is_entire_line {
                 return Some(false);
             }
 
@@ -5151,6 +5151,89 @@ mod tests {
                 abs_path: path!("/project/file.txt").into(),
             }
         );
+    }
+
+    #[gpui::test]
+    async fn test_paste_whole_line_copy_inserts_single_line_mention(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (message_editor, editor, mut cx) =
+            setup_paste_test_message_editor(json!({"file.md": "line 1\nline 2\nline 3\n"}), cx)
+                .await;
+
+        // Copying with an empty selection copies the whole line, including its
+        // trailing newline.
+        let clipboard = ClipboardItem::new_string_with_json_metadata(
+            "line 2\n".to_string(),
+            vec![editor::ClipboardSelection {
+                len: "line 2\n".len(),
+                is_entire_line: true,
+                first_line_indent: 0,
+                file_path: Some(PathBuf::from(path!("/project/file.md"))),
+                line_range: Some(1..=1),
+            }],
+        );
+        cx.write_to_clipboard(clipboard);
+
+        message_editor.update_in(&mut cx, |message_editor, window, cx| {
+            message_editor.paste(&Paste, window, cx);
+        });
+
+        let expected_uri = MentionUri::Selection {
+            abs_path: Some(path!("/project/file.md").into()),
+            line_range: 1..=1,
+            column: None,
+        }
+        .to_uri()
+        .to_string();
+
+        editor.update(&mut cx, |editor, cx| {
+            assert_eq!(editor.text(cx), format!("[@file.md (2)]({expected_uri}) "));
+        });
+
+        let contents = mention_contents(&message_editor, &mut cx).await;
+        let [(uri, Mention::Text { content, .. })] = contents.as_slice() else {
+            panic!("Unexpected mentions");
+        };
+
+        assert_eq!(content, "line 2\n");
+        assert_eq!(
+            uri,
+            &MentionUri::Selection {
+                abs_path: Some(path!("/project/file.md").into()),
+                line_range: 1..=1,
+                column: None,
+            }
+        );
+    }
+
+    #[gpui::test]
+    async fn test_paste_partial_line_copy_inserts_plain_text(cx: &mut TestAppContext) {
+        init_test(cx);
+        let (message_editor, editor, mut cx) =
+            setup_paste_test_message_editor(json!({"file.md": "line 1\nline 2\nline 3\n"}), cx)
+                .await;
+
+        let clipboard = ClipboardItem::new_string_with_json_metadata(
+            "line".to_string(),
+            vec![editor::ClipboardSelection {
+                len: "line".len(),
+                is_entire_line: false,
+                first_line_indent: 0,
+                file_path: Some(PathBuf::from(path!("/project/file.md"))),
+                line_range: Some(1..=1),
+            }],
+        );
+        cx.write_to_clipboard(clipboard);
+
+        message_editor.update_in(&mut cx, |message_editor, window, cx| {
+            message_editor.paste(&Paste, window, cx);
+        });
+
+        editor.update(&mut cx, |editor, cx| {
+            assert_eq!(editor.text(cx), "line");
+        });
+        assert!(mention_contents(&message_editor, &mut cx).await.is_empty());
     }
 
     #[gpui::test]

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -41,7 +41,19 @@ impl ClipboardSelection {
         let line_range = if file_path.is_some() {
             buffer
                 .range_to_buffer_range(range)
-                .map(|(_, buffer_range)| buffer_range.start.row..=buffer_range.end.row)
+                .map(|(_, buffer_range)| {
+                    // Whole-line copies extend to the start of the following line so that
+                    // the trailing newline is included, but that line contributes no text
+                    // and must not be reported as part of the range.
+                    let end_row = if buffer_range.end.column == 0
+                        && buffer_range.end.row > buffer_range.start.row
+                    {
+                        buffer_range.end.row - 1
+                    } else {
+                        buffer_range.end.row
+                    };
+                    buffer_range.start.row..=end_row
+                })
         } else {
             None
         };

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10568,9 +10568,75 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
     let selection = &selections[0];
     assert_eq!(
         selection.line_range,
-        Some(2..=5),
-        "line range should be from original file (rows 2-5), not multibuffer rows (0-2)"
+        Some(2..=4),
+        "line range should be from original file (rows 2-4), not multibuffer rows (0-2)"
     );
+}
+
+#[gpui::test]
+async fn test_clipboard_line_numbers_for_whole_line_copy(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(
+        path!("/file.txt"),
+        "first line\nsecond line\nthird line\nfourth line\nfifth line\n".into(),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/file.txt").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.txt"), cx)
+        })
+        .await
+        .unwrap();
+
+    let multibuffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), multibuffer, window, cx)
+    });
+
+    let line_range_after_copy = |cx: &mut VisualTestContext| {
+        let clipboard_selections: Option<Vec<ClipboardSelection>> = cx
+            .read_from_clipboard()
+            .and_then(|item| item.entries().first().cloned())
+            .and_then(|entry| match entry {
+                gpui::ClipboardEntry::String(text) => text.metadata_json(),
+                _ => None,
+            });
+        let selections = clipboard_selections.expect("should have clipboard selections");
+        assert_eq!(selections.len(), 1);
+        selections[0].line_range.clone()
+    };
+
+    // Copying with an empty selection copies the whole line, which extends to the
+    // start of the next line. Only the line the cursor is on should be reported.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(Default::default(), window, cx, |s| {
+            s.select_ranges([Point::new(1, 3)..Point::new(1, 3)]);
+        });
+        editor.copy(&Copy, window, cx);
+    });
+    assert_eq!(line_range_after_copy(cx), Some(1..=1));
+
+    // A selection that ends at the start of a later line doesn't include that line.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(Default::default(), window, cx, |s| {
+            s.select_ranges([Point::new(1, 0)..Point::new(3, 0)]);
+        });
+        editor.copy(&Copy, window, cx);
+    });
+    assert_eq!(line_range_after_copy(cx), Some(1..=2));
+
+    // A selection ending mid-line still includes that line.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(Default::default(), window, cx, |s| {
+            s.select_ranges([Point::new(1, 0)..Point::new(3, 4)]);
+        });
+        editor.copy(&Copy, window, cx);
+    });
+    assert_eq!(line_range_after_copy(cx), Some(1..=3));
 }
 
 #[gpui::test]


### PR DESCRIPTION
# Objective

- Fixes #63368

Placing the cursor on a line and copying with no selection, then pasting into the agent panel's message editor, produced a mention covering two lines (e.g. `file.md (5:6)`) instead of one. Due to this bug, the agent reads text from a line the user never referred to.

The bug is in `ClipboardSelection::for_buffer`. A whole-line copy expands the selection to `(N, 0)..(N + 1, 0)` so the trailing newline gets included in the copied text. However, the line range is derived as `buffer_range.start.row..=buffer_range.end.row`, treating an exclusive end position as an inclusive end row. Any copy ending at column 0 claimed one extra line, including multi-line copies (rows 5-7 came out as `5..=8`).

The range then flowed through `MessageEditor::paste_item`:

- `should_insert_creases` saw `start != end` and treated a single-line copy as multi-line.
- The crease label read `file.md (N+1:N+2)`.
- The mention resolved to `Point::new(start, 0)..Point::new(end + 1, 0)`, sending the extra line to the agent.

`ClipboardSelection.line_range` has one production consumer, the agent paste path, so fixing it is low risk.

## Solution


- **`crates/editor/src/clipboard.rs`**: when the mapped buffer range spans more than one row and ends at column 0, drop the trailing row as the line contributes no text. This covers `do_copy`, `cut_common`, and vim's yank. Copies ending mid-line, and the last-line-without-trailing-newline path (which ends at `line_len`, not column 0), are unaffected.

- **`crates/agent_ui/src/message_editor.rs`**: the crease guard used to skip single-line selections, which is correct for a partial copy (a word copied mid-line should paste as plain text). With the range fixed, a cursor-line copy now collapses to `N..=N` and would hit that same branch, dropping the file reference entirely. `ClipboardSelection` already carries `is_entire_line`, so the guard now checks that instead: whole-line copies still produce a mention, partial copies still paste as text.

- **`crates/acp_thread/src/mention.rs`**: `selection_name` always formatted `(start:end)`, so a correct single-line range would show as `file.md (5:5)`. It now collapses to `file.md (5)`, matching the issue. This changes every single-line selection mention label (`@selection`, pasted selections); no tests or callers depended on the old format.

**Not addressed here**

`MentionSet::confirm_mention_for_selection` and `format_selection_for_terminal` derive `start.row..=end.row` from a raw editor selection the same way. Selecting from line 5 to the start of line 8 via `@selection` will still claim line 8. It's the same bug at a different entry point with its own tests, which I left out to keep the change reviewable. I'd be happy to follow up, or fold it in with a shared helper.

## Testing

Automated:

- `crates/editor/src/editor_tests.rs`
  - New `test_clipboard_line_numbers_for_whole_line_copy`: a cursor-only copy on row 1 reports `1..=1`; a selection ending at the start of row 3 reports `1..=2`; a selection ending mid-row-3 reports `1..=3`.
  - `test_clipboard_line_numbers_from_multibuffer` had encoded the bug: it asserted `Some(2..=5)` for a copy of three lines (rows 2-4). Updated to `Some(2..=4)`.
- `crates/agent_ui/src/message_editor.rs`
  - New `test_paste_whole_line_copy_inserts_single_line_mention`: pasting whole-line clipboard metadata inserts a `[@file.md (2)](...)` mention resolving to `"line 2\n"`.
  - New `test_paste_partial_line_copy_inserts_plain_text`: a partial copy on the same line still pastes as plain text with no mention.

Suites run on my macOS (Apple Silicon M1 Pro). The change is platform-independent, though Windows has its own clipboard metadata path worth a sanity check.

Manual verification for reviewers:

1. Open any file, put the cursor on a line without selecting, and press Cmd+C.
2. Paste into the agent panel's message editor.
3. The mention should read `file.ext (N)` for the line the cursor was on. Hovering or expanding it should show only that line.
4. Also check: selecting several whole lines and pasting (range should end on the last line with text, not the one after), and copying a word mid-line and pasting (should still insert plain text).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Pasting a cursor-line copy into the agent panel:

| Before | After |
| --- | --- |
| `file.md (5:6)`, two lines sent to the agent | `file.md (5)`, only the line the cursor was on |

---

Release Notes:

- Fixed pasting a copied line into the agent panel referencing an extra line below it