### PR TITLE
Configure code completion icons from settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -397,7 +397,7 @@
     "struct": "S",
     "event": "E",
     "operator": "o",
-    "type_parameter": "T"
+    "type_parameter": "T",
   },
   // How to display diffs in the editor.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -370,6 +370,35 @@
   // 2. Display a single-letter badge, colorized based on the active syntax theme:
   //   "symbol"
   "completion_menu_item_kind": "off",
+  // Symbols used to represent LSP item kinds in the completions menu.
+  // Each value must be a single Unicode character.
+  "completion_menu_item_kind_symbols": {
+    "text": "t",
+    "method": "m",
+    "function": "f",
+    "constructor": "C",
+    "field": "f",
+    "variable": "v",
+    "class": "c",
+    "interface": "i",
+    "module": "M",
+    "property": "p",
+    "unit": "u",
+    "value": "v",
+    "enum": "e",
+    "keyword": "k",
+    "snippet": "s",
+    "color": "c",
+    "file": "F",
+    "reference": "r",
+    "folder": "D",
+    "enum_member": "e",
+    "constant": "c",
+    "struct": "S",
+    "event": "E",
+    "operator": "o",
+    "type_parameter": "T"
+  },
   // How to display diffs in the editor.
   //
   // Default: split

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -43,7 +43,10 @@ use crate::{
 };
 use crate::{CodeActionSource, EditorSettings};
 use collections::{HashSet, VecDeque};
-use settings::{CompletionDetailAlignment, CompletionMenuItemKind, Settings, SnippetSortOrder};
+use settings::{
+    CompletionDetailAlignment, CompletionMenuItemKind, CompletionMenuItemKindSymbols, Settings,
+    SnippetSortOrder,
+};
 
 pub const MENU_GAP: Pixels = px(4.);
 pub const MENU_ASIDE_X_PADDING: Pixels = px(16.);
@@ -920,6 +923,7 @@ impl CompletionsMenu {
         let editor_settings = EditorSettings::get_global(cx);
         let completion_detail_alignment = editor_settings.completion_detail_alignment;
         let completion_menu_item_kind = editor_settings.completion_menu_item_kind;
+        let completion_menu_item_kind_symbols = editor_settings.completion_menu_item_kind_symbols;
         let widest_completion_ix = if self.display_options.dynamic_width {
             let completions = self.completions.borrow();
             let widest_completion_ix = self
@@ -1135,6 +1139,7 @@ impl CompletionsMenu {
                                 completion.kind(),
                                 item_ix,
                                 &style,
+                                &completion_menu_item_kind_symbols,
                             )),
                         };
 
