### PR TITLE
markdown: Apply heading level text styles to the shaped text

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1938,8 +1938,14 @@ impl MarkdownElement {
         };
 
         let mut heading_style = self.style.heading.clone();
-        let heading_text_style = heading_style.text_style().clone();
+        let mut heading_text_style = heading_style.text_style().clone();
         heading.style().refine(&heading_style);
+
+        if let Some(level_style) =
+            heading_level_style(level, self.style.heading_level_styles.as_ref())
+        {
+            heading_text_style.refine(level_style);
+        }
 
         builder.push_text_style(TextStyleRefinement {
             text_align: Some(align),
@@ -3341,22 +3347,26 @@ fn apply_heading_style(
         };
     }
 
-    if let Some(styles) = custom_styles {
-        let style_opt = match level {
-            pulldown_cmark::HeadingLevel::H1 => &styles.h1,
-            pulldown_cmark::HeadingLevel::H2 => &styles.h2,
-            pulldown_cmark::HeadingLevel::H3 => &styles.h3,
-            pulldown_cmark::HeadingLevel::H4 => &styles.h4,
-            pulldown_cmark::HeadingLevel::H5 => &styles.h5,
-            pulldown_cmark::HeadingLevel::H6 => &styles.h6,
-        };
-
-        if let Some(style) = style_opt {
-            heading.style().text = style.clone();
-        }
+    if let Some(style) = heading_level_style(level, custom_styles) {
+        heading.style().text = style.clone();
     }
 
     heading
+}
+
+fn heading_level_style(
+    level: pulldown_cmark::HeadingLevel,
+    custom_styles: Option<&HeadingLevelStyles>,
+) -> Option<&TextStyleRefinement> {
+    let styles = custom_styles?;
+    match level {
+        pulldown_cmark::HeadingLevel::H1 => styles.h1.as_ref(),
+        pulldown_cmark::HeadingLevel::H2 => styles.h2.as_ref(),
+        pulldown_cmark::HeadingLevel::H3 => styles.h3.as_ref(),
+        pulldown_cmark::HeadingLevel::H4 => styles.h4.as_ref(),
+        pulldown_cmark::HeadingLevel::H5 => styles.h5.as_ref(),
+        pulldown_cmark::HeadingLevel::H6 => styles.h6.as_ref(),
+    }
 }
 
 fn render_wrap_code_block_button(


### PR DESCRIPTION
# Objective

Follow-up to #63118. That PR set the preview's headings to semibold and gave h6 a muted color through `heading_level_styles`, and the PR body says as much, but neither actually rendered. Headings in the preview came out at the base weight and color, which you can see in the after screenshot on that PR: every heading is regular while the bold body text and the table header cells are heavy.

I found this while looking into @Arcitec's report on #63118 about bold not rendering with SF Pro. That one turned out to be a different bug: SF Pro is a variable font, and the Linux text system does not pass the requested weight through to it. It is tracked in #60155 and #62832 has a fix up for it, so this PR does not touch it.

## Solution

`apply_heading_style` wrote the per-level style onto the heading div only. The div's text style reaches layout, which is why the font sizes worked, but the text runs are shaped from `MarkdownElementBuilder`'s style stack, and nothing ever pushed the level style onto that stack. So weight and color were dropped on the floor.

The fix pulls the level lookup out into `heading_level_style` and has `push_markdown_heading` refine the heading's run text style with it before pushing, alongside the existing div refinement. No style values change anywhere. The agent panel's level styles only set font size, so its rendering is identical before and after; I checked.

## Testing

- `cargo test -p markdown` and `./script/clippy` are clean.
- Smoke tested the preview on Linux with a document covering h1 to h6, headings containing bold, italic, code, and links, a wrapping heading, lists, blockquotes, tables, and code blocks. Headings are now semibold, h6 is muted, sizes and h1/h2 borders are unchanged.
- Checked the agent panel with a reply containing headings, bold, a list, and a table: unchanged.
- No new test. The test platform's text system is a no-op that returns the same `FontId` for every font, so an assertion on run weight could not fail.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (there are none)
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior (see Testing for why not)
- [x] Performance impact has been considered and is acceptable

## Showcase

Before is `main` at 399258feea, which already includes #63118, so the only difference is the heading weight and the h6 color.

| Before | After |
|--------|-------|
|  <img width="1933" height="2101" alt="zed_before" src="https://github.com/user-attachments/assets/b84d536a-235d-45bf-9b38-34027accc091" /> | <img width="1933" height="2101" alt="zed_after" src="https://github.com/user-attachments/assets/27d90afd-93c9-4118-96c8-f849b1ad096d" /> |

Release Notes:

- Fixed Markdown preview headings not rendering at their configured weight.
