### PR TITLE
Fixes

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -999,7 +999,18 @@ async fn download_remote_server_binary(
         "failed to download remote server release: {:?}",
         response.status()
     );
-    smol::io::copy(response.body_mut(), &mut temp_file).await?;
+    let expected_bytes = content_length(&response);
+    let downloaded_bytes = smol::io::copy(response.body_mut(), &mut temp_file).await?;
+    // A body that ends early reads as a clean EOF, so without this a truncated download is
+    // indistinguishable from a complete one and gets renamed into place as if whole.
+    if let Some(expected_bytes) = expected_bytes {
+        anyhow::ensure!(
+            downloaded_bytes == expected_bytes,
+            "remote server download is incomplete: got {downloaded_bytes} of {expected_bytes} bytes"
+        );
+    }
+    temp_file.flush().await?;
+    temp_file.sync_all().await?;
     smol::fs::rename(&temp, &target_path).await?;
 
     Ok(())
@@ -1062,13 +1073,30 @@ async fn cleanup_remote_server_cache(
     Ok(())
 }
 
+fn content_length<T>(response: &http_client::Response<T>) -> Option<u64> {
+    response
+        .headers()
+        .get(http_client::http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|total_bytes| *total_bytes > 0)
+}
+
 async fn download_release(
     target_path: &Path,
     release: ReleaseAsset,
     client: Arc<HttpClientWithUrl>,
     mut on_progress: impl FnMut(Option<f32>),
 ) -> Result<()> {
-    let mut target_file = File::create(&target_path).await?;
+    // Stage through a sibling temp file rather than streaming the response straight into the
+    // destination, so an interrupted download cannot leave a partial archive sitting at the
+    // path the installer then reads. This is what `download_remote_server_binary` above
+    // already does for the less consequential of the two downloads.
+    let parent = target_path
+        .parent()
+        .context("download target has no parent directory")?;
+    let temp = tempfile::Builder::new().tempfile_in(parent)?;
+    let mut target_file = File::create(temp.path()).await?;
 
     let mut response = client.get(&release.url, Default::default(), true).await?;
     anyhow::ensure!(
@@ -1077,12 +1105,7 @@ async fn download_release(
         response.status()
     );
 
-    let total_bytes = response
-        .headers()
-        .get(http_client::http::header::CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|total_bytes| *total_bytes > 0);
+    let total_bytes = content_length(&response);
 
     let mut downloaded_bytes: u64 = 0;
     let mut last_reported_percent: Option<u8> = None;
@@ -1106,7 +1129,22 @@ async fn download_release(
             }
         }
     }
+    // A body that ends early reads as a clean EOF, so an incomplete update would otherwise be
+    // installed as if it had downloaded whole.
+    if let Some(total_bytes) = total_bytes {
+        anyhow::ensure!(
+            downloaded_bytes == total_bytes,
+            "update download is incomplete: got {downloaded_bytes} of {total_bytes} bytes"
+        );
+    }
     target_file.flush().await?;