@@ -1658,6 +1663,7 @@ fn render_completion_kind_letter(
     kind: Option<CompletionItemKind>,
     item_ix: usize,
     style: &EditorStyle,
+    symbols: &CompletionMenuItemKindSymbols,
 ) -> AnyElement {
     let badge = div()
         .flex_none()
@@ -1669,7 +1675,7 @@ fn render_completion_kind_letter(
     let Some(kind) = kind else {
         return badge.into_any_element();
     };
-    let Some(letter) = completion_kind_letter(kind) else {
+    let Some(letter) = completion_kind_symbol(kind, symbols) else {
         return badge.into_any_element();
     };
 
@@ -1685,7 +1691,7 @@ fn render_completion_kind_letter(
     badge
         .id(("completion-kind", item_ix))
         .tooltip(Tooltip::text(completion_kind_name(kind)))
-        .child(letter)
+        .child(SharedString::from(letter))
         .when_some(color, |element, color| element.text_color(color))
         .into_any_element()
 }
@@ -1721,35 +1727,38 @@ fn completion_kind_name(kind: CompletionItemKind) -> &'static str {
     }
 }
 
-fn completion_kind_letter(kind: CompletionItemKind) -> Option<&'static str> {
-    Some(match kind {
-        CompletionItemKind::TEXT => "t",
-        CompletionItemKind::METHOD => "m",
-        CompletionItemKind::FUNCTION => "f",
-        CompletionItemKind::CONSTRUCTOR => "C",
-        CompletionItemKind::FIELD => "f",
-        CompletionItemKind::VARIABLE => "v",
-        CompletionItemKind::CLASS => "c",
-        CompletionItemKind::INTERFACE => "i",
-        CompletionItemKind::MODULE => "M",
-        CompletionItemKind::PROPERTY => "p",
-        CompletionItemKind::UNIT => "u",
-        CompletionItemKind::VALUE => "v",
-        CompletionItemKind::ENUM => "e",
-        CompletionItemKind::KEYWORD => "k",
-        CompletionItemKind::SNIPPET => "s",
-        CompletionItemKind::COLOR => "c",
-        CompletionItemKind::FILE => "F",
-        CompletionItemKind::REFERENCE => "r",
-        CompletionItemKind::FOLDER => "D",
-        CompletionItemKind::ENUM_MEMBER => "e",
-        CompletionItemKind::CONSTANT => "c",
-        CompletionItemKind::STRUCT => "S",
-        CompletionItemKind::EVENT => "E",
-        CompletionItemKind::OPERATOR => "o",
-        CompletionItemKind::TYPE_PARAMETER => "T",
-        _ => return None,
-    })
+fn completion_kind_symbol(
+    kind: CompletionItemKind,
+    symbols: &CompletionMenuItemKindSymbols,
+) -> Option<char> {
+    match kind {
+        CompletionItemKind::TEXT => symbols.text,
+        CompletionItemKind::METHOD => symbols.method,
+        CompletionItemKind::FUNCTION => symbols.function,
+        CompletionItemKind::CONSTRUCTOR => symbols.constructor,
+        CompletionItemKind::FIELD => symbols.field,
+        CompletionItemKind::VARIABLE => symbols.variable,
+        CompletionItemKind::CLASS => symbols.class,
+        CompletionItemKind::INTERFACE => symbols.interface,
+        CompletionItemKind::MODULE => symbols.module,
+        CompletionItemKind::PROPERTY => symbols.property,
+        CompletionItemKind::UNIT => symbols.unit,
+        CompletionItemKind::VALUE => symbols.value,
+        CompletionItemKind::ENUM => symbols.r#enum,
+        CompletionItemKind::KEYWORD => symbols.keyword,
+        CompletionItemKind::SNIPPET => symbols.snippet,
+        CompletionItemKind::COLOR => symbols.color,
+        CompletionItemKind::FILE => symbols.file,
+        CompletionItemKind::REFERENCE => symbols.reference,
+        CompletionItemKind::FOLDER => symbols.folder,
+        CompletionItemKind::ENUM_MEMBER => symbols.enum_member,
+        CompletionItemKind::CONSTANT => symbols.constant,
+        CompletionItemKind::STRUCT => symbols.r#struct,
+        CompletionItemKind::EVENT => symbols.event,
+        CompletionItemKind::OPERATOR => symbols.operator,
+        CompletionItemKind::TYPE_PARAMETER => symbols.type_parameter,
+        _ => None,
+    }
 }
 
 fn completion_kind_highlight_name(kind: CompletionItemKind) -> Option<&'static str> {
@@ -2172,6 +2181,33 @@ mod tests {
             fade_out: Some(0.5),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_completion_kind_symbol_uses_configured_symbols() {
+        let symbols = CompletionMenuItemKindSymbols {
+            function: Some('λ'),
+            r#enum: Some('ε'),
+            type_parameter: Some('τ'),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            completion_kind_symbol(CompletionItemKind::FUNCTION, &symbols),
+            Some('λ')
+        );
+        assert_eq!(
+            completion_kind_symbol(CompletionItemKind::ENUM, &symbols),
+            Some('ε')
+        );
+        assert_eq!(
+            completion_kind_symbol(CompletionItemKind::TYPE_PARAMETER, &symbols),
+            Some('τ')
+        );
+        assert_eq!(
+            completion_kind_symbol(CompletionItemKind::METHOD, &symbols),
+            None
+        );
     }
 
     #[test]

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1133,9 +1133,9 @@ impl CompletionsMenu {
                                 })
                             });
 
