### PR TITLE
editor: Keep deleted git-gutter marker visible at small custom widths

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5327,10 +5327,21 @@ impl EditorElement {
         });
     }
 
+    const DELETED_MARKER_WIDTH_RATIO: f32 = 0.35 / 0.275;
+
     fn gutter_strip_width(line_height: Pixels, cx: &App) -> Pixels {
         match EditorSettings::get_global(cx).gutter.git_gutter_width {
             GitGutterWidth::Custom(width) => px(*width),
             GitGutterWidth::Default => (0.275 * line_height).floor(),
+        }
+    }
+
+    fn deleted_marker_base_width(setting: GitGutterWidth, line_height: Pixels) -> Pixels {
+        match setting {
+            GitGutterWidth::Custom(width) => px(*width * Self::DELETED_MARKER_WIDTH_RATIO),
+            GitGutterWidth::Default => {
+                (0.275 * line_height * Self::DELETED_MARKER_WIDTH_RATIO).floor()
+            }
         }
     }
 
@@ -5369,10 +5380,10 @@ impl EditorElement {
                             .into();
                     let end_y = start_y + line_height;
 
-                    let width = match EditorSettings::get_global(cx).gutter.git_gutter_width {
-                        GitGutterWidth::Custom(width) => px(*width),
-                        GitGutterWidth::Default => (0.35 * line_height).floor(),
-                    };
+                    let width = Self::deleted_marker_base_width(
+                        EditorSettings::get_global(cx).gutter.git_gutter_width,
+                        line_height,
+                    );
                     let highlight_origin = gutter_bounds.origin + point(px(0.), start_y);
                     let highlight_size = size(width, end_y - start_y);
                     Bounds::new(highlight_origin, highlight_size)
@@ -12567,6 +12578,33 @@ mod tests {
         assert_eq!(
             calculate_wrap_width(SoftWrap::Bounded(200), px(400.0), em_width),
             Some(px(400.0)),
+        );
+    }
+
+    #[test]
+    fn test_deleted_marker_base_width() {
+        use settings::PixelSetting;
+
+        assert_eq!(
+            EditorElement::deleted_marker_base_width(GitGutterWidth::Default, px(22.0)),
+            px(7.0),
+        );
+
+        let boosted = EditorElement::deleted_marker_base_width(
+            GitGutterWidth::Custom(PixelSetting(6.0)),
+            px(22.0),
+        );
+        assert!(
+            boosted > px(6.0),
+            "boosted={boosted:?} must exceed the raw custom width so the deleted pill stays visible"
+        );
+
+        assert_eq!(
+            EditorElement::deleted_marker_base_width(
+                GitGutterWidth::Custom(PixelSetting(0.0)),
+                px(22.0),
+            ),
+            px(0.0),
         );
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #62923.
- When `gutter.git_gutter_width` is set to a small `Custom` value (e.g. `{"custom": 6.0}`), the deleted-line marker becomes disproportionately small. It is nearly invisible in the reporter's screenshots, while added/modified markers scale acceptably.

## Solution

- The deleted marker's `Default` arm uses a `0.35 * line_height` base; the strip's `Default` arm uses `0.275 * line_height`. That 27% larger base is what keeps the pill-shaped deleted marker visible next to the rectangular added/modified strips.
- The `Custom(N)` arm previously used `N` for both branches, dropping the boost. This PR routes the deleted-empty case through a new `deleted_marker_base_width(setting, line_height)` helper that applies a single `DELETED_MARKER_WIDTH_RATIO = 0.35 / 0.275` constant to both arms.
- Default-mode pixels are byte-identical because `floor(0.275 * lh * 0.35/0.275)` reduces to `floor(0.35 * lh)`. Custom-mode gains the same 1.273× multiplier the default has always had.

## Testing

- Added a pure `#[test] fn test_deleted_marker_base_width` covering three invariants:
  - `Default` at `line_height = 22.0` returns `7px`, identical to the previous default arm.
  - `Custom(6.0)` at `line_height = 22.0` returns a width greater than 6.0 (visibility preserved).
  - `Custom(0.0)` returns `0.0`, so the width-0 render path is unchanged.
- Verified locally on Windows: `cargo fmt --all -- --check`, `cargo check -p editor`, and `cargo clippy -p editor --all-targets -- -D warnings` all exit 0.
- I have not visually verified the rendered marker on macOS or Linux. A reviewer with the reporter's setup (`git_gutter_width: {"custom": 6.0}` on macOS) can confirm the pill stays visible.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the deleted git-gutter marker becoming nearly invisible when `git_gutter_width` is set to a small custom pixel value.
