### PR TITLE
git_ui: Stabilize submodule diffs

### DIFF
--- a/crates/git_ui/src/diff_multibuffer.rs
+++ b/crates/git_ui/src/diff_multibuffer.rs
@@ -727,10 +727,16 @@ impl DiffMultibuffer {
         let buffer = multibuffer.buffer(text_anchor.buffer_id)?;
 
         let file = buffer.read(cx).file()?;
-        Some(ProjectPath {
+        let project_path = ProjectPath {
             worktree_id: file.worktree_id(cx),
             path: file.path().clone(),
-        })
+        };
+        let current_repo = self.repo(cx)?;
+        let git_store = current_repo.read(cx).git_store()?;
+        let (path_repo, _) = git_store
+            .read(cx)
+            .repository_and_path_for_project_path(&project_path, cx)?;
+        (path_repo == current_repo).then_some(project_path)
     }
 
     pub(crate) fn added_to_workspace(

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1362,6 +1362,86 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_deploy_at_preserves_nested_active_repository(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {
+                    "modules": {
+                        "nested": {},
+                    },
+                },
+                "parent.txt": "changed parent\n",
+                "nested": {
+                    ".git": "gitdir: ../.git/modules/nested\n",
+                    "nested.txt": "changed nested\n",
+                },
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            Path::new(path!("/project/.git")),
+            &[("parent.txt", "original parent\n".to_string())],
+        );
+        fs.set_head_and_index_for_repo(
+            Path::new(path!("/project/nested/.git")),
+            &[("nested.txt", "original nested\n".to_string())],
+        );
+
+        let project = Project::test(fs, [Path::new(path!("/project"))], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        let (parent_repository, nested_repository) = project.read_with(cx, |project, cx| {
+            let mut repositories = project
+                .git_store()
+                .read(cx)
+                .repositories()
+                .values()
+                .cloned()
+                .collect::<Vec<_>>();
+            repositories
+                .sort_by_key(|repository| repository.read(cx).work_directory_abs_path.clone());
+            (repositories[0].clone(), repositories[1].clone())
+        });
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+        cx.run_until_parked();
+
+        parent_repository.update(cx, |repository, cx| repository.set_as_active_repository(cx));
+        cx.update(|window, cx| {
+            workspace.update(cx, |workspace, cx| {
+                ProjectDiff::deploy_at(workspace, None, window, cx)
+            });
+        });
+        cx.run_until_parked();
+
+        cx.focus(&workspace);
+        nested_repository.update(cx, |repository, cx| repository.set_as_active_repository(cx));
+        cx.update(|window, cx| {
+            workspace.update(cx, |workspace, cx| {
+                ProjectDiff::deploy_at(workspace, None, window, cx)
+            });
+        });
+        cx.run_until_parked();
+
+        let active_repository = project
+            .read_with(cx, |project, cx| project.active_repository(cx))
+            .expect("project should have an active repository");
+        assert_eq!(
+            active_repository.entity_id(),
+            nested_repository.entity_id(),
+            "opening a nested repository diff must preserve the explicit repository selection"
+        );
+    }
+
+    #[gpui::test]
     async fn test_project_diff_actions_filter_mixed_staged_and_unstaged_hunks(
         cx: &mut TestAppContext,
     ) {

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -6568,49 +6568,51 @@ impl Repository {
                     return Ok(());
                 };
 
-                let repo_diff_state_updates = this.update(&mut cx, |this, cx| {
-                    git_store.update(cx, |git_store, cx| {
-                        git_store
-                            .diffs
-                            .iter()
-                            .filter_map(|(buffer_id, diff_state)| {
-                                let buffer_store = git_store.buffer_store.read(cx);
-                                let buffer = buffer_store.get(*buffer_id)?;
-                                let file = File::from_dyn(buffer.read(cx).file())?;
-                                let abs_path = file.worktree.read(cx).absolutize(&file.path);
-                                let repo_path = this.abs_path_to_repo_path(&abs_path)?;
-                                let is_symlink = GitStore::file_is_symlink(file, cx);
-                                log::debug!(
-                                    "start reload diff bases for repo path {}",
-                                    repo_path.as_unix_str()
-                                );
-                                diff_state.update(cx, |diff_state, _| {
-                                    let has_unstaged_diff = diff_state
-                                        .unstaged_diff
-                                        .as_ref()
-                                        .is_some_and(|diff| diff.is_upgradable());
-                                    let has_staged_diff = diff_state
-                                        .staged_diff
-                                        .as_ref()
-                                        .is_some_and(|(diff, _)| diff.is_upgradable());
-                                    let has_uncommitted_diff = diff_state
-                                        .uncommitted_diff
-                                        .as_ref()
-                                        .is_some_and(|set| set.is_upgradable());
+                let repo_diff_state_updates = git_store.update(&mut cx, |git_store, cx| {
+                    git_store
+                        .diffs
+                        .iter()
+                        .filter_map(|(buffer_id, diff_state)| {
+                            let (repository, repo_path) =
+                                git_store.repository_and_path_for_buffer_id(*buffer_id, cx)?;
+                            if repository != this {
+                                return None;
+                            }
 
-                                    Some((
-                                        buffer,
-                                        repo_path,
-                                        is_symlink,
-                                        (has_unstaged_diff || has_staged_diff)
-                                            .then(|| diff_state.index_text.clone()),
-                                        (has_staged_diff || has_uncommitted_diff)
-                                            .then(|| diff_state.head_text.clone()),
-                                    ))
-                                })
+                            let buffer_store = git_store.buffer_store.read(cx);
+                            let buffer = buffer_store.get(*buffer_id)?;
+                            let file = File::from_dyn(buffer.read(cx).file())?;
+                            let is_symlink = GitStore::file_is_symlink(file, cx);
+                            log::debug!(
+                                "start reload diff bases for repo path {}",
+                                repo_path.as_unix_str()
+                            );
+                            diff_state.update(cx, |diff_state, _| {
+                                let has_unstaged_diff = diff_state
+                                    .unstaged_diff
+                                    .as_ref()
+                                    .is_some_and(|diff| diff.is_upgradable());
+                                let has_staged_diff = diff_state
+                                    .staged_diff
+                                    .as_ref()
+                                    .is_some_and(|(diff, _)| diff.is_upgradable());
+                                let has_uncommitted_diff = diff_state
+                                    .uncommitted_diff
+                                    .as_ref()
+                                    .is_some_and(|set| set.is_upgradable());
+
+                                Some((
+                                    buffer,
+                                    repo_path,
+                                    is_symlink,
+                                    (has_unstaged_diff || has_staged_diff)
+                                        .then(|| diff_state.index_text.clone()),
+                                    (has_staged_diff || has_uncommitted_diff)
+                                        .then(|| diff_state.head_text.clone()),
+                                ))
                             })
-                            .collect::<Vec<_>>()
-                    })
+                        })
+                        .collect::<Vec<_>>()
                 })?;
 
                 let buffer_diff_base_changes = cx
@@ -6696,6 +6698,14 @@ impl Repository {
                     for (buffer, diff_bases_change) in buffer_diff_base_changes {
                         let buffer_snapshot = buffer.read(cx).text_snapshot();
                         let buffer_id = buffer_snapshot.remote_id();
+                        let Some((repository, _)) =
+                            git_store.repository_and_path_for_buffer_id(buffer_id, cx)
+                        else {
+                            continue;
+                        };
+                        if repository != this {
+                            continue;
+                        }
                         let Some(diff_state) = git_store.diffs.get(&buffer_id) else {
                             continue;
                         };
@@ -11657,6 +11667,90 @@ mod tests {
                 "regular file should have a git diff base"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_parent_repository_does_not_reload_submodule_diff_base(cx: &mut TestAppContext) {
+        use util::rel_path::rel_path;
+
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {
+                    "modules": {
+                        "nested": {},
+                    },
+                },
+                "parent.txt": "parent\n",
+                "nested": {
+                    ".git": "gitdir: ../.git/modules/nested\n",
+                    "nested.txt": "working tree\n",
+                },
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            Path::new("/project/.git"),
+            &[("parent.txt", "parent\n".into())],
+        );
+        fs.set_head_and_index_for_repo(
+            Path::new("/project/nested/.git"),
+            &[("nested.txt", "committed\n".into())],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        let (worktree_id, git_store) = project.read_with(cx, |project, cx| {
+            (
+                project.worktrees(cx).next().unwrap().read(cx).id(),
+                project.git_store().clone(),
+            )
+        });
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path("nested/nested.txt")), cx)
+            })
+            .await
+            .unwrap();
+        let diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(buffer.clone(), cx)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            diff.read_with(cx, |diff, cx| diff.base_text_string(cx)),
+            Some("committed\n".to_string())
+        );
+
+        let parent_repository = git_store.read_with(cx, |git_store, cx| {
+            git_store
+                .repositories()
+                .values()
+                .find(|repository| {
+                    repository.read(cx).work_directory_abs_path.as_ref() == Path::new("/project")
+                })
+                .cloned()
+                .unwrap()
+        });
+        parent_repository.update(cx, |repository, cx| {
+            repository.reload_buffer_diff_bases(cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            diff.read_with(cx, |diff, cx| diff.base_text_string(cx)),
+            Some("committed\n".to_string()),
+            "refreshing the parent repository must not clear a submodule's diff base"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Fixes #55237.

Keep submodule diff views stable when repository refreshes occur. Parent repository refreshes could overwrite a nested repository buffer's diff base, while workspace focus changes could also replace an explicitly selected nested repository.

## Solution

- Resolve diff buffers to their innermost owning repository before reloading diff bases.
- Revalidate repository ownership after asynchronous revision loading so stale parent repository jobs cannot overwrite nested repository diff state.
- Only expose a diff's active project path when that path belongs to the repository displayed by the diff.
- Add regression coverage for preserving nested repository selection and diff bases.

## Testing

- `cargo test -q -p project test_parent_repository_does_not_reload_submodule_diff_base -- --nocapture`
- `cargo test -q -p git_ui test_deploy_at_preserves_nested_active_repository -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- Manually exercised the submodule diff workflow from #55237.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards (no new UI is introduced)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed submodule diff views losing their comparison base and shifting unexpectedly.