+    target_file.sync_all().await?;
+    drop(target_file);
+    smol::fs::rename(temp.path(), &target_path).await?;
+    // `persist` is not used here: the file has already been renamed away, and dropping the
+    // handle afterwards must not try to remove the destination.
+    temp.keep()?;
+
     if total_bytes.is_some() && last_reported_percent != Some(100) {
         on_progress(Some(1.0));
     }

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1722,6 +1722,7 @@ mod tests {
             language::DiskState::Present {
                 mtime: ::fs::MTime::from_seconds_and_nanos(100, 42),
                 size: 0,
+                inode: None,
             }
         }
 

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1721,7 +1721,7 @@ mod tests {
         fn disk_state(&self) -> language::DiskState {
             language::DiskState::Present {
                 mtime: ::fs::MTime::from_seconds_and_nanos(100, 42),
-                size: 0,
+                size: None,
                 inode: None,
             }
         }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -37,7 +37,6 @@ use git::repository::{GitRepository, RealGitRepository};
 use is_executable::IsExecutable;
 use rope::Rope;
 use serde::{Deserialize, Serialize};
-use smol::io::AsyncWriteExt;
 #[cfg(feature = "test-support")]
 use std::path::Component;
 use std::{
@@ -932,7 +931,15 @@ impl Fs for RealFs {
             let mut tmp_file =
                 tempfile::NamedTempFile::new_in(path.parent().unwrap_or(paths::temp_dir()))?;
             tmp_file.write_all(data.as_bytes())?;
-            tmp_file.persist(path)?;
+            // The rename is atomic against Zed itself crashing, but not against the machine
+            // crashing: a filesystem is free to persist the new directory entry before the
+            // file's data blocks, which leaves a zero-length file at the destination. Syncing
+            // the contents before the rename and the directory after it is what makes the
+            // replacement survive power loss.
+            copy_permissions_from_destination(&path, &tmp_file)?;
+            tmp_file.as_file().sync_all()?;
+            tmp_file.persist(&path)?;
+            fsync_parent_dir(&path)?;
             anyhow::Ok(())
         })
         .await?;
@@ -970,21 +977,14 @@ impl Fs for RealFs {
     }
 
     async fn save(&self, path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
-        let buffer_size = text.summary().len.min(10 * 1024);
-        if let Some(path) = path.parent() {
-            self.create_dir(path)
+        if let Some(parent) = path.parent() {
+            self.create_dir(parent)
                 .await
-                .with_context(|| format!("Failed to create directory at {:?}", path))?;
+                .with_context(|| format!("Failed to create directory at {:?}", parent))?;
         }
-        let file = smol::fs::File::create(path)
-            .await
-            .with_context(|| format!("Failed to create file at {:?}", path))?;
-        let mut writer = smol::io::BufWriter::with_capacity(buffer_size, file);
-        for chunk in text::chunks_with_line_ending(text, line_ending) {
-            writer.write_all(chunk.as_bytes()).await?;
-        }
-        writer.flush().await?;
-        Ok(())
+        let path = path.to_path_buf();
+        let text = text.clone();
+        smol::unblock(move || save_durably(&path, &text, line_ending)).await
     }
 
     async fn write(&self, path: &Path, content: &[u8]) -> Result<()> {
@@ -3527,6 +3527,149 @@ async fn file_id(path: impl AsRef<Path>) -> Result<u64> {
         Ok(((info.nFileIndexHigh as u64) << 32) | (info.nFileIndexLow as u64))
     })
     .await
+}
+
+/// Writes `text` to `path` so that neither a crash nor power loss can leave the destination
+/// truncated, half-written, or holding contents Zed already reported as saved.
+///
+/// `File::create` publishes an empty file before the new contents exist anywhere on disk, and
+/// flushing a `BufWriter` only moves bytes into the kernel's page cache, so the plain write is
+/// destructive at both ends: a crash mid-write destroys the previous contents, and a crash
+/// shortly after a "successful" save can still lose the new ones. Writing a sibling temporary
+/// file, syncing it, and renaming it over the destination keeps a complete version of the file
+/// visible at every instant.
+///
+/// The rename is only used where it does not change what the destination *is*. A path that does
+/// not exist yet, a non-regular file (FIFO, device), a file with other hard links, and a file
+/// whose ownership we cannot reproduce are all written in place instead, since renaming would
+/// respectively apply the temp file's restrictive mode, replace a special file with a regular
+/// one, break the link, or silently change the owner. Those paths are still synced.
+fn save_durably(path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
+    let path = resolve_final_symlink(path);
+
+    let replaceable = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata.is_file() && hard_link_count(&metadata) <= 1,
+        Err(_) => false,
+    };
+    if replaceable && let Some(parent) = path.parent() {
+        match save_via_rename(&path, parent, text, line_ending) {
+            Ok(()) => return Ok(()),
+            // Nothing has touched the destination yet, so falling back is never worse than
+            // writing in place would have been to begin with.
+            Err(error) => log::warn!(
+                "failed to replace {path:?} via a temporary file ({error:#}), writing in place"
+            ),
+        }
+    }
+
+    save_in_place(&path, text, line_ending)
+        .with_context(|| format!("Failed to write file at {:?}", path))
+}
+
+fn save_via_rename(path: &Path, parent: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
+    let mut temp_file = tempfile::NamedTempFile::new_in(parent)?;
+    write_rope(temp_file.as_file_mut(), text, line_ending)?;
+    copy_permissions_from_destination(path, &temp_file)?;
+    temp_file.as_file().sync_all()?;
+    temp_file.persist(path)?;
+    fsync_parent_dir(path)?;
+    Ok(())
+}
+
+fn save_in_place(path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write_rope(&mut file, text, line_ending)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn write_rope(file: &mut std::fs::File, text: &Rope, line_ending: LineEnding) -> io::Result<()> {
+    let buffer_size = text.summary().len.min(10 * 1024).max(1);
+    let mut writer = io::BufWriter::with_capacity(buffer_size, file);
+    for chunk in text::chunks_with_line_ending(text, line_ending) {
+        writer.write_all(chunk.as_bytes())?;
+    }
+    writer.flush()
+}
+
+/// Resolves `path` when its final component is a symlink, so that the contents are written
+/// through to the link's target the way an in-place write would. Left as-is when the link
+/// cannot be resolved: the caller then writes in place, which follows the link itself.
+fn resolve_final_symlink(path: &Path) -> PathBuf {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => std::fs::canonicalize(path)
+            .unwrap_or_else(|error| {
+                log::warn!("failed to resolve symlink {path:?} ({error}), writing through it");
+                path.to_path_buf()
+            }),
+        _ => path.to_path_buf(),
+    }
+}
+
+/// Gives a temporary file the mode, and where it differs from ours the ownership, of the
+/// destination it is about to replace. `NamedTempFile` is created 0600 and `persist` keeps the
+/// temp file's own metadata, so without this a replaced file loses its permissions. Returns an
+/// error rather than proceeding when ownership cannot be reproduced, which sends the caller
+/// back to writing in place.
+fn copy_permissions_from_destination(
+    path: &Path,
+    temp_file: &tempfile::NamedTempFile,
+) -> Result<()> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        // A file that does not exist yet has nothing to preserve.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    temp_file
+        .as_file()
+        .set_permissions(metadata.permissions())?;
+    copy_ownership_from_destination(&metadata, temp_file.path())?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_ownership_from_destination(metadata: &std::fs::Metadata, temp_path: &Path) -> Result<()> {
+    let (uid, gid) = (metadata.uid(), metadata.gid());
+    if uid == unsafe { libc::geteuid() } && gid == unsafe { libc::getegid() } {
+        return Ok(());
+    }
+    std::os::unix::fs::chown(temp_path, Some(uid), Some(gid))
+        .with_context(|| format!("Failed to preserve ownership of {:?}", temp_path))
+}
+
+#[cfg(not(unix))]
+fn copy_ownership_from_destination(_: &std::fs::Metadata, _: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn hard_link_count(metadata: &std::fs::Metadata) -> u64 {
+    metadata.nlink()
+}
+
+#[cfg(not(unix))]
+fn hard_link_count(_: &std::fs::Metadata) -> u64 {
+    1
+}
+
+/// Flushes the directory entry produced by a rename. The rename itself is atomic, but until the
+/// directory's own metadata is synced a system crash can leave the destination pointing at
+/// neither the old nor the new file.
+#[cfg(not(target_os = "windows"))]
+fn fsync_parent_dir(path: &Path) -> io::Result<()> {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    std::fs::File::open(parent)?.sync_all()
+}
+
+/// Windows has no handle for a directory's contents to sync, and `ReplaceFileW` already commits
+/// the replacement itself.
+#[cfg(target_os = "windows")]
+fn fsync_parent_dir(_path: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3543,7 +3543,15 @@ async fn file_id(path: impl AsRef<Path>) -> Result<u64> {
 /// not exist yet, a non-regular file (FIFO, device), a file with other hard links, and a file
 /// whose ownership we cannot reproduce are all written in place instead, since renaming would
 /// respectively apply the temp file's restrictive mode, replace a special file with a regular
-/// one, break the link, or silently change the owner. Those paths are still synced.
+/// one, break the link, or silently change the owner. A symlink is not among them: it is
+/// resolved first and its target replaced, which leaves the link itself intact.
+///
+/// Writing in place keeps the truncate window this function exists to close, and that is the
+/// cost of the guarantee those destinations need instead - a hard link that survives the save
+/// cannot also be replaced by a different file. The in-place writes are still synced, so they
+/// keep the second guarantee: a save that reports success has reached the disk. Only a file
+/// with other hard links, one whose ownership we cannot reproduce, and a symlink we could not
+/// resolve are exposed; a path that does not exist yet has no previous contents to lose.
 fn save_durably(path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()> {
     let path = resolve_final_symlink(path);
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3584,7 +3584,7 @@ fn save_in_place(path: &Path, text: &Rope, line_ending: LineEnding) -> Result<()
 }
 
 fn write_rope(file: &mut std::fs::File, text: &Rope, line_ending: LineEnding) -> io::Result<()> {
-    let buffer_size = text.summary().len.min(10 * 1024).max(1);
+    let buffer_size = text.summary().len.clamp(1, 10 * 1024);
     let mut writer = io::BufWriter::with_capacity(buffer_size, file);
     for chunk in text::chunks_with_line_ending(text, line_ending) {
         writer.write_all(chunk.as_bytes())?;

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -15,6 +15,7 @@ use fs::*;
 use gpui::{BackgroundExecutor, TestAppContext};
 use serde_json::json;
 use tempfile::TempDir;
+use text::LineEnding;
 use util::path;
 
 #[gpui::test]
@@ -455,6 +456,100 @@ async fn test_realfs_atomic_write_non_existing_file(executor: BackgroundExecutor
     gpui::block_on(fs.atomic_write(file_to_be_replaced.clone(), "Hello".into())).unwrap();
     let content = std::fs::read_to_string(&file_to_be_replaced).unwrap();
     assert_eq!(content, "Hello");
+}
+
+#[gpui::test]
+async fn test_realfs_save_replaces_contents(executor: BackgroundExecutor) {
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("file.txt");
+    std::fs::write(&path, "Hello").unwrap();
+
+    gpui::block_on(fs.save(&path, &"World".into(), LineEnding::Unix)).unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "World");
+
+    // A file that does not exist yet is created rather than replaced.
+    let new_path = temp_dir.path().join("new.txt");
+    gpui::block_on(fs.save(&new_path, &"Fresh".into(), LineEnding::Unix)).unwrap();
+    assert_eq!(std::fs::read_to_string(&new_path).unwrap(), "Fresh");
+}
+
+/// Replacing a file by renaming a temporary one over it would otherwise hand the destination
+/// the temp file's 0600 mode.
+#[gpui::test]
+#[cfg(unix)]
+async fn test_realfs_save_preserves_permissions(executor: BackgroundExecutor) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("script.sh");
+    std::fs::write(&path, "old").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    gpui::block_on(fs.save(&path, &"new".into(), LineEnding::Unix)).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o755);
+}
+
+/// A rename would detach the destination from its other links, so a linked file has to be
+/// written in place instead.
+#[gpui::test]
+#[cfg(unix)]
+async fn test_realfs_save_preserves_hard_links(executor: BackgroundExecutor) {
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("file.txt");
+    let link = temp_dir.path().join("link.txt");
+    std::fs::write(&path, "old").unwrap();
+    std::fs::hard_link(&path, &link).unwrap();
+
+    gpui::block_on(fs.save(&path, &"new".into(), LineEnding::Unix)).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+    assert_eq!(std::fs::read_to_string(&link).unwrap(), "new");
+}
+
+/// Writing through a symlink must update its target and leave the link itself in place.
+#[gpui::test]
+#[cfg(unix)]
+async fn test_realfs_save_writes_through_symlink(executor: BackgroundExecutor) {
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let target = temp_dir.path().join("target.txt");
+    let link = temp_dir.path().join("link.txt");
+    std::fs::write(&target, "old").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    gpui::block_on(fs.save(&link, &"new".into(), LineEnding::Unix)).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "new");
+    assert!(
+        std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[gpui::test]
+#[cfg(unix)]
+async fn test_realfs_atomic_write_preserves_permissions(executor: BackgroundExecutor) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("settings.json");
+    std::fs::write(&path, "{}").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    gpui::block_on(fs.atomic_write(path.clone(), "{\"a\": 1}".into())).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "{\"a\": 1}");
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o644);
 }
 
 #[gpui::test]

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -499,29 +499,38 @@ async fn test_realfs_save_preserves_permissions(executor: BackgroundExecutor) {
 #[gpui::test]
 #[cfg(unix)]
 async fn test_realfs_save_preserves_hard_links(executor: BackgroundExecutor) {
+    use std::os::unix::fs::MetadataExt as _;
+
     let fs = RealFs::new(None, executor);
     let temp_dir = TempDir::new().unwrap();
     let path = temp_dir.path().join("file.txt");
     let link = temp_dir.path().join("link.txt");
     std::fs::write(&path, "old").unwrap();
     std::fs::hard_link(&path, &link).unwrap();
+    let inode_before = std::fs::metadata(&path).unwrap().ino();
 
     gpui::block_on(fs.save(&path, &"new".into(), LineEnding::Unix)).unwrap();
 
     assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
     assert_eq!(std::fs::read_to_string(&link).unwrap(), "new");
+    // Both names still refer to one file, which is only true of a write made in place. This
+    // is the case that keeps the truncate window: the link cannot survive a replacement.
+    assert_eq!(std::fs::metadata(&path).unwrap().ino(), inode_before);
 }
 
 /// Writing through a symlink must update its target and leave the link itself in place.
 #[gpui::test]
 #[cfg(unix)]
 async fn test_realfs_save_writes_through_symlink(executor: BackgroundExecutor) {
+    use std::os::unix::fs::MetadataExt as _;
+
     let fs = RealFs::new(None, executor);
     let temp_dir = TempDir::new().unwrap();
     let target = temp_dir.path().join("target.txt");
     let link = temp_dir.path().join("link.txt");
     std::fs::write(&target, "old").unwrap();
     std::os::unix::fs::symlink(&target, &link).unwrap();
+    let inode_before = std::fs::metadata(&target).unwrap().ino();
 
     gpui::block_on(fs.save(&link, &"new".into(), LineEnding::Unix)).unwrap();
 
@@ -532,6 +541,9 @@ async fn test_realfs_save_writes_through_symlink(executor: BackgroundExecutor) {
             .file_type()
             .is_symlink()
     );
+    // Unlike a hard link, a symlink does not force the write in place: the target is replaced
+    // by a rename, and the link keeps pointing at the path that now holds the new file.
+    assert_ne!(std::fs::metadata(&target).unwrap().ino(), inode_before);
 }
 
 #[gpui::test]

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -404,8 +404,16 @@ pub enum DiskState {
     /// operations and sync clients all do - would otherwise compare equal to the previous
     /// state, so no reload is requested and the buffer stays stale indefinitely. Most such
     /// tools replace the file by renaming a new one over it, which changes its identity even
-    /// when neither timestamp nor length moved. `None` where identity is unknown, which is the
-    /// case for files described over the wire.
+    /// when neither timestamp nor length moved.
+    ///
+    /// Identity does not close that gap entirely: a tool that rewrites the file *in place* to
+    /// the same length within one mtime tick keeps all three fields and is still invisible
+    /// here. Only hashing the contents would catch it, and that would mean reading every file
+    /// on every scan.
+    ///
+    /// `None` where identity is unknown, which is the case for files described over the wire.
+    /// Compare two states with [`DiskState::differs_from`] rather than `==`, so that an
+    /// unknown identity is not itself read as a change.
     Present {
         mtime: MTime,
         size: u64,
@@ -419,6 +427,33 @@ pub enum DiskState {
 }
 
 impl DiskState {
+    /// Whether these two observations of a file describe contents that may differ.
+    ///
+    /// This is deliberately not `!=`. Identity is compared only when both observations know
+    /// it, so a state that arrived over the wire - which carries none - is judged on the
+    /// fields the two have in common rather than being reported as changed for that reason
+    /// alone.
+    pub fn differs_from(self, other: Self) -> bool {
+        match (self, other) {
+            (
+                DiskState::Present { mtime, size, inode },
+                DiskState::Present {
+                    mtime: other_mtime,
+                    size: other_size,
+                    inode: other_inode,
+                },
+            ) => {
+                mtime != other_mtime
+                    || size != other_size
+                    || match (inode, other_inode) {
+                        (Some(inode), Some(other_inode)) => inode != other_inode,
+                        _ => false,
+                    }
+            }
+            _ => self != other,
+        }
+    }
+
     /// Returns the file's last known modification time on disk.
     pub fn mtime(self) -> Option<MTime> {
         match self {
@@ -1734,7 +1769,7 @@ impl Buffer {
 
             let old_state = old_file.disk_state();
             let new_state = new_file.disk_state();
-            if old_state != new_state {
+            if old_state.differs_from(new_state) {
                 file_changed = true;
                 if !was_dirty && matches!(new_state, DiskState::Present { .. }) {
                     cx.emit(BufferEvent::ReloadNeeded)

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -398,25 +398,25 @@ pub enum DiskState {
     New,
     /// File present on the filesystem.
     ///
-    /// `inode` is the file's identity as reported by the filesystem, and is part of this
-    /// state because `{mtime, size}` alone cannot see an external write: a tool that rewrites
-    /// a file to the same length within one mtime tick - formatters, build steps, `git`
-    /// operations and sync clients all do - would otherwise compare equal to the previous
-    /// state, so no reload is requested and the buffer stays stale indefinitely. Most such
-    /// tools replace the file by renaming a new one over it, which changes its identity even
-    /// when neither timestamp nor length moved.
+    /// `size` and `inode` accompany `mtime` because the timestamp alone cannot see an external
+    /// write: a tool that rewrites a file within one mtime tick - formatters, build steps,
+    /// `git` operations and sync clients all do - would otherwise compare equal to the
+    /// previous state, so no reload is requested and the buffer stays stale indefinitely. A
+    /// rewrite that changes the file's length is caught by `size`, and one that keeps it is
+    /// usually caught by `inode`, since most such tools replace the file by renaming a new one
+    /// over it.
     ///
-    /// Identity does not close that gap entirely: a tool that rewrites the file *in place* to
-    /// the same length within one mtime tick keeps all three fields and is still invisible
-    /// here. Only hashing the contents would catch it, and that would mean reading every file
-    /// on every scan.
+    /// A gap remains: a tool that rewrites the file *in place* to the same length within one
+    /// mtime tick keeps all three fields and is invisible here. Only hashing the contents
+    /// would catch it, and that would mean reading every file on every scan.
     ///
-    /// `None` where identity is unknown, which is the case for files described over the wire.
-    /// Compare two states with [`DiskState::differs_from`] rather than `==`, so that an
-    /// unknown identity is not itself read as a change.
+    /// Either field is `None` where that observation could not establish it, which is the case
+    /// for a file described over the wire whose worktree entry has not arrived yet. Compare
+    /// two states with [`DiskState::differs_from`] rather than `==`, so that a field one side
+    /// could not see is not itself read as a change.
     Present {
         mtime: MTime,
-        size: u64,
+        size: Option<u64>,
         inode: Option<u64>,
     },
     /// Deleted file that was previously present.
@@ -429,11 +429,15 @@ pub enum DiskState {
 impl DiskState {
     /// Whether these two observations of a file describe contents that may differ.
     ///
-    /// This is deliberately not `!=`. Identity is compared only when both observations know
-    /// it, so a state that arrived over the wire - which carries none - is judged on the
-    /// fields the two have in common rather than being reported as changed for that reason
-    /// alone.
+    /// This is deliberately not `!=`. Size and identity are compared only where both
+    /// observations established them, so a state assembled from a worktree that has not fully
+    /// arrived is judged on the fields the two have in common, rather than being reported as
+    /// changed for what one of them could not see.
     pub fn differs_from(self, other: Self) -> bool {
+        fn known_and_different(one: Option<u64>, other: Option<u64>) -> bool {
+            matches!((one, other), (Some(one), Some(other)) if one != other)
+        }
+
         match (self, other) {
             (
                 DiskState::Present { mtime, size, inode },
@@ -444,11 +448,8 @@ impl DiskState {
                 },
             ) => {
                 mtime != other_mtime
-                    || size != other_size
-                    || match (inode, other_inode) {
-                        (Some(inode), Some(other_inode)) => inode != other_inode,
-                        _ => false,
-                    }
+                    || known_and_different(size, other_size)
+                    || known_and_different(inode, other_inode)
             }
             _ => self != other,
         }
@@ -464,11 +465,12 @@ impl DiskState {
         }
     }
 
-    /// Returns the file's size on disk in bytes.
+    /// Returns the file's size on disk in bytes, where the file is present and the observation
+    /// established its size.
     pub fn size(self) -> Option<u64> {
         match self {
             DiskState::New => None,
-            DiskState::Present { size, .. } => Some(size),
+            DiskState::Present { size, .. } => size,
             DiskState::Deleted => None,
             DiskState::Historic { .. } => None,
         }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -397,7 +397,20 @@ pub enum DiskState {
     /// File created in Zed that has not been saved.
     New,
     /// File present on the filesystem.
-    Present { mtime: MTime, size: u64 },
+    ///
+    /// `inode` is the file's identity as reported by the filesystem, and is part of this
+    /// state because `{mtime, size}` alone cannot see an external write: a tool that rewrites
+    /// a file to the same length within one mtime tick - formatters, build steps, `git`
+    /// operations and sync clients all do - would otherwise compare equal to the previous
+    /// state, so no reload is requested and the buffer stays stale indefinitely. Most such
+    /// tools replace the file by renaming a new one over it, which changes its identity even
+    /// when neither timestamp nor length moved. `None` where identity is unknown, which is the
+    /// case for files described over the wire.
+    Present {
+        mtime: MTime,
+        size: u64,
+        inode: Option<u64>,
+    },
     /// Deleted file that was previously present.
     Deleted,
     /// An old version of a file that was previously present
@@ -2471,10 +2484,15 @@ impl Buffer {
         };
         match file.disk_state() {
             DiskState::New => false,
+            // Inequality, not `>`: an mtime that is merely *different* from the one recorded
+            // at the last save or reload means the file changed underneath us. Requiring it to
+            // be strictly greater misses every case `MTime`'s own documentation warns about -
+            // coarse mtime granularity making a same-tick external write compare equal, clock
+            // adjustments, restored backups, and tools that preserve timestamps (`cp -p`,
+            // `rsync -t`, `touch -r`) - and this check is the only thing standing between a
+            // save and silently overwriting newer contents on disk.
             DiskState::Present { mtime, .. } => match self.saved_mtime {
-                Some(saved_mtime) => {
-                    mtime.bad_is_greater_than(saved_mtime) && self.has_unsaved_edits()
-                }
+                Some(saved_mtime) => mtime != saved_mtime && self.has_unsaved_edits(),
                 None => true,
             },
             DiskState::Deleted => false,

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::Buffer;
 use clock::ReplicaId;
 use collections::BTreeMap;
+use fs::MTime;
 use futures::FutureExt as _;
 use futures_lite::future::yield_now;
 use gpui::{App, AppContext as _, BorrowAppContext, Entity};
@@ -5443,4 +5444,31 @@ fn test_formatted_chunks(cx: &mut gpui::App) {
             );
         }
     }
+}
+
+#[test]
+fn test_disk_state_differs_from() {
+    let mtime = MTime::from_seconds_and_nanos(100, 0);
+    let later = MTime::from_seconds_and_nanos(200, 0);
+    let present = |mtime, size, inode| DiskState::Present { mtime, size, inode };
+
+    assert!(!present(mtime, 10, Some(1)).differs_from(present(mtime, 10, Some(1))));
+    assert!(present(mtime, 10, Some(1)).differs_from(present(later, 10, Some(1))));
+    assert!(present(mtime, 10, Some(1)).differs_from(present(mtime, 20, Some(1))));
+
+    // The case identity exists for: an external tool renamed a new file of the same length
+    // over this one within a single mtime tick.
+    assert!(present(mtime, 10, Some(1)).differs_from(present(mtime, 10, Some(2))));
+
+    // An unknown identity is not itself a change, in either direction, so a state that came
+    // over the wire does not report every update as one.
+    assert!(!present(mtime, 10, Some(1)).differs_from(present(mtime, 10, None)));
+    assert!(!present(mtime, 10, None).differs_from(present(mtime, 10, Some(1))));
+    assert!(!present(mtime, 10, None).differs_from(present(mtime, 10, None)));
+    assert!(present(mtime, 10, None).differs_from(present(later, 10, None)));
+
+    // Everything else compares structurally.
+    assert!(DiskState::New.differs_from(DiskState::Deleted));
+    assert!(DiskState::New.differs_from(present(mtime, 0, None)));
+    assert!(!DiskState::Deleted.differs_from(DiskState::Deleted));
 }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -5450,25 +5450,33 @@ fn test_formatted_chunks(cx: &mut gpui::App) {
 fn test_disk_state_differs_from() {
     let mtime = MTime::from_seconds_and_nanos(100, 0);
     let later = MTime::from_seconds_and_nanos(200, 0);
-    let present = |mtime, size, inode| DiskState::Present { mtime, size, inode };
+    let present = |mtime, size, inode| DiskState::Present {
+        mtime,
+        size: Some(size),
+        inode: Some(inode),
+    };
+    let partial = |mtime, size, inode| DiskState::Present { mtime, size, inode };
 
-    assert!(!present(mtime, 10, Some(1)).differs_from(present(mtime, 10, Some(1))));
-    assert!(present(mtime, 10, Some(1)).differs_from(present(later, 10, Some(1))));
-    assert!(present(mtime, 10, Some(1)).differs_from(present(mtime, 20, Some(1))));
+    assert!(!present(mtime, 10, 1).differs_from(present(mtime, 10, 1)));
+    assert!(present(mtime, 10, 1).differs_from(present(later, 10, 1)));
+    assert!(present(mtime, 10, 1).differs_from(present(mtime, 20, 1)));
 
     // The case identity exists for: an external tool renamed a new file of the same length
     // over this one within a single mtime tick.
-    assert!(present(mtime, 10, Some(1)).differs_from(present(mtime, 10, Some(2))));
+    assert!(present(mtime, 10, 1).differs_from(present(mtime, 10, 2)));
 
-    // An unknown identity is not itself a change, in either direction, so a state that came
-    // over the wire does not report every update as one.
-    assert!(!present(mtime, 10, Some(1)).differs_from(present(mtime, 10, None)));
-    assert!(!present(mtime, 10, None).differs_from(present(mtime, 10, Some(1))));
-    assert!(!present(mtime, 10, None).differs_from(present(mtime, 10, None)));
-    assert!(present(mtime, 10, None).differs_from(present(later, 10, None)));
+    // A field one side could not establish is not itself a change, in either direction, so a
+    // file whose worktree entry has not arrived does not report every update as one.
+    assert!(!present(mtime, 10, 1).differs_from(partial(mtime, Some(10), None)));
+    assert!(!partial(mtime, None, None).differs_from(present(mtime, 10, 1)));
+    assert!(!partial(mtime, None, None).differs_from(partial(mtime, None, None)));
+    assert!(partial(mtime, None, None).differs_from(partial(later, None, None)));
+
+    // What both sides do know still decides it.
+    assert!(partial(mtime, Some(10), None).differs_from(partial(mtime, Some(20), None)));
 
     // Everything else compares structurally.
     assert!(DiskState::New.differs_from(DiskState::Deleted));
-    assert!(DiskState::New.differs_from(present(mtime, 0, None)));
+    assert!(DiskState::New.differs_from(partial(mtime, None, None)));
     assert!(!DiskState::Deleted.differs_from(DiskState::Deleted));
 }

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -311,7 +311,10 @@ impl LanguageServerState {
                 let button = ContextMenuEntry::new(label).handler({
                     let state = cx.entity();
                     move |_, cx| {
-                        let lsp_store = state.read(cx).lsp_store.clone();
+                        let lsp_store = state.update(cx, |state, _| {
+                            state.language_servers.clear_failed_binary_statuses();
+                            state.lsp_store.clone()
+                        });
                         lsp_store
                             .update(cx, |lsp_store, cx| {
                                 if restart {
@@ -770,6 +773,20 @@ impl LanguageServers {
     /// reaching end-of-life via restart). `binary_statuses` is intentionally
     /// preserved — it is keyed by name and shared across restart cycles to
     /// drive the "Downloading… → Starting…" status UX.
+    /// Drops terminal failure statuses.
+    ///
+    /// `binary_statuses` is name-keyed and is otherwise only ever inserted into, so a server
+    /// whose binary could not start stays reported for the lifetime of the process: closing
+    /// every file of that language does not clear it, and neither does stopping or restarting
+    /// all servers, since those iterate running servers and one that never started is not among
+    /// them. The continuity this map exists for covers the steps on the way to running
+    /// ("Downloading…" → "Starting…") across a restart cycle, not a terminal failure - a fresh
+    /// attempt reports that again by itself if it still fails.
+    fn clear_failed_binary_statuses(&mut self) {
+        self.binary_statuses
+            .retain(|_, server| !matches!(server.status, BinaryStatus::Failed { .. }));
+    }
+
     fn remove_server(&mut self, server_id: LanguageServerId) {
         self.health_statuses.remove(&server_id);
         self.servers_per_buffer_abs_path
@@ -1222,13 +1239,19 @@ impl LspButton {
                 });
                 new_lsp_items.extend(worktree_servers.into_iter().map(ServerData::into_lsp_item));
             }
-            if !new_lsp_items.is_empty() {
-                if can_stop_all {
-                    new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: true });
-                    new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: false });
-                } else if can_restart_all {
-                    new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: true });
-                }
+            // `can_restart_all` is true precisely when every server is stopped, which is also
+            // when there is nothing left to list. Gating these buttons on a non-empty item list
+            // therefore made "Restart All Servers" - which doubles as the only way to start
+            // servers again - unreachable in exactly the state it exists for, leaving an empty
+            // menu with no affordance after "Stop All Servers". A project that has never had a
+            // language server still gets no button, since it has no statuses of either kind.
+            let has_known_servers = !state.language_servers.health_statuses.is_empty()
+                || !state.language_servers.binary_statuses.is_empty();
+            if can_stop_all {
+                new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: true });
+                new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: false });
+            } else if can_restart_all && has_known_servers {
+                new_lsp_items.push(LspMenuItem::ToggleServersButton { restart: true });
             }
 
             state.items = new_lsp_items;

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1134,6 +1134,7 @@ impl LanguageServer {
         let server = self.server.clone();
         let name = self.name.clone();
         let server_id = self.server_id;
+        let drain_executor = self.executor.clone();
         let mut timer = self.executor.timer(SERVER_SHUTDOWN_TIMEOUT).fuse();
         Some(async move {
             log::debug!("language server shutdown started");
@@ -1162,8 +1163,27 @@ impl LanguageServer {
             response_handlers.lock().take();
             Self::notify_internal::<notification::Exit>(&notification_serializers, ()).ok();
             notification_serializers.close();
-            output_done.recv().await;
-            server.lock().take().map(|mut child| child.kill());
+
+            // Bound the drain. The kill below sits behind this await, so a server whose io
+            // handling never finishes (busy server, full pipe, stuck writer) would keep the
+            // process alive indefinitely - and the caller has already scrubbed this server
+            // from its registries and detached this task, so nothing would ever notice.
+            let mut drain_timer = drain_executor.timer(SERVER_SHUTDOWN_TIMEOUT).fuse();
+            select! {
+                _ = output_done.recv().fuse() => {}
+                () = drain_timer => {
+                    log::warn!("timeout waiting for language server {name} (id {server_id}) to drain its output before being killed");
+                }
+            }
+
+            // Kill unconditionally rather than only after a clean drain: by this point the
+            // server is administratively unreachable, so a surviving process would keep its
+            // notification handlers wired with nothing left able to stop it.
+            if let Some(mut child) = server.lock().take()
+                && let Err(error) = child.kill()
+            {
+                log::warn!("failed to kill language server {name} (id {server_id}): {error}");
+            }
             drop(tasks);
             log::debug!("language server shutdown finished");
             Some(())

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -564,6 +564,7 @@ impl LocalBufferStore {
                         Some(mtime) => DiskState::Present {
                             mtime,
                             size: entry.size,
+                            inode: Some(entry.inode),
                         },
                         None => old_file.disk_state,
                     },

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -563,7 +563,7 @@ impl LocalBufferStore {
                     disk_state: match entry.mtime {
                         Some(mtime) => DiskState::Present {
                             mtime,
-                            size: entry.size,
+                            size: Some(entry.size),
                             inode: Some(entry.inode),
                         },
                         None => old_file.disk_state,

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -206,7 +206,7 @@ impl ImageItem {
 
         let old_state = old_file.disk_state();
         let new_state = new_file.disk_state();
-        if old_state != new_state {
+        if old_state.differs_from(new_state) {
             file_changed = true;
             if matches!(new_state, DiskState::Present { .. }) {
                 cx.emit(ImageItemEvent::ReloadNeeded)

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -852,6 +852,7 @@ impl LocalImageStore {
                         Some(mtime) => DiskState::Present {
                             mtime,
                             size: entry.size,
+                            inode: Some(entry.inode),
                         },
                         None => old_file.disk_state,
                     },

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -851,7 +851,7 @@ impl LocalImageStore {
                     disk_state: match entry.mtime {
                         Some(mtime) => DiskState::Present {
                             mtime,
-                            size: entry.size,
+                            size: Some(entry.size),
                             inode: Some(entry.inode),
                         },
                         None => old_file.disk_state,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2843,6 +2843,17 @@ impl LocalLspStore {
                 .then_with(|| compare_diagnostics(&a.diagnostic, &b.diagnostic))
         });
 
+        // The LSP spec makes `PublishDiagnosticsParams.version` optional and many servers
+        // omit it. Such a server analyzed the last text we sent it, which is not
+        // necessarily the buffer's current text, so resolve against that version instead
+        // of clipping the ranges onto whatever is on screen now.
+        let version = version.or_else(|| {
+            self.buffer_snapshots
+                .get(&buffer.read(cx).remote_id())
+                .and_then(|snapshots| snapshots.get(&server_id))
+                .and_then(|snapshots| snapshots.last())
+                .map(|snapshot| snapshot.version)
+        });
         let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
 
         let edits_since_save = std::cell::LazyCell::new(|| {
@@ -3253,12 +3264,26 @@ impl LocalLspStore {
                 anyhow::bail!("no snapshots found for buffer {buffer_id} and server {server_id}");
             };
 
+            // A server that publishes for a version the user has already typed past is
+            // ordinary, not exceptional: only `OLD_VERSIONS_TO_RETAIN` versions are kept.
+            // Coordinates are turned into anchors against whatever snapshot is returned
+            // here, and the buffer transforms anchors forward on its own, so resolving
+            // against the closest older snapshot keeps the positions the server meant.
+            // Requiring an exact match instead turns every lag spike into a dropped
+            // update, which leaves the previously applied diagnostics on screen.
+            let index = match snapshots.binary_search_by_key(&version, |e| e.version) {
+                Ok(index) => index,
+                Err(insertion_index) => insertion_index.saturating_sub(1),
+            };
             let found_snapshot = snapshots
-                    .binary_search_by_key(&version, |e| e.version)
-                    .map(|ix| snapshots[ix].snapshot.clone())
-                    .map_err(|_| {
-                        anyhow!("snapshot not found for buffer {buffer_id} server {server_id} at version {version}")
-                    })?;
+                .get(index)
+                .with_context(|| {
+                    format!(
+                        "no snapshot retained for buffer {buffer_id} server {server_id} at version {version}"
+                    )
+                })?
+                .snapshot
+                .clone();
 
             snapshots.retain(|snapshot| snapshot.version + OLD_VERSIONS_TO_RETAIN >= version);
             Ok(found_snapshot)
@@ -8855,12 +8880,20 @@ impl LspStore {
         for language_server in language_servers {
             let language_server = language_server.clone();
 
-            let buffer_snapshots = self
-                .as_local_mut()?
-                .buffer_snapshots
-                .get_mut(&buffer.remote_id())
-                .and_then(|m| m.get_mut(&language_server.server_id()))?;
-            let previous_snapshot = buffer_snapshots.last()?;
+            // `?` here would return from the whole function, so a server that has not
+            // been sent `didOpen` yet would also starve every remaining server of this
+            // edit. Such a server has no state to update: its `didOpen` carries the
+            // current text.
+            let Some(buffer_snapshots) = self
+                .as_local_mut()
+                .and_then(|local| local.buffer_snapshots.get_mut(&buffer.remote_id()))
+                .and_then(|snapshots| snapshots.get_mut(&language_server.server_id()))
+            else {
+                continue;
+            };
+            let Some(previous_snapshot) = buffer_snapshots.last() else {
+                continue;
+            };
 
             // If the line ending differs from what this server was last sent, the LF-normalized
             // rope is byte-identical so `edits_since` yields no diffs. We must resync the whole
@@ -8932,22 +8965,31 @@ impl LspStore {
             };
 
             let next_version = previous_snapshot.version + 1;
+            // Record the version only after the server has actually been told about it.
+            // Advancing the ledger on a failed send would make every later `didChange` a
+            // delta on top of text the server never received, and nothing resyncs it.
+            // Leaving the version behind instead makes the next edit send a delta that
+            // covers this one too.
+            if let Err(error) = language_server.notify::<lsp::notification::DidChangeTextDocument>(
+                lsp::DidChangeTextDocumentParams {
+                    text_document: lsp::VersionedTextDocumentIdentifier::new(
+                        uri.clone(),
+                        next_version,
+                    ),
+                    content_changes,
+                },
+            ) {
+                log::error!(
+                    "failed to send didChange to language server {}: {error:#}",
+                    language_server.server_id()
+                );
+                continue;
+            }
+
             buffer_snapshots.push(LspBufferSnapshot {
                 version: next_version,
                 snapshot: next_snapshot.clone(),
             });
-
-            language_server
-                .notify::<lsp::notification::DidChangeTextDocument>(
-                    lsp::DidChangeTextDocumentParams {
-                        text_document: lsp::VersionedTextDocumentIdentifier::new(
-                            uri.clone(),
-                            next_version,
-                        ),
-                        content_changes,
-                    },
-                )
-                .ok();
             self.pull_workspace_diagnostics(language_server.server_id());
         }
 
@@ -9395,7 +9437,7 @@ impl LspStore {
                 self.worktree_store.read(cx).find_worktree(abs_path, cx)
             else {
                 log::warn!("skipping diagnostics update, no worktree found for path {abs_path:?}");
-                return Ok(());
+                continue;
             };
 
             let worktree_id = worktree.read(cx).id();
@@ -9404,8 +9446,12 @@ impl LspStore {
                 path: relative_path,
             };
 
-            let document_uri = lsp::Uri::from_file_path(abs_path)
-                .map_err(|()| anyhow!("Failed to convert buffer path {abs_path:?} to lsp Uri"))?;
+            let Ok(document_uri) = lsp::Uri::from_file_path(abs_path) else {
+                log::warn!(
+                    "skipping diagnostics update, failed to convert buffer path {abs_path:?} to lsp Uri"
+                );
+                continue;
+            };
             if let Some(buffer_handle) = self.buffer_store.read(cx).get_by_path(&project_path) {
                 let snapshot = buffer_handle.read(cx).snapshot();
                 let buffer = buffer_handle.read(cx);
@@ -9421,7 +9467,8 @@ impl LspStore {
                     })
                     .collect::<Vec<_>>();
 
-                self.as_local_mut()
+                let updated_buffer_diagnostics = self
+                    .as_local_mut()
                     .context("cannot merge diagnostics on a remote LspStore")?
                     .update_buffer_diagnostics(
                         &buffer_handle,
@@ -9432,7 +9479,15 @@ impl LspStore {
                         update.diagnostics.diagnostics.clone(),
                         reused_diagnostics.clone(),
                         cx,
-                    )?;
+                    );
+                // Failing one document must not discard the updates batched alongside it,
+                // each of which would otherwise keep rendering its previous set.
+                if let Err(error) = updated_buffer_diagnostics {
+                    log::error!(
+                        "failed to update diagnostics for {abs_path:?} from language server {server_id}: {error:#}"
+                    );
+                    continue;
+                }
 
                 update.diagnostics.diagnostics.extend(reused_diagnostics);
             } else if let Some(local) = self.as_local() {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -12015,13 +12015,37 @@ impl LspStore {
                     .timer(SERVER_LAUNCHING_BEFORE_SHUTDOWN_TIMEOUT)
                     .fuse();
 
-                select! {
-                    server = startup.fuse() => server,
+                let mut startup = startup.fuse();
+                let mut launch_timed_out = false;
+                let server = select! {
+                    server = startup => server,
                     () = timer => {
-                        log::info!("timeout waiting for language server {name} to finish launching before stopping");
+                        launch_timed_out = true;
                         None
                     },
+                };
+
+                // Giving up on the wait must not mean giving up on the process. The launch
+                // carries on regardless, while the caller has already removed this server from
+                // every registry, so a process left running here is unreachable: its handlers
+                // stay wired under an id nothing iterates, and no later "Stop All" can reach it.
+                // Wait for the launch on its own task instead and shut it down when it lands.
+                if launch_timed_out {
+                    log::info!(
+                        "timeout waiting for language server {name} to finish launching before stopping; \
+                         it will be shut down once its launch completes"
+                    );
+                    cx.background_spawn(async move {
+                        if let Some(server) = startup.await
+                            && let Some(shutdown) = server.shutdown()
+                        {
+                            shutdown.await;
+                        }
+                    })
+                    .detach();
+                    return;
                 }
+                server
             }
 
             Some(LanguageServerState::Running { server, .. }) => Some(server),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2409,16 +2409,38 @@ impl LocalLspStore {
                 .global_lsp_settings
                 .get_request_timeout()
         });
+        // The server frames both the range it is asked to format and the edits it returns in
+        // the document it last received, which is not necessarily the buffer's current text.
+        // Resolving the anchors against that snapshot sends the server coordinates for the
+        // text it actually holds; the returned edits are then converted back in the same
+        // version, so the buffer maps them forward itself.
+        //
+        // TODO(#22930): when formatting a multibuffer selection, this buffer may never have
+        // been sent to this server at all. There is no version to frame against in that case
+        // and the current snapshot is the only available approximation.
+        let server_version = this.update(cx, |this, cx| {
+            this.as_local()?.latest_version_sent_to_server(
+                buffer_handle.read(cx).remote_id(),
+                language_server.server_id(),
+            )
+        })?;
+
         let lsp_edits = {
             let mut lsp_ranges = Vec::new();
-            this.update(cx, |_this, cx| {
-                // TODO(#22930): In the case of formatting multibuffer selections, this buffer may
-                // not have been sent to the language server. This seems like a fairly systemic
-                // issue, though, the resolution probably is not specific to formatting.
-                //
-                // TODO: Instead of using current snapshot, should use the latest snapshot sent to
-                // LSP.
-                let snapshot = buffer_handle.read(cx).snapshot();
+            this.update(cx, |this, cx| {
+                let snapshot = this
+                    .as_local_mut()
+                    .and_then(|local| {
+                        local
+                            .buffer_snapshot_for_lsp_version(
+                                buffer_handle,
+                                language_server.server_id(),
+                                server_version,
+                                cx,
+                            )
+                            .ok()
+                    })
+                    .unwrap_or_else(|| buffer_handle.read(cx).text_snapshot());
                 for range in ranges {
                     lsp_ranges.push(range_to_lsp(range.to_point_utf16(&snapshot))?);
                 }
@@ -2506,7 +2528,7 @@ impl LocalLspStore {
                     buffer_handle,
                     lsp_edits,
                     language_server.server_id(),
-                    None,
+                    server_version,
                     cx,
                 )
             })?
@@ -2847,13 +2869,8 @@ impl LocalLspStore {
         // omit it. Such a server analyzed the last text we sent it, which is not
         // necessarily the buffer's current text, so resolve against that version instead
         // of clipping the ranges onto whatever is on screen now.
-        let version = version.or_else(|| {
-            self.buffer_snapshots
-                .get(&buffer.read(cx).remote_id())
-                .and_then(|snapshots| snapshots.get(&server_id))
-                .and_then(|snapshots| snapshots.last())
-                .map(|snapshot| snapshot.version)
-        });
+        let version = version
+            .or_else(|| self.latest_version_sent_to_server(buffer.read(cx).remote_id(), server_id));
         let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
 
         let edits_since_save = std::cell::LazyCell::new(|| {
@@ -3237,6 +3254,31 @@ impl LocalLspStore {
                 }
             }
         });
+    }
+
+    /// The document version this server was last told about, which is the version its
+    /// responses are framed in. Coordinates travelling in either direction between Zed and a
+    /// language server belong in this version, not in whatever the buffer happens to hold now.
+    fn latest_version_sent_to_server(
+        &self,
+        buffer_id: BufferId,
+        server_id: LanguageServerId,
+    ) -> Option<i32> {
+        Some(
+            self.latest_snapshot_sent_to_server(buffer_id, server_id)?
+                .version,
+        )
+    }
+
+    fn latest_snapshot_sent_to_server(
+        &self,
+        buffer_id: BufferId,
+        server_id: LanguageServerId,
+    ) -> Option<&LspBufferSnapshot> {
+        self.buffer_snapshots
+            .get(&buffer_id)
+            .and_then(|snapshots| snapshots.get(&server_id))
+            .and_then(|snapshots| snapshots.last())
     }
 
     fn buffer_snapshot_for_lsp_version(

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -3218,6 +3218,90 @@ async fn test_restarted_server_reporting_invalid_buffer_version(cx: &mut gpui::T
 }
 
 #[gpui::test]
+async fn test_diagnostics_for_pruned_buffer_version(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({ "a.rs": "const A: i32 = 1;" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/a.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let mut fake_server = fake_servers.next().await.unwrap();
+    fake_server
+        .receive_notification::<lsp::notification::DidOpenTextDocument>()
+        .await;
+
+    // Type far enough that the earliest versions fall outside the retained window.
+    let mut versions = Vec::new();
+    for _ in 0..15 {
+        buffer.update(cx, |buffer, cx| {
+            let end = buffer.len();
+            buffer.edit([(end..end, " ")], None, cx);
+        });
+        cx.executor().run_until_parked();
+        versions.push(
+            fake_server
+                .receive_notification::<lsp::notification::DidChangeTextDocument>()
+                .await
+                .text_document
+                .version,
+        );
+    }
+    let oldest_version = versions[0];
+    let newest_version = *versions.last().unwrap();
+    assert!(newest_version - oldest_version > 10);
+
+    // Publishing for the newest version prunes the snapshots kept for older ones.
+    let uri = lsp::Uri::from_file_path(path!("/dir/a.rs")).unwrap();
+    fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
+        uri: uri.clone(),
+        version: Some(newest_version),
+        diagnostics: Vec::new(),
+    });
+    cx.executor().run_until_parked();
+
+    // A slow server publishing for one of those pruned versions must still have its
+    // diagnostics applied, rather than leaving the previous set on screen.
+    fake_server.notify::<lsp::notification::PublishDiagnostics>(lsp::PublishDiagnosticsParams {
+        uri,
+        version: Some(oldest_version),
+        diagnostics: vec![lsp::Diagnostic {
+            range: lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 7)),
+            severity: Some(lsp::DiagnosticSeverity::ERROR),
+            message: lsp::DiagnosticMessage::String("unused constant".to_string()),
+            ..Default::default()
+        }],
+    });
+    cx.executor().run_until_parked();
+
+    buffer.update(cx, |buffer, _| {
+        let snapshot = buffer.snapshot();
+        assert_eq!(
+            snapshot
+                .diagnostics_in_range::<_, usize>(0..buffer.len(), false)
+                .map(|entry| (
+                    entry.range.start..entry.range.end,
+                    entry.diagnostic.message.to_string()
+                ))
+                .collect::<Vec<_>>(),
+            vec![(6..7, "unused constant".to_string())],
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_cancel_language_server_work(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -7032,6 +7032,74 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
     });
 }
 
+/// `proto::File` carries neither size nor identity, so a guest reconstructing one has to
+/// recover both from the worktree entry the host already sent it. Without that, every remote
+/// file's disk state disagrees with the host's and is blind to any rewrite that leaves the
+/// mtime alone.
+#[gpui::test]
+async fn test_remote_file_recovers_size_and_inode_from_its_entry(cx: &mut gpui::TestAppContext) {
+    use language::File as _;
+    use worktree::File;
+
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({ "a": { "file1": "some contents" } }));
+    let project = Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let tree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    tree.flush_fs_events(cx).await;
+
+    let metadata = tree.update(cx, |tree, _| tree.metadata_proto());
+    let updates = Arc::new(Mutex::new(Vec::new()));
+    tree.update(cx, |tree, cx| {
+        let updates = updates.clone();
+        tree.observe_updates(0, cx, move |update| {
+            updates.lock().push(update);
+            async { true }
+        });
+    });
+
+    let remote = cx.update(|cx| {
+        Worktree::remote(
+            0,
+            ReplicaId::REMOTE_SERVER,
+            metadata,
+            project.read(cx).client().into(),
+            project.read(cx).path_style(cx),
+            cx,
+        )
+    });
+    cx.executor().run_until_parked();
+    remote.update(cx, |remote, _| {
+        for update in updates.lock().drain(..) {
+            remote.as_remote_mut().unwrap().update_from_remote(update);
+        }
+    });
+    cx.executor().run_until_parked();
+
+    let host_file = cx.update(|cx| {
+        let entry = tree
+            .read(cx)
+            .entry_for_path(rel_path("a/file1"))
+            .expect("no entry for a/file1")
+            .clone();
+        File::for_entry(entry, tree.clone())
+    });
+
+    let host_state = host_file.disk_state();
+    assert_eq!(host_state.size(), Some("some contents".len() as u64));
+
+    let guest_file = cx.update(|cx| {
+        let proto = host_file.to_proto(cx);
+        File::from_proto(proto, remote.clone(), cx).unwrap()
+    });
+
+    // The guest sees exactly what the host does, so comparing the two is meaningful and a
+    // same-length rewrite on the host is still visible to it.
+    assert_eq!(guest_file.disk_state(), host_state);
+    assert!(!guest_file.disk_state().differs_from(host_state));
+}
+
 #[cfg(target_os = "linux")]
 #[gpui::test(retries = 5)]
 async fn test_recreated_directory_receives_child_events(cx: &mut gpui::TestAppContext) {

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -76,18 +76,28 @@ impl LocalKernelSpecification {
     }
 }
 
-// Find a set of open ports. This creates a listener with port set to 0. The listener will be closed at the end when it goes out of scope.
-// There's a race condition between closing the ports and usage by a kernel, but it's inherent to the Jupyter protocol.
-async fn peek_ports(ip: IpAddr) -> Result<[u16; 5]> {
-    let mut addr_zeroport: SocketAddr = SocketAddr::new(ip, 0);
-    addr_zeroport.set_port(0);
+/// Reserves five free ports by binding port 0 five times and reading back what the OS chose.
+///
+/// The listeners are returned rather than dropped here, and must be held until immediately
+/// before the kernel is spawned. Releasing each one at the end of its own loop iteration -
+/// which is what this did, despite a comment claiming they were closed "at the end" - frees
+/// port N before port N+1 is chosen, so the OS is free to hand the same port back and the
+/// five "distinct" ports can collide. It also left the ports unclaimed across the connection
+/// file write and the whole kernel startup, rather than across the spawn alone.
+///
+/// The window cannot be closed entirely below Jupyter protocol 5.6, which added kernel-side
+/// handshaking so the kernel picks its own ports and reports them back; holding the
+/// reservations until spawn is the mitigation available to a client speaking the older flow.
+async fn peek_ports(ip: IpAddr) -> Result<(Vec<TcpListener>, [u16; 5])> {
+    let addr_zeroport: SocketAddr = SocketAddr::new(ip, 0);
+    let mut listeners = Vec::with_capacity(5);
     let mut ports: [u16; 5] = [0; 5];
-    for i in 0..5 {
+    for port in &mut ports {
         let listener = TcpListener::bind(addr_zeroport).await?;
-        let addr = listener.local_addr()?;
-        ports[i] = addr.port();
+        *port = listener.local_addr()?.port();
+        listeners.push(listener);
     }
-    Ok(ports)
+    Ok((listeners, ports))
 }
 
 pub struct NativeRunningKernel {
@@ -122,7 +132,7 @@ impl NativeRunningKernel {
     ) -> Task<Result<Box<dyn RunningKernel>>> {
         window.spawn(cx, async move |cx| {
             let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-            let ports = peek_ports(ip).await?;
+            let (port_reservations, ports) = peek_ports(ip).await?;
 
             let connection_info = ConnectionInfo {
                 transport: Transport::TCP,
@@ -147,6 +157,10 @@ impl NativeRunningKernel {
 
             let mut cmd = kernel_specification.command(&connection_path)?;
             cmd.current_dir(&working_directory);
+
+            // Release the reserved ports as late as possible. The kernel binds them itself
+            // moments after starting, and until this point nothing else can take them.
+            drop(port_reservations);
 
             let mut process = util::process::Child::spawn(
                 cmd,

--- a/crates/repl/src/kernels/wsl_kernel.rs
+++ b/crates/repl/src/kernels/wsl_kernel.rs
@@ -25,18 +25,28 @@ use std::{
 
 use uuid::Uuid;
 
-// Find a set of open ports. This creates a listener with port set to 0. The listener will be closed at the end when it goes out of scope.
-// There's a race condition between closing the ports and usage by a kernel, but it's inherent to the Jupyter protocol.
-async fn peek_ports(ip: IpAddr) -> Result<[u16; 5]> {
-    let mut addr_zeroport: SocketAddr = SocketAddr::new(ip, 0);
-    addr_zeroport.set_port(0);
+/// Reserves five free ports by binding port 0 five times and reading back what the OS chose.
+///
+/// The listeners are returned rather than dropped here, and must be held until immediately
+/// before the kernel is spawned. Releasing each one at the end of its own loop iteration -
+/// which is what this did, despite a comment claiming they were closed "at the end" - frees
+/// port N before port N+1 is chosen, so the OS is free to hand the same port back and the
+/// five "distinct" ports can collide. It also left the ports unclaimed across the connection
+/// file write and the whole kernel startup, rather than across the spawn alone.
+///
+/// The window cannot be closed entirely below Jupyter protocol 5.6, which added kernel-side
+/// handshaking so the kernel picks its own ports and reports them back; holding the
+/// reservations until spawn is the mitigation available to a client speaking the older flow.
+async fn peek_ports(ip: IpAddr) -> Result<(Vec<TcpListener>, [u16; 5])> {
+    let addr_zeroport: SocketAddr = SocketAddr::new(ip, 0);
+    let mut listeners = Vec::with_capacity(5);
     let mut ports: [u16; 5] = [0; 5];
-    for i in 0..5 {
+    for port in &mut ports {
         let listener = TcpListener::bind(addr_zeroport).await?;
-        let addr = listener.local_addr()?;
-        ports[i] = addr.port();
+        *port = listener.local_addr()?.port();
+        listeners.push(listener);
     }
-    Ok(ports)
+    Ok((listeners, ports))
 }
 
 pub struct WslRunningKernel {
@@ -88,7 +98,7 @@ impl WslRunningKernel {
             // This avoids issues where the VM IP is unreachable or binding fails on Windows.
             let connect_ip = "127.0.0.1".to_string();
 
-            let ports = peek_ports(bind_ip).await?;
+            let (port_reservations, ports) = peek_ports(bind_ip).await?;
 
             let connection_info = ConnectionInfo {
                 transport: Transport::TCP,
@@ -270,6 +280,10 @@ impl WslRunningKernel {
                 .arg("-l")
                 .arg("-c")
                 .arg(&shell_command);
+
+            // Release the reserved ports as late as possible. The kernel binds them itself
+            // moments after starting, and until this point nothing else can take them.
+            drop(port_reservations);
 
             let mut process = cmd
                 .stdout(util::command::Stdio::piped())

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1684,6 +1684,7 @@ impl LocalWorktree {
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
                             size: metadata.len,
+                            inode: Some(metadata.inode),
                         },
                         is_local: true,
                         is_private,
@@ -1742,6 +1743,7 @@ impl LocalWorktree {
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
                             size: metadata.len,
+                            inode: Some(metadata.inode),
                         },
                         is_local: true,
                         is_private,
@@ -1902,6 +1904,7 @@ impl LocalWorktree {
                     disk_state: DiskState::Present {
                         mtime: metadata.mtime,
                         size: metadata.len,
+                        inode: Some(metadata.inode),
                     },
                     entry_id: None,
                     is_local: true,
@@ -3883,6 +3886,7 @@ impl File {
                 DiskState::Present {
                     mtime,
                     size: entry.size,
+                    inode: Some(entry.inode),
                 }
             } else {
                 DiskState::New
@@ -3912,7 +3916,11 @@ impl File {
         } else if proto.is_deleted {
             DiskState::Deleted
         } else if let Some(mtime) = proto.mtime.map(&Into::into) {
-            DiskState::Present { mtime, size: 0 }
+            DiskState::Present {
+                mtime,
+                size: 0,
+                inode: None,
+            }
         } else {
             DiskState::New
         };

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1683,7 +1683,7 @@ impl LocalWorktree {
                         path,
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
-                            size: metadata.len,
+                            size: Some(metadata.len),
                             inode: Some(metadata.inode),
                         },
                         is_local: true,
@@ -1742,7 +1742,7 @@ impl LocalWorktree {
                         path,
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
-                            size: metadata.len,
+                            size: Some(metadata.len),
                             inode: Some(metadata.inode),
                         },
                         is_local: true,
@@ -1903,7 +1903,7 @@ impl LocalWorktree {
                     path,
                     disk_state: DiskState::Present {
                         mtime: metadata.mtime,
-                        size: metadata.len,
+                        size: Some(metadata.len),
                         inode: Some(metadata.inode),
                     },
                     entry_id: None,
@@ -3885,7 +3885,7 @@ impl File {
             disk_state: if let Some(mtime) = entry.mtime {
                 DiskState::Present {
                     mtime,
-                    size: entry.size,
+                    size: Some(entry.size),
                     inode: Some(entry.inode),
                 }
             } else {
@@ -3916,10 +3916,19 @@ impl File {
         } else if proto.is_deleted {
             DiskState::Deleted
         } else if let Some(mtime) = proto.mtime.map(&Into::into) {
+            // `proto::File` carries no size or identity, but `proto::Entry` carries both and
+            // the worktree they belong to is already here, so recover them from the entry
+            // rather than leaving this observation blind to every same-mtime rewrite. The
+            // entry is missing when its worktree update has not arrived yet, and both fields
+            // stay unknown until it does.
+            let entry = proto
+                .entry_id
+                .map(ProjectEntryId::from_proto)
+                .and_then(|entry_id| worktree.read(cx).entry_for_id(entry_id));
             DiskState::Present {
                 mtime,
-                size: 0,
-                inode: None,
+                size: entry.map(|entry| entry.size),
+                inode: entry.map(|entry| entry.inode),
             }
         } else {
             DiskState::New


### PR DESCRIPTION
- Fixes #63177
- Fixes #63174
- Fixes #43864
- Fixes #61896

Seventeen defects fixed across the LSP synchronization layer, the save path, change detection (local and remote), server lifecycle, the status UI, the updater, and kernel port reservation. Nine commits, each self-contained and reviewable on its own. The affected crates' suites are green at every step (1,604 tests at the widest run, full editor suite included); clippy and rustfmt clean. The Postgres-backed collab suite could not be run in the build environment; the collab crate compiles against the changes.

## LSP document synchronization (`project: Keep LSP document state in sync when a step fails`)

- `on_buffer_edited` used `?` inside its per-server loop, so one server without a snapshot entry starved every remaining server of the edit. It now continues past that server: one that has not been sent `didOpen` has no state to update.
- The same function recorded the new snapshot in the version ledger before sending `didChange`, and discarded the send result. It now sends first and records only on success. A failed send self-heals: the next delta is computed against the last recorded snapshot, so it covers the dropped change. LSP requires monotonic versions, not consecutive ones.
- `merge_diagnostic_entries` returned from the whole function when one document could not be mapped to a worktree, discarding the rest of the batch. It now skips that document, which is what its log message already claimed it did.
- `buffer_snapshot_for_lsp_version` required an exact version match against the 10 retained snapshots, so a publish for a version the user had typed past was dropped entirely. It now resolves against the closest retained older snapshot; positions become anchors and the buffer maps them forward.
- A publish with `version: None` resolved against the current buffer text. It now resolves against the last version actually sent to that server.
- A line-ending change produces no diffs against the LF-normalized rope, so it now triggers a full-document resync; previously the server kept the old line endings indefinitely.

Regression test: `test_diagnostics_for_pruned_buffer_version`, confirmed to fail against the unfixed source.

## Save durability and change detection (`fs: Make saves durable and external changes detectable`)

- `RealFs::save` wrote with `File::create`, truncating the destination before writing, and never fsynced. It now stages a sibling temp file, syncs it, copies the destination's mode and ownership, renames, and fsyncs the parent directory. Symlinks are resolved first, so the target is replaced by rename and the link stays intact. Paths where a rename would change the nature of the file (nonexistent targets, hard-linked files, non-regular files, unresolvable symlinks, irreproducible ownership) fall back to an in-place write that is now also synced. The crash window that produced #63177 is closed on the rename path.
- `atomic_write` now fsyncs before `persist` and the directory after, and copies the destination's permissions instead of leaving the temp file's 0600 mode behind.
- `Buffer::has_conflict` compared mtimes with an ordering that `MTime`'s own documentation warns against. Any mtime different from the one recorded at last save or reload is now a conflict.
- `DiskState::Present` carries the file's size and identity as optional fields. Change detection compares states with an explicit `differs_from`, in which each participates only when both observations know it: rename-based replacement is detected even when size and mtime tick are unchanged, and a field one observation could not determine never decides the comparison. Remote files recover both fields from the worktree entry the wire already carries (`File::from_proto` looks the entry up by id), so a guest's change detection no longer rests on mtime alone. This is the mechanism behind #63174.

Four new `RealFs::save` tests cover permission preservation, hard links, symlink write-through, and content; the hard-link and symlink tests fail against a naive temp-and-rename implementation, which is why the fallback exists. A remote-worktree round trip (`test_remote_file_recovers_size_and_inode_from_its_entry`) proves a guest recovers size and identity from its entry, and fails without the recovery.

## Server lifecycle and status UI (`lsp: Stop abandoning language servers and their status UI`)

- A server stopped while still launching got 5 seconds, after which the function returned without killing it, leaving a live process with wired notification handlers and no registry entry. The launch is now awaited on a detached task and the server shut down when it lands.
- `LanguageServer::shutdown` awaited the output drain without a timeout, with `child.kill()` behind that await. The drain is now bounded and the kill unconditional.
- The server menu rendered its action buttons only when the item list was non-empty, so "Stop All Servers" hid "Restart All Servers", the exact button for that state. The gate is now whether the project has ever had servers. This restores the recovery path #61896 reports as missing; stopped servers are still removed from the list rather than displayed as stopped, which would be a separate presentation change.
- `binary_statuses` entries were inserted and never removed, so a `Failed` status outlived every restart until app quit. Stopping or restarting all servers now clears failed entries.

## Range formatting (`project: Frame range formatting in the version the server holds`)

Outgoing ranges were converted from the current snapshot and returned edits converted back with `version: None`, so both directions could use text the server never received. Both are now framed in the version last sent to that server. The multibuffer case from #22930 has no version to frame against and keeps the current snapshot; the TODO now states exactly that remainder.

## Updater (`auto_update: Stage downloads and reject truncated ones`)

- `download_release` streamed the HTTP response directly into the destination. It now stages through a sibling temp file and renames, as `download_remote_server_binary` already did.
- Both helpers treated a prematurely ended HTTP body as a clean EOF, so a truncated download installed as if whole. Received bytes are now checked against `Content-Length`.

## Kernel ports (`repl: Hold reserved kernel ports until the kernel is spawned`)

`peek_ports` dropped each listener at the end of its own loop iteration, so the OS could reissue the same port and the five reserved ports could collide, on top of leaving them unreserved across a connection-file write and the kernel's entire startup. All five listeners are now held until immediately before spawn.

## Related issues, intentionally without closing keywords

- #46474 (Node.js processes surviving Zed exit): the graceful shutdown path is fixed here (bounded drain, unconditional kill); children orphaned by a hard crash of the editor itself are out of reach of any shutdown code and would need process-group or parent-death signaling.
- #18534 and #59959 (buffers not picking up external changes): resolved by the identity field for the common case of tools that replace files by rename; cases where the watcher never delivers an event for the path are a different mechanism.

## Not changed, deliberately

- Pushed diagnostics are not scoped to the publishing server's registered interests: any server can still decorate any file, and restarting the offender helps only until the fresh instance republishes. Scoping this correctly is a change to how server registrations are modeled.
- `bad_is_greater_than` retains two callers (`extension_host.rs:435`, `agent_server_store.rs:1099`), both cache-freshness checks. Its documentation has called it temporary since November 2024. This PR removes the one caller where the comparison could destroy data; the remaining two can adopt the same inequality, at which point the method can be deleted and "temporary" becomes true retroactively.

Release Notes:

- Fixed a crash during save being able to destroy the file's previous contents.
- Fixed edits made by external tools going undetected when file size and timestamp were unchanged.
- Fixed shared projects not detecting external file changes that kept the timestamp unchanged.
- Fixed diagnostics getting stuck at stale positions until a language server restart.
- Fixed stopped language servers surviving as orphaned processes.
- Fixed the language server menu losing its restart action after stopping all servers.
- Fixed failed server statuses persisting until app restart.
- Fixed truncated editor updates being treated as complete downloads.
- Fixed Jupyter kernel launches occasionally failing due to colliding or stolen ports.
