### PR TITLE
Improve Git performance in large repositories

### DIFF
--- a/crates/agent_ui/src/thread_worktree_archive.rs
+++ b/crates/agent_ui/src/thread_worktree_archive.rs
@@ -692,7 +692,7 @@ pub async fn restore_worktree_via_git(
     if let Some(branch_name) = &row.branch_name {
         // Attempt to check out the branch the worktree was previously on.
         let checkout_result = wt_repo
-            .update(cx, |repo, _cx| repo.change_branch(branch_name.clone()))
+            .update(cx, |repo, cx| repo.change_branch(branch_name.clone(), cx))
             .await;
 
         match checkout_result.map_err(|e| anyhow!("{e}")).flatten() {

--- a/crates/collab/tests/integration/git_tests.rs
+++ b/crates/collab/tests/integration/git_tests.rs
@@ -968,8 +968,8 @@ async fn test_branch_list_sync(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -7421,8 +7421,8 @@ async fn test_remote_git_branches(
     assert_eq!(branches_b, branches_set);
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch(new_branch.to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -7459,8 +7459,8 @@ async fn test_remote_git_branches(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repository, _cx| {
-            repository.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repository, cx| {
+            repository.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
+++ b/crates/collab/tests/integration/remote_editing_collaboration_tests.rs
@@ -311,8 +311,8 @@ async fn test_ssh_collaboration_git_branches(
     assert_eq!(&branches_b, &branches_set);
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repo_b, _cx| {
-            repo_b.change_branch(new_branch.to_string())
+        repo_b.update(cx, |repo_b, cx| {
+            repo_b.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -351,8 +351,8 @@ async fn test_ssh_collaboration_git_branches(
     .unwrap();
 
     cx_b.update(|cx| {
-        repo_b.update(cx, |repo_b, _cx| {
-            repo_b.change_branch("totally-new-branch".to_string())
+        repo_b.update(cx, |repo_b, cx| {
+            repo_b.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -113,6 +113,16 @@ impl FakeGitRepositoryState {
 }
 
 impl FakeGitRepository {
+    fn branch_ref_name(branch_name: &str) -> SharedString {
+        if branch_name.starts_with("refs/") {
+            branch_name.into()
+        } else if branch_name.contains('/') {
+            format!("refs/remotes/{branch_name}").into()
+        } else {
+            format!("refs/heads/{branch_name}").into()
+        }
+    }
+
     fn with_state_async<F, T>(&self, write: bool, f: F) -> BoxFuture<'static, Result<T>>
     where
         F: 'static + Send + FnOnce(&mut FakeGitRepositoryState) -> Result<T>,
@@ -530,20 +540,11 @@ impl GitRepository for FakeGitRepository {
             let mut branches = state
                 .branches
                 .iter()
-                .map(|branch_name| {
-                    let ref_name = if branch_name.starts_with("refs/") {
-                        branch_name.into()
-                    } else if branch_name.contains('/') {
-                        format!("refs/remotes/{branch_name}").into()
-                    } else {
-                        format!("refs/heads/{branch_name}").into()
-                    };
-                    Branch {
-                        is_head: Some(branch_name) == current_branch.as_ref(),
-                        ref_name,
-                        most_recent_commit: None,
-                        upstream: None,
-                    }
+                .map(|branch_name| Branch {
+                    is_head: Some(branch_name) == current_branch.as_ref(),
+                    ref_name: Self::branch_ref_name(branch_name),
+                    most_recent_commit: None,
+                    upstream: None,
                 })
                 .collect::<Vec<_>>();
             // compute snapshot expects these to be sorted by ref_name
@@ -933,10 +934,11 @@ impl GitRepository for FakeGitRepository {
         async { Ok(()) }.boxed()
     }
 
-    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>> {
-        self.with_state_async(true, |state| {
+    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<SharedString>> {
+        self.with_state_async(true, move |state| {
+            let branch_ref = Self::branch_ref_name(&name);
             state.current_branch_name = Some(name);
-            Ok(())
+            Ok(branch_ref)
         })
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -846,7 +846,7 @@ pub trait GitRepository: Send + Sync {
 
     fn branches(&self) -> BoxFuture<'_, Result<BranchesScanResult>>;
 
-    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>>;
+    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<SharedString>>;
     fn create_branch(&self, name: String, base_branch: Option<String>)
     -> BoxFuture<'_, Result<()>>;
     fn rename_branch(&self, branch: String, new_name: String) -> BoxFuture<'_, Result<()>>;
@@ -2343,7 +2343,7 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
-    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>> {
+    fn change_branch(&self, name: String) -> BoxFuture<'_, Result<SharedString>> {
         let git_binary = self.git_binary_in_worktree();
         self.executor
             .spawn(async move {
@@ -2355,7 +2355,7 @@ impl GitRepository for RealGitRepository {
                     .is_ok()
                 {
                     git_binary.run(&["checkout", &name]).await?;
-                    return anyhow::Ok(());
+                    return anyhow::Ok(local_ref.into());
                 }
 
                 let remote_ref = format!("refs/remotes/{name}");
@@ -2389,7 +2389,7 @@ impl GitRepository for RealGitRepository {
                     }
 
                     git_binary.run(&["checkout", branch_name]).await?;
-                    return anyhow::Ok(());
+                    return anyhow::Ok(local_branch_ref.into());
                 }
 
                 anyhow::bail!("Branch '{}' not found", name);
@@ -4958,10 +4958,11 @@ mod tests {
                 .is_err()
         );
 
-        repository
+        let branch_ref = repository
             .change_branch("origin/feature".to_string())
             .await
             .unwrap();
+        assert_eq!(branch_ref.as_ref(), "refs/heads/feature");
 
         let git = repository.git_binary_in_worktree().unwrap();
         assert_eq!(
@@ -5034,10 +5035,11 @@ mod tests {
                 .is_err()
         );
 
-        repository
+        let branch_ref = repository
             .change_branch("origin/HEAD".to_string())
             .await
             .unwrap();
+        assert_eq!(branch_ref.as_ref(), "refs/heads/feature");
 
         let git = repository.git_binary_in_worktree().unwrap();
         assert_eq!(
@@ -5089,10 +5091,11 @@ mod tests {
         .unwrap();
         git.run(&["checkout", "-b", "scratch"]).await.unwrap();
 
-        repository
+        let branch_ref = repository
             .change_branch("upstream/HEAD".to_string())
             .await
             .unwrap();
+        assert_eq!(branch_ref.as_ref(), "refs/heads/main");
 
         let git = repository.git_binary_in_worktree().unwrap();
         assert_eq!(

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1567,8 +1567,10 @@ impl PickerDelegate for BranchListDelegate {
 
                 let branch = branch.clone();
                 cx.spawn(async move |_, cx| {
-                    repo.update(cx, |repo, _| repo.change_branch(branch.name().to_string()))
-                        .await??;
+                    repo.update(cx, |repo, cx| {
+                        repo.change_branch(branch.name().to_string(), cx)
+                    })
+                    .await??;
 
                     anyhow::Ok(())
                 })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -67,7 +67,8 @@ use project::git_store::GitAccess;
 use project::{
     Fs, Project, ProjectPath,
     git_store::{
-        CommitDataState, GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op,
+        CommitDataState, GitGraphEvent, GitStoreEvent, Repository, RepositoryEvent, RepositoryId,
+        pending_op,
     },
     project_settings::{GitPathStyle, ProjectSettings},
 };
@@ -568,12 +569,12 @@ enum CommitHistory {
     Loading,
     /// A non-empty list can still grow on later fetches.
     /// An empty list means the repository has no commits.
-    Loaded(Rc<[CommitHistoryEntry]>),
+    Loaded(Vec<CommitHistoryEntry>),
     Error(SharedString),
 }
 
 fn commit_history_from_response(
-    entries: Rc<[CommitHistoryEntry]>,
+    entries: Vec<CommitHistoryEntry>,
     is_loading: bool,
     error: Option<SharedString>,
 ) -> CommitHistory {
@@ -584,7 +585,7 @@ fn commit_history_from_response(
     } else if is_loading {
         CommitHistory::Loading
     } else {
-        CommitHistory::Loaded(Rc::from([]))
+        CommitHistory::Loaded(Vec::new())
     }
 }
 
@@ -4724,7 +4725,6 @@ impl GitPanel {
         }
         self.active_repository = new_active_repository;
         self.reopen_commit_buffer(window, cx);
-        self.preload_commit_history(cx);
         if self.active_tab == GitPanelTab::History {
             self.load_commit_history(cx);
         }
@@ -6708,23 +6708,6 @@ impl GitPanel {
         cx.notify();
     }
 
-    fn preload_commit_history(&mut self, cx: &mut Context<Self>) {
-        let Some(active_repository) = self.active_repository.as_ref() else {
-            return;
-        };
-
-        let Some(log_source) = Self::commit_history_log_source(active_repository, cx) else {
-            return;
-        };
-        let log_order = LogOrder::DateOrder;
-
-        // Kick off the git log fetch so data is ready when the user switches to History.
-        // graph_data() is idempotent — if already loading/loaded, this is a no-op.
-        active_repository.update(cx, |repository, cx| {
-            repository.graph_data(log_source, log_order, 0..0, cx);
-        });
-    }
-
     fn load_commit_history(&mut self, cx: &mut Context<Self>) {
         let Some(active_repository) = self.active_repository.clone() else {
             return;
@@ -6734,10 +6717,10 @@ impl GitPanel {
             self._repo_subscriptions.push(cx.subscribe(
                 &active_repository,
                 |this, _repo, event, cx| {
-                    if let RepositoryEvent::GraphEvent(_, _) = event {
-                        if this.active_tab == GitPanelTab::History {
-                            this.fetch_commit_history_entries(cx);
-                        }
+                    if let RepositoryEvent::GraphEvent(graph_data_key, graph_event) = event
+                        && this.active_tab == GitPanelTab::History
+                    {
+                        this.update_commit_history_entries(graph_data_key, graph_event, cx);
                     }
                 },
             ));
@@ -6757,14 +6740,14 @@ impl GitPanel {
 
         let Some(log_source) = Self::commit_history_log_source(&active_repository, cx) else {
             // No HEAD commit at all (unborn/empty repository).
-            self.set_commit_history(CommitHistory::Loaded(Rc::from([])), cx);
+            self.set_commit_history(CommitHistory::Loaded(Vec::new()), cx);
             return;
         };
         let log_order = LogOrder::DateOrder;
 
         let (entries, is_loading, error) = active_repository.update(cx, |repository, cx| {
             let response = repository.graph_data(log_source, log_order, 0..usize::MAX, cx);
-            let entries: Rc<[CommitHistoryEntry]> = response
+            let entries = response
                 .commits
                 .iter()
                 .map(CommitHistoryEntry::from)
@@ -6775,16 +6758,99 @@ impl GitPanel {
         self.set_commit_history(commit_history_from_response(entries, is_loading, error), cx);
     }
 
+    fn update_commit_history_entries(
+        &mut self,
+        graph_data_key: &(LogSource, LogOrder),
+        graph_event: &GitGraphEvent,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(active_repository) = self.active_repository.clone() else {
+            return;
+        };
+        let Some(log_source) = Self::commit_history_log_source(&active_repository, cx) else {
+            return;
+        };
+        let expected_graph_data_key = (log_source, LogOrder::DateOrder);
+        if graph_data_key != &expected_graph_data_key {
+            return;
+        }
+
+        match graph_event {
+            GitGraphEvent::CountUpdated(total_count) => {
+                let current_count = self.commit_history_entries().len();
+                if *total_count < current_count {
+                    self.fetch_commit_history_entries(cx);
+                    return;
+                }
+                if *total_count == current_count {
+                    return;
+                }
+
+                let (new_entries, is_loading, error) =
+                    active_repository.update(cx, |repository, cx| {
+                        let response = repository.graph_data(
+                            expected_graph_data_key.0,
+                            expected_graph_data_key.1,
+                            current_count..*total_count,
+                            cx,
+                        );
+                        let entries = response
+                            .commits
+                            .iter()
+                            .map(CommitHistoryEntry::from)
+                            .collect::<Vec<_>>();
+                        (entries, response.is_loading, response.error)
+                    });
+
+                if let CommitHistory::Loaded(entries) = &mut self.commit_history {
+                    entries.extend(new_entries);
+                    self.clamp_focused_history_entry();
+                    cx.notify();
+                } else {
+                    self.set_commit_history(
+                        commit_history_from_response(new_entries, is_loading, error),
+                        cx,
+                    );
+                }
+            }
+            GitGraphEvent::FullyLoaded | GitGraphEvent::LoadingError => {
+                if matches!(
+                    &self.commit_history,
+                    CommitHistory::Loaded(entries) if !entries.is_empty()
+                ) {
+                    return;
+                }
+
+                let (is_loading, error) = active_repository.update(cx, |repository, cx| {
+                    let response = repository.graph_data(
+                        expected_graph_data_key.0,
+                        expected_graph_data_key.1,
+                        0..0,
+                        cx,
+                    );
+                    (response.is_loading, response.error)
+                });
+                self.set_commit_history(
+                    commit_history_from_response(Vec::new(), is_loading, error),
+                    cx,
+                );
+            }
+        }
+    }
+
     fn set_commit_history(&mut self, commit_history: CommitHistory, cx: &mut Context<Self>) {
         let changed = self.commit_history != commit_history;
         self.commit_history = commit_history;
-        // Keep the focused entry within range as the history grows or clears.
-        let count = self.commit_history_entries().len();
-        let focused = self.focused_history_entry.unwrap_or(0);
-        self.focused_history_entry = (count > 0).then(|| focused.min(count - 1));
+        self.clamp_focused_history_entry();
         if changed {
             cx.notify();
         }
+    }
+
+    fn clamp_focused_history_entry(&mut self) {
+        let count = self.commit_history_entries().len();
+        let focused = self.focused_history_entry.unwrap_or(0);
+        self.focused_history_entry = (count > 0).then(|| focused.min(count - 1));
     }
 
     fn commit_history_log_source(
@@ -6820,7 +6886,6 @@ impl GitPanel {
         let CommitHistory::Loaded(entries) = &self.commit_history else {
             return None;
         };
-        let entries = entries.clone();
         let active_repository = self.active_repository.as_ref()?;
         let workspace = self.workspace.clone();
         let repo_weak = active_repository.downgrade();
@@ -6861,9 +6926,18 @@ impl GitPanel {
                                 .unwrap_or(time::UtcOffset::UTC);
                             let now = time::OffsetDateTime::now_utc();
 
+                            let visible_entries = git_panel
+                                .read_with(cx, |panel, _| {
+                                    let entries = panel.commit_history_entries();
+                                    let start = range.start.min(entries.len());
+                                    let end = range.end.min(entries.len());
+                                    entries[start..end].to_vec()
+                                })
+                                .unwrap_or_default();
+
                             let visible_data: Vec<Option<Arc<CommitData>>> = repo_weak
                                 .update(cx, |repository, cx| {
-                                    entries[range.clone()]
+                                    visible_entries
                                         .iter()
                                         .map(|entry| {
                                             match repository.fetch_commit_data(entry.sha, false, cx)
@@ -6876,8 +6950,8 @@ impl GitPanel {
                                 })
                                 .unwrap_or_default();
 
-                            entries[range.clone()]
-                                .iter()
+                            visible_entries
+                                .into_iter()
                                 .zip(visible_data)
                                 .enumerate()
                                 .map(|(ix, (entry, data))| {
@@ -6886,7 +6960,7 @@ impl GitPanel {
                                     let sha_shared: SharedString = sha_string.clone().into();
                                     let short_sha: SharedString =
                                         sha_string[..7.min(sha_string.len())].to_string().into();
-                                    let tag_names = entry.tag_names.clone();
+                                    let tag_names = entry.tag_names;
 
                                     let (subject, author_name, author_email, timestamp): (
                                         SharedString,
@@ -9810,17 +9884,17 @@ mod tests {
         );
     }
 
-    async fn history_panel_for_project(
+    async fn git_panel_for_project(
         fs: Arc<FakeFs>,
         cx: &mut TestAppContext,
-    ) -> Entity<GitPanel> {
+    ) -> (Entity<GitPanel>, VisualTestContext) {
         let project = Project::test(fs, [Path::new(path!("/root/project"))], cx).await;
         let window_handle =
             cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace = window_handle
             .read_with(cx, |mw, _| mw.workspace().clone())
             .unwrap();
-        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
 
         cx.read(|cx| {
             project
@@ -9836,8 +9910,17 @@ mod tests {
         .await;
         cx.executor().run_until_parked();
 
-        let panel = workspace.update_in(cx, GitPanel::new);
-        panel.update_in(cx, |panel, window, cx| {
+        let panel = workspace.update_in(&mut cx, GitPanel::new);
+        cx.run_until_parked();
+        (panel, cx)
+    }
+
+    async fn history_panel_for_project(
+        fs: Arc<FakeFs>,
+        cx: &mut TestAppContext,
+    ) -> Entity<GitPanel> {
+        let (panel, mut cx) = git_panel_for_project(fs, cx).await;
+        panel.update_in(&mut cx, |panel, window, cx| {
             panel.activate_history_tab(&ActivateHistoryTab, window, cx);
         });
         cx.run_until_parked();
@@ -9849,6 +9932,31 @@ mod tests {
             !matches!(panel.commit_history, CommitHistory::Loading)
         })
         .await;
+    }
+
+    #[gpui::test]
+    async fn test_changes_tab_does_not_preload_commit_history(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree("/root", json!({ "project": { ".git": {} } }))
+            .await;
+
+        let dot_git = Path::new(path!("/root/project/.git"));
+        fs.set_branch_name(dot_git, Some("main"));
+        fs.set_head_for_repo(dot_git, &[], "0123456789012345678901234567890123456789");
+
+        let (panel, cx) = git_panel_for_project(fs, cx).await;
+
+        panel.read_with(&cx, |panel, cx| {
+            assert_eq!(panel.active_tab, GitPanelTab::Changes);
+            let repository = panel.active_repository.as_ref().unwrap().read(cx);
+            assert!(
+                repository
+                    .get_graph_data(LogSource::Branch("main".into()), LogOrder::DateOrder)
+                    .is_none()
+            );
+        });
     }
 
     #[gpui::test]
@@ -9870,7 +9978,7 @@ mod tests {
 
         wait_for_commit_history_to_settle(&panel, cx).await;
         panel.read_with(cx, |panel, _| {
-            assert_eq!(panel.commit_history, CommitHistory::Loaded(Rc::from([])));
+            assert_eq!(panel.commit_history, CommitHistory::Loaded(Vec::new()));
         });
     }
 
@@ -9901,10 +10009,10 @@ mod tests {
         panel.read_with(cx, |panel, _| {
             assert_eq!(
                 panel.commit_history,
-                CommitHistory::Loaded(Rc::from([CommitHistoryEntry {
+                CommitHistory::Loaded(vec![CommitHistoryEntry {
                     sha,
                     tag_names: Vec::new(),
-                }]))
+                }])
             );
         });
     }
@@ -9957,11 +10065,11 @@ mod tests {
     fn test_commit_history_from_response() {
         let sha: Oid = "0123456789012345678901234567890123456789".parse().unwrap();
         let error = SharedString::from("git log failed");
-        let entries: Rc<[CommitHistoryEntry]> = Rc::from([CommitHistoryEntry {
+        let entries = vec![CommitHistoryEntry {
             sha,
             tag_names: Vec::new(),
-        }]);
-        let no_entries: Rc<[CommitHistoryEntry]> = Rc::from([]);
+        }];
+        let no_entries = Vec::new();
 
         // Commits win even while the fetch task still reports `is_loading`.
         assert_eq!(

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -812,6 +812,8 @@ enum GitJobKey {
 }
 
 impl GitStore {
+    const MAX_INCREMENTAL_STATUS_PATHS: usize = 100;
+
     pub fn local(
         worktree_store: &Entity<WorktreeStore>,
         buffer_store: Entity<BufferStore>,
@@ -4217,8 +4219,8 @@ impl GitStore {
         let branch_name = envelope.payload.branch_name;
 
         repository_handle
-            .update(&mut cx, |repository_handle, _| {
-                repository_handle.change_branch(branch_name)
+            .update(&mut cx, |repository_handle, cx| {
+                repository_handle.change_branch(branch_name, cx)
             })
             .await??;
 
@@ -5142,7 +5144,11 @@ impl GitStore {
             coalesced.push(path);
         }
 
-        coalesced
+        if coalesced.len() > Self::MAX_INCREMENTAL_STATUS_PATHS {
+            vec![RepoPath::from_rel_path(RelPath::empty())]
+        } else {
+            coalesced
+        }
     }
 
     fn process_updated_entries(
@@ -7378,7 +7384,7 @@ impl Repository {
         cx: &mut AsyncApp,
     ) -> Result<(), SharedString> {
         let (request_tx, request_rx) =
-            async_channel::unbounded::<Vec<Arc<InitialGraphCommitData>>>();
+            async_channel::bounded::<Vec<Arc<InitialGraphCommitData>>>(1);
 
         let task = cx.background_executor().spawn({
             let log_source = log_source.clone();
@@ -7400,6 +7406,7 @@ impl Repository {
                 cx,
             )
             .await;
+            yield_now().await;
         }
 
         task.await?;
@@ -9644,15 +9651,69 @@ impl Repository {
         )
     }
 
-    pub fn change_branch(&mut self, branch_name: String) -> oneshot::Receiver<Result<()>> {
+    pub fn change_branch(
+        &mut self,
+        branch_name: String,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
+        let updates_tx = self
+            .git_store()
+            .and_then(|git_store| match &git_store.read(cx).state {
+                GitStoreState::Local { downstream, .. } => downstream
+                    .as_ref()
+                    .map(|downstream| downstream.updates_tx.clone()),
+                _ => None,
+            });
+        let this = cx.weak_entity();
         self.send_job(
             "change_branch",
             Some(format!("git switch {branch_name}").into()),
-            move |repo, _cx| async move {
+            move |repo, mut cx| async move {
                 match repo {
                     RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
-                        backend.change_branch(branch_name).await
+                        let branch_ref = backend.change_branch(branch_name).await?;
+                        let snapshot = this.update(&mut cx, |this, cx| {
+                            let mut branch_list = this.snapshot.branch_list.to_vec();
+                            let mut branch = None;
+                            for candidate in &mut branch_list {
+                                candidate.is_head = candidate.ref_name == branch_ref;
+                                if candidate.is_head {
+                                    branch = Some(candidate.clone());
+                                }
+                            }
+
+                            let branch = branch.unwrap_or_else(|| {
+                                let branch = Branch {
+                                    is_head: true,
+                                    ref_name: branch_ref,
+                                    upstream: None,
+                                    most_recent_commit: None,
+                                };
+                                branch_list.push(branch.clone());
+                                branch_list
+                                    .sort_by(|left, right| left.ref_name.cmp(&right.ref_name));
+                                branch
+                            });
+                            let branch_list: Arc<[Branch]> = branch_list.into();
+                            let head_changed = this.snapshot.branch.as_ref() != Some(&branch);
+                            let branch_list_changed = *this.snapshot.branch_list != *branch_list;
+                            this.snapshot.branch = Some(branch);
+                            this.snapshot.branch_list = branch_list;
+                            if head_changed {
+                                cx.emit(RepositoryEvent::HeadChanged);
+                            }
+                            if branch_list_changed {
+                                cx.emit(RepositoryEvent::BranchListChanged);
+                            }
+                            this.snapshot.clone()
+                        })?;
+                        if let Some(updates_tx) = updates_tx {
+                            updates_tx
+                                .unbounded_send(DownstreamUpdate::UpdateRepository(snapshot))
+                                .log_err();
+                        }
+                        Ok(())
                     }
                     RepositoryState::Remote(RemoteRepositoryState { project_id, client }) => {
                         client
@@ -12203,6 +12264,15 @@ mod tests {
             coalesced,
             repo_paths(&["submodule/a.txt", "submodule/nested/b.txt", "top_level.rs"])
         );
+    }
+
+    #[test]
+    fn coalesce_repo_paths_uses_root_for_oversized_batches() {
+        let paths = (0..=GitStore::MAX_INCREMENTAL_STATUS_PATHS)
+            .map(|index| repo_path(&format!("directory-{index}/file")))
+            .collect();
+
+        assert_eq!(GitStore::coalesce_repo_paths(paths), repo_paths(&[""]));
     }
 }
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -13858,6 +13858,56 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_change_branch_refreshes_repository_without_fs_events(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "file.txt": "text",
+        }),
+    )
+    .await;
+    fs.insert_branches(path!("/root/.git").as_ref(), &["main", "feature"]);
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let repository = project.read_with(cx, |project, cx| {
+        project.repositories(cx).values().next().unwrap().clone()
+    });
+    let branch_name = |repository: &Repository, _cx: &App| {
+        repository
+            .snapshot()
+            .branch
+            .as_ref()
+            .map(|branch| branch.name().to_string())
+    };
+    assert_eq!(
+        repository.read_with(cx, branch_name),
+        Some("main".to_string())
+    );
+
+    fs.pause_events();
+    repository
+        .update(cx, |repository, cx| {
+            repository.change_branch("feature".to_string(), cx)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        repository.read_with(cx, branch_name),
+        Some("feature".to_string())
+    );
+    fs.unpause_events_and_flush();
+}
+
+#[gpui::test]
 async fn test_git_repository_status_removes_directory_descendants(cx: &mut gpui::TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -3738,8 +3738,8 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     assert_eq!(&remote_branches, &branches_set);
 
     cx.update(|cx| {
-        repository.update(cx, |repository, _cx| {
-            repository.change_branch(new_branch.to_string())
+        repository.update(cx, |repository, cx| {
+            repository.change_branch(new_branch.to_string(), cx)
         })
     })
     .await
@@ -3778,8 +3778,8 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     .unwrap();
 
     cx.update(|cx| {
-        repository.update(cx, |repo, _cx| {
-            repo.change_branch("totally-new-branch".to_string())
+        repository.update(cx, |repo, cx| {
+            repo.change_branch("totally-new-branch".to_string(), cx)
         })
     })
     .await


### PR DESCRIPTION
# Objective

- Improve Git responsiveness in very large repositories such as nixpkgs.
- Prevent branch switching from waiting for expensive filesystem-driven repository refreshes.
- Prevent loading large commit histories from making the UI choppy or unresponsive.

## Solution

- After a branch checkout succeeds, update Zed’s repository state immediately and notify anything observing it. This avoids waiting for a filesystem event and removes an extra Git command that was previously needed to rediscover the active branch.
- When more than 100 paths change at once, refresh Git status from the repository root instead of processing every path individually. This prevents branch switches in large repositories from triggering thousands of incremental status updates.
- Keep at most one commit-history batch queued at a time and give the UI an opportunity to run between batches. This prevents a large history load from overwhelming the foreground thread.
- Load commit history only after the History tab is opened instead of preloading it while the user is viewing Changes.
- As history batches arrive, request and append only the newly available commits instead of rebuilding the entire list.
- When drawing the history list, process only the visible rows instead of copying every loaded commit.

## Testing

- Tested branch switching and large commit-history loading manually with the nixpkgs repository on my linux machine
- Verified that branch switching completes promptly and the History tab remains responsive while loading many commits.
- Ran the relevant branch-switching, commit-history, and path-coalescing tests.
- I didn't test other platforms. Reviewers can test by opening a large repository like nixpkgs, switching branches, and loading a long commit history.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved Git panel responsiveness and branch switching in large repositories.