### PR TITLE
Make mermaid diagram font family configurable

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -85,6 +85,9 @@
   "markdown_preview_font_family": null,
   // The font family for code blocks in the markdown preview. Falls back to the editor font family if unset.
   "markdown_preview_code_font_family": null,
+  // The font family for Mermaid diagrams in the agent panel and markdown preview.
+  // Falls back to the UI font family if unset.
+  "mermaid_font_family": null,
   // How much to fade out unused code.
   "unnecessary_code_fade": 0.3,
   // Active pane styling settings.

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -370,7 +370,7 @@ fn build_mermaid_theme(cx: &Context<Markdown>) -> mermaid_render::MermaidTheme {
 
     mermaid_render::MermaidTheme {
         dark_mode: is_dark,
-        font_family: mermaid_font_family(theme_settings.ui_font.family.as_ref()),
+        font_family: mermaid_font_family(theme_settings.mermaid_font_family().as_ref()),
         background: colors.editor_background,
         primary_color: colors.surface_background,
         primary_text_color: colors.text,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1013,6 +1013,7 @@ impl VsCodeSettings {
             markdown_preview_code_font_family: None,
             markdown_preview_font_size: None,
             markdown_preview_theme: None,
+            mermaid_font_family: None,
             theme: None,
             icon_theme: None,
             ui_density: None,

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -226,6 +226,9 @@ pub struct ThemeSettingsContent {
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.
     pub markdown_preview_theme: Option<ThemeSelection>,
+    /// The name of a font to use for rendering Mermaid diagrams in the agent
+    /// panel and markdown preview. Falls back to the UI font if unset.
+    pub mermaid_font_family: Option<FontFamilyName>,
     /// The name of the Zed theme to use.
     pub theme: Option<ThemeSelection>,
     /// The name of the icon theme to use.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1293,6 +1293,32 @@ fn appearance_page() -> SettingsPage {
         ]
     }
 
+    fn mermaid_font_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Mermaid Font"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Font Family",
+                description: "Font family for Mermaid diagrams in the agent panel and markdown preview. Falls back to the UI font family.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("mermaid_font_family"),
+                    pick: |settings_content| {
+                        settings_content
+                            .theme
+                            .mermaid_font_family
+                            .as_ref()
+                            .or(settings_content.theme.ui_font_family.as_ref())
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.theme.mermaid_font_family = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn text_rendering_section() -> [SettingsPageItem; 2] {
         [
             SettingsPageItem::SectionHeader("Text Rendering"),
@@ -1536,6 +1562,7 @@ fn appearance_page() -> SettingsPage {
         ui_font_section(),
         agent_panel_font_section(),
         markdown_preview_font_section(),
+        mermaid_font_section(),
         text_rendering_section(),
         cursor_section(),
         highlighting_section(),

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -75,6 +75,9 @@ pub struct ThemeSettings {
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.
     pub markdown_preview_theme: Option<ThemeSelection>,
+    /// The font family used for Mermaid diagrams.
+    /// Falls back to the UI font family if unset.
+    mermaid_font_family: Option<SharedString>,
     /// The line height for buffers, and the terminal.
     ///
     /// Changing this may affect the spacing of some UI elements.
@@ -442,6 +445,14 @@ impl ThemeSettings {
             .unwrap_or(&self.buffer_font.family)
     }
 
+    /// Returns the font family to use for Mermaid diagrams,
+    /// falling back to the UI font family when unset.
+    pub fn mermaid_font_family(&self) -> &SharedString {
+        self.mermaid_font_family
+            .as_ref()
+            .unwrap_or(&self.ui_font.family)
+    }
+
     /// Returns the markdown preview font size.
     ///
     /// Note: the fallback deliberately uses `self.ui_font_size` instead of `ui_font_size(cx)`,
@@ -756,6 +767,10 @@ impl settings::Settings for ThemeSettings {
                 .markdown_preview_theme
                 .clone()
                 .map(ThemeSelection::from),
+            mermaid_font_family: content
+                .mermaid_font_family
+                .as_ref()
+                .map(|font| font.0.clone().into()),
             theme: theme_selection,
             experimental_theme_overrides: content.experimental_theme_overrides.clone(),
             theme_overrides: content.theme_overrides.clone(),

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -86,7 +86,11 @@ If you would like to use distinct themes for light mode/dark mode that can be se
   "markdown_preview_font_family": null,
   // Controls the font family for code blocks in the markdown preview.
   // If not specified, it falls back to the editor font family.
-  "markdown_preview_code_font_family": null
+  "markdown_preview_code_font_family": null,
+
+  // Controls the font family for Mermaid diagrams in the agent panel and
+  // markdown preview. If not specified, it falls back to the UI font family.
+  "mermaid_font_family": "Inter"
 ```
 
 ### Font ligatures


### PR DESCRIPTION
# Objective

Fix #63428

## Solution

Add a settings option `"mermaid_font_family"` to allow escape from `"ui_font_family"`. Does not affect any default behavior.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="2426" height="1456" alt="Image" src="https://github.com/user-attachments/assets/70ec2ae3-a184-4523-bce2-272c8f33b840" />

<img width="1838" height="668" alt="image" src="https://github.com/user-attachments/assets/93711957-8f9c-42cd-afc0-a1ac84f1d7a3" />

Release Notes:

- Make mermaid diagram font family configurable to fix #63428
