### PR TITLE
fs: Stop FakeFs deleting files it should leave alone

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2991,6 +2991,14 @@ impl Fs for FakeFs {
             }
         })?;
 
+        // POSIX `rename` succeeds without doing anything when both names resolve
+        // to the same file. Falling through would assign the entry onto itself
+        // and then remove it, destroying the file. The lookup above has already
+        // reported a missing source, so only an existing one reaches here.
+        if old_path == new_path {
+            return Ok(());
+        }
+
         let inode = match moved_entry {
             FakeFsEntry::File { inode, .. } => inode,
             FakeFsEntry::Dir { inode, .. } => inode,

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2997,14 +2997,18 @@ impl Fs for FakeFs {
             _ => 0,
         };
 
-        state.moves.insert(inode, new_path.clone());
-
+        let mut moved = true;
         state.write_path(&new_path, |e| {
             match e {
                 btree_map::Entry::Occupied(mut e) => {
                     if options.overwrite {
                         *e.get_mut() = moved_entry;
-                    } else if !options.ignore_if_exists {
+                    } else if options.ignore_if_exists {
+                        // `RealFs` reports success without moving anything here,
+                        // leaving the source in place. Removing it instead would
+                        // destroy a file the caller still expects to find.
+                        moved = false;
+                    } else {
                         anyhow::bail!("path already exists: {new_path:?}");
                     }
                 }
@@ -3014,6 +3018,12 @@ impl Fs for FakeFs {
             }
             Ok(())
         })?;
+
+        if !moved {
+            return Ok(());
+        }
+
+        state.moves.insert(inode, new_path.clone());
 
         state
             .write_path(&old_path, |e| {

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -591,6 +591,43 @@ async fn test_realfs_rename_ignore_if_exists_leaves_source_and_target_unchanged(
 }
 
 #[gpui::test]
+async fn test_fake_fs_rename_ignore_if_exists_leaves_source_and_target_unchanged(
+    executor: BackgroundExecutor,
+) {
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "source.txt": "from source",
+            "target.txt": "from target",
+        }),
+    )
+    .await;
+
+    let result = fs
+        .rename(
+            Path::new(path!("/root/source.txt")),
+            Path::new(path!("/root/target.txt")),
+            RenameOptions {
+                ignore_if_exists: true,
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(result.is_ok());
+
+    assert_eq!(
+        fs.load(Path::new(path!("/root/source.txt"))).await.unwrap(),
+        "from source"
+    );
+    assert_eq!(
+        fs.load(Path::new(path!("/root/target.txt"))).await.unwrap(),
+        "from target"
+    );
+}
+
+#[gpui::test]
 #[cfg(unix)]
 async fn test_realfs_broken_symlink_metadata(executor: BackgroundExecutor) {
     let tempdir = TempDir::new().unwrap();

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -604,6 +604,11 @@ async fn test_fake_fs_rename_ignore_if_exists_leaves_source_and_target_unchanged
     )
     .await;
 
+    let handle = fs
+        .open_handle(Path::new(path!("/root/source.txt")))
+        .await
+        .unwrap();
+
     let result = fs
         .rename(
             Path::new(path!("/root/source.txt")),
@@ -625,6 +630,40 @@ async fn test_fake_fs_rename_ignore_if_exists_leaves_source_and_target_unchanged
         fs.load(Path::new(path!("/root/target.txt"))).await.unwrap(),
         "from target"
     );
+
+    // An ignored rename must not be recorded as a move either, or a handle held
+    // across it reports a path its file never went to.
+    assert!(
+        handle.current_path(&(fs.clone() as Arc<dyn Fs>)).is_err(),
+        "an ignored rename should not record a move"
+    );
+}
+
+#[gpui::test]
+async fn test_fake_fs_rename_onto_itself_keeps_the_file(executor: BackgroundExecutor) {
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "a.txt": "content",
+        }),
+    )
+    .await;
+
+    let path = Path::new(path!("/root/a.txt"));
+    let result = fs
+        .rename(
+            path,
+            path,
+            RenameOptions {
+                overwrite: true,
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(result.is_ok());
+    assert_eq!(fs.load(path).await.unwrap(), "content");
 }
 
 #[gpui::test]


### PR DESCRIPTION
# Objective

`FakeFs::rename` deletes files in two cases where `RealFs` leaves them alone. Tests written against the fake see a file vanish where the real filesystem keeps it, so the behavior cannot be tested at all and anything relying on it drifts unnoticed.

There is already a test for the first case for `RealFs`, `test_realfs_rename_ignore_if_exists_leaves_source_and_target_unchanged`, but the fake had no counterpart.

## Solution

Return early in both cases instead of falling through to the removal.

For `ignoreIfExists` onto an existing target, `RealFs` reports success and does not move anything. The fake kept the target but removed the source. The fix also stops recording a move that never happened, which would otherwise leave an open file handle pointing at the wrong path.

For a rename onto itself with `overwrite`, POSIX requires success with no action. The fake assigned the entry onto itself and then removed it. I found this while fixing the first one, and included it.

## Testing

I extended an existing test, and added two new ones. Each fails on `main` and passes here.

I found this issue while working on #5369, where an LSP rename can send `ignoreIfExists` and the fake made the resulting bug impossible to write a test for.

Ran the tests only on macOS as the area seems platform agnostic, but please let me know if I need to run them across all platforms.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
