### PR TITLE
agent_ui: Keep Follow toggle off after idle disable

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2993,17 +2993,15 @@ impl ThreadView {
         let following = self.is_following(cx);
 
         self.should_be_following = !following;
-        if self.thread.read(cx).status() == ThreadStatus::Generating {
-            self.workspace
-                .update(cx, |workspace, cx| {
-                    if following {
-                        workspace.unfollow(CollaboratorId::Agent, window, cx);
-                    } else {
-                        workspace.follow(CollaboratorId::Agent, window, cx);
-                    }
-                })
-                .ok();
-        }
+        self.workspace
+            .update(cx, |workspace, cx| {
+                if following {
+                    workspace.unfollow(CollaboratorId::Agent, window, cx);
+                } else {
+                    workspace.follow(CollaboratorId::Agent, window, cx);
+                }
+            })
+            .ok();
 
         telemetry::event!("Follow Agent Selected", following = !following);
     }


### PR DESCRIPTION
# Objective

Fixes #62973.

The Agent panel Follow toggle did not stick after you turned it off. Once Follow had been on, every later message turned the icon back on.

## Solution

`ThreadView::toggle_following` only called `workspace.unfollow` / `follow` while the thread was `Generating`. Turning Follow off while idle updated `should_be_following` but left the workspace still following the Agent. At the end of the next successful turn, `should_be_following` is copied from `workspace.is_being_followed(Agent)`, so that leftover follow state flipped the icon back on.

The toggle now always applies follow/unfollow. The end-of-turn sync is unchanged (it still remembers unfollow-by-navigating-away mid-generation). `ChatWithFollow` (`cmd-enter`) is unchanged.

## Testing

- Reproduced the bug on the macOS `Zed.app` build.
- Applied the change, built `cargo build -p zed`, and ran `target/debug/zed`.
- Same steps after the fix: turn Follow on, turn it off while idle, send a message. The icon stayed off.
- Follow still works when turned back on.
- No new unit test: this path needs a live `Workspace`, and there is no existing harness around `toggle_following`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before (`Zed.app`): turn Follow off while idle, send a message, the icon comes back on.


https://github.com/user-attachments/assets/3b98714a-42a0-4215-accb-0e2e6fd3213c



After (debug build with this change): same steps, the icon stays off.


https://github.com/user-attachments/assets/bb4dbf67-c937-409d-a79c-015bb3538d64



---

Release Notes:

- Fixed the Agent panel Follow toggle turning itself back on after being disabled ([#62973](https://github.com/zed-industries/zed/issues/62973))
