### PR TITLE
sidebar: Show branches and detached HEAD in agent threads

### DIFF
--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -374,6 +374,7 @@ impl ThreadMetadata {
 pub fn worktree_info_from_thread_paths<S: std::hash::BuildHasher>(
     worktree_paths: &WorktreePaths,
     branch_names: &std::collections::HashMap<PathBuf, SharedString, S>,
+    detached_paths: &std::collections::HashSet<PathBuf>,
 ) -> Vec<ThreadItemWorktreeInfo> {
     let mut infos: Vec<ThreadItemWorktreeInfo> = Vec::new();
     let mut linked_short_names: Vec<(SharedString, SharedString)> = Vec::new();
@@ -396,6 +397,7 @@ pub fn worktree_info_from_thread_paths<S: std::hash::BuildHasher>(
                 highlight_positions: Vec::new(),
                 kind: WorktreeKind::Linked,
                 branch_name: branch_names.get(folder_path).cloned(),
+                detached: detached_paths.contains(folder_path),
             });
         } else {
             let Some(name) = folder_path.file_name() else {
@@ -407,6 +409,7 @@ pub fn worktree_info_from_thread_paths<S: std::hash::BuildHasher>(
                 highlight_positions: Vec::new(),
                 kind: WorktreeKind::Main,
                 branch_name: branch_names.get(folder_path).cloned(),
+                detached: false,
             });
         }
     }

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -655,6 +655,7 @@ impl ThreadsArchiveView {
                 let worktrees = worktree_info_from_thread_paths(
                     &thread.worktree_paths,
                     &branch_names_for_thread,
+                    &HashSet::new(),
                 );
 
                 let archived_color = Color::Custom(cx.theme().colors().icon_muted.opacity(0.6));

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -109,6 +109,7 @@ CREATE TABLE "project_repositories" (
     "remote_upstream_url" VARCHAR,
     "remote_origin_url" VARCHAR,
     "linked_worktrees" VARCHAR,
+    "is_detached_head" BOOLEAN NOT NULL DEFAULT FALSE,
     "repository_dir_abs_path" VARCHAR,
     "common_dir_abs_path" VARCHAR,
     PRIMARY KEY (project_id, id)

--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -313,6 +313,7 @@ CREATE TABLE public.project_repositories (
     remote_upstream_url character varying,
     remote_origin_url character varying,
     linked_worktrees text,
+    is_detached_head boolean NOT NULL DEFAULT false,
     repository_dir_abs_path character varying,
     common_dir_abs_path character varying
 );

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -386,6 +386,7 @@ impl Database {
                 linked_worktrees: ActiveValue::Set(Some(
                     serde_json::to_string(&update.linked_worktrees).unwrap(),
                 )),
+                is_detached_head: ActiveValue::set(update.is_detached_head),
             })
             .on_conflict(
                 OnConflict::columns([
@@ -403,6 +404,7 @@ impl Database {
                     project_repository::Column::RepositoryDirAbsPath,
                     project_repository::Column::CommonDirAbsPath,
                     project_repository::Column::LinkedWorktrees,
+                    project_repository::Column::IsDetachedHead,
                 ])
                 .to_owned(),
             )
@@ -911,6 +913,7 @@ impl Database {
                             .as_deref()
                             .and_then(|s| serde_json::from_str(s).ok())
                             .unwrap_or_default(),
+                        is_detached_head: db_repository_entry.is_detached_head,
                     });
                 }
             }

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -809,6 +809,7 @@ impl Database {
                                 .as_deref()
                                 .and_then(|s| serde_json::from_str(s).ok())
                                 .unwrap_or_default(),
+                            is_detached_head: db_repository.is_detached_head,
                         });
                     }
                 }

