### PR TITLE
util: Prevent panic when parsing a malformed shell variable

### DIFF
--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -234,13 +234,13 @@ impl ShellKind {
 
     fn to_cmd_variable(input: &str) -> String {
         if let Some(var_str) = input.strip_prefix("${") {
-            if var_str.find(':').is_none() {
-                // If the input starts with "${", remove the trailing "}"
-                format!("%{}%", &var_str[..var_str.len() - 1])
-            } else {
+            match var_str.strip_suffix('}') {
                 // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
                 // which will result in the task failing to run in such cases.
-                input.into()
+                Some(var_name) if !var_name.is_empty() && !var_name.contains(':') => {
+                    format!("%{var_name}%")
+                }
+                _ => input.into(),
             }
         } else if let Some(var_str) = input.strip_prefix('$') {
             // If the input starts with "$", directly append to "$env:"
@@ -253,13 +253,13 @@ impl ShellKind {
 
     fn to_powershell_variable(input: &str) -> String {
         if let Some(var_str) = input.strip_prefix("${") {
-            if var_str.find(':').is_none() {
-                // If the input starts with "${", remove the trailing "}"
-                format!("$env:{}", &var_str[..var_str.len() - 1])
-            } else {
+            match var_str.strip_suffix('}') {
                 // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
                 // which will result in the task failing to run in such cases.
-                input.into()
+                Some(var_name) if !var_name.is_empty() && !var_name.contains(':') => {
+                    format!("$env:{var_name}")
+                }
+                _ => input.into(),
             }
         } else if let Some(var_str) = input.strip_prefix('$') {
             // If the input starts with "$", directly append to "$env:"
@@ -941,6 +941,36 @@ mod tests {
             assert!(quoted.starts_with('\''));
             assert!(quoted.ends_with('\''));
             assert!(quoted.contains("O''Brien"));
+        }
+    }
+
+    #[test]
+    fn test_to_shell_variable() {
+        assert_eq!(ShellKind::PowerShell.to_shell_variable("${FOO}"), "$env:FOO");
+        assert_eq!(ShellKind::Pwsh.to_shell_variable("${FOO}"), "$env:FOO");
+        assert_eq!(ShellKind::Cmd.to_shell_variable("${FOO}"), "%FOO%");
+        assert_eq!(ShellKind::Nushell.to_shell_variable("${FOO}"), "$env.FOO");
+        assert_eq!(ShellKind::Posix.to_shell_variable("${FOO}"), "${FOO}");
+
+        assert_eq!(ShellKind::PowerShell.to_shell_variable("$FOO"), "$env:FOO");
+        assert_eq!(ShellKind::PowerShell.to_shell_variable("${日本}"), "$env:日本");
+        assert_eq!(
+            ShellKind::PowerShell.to_shell_variable("${FOO:-bar}"),
+            "${FOO:-bar}"
+        );
+    }
+
+    #[test]
+    fn test_to_shell_variable_malformed_is_passed_through() {
+        for input in ["${", "${FOO", "${café", "${}", "${日本"] {
+            for shell_kind in [
+                ShellKind::PowerShell,
+                ShellKind::Pwsh,
+                ShellKind::Cmd,
+                ShellKind::Nushell,
+            ] {
+                assert_eq!(shell_kind.to_shell_variable(input), input);
+            }
         }
     }
 }

--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -946,14 +946,20 @@ mod tests {
 
     #[test]
     fn test_to_shell_variable() {
-        assert_eq!(ShellKind::PowerShell.to_shell_variable("${FOO}"), "$env:FOO");
+        assert_eq!(
+            ShellKind::PowerShell.to_shell_variable("${FOO}"),
+            "$env:FOO"
+        );
         assert_eq!(ShellKind::Pwsh.to_shell_variable("${FOO}"), "$env:FOO");
         assert_eq!(ShellKind::Cmd.to_shell_variable("${FOO}"), "%FOO%");
         assert_eq!(ShellKind::Nushell.to_shell_variable("${FOO}"), "$env.FOO");
         assert_eq!(ShellKind::Posix.to_shell_variable("${FOO}"), "${FOO}");
 
         assert_eq!(ShellKind::PowerShell.to_shell_variable("$FOO"), "$env:FOO");
-        assert_eq!(ShellKind::PowerShell.to_shell_variable("${日本}"), "$env:日本");
+        assert_eq!(
+            ShellKind::PowerShell.to_shell_variable("${日本}"),
+            "$env:日本"
+        );
         assert_eq!(
             ShellKind::PowerShell.to_shell_variable("${FOO:-bar}"),
             "${FOO:-bar}"

--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -235,11 +235,11 @@ impl ShellKind {
     fn to_cmd_variable(input: &str) -> String {
         if let Some(var_str) = input.strip_prefix("${") {
             match var_str.strip_suffix('}') {
-                // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
-                // which will result in the task failing to run in such cases.
                 Some(var_name) if !var_name.is_empty() && !var_name.contains(':') => {
                     format!("%{var_name}%")
                 }
+                // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
+                // which will result in the task failing to run in such cases.
                 _ => input.into(),
             }
         } else if let Some(var_str) = input.strip_prefix('$') {
@@ -254,11 +254,11 @@ impl ShellKind {
     fn to_powershell_variable(input: &str) -> String {
         if let Some(var_str) = input.strip_prefix("${") {
             match var_str.strip_suffix('}') {
-                // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
-                // which will result in the task failing to run in such cases.
                 Some(var_name) if !var_name.is_empty() && !var_name.contains(':') => {
                     format!("$env:{var_name}")
                 }
+                // `${SOME_VAR:-SOME_DEFAULT}`, we currently do not handle this situation,
+                // which will result in the task failing to run in such cases.
                 _ => input.into(),
             }
         } else if let Some(var_str) = input.strip_prefix('$') {


### PR DESCRIPTION
# Objective

`to_cmd_variable` and `to_powershell_variable` removed the last byte of a
`${...}` argument assuming it was the closing brace, without checking one was
there

```rust
// If the input starts with "${", remove the trailing "}"
format!("$env:{}", &var_str[..var_str.len() - 1])
```

# Solution

Use strip_suffix('}') and pass the input through when it isn't a variable reference

## Testing

added tests to cover this 


To reproduce on Windows, add a context server with a malformed argument to settings.json:

``` 

"context_servers": {
  "crash-repro": {
    "command": "does-not-matter",
    "args": ["${"]
  }
}
} 
````
Opening the agent panel and zed will crash


Release Notes:

- Fixed a panic when converting a malformed `${` shell variable reference on Windows