### PR TITLE
Fix agent pane splitting lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3300,7 +3300,7 @@ impl AgentPanel {
 
     pub fn dismiss_all_notifications(&mut self, cx: &mut Context<Self>) -> bool {
         let mut dismissed = false;
-        for conversation_view in self.conversation_views() {
+        for conversation_view in self.conversation_views(cx) {
             dismissed |= conversation_view.update(cx, |view, cx| view.dismiss_notifications(cx));
         }
         let had_terminal_notifications = self
@@ -4876,7 +4876,7 @@ impl AgentPanel {
         cx: &mut Context<Self>,
     ) {
         let item_id = item.entity_id();
-        let release = cx.observe_release(item, move |this, _item, _cx| {
+        let release = cx.observe_release(item, move |this, _item, cx| {
             if this
                 .center_terminals
                 .get(&terminal_id)
@@ -4884,6 +4884,7 @@ impl AgentPanel {
             {
                 this.center_terminals.remove(&terminal_id);
                 this.clear_last_center_entry(CenterEntry::Terminal(terminal_id));
+                this.request_close_terminal_from_terminal_event(terminal_id, cx);
             }
         });
         self.center_terminals.insert(
@@ -4988,12 +4989,28 @@ impl AgentPanel {
         })
     }
 
-    pub fn conversation_views(&self) -> Vec<Entity<ConversationView>> {
-        self.active_conversation_view()
+    pub fn conversation_views(&self, cx: &App) -> Vec<Entity<ConversationView>> {
+        let mut views = self
+            .active_conversation_view()
             .into_iter()
             .cloned()
             .chain(self.retained_threads.values().cloned())
-            .collect()
+            .collect::<Vec<_>>();
+
+        for center in self.center_threads.values() {
+            let Some(item) = center.item.upgrade() else {
+                continue;
+            };
+            let conversation_view = item.read(cx).conversation_view().clone();
+            if !views
+                .iter()
+                .any(|view| view.entity_id() == conversation_view.entity_id())
+            {
+                views.push(conversation_view);
+            }
+        }
+
+        views
     }
 
     pub fn active_thread_view(&self, cx: &App) -> Option<Entity<ThreadView>> {
@@ -10438,6 +10455,15 @@ mod tests {
             panel.read_with(&cx, |panel, cx| panel.active_center_thread_id(cx)),
             Some(second_thread_id)
         );
+        assert!(
+            panel.read_with(&cx, |panel, cx| {
+                panel
+                    .conversation_views(cx)
+                    .iter()
+                    .any(|view| view.read(cx).thread_id == first_thread_id)
+            }),
+            "center-owned threads must remain available to sidebar status aggregation"
+        );
     }
 
     #[gpui::test]
@@ -10848,6 +10874,56 @@ mod tests {
             );
         });
         assert!(!panel.read_with(&cx, |panel, _cx| panel.has_terminal(terminal_id)));
+    }
+
+    #[gpui::test]
+    async fn test_closing_center_tab_emits_terminal_close_requested(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+
+        let close_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let _subscription = cx.update(|_window, cx| {
+            let close_requested = close_requested.clone();
+            cx.subscribe(&panel, move |_, event: &AgentPanelEvent, _| {
+                if matches!(event, AgentPanelEvent::TerminalCloseRequested { .. }) {
+                    close_requested.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+            })
+        });
+
+        let terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Build", true, window, cx)
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_terminal_in_center(terminal_id, None, window, cx));
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            let pane = workspace.active_pane().clone();
+            let item = workspace
+                .active_item_as::<AgentTerminalPane>(cx)
+                .expect("active item should be AgentTerminalPane");
+            pane.update(cx, |pane, cx| {
+                pane.close_item_by_id(item.entity_id(), workspace::SaveIntent::Skip, window, cx)
+                    .detach();
+            });
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace.items_of_type::<AgentTerminalPane>(cx).count(),
+                0,
+                "center tab must be closed"
+            );
+        });
+        assert!(
+            close_requested.load(std::sync::atomic::Ordering::SeqCst),
+            "TerminalCloseRequested event must be emitted when center tab is closed"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -38,6 +38,7 @@ use zed_actions::{
 use crate::ExpandMessageEditor;
 use crate::ManageProfiles;
 use crate::agent_connection_store::AgentConnectionStore;
+use crate::center_pane_store::AgentCenterPaneDb;
 use crate::completion_provider::{AgentContextSelection, AgentContextSource};
 use crate::terminal_thread_metadata_store::{
     TerminalThreadMetadata, TerminalThreadMetadataStore, compose_terminal_thread_title,
@@ -99,10 +100,11 @@ use ui::{
 };
 use util::ResultExt as _;
 use workspace::{
-    CollaboratorId, DraggedSelection, DraggedTab, MultiWorkspace, PathList, SerializedPathList,
-    SplitDirection, ToggleWorkspaceSidebar, ToggleZoom, ToolbarItemView, Workspace, WorkspaceId,
+    CollaboratorId, DraggedSelection, DraggedTab, ItemId, MultiWorkspace, PathList,
+    SerializedPathList, SplitDirection, ToggleWorkspaceSidebar, ToggleZoom, ToolbarItemView,
+    Workspace, WorkspaceId,
     dock::{DockPosition, Panel, PanelEvent},
-    item::{ItemEvent, ItemHandle},
+    item::{Item, ItemEvent, ItemHandle, SerializableItem},
 };
 
 const AGENT_PANEL_KEY: &str = "agent_panel";
@@ -200,6 +202,307 @@ pub struct NewEntryOption {
     pub label: SharedString,
     pub icon: NewEntryIcon,
     pub kind: NewEntryKind,
+}
+
+struct CenterItem<T: 'static> {
+    item: WeakEntity<T>,
+    _release: Subscription,
+}
+
+/// The panel entry most recently handed to a center pane.
+///
+/// The panel also persists this as a fallback for older workspace layouts.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CenterEntry {
+    Thread(ThreadId),
+    Terminal(TerminalId),
+}
+
+/// Adapts an agent panel terminal so it can live in a workspace pane.
+///
+/// The panel and the workspace pane share the same `TerminalView` entity; this wrapper exists so
+/// the panel keeps sole ownership of it. Adding the `TerminalView` to a pane directly would let the
+/// workspace serialize it as a plain `"Terminal"` item, and a restart would then restore a second,
+/// panel-less terminal alongside the one the panel restores from its own metadata.
+pub struct AgentTerminalPane {
+    terminal_view: Entity<TerminalView>,
+    terminal_id: TerminalId,
+    panel: WeakEntity<AgentPanel>,
+    _title_subscription: Subscription,
+}
+
+impl AgentTerminalPane {
+    fn new(
+        terminal_view: Entity<TerminalView>,
+        terminal_id: TerminalId,
+        panel: WeakEntity<AgentPanel>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let title_subscription =
+            cx.subscribe(&terminal_view, |_this, _terminal, event: &ItemEvent, cx| {
+                if matches!(event, ItemEvent::UpdateTab) {
+                    cx.emit(ItemEvent::UpdateTab);
+                }
+            });
+        Self {
+            terminal_view,
+            terminal_id,
+            panel,
+            _title_subscription: title_subscription,
+        }
+    }
+
+    pub fn terminal_id(&self) -> TerminalId {
+        self.terminal_id
+    }
+}
+
+impl Item for AgentTerminalPane {
+    type Event = ItemEvent;
+
+    fn include_in_nav_history() -> bool {
+        false
+    }
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        self.panel
+            .read_with(cx, |panel, cx| {
+                panel
+                    .terminals
+                    .get(&self.terminal_id)
+                    .map(|terminal| terminal.title(cx))
+            })
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| {
+                AgentTerminal::terminal_title_for_view(self.terminal_view.read(cx), cx)
+            })
+    }
+
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::Terminal))
+    }
+
+    fn to_item_events(event: &Self::Event, emit: &mut dyn FnMut(ItemEvent)) {
+        emit(*event);
+    }
+}
+
+impl EventEmitter<ItemEvent> for AgentTerminalPane {}
+
+impl Focusable for AgentTerminalPane {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.terminal_view.focus_handle(cx)
+    }
+}
+
+impl Render for AgentTerminalPane {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().size_full().child(self.terminal_view.clone())
+    }
+}
+
+async fn load_agent_panel_for_center_pane(
+    workspace: &WeakEntity<Workspace>,
+    cx: &mut AsyncWindowContext,
+) -> Result<Entity<AgentPanel>> {
+    if let Some(panel) =
+        workspace.read_with(cx, |workspace, cx| workspace.panel::<AgentPanel>(cx))?
+    {
+        return Ok(panel);
+    }
+
+    let loaded_panel = AgentPanel::load(workspace.clone(), cx.clone()).await?;
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.panel::<AgentPanel>(cx).unwrap_or_else(|| {
+            workspace.add_panel(loaded_panel.clone(), window, cx);
+            loaded_panel
+        })
+    })
+}
+
+impl SerializableItem for crate::ConversationPane {
+    fn serialized_item_kind() -> &'static str {
+        "AgentConversationPane"
+    }
+
+    fn cleanup(
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        AgentCenterPaneDb::global(cx).cleanup_threads(workspace_id, alive_items, cx)
+    }
+
+    fn deserialize(
+        _project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<Entity<Self>>> {
+        let db = AgentCenterPaneDb::global(cx);
+        window.spawn(cx, async move |cx| {
+            let thread_id = db
+                .thread_id(workspace_id, item_id)?
+                .context("missing agent conversation pane metadata")
+                .and_then(|thread_id| ThreadId::from_key_string(&thread_id))?;
+            let (thread_store, reload_task) = cx.update(|_window, cx| {
+                let store = ThreadMetadataStore::global(cx);
+                let reload_task = store.read(cx).reload_task();
+                (store, reload_task)
+            })?;
+            reload_task.await;
+            let metadata = thread_store
+                .read_with(cx, |store, _cx| store.entry(thread_id).cloned())
+                .context("missing thread for agent conversation pane")?;
+
+            let panel = load_agent_panel_for_center_pane(&workspace, cx).await?;
+
+            panel.update_in(cx, |panel, window, cx| {
+                panel.load_agent_thread(
+                    Agent::from(metadata.agent_id.clone()),
+                    thread_id,
+                    Some(metadata.folder_paths().clone()),
+                    metadata.title,
+                    false,
+                    AgentThreadSource::AgentPanel,
+                    window,
+                    cx,
+                );
+                let conversation_view = panel
+                    .conversation_view_for_id(&thread_id, cx)
+                    .cloned()
+                    .context("failed to restore agent conversation pane")?;
+                let item =
+                    cx.new(|cx| crate::ConversationPane::new(conversation_view, thread_id, cx));
+                panel.register_center_thread(thread_id, &item, cx);
+                panel.last_center_entry = Some(CenterEntry::Thread(thread_id));
+                if panel.active_thread_id(cx) == Some(thread_id) {
+                    panel.set_base_view(BaseView::Uninitialized, false, window, cx);
+                }
+                Ok(item)
+            })?
+        })
+    }
+
+    fn serialize(
+        &mut self,
+        workspace: &mut Workspace,
+        item_id: ItemId,
+        _closing: bool,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        let workspace_id = workspace.database_id()?;
+        let thread_id = self.thread_id().to_key_string();
+        let db = AgentCenterPaneDb::global(cx);
+        Some(cx.background_spawn(
+            async move { db.save_thread(workspace_id, item_id, thread_id).await },
+        ))
+    }
+
+    fn should_serialize(&self, _event: &Self::Event) -> bool {
+        false
+    }
+}
+
+impl SerializableItem for AgentTerminalPane {
+    fn serialized_item_kind() -> &'static str {
+        "AgentTerminalPane"
+    }
+
+    fn cleanup(
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        AgentCenterPaneDb::global(cx).cleanup_terminals(workspace_id, alive_items, cx)
+    }
+
+    fn deserialize(
+        _project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<Entity<Self>>> {
+        let db = AgentCenterPaneDb::global(cx);
+        window.spawn(cx, async move |cx| {
+            let terminal_id = db
+                .terminal_id(workspace_id, item_id)?
+                .context("missing agent terminal pane metadata")
+                .and_then(|terminal_id| TerminalId::from_key_string(&terminal_id))?;
+            let (terminal_store, reload_task) = cx.update(|_window, cx| {
+                let store = TerminalThreadMetadataStore::global(cx);
+                let reload_task = store.read(cx).reload_task();
+                (store, reload_task)
+            })?;
+            reload_task.await;
+            let metadata = terminal_store
+                .read_with(cx, |store, _cx| store.entry(terminal_id).cloned())
+                .context("missing terminal for agent terminal pane")?;
+
+            let panel = load_agent_panel_for_center_pane(&workspace, cx).await?;
+            let terminal_view = panel.update_in(cx, |panel, window, cx| {
+                if !panel.supports_terminal(cx) {
+                    anyhow::bail!("this project cannot restore an agent terminal pane");
+                }
+                let receiver = panel.wait_for_terminal_view(terminal_id);
+                if !panel.has_terminal(terminal_id) {
+                    panel.restore_terminal(
+                        metadata,
+                        false,
+                        AgentThreadSource::AgentPanel,
+                        None,
+                        window,
+                        cx,
+                    );
+                }
+                Ok(receiver)
+            })??;
+            let terminal_view = terminal_view
+                .recv()
+                .await
+                .context("failed to restore agent terminal pane")?;
+
+            let item = cx.update(|_window, cx| {
+                cx.new(|cx| {
+                    AgentTerminalPane::new(terminal_view, terminal_id, panel.downgrade(), cx)
+                })
+            })?;
+            panel.update_in(cx, |panel, window, cx| {
+                panel.register_center_terminal(terminal_id, &item, cx);
+                panel.last_center_entry = Some(CenterEntry::Terminal(terminal_id));
+                if panel.active_terminal_id() == Some(terminal_id) {
+                    panel.set_base_view(BaseView::Uninitialized, false, window, cx);
+                }
+            })?;
+            Ok(item)
+        })
+    }
+
+    fn serialize(
+        &mut self,
+        workspace: &mut Workspace,
+        item_id: ItemId,
+        _closing: bool,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        let workspace_id = workspace.database_id()?;
+        let terminal_id = self.terminal_id.to_key_string();
+        let db = AgentCenterPaneDb::global(cx);
+        Some(cx.background_spawn(async move {
+            db.save_terminal(workspace_id, item_id, terminal_id).await
+        }))
+    }
+
+    fn should_serialize(&self, _event: &Self::Event) -> bool {
+        false
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -389,6 +692,9 @@ struct SerializedActiveThread {
 }
 
 pub fn init(cx: &mut App) {
+    workspace::register_serializable_item::<crate::ConversationPane>(cx);
+    workspace::register_serializable_item::<AgentTerminalPane>(cx);
+
     cx.observe_new(
         |workspace: &mut Workspace, _window, _cx: &mut Context<Workspace>| {
             workspace
@@ -1189,6 +1495,15 @@ pub struct AgentPanel {
     terminals: HashMap<TerminalId, AgentTerminal>,
     pending_terminal_spawn: Option<TerminalId>,
     pending_terminal_center_open: HashMap<TerminalId, Option<SplitDirection>>,
+    terminal_view_waiters: HashMap<TerminalId, Vec<async_channel::Sender<Entity<TerminalView>>>>,
+    /// Center pane items the panel handed its threads and terminals to.
+    ///
+    /// The panel is often updated from inside a `Workspace` update (a sidebar click, for one), so
+    /// it cannot read the workspace to answer "is this entry in the center?". This registry answers
+    /// it without touching the workspace; entries drop themselves when the pane releases the item.
+    center_threads: HashMap<ThreadId, CenterItem<crate::ConversationPane>>,
+    center_terminals: HashMap<TerminalId, CenterItem<AgentTerminalPane>>,
+    last_center_entry: Option<CenterEntry>,
     /// Split links for terminals created or restored in this session.
     /// `terminal_metadata` rebuilds metadata from live terminal state on every
     /// persist, so without this the link would be written away by the first
@@ -1223,20 +1538,31 @@ impl AgentPanel {
 
         let selected_agent = self.selected_agent.clone();
         let last_created_entry_kind = self.last_created_entry_kind;
+        // Keep the panel fallback so layouts saved before center panes became serializable still
+        // restore their last active entry.
         let last_active_terminal_id = self
             .active_terminal_id()
+            .or_else(|| self.serializable_center_terminal_id())
             .map(|terminal_id| terminal_id.to_key_string());
 
         let last_active_thread = if last_active_terminal_id.is_some() {
             None
         } else {
-            let is_draft_active = self.active_thread_is_draft(cx);
-            let active_thread_id = self.active_thread_id(cx);
-            let active_thread_agent = self
-                .active_conversation_view()
+            let active_conversation_view = self.serializable_conversation_view(cx);
+            let active_agent_thread = active_conversation_view
+                .as_ref()
+                .and_then(|cv| cv.read(cx).root_thread(cx));
+            let is_draft_active = active_agent_thread
+                .as_ref()
+                .is_some_and(|thread| thread.read(cx).is_draft_thread());
+            let active_thread_id = active_conversation_view
+                .as_ref()
+                .map(|cv| cv.read(cx).thread_id);
+            let active_thread_agent = active_conversation_view
+                .as_ref()
                 .map(|cv| cv.read(cx).agent_key().clone())
                 .unwrap_or_else(|| self.selected_agent.clone());
-            self.active_agent_thread(cx)
+            active_agent_thread
                 .map(|thread| {
                     let thread = thread.read(cx);
 
@@ -1259,7 +1585,7 @@ impl AgentPanel {
                     if is_draft_active {
                         return None;
                     }
-                    let conversation_view = self.active_conversation_view()?;
+                    let conversation_view = active_conversation_view.as_ref()?;
                     let session_id = conversation_view.read(cx).root_session_id.clone()?;
                     let metadata = ThreadMetadataStore::try_global(cx)
                         .and_then(|store| store.read(cx).entry_by_session(&session_id).cloned());
@@ -1518,7 +1844,7 @@ impl AgentPanel {
         })
     }
 
-    pub(crate) fn new(workspace: &Workspace, _window: &mut Window, cx: &mut Context<Self>) -> Self {
+    pub(crate) fn new(workspace: &Workspace, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let fs = workspace.app_state().fs.clone();
         let user_store = workspace.app_state().user_store.clone();
         let project = workspace.project();
@@ -1575,10 +1901,14 @@ impl AgentPanel {
                 _ => {}
             });
 
-        let _thread_metadata_store_subscription = cx.subscribe(
+        let _thread_metadata_store_subscription = cx.subscribe_in(
             &ThreadMetadataStore::global(cx),
-            |this, _store, event, cx| {
+            window,
+            |this, _store, event, window, cx| {
                 let ThreadMetadataStoreEvent::ThreadArchived(thread_id) = event;
+                // The center pane holds its own reference to the conversation, so dropping only
+                // the retained one would leave an archived thread running in a tab.
+                this.close_center_item_for_thread(*thread_id, window, cx);
                 if this.retained_threads.remove(thread_id).is_some() {
                     cx.notify();
                 }
@@ -1608,6 +1938,10 @@ impl AgentPanel {
             terminals: HashMap::default(),
             pending_terminal_spawn: None,
             pending_terminal_center_open: HashMap::default(),
+            terminal_view_waiters: HashMap::default(),
+            center_threads: HashMap::default(),
+            center_terminals: HashMap::default(),
+            last_center_entry: None,
             terminal_split_parents: HashMap::default(),
             new_thread_menu_handle: PopoverMenuHandle::default(),
             agent_panel_menu_handle: PopoverMenuHandle::default(),
@@ -2151,6 +2485,7 @@ impl AgentPanel {
                         }
                         this.pending_terminal_center_open.remove(&terminal_id);
                         this.terminal_split_parents.remove(&terminal_id);
+                        this.terminal_view_waiters.remove(&terminal_id);
                         cx.notify();
                     })
                     .log_err();
@@ -2304,7 +2639,7 @@ impl AgentPanel {
             .map(|title| title.to_string())
             .unwrap_or_default();
         let mut terminal = AgentTerminal {
-            view: terminal_view,
+            view: terminal_view.clone(),
             title_editor: None,
             title_editor_initial_title: None,
             title_editor_subscription: None,
@@ -2325,6 +2660,11 @@ impl AgentPanel {
         terminal.refresh_metadata(cx);
         terminal.report_started_terminal_program(terminal_id, source, cx);
         self.terminals.insert(terminal_id, terminal);
+        if let Some(waiters) = self.terminal_view_waiters.remove(&terminal_id) {
+            for waiter in waiters {
+                waiter.try_send(terminal_view.clone()).log_err();
+            }
+        }
         self.persist_terminal_metadata(terminal_id, cx);
         self.emit_terminal_thread_started(terminal_id, source, cx);
         if select {
@@ -2344,6 +2684,24 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.terminals.contains_key(&terminal_id) {
+            return;
+        }
+        // Same ownership rule as threads: a terminal living in the center stays there.
+        if self.terminal_is_in_center(terminal_id) {
+            if focus {
+                cx.defer_in(window, move |this, window, cx| {
+                    this.focus_terminal_in_center(terminal_id, window, cx);
+                });
+            }
+            self.dismiss_terminal_notifications(terminal_id, cx);
+            if let Some(terminal) = self.terminals.get_mut(&terminal_id) {
+                terminal.has_notification = false;
+            }
+            cx.emit(AgentPanelEvent::EntryChanged);
+            cx.notify();
+            return;
+        }
         let Some(terminal) = self.terminals.get_mut(&terminal_id) else {
             return;
         };
@@ -2357,6 +2715,22 @@ impl AgentPanel {
             cx.emit(AgentPanelEvent::EntryChanged);
             cx.notify();
         }
+    }
+
+    fn wait_for_terminal_view(
+        &mut self,
+        terminal_id: TerminalId,
+    ) -> async_channel::Receiver<Entity<TerminalView>> {
+        let (sender, receiver) = async_channel::bounded(1);
+        if let Some(terminal) = self.terminals.get(&terminal_id) {
+            sender.try_send(terminal.view.clone()).log_err();
+        } else {
+            self.terminal_view_waiters
+                .entry(terminal_id)
+                .or_default()
+                .push(sender);
+        }
+        receiver
     }
 
     pub fn close_terminal(
@@ -2389,10 +2763,12 @@ impl AgentPanel {
         if self.pending_terminal_spawn == Some(terminal_id) {
             self.pending_terminal_spawn = None;
         }
+        self.terminal_view_waiters.remove(&terminal_id);
         self.dismiss_terminal_notifications(terminal_id, cx);
         if self.terminals.remove(&terminal_id).is_none() {
             return;
         }
+        self.close_center_item_for_terminal(terminal_id, window, cx);
         self.terminal_split_parents.remove(&terminal_id);
         if let Some(store) = TerminalThreadMetadataStore::try_global(cx) {
             store.update(cx, |store, cx| {
@@ -2960,21 +3336,14 @@ impl AgentPanel {
     }
 
     fn terminal_center_visible(&self, terminal_id: TerminalId, cx: &App) -> bool {
-        let Some(terminal_view) = self
-            .terminals
-            .get(&terminal_id)
-            .map(|terminal| &terminal.view)
-        else {
-            return false;
-        };
         let Some(workspace) = self.workspace.upgrade() else {
             return false;
         };
         workspace.read(cx).panes().iter().any(|pane| {
             pane.read(cx)
                 .active_item()
-                .and_then(|item| item.to_any_view().downcast::<TerminalView>().ok())
-                .is_some_and(|item| item.entity_id() == terminal_view.entity_id())
+                .and_then(|item| item.to_any_view().downcast::<AgentTerminalPane>().ok())
+                .is_some_and(|item| item.read(cx).terminal_id() == terminal_id)
         })
     }
 
@@ -3107,6 +3476,20 @@ impl AgentPanel {
         cx: &mut Context<Self>,
     ) -> Entity<ConversationView> {
         let desired_agent = self.selected_agent(cx);
+
+        // Unreachable while `register_center_thread` releases the slot, but it
+        // keeps this function correct on its own: handing back a center-owned
+        // view would render one conversation on two surfaces. Park it rather
+        // than deleting its metadata — the thread still exists in the center.
+        if let Some(draft) = self.draft_thread.clone()
+            && self.thread_is_in_center(draft.read(cx).thread_id)
+        {
+            let thread_id = draft.read(cx).thread_id;
+            self.draft_thread = None;
+            self._draft_editor_observation = None;
+            self.retained_threads.insert(thread_id, draft);
+        }
+
         if let Some(draft) = &self.draft_thread {
             let draft_entity = draft.entity_id();
             let agent_matches = *draft.read(cx).agent_key() == desired_agent;
@@ -3424,6 +3807,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.close_center_item_for_thread(id, window, cx);
         self.retained_threads.remove(&id);
         ThreadMetadataStore::global(cx).update(cx, |store, cx| {
             store.delete(id, cx);
@@ -4104,6 +4488,39 @@ impl AgentPanel {
         }
     }
 
+    /// The conversation the panel should persist as its last active thread: the one in the panel,
+    /// or — when the panel handed its base view to a center pane — the one it handed over.
+    fn serializable_conversation_view(&self, cx: &App) -> Option<Entity<ConversationView>> {
+        if let Some(conversation_view) = self.active_conversation_view() {
+            return Some(conversation_view.clone());
+        }
+        let CenterEntry::Thread(thread_id) = self.serializable_center_entry()? else {
+            return None;
+        };
+        self.conversation_view_for_id(&thread_id, cx).cloned()
+    }
+
+    fn serializable_center_terminal_id(&self) -> Option<TerminalId> {
+        match self.serializable_center_entry()? {
+            CenterEntry::Terminal(terminal_id) => Some(terminal_id),
+            CenterEntry::Thread(_) => None,
+        }
+    }
+
+    fn serializable_center_entry(&self) -> Option<CenterEntry> {
+        if !matches!(self.base_view, BaseView::Uninitialized) {
+            return None;
+        }
+        match self.last_center_entry? {
+            CenterEntry::Thread(thread_id) => self
+                .thread_is_in_center(thread_id)
+                .then_some(CenterEntry::Thread(thread_id)),
+            CenterEntry::Terminal(terminal_id) => self
+                .terminal_is_in_center(terminal_id)
+                .then_some(CenterEntry::Terminal(terminal_id)),
+        }
+    }
+
     pub(crate) fn visible_conversation_view(&self) -> Option<&Entity<ConversationView>> {
         match self.visible_surface() {
             VisibleSurface::AgentThread(conversation_view) => Some(conversation_view),
@@ -4165,22 +4582,26 @@ impl AgentPanel {
         })
     }
 
-    pub fn new_entry_options(&self, cx: &App) -> Vec<NewEntryOption> {
-        let mut options = Vec::new();
-
-        if self.supports_terminal(cx) {
-            options.push(NewEntryOption {
+    pub fn closed_project_new_entry_options() -> Vec<NewEntryOption> {
+        vec![
+            NewEntryOption {
                 label: "Terminal".into(),
                 icon: NewEntryIcon::Named(IconName::Terminal),
                 kind: NewEntryKind::Terminal,
-            });
-        }
+            },
+            NewEntryOption {
+                label: Agent::NativeAgent.label(),
+                icon: NewEntryIcon::Named(IconName::ZedAgent),
+                kind: NewEntryKind::Thread(Agent::NativeAgent),
+            },
+        ]
+    }
 
-        options.push(NewEntryOption {
-            label: Agent::NativeAgent.label(),
-            icon: NewEntryIcon::Named(IconName::ZedAgent),
-            kind: NewEntryKind::Thread(Agent::NativeAgent),
-        });
+    pub fn new_entry_options(&self, cx: &App) -> Vec<NewEntryOption> {
+        let mut options = Self::closed_project_new_entry_options();
+        if !self.supports_terminal(cx) {
+            options.retain(|option| !matches!(option.kind, NewEntryKind::Terminal));
+        }
 
         if self.project.read(cx).is_via_collab() {
             return options;
@@ -4261,17 +4682,6 @@ impl AgentPanel {
                     });
                 }
                 self.open_thread_in_center(thread_id, split_direction, window, cx);
-
-                // The draft now lives in the center, so release the panel's
-                // single new-draft slot; otherwise the next split would reuse
-                // it instead of starting a second agent.
-                if let Some(draft) = self.draft_thread.clone()
-                    && draft.read(cx).thread_id == thread_id
-                {
-                    self.draft_thread = None;
-                    self._draft_editor_observation = None;
-                    self.retained_threads.insert(thread_id, draft);
-                }
             }
         }
     }
@@ -4291,7 +4701,8 @@ impl AgentPanel {
         };
 
         if !self.focus_thread_in_center(thread_id, window, cx) {
-            let item = cx.new(|_| crate::ConversationPane::new(conversation_view, thread_id));
+            let item = cx.new(|cx| crate::ConversationPane::new(conversation_view, thread_id, cx));
+            self.register_center_thread(thread_id, &item, cx);
             workspace.update(cx, |workspace, cx| {
                 if let Some(split_direction) = split_direction {
                     workspace.split_item(split_direction, Box::new(item), window, cx);
@@ -4301,6 +4712,7 @@ impl AgentPanel {
             });
         }
 
+        self.last_center_entry = Some(CenterEntry::Thread(thread_id));
         if self.active_thread_id(cx) == Some(thread_id) {
             self.set_base_view(BaseView::Uninitialized, false, window, cx);
         }
@@ -4326,6 +4738,18 @@ impl AgentPanel {
         workspace.update(cx, |workspace, cx| {
             workspace.activate_item(&existing, true, true, window, cx)
         })
+    }
+
+    pub fn thread_is_in_center(&self, thread_id: ThreadId) -> bool {
+        self.center_threads
+            .get(&thread_id)
+            .is_some_and(|center| center.item.upgrade().is_some())
+    }
+
+    pub fn terminal_is_in_center(&self, terminal_id: TerminalId) -> bool {
+        self.center_terminals
+            .get(&terminal_id)
+            .is_some_and(|center| center.item.upgrade().is_some())
     }
 
     pub fn active_center_thread_id(&self, cx: &App) -> Option<ThreadId> {
@@ -4360,21 +4784,19 @@ impl AgentPanel {
         };
 
         if !self.focus_terminal_in_center(terminal_id, window, cx) {
+            let panel = cx.weak_entity();
+            let item = cx.new(|cx| AgentTerminalPane::new(terminal_view, terminal_id, panel, cx));
+            self.register_center_terminal(terminal_id, &item, cx);
             workspace.update(cx, |workspace, cx| {
                 if let Some(split_direction) = split_direction {
-                    workspace.split_item(split_direction, Box::new(terminal_view), window, cx);
+                    workspace.split_item(split_direction, Box::new(item), window, cx);
                 } else {
-                    workspace.add_item_to_active_pane(
-                        Box::new(terminal_view),
-                        None,
-                        true,
-                        window,
-                        cx,
-                    );
+                    workspace.add_item_to_active_pane(Box::new(item), None, true, window, cx);
                 }
             });
         }
 
+        self.last_center_entry = Some(CenterEntry::Terminal(terminal_id));
         if self.active_terminal_id() == Some(terminal_id) {
             self.set_base_view(BaseView::Uninitialized, false, window, cx);
         }
@@ -4387,20 +4809,13 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(terminal_view) = self
-            .terminals
-            .get(&terminal_id)
-            .map(|terminal| terminal.view.clone())
-        else {
-            return false;
-        };
         let Some(workspace) = self.workspace.upgrade() else {
             return false;
         };
         let existing = workspace
             .read(cx)
-            .items_of_type::<TerminalView>(cx)
-            .find(|item| item.entity_id() == terminal_view.entity_id());
+            .items_of_type::<AgentTerminalPane>(cx)
+            .find(|item| item.read(cx).terminal_id() == terminal_id);
         let Some(existing) = existing else {
             return false;
         };
@@ -4411,10 +4826,130 @@ impl AgentPanel {
 
     pub fn active_center_terminal_id(&self, cx: &App) -> Option<TerminalId> {
         let workspace = self.workspace.upgrade()?;
-        let terminal_view = workspace.read(cx).active_item_as::<TerminalView>(cx)?;
-        self.terminals.iter().find_map(|(terminal_id, terminal)| {
-            (terminal.view.entity_id() == terminal_view.entity_id()).then_some(*terminal_id)
-        })
+        let item = workspace.read(cx).active_item_as::<AgentTerminalPane>(cx)?;
+        Some(item.read(cx).terminal_id())
+    }
+
+    fn register_center_thread(
+        &mut self,
+        thread_id: ThreadId,
+        item: &Entity<crate::ConversationPane>,
+        cx: &mut Context<Self>,
+    ) {
+        // Ownership is created here, so this is where the panel gives up its
+        // claim on the view. Parking the draft (rather than deleting it) keeps
+        // the thread's sidebar entry alive: it is a real thread now, it just
+        // lives in the center.
+        if let Some(draft) = self.draft_thread.clone()
+            && draft.read(cx).thread_id == thread_id
+        {
+            self.draft_thread = None;
+            self._draft_editor_observation = None;
+            self.retained_threads.insert(thread_id, draft);
+            self.serialize(cx);
+        }
+
+        let item_id = item.entity_id();
+        let release = cx.observe_release(item, move |this, _item, _cx| {
+            if this
+                .center_threads
+                .get(&thread_id)
+                .is_some_and(|center| center.item.entity_id() == item_id)
+            {
+                this.center_threads.remove(&thread_id);
+                this.clear_last_center_entry(CenterEntry::Thread(thread_id));
+            }
+        });
+        self.center_threads.insert(
+            thread_id,
+            CenterItem {
+                item: item.downgrade(),
+                _release: release,
+            },
+        );
+    }
+
+    fn register_center_terminal(
+        &mut self,
+        terminal_id: TerminalId,
+        item: &Entity<AgentTerminalPane>,
+        cx: &mut Context<Self>,
+    ) {
+        let item_id = item.entity_id();
+        let release = cx.observe_release(item, move |this, _item, _cx| {
+            if this
+                .center_terminals
+                .get(&terminal_id)
+                .is_some_and(|center| center.item.entity_id() == item_id)
+            {
+                this.center_terminals.remove(&terminal_id);
+                this.clear_last_center_entry(CenterEntry::Terminal(terminal_id));
+            }
+        });
+        self.center_terminals.insert(
+            terminal_id,
+            CenterItem {
+                item: item.downgrade(),
+                _release: release,
+            },
+        );
+    }
+
+    /// Removes the center pane item that mirrors a panel entry, if any.
+    ///
+    /// The panel owns the underlying entity, so every path that drops an entry from the panel must
+    /// drop the center item too; otherwise the pane keeps rendering — and keeps alive — an entry
+    /// the panel no longer tracks. The removal is deferred because these paths can run while the
+    /// workspace is already being updated.
+    fn close_center_item_for_terminal(
+        &mut self,
+        terminal_id: TerminalId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.clear_last_center_entry(CenterEntry::Terminal(terminal_id));
+        let Some(center) = self.center_terminals.remove(&terminal_id) else {
+            return;
+        };
+        self.close_center_item(center.item.entity_id(), window, cx);
+    }
+
+    fn close_center_item_for_thread(
+        &mut self,
+        thread_id: ThreadId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.clear_last_center_entry(CenterEntry::Thread(thread_id));
+        let Some(center) = self.center_threads.remove(&thread_id) else {
+            return;
+        };
+        self.close_center_item(center.item.entity_id(), window, cx);
+    }
+
+    fn clear_last_center_entry(&mut self, entry: CenterEntry) {
+        if self.last_center_entry == Some(entry) {
+            self.last_center_entry = None;
+        }
+    }
+
+    fn close_center_item(
+        &self,
+        item_id: gpui::EntityId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        cx.defer_in(window, move |_this, window, cx| {
+            let panes = workspace.read(cx).panes().to_vec();
+            for pane in panes {
+                pane.update(cx, |pane, cx| {
+                    pane.remove_item(item_id, false, true, window, cx);
+                });
+            }
+        });
     }
 
     pub fn regenerate_thread_title(
@@ -4562,22 +5097,11 @@ impl AgentPanel {
     }
 
     fn cleanup_retained_threads(&mut self, cx: &App) {
-        let center_thread_ids = self
-            .workspace
-            .upgrade()
-            .map(|workspace| {
-                workspace
-                    .read(cx)
-                    .items_of_type::<crate::ConversationPane>(cx)
-                    .map(|item| item.read(cx).thread_id())
-                    .collect::<HashSet<_>>()
-            })
-            .unwrap_or_default();
         let mut potential_removals = self
             .retained_threads
             .iter()
             .filter(|(thread_id, view)| {
-                if center_thread_ids.contains(thread_id) {
+                if self.thread_is_in_center(**thread_id) {
                     return false;
                 }
                 let Some(thread_view) = view.read(cx).root_thread_view() else {
@@ -4618,6 +5142,18 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        match &new_view {
+            BaseView::AgentThread { conversation_view } => debug_assert!(
+                !self.thread_is_in_center(conversation_view.read(cx).thread_id),
+                "a center-owned thread must not also render in the panel"
+            ),
+            BaseView::Terminal { terminal_id } => debug_assert!(
+                !self.terminal_is_in_center(*terminal_id),
+                "a center-owned terminal must not also render in the panel"
+            ),
+            BaseView::Uninitialized => {}
+        }
+
         let old_view = std::mem::replace(&mut self.base_view, new_view);
         self.retain_running_thread(old_view, cx);
 
@@ -4783,6 +5319,19 @@ impl AgentPanel {
             store.update(cx, |store, cx| {
                 store.unarchive(thread_id, cx);
             });
+        }
+
+        // A thread that was split into the center is owned by that pane. Moving it back into the
+        // panel would leave the same `ConversationView` rendered by both surfaces, so reveal the
+        // center item instead.
+        if self.thread_is_in_center(thread_id) {
+            if focus {
+                cx.defer_in(window, move |this, window, cx| {
+                    this.focus_thread_in_center(thread_id, window, cx);
+                });
+            }
+            cx.emit(AgentPanelEvent::ActiveViewChanged);
+            return;
         }
 
         // Check if the active view already holds this thread.
@@ -9892,6 +10441,53 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_splitting_a_draft_releases_the_panel_draft_slot(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.activate_draft(false, AgentThreadSource::Sidebar, window, cx);
+        });
+        cx.run_until_parked();
+
+        let draft_thread_id = panel
+            .read_with(&cx, |panel, cx| {
+                panel.draft_thread.as_ref().map(|d| d.read(cx).thread_id)
+            })
+            .expect("the panel should start with a draft");
+
+        // The sidebar's Split action opens the origin in the center and nothing
+        // else, so the draft slot has to be released by the center-open itself.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(draft_thread_id, None, window, cx));
+        });
+        cx.run_until_parked();
+
+        assert!(
+            panel.read_with(&cx, |panel, _cx| panel.draft_thread.is_none()),
+            "the panel must give up its draft slot once the draft lives in the center"
+        );
+
+        // Re-activating the panel must build a fresh draft rather than
+        // re-adopting the one the center pane now owns.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.ensure_thread_initialized(window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_ne!(
+            panel.read_with(&cx, |panel, cx| panel.active_thread_id(cx)),
+            Some(draft_thread_id),
+            "the same conversation must not render in the panel and the center simultaneously"
+        );
+        assert!(
+            cx.read(|cx| ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(draft_thread_id)
+                .is_some()),
+            "parking the draft must not delete the thread's sidebar entry"
+        );
+    }
+
+    #[gpui::test]
     async fn test_create_entry_in_center_splits_beside_existing_thread(cx: &mut TestAppContext) {
         let (panel, mut cx) = setup_panel(cx).await;
         open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
@@ -9967,7 +10563,7 @@ mod tests {
 
         assert_eq!(
             workspace.read_with(&cx, |workspace, cx| {
-                workspace.items_of_type::<TerminalView>(cx).count()
+                workspace.items_of_type::<AgentTerminalPane>(cx).count()
             }),
             1,
             "the split terminal should open in the center pane"
@@ -10038,7 +10634,7 @@ mod tests {
 
         assert_eq!(
             workspace.read_with(&cx, |workspace, cx| {
-                workspace.items_of_type::<TerminalView>(cx).count()
+                workspace.items_of_type::<AgentTerminalPane>(cx).count()
             }),
             1
         );
@@ -10147,6 +10743,153 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_loading_center_thread_does_not_move_it_back_into_the_panel(
+        cx: &mut TestAppContext,
+    ) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let thread_id = active_thread_id(&panel, &cx);
+        let agent = panel.read_with(&cx, |panel, _cx| panel.selected_agent.clone());
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+        });
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.load_agent_thread(
+                agent,
+                thread_id,
+                None,
+                None,
+                true,
+                AgentThreadSource::Sidebar,
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        assert!(
+            panel.read_with(&cx, |panel, _cx| matches!(
+                panel.base_view,
+                BaseView::Uninitialized
+            )),
+            "the thread stays owned by the center pane, so the panel must not render it too"
+        );
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace
+                    .items_of_type::<crate::ConversationPane>(cx)
+                    .count(),
+                1
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_archiving_center_thread_closes_its_center_item(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+        });
+        cx.run_until_parked();
+
+        cx.update(|_window, cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.archive(thread_id, None, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace
+                    .items_of_type::<crate::ConversationPane>(cx)
+                    .count(),
+                0,
+                "an archived thread must not keep running in a center tab"
+            );
+        });
+        assert!(!panel.read_with(&cx, |panel, _cx| panel.thread_is_in_center(thread_id)));
+    }
+
+    #[gpui::test]
+    async fn test_closing_terminal_closes_its_center_item(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+
+        let terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Build", true, window, cx)
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_terminal_in_center(terminal_id, None, window, cx));
+        });
+        cx.run_until_parked();
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.close_terminal(terminal_id, window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace.items_of_type::<AgentTerminalPane>(cx).count(),
+                0,
+                "closing the terminal must take its center tab — and its pty — with it"
+            );
+        });
+        assert!(!panel.read_with(&cx, |panel, _cx| panel.has_terminal(terminal_id)));
+    }
+
+    #[gpui::test]
+    async fn test_center_terminal_uses_agent_terminal_serialization(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+
+        let terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Build", true, window, cx)
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_terminal_in_center(terminal_id, None, window, cx));
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace.items_of_type::<TerminalView>(cx).count(),
+                0,
+                "a bare TerminalView in a pane would be serialized and restored without the panel"
+            );
+            for pane in workspace.panes() {
+                for item in pane.read(cx).items() {
+                    assert_eq!(
+                        item.to_serializable_item_handle(cx)
+                            .map(|item| item.serialized_item_kind()),
+                        Some("AgentTerminalPane"),
+                        "agent panel terminals must use their own serialization kind"
+                    );
+                }
+            }
+        });
+
+        assert_eq!(
+            panel.read_with(&cx, |panel, _cx| panel.serializable_center_terminal_id()),
+            Some(terminal_id)
+        );
+    }
+
+    #[gpui::test]
     async fn test_open_two_terminal_threads_side_by_side(cx: &mut TestAppContext) {
         let (panel, mut cx) = setup_panel(cx).await;
         let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
@@ -10175,7 +10918,7 @@ mod tests {
         });
 
         workspace.read_with(&cx, |workspace, cx| {
-            assert_eq!(workspace.items_of_type::<TerminalView>(cx).count(), 2);
+            assert_eq!(workspace.items_of_type::<AgentTerminalPane>(cx).count(), 2);
             assert_eq!(workspace.panes().len(), 2);
         });
         assert_eq!(

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -43,7 +43,9 @@ use crate::terminal_thread_metadata_store::{
     TerminalThreadMetadata, TerminalThreadMetadataStore, compose_terminal_thread_title,
     terminal_title_without_prefix,
 };
-use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore, ThreadMetadataStoreEvent};
+use crate::thread_metadata_store::{
+    SplitParent, ThreadId, ThreadMetadataStore, ThreadMetadataStoreEvent,
+};
 use crate::{
     Agent, AgentInitialContent, AgentThreadSource, ExternalSourcePrompt, NewExternalAgentThread,
     NewNativeAgentThreadFromSummary,
@@ -98,7 +100,7 @@ use ui::{
 use util::ResultExt as _;
 use workspace::{
     CollaboratorId, DraggedSelection, DraggedTab, MultiWorkspace, PathList, SerializedPathList,
-    ToggleWorkspaceSidebar, ToggleZoom, ToolbarItemView, Workspace, WorkspaceId,
+    SplitDirection, ToggleWorkspaceSidebar, ToggleZoom, ToolbarItemView, Workspace, WorkspaceId,
     dock::{DockPosition, Panel, PanelEvent},
     item::{ItemEvent, ItemHandle},
 };
@@ -164,7 +166,7 @@ impl MaxIdleRetainedThreads {
 pub struct TerminalId(uuid::Uuid);
 
 impl TerminalId {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self(uuid::Uuid::new_v4())
     }
 
@@ -181,6 +183,23 @@ impl fmt::Display for TerminalId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(formatter)
     }
+}
+
+pub enum NewEntryIcon {
+    Named(IconName),
+    CustomSvg(SharedString),
+}
+
+#[derive(Clone)]
+pub enum NewEntryKind {
+    Terminal,
+    Thread(Agent),
+}
+
+pub struct NewEntryOption {
+    pub label: SharedString,
+    pub icon: NewEntryIcon,
+    pub kind: NewEntryKind,
 }
 
 #[derive(Clone, Debug)]
@@ -1169,6 +1188,12 @@ pub struct AgentPanel {
     retained_threads: HashMap<ThreadId, Entity<ConversationView>>,
     terminals: HashMap<TerminalId, AgentTerminal>,
     pending_terminal_spawn: Option<TerminalId>,
+    pending_terminal_center_open: HashMap<TerminalId, Option<SplitDirection>>,
+    /// Split links for terminals created or restored in this session.
+    /// `terminal_metadata` rebuilds metadata from live terminal state on every
+    /// persist, so without this the link would be written away by the first
+    /// title change after a split.
+    terminal_split_parents: HashMap<TerminalId, SplitParent>,
     new_thread_menu_handle: PopoverMenuHandle<ContextMenu>,
     agent_panel_menu_handle: PopoverMenuHandle<ContextMenu>,
     _extension_subscription: Option<Subscription>,
@@ -1582,6 +1607,8 @@ impl AgentPanel {
             retained_threads: HashMap::default(),
             terminals: HashMap::default(),
             pending_terminal_spawn: None,
+            pending_terminal_center_open: HashMap::default(),
+            terminal_split_parents: HashMap::default(),
             new_thread_menu_handle: PopoverMenuHandle::default(),
             agent_panel_menu_handle: PopoverMenuHandle::default(),
 
@@ -2000,14 +2027,18 @@ impl AgentPanel {
         source: AgentThreadSource,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) {
+    ) -> Option<TerminalId> {
         if !self.supports_terminal(cx) {
-            return;
+            return None;
         }
         self.set_last_created_entry_kind_from_user_action(AgentPanelEntryKind::Terminal, cx);
         let working_directory = self.terminal_working_directory(workspace, cx);
+        let terminal_id = TerminalId::new();
+        self.pending_terminal_spawn = Some(terminal_id);
+
+        #[cfg(not(test))]
         self.spawn_terminal(
-            TerminalId::new(),
+            terminal_id,
             working_directory,
             None,
             None,
@@ -2019,6 +2050,30 @@ impl AgentPanel {
             window,
             cx,
         );
+
+        #[cfg(test)]
+        if let Err(error) = self.insert_display_only_terminal(
+            terminal_id,
+            working_directory,
+            None,
+            None,
+            None,
+            true,
+            true,
+            true,
+            source,
+            window,
+            cx,
+        ) {
+            log::error!("failed to spawn test agent panel terminal: {error:#}");
+            if self.pending_terminal_spawn == Some(terminal_id) {
+                self.pending_terminal_spawn = None;
+            }
+            cx.notify();
+            return None;
+        }
+
+        Some(terminal_id)
     }
 
     fn terminal_working_directory(
@@ -2093,8 +2148,10 @@ impl AgentPanel {
                     this.update(cx, |this, cx| {
                         if this.pending_terminal_spawn == Some(terminal_id) {
                             this.pending_terminal_spawn = None;
-                            cx.notify();
                         }
+                        this.pending_terminal_center_open.remove(&terminal_id);
+                        this.terminal_split_parents.remove(&terminal_id);
+                        cx.notify();
                     })
                     .log_err();
                     return anyhow::Ok(());
@@ -2273,6 +2330,9 @@ impl AgentPanel {
         if select {
             self.set_base_view(BaseView::Terminal { terminal_id }, focus, window, cx);
         }
+        if let Some(split_direction) = self.pending_terminal_center_open.remove(&terminal_id) {
+            self.open_terminal_in_center(terminal_id, split_direction, window, cx);
+        }
         cx.emit(AgentPanelEvent::EntryChanged);
         cx.notify();
     }
@@ -2333,6 +2393,7 @@ impl AgentPanel {
         if self.terminals.remove(&terminal_id).is_none() {
             return;
         }
+        self.terminal_split_parents.remove(&terminal_id);
         if let Some(store) = TerminalThreadMetadataStore::try_global(cx) {
             store.update(cx, |store, cx| {
                 store.delete(terminal_id, cx);
@@ -2431,6 +2492,18 @@ impl AgentPanel {
             worktree_paths: project.worktree_paths(cx),
             remote_connection: project.remote_connection_options(cx),
             working_directory: terminal.working_directory.clone(),
+            split_parent: self
+                .terminal_split_parents
+                .get(&terminal_id)
+                .copied()
+                .or_else(|| {
+                    TerminalThreadMetadataStore::try_global(cx).and_then(|store| {
+                        store
+                            .read(cx)
+                            .entry(terminal_id)
+                            .and_then(|metadata| metadata.split_parent)
+                    })
+                }),
         })
     }
 
@@ -2453,6 +2526,10 @@ impl AgentPanel {
         }
 
         self.pending_terminal_spawn = Some(metadata.terminal_id);
+        if let Some(parent) = metadata.split_parent {
+            self.terminal_split_parents
+                .insert(metadata.terminal_id, parent);
+        }
         let working_directory = self.terminal_restore_working_directory(&metadata, workspace, cx);
         let initial_title = Self::terminal_restore_initial_title(&metadata);
         self.spawn_terminal(
@@ -2865,7 +2942,9 @@ impl AgentPanel {
         if !window.is_window_active() {
             return false;
         }
-        if !self.terminal_surface_visible(terminal_id) {
+        if !self.terminal_surface_visible(terminal_id)
+            && !self.terminal_center_visible(terminal_id, cx)
+        {
             return false;
         }
         let Some(workspace) = self.workspace.upgrade() else {
@@ -2877,7 +2956,26 @@ impl AgentPanel {
                 return false;
             }
         }
-        AgentPanel::is_visible(&workspace, cx)
+        AgentPanel::is_visible(&workspace, cx) || self.terminal_center_visible(terminal_id, cx)
+    }
+
+    fn terminal_center_visible(&self, terminal_id: TerminalId, cx: &App) -> bool {
+        let Some(terminal_view) = self
+            .terminals
+            .get(&terminal_id)
+            .map(|terminal| &terminal.view)
+        else {
+            return false;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+        workspace.read(cx).panes().iter().any(|pane| {
+            pane.read(cx)
+                .active_item()
+                .and_then(|item| item.to_any_view().downcast::<TerminalView>().ok())
+                .is_some_and(|item| item.entity_id() == terminal_view.entity_id())
+        })
     }
 
     fn terminal_surface_visible(&self, terminal_id: TerminalId) -> bool {
@@ -4067,6 +4165,258 @@ impl AgentPanel {
         })
     }
 
+    pub fn new_entry_options(&self, cx: &App) -> Vec<NewEntryOption> {
+        let mut options = Vec::new();
+
+        if self.supports_terminal(cx) {
+            options.push(NewEntryOption {
+                label: "Terminal".into(),
+                icon: NewEntryIcon::Named(IconName::Terminal),
+                kind: NewEntryKind::Terminal,
+            });
+        }
+
+        options.push(NewEntryOption {
+            label: Agent::NativeAgent.label(),
+            icon: NewEntryIcon::Named(IconName::ZedAgent),
+            kind: NewEntryKind::Thread(Agent::NativeAgent),
+        });
+
+        if self.project.read(cx).is_via_collab() {
+            return options;
+        }
+
+        let agent_server_store = self.project.read(cx).agent_server_store().read(cx);
+        let registry_store = project::AgentRegistryStore::try_global(cx);
+        let registry_store = registry_store.as_ref().map(|store| store.read(cx));
+
+        let external_agents = agent_server_store
+            .external_agents()
+            .map(|agent_id| {
+                let display_name = agent_server_store
+                    .agent_display_name(agent_id)
+                    .or_else(|| {
+                        registry_store
+                            .as_ref()
+                            .and_then(|store| store.agent(agent_id))
+                            .map(|agent| agent.name().clone())
+                    })
+                    .unwrap_or_else(|| agent_id.0.clone());
+                let icon_path = agent_server_store.agent_icon(agent_id).or_else(|| {
+                    registry_store
+                        .as_ref()
+                        .and_then(|store| store.agent(agent_id))
+                        .and_then(|agent| agent.icon_path().cloned())
+                });
+                NewEntryOption {
+                    label: display_name,
+                    icon: icon_path
+                        .map(NewEntryIcon::CustomSvg)
+                        .unwrap_or(NewEntryIcon::Named(IconName::Sparkle)),
+                    kind: NewEntryKind::Thread(Agent::Custom {
+                        id: agent_id.clone(),
+                    }),
+                }
+            })
+            .sorted_unstable_by_key(|option| option.label.to_lowercase());
+
+        options.extend(external_agents);
+        options
+    }
+
+    pub fn create_entry_in_center(
+        &mut self,
+        kind: NewEntryKind,
+        workspace: Option<&Workspace>,
+        split_direction: Option<SplitDirection>,
+        split_parent: Option<SplitParent>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match kind {
+            NewEntryKind::Terminal => {
+                let Some(terminal_id) =
+                    self.new_terminal(workspace, AgentThreadSource::Sidebar, window, cx)
+                else {
+                    return;
+                };
+                if let Some(parent) = split_parent {
+                    self.terminal_split_parents.insert(terminal_id, parent);
+                    self.persist_terminal_metadata(terminal_id, cx);
+                }
+                self.open_terminal_in_center(terminal_id, split_direction, window, cx);
+            }
+            NewEntryKind::Thread(agent) => {
+                if !self.has_open_project(cx) {
+                    return;
+                }
+                self.selected_agent = agent;
+                self.activate_new_thread(false, AgentThreadSource::Sidebar, window, cx);
+                let Some(thread_id) = self.active_thread_id(cx) else {
+                    return;
+                };
+                if let Some(parent) = split_parent {
+                    ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                        store.set_split_parent(thread_id, parent, cx);
+                    });
+                }
+                self.open_thread_in_center(thread_id, split_direction, window, cx);
+
+                // The draft now lives in the center, so release the panel's
+                // single new-draft slot; otherwise the next split would reuse
+                // it instead of starting a second agent.
+                if let Some(draft) = self.draft_thread.clone()
+                    && draft.read(cx).thread_id == thread_id
+                {
+                    self.draft_thread = None;
+                    self._draft_editor_observation = None;
+                    self.retained_threads.insert(thread_id, draft);
+                }
+            }
+        }
+    }
+
+    pub fn open_thread_in_center(
+        &mut self,
+        thread_id: ThreadId,
+        split_direction: Option<SplitDirection>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(conversation_view) = self.conversation_view_for_id(&thread_id, cx).cloned() else {
+            return false;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+
+        if !self.focus_thread_in_center(thread_id, window, cx) {
+            let item = cx.new(|_| crate::ConversationPane::new(conversation_view, thread_id));
+            workspace.update(cx, |workspace, cx| {
+                if let Some(split_direction) = split_direction {
+                    workspace.split_item(split_direction, Box::new(item), window, cx);
+                } else {
+                    workspace.add_item_to_active_pane(Box::new(item), None, true, window, cx);
+                }
+            });
+        }
+
+        if self.active_thread_id(cx) == Some(thread_id) {
+            self.set_base_view(BaseView::Uninitialized, false, window, cx);
+        }
+        true
+    }
+
+    pub fn focus_thread_in_center(
+        &self,
+        thread_id: ThreadId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+        let existing = workspace
+            .read(cx)
+            .items_of_type::<crate::ConversationPane>(cx)
+            .find(|item| item.read(cx).thread_id() == thread_id);
+        let Some(existing) = existing else {
+            return false;
+        };
+        workspace.update(cx, |workspace, cx| {
+            workspace.activate_item(&existing, true, true, window, cx)
+        })
+    }
+
+    pub fn active_center_thread_id(&self, cx: &App) -> Option<ThreadId> {
+        let workspace = self.workspace.upgrade()?;
+        workspace
+            .read(cx)
+            .active_item_as::<crate::ConversationPane>(cx)
+            .map(|item| item.read(cx).thread_id())
+    }
+
+    pub fn open_terminal_in_center(
+        &mut self,
+        terminal_id: TerminalId,
+        split_direction: Option<SplitDirection>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(terminal_view) = self
+            .terminals
+            .get(&terminal_id)
+            .map(|terminal| terminal.view.clone())
+        else {
+            if self.pending_terminal_spawn == Some(terminal_id) {
+                self.pending_terminal_center_open
+                    .insert(terminal_id, split_direction);
+                return true;
+            }
+            return false;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+
+        if !self.focus_terminal_in_center(terminal_id, window, cx) {
+            workspace.update(cx, |workspace, cx| {
+                if let Some(split_direction) = split_direction {
+                    workspace.split_item(split_direction, Box::new(terminal_view), window, cx);
+                } else {
+                    workspace.add_item_to_active_pane(
+                        Box::new(terminal_view),
+                        None,
+                        true,
+                        window,
+                        cx,
+                    );
+                }
+            });
+        }
+
+        if self.active_terminal_id() == Some(terminal_id) {
+            self.set_base_view(BaseView::Uninitialized, false, window, cx);
+        }
+        true
+    }
+
+    pub fn focus_terminal_in_center(
+        &self,
+        terminal_id: TerminalId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(terminal_view) = self
+            .terminals
+            .get(&terminal_id)
+            .map(|terminal| terminal.view.clone())
+        else {
+            return false;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+        let existing = workspace
+            .read(cx)
+            .items_of_type::<TerminalView>(cx)
+            .find(|item| item.entity_id() == terminal_view.entity_id());
+        let Some(existing) = existing else {
+            return false;
+        };
+        workspace.update(cx, |workspace, cx| {
+            workspace.activate_item(&existing, true, true, window, cx)
+        })
+    }
+
+    pub fn active_center_terminal_id(&self, cx: &App) -> Option<TerminalId> {
+        let workspace = self.workspace.upgrade()?;
+        let terminal_view = workspace.read(cx).active_item_as::<TerminalView>(cx)?;
+        self.terminals.iter().find_map(|(terminal_id, terminal)| {
+            (terminal.view.entity_id() == terminal_view.entity_id()).then_some(*terminal_id)
+        })
+    }
+
     pub fn regenerate_thread_title(
         &mut self,
         thread_id: ThreadId,
@@ -4212,10 +4562,24 @@ impl AgentPanel {
     }
 
     fn cleanup_retained_threads(&mut self, cx: &App) {
+        let center_thread_ids = self
+            .workspace
+            .upgrade()
+            .map(|workspace| {
+                workspace
+                    .read(cx)
+                    .items_of_type::<crate::ConversationPane>(cx)
+                    .map(|item| item.read(cx).thread_id())
+                    .collect::<HashSet<_>>()
+            })
+            .unwrap_or_default();
         let mut potential_removals = self
             .retained_threads
             .iter()
-            .filter(|(_id, view)| {
+            .filter(|(thread_id, view)| {
+                if center_thread_ids.contains(thread_id) {
+                    return false;
+                }
                 let Some(thread_view) = view.read(cx).root_thread_view() else {
                     return true;
                 };
@@ -7585,6 +7949,7 @@ mod tests {
             worktree_paths: project.read_with(cx, |project, cx| project.worktree_paths(cx)),
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         };
         assert_eq!(metadata.working_directory, None);
 
@@ -7669,6 +8034,7 @@ mod tests {
             )])),
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         };
         let terminal_id = metadata.terminal_id;
         panel
@@ -7842,6 +8208,7 @@ mod tests {
             )])),
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         };
         panel
             .update_in(&mut cx, |panel, window, cx| {
@@ -8060,6 +8427,7 @@ mod tests {
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
                         archived: false,
+                        split_parent: None,
                     },
                     cx,
                 );
@@ -9428,6 +9796,395 @@ mod tests {
         (panel, cx)
     }
 
+    #[gpui::test]
+    async fn test_open_thread_in_center_moves_conversation_out_of_panel(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+
+        let opened = panel.update_in(&mut cx, |panel, window, cx| {
+            panel.open_thread_in_center(thread_id, None, window, cx)
+        });
+
+        assert!(opened, "the active thread should open in the center");
+        let pane_item = workspace
+            .read_with(&cx, |workspace, cx| {
+                workspace.active_item_as::<crate::ConversationPane>(cx)
+            })
+            .expect("the center pane should contain the conversation");
+        assert_eq!(
+            pane_item.read_with(&cx, |item, _cx| item.thread_id()),
+            thread_id
+        );
+        assert!(
+            panel
+                .read_with(&cx, |panel, cx| panel.active_thread_id(cx))
+                .is_none(),
+            "the same conversation must not render in the panel and center simultaneously"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_cleanup_retained_threads_preserves_center_thread(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        cx.update(|_window, cx| cx.set_global(MaxIdleRetainedThreads(0)));
+        let connection = StubAgentConnection::new().with_supports_load_session(true);
+        let (session_id, thread_id) =
+            open_generating_thread_with_loadable_connection(&panel, &connection, &mut cx);
+        connection.end_turn(session_id, acp::StopReason::EndTurn);
+        cx.run_until_parked();
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+        });
+
+        assert!(
+            panel.read_with(&cx, |panel, _cx| {
+                panel.retained_threads.contains_key(&thread_id)
+            }),
+            "center threads must remain owned by the panel even when idle retention is disabled"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_open_two_threads_side_by_side(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let first_thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(first_thread_id, None, window, cx));
+        });
+
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+        let second_thread_id = active_thread_id(&panel, &cx);
+        assert_ne!(first_thread_id, second_thread_id);
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(
+                second_thread_id,
+                Some(SplitDirection::Right),
+                window,
+                cx,
+            ));
+        });
+
+        workspace.read_with(&cx, |workspace, cx| {
+            let thread_ids = workspace
+                .items_of_type::<crate::ConversationPane>(cx)
+                .map(|item| item.read(cx).thread_id())
+                .collect::<HashSet<_>>();
+            assert_eq!(thread_ids.len(), 2);
+            assert!(thread_ids.contains(&first_thread_id));
+            assert!(thread_ids.contains(&second_thread_id));
+            assert_eq!(workspace.panes().len(), 2);
+        });
+        assert_eq!(
+            panel.read_with(&cx, |panel, cx| panel.active_center_thread_id(cx)),
+            Some(second_thread_id)
+        );
+    }
+
+    #[gpui::test]
+    async fn test_create_entry_in_center_splits_beside_existing_thread(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let existing_thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(existing_thread_id, None, window, cx));
+            panel.create_entry_in_center(
+                NewEntryKind::Thread(Agent::NativeAgent),
+                None,
+                Some(SplitDirection::Right),
+                Some(SplitParent::Thread(existing_thread_id)),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let thread_ids = workspace.read_with(&cx, |workspace, cx| {
+            workspace
+                .items_of_type::<crate::ConversationPane>(cx)
+                .map(|item| item.read(cx).thread_id())
+                .collect::<HashSet<_>>()
+        });
+        assert_eq!(
+            thread_ids.len(),
+            2,
+            "the new thread should sit beside the thread it was split from"
+        );
+        assert!(thread_ids.contains(&existing_thread_id));
+        workspace.read_with(&cx, |workspace, _cx| assert_eq!(workspace.panes().len(), 2));
+
+        let new_thread_id = thread_ids
+            .into_iter()
+            .find(|id| *id != existing_thread_id)
+            .expect("the split should have created a second thread");
+        let split_parent = cx.read(|cx| {
+            ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(new_thread_id)
+                .and_then(|metadata| metadata.split_parent)
+        });
+        assert_eq!(
+            split_parent,
+            Some(SplitParent::Thread(existing_thread_id)),
+            "the new thread must record the thread it was split from"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_split_terminal_records_its_origin(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        cx.update(|_window, cx| TerminalThreadMetadataStore::init_global(cx));
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let existing_thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(existing_thread_id, None, window, cx));
+            panel.create_entry_in_center(
+                NewEntryKind::Terminal,
+                None,
+                Some(SplitDirection::Right),
+                Some(SplitParent::Thread(existing_thread_id)),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            workspace.read_with(&cx, |workspace, cx| {
+                workspace.items_of_type::<TerminalView>(cx).count()
+            }),
+            1,
+            "the split terminal should open in the center pane"
+        );
+
+        let terminal_id = panel.read_with(&cx, |panel, cx| {
+            panel
+                .terminals(cx)
+                .first()
+                .map(|terminal| terminal.id)
+                .expect("the split should have created a terminal")
+        });
+
+        // A title change re-persists the terminal from live state; the link
+        // must survive that round trip.
+        panel.update_in(&mut cx, |panel, _window, cx| {
+            panel.persist_terminal_metadata(terminal_id, cx);
+        });
+        cx.run_until_parked();
+
+        let split_parent = cx.read(|cx| {
+            TerminalThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(terminal_id)
+                .and_then(|metadata| metadata.split_parent)
+        });
+        assert_eq!(
+            split_parent,
+            Some(SplitParent::Thread(existing_thread_id)),
+            "the new terminal must record the thread it was split from"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_pending_terminal_opens_in_center_after_spawn(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let thread_id = active_thread_id(&panel, &cx);
+        let terminal_id = TerminalId::new();
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+            panel.pending_terminal_spawn = Some(terminal_id);
+            assert!(panel.open_terminal_in_center(
+                terminal_id,
+                Some(SplitDirection::Right),
+                window,
+                cx,
+            ));
+            panel
+                .insert_display_only_terminal(
+                    terminal_id,
+                    None,
+                    Some("Pending terminal".into()),
+                    None,
+                    None,
+                    true,
+                    false,
+                    true,
+                    AgentThreadSource::Sidebar,
+                    window,
+                    cx,
+                )
+                .expect("pending terminal should finish spawning");
+        });
+
+        assert_eq!(
+            workspace.read_with(&cx, |workspace, cx| {
+                workspace.items_of_type::<TerminalView>(cx).count()
+            }),
+            1
+        );
+        assert_eq!(
+            workspace.read_with(&cx, |workspace, _cx| workspace.panes().len()),
+            2
+        );
+    }
+
+    #[gpui::test]
+    async fn test_splitting_twice_creates_two_new_threads(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let existing_thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(existing_thread_id, None, window, cx));
+            for _ in 0..2 {
+                panel.create_entry_in_center(
+                    NewEntryKind::Thread(Agent::NativeAgent),
+                    None,
+                    Some(SplitDirection::Right),
+                    None,
+                    window,
+                    cx,
+                );
+            }
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(&cx, |workspace, cx| {
+            let thread_ids = workspace
+                .items_of_type::<crate::ConversationPane>(cx)
+                .map(|item| item.read(cx).thread_id())
+                .collect::<HashSet<_>>();
+            assert_eq!(thread_ids.len(), 3, "each split should add its own thread");
+            assert!(thread_ids.contains(&existing_thread_id));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_new_entry_options_offer_terminal_and_zed_agent(cx: &mut TestAppContext) {
+        let (panel, cx) = setup_panel(cx).await;
+
+        let kinds = panel.read_with(&cx, |panel, cx| {
+            panel
+                .new_entry_options(cx)
+                .into_iter()
+                .map(|option| (option.label, option.kind))
+                .collect::<Vec<_>>()
+        });
+
+        assert!(
+            kinds
+                .iter()
+                .any(|(_, kind)| matches!(kind, NewEntryKind::Terminal)),
+            "expected a terminal option, got {:?}",
+            kinds.iter().map(|(label, _)| label).collect::<Vec<_>>()
+        );
+        assert!(
+            kinds
+                .iter()
+                .any(|(_, kind)| matches!(kind, NewEntryKind::Thread(Agent::NativeAgent))),
+            "expected a Zed agent option, got {:?}",
+            kinds.iter().map(|(label, _)| label).collect::<Vec<_>>()
+        );
+    }
+
+    #[gpui::test]
+    async fn test_reopening_center_thread_focuses_existing_item(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        cx.run_until_parked();
+
+        let thread_id = active_thread_id(&panel, &cx);
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+            assert!(panel.open_thread_in_center(
+                thread_id,
+                Some(SplitDirection::Right),
+                window,
+                cx,
+            ));
+        });
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(
+                workspace
+                    .items_of_type::<crate::ConversationPane>(cx)
+                    .count(),
+                1
+            );
+            assert_eq!(workspace.panes().len(), 1);
+            assert_eq!(
+                workspace
+                    .active_item_as::<crate::ConversationPane>(cx)
+                    .unwrap()
+                    .read(cx)
+                    .thread_id(),
+                thread_id
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_open_two_terminal_threads_side_by_side(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+        let workspace = panel.read_with(&cx, |panel, _cx| panel.workspace.upgrade().unwrap());
+
+        let first_terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Build", true, window, cx)
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_terminal_in_center(first_terminal_id, None, window, cx));
+        });
+
+        let second_terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Server", true, window, cx)
+            })
+            .unwrap();
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.open_terminal_in_center(
+                second_terminal_id,
+                Some(SplitDirection::Right),
+                window,
+                cx,
+            ));
+        });
+
+        workspace.read_with(&cx, |workspace, cx| {
+            assert_eq!(workspace.items_of_type::<TerminalView>(cx).count(), 2);
+            assert_eq!(workspace.panes().len(), 2);
+        });
+        assert_eq!(
+            panel.read_with(&cx, |panel, cx| panel.active_center_terminal_id(cx)),
+            Some(second_terminal_id)
+        );
+        assert_eq!(panel.read_with(&cx, |panel, _cx| panel.terminals.len()), 2);
+    }
+
     fn expected_terminal_drop_text(paths: &[PathBuf]) -> String {
         let mut text = String::new();
         for path in paths {
@@ -9805,6 +10562,7 @@ mod tests {
             )])),
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         };
 
         panel.update_in(&mut cx, |panel, window, cx| {
@@ -9856,6 +10614,7 @@ mod tests {
             )])),
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         };
 
         panel.update_in(&mut cx, |panel, window, cx| {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -72,8 +72,8 @@ use workspace::{OpenOptions, Workspace};
 use crate::agent_configuration::ManageProfilesModal;
 pub use crate::agent_connection_store::{ActiveAcpConnection, AgentConnectionStore};
 pub use crate::agent_panel::{
-    AgentPanel, AgentPanelEvent, AgentPanelTerminalInfo, MaxIdleRetainedThreads, NewEntryIcon,
-    NewEntryKind, NewEntryOption, TerminalId, ThreadTitleRegenerationResult,
+    AgentPanel, AgentPanelEvent, AgentPanelTerminalInfo, AgentTerminalPane, MaxIdleRetainedThreads,
+    NewEntryIcon, NewEntryKind, NewEntryOption, TerminalId, ThreadTitleRegenerationResult,
 };
 use crate::agent_registry_ui::AgentRegistryPage;
 pub use crate::inline_assistant::InlineAssistant;

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -71,16 +71,16 @@ use workspace::{OpenOptions, Workspace};
 use crate::agent_configuration::ManageProfilesModal;
 pub use crate::agent_connection_store::{ActiveAcpConnection, AgentConnectionStore};
 pub use crate::agent_panel::{
-    AgentPanel, AgentPanelEvent, AgentPanelTerminalInfo, MaxIdleRetainedThreads, TerminalId,
-    ThreadTitleRegenerationResult,
+    AgentPanel, AgentPanelEvent, AgentPanelTerminalInfo, MaxIdleRetainedThreads, NewEntryIcon,
+    NewEntryKind, NewEntryOption, TerminalId, ThreadTitleRegenerationResult,
 };
 use crate::agent_registry_ui::AgentRegistryPage;
 pub use crate::inline_assistant::InlineAssistant;
 pub use crate::message_editor::MessageEditorEvent;
-pub use crate::thread_metadata_store::ThreadId;
+pub use crate::thread_metadata_store::{SplitParent, ThreadId};
 pub use agent_diff::{AgentDiffPane, AgentDiffToolbar};
 pub use conversation_view::open_markdown_in_workspace;
-pub use conversation_view::{ConversationView, StateChange};
+pub use conversation_view::{ConversationPane, ConversationView, StateChange};
 pub use external_source_prompt::ExternalSourcePrompt;
 pub(crate) use mode_selector::ModeSelector;
 pub(crate) use model_selector::ModelSelector;

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -5,6 +5,7 @@ mod agent_model_selector;
 mod agent_panel;
 mod agent_registry_ui;
 mod buffer_codegen;
+mod center_pane_store;
 mod completion_provider;
 mod config_options;
 mod context;

--- a/crates/agent_ui/src/center_pane_store.rs
+++ b/crates/agent_ui/src/center_pane_store.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use db::{
+    query,
+    sqlez::{domain::Domain, statement::Statement, thread_safe_connection::ThreadSafeConnection},
+    sqlez_macros::sql,
+};
+use gpui::{App, Task};
+use workspace::{ItemId, WorkspaceDb, WorkspaceId, delete_unloaded_items};
+
+pub struct AgentCenterPaneDb(ThreadSafeConnection);
+
+impl Domain for AgentCenterPaneDb {
+    const NAME: &str = stringify!(AgentCenterPaneDb);
+
+    const MIGRATIONS: &[&str] = &[sql!(
+        CREATE TABLE agent_conversation_panes (
+            workspace_id INTEGER NOT NULL,
+            item_id INTEGER NOT NULL,
+            thread_id TEXT NOT NULL,
+            PRIMARY KEY(workspace_id, item_id),
+            FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+            ON DELETE CASCADE
+        ) STRICT;
+
+        CREATE TABLE agent_terminal_panes (
+            workspace_id INTEGER NOT NULL,
+            item_id INTEGER NOT NULL,
+            terminal_id TEXT NOT NULL,
+            PRIMARY KEY(workspace_id, item_id),
+            FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+            ON DELETE CASCADE
+        ) STRICT;
+    )];
+}
+
+db::static_connection!(AgentCenterPaneDb, [WorkspaceDb]);
+
+impl AgentCenterPaneDb {
+    pub async fn save_thread(
+        &self,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        thread_id: String,
+    ) -> Result<()> {
+        self.write(move |connection| {
+            let mut statement = Statement::prepare(
+                connection,
+                "INSERT INTO agent_conversation_panes(workspace_id, item_id, thread_id) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(workspace_id, item_id) DO UPDATE SET thread_id = excluded.thread_id",
+            )?;
+            let mut index = statement.bind(&workspace_id, 1)?;
+            index = statement.bind(&item_id, index)?;
+            statement.bind(&thread_id, index)?;
+            statement.exec()
+        })
+        .await
+    }
+
+    query! {
+        pub fn thread_id(workspace_id: WorkspaceId, item_id: ItemId) -> Result<Option<String>> {
+            SELECT thread_id
+            FROM agent_conversation_panes
+            WHERE workspace_id = ? AND item_id = ?
+        }
+    }
+
+    pub async fn save_terminal(
+        &self,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        terminal_id: String,
+    ) -> Result<()> {
+        self.write(move |connection| {
+            let mut statement = Statement::prepare(
+                connection,
+                "INSERT INTO agent_terminal_panes(workspace_id, item_id, terminal_id) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(workspace_id, item_id) DO UPDATE SET terminal_id = excluded.terminal_id",
+            )?;
+            let mut index = statement.bind(&workspace_id, 1)?;
+            index = statement.bind(&item_id, index)?;
+            statement.bind(&terminal_id, index)?;
+            statement.exec()
+        })
+        .await
+    }
+
+    query! {
+        pub fn terminal_id(workspace_id: WorkspaceId, item_id: ItemId) -> Result<Option<String>> {
+            SELECT terminal_id
+            FROM agent_terminal_panes
+            WHERE workspace_id = ? AND item_id = ?
+        }
+    }
+
+    pub fn cleanup_threads(
+        &self,
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        delete_unloaded_items(
+            alive_items,
+            workspace_id,
+            "agent_conversation_panes",
+            &self.0,
+            cx,
+        )
+    }
+
+    pub fn cleanup_terminals(
+        &self,
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        delete_unloaded_items(
+            alive_items,
+            workspace_id,
+            "agent_terminal_panes",
+            &self.0,
+            cx,
+        )
+    }
+}

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -122,13 +122,25 @@ pub use thread_view::*;
 pub struct ConversationPane {
     conversation_view: Entity<ConversationView>,
     thread_id: ThreadId,
+    _title_subscription: Subscription,
 }
 
 impl ConversationPane {
-    pub fn new(conversation_view: Entity<ConversationView>, thread_id: ThreadId) -> Self {
+    pub fn new(
+        conversation_view: Entity<ConversationView>,
+        thread_id: ThreadId,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let title_subscription = cx.subscribe(
+            &conversation_view,
+            |_this, _view, _: &RootThreadUpdated, cx| {
+                cx.emit(workspace::item::ItemEvent::UpdateTab);
+            },
+        );
         Self {
             conversation_view,
             thread_id,
+            _title_subscription: title_subscription,
         }
     }
 
@@ -142,7 +154,7 @@ impl ConversationPane {
 }
 
 impl Item for ConversationPane {
-    type Event = ();
+    type Event = workspace::item::ItemEvent;
 
     fn include_in_nav_history() -> bool {
         false
@@ -151,9 +163,13 @@ impl Item for ConversationPane {
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
         self.conversation_view.read(cx).title(cx)
     }
+
+    fn to_item_events(event: &Self::Event, emit: &mut dyn FnMut(workspace::item::ItemEvent)) {
+        emit(*event);
+    }
 }
 
-impl EventEmitter<()> for ConversationPane {}
+impl EventEmitter<workspace::item::ItemEvent> for ConversationPane {}
 
 impl Focusable for ConversationPane {
     fn focus_handle(&self, cx: &App) -> FocusHandle {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -71,7 +71,8 @@ use util::{
     time::duration_alt_display,
 };
 use workspace::{
-    CollaboratorId, MultiWorkspace, NewTerminal, PathList, Workspace, path_link::sanitize_path_text,
+    CollaboratorId, Item, MultiWorkspace, NewTerminal, PathList, Workspace,
+    path_link::sanitize_path_text,
 };
 use zed_actions::agent::{Chat, ToggleModelSelector};
 
@@ -113,6 +114,58 @@ mod thread_search_bar;
 mod thread_view;
 pub use message_queue::*;
 pub use thread_view::*;
+
+/// Adapts an agent conversation so it can live in a workspace pane.
+///
+/// The agent panel and workspace pane share the same `ConversationView` entity. The panel moves
+/// that entity into this item instead of creating a second view for the same thread.
+pub struct ConversationPane {
+    conversation_view: Entity<ConversationView>,
+    thread_id: ThreadId,
+}
+
+impl ConversationPane {
+    pub fn new(conversation_view: Entity<ConversationView>, thread_id: ThreadId) -> Self {
+        Self {
+            conversation_view,
+            thread_id,
+        }
+    }
+
+    pub fn thread_id(&self) -> ThreadId {
+        self.thread_id
+    }
+
+    pub fn conversation_view(&self) -> &Entity<ConversationView> {
+        &self.conversation_view
+    }
+}
+
+impl Item for ConversationPane {
+    type Event = ();
+
+    fn include_in_nav_history() -> bool {
+        false
+    }
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        self.conversation_view.read(cx).title(cx)
+    }
+}
+
+impl EventEmitter<()> for ConversationPane {}
+
+impl Focusable for ConversationPane {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.conversation_view.read(cx).focus_handle(cx)
+    }
+}
+
+impl Render for ConversationPane {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().size_full().child(self.conversation_view.clone())
+    }
+}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ThreadFeedback {
@@ -2861,7 +2914,8 @@ impl ConversationView {
         let multi_workspace = multi_workspace.read(cx);
         multi_workspace.sidebar_open() && multi_workspace.is_threads_list_view_active(cx)
             || multi_workspace.workspace() == &workspace
-                && self.is_visible_in_agent_panel(&workspace, cx)
+                && (self.is_visible_in_agent_panel(&workspace, cx)
+                    || self.is_visible_in_center(&workspace, cx))
     }
 
     fn is_visible_in_agent_panel(&self, workspace: &Entity<Workspace>, cx: &Context<Self>) -> bool {
@@ -2878,6 +2932,15 @@ impl ConversationView {
                 })
     }
 
+    fn is_visible_in_center(&self, workspace: &Entity<Workspace>, cx: &Context<Self>) -> bool {
+        workspace.read(cx).panes().iter().any(|pane| {
+            pane.read(cx)
+                .active_item()
+                .and_then(|item| item.to_any_view().downcast::<ConversationPane>().ok())
+                .is_some_and(|item| item.read(cx).conversation_view().entity_id() == cx.entity_id())
+        })
+    }
+
     fn agent_status_visible(&self, window: &Window, cx: &Context<Self>) -> bool {
         if !window.is_window_active() {
             return false;
@@ -2886,9 +2949,10 @@ impl ConversationView {
         if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() {
             self.is_visible(&multi_workspace, cx)
         } else {
-            self.workspace
-                .upgrade()
-                .is_some_and(|workspace| self.is_visible_in_agent_panel(&workspace, cx))
+            self.workspace.upgrade().is_some_and(|workspace| {
+                self.is_visible_in_agent_panel(&workspace, cx)
+                    || self.is_visible_in_center(&workspace, cx)
+            })
         }
     }
 
@@ -2898,9 +2962,10 @@ impl ConversationView {
             && if let Some(mw) = window.root::<MultiWorkspace>().flatten() {
                 self.is_visible(&mw, cx)
             } else {
-                self.workspace
-                    .upgrade()
-                    .is_some_and(|workspace| self.is_visible_in_agent_panel(&workspace, cx))
+                self.workspace.upgrade().is_some_and(|workspace| {
+                    self.is_visible_in_agent_panel(&workspace, cx)
+                        || self.is_visible_in_center(&workspace, cx)
+                })
             };
         let settings = AgentSettings::get_global(cx);
         if settings.play_sound_when_agent_done.should_play(visible) {
@@ -4714,6 +4779,7 @@ pub(crate) mod tests {
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
                         archived: false,
+                        split_parent: None,
                     },
                     cx,
                 );

--- a/crates/agent_ui/src/terminal_thread_metadata_store.rs
+++ b/crates/agent_ui/src/terminal_thread_metadata_store.rs
@@ -17,7 +17,10 @@ use ui::{App, Context, SharedString};
 use util::ResultExt as _;
 use workspace::PathList;
 
-use crate::{TerminalId, thread_metadata_store::WorktreePaths};
+use crate::{
+    TerminalId,
+    thread_metadata_store::{SplitParent, WorktreePaths},
+};
 
 pub fn init(cx: &mut App) {
     TerminalThreadMetadataStore::init_global(cx);
@@ -53,6 +56,7 @@ pub struct TerminalThreadMetadata {
     pub worktree_paths: WorktreePaths,
     pub remote_connection: Option<RemoteConnectionOptions>,
     pub working_directory: Option<PathBuf>,
+    pub split_parent: Option<SplitParent>,
 }
 
 impl TerminalThreadMetadata {
@@ -445,20 +449,25 @@ struct TerminalThreadMetadataDb(ThreadSafeConnection);
 impl Domain for TerminalThreadMetadataDb {
     const NAME: &str = stringify!(TerminalThreadMetadataDb);
 
-    const MIGRATIONS: &[&str] = &[sql!(
-        CREATE TABLE IF NOT EXISTS sidebar_terminal_threads(
-            terminal_id TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            custom_title TEXT,
-            created_at TEXT NOT NULL,
-            working_directory TEXT,
-            folder_paths TEXT,
-            folder_paths_order TEXT,
-            main_worktree_paths TEXT,
-            main_worktree_paths_order TEXT,
-            remote_connection TEXT
-        ) STRICT;
-    )];
+    const MIGRATIONS: &[&str] = &[
+        sql!(
+            CREATE TABLE IF NOT EXISTS sidebar_terminal_threads(
+                terminal_id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                custom_title TEXT,
+                created_at TEXT NOT NULL,
+                working_directory TEXT,
+                folder_paths TEXT,
+                folder_paths_order TEXT,
+                main_worktree_paths TEXT,
+                main_worktree_paths_order TEXT,
+                remote_connection TEXT
+            ) STRICT;
+        ),
+        sql!(
+            ALTER TABLE sidebar_terminal_threads ADD COLUMN split_parent TEXT;
+        ),
+    ];
 }
 
 db::static_connection!(TerminalThreadMetadataDb, []);
@@ -468,7 +477,7 @@ impl TerminalThreadMetadataDb {
         self.select::<TerminalThreadMetadata>(
             "SELECT terminal_id, title, custom_title, created_at, \
             working_directory, folder_paths, folder_paths_order, main_worktree_paths, \
-            main_worktree_paths_order, remote_connection \
+            main_worktree_paths_order, remote_connection, split_parent \
             FROM sidebar_terminal_threads \
             ORDER BY created_at DESC",
         )?()
@@ -502,10 +511,11 @@ impl TerminalThreadMetadataDb {
             .map(serde_json::to_string)
             .transpose()
             .context("serialize terminal thread remote connection")?;
+        let split_parent = row.split_parent.map(|parent| parent.to_key_string());
 
         self.write(move |conn| {
-            let sql = "INSERT INTO sidebar_terminal_threads(terminal_id, title, custom_title, created_at, working_directory, folder_paths, folder_paths_order, main_worktree_paths, main_worktree_paths_order, remote_connection) \
-                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) \
+            let sql = "INSERT INTO sidebar_terminal_threads(terminal_id, title, custom_title, created_at, working_directory, folder_paths, folder_paths_order, main_worktree_paths, main_worktree_paths_order, remote_connection, split_parent) \
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
                        ON CONFLICT(terminal_id) DO UPDATE SET \
                            title = excluded.title, \
                            custom_title = excluded.custom_title, \
@@ -515,7 +525,8 @@ impl TerminalThreadMetadataDb {
                            folder_paths_order = excluded.folder_paths_order, \
                            main_worktree_paths = excluded.main_worktree_paths, \
                            main_worktree_paths_order = excluded.main_worktree_paths_order, \
-                           remote_connection = excluded.remote_connection";
+                           remote_connection = excluded.remote_connection, \
+                           split_parent = excluded.split_parent";
             let mut stmt = Statement::prepare(conn, sql)?;
             let mut i = stmt.bind(&terminal_id, 1)?;
             i = stmt.bind(&title, i)?;
@@ -526,7 +537,8 @@ impl TerminalThreadMetadataDb {
             i = stmt.bind(&folder_paths_order, i)?;
             i = stmt.bind(&main_worktree_paths, i)?;
             i = stmt.bind(&main_worktree_paths_order, i)?;
-            stmt.bind(&remote_connection, i)?;
+            i = stmt.bind(&remote_connection, i)?;
+            stmt.bind(&split_parent, i)?;
             stmt.exec()
         })
         .await
@@ -562,6 +574,11 @@ impl Column for TerminalThreadMetadata {
             Column::column(statement, next)?;
         let (remote_connection_json, next): (Option<String>, i32) =
             Column::column(statement, next)?;
+        let (split_parent, next): (Option<String>, i32) = Column::column(statement, next)?;
+
+        let split_parent = split_parent
+            .as_deref()
+            .and_then(|value| SplitParent::from_key_string(value).log_err());
 
         let folder_paths = folder_paths_str
             .map(|paths| {
@@ -601,6 +618,7 @@ impl Column for TerminalThreadMetadata {
                 worktree_paths,
                 remote_connection,
                 working_directory: working_directory.map(PathBuf::from),
+                split_parent,
             },
             next,
         ))
@@ -630,6 +648,7 @@ mod tests {
             worktree_paths,
             remote_connection: None,
             working_directory: None,
+            split_parent: None,
         }
     }
 
@@ -657,6 +676,36 @@ mod tests {
 
         metadata.title = "Thinking".into();
         assert_eq!(metadata.display_title().as_ref(), "Fix bug");
+    }
+
+    #[gpui::test]
+    async fn test_database_round_trips_split_parent(_cx: &mut TestAppContext) {
+        let mut metadata = metadata(
+            "Split Terminal",
+            WorktreePaths::from_folder_paths(&PathList::new(&[Path::new("/project-a")])),
+        );
+        let parent = SplitParent::Thread(crate::ThreadId::new());
+        metadata.split_parent = Some(parent);
+
+        let thread = std::thread::current();
+        let test_name = thread.name().unwrap_or("unknown_test");
+        let db_name = format!("TERMINAL_THREAD_METADATA_DB_{}", test_name);
+        let db = TerminalThreadMetadataDb(gpui::block_on(db::open_test_db::<
+            TerminalThreadMetadataDb,
+        >(&db_name)));
+
+        db.save(metadata)
+            .await
+            .expect("split terminal metadata should save");
+
+        let rows = db.list().expect("split terminal metadata should load");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows.first()
+                .expect("one metadata row should exist")
+                .split_parent,
+            Some(parent)
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -1283,6 +1283,24 @@ mod tests {
         assert!(archived.archived);
     }
 
+    #[test]
+    fn test_reads_channel_database_without_split_parent_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let connection = create_channel_db(dir.path(), ReleaseChannel::Nightly);
+        connection
+            .exec("ALTER TABLE sidebar_threads DROP COLUMN split_parent")
+            .unwrap()()
+        .unwrap();
+        insert_thread(&connection, "Legacy Thread", "2025-01-15T10:00:00Z", false);
+        drop(connection);
+
+        let threads = read_threads_from_channel(dir.path(), ReleaseChannel::Nightly).unwrap();
+
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].display_title().as_ref(), "Legacy Thread");
+        assert_eq!(threads[0].split_parent, None);
+    }
+
     fn init_test(cx: &mut TestAppContext) {
         let fs = fs::FakeFs::new(cx.executor());
         cx.update(|cx| {

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -882,6 +882,7 @@ fn collect_importable_threads(
                 worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                 remote_connection: remote_connection.clone(),
                 archived: true,
+                split_parent: None,
             });
         }
     }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -57,6 +57,34 @@ impl Column for ThreadId {
     }
 }
 
+/// The sidebar entry a thread or terminal was split off from, so the sidebar
+/// can nest it under its origin.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum SplitParent {
+    Thread(ThreadId),
+    Terminal(crate::TerminalId),
+}
+
+impl SplitParent {
+    pub fn to_key_string(&self) -> String {
+        match self {
+            Self::Thread(thread_id) => format!("thread:{}", thread_id.to_key_string()),
+            Self::Terminal(terminal_id) => format!("terminal:{}", terminal_id.to_key_string()),
+        }
+    }
+
+    pub fn from_key_string(value: &str) -> anyhow::Result<Self> {
+        let (kind, id) = value
+            .split_once(':')
+            .with_context(|| format!("split parent key {value:?} is missing a kind prefix"))?;
+        match kind {
+            "thread" => Ok(Self::Thread(ThreadId(uuid::Uuid::parse_str(id)?))),
+            "terminal" => Ok(Self::Terminal(crate::TerminalId::from_key_string(id)?)),
+            _ => anyhow::bail!("unknown split parent kind {kind:?} in key {value:?}"),
+        }
+    }
+}
+
 const THREAD_REMOTE_CONNECTION_MIGRATION_KEY: &str = "thread-metadata-remote-connection-backfill";
 const THREAD_ID_MIGRATION_KEY: &str = "thread-metadata-thread-id-backfill";
 
@@ -142,6 +170,7 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
                         worktree_paths: WorktreePaths::from_folder_paths(&entry.folder_paths),
                         remote_connection: None,
                         archived: true,
+                        split_parent: None,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -323,6 +352,7 @@ pub struct ThreadMetadata {
     pub worktree_paths: WorktreePaths,
     pub remote_connection: Option<RemoteConnectionOptions>,
     pub archived: bool,
+    pub split_parent: Option<SplitParent>,
 }
 
 impl ThreadMetadata {
@@ -507,6 +537,9 @@ pub struct ThreadMetadataStore {
     conversation_subscriptions: HashMap<gpui::EntityId, Subscription>,
     pending_thread_ops_tx: async_channel::Sender<DbOperation>,
     in_flight_archives: HashMap<ThreadId, (Task<()>, async_channel::Sender<()>)>,
+    /// Split links recorded before their thread had a metadata row, applied by
+    /// [`Self::handle_conversation_event`] when that row is first written.
+    pending_split_parents: HashMap<ThreadId, SplitParent>,
     _db_operations_task: Task<()>,
 }
 
@@ -855,6 +888,26 @@ impl ThreadMetadataStore {
         };
     }
 
+    /// Records which entry `thread_id` was split off from. A brand-new draft
+    /// has no metadata row until its first conversation event, so the link is
+    /// held here until that row is written.
+    pub fn set_split_parent(
+        &mut self,
+        thread_id: ThreadId,
+        parent: SplitParent,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(thread) = self.threads.get(&thread_id) else {
+            self.pending_split_parents.insert(thread_id, parent);
+            return;
+        };
+        self.save_internal(ThreadMetadata {
+            split_parent: Some(parent),
+            ..thread.clone()
+        });
+        cx.notify();
+    }
+
     pub fn archive(
         &mut self,
         thread_id: ThreadId,
@@ -1155,6 +1208,7 @@ impl ThreadMetadataStore {
             }
         }
         self.threads.remove(&thread_id);
+        self.pending_split_parents.remove(&thread_id);
         self.pending_thread_ops_tx
             .try_send(DbOperation::Delete(thread_id))
             .log_err();
@@ -1245,6 +1299,7 @@ impl ThreadMetadataStore {
             conversation_subscriptions: HashMap::default(),
             pending_thread_ops_tx: tx,
             in_flight_archives: HashMap::default(),
+            pending_split_parents: HashMap::default(),
             _db_operations_task,
         };
         let _ = this.reload(cx);
@@ -1350,6 +1405,9 @@ impl ThreadMetadataStore {
             worktree_paths,
             remote_connection,
             archived,
+            split_parent: existing_thread
+                .and_then(|thread| thread.split_parent)
+                .or_else(|| self.pending_split_parents.remove(&thread_id)),
         };
 
         self.save(metadata, cx);
@@ -1462,6 +1520,9 @@ impl Domain for ThreadMetadataDb {
         sql!(
             ALTER TABLE sidebar_threads ADD COLUMN title_override TEXT;
         ),
+        sql!(
+            ALTER TABLE sidebar_threads ADD COLUMN split_parent TEXT;
+        ),
     ];
 }
 
@@ -1478,7 +1539,7 @@ impl ThreadMetadataDb {
 
     const LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
         created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
-        main_worktree_paths_order, remote_connection, title_override \
+        main_worktree_paths_order, remote_connection, title_override, split_parent \
         FROM sidebar_threads \
         ORDER BY updated_at DESC";
 
@@ -1529,12 +1590,13 @@ impl ThreadMetadataDb {
             .transpose()
             .context("serialize thread metadata remote connection")?;
         let title_override = row.title_override.as_ref().map(|t| t.to_string());
+        let split_parent = row.split_parent.map(|parent| parent.to_key_string());
         let thread_id = row.thread_id;
         let archived = row.archived;
 
         self.write(move |conn| {
-            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection, title_override) \
-                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection, title_override, split_parent) \
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
                        ON CONFLICT(thread_id) DO UPDATE SET \
                            session_id = excluded.session_id, \
                            agent_id = excluded.agent_id, \
@@ -1548,7 +1610,8 @@ impl ThreadMetadataDb {
                            main_worktree_paths = excluded.main_worktree_paths, \
                            main_worktree_paths_order = excluded.main_worktree_paths_order, \
                            remote_connection = excluded.remote_connection, \
-                           title_override = excluded.title_override";
+                           title_override = excluded.title_override, \
+                           split_parent = excluded.split_parent";
             let mut stmt = Statement::prepare(conn, sql)?;
             let mut i = stmt.bind(&thread_id, 1)?;
             i = stmt.bind(&session_id, i)?;
@@ -1563,7 +1626,8 @@ impl ThreadMetadataDb {
             i = stmt.bind(&main_worktree_paths, i)?;
             i = stmt.bind(&main_worktree_paths_order, i)?;
             i = stmt.bind(&remote_connection, i)?;
-            stmt.bind(&title_override, i)?;
+            i = stmt.bind(&title_override, i)?;
+            stmt.bind(&split_parent, i)?;
             stmt.exec()
         })
         .await
@@ -1721,6 +1785,11 @@ impl Column for ThreadMetadata {
         let (remote_connection_json, next): (Option<String>, i32) =
             Column::column(statement, next)?;
         let (title_override, next): (Option<String>, i32) = Column::column(statement, next)?;
+        let (split_parent, next): (Option<String>, i32) = Column::column(statement, next)?;
+
+        let split_parent = split_parent
+            .as_deref()
+            .and_then(|value| SplitParent::from_key_string(value).log_err());
 
         let agent_id = agent_id
             .map(|id| AgentId::new(id))
@@ -1787,6 +1856,7 @@ impl Column for ThreadMetadata {
                 worktree_paths,
                 remote_connection,
                 archived,
+                split_parent,
             },
             next,
         ))
@@ -1877,6 +1947,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
             remote_connection: None,
+            split_parent: None,
         }
     }
 
@@ -1944,6 +2015,38 @@ mod tests {
         metadata.title_override = None;
         assert_eq!(metadata.title().as_deref(), Some("Agent Generated Title"));
         assert_eq!(metadata.display_title().as_ref(), "Agent Generated Title");
+    }
+
+    #[gpui::test]
+    async fn test_database_round_trips_split_parent(_cx: &mut TestAppContext) {
+        let mut metadata = make_metadata(
+            "session-1",
+            "Split Thread",
+            Utc::now(),
+            PathList::new(&[Path::new("/project-a")]),
+        );
+        let parent = SplitParent::Terminal(crate::TerminalId::new());
+        metadata.split_parent = Some(parent);
+
+        let thread = std::thread::current();
+        let test_name = thread.name().unwrap_or("unknown_test");
+        let db_name = format!("THREAD_METADATA_DB_{}", test_name);
+        let db = ThreadMetadataDb(gpui::block_on(db::open_test_db::<ThreadMetadataDb>(
+            &db_name,
+        )));
+
+        db.save(metadata)
+            .await
+            .expect("split thread metadata should save");
+
+        let rows = db.list().expect("split thread metadata should load");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows.first()
+                .expect("one metadata row should exist")
+                .split_parent,
+            Some(parent)
+        );
     }
 
     #[gpui::test]
@@ -2171,6 +2274,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&second_paths),
             remote_connection: None,
             archived: false,
+            split_parent: None,
         };
 
         cx.update(|cx| {
@@ -2256,6 +2360,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&project_a_paths),
             remote_connection: None,
             archived: false,
+            split_parent: None,
         };
 
         cx.update(|cx| {
@@ -2382,6 +2487,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&project_paths),
             remote_connection: None,
             archived: false,
+            split_parent: None,
         };
 
         cx.update(|cx| {
@@ -3126,6 +3232,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: linked_worktree_paths.clone(),
             remote_connection: None,
+            split_parent: None,
         };
 
         let remote_linked_thread = ThreadMetadata {
@@ -3140,6 +3247,7 @@ mod tests {
             interacted_at: None,
             worktree_paths: linked_worktree_paths,
             remote_connection: Some(remote_a.clone()),
+            split_parent: None,
         };
 
         cx.update(|cx| {

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -38,6 +38,10 @@ impl ThreadId {
         Self(uuid::Uuid::new_v4())
     }
 
+    pub(crate) fn from_key_string(key: &str) -> anyhow::Result<Self> {
+        Ok(Self(uuid::Uuid::parse_str(key)?))
+    }
+
     /// Stable, hyphenated string form suitable for use as a key.
     pub fn to_key_string(&self) -> String {
         self.0.hyphenated().to_string()
@@ -95,7 +99,18 @@ const THREAD_ID_MIGRATION_KEY: &str = "thread-metadata-thread-id-backfill";
 pub(crate) fn list_thread_metadata_from_connection(
     connection: &db::sqlez::connection::Connection,
 ) -> anyhow::Result<Vec<ThreadMetadata>> {
-    connection.select::<ThreadMetadata>(ThreadMetadataDb::LIST_QUERY)?()
+    let has_split_parent = connection.select_row::<i64>(
+        "SELECT COUNT(*) FROM pragma_table_info('sidebar_threads') \
+             WHERE name = 'split_parent'",
+    )?()?
+    .unwrap_or_default()
+        > 0;
+    let query = if has_split_parent {
+        ThreadMetadataDb::LIST_QUERY
+    } else {
+        ThreadMetadataDb::LEGACY_LIST_QUERY
+    };
+    connection.select::<ThreadMetadata>(query)?()
 }
 
 /// Run the `ThreadMetadataDb` migrations on a raw connection.
@@ -1540,6 +1555,12 @@ impl ThreadMetadataDb {
     const LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
         created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
         main_worktree_paths_order, remote_connection, title_override, split_parent \
+        FROM sidebar_threads \
+        ORDER BY updated_at DESC";
+
+    const LEGACY_LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
+        created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
+        main_worktree_paths_order, remote_connection, title_override, NULL AS split_parent \
         FROM sidebar_threads \
         ORDER BY updated_at DESC";
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3827,19 +3827,15 @@ impl Sidebar {
         workspace: ThreadEntryWorkspace,
         cx: &App,
     ) -> ContextMenu {
-        let Some(panel_workspace) = (match &workspace {
-            ThreadEntryWorkspace::Open(workspace) => Some(workspace.clone()),
-            ThreadEntryWorkspace::Closed { .. } => sidebar
-                .upgrade()
-                .and_then(|sidebar| sidebar.read(cx).multi_workspace.upgrade())
-                .map(|multi_workspace| multi_workspace.read(cx).workspace().clone()),
-        }) else {
-            return menu;
+        let options = match &workspace {
+            ThreadEntryWorkspace::Open(workspace) => {
+                let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+                    return menu;
+                };
+                panel.read(cx).new_entry_options(cx)
+            }
+            ThreadEntryWorkspace::Closed { .. } => AgentPanel::closed_project_new_entry_options(),
         };
-        let Some(panel) = panel_workspace.read(cx).panel::<AgentPanel>(cx) else {
-            return menu;
-        };
-        let options = panel.read(cx).new_entry_options(cx);
         if options.is_empty() {
             return menu;
         }
@@ -6818,7 +6814,26 @@ impl Sidebar {
             });
 
         if is_draft || thread.metadata.session_id.is_none() {
-            return thread_item.into_any_element();
+            let context_menu_id = SharedString::from(format!("thread-context-menu-{}", ix));
+            let sidebar = cx.weak_entity();
+            let center_metadata = thread.metadata.clone();
+            return right_click_menu(context_menu_id)
+                .trigger(move |_, _, _| thread_item)
+                .menu(move |window, cx| {
+                    let sidebar = sidebar.clone();
+                    let center_metadata = center_metadata.clone();
+                    let center_workspace = center_workspace.clone();
+                    ContextMenu::build(window, cx, move |menu, _window, cx| {
+                        Self::add_split_submenu(
+                            menu,
+                            &sidebar,
+                            SplitOrigin::Thread(center_metadata.clone()),
+                            center_workspace.clone(),
+                            cx,
+                        )
+                    })
+                })
+                .into_any_element();
         }
 
         let Some(session_id) = thread.metadata.session_id.clone() else {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -414,6 +414,16 @@ fn thread_metadata_would_render_sidebar_row(
     draft_display_label_for_thread_metadata(metadata, workspace, cx).is_some()
 }
 
+fn thread_is_center_owned(thread_id: ThreadId, workspace: &ThreadEntryWorkspace, cx: &App) -> bool {
+    match workspace {
+        ThreadEntryWorkspace::Open(workspace) => workspace
+            .read(cx)
+            .panel::<AgentPanel>(cx)
+            .is_some_and(|panel| panel.read(cx).thread_is_in_center(thread_id)),
+        ThreadEntryWorkspace::Closed { .. } => false,
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum DraftKind {
     WithContent,
@@ -1835,21 +1845,29 @@ impl Sidebar {
                 }
                 threads.retain(|thread| thread.draft.is_none() || thread.metadata.title.is_some());
 
-                // Keep empty drafts only while their thread is active; preserve
-                // drafts with content because they hold user-typed state.
+                // Center-owned empty drafts remain independently usable even when another pane
+                // is active, so each one must keep its sidebar entry.
                 let pending_activation = self.pending_thread_activation;
-                let active_panel_thread_id = active_workspace
+                let actively_viewed_thread_id = active_workspace
                     .as_ref()
                     .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx))
-                    .and_then(|panel| panel.read(cx).active_thread_id(cx));
+                    .and_then(|panel| {
+                        let panel = panel.read(cx);
+                        panel
+                            .active_center_thread_id(cx)
+                            .or_else(|| panel.active_thread_id(cx))
+                    });
                 threads.retain(|thread| {
                     if thread.draft != Some(DraftKind::Empty) {
+                        return true;
+                    }
+                    if thread_is_center_owned(thread.metadata.thread_id, &thread.workspace, cx) {
                         return true;
                     }
                     if pending_activation.is_some() {
                         return false;
                     }
-                    Some(thread.metadata.thread_id) == active_panel_thread_id
+                    Some(thread.metadata.thread_id) == actively_viewed_thread_id
                 });
 
                 // Build a lookup from live_infos and compute running/waiting
@@ -2277,7 +2295,7 @@ impl Sidebar {
             .read(cx)
             .workspaces()
             .filter_map(|ws| ws.read(cx).panel::<AgentPanel>(cx))
-            .flat_map(|panel| panel.read(cx).conversation_views())
+            .flat_map(|panel| panel.read(cx).conversation_views(cx))
             .collect();
 
         for cv in draft_conversation_views {
@@ -3942,21 +3960,25 @@ impl Sidebar {
             multi_workspace.activate(workspace.clone(), None, window, cx);
         });
 
+        let center_workspace = workspace.clone();
         let split = move |panel: Entity<AgentPanel>,
-                          workspace: Option<&Workspace>,
+                          terminal_workspace: Option<&Workspace>,
                           window: &mut Window,
                           cx: &mut App| {
             panel.update(cx, |panel, cx| {
                 let split_parent = origin.split_key();
-                origin.open_in_center(panel, workspace, window, cx);
+                origin.open_in_center(panel, terminal_workspace, window, cx);
                 panel.create_entry_in_center(
                     kind,
-                    workspace,
+                    terminal_workspace,
                     Some(SplitDirection::Right),
                     Some(split_parent),
                     window,
                     cx,
                 );
+            });
+            center_workspace.update(cx, |workspace, cx| {
+                workspace.close_panel::<AgentPanel>(window, cx);
             });
         };
 
@@ -6589,6 +6611,8 @@ impl Sidebar {
         let is_selected = is_active;
         let is_draft = thread.draft.is_some();
         let is_empty_draft = thread.draft == Some(DraftKind::Empty);
+        let is_center_owned =
+            thread_is_center_owned(thread.metadata.thread_id, &thread.workspace, cx);
         let is_running = matches!(
             thread.status,
             AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation
@@ -6737,8 +6761,8 @@ impl Sidebar {
                     )
                 } else {
                     match thread.draft {
-                        Some(DraftKind::Empty) => None,
-                        Some(DraftKind::WithContent) => Some(
+                        Some(DraftKind::Empty) if !is_center_owned => None,
+                        Some(DraftKind::Empty | DraftKind::WithContent) => Some(
                             IconButton::new("discard_thread", IconName::Close)
                                 .icon_size(IconSize::Small)
                                 .tooltip(Tooltip::text("Discard Draft"))
@@ -8453,7 +8477,7 @@ fn all_thread_infos_for_workspace(
     };
     let agent_panel = agent_panel.read(cx);
     let threads = agent_panel
-        .conversation_views()
+        .conversation_views(cx)
         .into_iter()
         .filter_map(|conversation_view| {
             let has_pending_tool_call = conversation_view

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -17,9 +17,10 @@ use agent_ui::threads_archive_view::{
 };
 use agent_ui::{
     AcpThreadImportOnboarding, Agent, AgentPanel, AgentPanelEvent, AgentThreadSource,
-    ArchiveSelectedThread, CrossChannelImportOnboarding, DEFAULT_THREAD_TITLE, NewTerminalThread,
-    NewThread, RenameSelectedThread, TerminalId, ThreadId, ThreadImportModal,
-    ThreadTitleRegenerationResult, channels_with_threads, import_threads_from_other_channels,
+    ArchiveSelectedThread, CrossChannelImportOnboarding, DEFAULT_THREAD_TITLE, NewEntryIcon,
+    NewEntryKind, NewTerminalThread, NewThread, RenameSelectedThread, SplitParent, TerminalId,
+    ThreadId, ThreadImportModal, ThreadTitleRegenerationResult, channels_with_threads,
+    import_threads_from_other_channels,
 };
 use agent_ui::{MessageEditorEvent, StateChange, thread_worktree_archive};
 use chrono::{DateTime, Utc};
@@ -67,8 +68,9 @@ use util::path_list::PathList;
 use workspace::{
     CloseWindow, FocusWorkspaceSidebar, MoveProjectDown, MoveProjectUp, MultiWorkspace,
     MultiWorkspaceEvent, NextProject, NextThread, Open, OpenMode, PreviousProject, PreviousThread,
-    ProjectGroupKey, RemovalIntent, SaveIntent, Sidebar as WorkspaceSidebar, SidebarSide, Toast,
-    ToggleWorkspaceSidebar, Workspace, notifications::NotificationId, sidebar_side_context_menu,
+    ProjectGroupKey, RemovalIntent, SaveIntent, Sidebar as WorkspaceSidebar, SidebarSide,
+    SplitDirection, Toast, ToggleWorkspaceSidebar, Workspace, notifications::NotificationId,
+    sidebar_side_context_menu,
 };
 
 use git_ui_core::worktree_service::{RemoteBranchName, worktree_create_targets};
@@ -208,6 +210,77 @@ struct ActiveThreadInfo {
     is_background: bool,
     is_title_generating: bool,
     diff_stats: DiffStats,
+}
+
+#[derive(Clone)]
+enum SplitOrigin {
+    Thread(ThreadMetadata),
+    Terminal(TerminalThreadMetadata),
+}
+
+impl SplitOrigin {
+    fn split_key(&self) -> SplitParent {
+        match self {
+            SplitOrigin::Thread(metadata) => SplitParent::Thread(metadata.thread_id),
+            SplitOrigin::Terminal(metadata) => SplitParent::Terminal(metadata.terminal_id),
+        }
+    }
+
+    fn active_entry(&self, workspace: &Entity<Workspace>) -> ActiveEntry {
+        match self {
+            SplitOrigin::Thread(metadata) => ActiveEntry::Thread {
+                thread_id: metadata.thread_id,
+                session_id: metadata.session_id.clone(),
+                workspace: workspace.clone(),
+            },
+            SplitOrigin::Terminal(metadata) => ActiveEntry::Terminal {
+                terminal_id: metadata.terminal_id,
+                workspace: workspace.clone(),
+            },
+        }
+    }
+
+    fn open_in_center(
+        &self,
+        panel: &mut AgentPanel,
+        workspace: Option<&Workspace>,
+        window: &mut Window,
+        cx: &mut Context<AgentPanel>,
+    ) {
+        match self {
+            SplitOrigin::Thread(metadata) => {
+                if panel
+                    .conversation_view_for_id(&metadata.thread_id, cx)
+                    .is_none()
+                {
+                    panel.load_agent_thread(
+                        Agent::from(metadata.agent_id.clone()),
+                        metadata.thread_id,
+                        Some(metadata.folder_paths().clone()),
+                        metadata.title.clone(),
+                        false,
+                        AgentThreadSource::Sidebar,
+                        window,
+                        cx,
+                    );
+                }
+                panel.open_thread_in_center(metadata.thread_id, None, window, cx);
+            }
+            SplitOrigin::Terminal(metadata) => {
+                if !panel.has_terminal(metadata.terminal_id) {
+                    panel.restore_terminal(
+                        metadata.clone(),
+                        false,
+                        AgentThreadSource::Sidebar,
+                        workspace,
+                        window,
+                        cx,
+                    );
+                }
+                panel.open_terminal_in_center(metadata.terminal_id, None, window, cx);
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -361,6 +434,8 @@ struct ThreadEntry {
     highlight_positions: Vec<usize>,
     worktrees: Vec<ThreadItemWorktreeInfo>,
     diff_stats: DiffStats,
+    depth: usize,
+    has_split_children: bool,
 }
 
 #[derive(Clone)]
@@ -370,6 +445,8 @@ struct TerminalEntry {
     worktrees: Vec<ThreadItemWorktreeInfo>,
     has_notification: bool,
     highlight_positions: Vec<usize>,
+    depth: usize,
+    has_split_children: bool,
 }
 
 impl ThreadEntry {
@@ -496,8 +573,8 @@ enum EntryShape {
         // `!is_collapsed && !has_threads`).
         is_collapsed: bool,
     },
-    Thread(ThreadId),
-    Terminal(TerminalId),
+    Thread(ThreadId, usize),
+    Terminal(TerminalId, usize),
 }
 
 impl SidebarContents {
@@ -769,6 +846,9 @@ pub struct Sidebar {
     thread_switcher: Option<Entity<ThreadSwitcher>>,
     _thread_switcher_subscriptions: Vec<gpui::Subscription>,
     pending_thread_activation: Option<agent_ui::ThreadId>,
+    /// Split parents whose nested children are hidden. Session-only: the
+    /// `split_parent` links themselves are persisted, this collapse state is not.
+    collapsed_splits: HashSet<SplitParent>,
     /// Persists live thread statuses across rebuilds so that Running→Completed
     /// transitions can be detected even when the group is collapsed (and
     /// thread entries are not present in the list).
@@ -913,6 +993,7 @@ impl Sidebar {
             thread_switcher: None,
             _thread_switcher_subscriptions: Vec::new(),
             pending_thread_activation: None,
+            collapsed_splits: HashSet::new(),
             live_thread_statuses: HashMap::new(),
             draft_kinds: HashMap::new(),
             view: SidebarView::default(),
@@ -932,6 +1013,13 @@ impl Sidebar {
 
     fn serialize(&mut self, cx: &mut Context<Self>) {
         cx.emit(workspace::SidebarEvent::SerializeNeeded);
+    }
+
+    fn toggle_split_collapsed(&mut self, key: SplitParent, cx: &mut Context<Self>) {
+        if !self.collapsed_splits.remove(&key) {
+            self.collapsed_splits.insert(key);
+        }
+        self.update_entries(cx);
     }
 
     fn is_group_collapsed(&self, key: &ProjectGroupKey, cx: &App) -> bool {
@@ -1014,13 +1102,28 @@ impl Sidebar {
         cx.subscribe_in(
             workspace,
             window,
-            move |this, workspace, event: &workspace::Event, window, cx| {
-                if let workspace::Event::PanelAdded(view) = event {
+            move |this, workspace, event: &workspace::Event, window, cx| match event {
+                workspace::Event::PanelAdded(view) => {
                     if let Ok(agent_panel) = view.clone().downcast::<AgentPanel>() {
                         this.subscribe_to_agent_panel(workspace, &agent_panel, window, cx);
                         this.schedule_update_entries(false, cx);
                     }
                 }
+                workspace::Event::ActiveItemChanged => {
+                    let workspace = workspace.clone();
+                    cx.defer_in(window, move |this, _window, cx| {
+                        if !this.is_active_workspace(&workspace, cx) {
+                            return;
+                        }
+                        if !this.sync_active_entry_from_center(&workspace, cx)
+                            && let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx)
+                        {
+                            this.sync_active_entry_from_panel(&panel, cx);
+                        }
+                        this.schedule_update_entries(false, cx);
+                    });
+                }
+                _ => {}
             },
         )
         .detach();
@@ -1128,12 +1231,49 @@ impl Sidebar {
     }
 
     fn sync_active_entry_from_active_workspace(&mut self, cx: &App) {
-        let panel = self
-            .active_workspace(cx)
-            .and_then(|ws| ws.read(cx).panel::<AgentPanel>(cx));
+        let Some(workspace) = self.active_workspace(cx) else {
+            return;
+        };
+        if self.sync_active_entry_from_center(&workspace, cx) {
+            return;
+        }
+        let panel = workspace.read(cx).panel::<AgentPanel>(cx);
         if let Some(panel) = panel {
             self.sync_active_entry_from_panel(&panel, cx);
         }
+    }
+
+    fn sync_active_entry_from_center(&mut self, workspace: &Entity<Workspace>, cx: &App) -> bool {
+        let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+            return false;
+        };
+        let panel = panel.read(cx);
+
+        if let Some(thread_id) = panel.active_center_thread_id(cx) {
+            let session_id = ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(thread_id)
+                .and_then(|metadata| metadata.session_id.clone());
+            self.active_entry = Some(ActiveEntry::Thread {
+                thread_id,
+                session_id,
+                workspace: workspace.clone(),
+            });
+            if self.pending_thread_activation == Some(thread_id) {
+                self.pending_thread_activation = None;
+            }
+            return true;
+        }
+
+        if let Some(terminal_id) = panel.active_center_terminal_id(cx) {
+            self.active_entry = Some(ActiveEntry::Terminal {
+                terminal_id,
+                workspace: workspace.clone(),
+            });
+            return true;
+        }
+
+        false
     }
 
     /// When switching workspaces, the active panel may still be showing
@@ -1474,6 +1614,8 @@ impl Sidebar {
                         worktrees,
                         has_notification,
                         highlight_positions: Vec::new(),
+                        depth: 0,
+                        has_split_children: false,
                     }
                 };
 
@@ -1589,6 +1731,8 @@ impl Sidebar {
                             highlight_positions: Vec::new(),
                             worktrees,
                             diff_stats: DiffStats::default(),
+                            depth: 0,
+                            has_split_children: false,
                         })
                     };
 
@@ -1906,6 +2050,7 @@ impl Sidebar {
                     matched_threads,
                     &mut current_session_ids,
                     &mut current_thread_ids,
+                    &self.collapsed_splits,
                 );
             } else {
                 let has_terminal_notifications = terminals
@@ -1956,6 +2101,7 @@ impl Sidebar {
                     threads,
                     &mut current_session_ids,
                     &mut current_thread_ids,
+                    &self.collapsed_splits,
                 );
             }
         }
@@ -2072,8 +2218,12 @@ impl Sidebar {
                     .map(|state| !state.expanded)
                     .unwrap_or(false),
             },
-            ListEntry::Thread(thread) => EntryShape::Thread(thread.metadata.thread_id),
-            ListEntry::Terminal(terminal) => EntryShape::Terminal(terminal.metadata.terminal_id),
+            ListEntry::Thread(thread) => {
+                EntryShape::Thread(thread.metadata.thread_id, thread.depth)
+            }
+            ListEntry::Terminal(terminal) => {
+                EntryShape::Terminal(terminal.metadata.terminal_id, terminal.depth)
+            }
         })
     }
 
@@ -3670,6 +3820,172 @@ impl Sidebar {
         .detach_and_log_err(cx);
     }
 
+    fn add_split_submenu(
+        menu: ContextMenu,
+        sidebar: &WeakEntity<Self>,
+        origin: SplitOrigin,
+        workspace: ThreadEntryWorkspace,
+        cx: &App,
+    ) -> ContextMenu {
+        let Some(panel_workspace) = (match &workspace {
+            ThreadEntryWorkspace::Open(workspace) => Some(workspace.clone()),
+            ThreadEntryWorkspace::Closed { .. } => sidebar
+                .upgrade()
+                .and_then(|sidebar| sidebar.read(cx).multi_workspace.upgrade())
+                .map(|multi_workspace| multi_workspace.read(cx).workspace().clone()),
+        }) else {
+            return menu;
+        };
+        let Some(panel) = panel_workspace.read(cx).panel::<AgentPanel>(cx) else {
+            return menu;
+        };
+        let options = panel.read(cx).new_entry_options(cx);
+        if options.is_empty() {
+            return menu;
+        }
+
+        let sidebar = sidebar.clone();
+        menu.submenu("Split", move |mut submenu, _window, _cx| {
+            for option in &options {
+                let mut entry = ContextMenuEntry::new(option.label.clone());
+                entry = match &option.icon {
+                    NewEntryIcon::Named(icon) => entry.icon(*icon),
+                    NewEntryIcon::CustomSvg(path) => entry.custom_icon_svg(path.clone()),
+                };
+                entry = entry.icon_color(Color::Muted).handler({
+                    let sidebar = sidebar.clone();
+                    let origin = origin.clone();
+                    let workspace = workspace.clone();
+                    let kind = option.kind.clone();
+                    move |window, cx| {
+                        sidebar
+                            .update(cx, |sidebar, cx| {
+                                sidebar.split_entry(
+                                    origin.clone(),
+                                    workspace.clone(),
+                                    kind.clone(),
+                                    window,
+                                    cx,
+                                );
+                            })
+                            .ok();
+                    }
+                });
+                submenu = submenu.item(entry);
+            }
+            submenu
+        })
+    }
+
+    fn split_entry(
+        &mut self,
+        origin: SplitOrigin,
+        workspace: ThreadEntryWorkspace,
+        kind: NewEntryKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match workspace {
+            ThreadEntryWorkspace::Open(workspace) => {
+                self.split_entry_in_workspace(&workspace, origin, kind, window, cx)
+            }
+            ThreadEntryWorkspace::Closed {
+                folder_paths,
+                project_group_key,
+            } => {
+                let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+                    return;
+                };
+                let host = project_group_key.host();
+                let active_workspace = multi_workspace.read(cx).workspace().clone();
+                let modal_workspace = active_workspace.clone();
+                let open_task = multi_workspace.update(cx, |multi_workspace, cx| {
+                    multi_workspace.find_or_create_workspace(
+                        folder_paths,
+                        host,
+                        Some(project_group_key),
+                        |options, window, cx| connect_remote(active_workspace, options, window, cx),
+                        None,
+                        OpenMode::Activate,
+                        None,
+                        window,
+                        cx,
+                    )
+                });
+                cx.spawn_in(window, async move |this, cx| {
+                    let result = open_task.await;
+                    remote_connection::dismiss_connection_modal(&modal_workspace, cx);
+                    let workspace = result?;
+                    this.update_in(cx, |this, window, cx| {
+                        this.split_entry_in_workspace(&workspace, origin, kind, window, cx);
+                    })?;
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            }
+        }
+    }
+
+    fn split_entry_in_workspace(
+        &mut self,
+        workspace: &Entity<Workspace>,
+        origin: SplitOrigin,
+        kind: NewEntryKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+            return;
+        };
+
+        self.active_entry = Some(origin.active_entry(workspace));
+        if let SplitOrigin::Terminal(metadata) = &origin {
+            self.record_terminal_access(metadata.terminal_id);
+        }
+        multi_workspace.update(cx, |multi_workspace, cx| {
+            multi_workspace.activate(workspace.clone(), None, window, cx);
+        });
+
+        let split = move |panel: Entity<AgentPanel>,
+                          workspace: Option<&Workspace>,
+                          window: &mut Window,
+                          cx: &mut App| {
+            panel.update(cx, |panel, cx| {
+                let split_parent = origin.split_key();
+                origin.open_in_center(panel, workspace, window, cx);
+                panel.create_entry_in_center(
+                    kind,
+                    workspace,
+                    Some(SplitDirection::Right),
+                    Some(split_parent),
+                    window,
+                    cx,
+                );
+            });
+        };
+
+        if let Some(panel) = workspace.read(cx).panel::<AgentPanel>(cx) {
+            split(panel, None, window, cx);
+        } else {
+            let workspace = workspace.downgrade();
+            let mut async_window_cx = window.to_async(cx);
+            cx.spawn(async move |_this, _cx| {
+                let panel = AgentPanel::load(workspace.clone(), async_window_cx.clone()).await?;
+                workspace.update_in(&mut async_window_cx, |workspace, window, cx| {
+                    let panel = workspace.panel::<AgentPanel>(cx).unwrap_or_else(|| {
+                        workspace.add_panel(panel.clone(), window, cx);
+                        panel.clone()
+                    });
+                    split(panel, Some(workspace), window, cx);
+                })?;
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
+
+        self.update_entries(cx);
+    }
+
     fn open_closed_native_thread_as_markdown(
         session_id: &acp::SessionId,
         title: Option<SharedString>,
@@ -3860,9 +4176,19 @@ impl Sidebar {
         };
 
         if self.is_thread_active_in_workspace(&metadata.thread_id, workspace, cx) {
-            workspace.update(cx, |workspace, cx| {
-                workspace.focus_panel::<AgentPanel>(window, cx);
-            });
+            let focused_center = workspace
+                .read(cx)
+                .panel::<AgentPanel>(cx)
+                .is_some_and(|panel| {
+                    panel.update(cx, |panel, cx| {
+                        panel.focus_thread_in_center(metadata.thread_id, window, cx)
+                    })
+                });
+            if !focused_center {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.focus_panel::<AgentPanel>(window, cx);
+                });
+            }
             return;
         }
 
@@ -3883,6 +4209,20 @@ impl Sidebar {
                 multi_workspace.retain_active_workspace(cx);
             }
         });
+
+        let focused_center = workspace
+            .read(cx)
+            .panel::<AgentPanel>(cx)
+            .is_some_and(|panel| {
+                panel.update(cx, |panel, cx| {
+                    panel.focus_thread_in_center(metadata.thread_id, window, cx)
+                })
+            });
+        if focused_center {
+            self.pending_thread_activation = None;
+            self.update_entries(cx);
+            return;
+        }
 
         Self::load_agent_thread_in_workspace(workspace, metadata, true, window, cx);
 
@@ -4590,6 +4930,19 @@ impl Sidebar {
                 multi_workspace.retain_active_workspace(cx);
             }
         });
+
+        let focused_center = workspace
+            .read(cx)
+            .panel::<AgentPanel>(cx)
+            .is_some_and(|panel| {
+                panel.update(cx, |panel, cx| {
+                    panel.focus_terminal_in_center(terminal_id, window, cx)
+                })
+            });
+        if focused_center {
+            self.update_entries(cx);
+            return;
+        }
 
         Self::load_agent_terminal_in_workspace(workspace, &metadata, true, window, cx);
 
@@ -5711,12 +6064,125 @@ impl Sidebar {
         metadata.interacted_at.unwrap_or(metadata.updated_at)
     }
 
+    /// Reorders a group's rows so that an entry created by splitting sits
+    /// directly beneath the entry it was split from, indented one level. Rows
+    /// whose parent is not in this group stay at the top level, and a parent
+    /// chain that loops back on itself is left flat rather than recursed into.
+    fn nest_split_children(
+        entries: Vec<ListEntry>,
+        collapsed: &HashSet<SplitParent>,
+    ) -> Vec<ListEntry> {
+        fn key_of(entry: &ListEntry) -> Option<SplitParent> {
+            match entry {
+                ListEntry::Thread(thread) => Some(SplitParent::Thread(thread.metadata.thread_id)),
+                ListEntry::Terminal(terminal) => {
+                    Some(SplitParent::Terminal(terminal.metadata.terminal_id))
+                }
+                ListEntry::ProjectHeader { .. } => None,
+            }
+        }
+
+        fn parent_of(entry: &ListEntry) -> Option<SplitParent> {
+            match entry {
+                ListEntry::Thread(thread) => thread.metadata.split_parent,
+                ListEntry::Terminal(terminal) => terminal.metadata.split_parent,
+                ListEntry::ProjectHeader { .. } => None,
+            }
+        }
+
+        fn set_nesting(entry: &mut ListEntry, depth: usize, has_children: bool) {
+            match entry {
+                ListEntry::Thread(thread) => {
+                    let thread = Arc::make_mut(thread);
+                    thread.depth = depth;
+                    thread.has_split_children = has_children;
+                }
+                ListEntry::Terminal(terminal) => {
+                    terminal.depth = depth;
+                    terminal.has_split_children = has_children;
+                }
+                ListEntry::ProjectHeader { .. } => {}
+            }
+        }
+
+        let present: HashSet<SplitParent> = entries.iter().filter_map(key_of).collect();
+        let mut children: HashMap<SplitParent, Vec<usize>> = HashMap::default();
+        let mut roots: Vec<usize> = Vec::new();
+        for (ix, entry) in entries.iter().enumerate() {
+            match parent_of(entry).filter(|parent| present.contains(parent)) {
+                Some(parent) => children.entry(parent).or_default().push(ix),
+                None => roots.push(ix),
+            }
+        }
+
+        let child_indices = |entry: &ListEntry| -> &[usize] {
+            key_of(entry)
+                .and_then(|key| children.get(&key))
+                .map(Vec::as_slice)
+                .unwrap_or_default()
+        };
+
+        let mut hidden: HashSet<usize> = HashSet::new();
+        for (collapsed_ix, entry) in entries.iter().enumerate() {
+            if !key_of(entry).is_some_and(|key| collapsed.contains(&key)) {
+                continue;
+            }
+
+            let mut visited = HashSet::from([collapsed_ix]);
+            let mut stack = child_indices(entry).to_vec();
+            while let Some(ix) = stack.pop() {
+                if !visited.insert(ix) {
+                    continue;
+                }
+                hidden.insert(ix);
+                if let Some(entry) = entries.get(ix) {
+                    stack.extend(child_indices(entry).iter().copied());
+                }
+            }
+        }
+
+        let mut entries: Vec<Option<ListEntry>> = entries.into_iter().map(Some).collect();
+        let mut ordered = Vec::with_capacity(entries.len());
+        let mut stack: Vec<(usize, usize)> = roots.into_iter().rev().map(|ix| (ix, 0)).collect();
+        while let Some((ix, depth)) = stack.pop() {
+            // `take` doubles as the cycle guard: an entry reachable twice
+            // through a parent loop is emitted once and never revisited.
+            let Some(mut entry) = entries.get_mut(ix).and_then(Option::take) else {
+                continue;
+            };
+            let key = key_of(&entry);
+            let child_indices: Vec<usize> = key
+                .as_ref()
+                .and_then(|key| children.get(key))
+                .cloned()
+                .unwrap_or_default();
+            set_nesting(&mut entry, depth, !child_indices.is_empty());
+            ordered.push(entry);
+            if key.is_some_and(|key| collapsed.contains(&key)) {
+                continue;
+            }
+            stack.extend(child_indices.iter().rev().map(|ix| (*ix, depth + 1)));
+        }
+
+        // Whatever is left sat in a parent cycle, so no root ever reached it.
+        // Keep those rows visible rather than dropping them from the sidebar.
+        for (ix, entry) in entries.into_iter().enumerate() {
+            if let Some(entry) = entry
+                && !hidden.contains(&ix)
+            {
+                ordered.push(entry);
+            }
+        }
+        ordered
+    }
+
     fn push_entries_by_display_time(
         entries: &mut Vec<ListEntry>,
         terminals: Vec<TerminalEntry>,
         threads: Vec<Arc<ThreadEntry>>,
         current_session_ids: &mut HashSet<acp::SessionId>,
         current_thread_ids: &mut HashSet<agent_ui::ThreadId>,
+        collapsed_splits: &HashSet<SplitParent>,
     ) {
         fn display_time(entry: &ListEntry) -> DateTime<Utc> {
             match entry {
@@ -5733,9 +6199,10 @@ impl Sidebar {
             .into_iter()
             .map(ListEntry::Terminal)
             .chain(threads.into_iter().map(ListEntry::Thread))
-            .sorted_by_key(|right| std::cmp::Reverse(display_time(right)));
+            .sorted_by_key(|right| std::cmp::Reverse(display_time(right)))
+            .collect::<Vec<_>>();
 
-        for entry in row_entries {
+        for entry in Sidebar::nest_split_children(row_entries, collapsed_splits) {
             if let ListEntry::Thread(thread) = &entry {
                 if let Some(session_id) = &thread.metadata.session_id {
                     current_session_ids.insert(session_id.clone());
@@ -6120,6 +6587,7 @@ impl Sidebar {
         let title: SharedString = thread.metadata.display_title();
         let metadata = thread.metadata.clone();
         let thread_workspace = thread.workspace.clone();
+        let center_workspace = thread.workspace.clone();
 
         let is_hovered = self.hovered_thread_index == Some(ix);
         let is_selected = is_active;
@@ -6167,7 +6635,17 @@ impl Sidebar {
                 .regenerating_titles
                 .contains(&thread.metadata.thread_id);
 
+        let split_key = SplitParent::Thread(thread.metadata.thread_id);
         let thread_item = ThreadItem::new(id, title.clone())
+            .indent_level(thread.depth)
+            .when(thread.has_split_children, |this| {
+                this.split_toggle(
+                    !self.collapsed_splits.contains(&split_key),
+                    cx.listener(move |this, _, _window, cx| {
+                        this.toggle_split_collapsed(split_key, cx);
+                    }),
+                )
+            })
             .base_bg(sidebar_bg)
             .icon(icon)
             .when(is_draft, |this| {
@@ -6359,6 +6837,7 @@ impl Sidebar {
         let is_zed_thread = thread.metadata.agent_id.as_ref() == ZED_AGENT_ID.as_ref();
         let can_open_as_markdown = thread.is_live || is_zed_thread;
         let folder_paths = thread.metadata.folder_paths().clone();
+        let center_metadata = thread.metadata.clone();
 
         right_click_menu(context_menu_id)
             .trigger(move |_, _, _| thread_item)
@@ -6374,6 +6853,8 @@ impl Sidebar {
                     let markdown_title = markdown_title.clone();
                     let rename_title = rename_title.clone();
                     let folder_paths = folder_paths.clone();
+                    let center_metadata = center_metadata.clone();
+                    let center_workspace = center_workspace.clone();
                     ContextMenu::build(_window, cx, move |mut menu, _window, _cx| {
                         menu = menu.entry("Rename Title", None, {
                             let sidebar = sidebar.clone();
@@ -6414,6 +6895,14 @@ impl Sidebar {
                                 }
                             });
                         }
+
+                        menu = Self::add_split_submenu(
+                            menu,
+                            &sidebar,
+                            SplitOrigin::Thread(center_metadata.clone()),
+                            center_workspace.clone(),
+                            _cx,
+                        );
 
                         if can_open_as_markdown {
                             menu = menu.entry("Open Thread as Markdown", None, {
@@ -6486,6 +6975,8 @@ impl Sidebar {
             .blend(color.panel_background.opacity(0.25));
         let metadata = terminal.metadata.clone();
         let workspace = terminal.workspace.clone();
+        let center_metadata = terminal.metadata.clone();
+        let center_workspace = terminal.workspace.clone();
         let focus_handle = self.focus_handle.clone();
         let worktrees = apply_worktree_label_mode(
             terminal.worktrees.clone(),
@@ -6500,7 +6991,17 @@ impl Sidebar {
                 None => (None, display_title, terminal.highlight_positions.clone()),
             };
 
-        ThreadItem::new(id, title)
+        let split_key = SplitParent::Terminal(terminal.metadata.terminal_id);
+        let terminal_item = ThreadItem::new(id, title)
+            .indent_level(terminal.depth)
+            .when(terminal.has_split_children, |this| {
+                this.split_toggle(
+                    !self.collapsed_splits.contains(&split_key),
+                    cx.listener(move |this, _, _window, cx| {
+                        this.toggle_split_collapsed(split_key, cx);
+                    }),
+                )
+            })
             .base_bg(sidebar_bg)
             .icon(IconName::Terminal)
             .when_some(icon_char, |this, icon_char| this.icon_char(icon_char))
@@ -6553,7 +7054,25 @@ impl Sidebar {
                         cx,
                     );
                 }
-            }))
+            }));
+
+        let sidebar = cx.weak_entity();
+        right_click_menu(SharedString::from(format!("terminal-context-menu-{ix}")))
+            .trigger(move |_, _, _| terminal_item)
+            .menu(move |window, cx| {
+                let sidebar = sidebar.clone();
+                let workspace = center_workspace.clone();
+                let metadata = center_metadata.clone();
+                ContextMenu::build(window, cx, move |menu, _window, cx| {
+                    Self::add_split_submenu(
+                        menu,
+                        &sidebar,
+                        SplitOrigin::Terminal(metadata.clone()),
+                        workspace.clone(),
+                        cx,
+                    )
+                })
+            })
             .into_any_element()
     }
 

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -458,6 +458,7 @@ fn save_thread_metadata(
             worktree_paths,
             archived: false,
             remote_connection,
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });
@@ -494,6 +495,7 @@ fn save_thread_metadata_with_main_paths(
         worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, folder_paths).unwrap(),
         archived: false,
         remote_connection: None,
+        split_parent: None,
     };
     cx.update(|cx| {
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -521,6 +523,7 @@ fn save_draft_metadata_with_main_paths(
         worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, folder_paths).unwrap(),
         archived: false,
         remote_connection: None,
+        split_parent: None,
     };
     cx.update(|cx| {
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -1095,6 +1098,182 @@ async fn test_collapse_state_survives_worktree_key_change(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_split_children_nest_under_their_origin(cx: &mut TestAppContext) {
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let root_thread_id = ThreadId::new();
+    let child_terminal_id = TerminalId::new();
+
+    let thread = |title: &str, thread_id: ThreadId, split_parent: Option<SplitParent>| {
+        ListEntry::Thread(Arc::new(ThreadEntry {
+            metadata: ThreadMetadata {
+                thread_id,
+                session_id: Some(acp::SessionId::new(Arc::from(title))),
+                agent_id: AgentId::new("zed-agent"),
+                worktree_paths: WorktreePaths::default(),
+                title: Some(title.to_string().into()),
+                title_override: None,
+                updated_at: Utc::now(),
+                created_at: Some(Utc::now()),
+                interacted_at: None,
+                archived: false,
+                remote_connection: None,
+                split_parent,
+            },
+            icon: IconName::ZedAgent,
+            icon_from_external_svg: None,
+            status: AgentThreadStatus::Completed,
+            workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+            is_live: false,
+            is_background: false,
+            is_title_generating: false,
+            draft: None,
+            highlight_positions: Vec::new(),
+            worktrees: Vec::new(),
+            diff_stats: DiffStats::default(),
+            depth: 0,
+            has_split_children: false,
+        }))
+    };
+    let terminal = |title: &str, terminal_id: TerminalId, split_parent: Option<SplitParent>| {
+        ListEntry::Terminal(TerminalEntry {
+            metadata: TerminalThreadMetadata {
+                terminal_id,
+                title: title.to_string().into(),
+                custom_title: None,
+                created_at: Utc::now(),
+                worktree_paths: WorktreePaths::default(),
+                remote_connection: None,
+                working_directory: None,
+                split_parent,
+            },
+            workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+            worktrees: Vec::new(),
+            has_notification: false,
+            highlight_positions: Vec::new(),
+            depth: 0,
+            has_split_children: false,
+        })
+    };
+
+    let describe = |entries: &[ListEntry]| -> Vec<(String, usize, bool)> {
+        entries
+            .iter()
+            .map(|entry| match entry {
+                ListEntry::Thread(thread) => (
+                    thread.metadata.display_title().to_string(),
+                    thread.depth,
+                    thread.has_split_children,
+                ),
+                ListEntry::Terminal(terminal) => (
+                    terminal.metadata.display_title().to_string(),
+                    terminal.depth,
+                    terminal.has_split_children,
+                ),
+                ListEntry::ProjectHeader { label, .. } => (label.to_string(), 0, false),
+            })
+            .collect()
+    };
+
+    // Deliberately out of tree order: an unrelated row sits between the root
+    // and the rows split off from it.
+    let entries = vec![
+        thread("root", root_thread_id, None),
+        thread("unrelated", ThreadId::new(), None),
+        terminal(
+            "child",
+            child_terminal_id,
+            Some(SplitParent::Thread(root_thread_id)),
+        ),
+        thread(
+            "grandchild",
+            ThreadId::new(),
+            Some(SplitParent::Terminal(child_terminal_id)),
+        ),
+    ];
+
+    let nested = Sidebar::nest_split_children(entries.clone(), &HashSet::new());
+    assert_eq!(
+        describe(&nested),
+        vec![
+            ("root".to_string(), 0, true),
+            ("child".to_string(), 1, true),
+            ("grandchild".to_string(), 2, false),
+            ("unrelated".to_string(), 0, false),
+        ]
+    );
+
+    // Collapsing the root hides its whole subtree, not just its direct child.
+    let collapsed = HashSet::from([SplitParent::Thread(root_thread_id)]);
+    let nested = Sidebar::nest_split_children(entries, &collapsed);
+    assert_eq!(
+        describe(&nested),
+        vec![
+            ("root".to_string(), 0, true),
+            ("unrelated".to_string(), 0, false),
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_split_parent_cycle_leaves_rows_visible(cx: &mut TestAppContext) {
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let first_id = TerminalId::new();
+    let second_id = TerminalId::new();
+    let terminal = |title: &str, terminal_id: TerminalId, split_parent: Option<SplitParent>| {
+        ListEntry::Terminal(TerminalEntry {
+            metadata: TerminalThreadMetadata {
+                terminal_id,
+                title: title.to_string().into(),
+                custom_title: None,
+                created_at: Utc::now(),
+                worktree_paths: WorktreePaths::default(),
+                remote_connection: None,
+                working_directory: None,
+                split_parent,
+            },
+            workspace: ThreadEntryWorkspace::Open(workspace.clone()),
+            worktrees: Vec::new(),
+            has_notification: false,
+            highlight_positions: Vec::new(),
+            depth: 0,
+            has_split_children: false,
+        })
+    };
+
+    let entries = vec![
+        terminal("first", first_id, Some(SplitParent::Terminal(second_id))),
+        terminal("second", second_id, Some(SplitParent::Terminal(first_id))),
+    ];
+
+    let nested = Sidebar::nest_split_children(entries.clone(), &HashSet::new());
+    assert_eq!(
+        nested.len(),
+        2,
+        "rows in a split-parent cycle must stay visible rather than vanish"
+    );
+
+    let collapsed = HashSet::from([SplitParent::Terminal(first_id)]);
+    let nested = Sidebar::nest_split_children(entries, &collapsed);
+    assert_eq!(
+        nested.len(),
+        1,
+        "a collapsed row in a cycle must remain visible"
+    );
+    assert!(matches!(
+        &nested[0],
+        ListEntry::Terminal(terminal) if terminal.metadata.terminal_id == first_id
+    ));
+}
+
+#[gpui::test]
 async fn test_neighboring_activatable_entry_stays_within_project(cx: &mut TestAppContext) {
     let project = init_test_project("/my-project", cx).await;
     let (multi_workspace, cx) =
@@ -1126,6 +1305,7 @@ async fn test_neighboring_activatable_entry_stays_within_project(cx: &mut TestAp
                 interacted_at: None,
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             icon: IconName::ZedAgent,
             icon_from_external_svg: None,
@@ -1138,6 +1318,8 @@ async fn test_neighboring_activatable_entry_stays_within_project(cx: &mut TestAp
             highlight_positions: Vec::new(),
             worktrees: Vec::new(),
             diff_stats: DiffStats::default(),
+            depth: 0,
+            has_split_children: false,
         }))
     };
 
@@ -1218,6 +1400,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     interacted_at: None,
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 icon: IconName::ZedAgent,
                 icon_from_external_svg: None,
@@ -1230,6 +1413,8 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                 highlight_positions: Vec::new(),
                 worktrees: Vec::new(),
                 diff_stats: DiffStats::default(),
+                depth: 0,
+                has_split_children: false,
             })),
             // Active thread with Running status
             ListEntry::Thread(Arc::new(ThreadEntry {
@@ -1245,6 +1430,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     interacted_at: None,
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 icon: IconName::ZedAgent,
                 icon_from_external_svg: None,
@@ -1257,6 +1443,8 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                 highlight_positions: Vec::new(),
                 worktrees: Vec::new(),
                 diff_stats: DiffStats::default(),
+                depth: 0,
+                has_split_children: false,
             })),
             // Active thread with Error status
             ListEntry::Thread(Arc::new(ThreadEntry {
@@ -1272,6 +1460,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     interacted_at: None,
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 icon: IconName::ZedAgent,
                 icon_from_external_svg: None,
@@ -1284,6 +1473,8 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                 highlight_positions: Vec::new(),
                 worktrees: Vec::new(),
                 diff_stats: DiffStats::default(),
+                depth: 0,
+                has_split_children: false,
             })),
             // Thread with WaitingForConfirmation status, not active
             // remote_connection: None,
@@ -1300,6 +1491,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     interacted_at: None,
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 icon: IconName::ZedAgent,
                 icon_from_external_svg: None,
@@ -1312,6 +1504,8 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                 highlight_positions: Vec::new(),
                 worktrees: Vec::new(),
                 diff_stats: DiffStats::default(),
+                depth: 0,
+                has_split_children: false,
             })),
             // Background thread that completed (should show notification)
             // remote_connection: None,
@@ -1328,6 +1522,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     interacted_at: None,
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 icon: IconName::ZedAgent,
                 icon_from_external_svg: None,
@@ -1340,6 +1535,8 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                 highlight_positions: Vec::new(),
                 worktrees: Vec::new(),
                 diff_stats: DiffStats::default(),
+                depth: 0,
+                has_split_children: false,
             })),
             // Collapsed project header
             ListEntry::ProjectHeader {
@@ -1803,6 +2000,35 @@ fn setup_sidebar_with_agent_panel(
 }
 
 #[gpui::test]
+async fn test_center_thread_updates_sidebar_active_entry(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    open_thread_with_connection(&panel, StubAgentConnection::new(), cx);
+    let thread_id = active_thread_id(&panel, cx);
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(panel.open_thread_in_center(thread_id, None, window, cx));
+    });
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert!(matches!(
+            &sidebar.active_entry,
+            Some(ActiveEntry::Thread {
+                thread_id: active_thread_id,
+                workspace: active_workspace,
+                ..
+            }) if *active_thread_id == thread_id && active_workspace == &workspace
+        ));
+    });
+}
+
+#[gpui::test]
 async fn test_agent_panel_terminals_appear_in_sidebar_and_search(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =
@@ -2027,6 +2253,7 @@ async fn test_terminal_metadata_is_deduped_across_project_groups(cx: &mut TestAp
         .unwrap(),
         remote_connection: None,
         working_directory: None,
+        split_parent: None,
     };
 
     cx.update(|_, cx| {
@@ -3258,6 +3485,7 @@ async fn test_thread_switcher_includes_terminal_metadata_for_open_project_group(
         .unwrap(),
         remote_connection: None,
         working_directory: None,
+        split_parent: None,
     };
     cx.update(|_, cx| {
         TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
@@ -3365,6 +3593,7 @@ async fn test_thread_switcher_preserves_closed_terminal_linked_worktree_workspac
         .unwrap(),
         remote_connection: None,
         working_directory: None,
+        split_parent: None,
     };
     cx.update(|_, cx| {
         TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
@@ -3513,6 +3742,7 @@ async fn test_archive_selected_terminal_archives_closed_linked_worktree(cx: &mut
         .unwrap(),
         remote_connection: None,
         working_directory: None,
+        split_parent: None,
     };
     cx.update(|_, cx| {
         TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
@@ -7578,6 +7808,7 @@ async fn test_sidebar_keeps_multi_root_thread_with_stale_main_paths(cx: &mut Tes
                     worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                     archived: false,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 cx,
             )
@@ -7661,6 +7892,7 @@ async fn test_activate_archived_thread_with_saved_paths_activates_matching_works
                 )])),
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             window,
             cx,
@@ -7731,6 +7963,7 @@ async fn test_activate_archived_thread_cwd_fallback_with_matching_workspace(
                 ])),
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             window,
             cx,
@@ -7797,6 +8030,7 @@ async fn test_activate_archived_thread_no_paths_no_cwd_uses_active_workspace(
                 worktree_paths: WorktreePaths::default(),
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             window,
             cx,
@@ -7855,6 +8089,7 @@ async fn test_activate_archived_thread_saved_paths_opens_new_workspace(cx: &mut 
                 worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             window,
             cx,
@@ -7914,6 +8149,7 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window(cx: &m
                 )])),
                 archived: false,
                 remote_connection: None,
+                split_parent: None,
             },
             window,
             cx,
@@ -7993,6 +8229,7 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window_with_t
         )])),
         archived: false,
         remote_connection: None,
+        split_parent: None,
     };
     seed_thread_metadata(metadata.clone(), cx_a);
 
@@ -8076,6 +8313,7 @@ async fn test_activate_archived_thread_prefers_current_window_for_matching_paths
         )])),
         archived: false,
         remote_connection: None,
+        split_parent: None,
     };
     seed_thread_metadata(metadata.clone(), cx_a);
 
@@ -8406,6 +8644,7 @@ async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppCon
             )])),
             archived: false,
             remote_connection: Some(remote_host),
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });
@@ -9060,6 +9299,7 @@ async fn test_archive_last_worktree_thread_not_blocked_by_remote_thread_at_same_
             )])),
             archived: false,
             remote_connection: Some(remote_host),
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| {
             store.save(metadata, cx);
@@ -9873,6 +10113,7 @@ async fn test_unarchive_first_thread_in_group_does_not_create_spurious_draft(
                     worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 cx,
             )
@@ -9967,6 +10208,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
                     worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 cx,
             )
@@ -10196,6 +10438,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
                     ])),
                     archived: true,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 cx,
             )
@@ -11049,6 +11292,7 @@ async fn test_unarchive_linked_worktree_thread_into_project_group_shows_only_res
                     .expect("main and folder paths should be well-formed"),
                     archived: true,
                     remote_connection: None,
+                    split_parent: None,
                 },
                 cx,
             )
@@ -11598,6 +11842,7 @@ async fn test_legacy_thread_with_canonical_path_opens_main_repo_workspace(cx: &m
             )])),
             archived: false,
             remote_connection: None,
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });
@@ -12586,6 +12831,7 @@ mod property_test {
             worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, path_list).unwrap(),
             archived: false,
             remote_connection: None,
+            split_parent: None,
         };
         cx.update(|_, cx| {
             ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx))
@@ -12659,6 +12905,7 @@ mod property_test {
                         worktree_paths: project.read(cx).worktree_paths(cx),
                         archived: false,
                         remote_connection: project.read(cx).remote_connection_options(cx),
+                        split_parent: None,
                     });
                     cx.update(|_, cx| {
                         ThreadMetadataStore::global(cx)
@@ -13527,6 +13774,7 @@ async fn test_remote_project_integration_does_not_briefly_render_as_separate_pro
             .unwrap(),
             archived: false,
             remote_connection,
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });
@@ -14492,6 +14740,7 @@ async fn test_remote_archive_thread_with_active_connection(
             .unwrap(),
             archived: false,
             remote_connection,
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });
@@ -14633,6 +14882,7 @@ async fn test_remote_linked_worktree_workspace_to_remove_uses_remote_connection(
             .unwrap(),
             archived: false,
             remote_connection: Some(remote_connection.clone()),
+            split_parent: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
     });

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -2029,6 +2029,213 @@ async fn test_center_thread_updates_sidebar_active_entry(cx: &mut TestAppContext
 }
 
 #[gpui::test]
+async fn test_splitting_terminal_into_center_closes_agent_panel(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let terminal_id = panel
+        .update_in(cx, |panel, window, cx| {
+            panel.insert_test_terminal("First", true, window, cx)
+        })
+        .expect("the origin terminal should be created");
+    cx.run_until_parked();
+
+    let metadata = cx.read(|cx| {
+        TerminalThreadMetadataStore::global(cx)
+            .read(cx)
+            .entry(terminal_id)
+            .cloned()
+            .expect("the origin terminal should have metadata")
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.focus_panel::<AgentPanel>(window, cx);
+    });
+    assert!(cx.read(|cx| AgentPanel::is_visible(&workspace, cx)));
+
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.split_entry_in_workspace(
+            &workspace,
+            SplitOrigin::Terminal(metadata),
+            NewEntryKind::Terminal,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    assert!(
+        !cx.read(|cx| AgentPanel::is_visible(&workspace, cx)),
+        "moving terminal work into center panes should not leave the Agent Panel visible"
+    );
+}
+
+#[gpui::test]
+async fn test_splitting_agent_into_center_keeps_draft_in_sidebar(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let terminal_id = panel
+        .update_in(cx, |panel, window, cx| {
+            panel.insert_test_terminal("First", true, window, cx)
+        })
+        .expect("the origin terminal should be created");
+    cx.run_until_parked();
+
+    let metadata = cx.read(|cx| {
+        TerminalThreadMetadataStore::global(cx)
+            .read(cx)
+            .entry(terminal_id)
+            .cloned()
+            .expect("the origin terminal should have metadata")
+    });
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.split_entry_in_workspace(
+            &workspace,
+            SplitOrigin::Terminal(metadata.clone()),
+            NewEntryKind::Thread(Agent::NativeAgent),
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    let center_thread_id = panel
+        .read_with(cx, |panel, cx| panel.active_center_thread_id(cx))
+        .expect("the new agent draft should be active in a center pane");
+    assert!(
+        sidebar.read_with(cx, |sidebar, _cx| {
+            sidebar.contents.entries.iter().any(|entry| {
+                matches!(entry, ListEntry::Thread(thread) if thread.metadata.thread_id == center_thread_id)
+            })
+        }),
+        "a center-owned empty agent draft should remain visible in the sidebar"
+    );
+
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.split_entry_in_workspace(
+            &workspace,
+            SplitOrigin::Terminal(metadata),
+            NewEntryKind::Thread(Agent::NativeAgent),
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    let second_center_thread_id = panel
+        .read_with(cx, |panel, cx| panel.active_center_thread_id(cx))
+        .expect("the second agent draft should be active in a center pane");
+    assert_ne!(center_thread_id, second_center_thread_id);
+    assert_eq!(
+        sidebar.read_with(cx, |sidebar, _cx| {
+            sidebar
+                .contents
+                .entries
+                .iter()
+                .filter(|entry| {
+                    matches!(entry, ListEntry::Thread(thread) if thread.metadata.thread_id == center_thread_id || thread.metadata.thread_id == second_center_thread_id)
+                })
+                .count()
+        }),
+        2,
+        "every empty agent draft that owns a center pane should remain visible in the sidebar"
+    );
+
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.remove_draft(
+            center_thread_id,
+            &ThreadEntryWorkspace::Open(workspace.clone()),
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    assert!(!panel.read_with(cx, |panel, _cx| {
+        panel.thread_is_in_center(center_thread_id)
+    }));
+    assert!(panel.read_with(cx, |panel, _cx| {
+        panel.thread_is_in_center(second_center_thread_id)
+    }));
+    assert!(
+        !sidebar.read_with(cx, |sidebar, _cx| {
+            sidebar.contents.entries.iter().any(|entry| {
+                matches!(entry, ListEntry::Thread(thread) if thread.metadata.thread_id == center_thread_id)
+            })
+        }),
+        "discarding a center-owned draft should remove its sidebar row"
+    );
+}
+
+#[gpui::test]
+async fn test_center_owned_draft_survives_activating_another_workspace(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/project-a", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let terminal_id = panel
+        .update_in(cx, |panel, window, cx| {
+            panel.insert_test_terminal("First", true, window, cx)
+        })
+        .expect("the origin terminal should be created");
+    cx.run_until_parked();
+
+    let metadata = cx.read(|cx| {
+        TerminalThreadMetadataStore::global(cx)
+            .read(cx)
+            .entry(terminal_id)
+            .cloned()
+            .expect("the origin terminal should have metadata")
+    });
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.split_entry_in_workspace(
+            &workspace,
+            SplitOrigin::Terminal(metadata),
+            NewEntryKind::Thread(Agent::NativeAgent),
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    let center_thread_id = panel
+        .read_with(cx, |panel, cx| panel.active_center_thread_id(cx))
+        .expect("the new agent draft should be active in a center pane");
+
+    // Activating a different workspace must not hide the first workspace's
+    // center-owned draft: the pane it owns is still open.
+    let fs = cx.update(|_, cx| <dyn fs::Fs>::global(cx));
+    let project_b = project::Project::test(fs, [], cx).await;
+    multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+        multi_workspace.test_add_workspace(project_b, window, cx);
+    });
+    cx.run_until_parked();
+
+    assert!(
+        sidebar.read_with(cx, |sidebar, _cx| {
+            sidebar.contents.entries.iter().any(|entry| {
+                matches!(entry, ListEntry::Thread(thread) if thread.metadata.thread_id == center_thread_id)
+            })
+        }),
+        "a center-owned empty draft should stay in the sidebar while another workspace is active"
+    );
+}
+
+#[gpui::test]
 async fn test_agent_panel_terminals_appear_in_sidebar_and_search(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =
@@ -2159,6 +2366,78 @@ async fn test_closing_last_agent_panel_terminal_restores_empty_header(cx: &mut T
         vec!["> [my-project]"]
     );
     assert_project_header_has_threads(&sidebar, "my-project", true, cx);
+}
+
+#[gpui::test]
+async fn test_closing_center_tab_closes_terminal_in_sidebar_and_panel(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+
+    let terminal_id = panel
+        .update_in(cx, |panel, window, cx| {
+            panel.insert_test_terminal("Dev Server", true, window, cx)
+        })
+        .expect("test terminal should be inserted");
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(panel.open_terminal_in_center(terminal_id, None, window, cx));
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .items_of_type::<agent_ui::AgentTerminalPane>(cx)
+                .count()
+        }),
+        1
+    );
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        let pane = workspace.active_pane().clone();
+        let item = workspace
+            .active_item_as::<agent_ui::AgentTerminalPane>(cx)
+            .expect("active item should be AgentTerminalPane");
+        pane.update(cx, |pane, cx| {
+            pane.close_item_by_id(item.entity_id(), workspace::SaveIntent::Skip, window, cx)
+                .detach();
+        });
+    });
+    cx.run_until_parked();
+
+    workspace.read_with(cx, |workspace, cx| {
+        assert_eq!(
+            workspace
+                .items_of_type::<agent_ui::AgentTerminalPane>(cx)
+                .count(),
+            0,
+            "center tab must be closed"
+        );
+    });
+
+    panel.read_with(cx, |panel, _cx| {
+        assert!(
+            !panel.has_terminal(terminal_id),
+            "terminal should be deleted from panel when center tab is closed"
+        );
+    });
+
+    let terminal_in_sidebar = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar.contents.entries.iter().any(|entry| match entry {
+            ListEntry::Terminal(terminal) => terminal.metadata.terminal_id == terminal_id,
+            _ => false,
+        })
+    });
+    assert!(
+        !terminal_in_sidebar,
+        "terminal should be removed from sidebar list when center tab is closed"
+    );
 }
 
 #[gpui::test]

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -1,4 +1,6 @@
-use crate::{CommonAnimationExt, DiffStat, GradientFade, HighlightedLabel, Tooltip, prelude::*};
+use crate::{
+    CommonAnimationExt, DiffStat, Disclosure, GradientFade, HighlightedLabel, Tooltip, prelude::*,
+};
 
 use gpui::{
     Animation, AnimationExt, ClickEvent, Hsla, MouseButton, SharedString,
@@ -64,6 +66,11 @@ pub struct ThreadItem {
     on_hover: Box<dyn Fn(&bool, &mut Window, &mut App) + 'static>,
     action_slot: Option<AnyElement>,
     base_bg: Option<Hsla>,
+    indent_level: usize,
+    split_toggle: Option<(
+        bool,
+        Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>,
+    )>,
 }
 
 impl ThreadItem {
@@ -99,11 +106,27 @@ impl ThreadItem {
             on_hover: Box::new(|_, _, _| {}),
             action_slot: None,
             base_bg: None,
+            indent_level: 0,
+            split_toggle: None,
         }
     }
 
     pub fn timestamp(mut self, timestamp: impl Into<SharedString>) -> Self {
         self.timestamp = timestamp.into();
+        self
+    }
+
+    pub fn indent_level(mut self, level: usize) -> Self {
+        self.indent_level = level;
+        self
+    }
+
+    pub fn split_toggle(
+        mut self,
+        expanded: bool,
+        on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.split_toggle = Some((expanded, Box::new(on_toggle)));
         self
     }
 
@@ -297,6 +320,35 @@ impl RenderOnce for ThreadItem {
                 .justify_center()
                 .when(!icon_visible, |this| this.invisible())
         };
+        let indent_level = self.indent_level;
+        let indent_guides = move || {
+            (0..indent_level).map(move |_| {
+                div()
+                    .w_3()
+                    .h_full()
+                    .flex_none()
+                    .border_l_1()
+                    .border_color(color.border_variant)
+            })
+        };
+
+        let toggle_id = format!("split-toggle-{}", self.id);
+        let toggle_slot =
+            |toggle: Option<(bool, Box<dyn Fn(&ClickEvent, &mut Window, &mut App)>)>| {
+                // A fixed-width slot either way, so a parent row's title stays
+                // aligned with the rows around it.
+                h_flex().w_4().flex_none().justify_center().when_some(
+                    toggle,
+                    |this, (expanded, on_toggle)| {
+                        this.child(
+                            Disclosure::new(toggle_id.clone(), expanded)
+                                .on_click(move |event, window, cx| on_toggle(event, window, cx)),
+                        )
+                    },
+                )
+            };
+        let has_split_toggle = self.split_toggle.is_some();
+
         let icon_color = self.icon_color.unwrap_or(Color::Muted);
         let agent_icon = if let Some(icon_char) = self.icon_char {
             Label::new(icon_char)
@@ -448,6 +500,10 @@ impl RenderOnce for ThreadItem {
                     .h_6()
                     .gap_2()
                     .justify_between()
+                    .children(indent_guides())
+                    .when_some(self.split_toggle, |this, toggle| {
+                        this.child(toggle_slot(Some(toggle)))
+                    })
                     .child(
                         h_flex()
                             .id("content")
@@ -487,6 +543,8 @@ impl RenderOnce for ThreadItem {
                 this.child(
                     h_flex()
                         .gap_1p5()
+                        .children(indent_guides())
+                        .when(has_split_toggle, |this| this.child(toggle_slot(None)))
                         .child(icon_container()) // Icon Spacing
                         .when(self.archived, |this| {
                             this.child(

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -9,6 +9,8 @@ use gpui::{
 use itertools::Itertools as _;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
+const MAX_INDENT_LEVEL: usize = 4;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum AgentThreadStatus {
     #[default]
@@ -320,7 +322,7 @@ impl RenderOnce for ThreadItem {
                 .justify_center()
                 .when(!icon_visible, |this| this.invisible())
         };
-        let indent_level = self.indent_level;
+        let indent_level = self.indent_level.min(MAX_INDENT_LEVEL);
         let indent_guides = move || {
             (0..indent_level).map(move |_| {
                 div()
@@ -342,6 +344,11 @@ impl RenderOnce for ThreadItem {
                     |this, (expanded, on_toggle)| {
                         this.child(
                             Disclosure::new(toggle_id.clone(), expanded)
+                                .tooltip(Tooltip::text(if expanded {
+                                    "Hide Split Threads"
+                                } else {
+                                    "Show Split Threads"
+                                }))
                                 .on_click(move |event, window, cx| on_toggle(event, window, cx)),
                         )
                     },
@@ -501,8 +508,8 @@ impl RenderOnce for ThreadItem {
                     .gap_2()
                     .justify_between()
                     .children(indent_guides())
-                    .when_some(self.split_toggle, |this, toggle| {
-                        this.child(toggle_slot(Some(toggle)))
+                    .when(has_split_toggle || self.indent_level > 0, |this| {
+                        this.child(toggle_slot(self.split_toggle))
                     })
                     .child(
                         h_flex()
@@ -544,7 +551,9 @@ impl RenderOnce for ThreadItem {
                     h_flex()
                         .gap_1p5()
                         .children(indent_guides())
-                        .when(has_split_toggle, |this| this.child(toggle_slot(None)))
+                        .when(has_split_toggle || self.indent_level > 0, |this| {
+                            this.child(toggle_slot(None))
+                        })
                         .child(icon_container()) // Icon Spacing
                         .when(self.archived, |this| {
                             this.child(


### PR DESCRIPTION
## Objective

Enable agent threads and terminals to split into center panes while preserving sidebar hierarchy and persisted state.

## Solution

- Add serializable center-pane adapters for agent conversations and terminals.
- Persist split-parent metadata and render nested, collapsible sidebar entries.
- Keep center-owned drafts and live status/notifications synchronized.
- Clean up the underlying terminal when its center tab closes.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p agent_ui --lib --no-fail-fast` (447 passed)
- `cargo test -p sidebar --lib --no-fail-fast` (151 passed)
- `./script/clippy -p agent_ui -p sidebar`
- `git diff --check`
- Manual macOS verification: created a terminal thread, invoked `Split → Zed Agent`, and verified the nested sidebar row plus side-by-side panes.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable; center views are deduplicated during aggregation

## Showcase

### Before

<img width="1624" height="974" alt="zed-agent-split-before" src="https://github.com/user-attachments/assets/f37e647e-fd8b-4e1c-b022-e83cf227f697" />

### After

<img width="1624" height="974" alt="zed-agent-split-after" src="https://github.com/user-attachments/assets/e54634ec-c994-4e41-8590-5618fb538ba4" />

The after capture shows a terminal and Zed Agent pane side by side, with the agent thread nested under its split parent in the Threads sidebar.

Release Notes:

- Improved splitting agent threads and terminals into center panes