--- a/crates/collab/src/db/tables/project_repository.rs
+++ b/crates/collab/src/db/tables/project_repository.rs
@@ -28,6 +28,7 @@ pub struct Model {
     pub common_dir_abs_path: Option<String>,
     // JSON array of linked worktree objects
     pub linked_worktrees: Option<String>,
+    pub is_detached_head: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/tests/integration/git_tests.rs
+++ b/crates/collab/tests/integration/git_tests.rs
@@ -5,6 +5,7 @@ use std::{
 
 use call::ActiveCall;
 use client::RECEIVE_TIMEOUT;
+use collab::rpc::RECONNECT_TIMEOUT;
 use collections::HashMap;
 use git::{
     Oid,
@@ -202,10 +203,10 @@ async fn load_commit_data_batch(
     commit_data
 }
 
-fn branch_list_snapshot(
+fn repository_head_snapshot(
     project: &gpui::Entity<project::Project>,
     cx: &mut TestAppContext,
-) -> (Option<String>, Vec<String>) {
+) -> (Option<String>, Vec<String>, bool) {
     project.read_with(cx, |project, cx| {
         let repos = project.repositories(cx);
         assert_eq!(repos.len(), 1, "project should have exactly 1 repository");
@@ -221,6 +222,7 @@ fn branch_list_snapshot(
                 .iter()
                 .map(|branch| branch.ref_name.to_string())
                 .collect(),
+            snapshot.is_detached_head,
         )
     })
 }
@@ -937,7 +939,7 @@ async fn test_branch_list_sync(
     let (project_a, _) = client_a.build_local_project(path!("/project"), cx_a).await;
     executor.run_until_parked();
 
-    let host_snapshot = branch_list_snapshot(&project_a, cx_a);
+    let host_snapshot = repository_head_snapshot(&project_a, cx_a);
     assert_eq!(host_snapshot.0.as_deref(), Some("main"));
     assert_eq!(
         host_snapshot.1,
@@ -978,7 +980,7 @@ async fn test_branch_list_sync(
 
     executor.run_until_parked();
 
-    let host_snapshot_after_update = branch_list_snapshot(&project_a, cx_a);
+    let host_snapshot_after_update = repository_head_snapshot(&project_a, cx_a);
     assert_eq!(
         host_snapshot_after_update.0.as_deref(),
         Some("totally-new-branch")
@@ -993,8 +995,91 @@ async fn test_branch_list_sync(
         ]
     );
 
-    let guest_snapshot_after_update = branch_list_snapshot(&project_b, cx_b);
+    let guest_snapshot_after_update = repository_head_snapshot(&project_b, cx_b);
     assert_eq!(guest_snapshot_after_update, host_snapshot_after_update);
+}
+
+#[gpui::test]
+async fn test_detached_head_sync(
+    executor: BackgroundExecutor,
+    cx_a: &mut TestAppContext,
+    cx_b: &mut TestAppContext,
+    cx_c: &mut TestAppContext,
+) {
+    let mut server = TestServer::start(executor.clone()).await;
+    let client_a = server.create_client(cx_a, "user_a").await;
+    let client_b = server.create_client(cx_b, "user_b").await;
+    let client_c = server.create_client(cx_c, "user_c").await;
+    server
+        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b), (&client_c, cx_c)])
+        .await;
+    let active_call_a = cx_a.read(ActiveCall::global);
+
+    let fs = client_a.fs();
+    fs.insert_tree(
+        path!("/project"),
+        json!({ ".git": {}, "file.txt": "content" }),
+    )
+    .await;
+    fs.set_branch_name(Path::new(path!("/project/.git")), Some("main"));
+    fs.insert_branches(Path::new(path!("/project/.git")), &["feature"]);
+    fs.add_linked_worktree_for_repo(
+        Path::new(path!("/project/.git")),
+        false,
+        GitWorktree {
+            path: PathBuf::from(path!("/detached-worktree")),
+            ref_name: None,
+            sha: "aaa111".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+
+    let (project_a, _) = client_a
+        .build_local_project(path!("/detached-worktree"), cx_a)
+        .await;
+    executor.run_until_parked();
+    assert!(repository_head_snapshot(&project_a, cx_a).2);
+
+    let project_id = active_call_a
+        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
+        .await
+        .unwrap();
+    let project_b = client_b.join_remote_project(project_id, cx_b).await;
+    executor.run_until_parked();
+    assert!(repository_head_snapshot(&project_b, cx_b).2);
+
+    let project_c = client_c.join_remote_project(project_id, cx_c).await;
+    executor.run_until_parked();
+    assert!(repository_head_snapshot(&project_c, cx_c).2);
+
+    server.disconnect_client(
+        client_b
+            .peer_id()
+            .expect("client B should have a peer id before disconnecting"),
+    );
+    // Make the database scan newer than client B's so rejoin returns repository state.
+    fs.with_git_state(Path::new(path!("/project/.git")), true, |_| {})
+        .expect("git state should exist");
+    executor.run_until_parked();
+    executor.advance_clock(RECEIVE_TIMEOUT + RECONNECT_TIMEOUT);
+    executor.run_until_parked();
+    assert!(client_b.status().borrow().is_connected());
+    assert!(repository_head_snapshot(&project_b, cx_b).2);
+
+    fs.insert_file(
+        path!("/project/.git/worktrees/detached-worktree/HEAD"),
+        b"ref: refs/heads/feature".to_vec(),
+    )
+    .await;
+    fs.with_git_state(Path::new(path!("/project/.git")), true, |_| {})
+        .unwrap();
+    executor.run_until_parked();
+
+    assert!(!repository_head_snapshot(&project_a, cx_a).2);
+    assert!(!repository_head_snapshot(&project_b, cx_b).2);
+    assert!(!repository_head_snapshot(&project_c, cx_c).2);
 }
 
 #[gpui::test]
@@ -1157,9 +1242,10 @@ async fn test_linked_worktrees_sync(
         .remove_worktree_for_repo(
             Path::new(path!("/project/.git")),
             true,
-            "refs/heads/bugfix-branch",
+            Path::new(path!("/worktrees/bugfix-branch")),
         )
-        .await;
+        .await
+        .unwrap();
 
     executor.run_until_parked();
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2188,32 +2188,50 @@ impl FakeFs {
         emit_git_event: bool,
         worktree: Worktree,
     ) {
-        let ref_name = worktree
-            .ref_name
-            .as_ref()
-            .expect("linked worktree must have a ref_name");
-        let branch_name = ref_name
-            .strip_prefix("refs/heads/")
-            .unwrap_or(ref_name.as_ref());
+        let directory_name = if let Some(ref_name) = &worktree.ref_name {
+            ref_name
+                .strip_prefix("refs/heads/")
+                .unwrap_or(ref_name.as_ref())
+                .to_string()
+        } else {
+            let base_directory_name = worktree
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_else(|| worktree.display_name())
+                .to_string();
+            let mut directory_name = base_directory_name.clone();
+            let mut suffix = 1;
+            while self
+                .is_dir(&dot_git.join("worktrees").join(&directory_name))
+                .await
+            {
+                directory_name = format!("{base_directory_name}{suffix}");
+                suffix += 1;
+            }
+            directory_name
+        };
 
-        // Create ref in git state.
-        self.with_git_state(dot_git, false, |state| {
-            state
-                .refs
-                .insert(ref_name.to_string(), worktree.sha.to_string());
-        })
-        .unwrap();
+        if let Some(ref_name) = &worktree.ref_name {
+            self.with_git_state(dot_git, false, |state| {
+                state
+                    .refs
+                    .insert(ref_name.to_string(), worktree.sha.to_string());
+            })
+            .unwrap();
+        }
 
         // Create .git/worktrees/<name>/ directory with HEAD, commondir, and gitdir.
-        let worktrees_entry_dir = dot_git.join("worktrees").join(branch_name);
+        let worktrees_entry_dir = dot_git.join("worktrees").join(directory_name);
         self.create_dir(&worktrees_entry_dir).await.unwrap();
 
-        self.write_file_internal(
-            worktrees_entry_dir.join("HEAD"),
-            format!("ref: {ref_name}").into_bytes(),
-            false,
-        )
-        .unwrap();
+        let head = worktree
+            .ref_name
+            .as_ref()
+            .map(|ref_name| format!("ref: {ref_name}"))
+            .unwrap_or_else(|| worktree.sha.to_string());
+        self.write_file_internal(worktrees_entry_dir.join("HEAD"), head.into_bytes(), false)
+            .unwrap();
 
         self.write_file_internal(
             worktrees_entry_dir.join("commondir"),
@@ -2249,32 +2267,26 @@ impl FakeFs {
         &self,
         dot_git: &Path,
         emit_git_event: bool,
-        ref_name: &str,
-    ) {
-        let branch_name = ref_name.strip_prefix("refs/heads/").unwrap_or(ref_name);
-        let worktrees_entry_dir = dot_git.join("worktrees").join(branch_name);
-
-        // Read gitdir to find the worktree checkout path.
-        let gitdir_content = self
-            .load_internal(worktrees_entry_dir.join("gitdir"))
-            .await
-            .unwrap();
-        let gitdir_str = String::from_utf8(gitdir_content).unwrap();
-        let worktree_path = PathBuf::from(gitdir_str.trim())
-            .parent()
-            .map(PathBuf::from)
-            .unwrap_or_default();
+        worktree_path: &Path,
+    ) -> Result<()> {
+        let dot_git_content = self.load_internal(worktree_path.join(".git")).await?;
+        let dot_git_content = String::from_utf8(dot_git_content)?;
+        let worktrees_entry_dir = PathBuf::from(
+            dot_git_content
+                .trim()
+                .strip_prefix("gitdir: ")
+                .context("worktree .git file missing gitdir pointer")?,
+        );
 
         // Remove the worktree checkout directory.
         self.remove_dir(
-            &worktree_path,
+            worktree_path,
             RemoveOptions {
                 recursive: true,
                 ignore_if_not_exists: true,
             },
         )
-        .await
-        .unwrap();
+        .await?;
 
         // Remove the .git/worktrees/<name>/ directory.
         self.remove_dir(
@@ -2284,12 +2296,13 @@ impl FakeFs {
                 ignore_if_not_exists: false,
             },
         )
-        .await
-        .unwrap();
+        .await?;
 
         if emit_git_event {
-            self.with_git_state(dot_git, true, |_| {}).unwrap();
+            self.with_git_state(dot_git, true, |_| {})?;
         }
+
+        Ok(())
     }
 
     pub fn set_unmerged_paths_for_repo(

--- a/crates/fs/tests/integration/fake_git_repo_tests.rs
+++ b/crates/fs/tests/integration/fake_git_repo_tests.rs
@@ -122,6 +122,58 @@ async fn test_fake_worktree_lifecycle(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_detached_worktree_admin_names_are_unique(cx: &mut TestAppContext) {
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project", json!({ ".git": {} })).await;
+    let repo = fs
+        .open_repo(Path::new("/project/.git"), None)
+        .expect("should open fake repo");
+
+    for (path, sha) in [("/a/review", "aaa111"), ("/b/review", "bbb222")] {
+        fs.add_linked_worktree_for_repo(
+            Path::new("/project/.git"),
+            false,
+            git::repository::Worktree {
+                path: PathBuf::from(path),
+                ref_name: None,
+                sha: sha.into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+    }
+
+    let worktrees = repo.worktrees().await.unwrap();
+    assert!(worktrees.iter().any(|worktree| {
+        worktree.path == Path::new("/a/review")
+            && worktree.ref_name.is_none()
+            && worktree.sha.as_ref() == "aaa111"
+    }));
+    assert!(worktrees.iter().any(|worktree| {
+        worktree.path == Path::new("/b/review")
+            && worktree.ref_name.is_none()
+            && worktree.sha.as_ref() == "bbb222"
+    }));
+
+    fs.remove_worktree_for_repo(Path::new("/project/.git"), false, Path::new("/a/review"))
+        .await
+        .unwrap();
+
+    let worktrees = repo.worktrees().await.unwrap();
+    assert!(
+        worktrees
+            .iter()
+            .all(|worktree| worktree.path != Path::new("/a/review"))
+    );
+    assert!(
+        worktrees
+            .iter()
+            .any(|worktree| worktree.path == Path::new("/b/review"))
+    );
+}
+
+#[gpui::test]
 async fn test_checkpoints(executor: BackgroundExecutor) {
     let fs = FakeFs::new(executor);
     fs.insert_tree(

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -551,6 +551,7 @@ pub struct RepositorySnapshot {
     pub branch_list: Arc<[Branch]>,
     pub branch_list_error: Option<SharedString>,
     pub head_commit: Option<CommitDetails>,
+    pub is_detached_head: bool,
     pub scan_id: u64,
     pub merge: MergeDetails,
     pub remote_origin_url: Option<String>,
@@ -6023,6 +6024,7 @@ impl RepositorySnapshot {
             branch_list: Arc::from([]),
             branch_list_error: None,
             head_commit: None,
+            is_detached_head: false,
             scan_id: 0,
             merge: Default::default(),
             remote_origin_url: None,
@@ -6078,6 +6080,7 @@ impl RepositorySnapshot {
                 .iter()
                 .map(worktree_to_proto)
                 .collect(),
+            is_detached_head: self.is_detached_head,
         }
     }
 
@@ -6165,6 +6168,7 @@ impl RepositorySnapshot {
                 .iter()
                 .map(worktree_to_proto)
                 .collect(),
+            is_detached_head: self.is_detached_head,
         }
     }
 
@@ -9830,11 +9834,15 @@ impl Repository {
             .head_commit_details
             .as_ref()
             .map(proto_to_commit_details);
-        if self.snapshot.branch != new_branch || self.snapshot.head_commit != new_head_commit {
+        if self.snapshot.branch != new_branch
+            || self.snapshot.head_commit != new_head_commit
+            || self.snapshot.is_detached_head != update.is_detached_head
+        {
             cx.emit(RepositoryEvent::HeadChanged)
         }
         self.snapshot.branch = new_branch;
         self.snapshot.head_commit = new_head_commit;
+        self.snapshot.is_detached_head = update.is_detached_head;
 
         if update.is_last_update {
             let new_branch_list: Arc<[Branch]> =
@@ -12248,6 +12256,11 @@ async fn compute_snapshot(
     } = branches;
     let branch = branches.iter().find(|branch| branch.is_head).cloned();
     let branch_list: Arc<[Branch]> = branches.into();
+    let is_detached_head = all_worktrees.iter().any(|worktree| {
+        worktree.path == *work_directory_abs_path
+            && worktree.ref_name.is_none()
+            && !worktree.is_bare
+    });
 
     let linked_worktrees: Arc<[GitWorktree]> = all_worktrees
         .into_iter()
@@ -12261,8 +12274,9 @@ async fn compute_snapshot(
     log::debug!("fetched remotes");
 
     let snapshot = this.update(cx, |this, cx| {
-        let head_changed =
-            branch != this.snapshot.branch || head_commit != this.snapshot.head_commit;
+        let head_changed = branch != this.snapshot.branch
+            || head_commit != this.snapshot.head_commit
+            || is_detached_head != this.snapshot.is_detached_head;
         let branch_list_changed = *branch_list != *this.snapshot.branch_list;
         let branch_list_error_changed = branch_list_error != this.snapshot.branch_list_error;
         let worktrees_changed = *linked_worktrees != *this.snapshot.linked_worktrees;
@@ -12274,6 +12288,7 @@ async fn compute_snapshot(
             branch_list: branch_list.clone(),
             branch_list_error,
             head_commit,
+            is_detached_head,
             remote_origin_url,
             remote_upstream_url,
             linked_worktrees,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -146,6 +146,7 @@ message UpdateRepository {
   optional string repository_dir_abs_path = 19;
   optional string common_dir_abs_path = 20;
   optional string branch_list_error = 21;
+  bool is_detached_head = 22;
 }
 
 message RemoveRepository {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -677,6 +677,7 @@ fn apply_worktree_label_mode(
         AgentThreadWorktreeLabel::Worktree => {
             for wt in &mut worktrees {
                 wt.branch_name = None;
+                wt.detached = false;
             }
         }
         AgentThreadWorktreeLabel::Branch => {
@@ -1422,6 +1423,7 @@ impl Sidebar {
             all_paths.into_iter().zip(path_details).collect();
 
         let mut branch_by_path: HashMap<PathBuf, SharedString> = HashMap::new();
+        let mut detached_paths = HashSet::new();
         for ws in &workspaces {
             let project = ws.read(cx).project().read(cx);
             for repo in project.repositories(cx).values() {
@@ -1432,17 +1434,21 @@ impl Sidebar {
                         SharedString::from(Arc::<str>::from(branch.name())),
                     );
                 }
+                if snapshot.is_linked_worktree() && snapshot.is_detached_head {
+                    detached_paths.insert(snapshot.work_directory_abs_path.to_path_buf());
+                }
                 for linked_wt in snapshot.linked_worktrees() {
                     if let Some(branch) = linked_wt.branch_name() {
                         branch_by_path.insert(
                             linked_wt.path.clone(),
                             SharedString::from(Arc::<str>::from(branch)),
                         );
+                    } else if !linked_wt.is_bare {
+                        detached_paths.insert(linked_wt.path.clone());
                     }
                 }
             }
         }
-
         for group in &groups {
             let group_key = &group.key;
             let group_workspaces = &group.workspaces;
@@ -1464,8 +1470,11 @@ impl Sidebar {
                 linked_worktree_path_lists_for_workspaces(group_workspaces, cx);
             let make_terminal_entry =
                 |metadata: TerminalThreadMetadata, workspace: ThreadEntryWorkspace| {
-                    let worktrees =
-                        worktree_info_from_thread_paths(&metadata.worktree_paths, &branch_by_path);
+                    let worktrees = worktree_info_from_thread_paths(
+                        &metadata.worktree_paths,
+                        &branch_by_path,
+                        &detached_paths,
+                    );
                     let has_notification =
                         live_notified_terminal_ids.contains(&metadata.terminal_id);
                     TerminalEntry {
@@ -1570,8 +1579,11 @@ impl Sidebar {
                 let make_thread_entry =
                     |row: ThreadMetadata, workspace: ThreadEntryWorkspace| -> Arc<ThreadEntry> {
                         let (icon, icon_from_external_svg) = resolve_agent_icon(&row.agent_id);
-                        let worktrees =
-                            worktree_info_from_thread_paths(&row.worktree_paths, &branch_by_path);
+                        let worktrees = worktree_info_from_thread_paths(
+                            &row.worktree_paths,
+                            &branch_by_path,
+                            &detached_paths,
+                        );
                         // Start drafts as `WithContent`; the post-processing
                         // pass below downgrades them to `Empty` if no draft
                         // label can be derived.

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -98,6 +98,19 @@ fn has_thread_entry(sidebar: &Sidebar, session_id: &acp::SessionId) -> bool {
         .any(|entry| matches!(entry, ListEntry::Thread(t) if t.metadata.session_id.as_ref() == Some(session_id)))
 }
 
+fn thread_entry_by_title<'a>(sidebar: &'a Sidebar, title: &str) -> Option<&'a ThreadEntry> {
+    sidebar
+        .contents
+        .entries
+        .iter()
+        .find_map(|entry| match entry {
+            ListEntry::Thread(thread) if thread.metadata.title.as_deref() == Some(title) => {
+                Some(thread.as_ref())
+            }
+            _ => None,
+        })
+}
+
 #[track_caller]
 fn assert_project_header_has_threads(
     sidebar: &Entity<Sidebar>,
@@ -14291,11 +14304,12 @@ fn test_worktree_info_branch_names_for_main_worktrees() {
             .into_iter()
             .collect();
 
-    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path);
+    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path, &HashSet::new());
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].kind, ui::WorktreeKind::Main);
     assert_eq!(infos[0].branch_name, Some(SharedString::from("feature-x")));
     assert_eq!(infos[0].worktree_name, Some(SharedString::from("myapp")));
+    assert!(!infos[0].detached);
 }
 
 #[test]
@@ -14312,13 +14326,14 @@ fn test_worktree_info_branch_names_for_linked_worktrees() {
     .into_iter()
     .collect();
 
-    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path);
+    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path, &HashSet::new());
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].kind, ui::WorktreeKind::Linked);
     assert_eq!(
         infos[0].branch_name,
         Some(SharedString::from("feature-branch"))
     );
+    assert!(!infos[0].detached);
 }
 
 #[test]
@@ -14328,11 +14343,232 @@ fn test_worktree_info_missing_branch_returns_none() {
 
     let branch_by_path: HashMap<PathBuf, SharedString> = HashMap::new();
 
-    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path);
+    let infos = worktree_info_from_thread_paths(&worktree_paths, &branch_by_path, &HashSet::new());
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].kind, ui::WorktreeKind::Main);
     assert_eq!(infos[0].branch_name, None);
     assert_eq!(infos[0].worktree_name, Some(SharedString::from("myapp")));
+    assert!(!infos[0].detached);
+}
+
+#[test]
+fn test_apply_worktree_label_mode_for_detached_worktree() {
+    let detached_worktree = ThreadItemWorktreeInfo {
+        worktree_name: Some("detached-worktree".into()),
+        detached: true,
+        kind: ui::WorktreeKind::Linked,
+        ..Default::default()
+    };
+
+    let both = apply_worktree_label_mode(
+        vec![detached_worktree.clone()],
+        AgentThreadWorktreeLabel::Both,
+    );
+    assert!(both[0].detached);
+    assert_eq!(both[0].worktree_name.as_deref(), Some("detached-worktree"));
+
+    let worktree = apply_worktree_label_mode(
+        vec![detached_worktree.clone()],
+        AgentThreadWorktreeLabel::Worktree,
+    );
+    assert!(!worktree[0].detached);
+    assert_eq!(
+        worktree[0].worktree_name.as_deref(),
+        Some("detached-worktree")
+    );
+
+    let branch =
+        apply_worktree_label_mode(vec![detached_worktree], AgentThreadWorktreeLabel::Branch);
+    assert!(branch[0].detached);
+    assert_eq!(
+        branch[0].worktree_name.as_deref(),
+        Some("detached-worktree")
+    );
+}
+
+#[gpui::test]
+async fn test_sidebar_worktree_info_for_base_and_detached_linked_checkout(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project", serde_json::json!({ ".git": {} }))
+        .await;
+    fs.set_branch_name(Path::new("/project/.git"), Some("main"));
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/detached-worktree"),
+            ref_name: None,
+            sha: "aaa".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let project = project::Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_thread_metadata_with_main_paths(
+        "base-thread",
+        "Base Thread",
+        PathList::new(&[PathBuf::from("/project")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        Utc::now(),
+        cx,
+    );
+    save_thread_metadata_with_main_paths(
+        "detached-thread",
+        "Detached Thread",
+        PathList::new(&[PathBuf::from("/detached-worktree")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        Utc::now(),
+        cx,
+    );
+    sidebar.update(cx, |sidebar, cx| sidebar.update_entries(cx));
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        let base = thread_entry_by_title(sidebar, "Base Thread")
+            .and_then(|thread| thread.worktrees.first())
+            .expect("base thread should have worktree metadata");
+        assert_eq!(base.kind, ui::WorktreeKind::Main);
+        assert_eq!(base.branch_name.as_deref(), Some("main"));
+        assert!(!base.detached);
+
+        let detached = thread_entry_by_title(sidebar, "Detached Thread")
+            .and_then(|thread| thread.worktrees.first())
+            .expect("detached thread should have worktree metadata");
+        assert_eq!(detached.kind, ui::WorktreeKind::Linked);
+        assert_eq!(detached.worktree_name.as_deref(), Some("detached-worktree"));
+        assert_eq!(detached.branch_name, None);
+        assert!(detached.detached);
+    });
+}
+
+#[gpui::test]
+async fn test_sidebar_worktree_info_for_current_detached_linked_checkout(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project", serde_json::json!({ ".git": {} }))
+        .await;
+    fs.set_branch_name(Path::new("/project/.git"), Some("main"));
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/detached-worktree"),
+            ref_name: None,
+            sha: "aaa".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let project = project::Project::test(fs.clone(), ["/detached-worktree".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+    save_thread_metadata(
+        acp::SessionId::new(Arc::from("detached-thread")),
+        Some("Detached Thread".into()),
+        Utc::now(),
+        None,
+        None,
+        &project,
+        cx,
+    );
+    sidebar.update(cx, |sidebar, cx| sidebar.update_entries(cx));
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        let detached = thread_entry_by_title(sidebar, "Detached Thread")
+            .and_then(|thread| thread.worktrees.first())
+            .expect("detached thread should have worktree metadata");
+        assert_eq!(detached.kind, ui::WorktreeKind::Linked);
+        assert_eq!(detached.worktree_name.as_deref(), Some("detached-worktree"));
+        assert_eq!(detached.branch_name, None);
+        assert!(detached.detached);
+    });
+}
+
+#[gpui::test]
+async fn test_multi_main_worktree_branch_labels_are_disambiguated(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    for project_path in ["/project_a", "/project_b"] {
+        fs.insert_tree(project_path, serde_json::json!({ ".git": {} }))
+            .await;
+        let dot_git = PathBuf::from(project_path).join(".git");
+        fs.set_branch_name(&dot_git, Some("main"));
+    }
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let project =
+        project::Project::test(fs, ["/project_a".as_ref(), "/project_b".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+    save_named_thread_metadata("multi-main", "Multi Main Thread", &project, cx).await;
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        let thread = thread_entry_by_title(sidebar, "Multi Main Thread")
+            .expect("multi-root thread should be present");
+        let mut labels = thread
+            .worktrees
+            .iter()
+            .map(|worktree| {
+                (
+                    worktree.worktree_name.as_deref().unwrap_or_default(),
+                    worktree.branch_name.as_deref().unwrap_or_default(),
+                    worktree.kind,
+                )
+            })
+            .collect::<Vec<_>>();
+        labels.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        assert_eq!(
+            labels,
+            vec![
+                ("project_a", "main", ui::WorktreeKind::Main),
+                ("project_b", "main", ui::WorktreeKind::Main),
+            ]
+        );
+    });
+
+    type_in_search(&sidebar, "project_a", cx);
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        let thread = thread_entry_by_title(sidebar, "Multi Main Thread")
+            .expect("matching multi-root thread should remain visible");
+        let project_a = thread
+            .worktrees
+            .iter()
+            .find(|worktree| worktree.worktree_name.as_deref() == Some("project_a"))
+            .expect("project_a metadata should be present");
+        assert!(!project_a.highlight_positions.is_empty());
+    });
 }
 
 #[gpui::test]

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -27,9 +27,39 @@ pub enum WorktreeKind {
 pub struct ThreadItemWorktreeInfo {
     pub worktree_name: Option<SharedString>,
     pub branch_name: Option<SharedString>,
+    pub detached: bool,
     pub full_path: SharedString,
     pub highlight_positions: Vec<usize>,
     pub kind: WorktreeKind,
+}
+
+impl ThreadItemWorktreeInfo {
+    fn display_labels(
+        &self,
+        show_main_worktree_name: bool,
+    ) -> Option<(Option<SharedString>, Option<SharedString>)> {
+        match self.kind {
+            WorktreeKind::Main => self.branch_name.clone().map(|branch_name| {
+                (
+                    if show_main_worktree_name {
+                        self.worktree_name.clone()
+                    } else {
+                        None
+                    },
+                    Some(branch_name),
+                )
+            }),
+            WorktreeKind::Linked => {
+                let branch_name = self
+                    .branch_name
+                    .clone()
+                    .or_else(|| self.detached.then(|| "Detached HEAD".into()));
+
+                (self.worktree_name.is_some() || branch_name.is_some())
+                    .then(|| (self.worktree_name.clone(), branch_name))
+            }
+        }
+    }
 }
 
 #[derive(IntoElement, RegisterComponent)]
@@ -251,6 +281,7 @@ impl ThreadItem {
 impl RenderOnce for ThreadItem {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let color = cx.theme().colors();
+        let show_main_worktree_name = self.worktrees.len() > 1;
         // The fade gradient paints a solid color over the title to blend it into
         // the row background, but a transparent window has no opaque surface to
         // fade into, so it renders as a visible patch; truncate the title instead.
@@ -409,14 +440,17 @@ impl RenderOnce for ThreadItem {
             AgentThreadStatus::Error | AgentThreadStatus::WaitingForConfirmation
         );
 
-        let linked_worktrees: Vec<ThreadItemWorktreeInfo> = self
+        let worktrees: Vec<_> = self
             .worktrees
             .into_iter()
-            .filter(|wt| wt.kind == WorktreeKind::Linked)
-            .filter(|wt| wt.worktree_name.is_some() || wt.branch_name.is_some())
+            .filter_map(|worktree| {
+                let (worktree_name, branch_name) =
+                    worktree.display_labels(show_main_worktree_name)?;
+                Some((worktree, worktree_name, branch_name))
+            })
             .collect();
 
-        let has_worktree = !linked_worktrees.is_empty();
+        let has_worktree = !worktrees.is_empty();
 
         let has_metadata = has_project_name
             || has_project_paths
@@ -488,122 +522,152 @@ impl RenderOnce for ThreadItem {
                     h_flex()
                         .gap_1p5()
                         .child(icon_container()) // Icon Spacing
-                        .when(self.archived, |this| {
-                            this.child(
-                                Icon::new(IconName::Archive).size(IconSize::XSmall).color(
-                                    Color::Custom(cx.theme().colors().icon_muted.opacity(0.5)),
-                                ),
-                            )
-                        })
-                        .when(
-                            has_project_name || has_project_paths || has_worktree,
-                            |this| {
-                                this.when_some(self.project_name, |this, name| {
+                        .child(
+                            h_flex()
+                                .min_w_0()
+                                .gap_1()
+                                .when(self.archived, |this| {
                                     this.child(
-                                        Label::new(name).size(LabelSize::Small).color(Color::Muted),
+                                        Icon::new(IconName::Archive).size(IconSize::XSmall).color(
+                                            Color::Custom(
+                                                cx.theme().colors().icon_muted.opacity(0.5),
+                                            ),
+                                        ),
                                     )
                                 })
                                 .when(
-                                    has_project_name && (has_project_paths || has_worktree),
+                                    has_project_name || has_project_paths || has_worktree,
+                                    |this| {
+                                        this.when_some(self.project_name, |this, name| {
+                                            this.child(
+                                                Label::new(name)
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                        })
+                                        .when(
+                                            has_project_name && (has_project_paths || has_worktree),
+                                            |this| this.child(dot_separator()),
+                                        )
+                                        .when_some(project_paths, |this, paths| {
+                                            this.child(
+                                                Label::new(paths)
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                        })
+                                        .when(has_project_paths && has_worktree, |this| {
+                                            this.child(dot_separator())
+                                        })
+                                        .children(
+                                            worktrees.into_iter().map(
+                                                |(worktree, worktree_name, branch_name)| {
+                                                    let has_real_branch =
+                                                        worktree.branch_name.is_some();
+                                                    let worktree_label =
+                                                        worktree_name.map(|name| {
+                                                            if worktree
+                                                                .highlight_positions
+                                                                .is_empty()
+                                                            {
+                                                                Label::new(name)
+                                                                    .size(LabelSize::Small)
+                                                                    .color(Color::Muted)
+                                                                    .truncate()
+                                                                    .into_any_element()
+                                                            } else {
+                                                                HighlightedLabel::new(
+                                                                    name,
+                                                                    worktree
+                                                                        .highlight_positions
+                                                                        .clone(),
+                                                                )
+                                                                .size(LabelSize::Small)
+                                                                .color(Color::Muted)
+                                                                .truncate()
+                                                                .into_any_element()
+                                                            }
+                                                        });
+
+                                                    let branch_label = branch_name.map(|branch| {
+                                                        Label::new(branch)
+                                                            .size(LabelSize::Small)
+                                                            .color(Color::Muted)
+                                                            .truncate()
+                                                            .into_any_element()
+                                                    });
+
+                                                    let show_separator = worktree_label.is_some()
+                                                        && branch_label.is_some();
+
+                                                    h_flex()
+                                                        .min_w_0()
+                                                        .gap_1()
+                                                        .when_some(worktree_label, |this, label| {
+                                                            this.child(
+                                                                h_flex()
+                                                                    .min_w_0()
+                                                                    .gap_0p5()
+                                                                    .child(
+                                                                        Icon::new(
+                                                                            IconName::GitWorktree,
+                                                                        )
+                                                                        .size(IconSize::XSmall)
+                                                                        .color(Color::Muted),
+                                                                    )
+                                                                    .child(label),
+                                                            )
+                                                        })
+                                                        .when(show_separator, |this| {
+                                                            this.child(
+                                                                dot_separator().flex_shrink_0(),
+                                                            )
+                                                        })
+                                                        .when_some(branch_label, |this, label| {
+                                                            this.child(
+                                                                h_flex()
+                                                                    .min_w_0()
+                                                                    .gap_0p5()
+                                                                    .when(has_real_branch, |this| {
+                                                                        this.child(
+                                                                            Icon::new(
+                                                                                IconName::GitBranch,
+                                                                            )
+                                                                            .size(IconSize::XSmall)
+                                                                            .color(Color::Muted),
+                                                                        )
+                                                                    })
+                                                                    .child(label),
+                                                            )
+                                                        })
+                                                },
+                                            ),
+                                        )
+                                    },
+                                )
+                                .when(
+                                    (has_project_name || has_project_paths || has_worktree)
+                                        && (has_diff_stats || has_timestamp),
                                     |this| this.child(dot_separator()),
                                 )
-                                .when_some(project_paths, |this, paths| {
+                                .when(has_diff_stats, |this| {
+                                    this.child(DiffStat::new(
+                                        diff_stat_id,
+                                        added_count,
+                                        removed_count,
+                                    ))
+                                })
+                                .when(has_diff_stats && has_timestamp, |this| {
+                                    this.child(dot_separator())
+                                })
+                                .when(has_timestamp, |this| {
                                     this.child(
-                                        Label::new(paths)
+                                        Label::new(timestamp.clone())
                                             .size(LabelSize::Small)
                                             .color(Color::Muted),
                                     )
-                                })
-                                .when(has_project_paths && has_worktree, |this| {
-                                    this.child(dot_separator())
-                                })
-                                .children(
-                                    linked_worktrees.into_iter().map(|wt| {
-                                        let worktree_label = wt.worktree_name.clone().map(|name| {
-                                            if wt.highlight_positions.is_empty() {
-                                                Label::new(name)
-                                                    .size(LabelSize::Small)
-                                                    .color(Color::Muted)
-                                                    .truncate()
-                                                    .into_any_element()
-                                            } else {
-                                                HighlightedLabel::new(
-                                                    name,
-                                                    wt.highlight_positions.clone(),
-                                                )
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted)
-                                                .truncate()
-                                                .into_any_element()
-                                            }
-                                        });
-
-                                        // When only the branch is shown, lead with a branch icon;
-                                        // otherwise keep the worktree icon (which "covers" both the
-                                        // worktree and any accompanying branch).
-                                        let chip_icon = if wt.worktree_name.is_none()
-                                            && wt.branch_name.is_some()
-                                        {
-                                            IconName::GitBranch
-                                        } else {
-                                            IconName::GitWorktree
-                                        };
-
-                                        let branch_label = wt.branch_name.map(|branch| {
-                                            Label::new(branch)
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted)
-                                                .truncate()
-                                                .into_any_element()
-                                        });
-
-                                        let show_separator =
-                                            worktree_label.is_some() && branch_label.is_some();
-
-                                        h_flex()
-                                            .min_w_0()
-                                            .gap_0p5()
-                                            .child(
-                                                Icon::new(chip_icon)
-                                                    .size(IconSize::XSmall)
-                                                    .color(Color::Muted),
-                                            )
-                                            .when_some(worktree_label, |this, label| {
-                                                this.child(label)
-                                            })
-                                            .when(show_separator, |this| {
-                                                this.child(
-                                                    Label::new("/")
-                                                        .size(LabelSize::Small)
-                                                        .color(separator_color)
-                                                        .flex_shrink_0(),
-                                                )
-                                            })
-                                            .when_some(branch_label, |this, label| {
-                                                this.child(label)
-                                            })
-                                    }),
-                                )
-                            },
-                        )
-                        .when(
-                            (has_project_name || has_project_paths || has_worktree)
-                                && (has_diff_stats || has_timestamp),
-                            |this| this.child(dot_separator()),
-                        )
-                        .when(has_diff_stats, |this| {
-                            this.child(DiffStat::new(diff_stat_id, added_count, removed_count))
-                        })
-                        .when(has_diff_stats && has_timestamp, |this| {
-                            this.child(dot_separator())
-                        })
-                        .when(has_timestamp, |this| {
-                            this.child(
-                                Label::new(timestamp.clone())
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
-                            )
-                        }),
+                                }),
+                        ),
                 )
             })
             .when(show_tooltip, |this| {
@@ -713,6 +777,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: None,
+                                detached: false,
                             }]),
                     )
                     .into_any_element(),
@@ -741,6 +806,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: None,
+                                detached: false,
                             }])
                             .added(42)
                             .removed(17)
@@ -760,6 +826,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("feature-branch".into()),
+                                detached: false,
                             }])
                             .added(42)
                             .removed(17)
@@ -779,6 +846,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("fix-very-long-branch-name-here".into()),
+                                detached: false,
                             }])
                             .added(108)
                             .removed(53)
@@ -787,7 +855,7 @@ impl Component for ThreadItem {
                     .into_any_element(),
             ),
             single_example(
-                "Main Worktree (hidden) + Changes + Timestamp",
+                "Main Worktree Branch + Changes + Timestamp",
                 container()
                     .child(
                         ThreadItem::new("ti-5e", "Main worktree branch with diff stats")
@@ -798,6 +866,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Main,
                                 branch_name: Some("sidebar-show-branch-name".into()),
+                                detached: false,
                             }])
                             .added(23)
                             .removed(8)
@@ -819,6 +888,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: None,
+                                detached: false,
                             }])
                             .timestamp("1h"),
                     )
@@ -836,6 +906,7 @@ impl Component for ThreadItem {
                                 highlight_positions: vec![0, 1, 2, 3],
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("fix-scrolling".into()),
+                                detached: false,
                             }])
                             .timestamp("3d"),
                     )
@@ -854,6 +925,7 @@ impl Component for ThreadItem {
                                     highlight_positions: Vec::new(),
                                     kind: WorktreeKind::Linked,
                                     branch_name: None,
+                                    detached: false,
                                 },
                                 ThreadItemWorktreeInfo {
                                     worktree_name: Some("fawn-otter".into()),
@@ -861,6 +933,7 @@ impl Component for ThreadItem {
                                     highlight_positions: Vec::new(),
                                     kind: WorktreeKind::Linked,
                                     branch_name: None,
+                                    detached: false,
                                 },
                             ])
                             .timestamp("2h"),
@@ -880,6 +953,7 @@ impl Component for ThreadItem {
                                     highlight_positions: Vec::new(),
                                     kind: WorktreeKind::Linked,
                                     branch_name: Some("fix".into()),
+                                    detached: false,
                                 },
                                 ThreadItemWorktreeInfo {
                                     worktree_name: Some("fawn-otter".into()),
@@ -887,6 +961,7 @@ impl Component for ThreadItem {
                                     highlight_positions: Vec::new(),
                                     kind: WorktreeKind::Linked,
                                     branch_name: Some("main".into()),
+                                    detached: false,
                                 },
                             ])
                             .timestamp("15m"),
