### PR TITLE
workspace: Fix panel toggle visibility checks

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1645,11 +1645,7 @@ impl AgentPanel {
             .panel::<Self>(cx)
             .is_some_and(|panel| panel.read(cx).enabled(cx))
         {
-            if workspace.is_panel_open::<Self>(cx) {
-                workspace.close_panel::<Self>(window, cx);
-            } else {
-                workspace.toggle_panel_focus::<Self>(window, cx);
-            }
+            workspace.toggle_panel::<AgentPanel>(window, cx);
         }
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1645,8 +1645,10 @@ impl AgentPanel {
             .panel::<Self>(cx)
             .is_some_and(|panel| panel.read(cx).enabled(cx))
         {
-            if !workspace.toggle_panel_focus::<Self>(window, cx) {
+            if workspace.is_panel_open::<Self>(cx) {
                 workspace.close_panel::<Self>(window, cx);
+            } else {
+                workspace.toggle_panel_focus::<Self>(window, cx);
             }
         }
     }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -118,13 +118,7 @@ pub fn init(cx: &mut App) {
             }
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if workspace.is_panel_open::<CollabPanel>(cx) {
-                workspace.close_panel::<CollabPanel>(window, cx);
-            } else {
-                if !workspace.toggle_panel_focus::<CollabPanel>(window, cx) {
-                    workspace.close_panel::<CollabPanel>(window, cx);
-                }
-            }
+            workspace.toggle_panel::<CollabPanel>(window, cx);
         });
         workspace.register_action(|_, _: &OpenChannelNotes, window, cx| {
             let channel_id = ActiveCall::global(cx)

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -118,8 +118,12 @@ pub fn init(cx: &mut App) {
             }
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if !workspace.toggle_panel_focus::<CollabPanel>(window, cx) {
+            if workspace.is_panel_open::<CollabPanel>(cx) {
                 workspace.close_panel::<CollabPanel>(window, cx);
+            } else {
+                if !workspace.toggle_panel_focus::<CollabPanel>(window, cx) {
+                    workspace.close_panel::<CollabPanel>(window, cx);
+                }
             }
         });
         workspace.register_action(|_, _: &OpenChannelNotes, window, cx| {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -118,8 +118,12 @@ pub fn init(cx: &mut App) {
                 workspace.toggle_panel_focus::<DebugPanel>(window, cx);
             })
             .register_action(|workspace, _: &Toggle, window, cx| {
-                if !workspace.toggle_panel_focus::<DebugPanel>(window, cx) {
+                if workspace.is_panel_open::<DebugPanel>(cx) {
                     workspace.close_panel::<DebugPanel>(window, cx);
+                } else {
+                    if !workspace.toggle_panel_focus::<DebugPanel>(window, cx) {
+                        workspace.close_panel::<DebugPanel>(window, cx);
+                    }
                 }
             })
             .register_action(|workspace: &mut Workspace, _: &Start, window, cx| {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -118,13 +118,7 @@ pub fn init(cx: &mut App) {
                 workspace.toggle_panel_focus::<DebugPanel>(window, cx);
             })
             .register_action(|workspace, _: &Toggle, window, cx| {
-                if workspace.is_panel_open::<DebugPanel>(cx) {
-                    workspace.close_panel::<DebugPanel>(window, cx);
-                } else {
-                    if !workspace.toggle_panel_focus::<DebugPanel>(window, cx) {
-                        workspace.close_panel::<DebugPanel>(window, cx);
-                    }
-                }
+                workspace.toggle_panel::<DebugPanel>(window, cx);
             })
             .register_action(|workspace: &mut Workspace, _: &Start, window, cx| {
                 NewProcessModal::show(workspace, window, NewProcessMode::Debug, None, cx);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -506,13 +506,7 @@ pub fn register(workspace: &mut Workspace) {
         workspace.toggle_panel_focus::<GitPanel>(window, cx);
     });
     workspace.register_action(|workspace, _: &Toggle, window, cx| {
-        if workspace.is_panel_open::<GitPanel>(cx) {
-            workspace.close_panel(window, cx);
-        } else {
-            if !workspace.toggle_panel_focus::<GitPanel>(window, cx) {
-                workspace.close_panel::<GitPanel>(window, cx);
-            }
-        }
+        workspace.toggle_panel::<GitPanel>(window, cx);
     });
     workspace.register_action(|workspace, _: &ExpandCommitEditor, window, cx| {
         CommitModal::toggle(workspace, None, window, cx)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -506,8 +506,12 @@ pub fn register(workspace: &mut Workspace) {
         workspace.toggle_panel_focus::<GitPanel>(window, cx);
     });
     workspace.register_action(|workspace, _: &Toggle, window, cx| {
-        if !workspace.toggle_panel_focus::<GitPanel>(window, cx) {
-            workspace.close_panel::<GitPanel>(window, cx);
+        if workspace.is_panel_open::<GitPanel>(cx) {
+            workspace.close_panel(window, cx);
+        } else {
+            if !workspace.toggle_panel_focus::<GitPanel>(window, cx) {
+                workspace.close_panel::<GitPanel>(window, cx);
+            }
         }
     });
     workspace.register_action(|workspace, _: &ExpandCommitEditor, window, cx| {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -656,8 +656,12 @@ pub fn init(cx: &mut App) {
             workspace.toggle_panel_focus::<OutlinePanel>(window, cx);
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if !workspace.toggle_panel_focus::<OutlinePanel>(window, cx) {
+            if workspace.is_panel_open::<OutlinePanel>(cx) {
                 workspace.close_panel::<OutlinePanel>(window, cx);
+            } else {
+                if !workspace.toggle_panel_focus::<OutlinePanel>(window, cx) {
+                    workspace.close_panel::<OutlinePanel>(window, cx);
+                }
             }
         });
     })

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -656,13 +656,7 @@ pub fn init(cx: &mut App) {
             workspace.toggle_panel_focus::<OutlinePanel>(window, cx);
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if workspace.is_panel_open::<OutlinePanel>(cx) {
-                workspace.close_panel::<OutlinePanel>(window, cx);
-            } else {
-                if !workspace.toggle_panel_focus::<OutlinePanel>(window, cx) {
-                    workspace.close_panel::<OutlinePanel>(window, cx);
-                }
-            }
+            workspace.toggle_panel::<OutlinePanel>(window, cx);
         });
     })
     .detach();

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -482,13 +482,7 @@ pub fn init(cx: &mut App) {
             workspace.toggle_panel_focus::<ProjectPanel>(window, cx);
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if workspace.is_panel_open::<ProjectPanel>(cx) {
-                workspace.close_panel::<ProjectPanel>(window, cx)
-            } else {
-                if !workspace.toggle_panel_focus::<ProjectPanel>(window, cx) {
-                    workspace.close_panel::<ProjectPanel>(window, cx);
-                }
-            }
+            workspace.toggle_panel::<ProjectPanel>(window, cx);
         });
 
         workspace.register_action(|workspace, _: &ToggleHideGitIgnore, _, cx| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -482,8 +482,12 @@ pub fn init(cx: &mut App) {
             workspace.toggle_panel_focus::<ProjectPanel>(window, cx);
         });
         workspace.register_action(|workspace, _: &Toggle, window, cx| {
-            if !workspace.toggle_panel_focus::<ProjectPanel>(window, cx) {
-                workspace.close_panel::<ProjectPanel>(window, cx);
+            if workspace.is_panel_open::<ProjectPanel>(cx) {
+                workspace.close_panel::<ProjectPanel>(window, cx)
+            } else {
+                if !workspace.toggle_panel_focus::<ProjectPanel>(window, cx) {
+                    workspace.close_panel::<ProjectPanel>(window, cx);
+                }
             }
         });
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -64,13 +64,7 @@ pub fn init(cx: &mut App) {
             });
             workspace.register_action(|workspace, _: &Toggle, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
-                    if workspace.is_panel_open::<TerminalPanel>(cx) {
-                        workspace.close_panel::<TerminalPanel>(window, cx);
-                    } else {
-                        if !workspace.toggle_panel_focus::<TerminalPanel>(window, cx) {
-                            workspace.close_panel::<TerminalPanel>(window, cx);
-                        }
-                    }
+                    workspace.toggle_panel::<TerminalPanel>(window, cx);
                 }
             });
         },

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -64,8 +64,12 @@ pub fn init(cx: &mut App) {
             });
             workspace.register_action(|workspace, _: &Toggle, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
-                    if !workspace.toggle_panel_focus::<TerminalPanel>(window, cx) {
+                    if workspace.is_panel_open::<TerminalPanel>(cx) {
                         workspace.close_panel::<TerminalPanel>(window, cx);
+                    } else {
+                        if !workspace.toggle_panel_focus::<TerminalPanel>(window, cx) {
+                            workspace.close_panel::<TerminalPanel>(window, cx);
+                        }
                     }
                 }
             });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4483,6 +4483,18 @@ impl Workspace {
         self.serialize_workspace(window, cx);
     }
 
