### PR TITLE
fs: Improved responsiveness when watching paths on slow or unresponsive filesystems

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -500,7 +500,11 @@ async fn poll_path_until_created(
 
         // Probe case sensitivity now that the path exists, rather than at add
         // time when it didn't.
-        let case_insensitive = case_insensitive_path(path.as_ref());
+        let case_insensitive = smol::unblock({
+            let path = path.clone();
+            move || case_insensitive_path(path.as_ref())
+        })
+        .await;
         let key = WatchKey::for_registration(SanitizedPath::new(&path), case_insensitive);
 
         if registrations.lock().contains_key(&key) {
@@ -508,12 +512,15 @@ async fn poll_path_until_created(
             return;
         }
 
-        match register_existing_path(
-            path.clone(),
-            case_insensitive,
-            tx.clone(),
-            pending_path_events.clone(),
-        ) {
+        let registration = smol::unblock({
+            let path = path.clone();
+            let tx = tx.clone();
+            let pending_path_events = pending_path_events.clone();
+            move || register_existing_path(path, case_insensitive, tx, pending_path_events)
+        })
+        .await;
+
+        match registration {
             Ok(Some(registration)) => {
                 {
                     let mut pending_registrations = pending_registrations.lock();


### PR DESCRIPTION
# Objective

When Zed watches a file or folder that doesn't exist yet, it retries every couple of seconds. Two steps in that retry can be slow: asking the filesystem whether it's case-sensitive (blocking sys call), and registering the watcher itself (which reads the whole folder tree when the watcher is recursive). If the system is slow to respond, those steps can hang for a long time as you can see inside the following logs:

```
2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.159457333s        - crates/fs/src/fs_watcher.rs:85:34

2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.155837042s        - crates/fs/src/fs_watcher.rs:85:34

2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.156099417s        - crates/fs/src/fs_watcher.rs:85:34

2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.155881292s        - crates/fs/src/fs_watcher.rs:85:34

2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.15603025s         - crates/fs/src/fs_watcher.rs:85:34

2026-08-23T11:42:56+02:00 INFO  [zed::reliability::hang_detection::logging] Background hang detected on Unknown:
Tasks(s) that ran too long
18.155880042s        - crates/fs/src/fs_watcher.rs:85:34
```

## Solution

My solution is to unblock the blocking code so that it doesn't hang a background thread whenever the filesystem is slow to respond. The task poll now returns pending while the syscall runs on the blocking pool, so other tasks can be polled in the meantime.

## Testing

Behavior is unchanged, so just testing if Zed still picks up created directories/files should be enough.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved responsiveness when watching paths on slow or unresponsive filesystems