@@ -906,6 +981,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("feature-branch".into()),
+                                detached: false,
                             }])
                             .timestamp("1d"),
                     )
@@ -927,6 +1003,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("feature".into()),
+                                detached: false,
                             }])
                             .timestamp("2mo"),
                     )
@@ -945,6 +1022,7 @@ impl Component for ThreadItem {
                                 highlight_positions: Vec::new(),
                                 kind: WorktreeKind::Linked,
                                 branch_name: Some("main".into()),
+                                detached: false,
                             }])
                             .added(15)
                             .removed(4)
@@ -984,5 +1062,55 @@ impl Component for ThreadItem {
         example_group(thread_item_examples)
             .vertical()
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_item_worktree_display_labels() {
+        let main = ThreadItemWorktreeInfo {
+            worktree_name: Some("zed".into()),
+            branch_name: Some("main".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            main.display_labels(false),
+            Some((None, Some("main".into())))
+        );
+        assert_eq!(
+            main.display_labels(true),
+            Some((Some("zed".into()), Some("main".into())))
+        );
+
+        let main_without_branch = ThreadItemWorktreeInfo {
+            worktree_name: Some("zed".into()),
+            ..Default::default()
+        };
+        assert_eq!(main_without_branch.display_labels(false), None);
+
+        let linked = ThreadItemWorktreeInfo {
+            worktree_name: Some("feature".into()),
+            branch_name: Some("feature-branch".into()),
+            kind: WorktreeKind::Linked,
+            ..Default::default()
+        };
+        assert_eq!(
+            linked.display_labels(false),
+            Some((Some("feature".into()), Some("feature-branch".into())))
+        );
+
+        let detached = ThreadItemWorktreeInfo {
+            worktree_name: Some("detached".into()),
+            detached: true,
+            kind: WorktreeKind::Linked,
+            ..Default::default()
+        };
+        assert_eq!(
+            detached.display_labels(false),
+            Some((Some("detached".into()), Some("Detached HEAD".into())))
+        );
     }
 }

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -2912,7 +2912,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                     .color(Color::Default),
             )
             .child(section_label(
-                "Linked worktree with branch (worktree / branch)",
+                "Linked worktree with branch (worktree • branch, both icons)",
             ))
             .child(
                 container().child(
@@ -2925,11 +2925,12 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Linked,
                             branch_name: Some("fix-scrolling".into()),
+                            detached: false,
                         }]),
                 ),
             )
             .child(section_label(
-                "Linked worktree without branch (detached HEAD)",
+                "Linked worktree without branch (worktree • Detached HEAD)",
             ))
             .child(
                 container().child(
@@ -2942,10 +2943,11 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Linked,
                             branch_name: None,
+                            detached: true,
                         }]),
                 ),
             )
