### PR TITLE
gpui: Ignore control characters delivered as IME text on macOS

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -59,6 +59,7 @@ use parking_lot::Mutex;
 use raw_window_handle as rwh;
 use smallvec::SmallVec;
 use std::{
+    borrow::Cow,
     cell::Cell,
     ffi::{CStr, CString, c_void},
     mem,
@@ -3087,10 +3088,37 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
 
         let text = text.to_str();
         let replacement_range = replacement_range.to_range();
+
+        // AppKit routes a keystroke here as text whenever it believes an input
+        // session is active. That belief outlives a composition the editor
+        // abandoned on losing focus, so backspace can arrive as U+0008 instead
+        // of being dispatched as an action.
+        let text = filter_disallowed_control_characters(text);
+        if text.is_empty() {
+            return;
+        }
+
         with_input_handler(this, |input_handler| {
-            input_handler.replace_text_in_range(replacement_range, text)
+            input_handler.replace_text_in_range(replacement_range, &text)
         });
     }
+}
+
+/// Removes control characters that must never reach a text buffer.
+///
+/// Tab, line feed and carriage return are preserved: those are legitimate text,
+/// and pasted input relies on them. Everything else matches the set the editor
+/// treats as invisible, see `editor::display_map::invisibles::is_invisible`.
+fn filter_disallowed_control_characters(text: &str) -> Cow<'_, str> {
+    fn is_disallowed(character: char) -> bool {
+        character.is_control() && !matches!(character, '\t' | '\n' | '\r')
+    }
+
+    if !text.contains(is_disallowed) {
+        return Cow::Borrowed(text);
+    }
+
+    Cow::Owned(text.replace(is_disallowed, ""))
 }
 
 extern "C" fn set_marked_text(
@@ -3581,5 +3609,39 @@ mod tests {
     #[test]
     fn display_id_for_screen_returns_none_for_null_screen() {
         assert_eq!(display_id_for_screen(nil), None);
+    }
+
+    #[test]
+    fn filter_disallowed_control_characters_keeps_ordinary_text() {
+        assert!(matches!(
+            filter_disallowed_control_characters("hello"),
+            Cow::Borrowed("hello")
+        ));
+        assert!(matches!(
+            filter_disallowed_control_characters("\u{d55c}\u{ae00}"),
+            Cow::Borrowed("\u{d55c}\u{ae00}")
+        ));
+    }
+
+    #[test]
+    fn filter_disallowed_control_characters_keeps_tab_and_newlines() {
+        assert!(matches!(
+            filter_disallowed_control_characters("a\tb\nc\r\nd"),
+            Cow::Borrowed("a\tb\nc\r\nd")
+        ));
+    }
+
+    #[test]
+    fn filter_disallowed_control_characters_drops_backspace() {
+        assert_eq!(filter_disallowed_control_characters("\u{8}"), "");
+        assert_eq!(filter_disallowed_control_characters("\u{ba48}\u{8}"), "\u{ba48}");
+    }
+
+    #[test]
+    fn filter_disallowed_control_characters_drops_remaining_controls() {
+        assert_eq!(filter_disallowed_control_characters("a\u{0}b"), "ab");
+        assert_eq!(filter_disallowed_control_characters("a\u{1b}b"), "ab");
+        assert_eq!(filter_disallowed_control_characters("a\u{7f}b"), "ab");
+        assert_eq!(filter_disallowed_control_characters("a\u{85}b"), "ab");
     }
 }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -3106,9 +3106,16 @@ extern "C" fn insert_text(this: &Object, _: Sel, text: id, replacement_range: NS
 
 /// Removes control characters that must never reach a text buffer.
 ///
-/// Tab, line feed and carriage return are preserved: those are legitimate text,
-/// and pasted input relies on them. Everything else matches the set the editor
-/// treats as invisible, see `editor::display_map::invisibles::is_invisible`.
+/// Tab, line feed and carriage return are preserved as a precaution, so that a
+/// source delivering them as text is not silently stripped. Key events do not
+/// take this path: they carry a `key_char`, and `is_ime_printable_key` excludes
+/// control characters, so tab and enter are dispatched as actions instead.
+/// Paste does not either, as `EntityInputHandler::paste` calls
+/// `replace_text_in_range` directly.
+///
+/// Everything else covers the control-character portion of the set the editor
+/// treats as invisible, see `editor::display_map::invisibles::is_invisible`,
+/// which is broader and also includes Unicode spaces and format characters.
 fn filter_disallowed_control_characters(text: &str) -> Cow<'_, str> {
     fn is_disallowed(character: char) -> bool {
         character.is_control() && !matches!(character, '\t' | '\n' | '\r')


### PR DESCRIPTION
# Objective

- Typing after an editor loses focus mid-composition leaves a character with no glyph in the buffer, which renders as an empty box.
- AppKit sends a keystroke to `insertText:` as text whenever it believes an input session is active. Since the whole GPUI window is a single `NSView`, a focus change inside it need not be visible to AppKit, so that belief can outlive the composition and the next keystroke arrives as text rather than being dispatched as an action. I could only reproduce this by opening a file through the CLI mid-composition; `cmd-p` and switching applications did not trigger it.
- Backspace therefore arrives as U+0008 and was written into the buffer verbatim. Escape arrives the same way as U+001B. This affects every consumer of `replace_text_in_range`, including the editor and the terminal.

## Solution

- Drop control characters in `insertText:` before handing the text to the input handler, keeping tab, line feed and carriage return. ~~Those are legitimate text, and pasted input relies on them.~~ **Correction:** paste does not reach this filter — `EntityInputHandler::paste` calls `replace_text_in_range` directly (`crates/gpui/src/input.rs:42`). Nor do tab and enter, which carry a `key_char` and are excluded from IME routing by the control-character check in `is_ime_printable_key` (`crates/gpui_macos/src/window.rs:2466`). I have not found an input path that delivers `\t\n\r` here, so the exception is precautionary.
- ~~This is the same set the editor already treats as invisible, and it matches how `gpui_windows` filters its own key events.~~ **Correction:** `is_invisible` is a broader set, also covering Unicode spaces and format characters, so this filter matches only its control-character portion. And `crates/gpui_windows/src/events.rs:1369` drops every control character with no exceptions, which makes this filter the more permissive of the two — shared intent, different allowed set.

## Testing

- Added unit tests covering ordinary text, the preserved whitespace characters, backspace, and the remaining control characters.
- Verified on macOS with the Apple 2-set Korean IME, using an instrumented build that logs `insert_text`, `set_marked_text` and `unmark_text`. Type continuously in a prompt, open a file through the CLI so an editor takes focus mid-composition, then press backspace. Before this change the buffer gains an empty box; copying it and dumping the code point yields U+0008. Over 659 log lines the filter stopped all 22 U+0008 and the single U+001B observed, so nothing is inserted.
- ~~After it, backspace deletes as expected and nothing is inserted.~~ **Correction:** this does not hold, and was written from the unit tests rather than from a build. See the known limitation below.

## Known limitation

**This filter is not sufficient on its own and should not land alone.** Backspace and escape carry no `key_char` (`crates/gpui_macos/src/events.rs:372`), so `window.rs:2480` routes them to the IME, which in this state answers with `insertText:` rather than `doCommandBySelector:(deleteBackward:)`. Dropping the text therefore removes the insertion and the delete together, leaving both keys dead rather than merely silent.

Clearing the marked range in `Editor::handle_blur` addresses the cause instead: AppKit closes the session, and the control characters stop arriving. Measured with that change and no filter at all, 308 log lines: 0 × U+0008, 0 × U+001B, backspace deleting normally. That fix is #63555.

This change is still worth having as defence in depth for input sources GPUI does not control, but it needs the upstream fix alongside it.

## Out of scope

While reproducing the above I also saw the composition in progress land in the newly focused editor, so a file the user never meant to touch picks up a few stray characters. Neither change addresses this: clearing the marked range invalidates stale coordinates but does not cancel the composition itself, which would need the AppKit input session torn down. Happy to file it separately.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed an empty box being inserted when typing after an editor lost focus during IME composition