-                        let kind_letter_slot = match completion_menu_item_kind {
+                        let kind_symbol_slot = match completion_menu_item_kind {
                             CompletionMenuItemKind::Off => None,
-                            CompletionMenuItemKind::Symbol => Some(render_completion_kind_letter(
+                            CompletionMenuItemKind::Symbol => Some(render_completion_kind_symbol(
                                 completion.kind(),
                                 item_ix,
                                 &style,
@@ -1143,15 +1143,15 @@ impl CompletionsMenu {
                             )),
                         };
 
-                        let start_slot = match (kind_letter_slot, icon_or_color_slot) {
-                            (Some(letter), Some(icon_or_color)) => Some(
+                        let start_slot = match (kind_symbol_slot, icon_or_color_slot) {
+                            (Some(kind_symbol), Some(icon_or_color)) => Some(
                                 h_flex()
                                     .gap_0p5()
-                                    .child(letter)
+                                    .child(kind_symbol)
                                     .child(icon_or_color)
                                     .into_any_element(),
                             ),
-                            (Some(letter), None) => Some(letter),
+                            (Some(kind_symbol), None) => Some(kind_symbol),
                             (None, slot) => slot,
                         };
 
@@ -1659,11 +1659,11 @@ impl CompletionsMenu {
     }
 }
 
-fn render_completion_kind_letter(
+fn render_completion_kind_symbol(
     kind: Option<CompletionItemKind>,
     item_ix: usize,
     style: &EditorStyle,
-    symbols: &CompletionMenuItemKindSymbols,
+    render_completion_kind_symbols: &CompletionMenuItemKindSymbols,
 ) -> AnyElement {
     let badge = div()
         .flex_none()
@@ -1675,7 +1675,7 @@ fn render_completion_kind_letter(
     let Some(kind) = kind else {
         return badge.into_any_element();
     };
-    let Some(letter) = completion_kind_symbol(kind, symbols) else {
+    let Some(symbol) = completion_kind_symbol(kind, render_completion_kind_symbols) else {
         return badge.into_any_element();
     };
 
@@ -1691,7 +1691,7 @@ fn render_completion_kind_letter(
     badge
         .id(("completion-kind", item_ix))
         .tooltip(Tooltip::text(completion_kind_name(kind)))
-        .child(SharedString::from(letter))
+        .child(SharedString::from(symbol))
         .when_some(color, |element, color| element.text_color(color))
         .into_any_element()
 }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -41,12 +41,9 @@ use crate::{
     actions::{ConfirmCodeAction, ConfirmCompletion},
     split_words, styled_runs_for_code_label,
 };
-use crate::{CodeActionSource, EditorSettings};
+use crate::{CodeActionSource, CompletionMenuItemKindSymbols, EditorSettings};
 use collections::{HashSet, VecDeque};
-use settings::{
-    CompletionDetailAlignment, CompletionMenuItemKind, CompletionMenuItemKindSymbols, Settings,
-    SnippetSortOrder,
-};
+use settings::{CompletionDetailAlignment, CompletionMenuItemKind, Settings, SnippetSortOrder};
 
 pub const MENU_GAP: Pixels = px(4.);
 pub const MENU_ASIDE_X_PADDING: Pixels = px(16.);
@@ -1732,31 +1729,31 @@ fn completion_kind_symbol(
     symbols: &CompletionMenuItemKindSymbols,
 ) -> Option<char> {
     match kind {
-        CompletionItemKind::TEXT => symbols.text,
-        CompletionItemKind::METHOD => symbols.method,
-        CompletionItemKind::FUNCTION => symbols.function,
-        CompletionItemKind::CONSTRUCTOR => symbols.constructor,
-        CompletionItemKind::FIELD => symbols.field,
-        CompletionItemKind::VARIABLE => symbols.variable,
-        CompletionItemKind::CLASS => symbols.class,
-        CompletionItemKind::INTERFACE => symbols.interface,
-        CompletionItemKind::MODULE => symbols.module,
-        CompletionItemKind::PROPERTY => symbols.property,
-        CompletionItemKind::UNIT => symbols.unit,
-        CompletionItemKind::VALUE => symbols.value,
-        CompletionItemKind::ENUM => symbols.r#enum,
-        CompletionItemKind::KEYWORD => symbols.keyword,
-        CompletionItemKind::SNIPPET => symbols.snippet,
-        CompletionItemKind::COLOR => symbols.color,
-        CompletionItemKind::FILE => symbols.file,
-        CompletionItemKind::REFERENCE => symbols.reference,
-        CompletionItemKind::FOLDER => symbols.folder,
-        CompletionItemKind::ENUM_MEMBER => symbols.enum_member,
-        CompletionItemKind::CONSTANT => symbols.constant,
-        CompletionItemKind::STRUCT => symbols.r#struct,
-        CompletionItemKind::EVENT => symbols.event,
-        CompletionItemKind::OPERATOR => symbols.operator,
-        CompletionItemKind::TYPE_PARAMETER => symbols.type_parameter,
+        CompletionItemKind::TEXT => Some(symbols.text),
+        CompletionItemKind::METHOD => Some(symbols.method),
+        CompletionItemKind::FUNCTION => Some(symbols.function),
+        CompletionItemKind::CONSTRUCTOR => Some(symbols.constructor),
+        CompletionItemKind::FIELD => Some(symbols.field),
+        CompletionItemKind::VARIABLE => Some(symbols.variable),
+        CompletionItemKind::CLASS => Some(symbols.class),
+        CompletionItemKind::INTERFACE => Some(symbols.interface),
+        CompletionItemKind::MODULE => Some(symbols.module),
+        CompletionItemKind::PROPERTY => Some(symbols.property),
+        CompletionItemKind::UNIT => Some(symbols.unit),
+        CompletionItemKind::VALUE => Some(symbols.value),
+        CompletionItemKind::ENUM => Some(symbols.r#enum),
+        CompletionItemKind::KEYWORD => Some(symbols.keyword),
+        CompletionItemKind::SNIPPET => Some(symbols.snippet),
+        CompletionItemKind::COLOR => Some(symbols.color),
+        CompletionItemKind::FILE => Some(symbols.file),
+        CompletionItemKind::REFERENCE => Some(symbols.reference),
+        CompletionItemKind::FOLDER => Some(symbols.folder),
+        CompletionItemKind::ENUM_MEMBER => Some(symbols.enum_member),
+        CompletionItemKind::CONSTANT => Some(symbols.constant),
+        CompletionItemKind::STRUCT => Some(symbols.r#struct),
+        CompletionItemKind::EVENT => Some(symbols.event),
+        CompletionItemKind::OPERATOR => Some(symbols.operator),
+        CompletionItemKind::TYPE_PARAMETER => Some(symbols.type_parameter),
         _ => None,
     }
 }
@@ -2181,33 +2178,6 @@ mod tests {
             fade_out: Some(0.5),
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn test_completion_kind_symbol_uses_configured_symbols() {
-        let symbols = CompletionMenuItemKindSymbols {
-            function: Some('λ'),
-            r#enum: Some('ε'),
-            type_parameter: Some('τ'),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            completion_kind_symbol(CompletionItemKind::FUNCTION, &symbols),
-            Some('λ')
-        );
-        assert_eq!(
-            completion_kind_symbol(CompletionItemKind::ENUM, &symbols),
-            Some('ε')
-        );
-        assert_eq!(
-            completion_kind_symbol(CompletionItemKind::TYPE_PARAMETER, &symbols),
-            Some('τ')
-        );
-        assert_eq!(
-            completion_kind_symbol(CompletionItemKind::METHOD, &symbols),
-            None
-        );
     }
 
     #[test]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -97,10 +97,10 @@ pub(crate) use edit_prediction::{
 pub use edit_prediction_types::Direction;
 pub use edit_prediction_types::EditPredictionRequestTrigger;
 pub use editor_settings::{
-    CompletionDetailAlignment, CompletionMenuItemKind, CurrentLineHighlight, DiffViewStyle,
-    DocumentColorsRenderMode, EditorSettings, EditorSettingsScrollbarProxy, OpenResultsIn,
-    ScrollBeyondLastLine, ScrollbarAxes, SearchSettings, ShowMinimap,
-    ui_scrollbar_settings_from_raw,
+    CompletionDetailAlignment, CompletionMenuItemKind, CompletionMenuItemKindSymbols,
+    CurrentLineHighlight, DiffViewStyle, DocumentColorsRenderMode, EditorSettings,
+    EditorSettingsScrollbarProxy, OpenResultsIn, ScrollBeyondLastLine, ScrollbarAxes,
+    SearchSettings, ShowMinimap, ui_scrollbar_settings_from_raw,
 };
 pub use element::{
     CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, PointForPosition,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -4,11 +4,11 @@ use gpui::App;
 use language::CursorShape;
 use project::project_settings::DiagnosticSeverity;
 pub use settings::{
-    CodeLens, CompletionDetailAlignment, CompletionMenuItemKind, CompletionMenuItemKindSymbols,
-    CurrentLineHighlight, DelayMs, DiffViewStyle, DisplayIn, DocumentColorsRenderMode,
-    DoubleClickInMultibuffer, GitGutterWidth, GoToDefinitionFallback, GoToDefinitionScrollStrategy,
-    MinimapThumb, MinimapThumbBorder, MultiCursorModifier, OpenResultsIn, ScrollBeyondLastLine,
-    ScrollbarDiagnostics, SeedQuerySetting, ShowMinimap, SnippetSortOrder,
+    CodeLens, CompletionDetailAlignment, CompletionMenuItemKind, CurrentLineHighlight, DelayMs,
+    DiffViewStyle, DisplayIn, DocumentColorsRenderMode, DoubleClickInMultibuffer, GitGutterWidth,
+    GoToDefinitionFallback, GoToDefinitionScrollStrategy, MinimapThumb, MinimapThumbBorder,
+    MultiCursorModifier, OpenResultsIn, ScrollBeyondLastLine, ScrollbarDiagnostics,
+    SeedQuerySetting, ShowMinimap, SnippetSortOrder,
 };
 use settings::{RegisterSetting, RelativeLineNumbers, Settings};
 use ui::scrollbars::ShowScrollbar;
@@ -72,6 +72,35 @@ pub struct EditorSettings {
     pub diff_view_style: DiffViewStyle,
     pub minimum_split_diff_width: f32,
     pub file_diff: FileDiffSettings,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CompletionMenuItemKindSymbols {
+    pub text: char,
+    pub method: char,
+    pub function: char,
+    pub constructor: char,
+    pub field: char,
+    pub variable: char,
+    pub class: char,
+    pub interface: char,
+    pub module: char,
+    pub property: char,
+    pub unit: char,
+    pub value: char,
+    pub r#enum: char,
+    pub keyword: char,
+    pub snippet: char,
+    pub color: char,
+    pub file: char,
+    pub reference: char,
+    pub folder: char,
+    pub enum_member: char,
+    pub constant: char,
+    pub r#struct: char,
+    pub event: char,
+    pub operator: char,
+    pub type_parameter: char,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -219,6 +248,7 @@ impl Settings for EditorSettings {
         let drag_and_drop_selection = editor.drag_and_drop_selection.unwrap();
         let sticky_scroll = editor.sticky_scroll.unwrap();
         let file_diff = content.git.as_ref().unwrap().file_diff.unwrap();
+        let completion_menu_item_kind_symbols = editor.completion_menu_item_kind_symbols.unwrap();
         Self {
             cursor_blink: editor.cursor_blink.unwrap(),
             cursor_shape: editor.cursor_shape.map(Into::into),
@@ -329,7 +359,33 @@ impl Settings for EditorSettings {
                 .unwrap(),
             completion_detail_alignment: editor.completion_detail_alignment.unwrap(),
             completion_menu_item_kind: editor.completion_menu_item_kind.unwrap(),
-            completion_menu_item_kind_symbols: editor.completion_menu_item_kind_symbols.unwrap(),
+            completion_menu_item_kind_symbols: CompletionMenuItemKindSymbols {
+                text: completion_menu_item_kind_symbols.text.unwrap(),
+                method: completion_menu_item_kind_symbols.method.unwrap(),
+                function: completion_menu_item_kind_symbols.function.unwrap(),
+                constructor: completion_menu_item_kind_symbols.constructor.unwrap(),
+                field: completion_menu_item_kind_symbols.field.unwrap(),
+                variable: completion_menu_item_kind_symbols.variable.unwrap(),
+                class: completion_menu_item_kind_symbols.class.unwrap(),
+                interface: completion_menu_item_kind_symbols.interface.unwrap(),
+                module: completion_menu_item_kind_symbols.module.unwrap(),
+                property: completion_menu_item_kind_symbols.property.unwrap(),
+                unit: completion_menu_item_kind_symbols.unit.unwrap(),
+                value: completion_menu_item_kind_symbols.value.unwrap(),
+                r#enum: completion_menu_item_kind_symbols.r#enum.unwrap(),
+                keyword: completion_menu_item_kind_symbols.keyword.unwrap(),
+                snippet: completion_menu_item_kind_symbols.snippet.unwrap(),
+                color: completion_menu_item_kind_symbols.color.unwrap(),
+                file: completion_menu_item_kind_symbols.file.unwrap(),
+                reference: completion_menu_item_kind_symbols.reference.unwrap(),
+                folder: completion_menu_item_kind_symbols.folder.unwrap(),
+                enum_member: completion_menu_item_kind_symbols.enum_member.unwrap(),
+                constant: completion_menu_item_kind_symbols.constant.unwrap(),
+                r#struct: completion_menu_item_kind_symbols.r#struct.unwrap(),
+                event: completion_menu_item_kind_symbols.event.unwrap(),
+                operator: completion_menu_item_kind_symbols.operator.unwrap(),
+                type_parameter: completion_menu_item_kind_symbols.type_parameter.unwrap(),
+            },
             diff_view_style: editor.diff_view_style.unwrap(),
             minimum_split_diff_width: editor.minimum_split_diff_width.unwrap(),
             file_diff: FileDiffSettings {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -4,11 +4,11 @@ use gpui::App;
 use language::CursorShape;
 use project::project_settings::DiagnosticSeverity;
 pub use settings::{
-    CodeLens, CompletionDetailAlignment, CompletionMenuItemKind, CurrentLineHighlight, DelayMs,
-    DiffViewStyle, DisplayIn, DocumentColorsRenderMode, DoubleClickInMultibuffer, GitGutterWidth,
-    GoToDefinitionFallback, GoToDefinitionScrollStrategy, MinimapThumb, MinimapThumbBorder,
-    MultiCursorModifier, OpenResultsIn, ScrollBeyondLastLine, ScrollbarDiagnostics,
-    SeedQuerySetting, ShowMinimap, SnippetSortOrder,
+    CodeLens, CompletionDetailAlignment, CompletionMenuItemKind, CompletionMenuItemKindSymbols,
+    CurrentLineHighlight, DelayMs, DiffViewStyle, DisplayIn, DocumentColorsRenderMode,
+    DoubleClickInMultibuffer, GitGutterWidth, GoToDefinitionFallback, GoToDefinitionScrollStrategy,
+    MinimapThumb, MinimapThumbBorder, MultiCursorModifier, OpenResultsIn, ScrollBeyondLastLine,
+    ScrollbarDiagnostics, SeedQuerySetting, ShowMinimap, SnippetSortOrder,
 };
 use settings::{RegisterSetting, RelativeLineNumbers, Settings};
 use ui::scrollbars::ShowScrollbar;
@@ -68,6 +68,7 @@ pub struct EditorSettings {
     pub completion_menu_scrollbar: ShowScrollbar,
     pub completion_detail_alignment: CompletionDetailAlignment,
     pub completion_menu_item_kind: CompletionMenuItemKind,
+    pub completion_menu_item_kind_symbols: CompletionMenuItemKindSymbols,
     pub diff_view_style: DiffViewStyle,
     pub minimum_split_diff_width: f32,
     pub file_diff: FileDiffSettings,
@@ -328,6 +329,7 @@ impl Settings for EditorSettings {
                 .unwrap(),
             completion_detail_alignment: editor.completion_detail_alignment.unwrap(),
             completion_menu_item_kind: editor.completion_menu_item_kind.unwrap(),
+            completion_menu_item_kind_symbols: editor.completion_menu_item_kind_symbols.unwrap(),
             diff_view_style: editor.diff_view_style.unwrap(),
             minimum_split_diff_width: editor.minimum_split_diff_width.unwrap(),
             file_diff: FileDiffSettings {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -325,6 +325,7 @@ impl VsCodeSettings {
             completion_menu_scrollbar: None,
             completion_detail_alignment: None,
             completion_menu_item_kind: None,
+            completion_menu_item_kind_symbols: None,
             diff_view_style: None,
             minimum_split_diff_width: None,
         }

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -1243,37 +1243,6 @@ impl Default for CenteredPaddingSettings {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::merge_from::MergeFrom as _;
-
-    #[test]
-    fn completion_menu_item_kind_symbols_merge_individually() {
-        let mut defaults = EditorSettingsContent {
-            completion_menu_item_kind_symbols: Some(CompletionMenuItemKindSymbols {
-                method: Some('m'),
-                function: Some('f'),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let user = EditorSettingsContent {
-            completion_menu_item_kind_symbols: Some(CompletionMenuItemKindSymbols {
-                function: Some('λ'),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        defaults.merge_from(&user);
-
-        let symbols = defaults.completion_menu_item_kind_symbols.unwrap();
-        assert_eq!(symbols.method, Some('m'));
-        assert_eq!(symbols.function, Some('λ'));
-    }
-}
-
 impl schemars::JsonSchema for CenteredPaddingSettings {
     fn schema_name() -> std::borrow::Cow<'static, str> {
         "CenteredPaddingSettings".into()

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -273,6 +273,11 @@ pub struct EditorSettingsContent {
     /// Default: off
     pub completion_menu_item_kind: Option<CompletionMenuItemKind>,
 
+    /// Symbols used to represent LSP item kinds in the completions menu.
+    /// Each value must be a single Unicode character. Unspecified values inherit
+    /// their defaults.
+    pub completion_menu_item_kind_symbols: Option<CompletionMenuItemKindSymbols>,
+
     /// How to display diffs in the editor.
     ///
     /// Default: split
@@ -347,6 +352,38 @@ pub enum CompletionMenuItemKind {
     #[default]
     Off,
     Symbol,
+}
+
+#[with_fallible_options]
+#[derive(
+    Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq,
+)]
+pub struct CompletionMenuItemKindSymbols {
+    pub text: Option<char>,
+    pub method: Option<char>,
+    pub function: Option<char>,
+    pub constructor: Option<char>,
+    pub field: Option<char>,
+    pub variable: Option<char>,
+    pub class: Option<char>,
+    pub interface: Option<char>,
+    pub module: Option<char>,
+    pub property: Option<char>,
+    pub unit: Option<char>,
+    pub value: Option<char>,
+    pub r#enum: Option<char>,
+    pub keyword: Option<char>,
+    pub snippet: Option<char>,
+    pub color: Option<char>,
+    pub file: Option<char>,
+    pub reference: Option<char>,
+    pub folder: Option<char>,
+    pub enum_member: Option<char>,
+    pub constant: Option<char>,
+    pub r#struct: Option<char>,
+    pub event: Option<char>,
+    pub operator: Option<char>,
+    pub type_parameter: Option<char>,
 }
 
 impl RelativeLineNumbers {
@@ -1203,6 +1240,37 @@ impl From<f32> for CenteredPaddingSettings {
 impl Default for CenteredPaddingSettings {
     fn default() -> Self {
         Self(Self::DEFAULT_PADDING as f32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge_from::MergeFrom as _;
+
+    #[test]
+    fn completion_menu_item_kind_symbols_merge_individually() {
+        let mut defaults = EditorSettingsContent {
+            completion_menu_item_kind_symbols: Some(CompletionMenuItemKindSymbols {
+                method: Some('m'),
+                function: Some('f'),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let user = EditorSettingsContent {
+            completion_menu_item_kind_symbols: Some(CompletionMenuItemKindSymbols {
+                function: Some('λ'),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        defaults.merge_from(&user);
+
+        let symbols = defaults.completion_menu_item_kind_symbols.unwrap();
+        assert_eq!(symbols.method, Some('m'));
+        assert_eq!(symbols.function, Some('λ'));
     }
 }
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -408,6 +408,36 @@ TBD: Centered layout related settings
   // of each entry in the completions menu. "symbol" shows a syntax-colored
   // single-letter badge.
   "completion_menu_item_kind": "off", // off, symbol
+  // Customize the single-character symbols used for completion item kinds.
+  // Symbols must be supported by the UI font or one of its fallbacks. To use
+  // Nerd Font glyphs, configure a Nerd Font as the UI font or a fallback.
+  "completion_menu_item_kind_symbols": {
+    "text": "t",
+    "method": "m",
+    "function": "f",
+    "constructor": "C",
+    "field": "f",
+    "variable": "v",
+    "class": "c",
+    "interface": "i",
+    "module": "M",
+    "property": "p",
+    "unit": "u",
+    "value": "v",
+    "enum": "e",
+    "keyword": "k",
+    "snippet": "s",
+    "color": "c",
+    "file": "F",
+    "reference": "r",
+    "folder": "D",
+    "enum_member": "e",
+    "constant": "c",
+    "struct": "S",
+    "event": "E",
+    "operator": "o",
+    "type_parameter": "T"
+  },
   // Turn on colorization of brackets in editors (configurable per language)
   "colorize_brackets": true,
 ```


### PR DESCRIPTION
# Objective

- Adds possibility to configure the Code completion icons described in #4943 

## Solution

- Keep hardcoded characters as `default.json` and merge custom from settings

## Testing

Scenarios:

- Without configuration - default was used
- Only certain fields in configuration - only configured fields were updated
- Empty `completion_menu_item_kind_symbols` block - default was used
- A word as a symbol - only invalid completion kind fall back to default

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

When combined with Nerd Font UI font or NF ui font fallback draws icons for completion items.

<img width="705" height="485" alt="image" src="https://github.com/user-attachments/assets/037c3718-af2f-48df-bccb-408dcd74760b" />

---

Release Notes:

- Added configurable code completion icons