-            .child(section_label("Main worktree with branch (nothing shown)"))
+            .child(section_label("Main worktree with branch (branch only)"))
             .child(
                 container().child(
                     ThreadItem::new("ti-main-branch", "Request for Long Classic Poem")
@@ -2957,7 +2959,36 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Main,
                             branch_name: Some("main".into()),
+                            detached: false,
                         }]),
+                ),
+            )
+            .child(section_label(
+                "Multiple main worktrees, one without a branch (visible name retained)",
+            ))
+            .child(
+                container().child(
+                    ThreadItem::new("ti-multi-main", "Coordinate multi-root changes")
+                        .icon(IconName::ZedAgent)
+                        .timestamp("3h")
+                        .worktrees(vec![
+                            ThreadItemWorktreeInfo {
+                                worktree_name: Some("zed".into()),
+                                full_path: "/projects/zed".into(),
+                                highlight_positions: Vec::new(),
+                                kind: WorktreeKind::Main,
+                                branch_name: Some("main".into()),
+                                detached: false,
+                            },
+                            ThreadItemWorktreeInfo {
+                                worktree_name: Some("zed-slides".into()),
+                                full_path: "/projects/zed-slides".into(),
+                                highlight_positions: Vec::new(),
+                                kind: WorktreeKind::Main,
+                                branch_name: None,
+                                detached: false,
+                            },
+                        ]),
                 ),
             )
             .child(section_label(
@@ -2974,6 +3005,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Main,
                             branch_name: None,
+                            detached: false,
                         }]),
                 ),
             )
