### PR TITLE
Fix C++ direct-initialization variable highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9528,6 +9528,7 @@ dependencies = [
  "tracing",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-elixir",
  "tree-sitter-embedded-template",
  "tree-sitter-heex",

--- a/crates/grammars/src/cpp/highlights.scm
+++ b/crates/grammars/src/cpp/highlights.scm
@@ -69,8 +69,18 @@
 (template_method
   name: (field_identifier) @function)
 
-(function_declarator
-  declarator: (identifier) @function)
+; `Type var(args)` in a function body is direct-initialization, not a function
+; declaration.
+(compound_statement
+  (declaration
+    declarator: (function_declarator
+      parameters: (parameter_list
+        (parameter_declaration
+          type: (type_identifier) @variable)))))
+
+((function_declarator
+  declarator: (identifier) @function) @function.declarator
+  (#not-has-parent-chain? @function.declarator declaration compound_statement))
 
 (function_declarator
   declarator: (qualified_identifier
@@ -93,7 +103,9 @@
 
 (auto) @type
 
-(type_identifier) @type
+((type_identifier) @type
+  (#not-has-parent-chain? @type
+    parameter_declaration parameter_list function_declarator declaration compound_statement))
 
 type: (primitive_type) @type.builtin
 

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -102,6 +102,7 @@ tree-sitter-md.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-ruby.workspace = true
 tree-sitter-c.workspace = true
+tree-sitter-cpp.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 toml.workspace = true

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -103,6 +103,7 @@ struct SyntaxMapCapturesLayer<'a> {
     depth: usize,
     captures: QueryCaptures<'a, 'a, 'static, TextProvider<'a>, &'a [u8]>,
     next_capture: Option<QueryCapture<'a>>,
+    query: &'a Query,
     grammar_index: usize,
     _query_cursor: QueryCursorHandle,
 }
@@ -1161,6 +1162,7 @@ impl<'a> SyntaxMapCaptures<'a> {
                 grammar_index,
                 next_capture: None,
                 captures,
+                query,
                 _query_cursor: query_cursor,
             };
 
@@ -1388,7 +1390,17 @@ impl<'a> SyntaxMapMatches<'a> {
 
 impl SyntaxMapCapturesLayer<'_> {
     fn advance(&mut self) {
-        self.next_capture = self.captures.next().map(|(mat, ix)| mat.captures[*ix]);
+        loop {
+            let Some((mat, capture_index)) = self.captures.next() else {
+                self.next_capture = None;
+                return;
+            };
+
+            if satisfies_custom_predicates(self.query, mat) {
+                self.next_capture = Some(mat.captures[*capture_index]);
+                return;
+            }
+        }
     }
 
     fn sort_key(&self) -> (usize, Reverse<usize>, usize) {
@@ -1450,6 +1462,8 @@ fn satisfies_custom_predicates(query: &Query, mat: &QueryMatch) -> bool {
         let satisfied = match predicate.operator.as_ref() {
             "has-parent?" => has_parent(&predicate.args, mat),
             "not-has-parent?" => !has_parent(&predicate.args, mat),
+            "has-parent-chain?" => has_parent_chain(&predicate.args, mat),
+            "not-has-parent-chain?" => !has_parent_chain(&predicate.args, mat),
             _ => true,
         };
         if !satisfied {
@@ -1476,6 +1490,33 @@ fn has_parent(args: &[QueryPredicateArg], mat: &QueryMatch) -> bool {
         .node
         .parent()
         .is_some_and(|p| p.kind() == parent_kind.as_ref())
+}
+
+fn has_parent_chain(args: &[QueryPredicateArg], mat: &QueryMatch) -> bool {
+    let Some(QueryPredicateArg::Capture(capture_ix)) = args.first() else {
+        return false;
+    };
+
+    let Some(capture) = mat.captures.iter().find(|c| c.index == *capture_ix) else {
+        return false;
+    };
+
+    let mut node = capture.node;
+    for parent_kind in &args[1..] {
+        let QueryPredicateArg::String(parent_kind) = parent_kind else {
+            return false;
+        };
+
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        if parent.kind() != parent_kind.as_ref() {
+            return false;
+        }
+        node = parent;
+    }
+
+    true
 }
 
 fn join_ranges(

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -400,6 +400,115 @@ fn test_rust_json_macro_empty_string_highlighting(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_highlight_captures_filter_custom_predicates(cx: &mut App) {
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Rust".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["rs".to_string()],
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    )
+    .with_queries(LanguageQueries {
+        highlights: Some(Cow::from(
+            "((closure_expression) @function (#not-has-parent-chain? @function arguments call_expression))",
+        )),
+        ..Default::default()
+    })
+    .expect("Could not parse queries"));
+
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    registry.add(language.clone());
+    let buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        "fn main() { let standalone = || {}; foo(|| {}); }",
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(language, &buffer);
+
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["function"],
+        "fn main() { let standalone = «|| {}»; foo(|| {}); }",
+    );
+}
+
+#[gpui::test]
+fn test_cpp_direct_initialization_highlights(cx: &mut App) {
+    // `Application app(appInfo);` inside a function body is direct
+    // initialization, not a function declaration (zed#61494). The identifier
+    // must not be captured as `@function` and the argument type must not be
+    // captured as `@type`.
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: LanguageName::new_static("C++"),
+                matcher: Arc::new(LanguageMatcher {
+                    path_suffixes: vec!["cpp".to_string()],
+                    ..Default::default()
+                }),
+                ..LanguageConfig::default()
+            },
+            Some(tree_sitter::Language::new(tree_sitter_cpp::LANGUAGE)),
+        )
+        .with_queries(LanguageQueries {
+            highlights: Some(Cow::from(include_str!(
+                "../../../grammars/src/cpp/highlights.scm"
+            ))),
+            ..Default::default()
+        })
+        .expect("Could not parse queries"),
+    );
+
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    registry.add(language.clone());
+    let buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        "int main() {\n    Application app(appInfo);\n}\n",
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(language, &buffer);
+
+    // Only `main` may be a function; the direct-initialization variable `app`
+    // must not be captured as `@function`.
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["function"],
+        "int «main»() {\n    Application app(appInfo);\n}\n",
+    );
+
+    // Only the declaration type stays a type; the parameter type `appInfo`
+    // must not be captured as `@type`.
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["type"],
+        "int main() {\n    «Application» app(appInfo);\n}\n",
+    );
+
+    // Both the variable and its initializer argument are captured as
+    // variables.
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["variable"],
+        "int «main»() {\n    Application «app»(«appInfo»);\n}\n",
+    );
+}
+
+#[gpui::test]
 fn test_typing_multiple_new_injections(cx: &mut App) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Rust",


### PR DESCRIPTION
Fixes #61494

## Objective

- `Type var(args)` inside a function body is direct initialization, not a function declaration, but tree-sitter-cpp's generic `(function_declarator declarator: (identifier) @function)` pattern matched it and overrode the `@variable` capture. The argument type was likewise captured as `@type`.
- Clangd's semantic tokens correctly identify these as variables, so the static tree-sitter highlighting disagreed with semantic analysis.

## Solution

- Add `has-parent-chain?` / `not-has-parent-chain?` custom predicates and evaluate all custom predicates while iterating syntax-highlight captures. Previously custom predicates were only evaluated on the match path, not on the highlight-capture path used for rendering.
- Use the new predicates in the C++ highlights query to exclude direct-initialization declarations from the `@function` and `@type` captures.

## Testing

- Added `test_cpp_direct_initialization_highlights`: loads the real C++ grammar and `highlights.scm`, asserting `app`/`appInfo` are captured as `@variable` and not as `@function`/`@type`.
- Added `test_highlight_captures_filter_custom_predicates`: exercises the new `not-has-parent-chain?` predicate through the highlight-capture path.
- `cargo test -p language`: 169 passed, 0 failed.
- `cargo clippy -p language --all-targets -- --deny warnings`: clean.
- `ts_query_ls format --check`: clean.
- Tested on Windows (x86_64).

This is a resubmission of #61725, addressing the failing `check_style` and `clippy` checks (unformatted query line + `Language` ownership in the test).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (N/A)
- [x] The content adheres to Zed's UI standards (N/A — syntax query + tests)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed C++ variables with direct-initialization syntax being highlighted as function declarations.
