### PR TITLE
Fix remote server startup on Windows SSH hosts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -955,6 +955,7 @@ features = [
     "Win32_System_RestartManager",
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",
+    "Win32_System_TaskScheduler",
     "Win32_System_Threading",
     "Win32_System_Variant",
     "Win32_System_WinRT",

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -999,7 +999,11 @@ impl SshRemoteConnection {
             .socket
             .run_command(
                 self.ssh_shell_kind,
-                "curl",
+                if self.ssh_platform.os.is_windows() {
+                    "curl.exe" // non-.exe curl is an alias for Invoke-WebRequest
+                } else {
+                    "curl"
+                },
                 &[
                     "-f",
                     "-L",

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -1097,7 +1097,7 @@ fn spawn_server_windows(binary_name: &Path, paths: &ServerPaths) -> Result<(), S
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    crate::windows::shell_execute_from_explorer(&binary_path, &parameters, &directory)
+    crate::windows::spawn_process_detached(&binary_path, &parameters, &directory)
         .map_err(|e| SpawnServerError::ProcessStatus(std::io::Error::other(e)))?;
 
     Ok(())

--- a/crates/remote_server/src/windows.rs
+++ b/crates/remote_server/src/windows.rs
@@ -1,6 +1,16 @@
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use windows::Win32::Foundation::{RPC_E_CHANGED_MODE, VARIANT_FALSE};
 use windows::Win32::System::Com::{
-    CLSCTX_LOCAL_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx, IDispatch,
-    IServiceProvider,
+    CLSCTX_INPROC_SERVER, CLSCTX_LOCAL_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance,
+    CoInitializeEx, IDispatch, IServiceProvider,
+};
+use windows::Win32::System::TaskScheduler::{
+    IExecAction, IRegisteredTask, ITaskFolder, ITaskService, TASK_ACTION_EXEC,
+    TASK_CREATE_OR_UPDATE, TASK_LOGON_INTERACTIVE_TOKEN, TASK_RUNLEVEL_LUA, TASK_STATE_RUNNING,
+    TASK_STATE_UNKNOWN, TaskScheduler,
 };
 use windows::Win32::System::Variant::VARIANT;
 use windows::Win32::UI::Shell::{
@@ -9,14 +19,113 @@ use windows::Win32::UI::Shell::{
 };
 use windows::core::{BSTR, Interface};
 
-pub fn shell_execute_from_explorer(
+const TASK_NAME: &str = "ZedRemoteServerLauncher";
+
+/// Spawns a process that outlives the current session, so that brief connection
+/// interruptions don't immediately kill the server.
+///
+/// On Windows, processes spawned from SSH are killed when the session
+/// closes, so we ask a more long-lived process to spawn it for us.
+/// - Best way to do it is to schedule a task, so the Task Scheduler service
+///   becomes the parent.
+/// - Asking the desktop Explorer to `ShellExecute` makes Explorer the parent,
+///   but needs a responsive interactive Explorer - unavailable when no one is
+///   logged in or the machine is in Modern Standby, so it is only a fallback.
+/// - We could also use WMI's `Win32_Process::Create`, but it could be
+///   blocked by Defender's PsExec/WMI attack surface reduction rule
+pub fn spawn_process_detached(file: &str, parameters: &str, directory: &str) -> anyhow::Result<()> {
+    init_com()?;
+    if let Err(task_error) = spawn_via_scheduled_task(file, parameters, directory) {
+        log::warn!(
+            "failed to spawn {file:?} via Task Scheduler, falling back to Explorer's ShellExecute: {task_error:#}"
+        );
+        shell_execute_from_explorer(file, parameters, directory)
+            .context("spawning via Explorer's ShellExecute")?;
+    }
+    Ok(())
+}
+
+fn init_com() -> anyhow::Result<()> {
+    let result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    // RPC_E_CHANGED_MODE means COM is already initialized with a different
+    // threading model, which is fine for our purposes.
+    if result.is_err() && result != RPC_E_CHANGED_MODE {
+        return Err(windows::core::Error::from_hresult(result)).context("initializing COM");
+    }
+    Ok(())
+}
+
+fn spawn_via_scheduled_task(file: &str, parameters: &str, directory: &str) -> anyhow::Result<()> {
+    unsafe {
+        let service: ITaskService = CoCreateInstance(&TaskScheduler, None, CLSCTX_INPROC_SERVER)
+            .context("creating TaskScheduler service")?;
+        service.Connect(
+            &VARIANT::default(),
+            &VARIANT::default(),
+            &VARIANT::default(),
+            &VARIANT::default(),
+        )?;
+        let root: ITaskFolder = service.GetFolder(&BSTR::from("\\"))?;
+
+        // Clear any triggerless task leaked by a run that died before its own cleanup.
+        let _ = root.DeleteTask(&BSTR::from(TASK_NAME), 0);
+
+        let task = service.NewTask(0)?;
+        let principal = task.Principal()?;
+        principal.SetLogonType(TASK_LOGON_INTERACTIVE_TOKEN)?; // current user
+        principal.SetRunLevel(TASK_RUNLEVEL_LUA)?; // unelevated
+
+        // Battery policy must not block or later stop the launch.
+        let settings = task.Settings()?;
+        settings.SetDisallowStartIfOnBatteries(VARIANT_FALSE)?;
+        settings.SetStopIfGoingOnBatteries(VARIANT_FALSE)?;
+        settings.SetExecutionTimeLimit(&BSTR::from("PT0S"))?;
+
+        let exec: IExecAction = task.Actions()?.Create(TASK_ACTION_EXEC)?.cast()?;
+        exec.SetPath(&BSTR::from(file))?;
+        if !parameters.is_empty() {
+            exec.SetArguments(&BSTR::from(parameters))?;
+        }
+        if !directory.is_empty() {
+            exec.SetWorkingDirectory(&BSTR::from(directory))?;
+        }
+
+        let registered: IRegisteredTask = root
+            .RegisterTaskDefinition(
+                &BSTR::from(TASK_NAME),
+                &task,
+                TASK_CREATE_OR_UPDATE.0,
+                &VARIANT::default(),
+                &VARIANT::default(),
+                TASK_LOGON_INTERACTIVE_TOKEN,
+                &VARIANT::default(),
+            )
+            .context("registering scheduled task")?;
+        registered.Run(&VARIANT::default()).context("running scheduled task")?;
+
+        // Wait until the action process is actually running before deleting the
+        // task (deleting right after launching is ok tho)
+        let mut launched = false;
+        for _ in 0..200 {
+            if registered.State().unwrap_or(TASK_STATE_UNKNOWN) == TASK_STATE_RUNNING {
+                launched = true;
+                break;
+            }
+            sleep(Duration::from_millis(50));
+        }
+
+        let _ = root.DeleteTask(&BSTR::from(TASK_NAME), 0);
+        anyhow::ensure!(launched, "scheduled task did not reach the Running state");
+        Ok(())
+    }
+}
+
+fn shell_execute_from_explorer(
     file: &str,
     parameters: &str,
     directory: &str,
 ) -> anyhow::Result<()> {
     unsafe {
-        CoInitializeEx(None, COINIT_APARTMENTTHREADED).unwrap();
-
         let mut _hwnd = Default::default();
         let shell_dispatch: IShellDispatch2 =
             CoCreateInstance::<_, IShellWindows>(&ShellWindows, None, CLSCTX_LOCAL_SERVER)?


### PR DESCRIPTION
# Objective
Fix connecting to Windows SSH hosts.

1. Let them download the server binary by curl
2. Stop getting stuck on "Starting proxy" when the Windows host is headless/locked (lacks an interactive Explorer shell)

```
INFO  [remote::transport::ssh] Remote is windows: true 
INFO  [remote::transport::ssh] Remote shell discovered: powershell.exe 
INFO  [remote::transport::ssh] Remote platform discovered: RemotePlatform { os: Windows, arch: X86_64 } 
INFO  [remote::transport::ssh] Remote OS version discovered: Some("10.0.26200") 
INFO  [remote::transport::ssh] curl is not available, trying wget 
INFO [remote::transport::ssh] Failed to download binary on server, attempting to download locally and then upload it the server: Neither curl nor wget is available 
INFO [remote::transport::ssh] uploading remote development server to ".zed_server/zed-remote-server-stable-1.17.2+stable.349.c8e44cfa7bda9b2e22c8d6934d78969352e7f61a.exe-download-35683.zip" (37675kb) 
INFO  [remote::transport::ssh] uploaded remote development server in 23.06152525s 
ERROR [remote::remote_client] failed to establish connection: Client exited with exit_code 1
```
<img width="193" height="205" alt="image" src="https://github.com/user-attachments/assets/a5f942c6-428d-4021-9505-d6fcd8b4f497" />

## Solution

### 1. `curl.exe` instead of `curl`
In PowerShell, `curl` is an alias for `Invoke-WebRequest`, which doesn't understand the `-f -L --connect-timeout` we pass to it and fails, forcing a fallback to uploading the binary over SSH. We just gotta use the actual `curl.exe` that ships with Windows these days.

### 2. Fix spawning on hosts that don't have an active, interactive explorer shell session

1. For context: We try to keep the server running for 10 minutes after an ssh session is closed to prevent re-building the whole state on brief interruptions. Normally, Windows would kill processes spawned from ssh sessions.
2. We currently launch the server by asking explorer.exe to spawn it and be the parent of the server's process (a common hack), so it outlives the SSH session
3. When the Explorer shell itself is locked/suspended/missing, asking it to spawn the server fails. In my case it said `The server process could not be started because the configured identity is incorrect`.
4. The fix is to ask Task Scheduler to spawn it and be the parent instead.

I originally did it using WMI via `Win32_Process::Create`, which gives us a PID/failure immediately without having to poll for a result, but the drawback is that WMI might be blocked by security policies.

## Testing

Verified on a Windows 11 host running the built-in OpenSSH. The server gets correctly spawned by the Task Scheduler service, parent is `svchost`, and it outlives the SSH session. Works when the host is in the partial-wake state 

- ~500ms for Task Scheduler to launch the server
- faster download of the binary


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] ~Unsafe blocks (if any) have justifying comments~ the `windows` crate is heavily unsafe so I followed the example set by `shell_execute_from_explorer`, lmk how you feel about it here
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] ~Tests cover the new/changed behavior~ I presume you'd rather not have tests calling out to Windows like that and any
- [x] Performance impact has been considered and is acceptable. 

## Release Notes:

- Fixed remote development failing to connect to locked/suspended Windows hosts over SSH