@@ -2989,6 +3021,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Linked,
                             branch_name: Some("stoic-reed".into()),
+                            detached: false,
                         }]),
                 ),
             )
@@ -3006,6 +3039,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Linked,
                             branch_name: Some("persist-worktree-3-wiring".into()),
+                            detached: false,
                         }]),
                 ),
             )
@@ -3025,6 +3059,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Linked,
                             branch_name: Some("feature-branch".into()),
+                            detached: false,
                         }]),
                 ),
             )
@@ -3044,11 +3079,12 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             branch_name: Some(
                                 "fix-very-long-branch-name-that-should-truncate".into(),
                             ),
+                            detached: false,
                         }]),
                 ),
             )
             .child(section_label(
-                "Main worktree with branch + diff stats + timestamp (branch hidden)",
+                "Main worktree with branch + diff stats + timestamp (branch shown)",
             ))
             .child(
                 container().child(
@@ -3063,6 +3099,7 @@ impl gpui::Render for ThreadItemBranchNameTestView {
                             highlight_positions: Vec::new(),
                             kind: WorktreeKind::Main,
                             branch_name: Some("sidebar-show-branch-name".into()),
+                            detached: false,
                         }]),
                 ),
             )
@@ -3075,7 +3112,7 @@ fn run_thread_item_branch_name_visual_tests(
     cx: &mut VisualTestAppContext,
     update_baseline: bool,
 ) -> Result<TestResult> {
-    let window_size = size(px(400.0), px(1150.0));
+    let window_size = size(px(400.0), px(1250.0));
     let bounds = Bounds {
         origin: point(px(0.0), px(0.0)),
         size: window_size,


### PR DESCRIPTION
# Objective

Show accurate Git context for agent threads in the sidebar. Base checkouts display their current branch, linked worktrees display their worktree and branch, and branchless linked worktrees display `Detached HEAD`.

This follows up on #53900 and keeps detached state accurate for remote clients, reconnects, and late joins.

## Solution

- Render base-worktree branches and explicit detached-HEAD state in `ThreadItem`, using a dot separator and branch icon for linked worktree branches.
- Carry `is_detached_head` through repository snapshots, protobuf updates, and collab persistence instead of encoding it as a synthetic branch name.
- Extend FakeFs and focused sidebar, project, collab, and visual fixtures to distinguish detached state from missing Git metadata.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_apply_worktree_label_mode_for_detached_worktree -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_sidebar_worktree_info_for_base_and_detached_linked_checkout -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_sidebar_worktree_info_for_current_detached_linked_checkout -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_multi_main_worktree_branch_labels_are_disambiguated -- --nocapture`
- `cargo test -p sidebar -p gpui_platform --features gpui_platform/runtime_shaders test_worktree_info_missing_branch_returns_none -- --nocapture`
- `cargo test -p fs test_detached_worktree_admin_names_are_unique`
- `cargo test -p fs test_fake_worktree_lifecycle`
- `cargo test -p project test_branch_list_sync`
- `cargo test -p collab -p gpui_platform --features gpui_platform/runtime_shaders test_detached_head_sync`
- `cargo test -p collab -p gpui_platform --features gpui_platform/runtime_shaders test_linked_worktrees_sync`
- `cargo build -p zed -p gpui_platform --bin zed_visual_test_runner --features visual-tests,gpui_platform/runtime_shaders`
- `./script/clippy`
- `git diff --check`
- Manually verified the base, linked-branch, and detached-HEAD labels in a local Zed build.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Before

<img width="291" height="165" alt="image" src="https://github.com/user-attachments/assets/1b4c4cae-efaf-4ec1-b783-ee8eb74988d6" />

## After

<img width="303" height="165" alt="image" src="https://github.com/user-attachments/assets/e5a85ca8-73a8-40cf-b13c-b258d63c2554" />

---

Release Notes:

- Branch name and icon is now shown for each thread in the thread sidebar including when the base branch is checked out, and it is now clear when a thread is in detached HEAD state.
