### PR TITLE
editor: Preserve the trailing newline when converting case

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7252,7 +7252,7 @@ impl Editor {
     }
 
     fn convert_text_case(text: &str, case: Case) -> String {
-        text.lines()
+        text.split('\n')
             .map(|line| {
                 let trimmed_start = line.trim_start();
                 let leading = &line[..line.len() - trimmed_start.len()];

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8181,6 +8181,16 @@ async fn test_manipulate_text(cx: &mut TestAppContext) {
         «    hello_world\t\tˇ»
     "});
 
+    cx.set_state(indoc! {"
+        «hello world
+        ˇ»goodbye
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_snake_case(&ConvertToSnakeCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «hello_world
+        ˇ»goodbye
+    "});
+
     // Test selections with `line_mode() = true`.
     cx.update_editor(|editor, _window, _cx| editor.selections.set_line_mode(true));
     cx.set_state(indoc! {"


### PR DESCRIPTION
# Objective
Case conversion commands deleted the newline at the end of the selection,
merging the selected line into the line below it.

To reproduce:

1. A buffer with two lines:

   ```
   hello world
   goodbye
   ```

2. Put the cursor on line 1 and run `editor: select line` — this selects
   `hello world\n`, newline included.
3. Run `editor: convert to upper camel case`.

Before: `HelloWorldgoodbye`, one line. After: `HelloWorld` / `goodbye`.

## Testing

Added a regression test to `test_manipulate_text`.


Release Notes:
- Fixed the case conversion commands deleting the line break when the selection
  ended at the start of the next line.