+    pub fn is_panel_open<T: Panel>(&self, cx: &mut Context<Self>) -> bool {
+        self.all_docks().iter().any(|dock| {
+            let dock = dock.read(cx);
+            println!("dock.is_open() = {}", dock.is_open());
+            println!(
+                "dock.panel::<T>().is_some() = {}",
+                dock.panel::<T>().is_some()
+            );
+            dock.is_open() && dock.panel_index_for_type::<T>() == dock.active_panel_index()
+        })
+    }
+
     /// Transfer focus to the panel of the given type.
     pub fn focus_panel<T: Panel>(
         &mut self,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4495,6 +4495,14 @@ impl Workspace {
         })
     }
 
+    pub fn toggle_panel<T: Panel>(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_panel_open::<T>(cx) {
+            self.close_panel::<T>(window, cx);
+        } else {
+            self.toggle_panel_focus::<T>(window, cx);
+        }
+    }
+
     /// Transfer focus to the panel of the given type.
     pub fn focus_panel<T: Panel>(
         &mut self,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4486,11 +4486,6 @@ impl Workspace {
     pub fn is_panel_open<T: Panel>(&self, cx: &mut Context<Self>) -> bool {
         self.all_docks().iter().any(|dock| {
             let dock = dock.read(cx);
-            println!("dock.is_open() = {}", dock.is_open());
-            println!(
-                "dock.panel::<T>().is_some() = {}",
-                dock.panel::<T>().is_some()
-            );
             dock.is_open() && dock.panel_index_for_type::<T>() == dock.active_panel_index()
         })
     }


### PR DESCRIPTION
# Objective

We're fixing toggle behavior for different panels and consolidate that into one simple workspace `toggle_panel` function. This PR is based on the issue raised in #63243. I saw that all of the panels behaved the same. 


## Solution

The solution was to consolidate a the check behind a simple workspace function: toggle_panel that check if a specific panel <T> is visible and decides what to do next: if its visible it will simply close it. otherwise it will follow the open & focus branch. 
I also added a function for checking if a panel is open. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed toggle function not closing the already open panels
