### PR TITLE
Fix fallback for non-image files

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -1090,6 +1090,7 @@ mod tests {
     use fs::{FakeFs, Fs as _};
     use gpui::{TestAppContext, VisualTestContext};
     use settings::SettingsStore;
+    use std::any::TypeId;
     use util::rel_path::rel_path;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -1346,6 +1347,53 @@ mod tests {
         cx.draw(point(px(0.), px(0.)), size(px(1.), px(1.)), |_, _| {
             split_image_view.clone().into_any_element()
         });
+    }
+
+    #[gpui::test]
+    async fn test_non_image_file_with_image_extension_opens_in_editor(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            editor::init(cx);
+            crate::init(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.create_dir(Path::new("/root"))
+            .await
+            .expect("test root should be created");
+        fs.insert_file("/root/test.pam", b"hello".to_vec()).await;
+
+        let project = Project::test(fs, [Path::new("/root")], cx).await;
+        let worktree_id = cx.update(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .expect("test project should contain a worktree")
+                .read(cx)
+                .id()
+        });
+
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let handle = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    ProjectPath {
+                        worktree_id,
+                        path: rel_path("test.pam").into(),
+                    },
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(handle.to_any_view().entity_type(), TypeId::of::<Editor>());
     }
 }
 

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Project, ProjectEntryId, ProjectItem, ProjectPath,
+    Project, ProjectEntryId, ProjectItem, ProjectItemNotApplicable, ProjectPath,
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
 use anyhow::{Context as _, Result};
@@ -462,7 +462,13 @@ impl ImageStore {
         cx.background_spawn(async move {
             Self::wait_for_loading_image(loading_watch)
                 .await
-                .map_err(|e| e.cloned())
+                .map_err(|e| {
+                    if e.is::<ProjectItemNotApplicable>() {
+                        anyhow::anyhow!(ProjectItemNotApplicable)
+                    } else {
+                        e.cloned()
+                    }
+                })
         })
     }
 
@@ -932,7 +938,9 @@ impl LocalImageStore {
 }
 
 fn create_gpui_image(content: Vec<u8>) -> anyhow::Result<Arc<gpui::Image>> {
-    let format = image::guess_format(&content)?;
+    let Ok(format) = image::guess_format(&content) else {
+        anyhow::bail!(ProjectItemNotApplicable);
+    };
 
     Ok(Arc::new(gpui::Image::from_bytes(
         match format {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -201,6 +201,17 @@ pub trait ProjectItem: 'static {
     fn is_dirty(&self) -> bool;
 }
 
+/// Returned by a [`ProjectItem::try_open`] task when async inspection shows the path is not
+/// applicable after all, so the next registered opener should be tried.
+#[derive(Debug)]
+pub struct ProjectItemNotApplicable;
+
+impl std::fmt::Display for ProjectItemNotApplicable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "project item not applicable")
+    }
+}
+
 #[derive(Clone)]
 pub enum OpenedBufferEvent {
     Disconnected,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -97,8 +97,8 @@ pub use persistence::{
 use persistence::{SerializedWindowBounds, model::SerializedWorkspace};
 use postage::stream::Stream;
 use project::{
-    DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
-    WorktreeSettings,
+    DirectoryLister, Project, ProjectEntryId, ProjectItemNotApplicable, ProjectPath, ResolvedPath,
+    Worktree, WorktreeId, WorktreeSettings,
     debugger::{breakpoint_store::BreakpointStoreEvent, session::ThreadStatus},
     project_settings::ProjectSettings,
     toolchain_store::ToolchainStoreEvent,
@@ -964,6 +964,9 @@ impl ProjectItemRegistry {
                             Ok((project_entry_id, build_workspace_item))
                         }
                         Err(e) => {
+                            if e.is::<ProjectItemNotApplicable>() {
+                                return Err(e);
+                            }
                             log::warn!("Failed to open a project item: {e:#}");
                             if e.error_code() == ErrorCode::Internal {
                                 if let Some(abs_path) =
@@ -1000,15 +1003,21 @@ impl ProjectItemRegistry {
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<(Option<ProjectEntryId>, WorkspaceItemBuilder)>> {
-        let Some(open_project_item) = self
-            .build_project_item_for_path_fns
-            .iter()
-            .rev()
-            .find_map(|open_project_item| open_project_item(project, path, window, cx))
-        else {
-            return Task::ready(Err(anyhow!("cannot open file {:?}", path.path)));
-        };
-        open_project_item
+        let builders = self.build_project_item_for_path_fns.clone();
+        let project = project.clone();
+        let path = path.clone();
+        window.spawn(cx, async move |cx| {
+            for build in builders.iter().rev() {
+                let Some(open) = cx.update(|window, cx| build(&project, &path, window, cx))? else {
+                    continue;
+                };
+                match open.await {
+                    Err(e) if e.is::<ProjectItemNotApplicable>() => continue,
+                    result => return result,
+                }
+            }
+            Err(anyhow!("cannot open file {:?}", path.path))
+        })
     }
 
     fn build_item<T: project::ProjectItem>(


### PR DESCRIPTION
Fixes #63449

The image viewer was picking files based on their extension before checking if the file was actually an image. Because of that, a normal text file like `test.pam` would end up showing the broken image view instead of opening in the editor.

This changes the opening flow so that if the image viewer checks the file and doesn't recognize it as an image, Workspace can try the next opener instead.

Valid images still open normally, and image decoding errors are still handled by the image viewer.

Added a regression test using a text `test.pam` file.

Tested with:

* `cargo test -p image_viewer --lib`
* `cargo test -p workspace --lib register_project_item_tests`
* `cargo fmt -- --check`
* `./script/clippy -p project -p workspace -p image_viewer`

Release Notes:

- Fixed non-image files with image extensions opening in the image viewer instead of the editor.
