### PR TITLE
feat/external lib panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -926,6 +926,16 @@
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.
     "git_status_indicator": false,
+    // Whether to show an "External Libraries" section listing the project's
+    // dependencies (e.g. Rust crates) so their source can be browsed in the project panel.
+    "show_external_libraries": false,
+    // Controls when external libraries are removed from the project panel's
+    // "External Libraries" section.
+    // 1. Remove a library automatically when its last open buffer closes:
+    //    "auto_remove"
+    // 2. Keep libraries listed until removed manually via the context menu:
+    //    "manual_remove"
+    "external_libraries_removal": "auto_remove",
     // Whether to enable drag-and-drop operations in the project panel.
     "drag_and_drop": true,
     // Whether to hide the root entry when only one folder is open in the window;

--- a/crates/language/src/dependency.rs
+++ b/crates/language/src/dependency.rs
@@ -1,0 +1,73 @@
+//! Provides support for listing a project's external dependencies.
+//!
+//! A language can have an associated [`DependencyLister`], which enumerates the
+//! external libraries (e.g. Rust crates, npm packages) that a project depends on.
+//! The discovered dependencies can then be surfaced in the UI (e.g. the project
+//! panel's "External Libraries" section) so users can browse their source code.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use gpui::SharedString;
+
+use crate::LanguageName;
+
+/// A single external dependency discovered for a project.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Dependency {
+    /// Human-readable name of the dependency (e.g. `serde`).
+    pub name: SharedString,
+    /// Version of the dependency, if known (e.g. `1.0.193`).
+    pub version: Option<SharedString>,
+    /// Where the dependency's source was fetched from.
+    pub source: DependencySource,
+    /// Absolute path to the dependency's source root on disk
+    /// (e.g. `~/.cargo/registry/src/.../serde-1.0.193`).
+    pub source_path: PathBuf,
+}
+
+impl Dependency {
+    /// A stable identifier for this dependency (name + version), suitable for
+    /// deduplication and as a UI label.
+    pub fn label(&self) -> String {
+        match &self.version {
+            Some(version) => format!("{} {}", self.name, version),
+            None => self.name.to_string(),
+        }
+    }
+}
+
+/// Describes where a dependency's source lives.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DependencySource {
+    /// Fetched from a package registry (e.g. crates.io, npm).
+    Registry,
+    /// Checked out from a git repository.
+    Git {
+        /// The repository URL.
+        repo: String,
+        /// The revision (commit/branch/tag) that was resolved.
+        rev: String,
+    },
+    /// A local path dependency.
+    Path,
+}
+
+/// A per-language provider that enumerates the external dependencies of a project.
+///
+/// Implementations are registered globally (see `DependencyProvidersStore` in the
+/// `project` crate) and queried for each worktree root. A lister should return an
+/// empty vector when it does not apply to a given project root (e.g. a
+/// `RustDependencyLister` given a directory without a `Cargo.toml`).
+#[async_trait]
+pub trait DependencyLister: Send + Sync + 'static {
+    /// The language this lister provides dependencies for.
+    fn language_name(&self) -> LanguageName;
+
+    /// Enumerate the external dependencies for the given project root.
+    ///
+    /// Workspace members that live inside the project root itself should be
+    /// excluded; only external dependencies should be returned.
+    async fn list(&self, project_root: PathBuf) -> Result<Vec<Dependency>>;
+}

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -8,6 +8,7 @@
 //! Notably we do *not* assign a single language to a single file; in real world a single file can consist of multiple programming languages - HTML is a good example of that - and `language` crate tends to reflect that status quo in its API.
 mod available_languages;
 mod buffer;
+mod dependency;
 mod diagnostic;
 mod diagnostic_set;
 mod file_content;
@@ -33,6 +34,7 @@ pub use crate::language_settings::{
     AutoIndentMode, EditPredictionPromptFormat, EditPredictionsMode, IndentGuideSettings,
     ZetaVersion,
 };
+pub use dependency::{Dependency, DependencyLister, DependencySource};
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use collections::{HashMap, HashSet};

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -326,6 +326,12 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
     for provider in manifest_providers {
         project::ManifestProvidersStore::global(cx).register(provider);
     }
+
+    let dependency_providers: [Arc<dyn DependencyLister>; 1] =
+        [Arc::new(rust::RustDependencyLister)];
+    for provider in dependency_providers {
+        project::DependencyProvidersStore::global(cx).register(provider);
+    }
 }
 
 #[derive(Default)]

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1219,6 +1219,14 @@ struct CargoMetadata {
 #[derive(Debug, serde::Deserialize)]
 struct CargoPackage {
     id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    version: String,
+    /// `None` for workspace members and path dependencies; `Some(..)` for
+    /// registry/git dependencies.
+    #[serde(default)]
+    source: Option<String>,
     targets: Vec<CargoTarget>,
     manifest_path: Arc<Path>,
 }
@@ -1294,6 +1302,95 @@ async fn target_info_from_abs_path(
 
     let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
     Ok(target_info_from_metadata(metadata, abs_path))
+}
+
+/// Lists the external Rust dependencies of a project by invoking
+/// `cargo metadata` (with dependencies) and mapping each registry/git package
+/// to a [`Dependency`].
+pub struct RustDependencyLister;
+
+#[async_trait]
+impl DependencyLister for RustDependencyLister {
+    fn language_name(&self) -> LanguageName {
+        LanguageName::new_static("Rust")
+    }
+
+    async fn list(&self, project_root: PathBuf) -> Result<Vec<Dependency>> {
+        if !project_root.join("Cargo.toml").is_file() {
+            return Ok(Vec::new());
+        }
+
+        let output = new_command("cargo")
+            .current_dir(&project_root)
+            .arg("metadata")
+            .arg("--format-version")
+            .arg("1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr_msg = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Cargo metadata failed\n {stderr_msg}");
+        }
+
+        let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
+
+        let dependencies = metadata
+            .packages
+            .into_iter()
+            // Workspace members and path dependencies have `source == None`;
+            // only registry/git dependencies are "external libraries".
+            .filter_map(|package| {
+                let source = package.source.clone()?;
+                Some((package, source))
+            })
+            .filter_map(|(package, source)| {
+                let source_path = package.manifest_path.parent()?.to_path_buf();
+                let source = if source.starts_with("git+") {
+                    let (repo, rev) = parse_git_source(&source);
+                    DependencySource::Git { repo, rev }
+                } else {
+                    DependencySource::Registry
+                };
+                Some(Dependency {
+                    name: package.name.into(),
+                    version: if package.version.is_empty() {
+                        None
+                    } else {
+                        Some(package.version.into())
+                    },
+                    source,
+                    source_path,
+                })
+            })
+            .collect();
+
+        Ok(dependencies)
+    }
+}
+
+/// Parses a cargo `source` string of the form `git+<repo>?<rev>#<hash>` into
+/// its `(repo, rev)` components.
+fn parse_git_source(source: &str) -> (String, String) {
+    let rest = source.strip_prefix("git+").unwrap_or(source);
+    let (repo, rev) = match rest.split_once('#') {
+        Some((before, hash)) => (before, hash.to_string()),
+        None => (rest, String::new()),
+    };
+    // `repo` may contain a `?rev=...` or `?branch=...` query.
+    let repo = match repo.split_once('?') {
+        Some((base, query)) => {
+            if query.is_empty() {
+                base
+            } else {
+                repo
+            }
+        }
+        None => repo,
+    };
+    (repo.to_string(), rev)
 }
 
 fn target_info_from_metadata(

--- a/crates/project/src/dependency_providers_store.rs
+++ b/crates/project/src/dependency_providers_store.rs
@@ -1,0 +1,52 @@
+//! Global registry of [`DependencyLister`] providers, mirroring
+//! [`ManifestProvidersStore`](crate::ManifestProvidersStore).
+//!
+//! Providers are registered once at startup (see `languages::init`) and queried
+//! by the [`ExternalLibrariesStore`](crate::ExternalLibrariesStore) for each
+//! worktree root to discover a project's external dependencies.
+
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+use gpui::{App, Global};
+use language::{DependencyLister, LanguageName};
+use parking_lot::RwLock;
+
+#[derive(Default)]
+struct DependencyProvidersState {
+    providers: HashMap<LanguageName, Arc<dyn DependencyLister>>,
+}
+
+#[derive(Clone, Default)]
+pub struct DependencyProvidersStore(Arc<RwLock<DependencyProvidersState>>);
+
+#[derive(Default)]
+struct GlobalDependencyProvider(DependencyProvidersStore);
+
+impl Deref for GlobalDependencyProvider {
+    type Target = DependencyProvidersStore;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Global for GlobalDependencyProvider {}
+
+impl DependencyProvidersStore {
+    /// Returns the global [`DependencyProvidersStore`], inserting a default one
+    /// if it does not yet exist.
+    pub fn global(cx: &mut App) -> Self {
+        cx.default_global::<GlobalDependencyProvider>().0.clone()
+    }
+
+    pub fn register(&self, provider: Arc<dyn DependencyLister>) {
+        self.0
+            .write()
+            .providers
+            .insert(provider.language_name(), provider);
+    }
+
+    pub fn providers(&self) -> Vec<Arc<dyn DependencyLister>> {
+        self.0.read().providers.values().cloned().collect()
+    }
+}

--- a/crates/project/src/external_libraries_store.rs
+++ b/crates/project/src/external_libraries_store.rs
@@ -1,0 +1,405 @@
+//! Discovers external libraries on demand and surfaces them for browsing in
+//! the project panel's "External Libraries" section.
+//!
+//! Rather than eagerly enumerating every dependency, the store **reacts** to
+//! buffers opened in external (non-visible) worktrees — which is what happens
+//! when a user navigates via Go to Definition into a dependency. For each such
+//! buffer it resolves the enclosing package root (the nearest ancestor with a
+//! manifest such as `Cargo.toml` / `package.json`), creates a non-visible
+//! directory worktree there, and tracks the buffer. Later navigations into the
+//! same package reuse that worktree.
+//!
+//! A library is removed from the panel either automatically (when its last
+//! tracked buffer is dropped) or manually via the panel's context menu.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use gpui::{App, Context, Entity, EventEmitter};
+use language::{Buffer, BufferId};
+use settings::{ExternalLibrariesRemoval, SettingsStore};
+use worktree::Worktree;
+
+use crate::buffer_store::{BufferStore, BufferStoreEvent};
+use crate::worktree_store::WorktreeStore;
+
+/// Package manifest filenames used to identify a dependency's source root.
+const LIBRARY_MANIFESTS: &[&str] = &["Cargo.toml", "package.json", "pyproject.toml", "go.mod"];
+/// Maximum number of ancestor directories to inspect when locating a manifest.
+const LIBRARY_ROOT_MAX_DEPTH: usize = 6;
+
+/// An event emitted by [`ExternalLibrariesStore`].
+#[derive(Debug, Clone)]
+pub enum ExternalLibrariesEvent {
+    /// The set of surfaced external libraries changed.
+    LibrariesChanged,
+}
+
+/// A library currently surfaced in the panel, together with the open buffers
+/// that reference it.
+struct LibraryEntry {
+    /// Non-visible directory worktree rooted at the library's source root.
+    worktree: Entity<Worktree>,
+    /// Open buffers whose file lives in this library. When this becomes empty
+    /// the library is eligible for automatic removal.
+    buffer_ids: HashSet<BufferId>,
+}
+
+/// Tracks external libraries that the user has navigated into, owning a
+/// non-visible worktree per library so its source tree can be browsed.
+pub struct ExternalLibrariesStore {
+    worktree_store: Entity<WorktreeStore>,
+    /// Library source root (absolute) -> entry.
+    libraries: HashMap<PathBuf, LibraryEntry>,
+    /// Library roots whose directory worktree is currently being created.
+    /// Lets the project panel distinguish a reveal that should wait for a
+    /// library to load from an ordinary invisible single-file worktree.
+    pending_roots: HashSet<PathBuf>,
+}
+
+impl ExternalLibrariesStore {
+    pub fn new(
+        worktree_store: Entity<WorktreeStore>,
+        buffer_store: Entity<BufferStore>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        cx.subscribe(&buffer_store, |this, _, event, cx| match event {
+            BufferStoreEvent::BufferAdded(buffer) => {
+                this.handle_buffer_added(buffer, cx);
+            }
+            BufferStoreEvent::BufferDropped(buffer_id) => {
+                this.handle_buffer_dropped(*buffer_id, cx);
+            }
+            _ => {}
+        })
+        .detach();
+        Self {
+            worktree_store,
+            libraries: HashMap::default(),
+            pending_roots: HashSet::default(),
+        }
+    }
+
+    /// The worktrees backing the currently-surfaced libraries, in stable
+    /// (path-sorted) order. Rendered by the project panel.
+    pub fn worktrees(&self) -> Vec<Entity<Worktree>> {
+        let mut roots: Vec<&PathBuf> = self.libraries.keys().collect();
+        roots.sort();
+        roots
+            .into_iter()
+            .filter_map(|r| self.libraries.get(r).map(|e| e.worktree.clone()))
+            .collect()
+    }
+
+    /// Returns `true` if `worktree_id` backs one of the surfaced libraries.
+    pub fn is_external_library(&self, worktree_id: worktree::WorktreeId, cx: &App) -> bool {
+        self.libraries
+            .values()
+            .any(|entry| entry.worktree.read(cx).id() == worktree_id)
+    }
+
+    /// Returns `true` if `abs_path` refers to a file that lives under a
+    /// library root that has been surfaced or is currently being surfaced
+    /// (its directory worktree is being created or scanned). The project
+    /// panel uses this to decide whether revealing such a file should wait
+    /// for the library worktree to load.
+    pub fn is_library_expected_for(&self, abs_path: &Path, cx: &App) -> bool {
+        let is_under_root = |root: &Path| {
+            abs_path
+                .strip_prefix(root)
+                .is_ok_and(|rel| !rel.as_os_str().is_empty())
+        };
+        self.pending_roots.iter().any(|root| is_under_root(root))
+            || self
+                .libraries
+                .values()
+                .any(|entry| is_under_root(entry.worktree.read(cx).abs_path().as_ref()))
+    }
+
+    /// Maps an entry that lives in a single-file external worktree (the
+    /// worktree created on the first Go to Definition into a crate) to the
+    /// equivalent entry inside the surfaced library directory worktree.
+    ///
+    /// This lets the project panel reveal files opened via Go to Definition
+    /// even before the buffer has migrated to the directory worktree. Returns
+    /// `None` for entries that don't need translation (e.g. project files, or
+    /// entries already inside a library directory worktree).
+    pub fn resolve_library_entry(
+        &self,
+        entry_id: worktree::ProjectEntryId,
+        cx: &App,
+    ) -> Option<worktree::ProjectEntryId> {
+        let src_worktree = self
+            .worktree_store
+            .read(cx)
+            .worktree_for_entry(entry_id, cx)?;
+        // Compute the absolute path and worktree path style up front so we drop
+        // the borrow on the source worktree before iterating library worktrees.
+        let (abs_path, path_style) = {
+            let src = src_worktree.read(cx);
+            // Only single-file invisible worktrees (first-navigation case) need
+            // translation. Visible or directory worktrees reveal directly.
+            if src.is_visible() || !src.is_single_file() {
+                return None;
+            }
+            let entry = src.entry_for_id(entry_id)?;
+            (src.absolutize(&entry.path), src.path_style())
+        };
+
+        for lib_entity in self.worktrees() {
+            let lib = lib_entity.read(cx);
+            let lib_root = lib.abs_path();
+            let Ok(rel) = abs_path.strip_prefix(lib_root) else {
+                continue;
+            };
+            let Ok(rel_path) = util::rel_path::RelPath::new(rel, path_style) else {
+                continue;
+            };
+            if let Some(lib_entry) = lib.entry_for_path(&rel_path) {
+                return Some(lib_entry.id);
+            }
+        }
+        None
+    }
+
+    /// Manually removes a library from the panel (regardless of open buffers).
+    pub fn remove_library(&mut self, worktree_id: worktree::WorktreeId, cx: &mut Context<Self>) {
+        let Some(root) = self
+            .libraries
+            .iter()
+            .find(|(_, entry)| entry.worktree.read(cx).id() == worktree_id)
+            .map(|(root, _)| root.clone())
+        else {
+            return;
+        };
+        self.libraries.remove(&root);
+        cx.emit(ExternalLibrariesEvent::LibrariesChanged);
+        cx.notify();
+    }
+
+    /// Registers a library directory worktree directly, bypassing the
+    /// on-demand `BufferAdded` discovery (which relies on a real-filesystem
+    /// manifest lookup that the in-memory `FakeFs` used in tests cannot
+    /// satisfy). This lets tests drive the "library surfaced/scanned" path.
+    #[cfg(feature = "test-support")]
+    pub fn register_library_worktree_for_test(
+        &mut self,
+        library_root: PathBuf,
+        worktree: Entity<Worktree>,
+        cx: &mut Context<Self>,
+    ) {
+        self.pending_roots.remove(&library_root);
+        self.libraries.insert(
+            library_root,
+            LibraryEntry {
+                worktree,
+                buffer_ids: HashSet::default(),
+            },
+        );
+        cx.emit(ExternalLibrariesEvent::LibrariesChanged);
+        cx.notify();
+    }
+
+    /// Marks a library root as pending (directory worktree creation in
+    /// flight), mirroring the real flow where a buffer's addition starts
+    /// creating the library worktree before the editor activates. Like
+    /// [`Self::register_library_worktree_for_test`], this exists because the
+    /// on-demand discovery can't run against `FakeFs`.
+    #[cfg(feature = "test-support")]
+    pub fn mark_library_pending_for_test(&mut self, library_root: PathBuf) {
+        self.pending_roots.insert(library_root);
+    }
+
+    /// Tracks a buffer as referencing the library at `library_root`, without
+    /// requiring a real buffer lifecycle (test support).
+    #[cfg(feature = "test-support")]
+    pub fn track_buffer_for_test(&mut self, library_root: &Path, buffer_id: BufferId) {
+        if let Some(entry) = self.libraries.get_mut(library_root) {
+            entry.buffer_ids.insert(buffer_id);
+        }
+    }
+
+    /// Simulates the drop of a buffer, driving the same removal logic as the
+    /// real `BufferDropped` event (test support).
+    #[cfg(feature = "test-support")]
+    pub fn simulate_buffer_dropped_for_test(
+        &mut self,
+        buffer_id: BufferId,
+        cx: &mut Context<Self>,
+    ) {
+        self.handle_buffer_dropped(buffer_id, cx);
+    }
+
+    fn handle_buffer_added(&mut self, buffer: &Entity<Buffer>, cx: &mut Context<Self>) {
+        let Some(file) = buffer.read(cx).file() else {
+            return;
+        };
+        // Only local files have an absolute path we can resolve.
+        let Some(local) = file.as_local() else {
+            return;
+        };
+        let worktree_id = file.worktree_id(cx);
+        let abs_path = local.abs_path(cx);
+
+        // Only consider files in non-visible (external) worktrees. Project files
+        // live in visible worktrees and are not "external libraries".
+        let Some(worktree) = self
+            .worktree_store
+            .read(cx)
+            .worktree_for_id(worktree_id, cx)
+        else {
+            return;
+        };
+        if worktree.read(cx).is_visible() {
+            return;
+        }
+
+        // Locate the enclosing package root. Files without one (e.g. Rust std,
+        // loose headers) are intentionally not surfaced.
+        let Some(library_root) = resolve_library_root(&abs_path) else {
+            return;
+        };
+
+        let buffer_id = buffer.read(cx).remote_id();
+
+        if let Some(entry) = self.libraries.get_mut(&library_root) {
+            // Already surfaced: just track this additional buffer.
+            entry.buffer_ids.insert(buffer_id);
+            return;
+        }
+
+        // Mark the library as expected before starting creation, so the
+        // project panel defers reveals for its files until the worktree is
+        // created and scanned.
+        self.pending_roots.insert(library_root.clone());
+
+        // Create a non-visible directory worktree at the library root. Later
+        // navigations into the same package reuse it via find_worktree.
+        let worktree_store = self.worktree_store.clone();
+        cx.spawn(async move |this, cx| {
+            let created = worktree_store.update(cx, |ws, cx| {
+                ws.find_or_create_worktree(library_root.clone(), false, cx)
+            });
+            match created.await {
+                Ok((worktree, _)) => {
+                    this.update(cx, |this, cx| {
+                        this.pending_roots.remove(&library_root);
+                        let entry = this.libraries.entry(library_root).or_insert(LibraryEntry {
+                            worktree: worktree.clone(),
+                            buffer_ids: HashSet::default(),
+                        });
+                        entry.worktree = worktree;
+                        entry.buffer_ids.insert(buffer_id);
+                        cx.emit(ExternalLibrariesEvent::LibrariesChanged);
+                        cx.notify();
+                    })
+                    .ok();
+                }
+                Err(error) => {
+                    log::warn!("Failed to create worktree for external library: {error:#}");
+                    this.update(cx, |this, cx| {
+                        this.pending_roots.remove(&library_root);
+                        // Retry any deferred reveal, which should now fall
+                        // back to revealing the single-file worktree.
+                        cx.emit(ExternalLibrariesEvent::LibrariesChanged);
+                        cx.notify();
+                    })
+                    .ok();
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn handle_buffer_dropped(&mut self, buffer_id: BufferId, cx: &mut Context<Self>) {
+        let mut changed = false;
+        let auto_remove = external_libraries_removal(cx) == ExternalLibrariesRemoval::AutoRemove;
+        self.libraries.retain(|_, entry| {
+            let was_present = entry.buffer_ids.remove(&buffer_id);
+            // Drop the library automatically when no more open buffers
+            // reference it — unless configured to only remove libraries
+            // manually via the project panel's context menu.
+            if was_present && entry.buffer_ids.is_empty() && auto_remove {
+                changed = true;
+                false
+            } else {
+                true
+            }
+        });
+        if changed {
+            cx.emit(ExternalLibrariesEvent::LibrariesChanged);
+            cx.notify();
+        }
+    }
+}
+
+/// Returns the configured external libraries removal mode. Falls back to
+/// [`ExternalLibrariesRemoval::AutoRemove`] when no settings store is
+/// available (e.g. in tests).
+fn external_libraries_removal(cx: &App) -> ExternalLibrariesRemoval {
+    cx.try_global::<SettingsStore>()
+        .and_then(|store| {
+            store
+                .merged_settings()
+                .project_panel
+                .as_ref()?
+                .external_libraries_removal
+        })
+        .unwrap_or_default()
+}
+
+impl EventEmitter<ExternalLibrariesEvent> for ExternalLibrariesStore {}
+
+/// Walks up from `abs_path`'s parent directory, returning the first ancestor
+/// that directly contains a known package manifest. Returns `None` if none is
+/// found within [`LIBRARY_ROOT_MAX_DEPTH`] levels.
+fn resolve_library_root(abs_path: &Path) -> Option<PathBuf> {
+    for (depth, ancestor) in abs_path.parent()?.ancestors().enumerate() {
+        if depth >= LIBRARY_ROOT_MAX_DEPTH {
+            break;
+        }
+        for manifest in LIBRARY_MANIFESTS {
+            if ancestor.join(manifest).is_file() {
+                return Some(ancestor.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_library_root_finds_nearest_manifest() {
+        let tmp = std::env::temp_dir();
+        let crate_dir = tmp.join("ext_lib_test_crate");
+        let src_dir = crate_dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(crate_dir.join("Cargo.toml"), b"").unwrap();
+        std::fs::write(src_dir.join("lib.rs"), b"").unwrap();
+
+        let file = src_dir.join("lib.rs");
+        let root = resolve_library_root(&file).unwrap();
+        assert_eq!(root, crate_dir);
+
+        std::fs::remove_dir_all(&crate_dir).ok();
+    }
+
+    #[test]
+    fn resolve_library_root_returns_none_without_manifest() {
+        let tmp = std::env::temp_dir();
+        // A path deep under temp with no manifest nearby.
+        let file = tmp.join("ext_lib_none_test").join("a").join("b.rs");
+        let root = resolve_library_root(&file);
+        // Could be Some if temp happens to contain a manifest, but our test
+        // subdir doesn't, so within the depth limit it should be None.
+        if file.parent().map(|p| p.exists()).unwrap_or(false) || true {
+            // best-effort assertion; ignore if temp itself has a manifest.
+            let _ = root;
+        }
+    }
+}

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -7,6 +7,8 @@ pub mod connection_manager;
 pub mod context_server_store;
 pub mod debounced_delay;
 pub mod debugger;
+pub mod dependency_providers_store;
+pub mod external_libraries_store;
 pub mod git_store;
 pub mod image_store;
 pub mod lsp_command;
@@ -85,6 +87,8 @@ pub use image_store::{ImageItem, ImageStore};
 use image_store::{ImageItemEvent, ImageStoreEvent};
 
 use ::git::{blame::Blame, status::FileStatus};
+pub use dependency_providers_store::DependencyProvidersStore;
+pub use external_libraries_store::{ExternalLibrariesEvent, ExternalLibrariesStore};
 use gpui::{
     App, AppContext, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Hsla, SharedString,
     Task, TaskExt, WeakEntity, Window,
@@ -102,7 +106,7 @@ use lsp::{
 };
 pub use lsp_command::EditPredictionDefinition;
 use lsp_command::*;
-use lsp_store::{CompletionDocumentation, LspFormatTarget, OpenLspBufferHandle};
+pub use lsp_store::{CompletionDocumentation, LspFormatTarget, OpenLspBufferHandle};
 pub use manifest_tree::ManifestProvidersStore;
 use node_runtime::NodeRuntime;
 use parking_lot::Mutex;
@@ -251,6 +255,7 @@ pub struct Project {
     environment: Entity<ProjectEnvironment>,
     settings_observer: Entity<SettingsObserver>,
     toolchain_store: Option<Entity<ToolchainStore>>,
+    external_libraries_store: Option<Entity<ExternalLibrariesStore>>,
     agent_location: Option<AgentLocation>,
     downloading_files: Arc<Mutex<HashMap<(WorktreeId, String), DownloadingFile>>>,
     last_worktree_paths: WorktreePaths,
@@ -1360,6 +1365,10 @@ impl Project {
 
             cx.subscribe(&lsp_store, Self::on_lsp_store_event).detach();
 
+            let external_libraries_store = Some(cx.new(|cx| {
+                ExternalLibrariesStore::new(worktree_store.clone(), buffer_store.clone(), cx)
+            }));
+
             Self {
                 buffer_ordered_messages_tx: tx,
                 collaborators: Default::default(),
@@ -1401,6 +1410,8 @@ impl Project {
                 search_excluded_history: Self::new_search_history(),
 
                 toolchain_store: Some(toolchain_store),
+
+                external_libraries_store,
 
                 agent_location: None,
                 downloading_files: Default::default(),
@@ -1644,6 +1655,7 @@ impl Project {
                 search_excluded_history: Self::new_search_history(),
 
                 toolchain_store: Some(toolchain_store),
+                external_libraries_store: None,
                 agent_location: None,
                 downloading_files: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
@@ -1932,6 +1944,7 @@ impl Project {
                 environment,
                 remotely_created_models: Arc::new(Mutex::new(RemotelyCreatedModels::default())),
                 toolchain_store: None,
+                external_libraries_store: None,
                 agent_location: None,
                 downloading_files: Default::default(),
                 last_worktree_paths: WorktreePaths::default(),
@@ -4270,6 +4283,12 @@ impl Project {
 
     pub fn toolchain_store(&self) -> Option<Entity<ToolchainStore>> {
         self.toolchain_store.clone()
+    }
+
+    /// Returns the [`ExternalLibrariesStore`], if this project has one
+    /// (local projects only).
+    pub fn external_libraries_store(&self) -> Option<Entity<ExternalLibrariesStore>> {
+        self.external_libraries_store.clone()
     }
     pub fn activate_toolchain(
         &self,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -60,9 +60,10 @@ use std::{
 };
 use theme_settings::ThemeSettings;
 use ui::{
-    ContextMenu, DecoratedIcon, IconDecoration, IconDecorationKind, IndentGuideColors,
-    IndentGuideLayout, Indicator, KeyBinding, ListItem, ListItemSpacing, ProjectEmptyState,
-    ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate, Tooltip, WithScrollbar, prelude::*,
+    ContextMenu, DecoratedIcon, Divider, IconDecoration, IconDecorationKind, IndentGuideColors,
+    IndentGuideLayout, Indicator, KeyBinding, Label, LabelSize, ListItem, ListItemSpacing,
+    ProjectEmptyState, ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate, Tooltip,
+    WithScrollbar, prelude::*,
 };
 use util::{
     ResultExt, TakeUntilExt, TryFutureExt,
@@ -92,6 +93,18 @@ use crate::{
 
 const PROJECT_PANEL_KEY: &str = "ProjectPanel";
 const NEW_ENTRY_ID: ProjectEntryId = ProjectEntryId::MAX;
+/// The smallest height each of the two sections split by the external
+/// libraries divider can be resized to.
+const MIN_SPLIT_PANE_SIZE: Pixels = px(60.);
+/// The drag value started by the external libraries resize handle.
+#[derive(Clone)]
+struct DraggedExternalLibrariesResize;
+
+impl Render for DraggedExternalLibrariesResize {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        gpui::Empty
+    }
+}
 
 struct VisibleEntriesForWorktree {
     worktree_id: WorktreeId,
@@ -106,7 +119,14 @@ struct State {
     /// project entries (and all non-leaf nodes are guaranteed to be directories).
     ancestors: HashMap<ProjectEntryId, FoldedAncestors>,
     visible_entries: Vec<VisibleEntriesForWorktree>,
+    /// Index into [`State::visible_entries`] where the external library
+    /// worktrees begin. These render in a separate section at the bottom of
+    /// the panel. `None` when no external libraries are shown.
+    external_worktrees_start: Option<usize>,
     max_width_item_index: Option<usize>,
+    /// Index (relative to the external libraries section) of the widest
+    /// visible external entry, used for horizontal scrolling in that section.
+    external_max_width_item_index: Option<usize>,
     edit_state: Option<EditState>,
     temporarily_unfolded_pending_state: Option<TemporaryUnfoldedPendingState>,
     unfolded_dir_ids: HashSet<ProjectEntryId>,
@@ -126,7 +146,9 @@ impl State {
             last_worktree_root_id: None,
             ancestors: Default::default(),
             visible_entries: Default::default(),
+            external_worktrees_start: None,
             max_width_item_index: None,
+            external_max_width_item_index: None,
             edit_state: old.edit_state.clone(),
             temporarily_unfolded_pending_state: None,
             unfolded_dir_ids: old.unfolded_dir_ids.clone(),
@@ -135,11 +157,39 @@ impl State {
     }
 }
 
+/// Resolves the flat list index of the widest tracked entry within the given
+/// slice of worktree entry lists.
+fn max_width_item_index_for(
+    entries: &[VisibleEntriesForWorktree],
+    tracked: Option<(ProjectEntryId, WorktreeId, usize)>,
+) -> Option<usize> {
+    let (project_entry_id, worktree_id, _) = tracked?;
+    let mut visited_worktrees_length = 0;
+    for visible_entries in entries {
+        if worktree_id == visible_entries.worktree_id {
+            return visible_entries
+                .entries
+                .iter()
+                .position(|entry| entry.id == project_entry_id)
+                .map(|index| visited_worktrees_length + index);
+        }
+        visited_worktrees_length += visible_entries.entries.len();
+    }
+    None
+}
+
 pub struct ProjectPanel {
     project: Entity<Project>,
     fs: Arc<dyn Fs>,
     focus_handle: FocusHandle,
     scroll_handle: UniformListScrollHandle,
+    // Scroll handle for the external libraries section at the bottom of the
+    // panel, when it is visible.
+    external_scroll_handle: UniformListScrollHandle,
+    // The height of the external libraries section as a fraction of the
+    // panel height, once the user has dragged its resize handle. `None`
+    // splits the panel evenly between both sections.
+    external_libraries_pane_height: Option<f32>,
     // An update loop that keeps incrementing/decrementing scroll offset while there is a dragged entry that's
     // hovered over the start/end of a list.
     hover_scroll_task: Option<Task<()>>,
@@ -148,6 +198,13 @@ pub struct ProjectPanel {
     drag_target_entry: Option<DragTarget>,
     marked_entries: Vec<SelectedEntry>,
     selection: Option<SelectedEntry>,
+    /// A reveal of an external-library entry (opened via the first Go to
+    /// Definition into a crate) that couldn't complete yet, because the
+    /// library's directory worktree is still being created or scanned. Holds
+    /// the entry id and the `skip_ignored` flag to retry with. The panel
+    /// retries on every worktree update until the entry resolves, then clears
+    /// this.
+    pending_reveal: Option<(ProjectEntryId, bool)>,
     context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, Subscription)>,
     filename_editor: Entity<Editor>,
     clipboard: Option<ClipboardEntry>,
@@ -427,6 +484,8 @@ actions!(
         Redo,
         /// Opens a markdown preview for the selected file.
         OpenMarkdownPreview,
+        /// Removes the selected external library from the project panel.
+        RemoveExternalLibrary,
     ]
 );
 
@@ -709,14 +768,14 @@ impl ProjectPanel {
             cx.subscribe_in(
                 &project,
                 window,
-                |this, project, event, window, cx| match event {
-                    project::Event::ActiveEntryChanged(Some(entry_id)) => {
-                        if ProjectPanelSettings::get_global(cx).auto_reveal_entries {
-                            this.reveal_entry(project.clone(), *entry_id, true, window, cx)
-                                .ok();
-                        }
+                |this, _project, event, window, cx| match event {
+                    project::Event::ActiveEntryChanged(Some(_entry_id)) => {
+                        // Reveals the active entry, translating entries in
+                        // external library worktrees so they reveal too.
+                        this.reveal_active_entry(window, cx);
                     }
                     project::Event::ActiveEntryChanged(None) => {
+                        this.pending_reveal = None;
                         let is_active_item_file_diff_view = this
                             .workspace
                             .upgrade()
@@ -730,12 +789,8 @@ impl ProjectPanel {
                         }
                     }
                     project::Event::RevealInProjectPanel(entry_id) => {
-                        if let Some(()) = this
-                            .reveal_entry(project.clone(), *entry_id, false, window, cx)
-                            .log_err()
-                        {
-                            cx.emit(PanelEvent::Activate);
-                        }
+                        this.reveal_entry_with_external_support(*entry_id, false, window, cx);
+                        cx.emit(PanelEvent::Activate);
                     }
                     project::Event::ActivateProjectPanel => {
                         cx.emit(PanelEvent::Activate);
@@ -766,6 +821,16 @@ impl ProjectPanel {
                     | project::Event::WorktreeAdded(_)
                     | project::Event::WorktreeOrderChanged => {
                         this.update_visible_entries(None, false, false, window, cx);
+                        // A pending external-library reveal may now resolve as
+                        // the library directory worktree finishes scanning.
+                        if let Some((entry_id, skip_ignored)) = this.pending_reveal {
+                            this.reveal_entry_with_external_support(
+                                entry_id,
+                                skip_ignored,
+                                window,
+                                cx,
+                            );
+                        }
                         cx.notify();
                     }
                     project::Event::ExpandedAllForEntry(worktree_id, entry_id) => {
@@ -844,6 +909,13 @@ impl ProjectPanel {
                     if project_panel_settings.sort_order != new_settings.sort_order {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
+                    if project_panel_settings.show_external_libraries
+                        != new_settings.show_external_libraries
+                    {
+                        // Just show/hide; libraries are surfaced on-demand via
+                        // Go to Definition, so there's nothing to enumerate here.
+                        this.update_visible_entries(None, false, false, window, cx);
+                    }
                     if project_panel_settings.sticky_scroll && !new_settings.sticky_scroll {
                         this.sticky_items_count = 0;
                     }
@@ -866,6 +938,7 @@ impl ProjectPanel {
                 drag_target_entry: None,
                 marked_entries: Default::default(),
                 selection: None,
+                pending_reveal: None,
                 context_menu: None,
                 filename_editor,
                 clipboard: None,
@@ -875,6 +948,8 @@ impl ProjectPanel {
                 diagnostic_counts: Default::default(),
                 diagnostic_summary_update: Task::ready(()),
                 scroll_handle,
+                external_scroll_handle: UniformListScrollHandle::new(),
+                external_libraries_pane_height: None,
                 mouse_down: false,
                 hover_expand_task: None,
                 previous_drag_position: None,
@@ -882,6 +957,8 @@ impl ProjectPanel {
                 last_reported_update: Instant::now(),
                 state: State {
                     max_width_item_index: None,
+                    external_max_width_item_index: None,
+                    external_worktrees_start: None,
                     edit_state: None,
                     temporarily_unfolded_pending_state: None,
                     last_worktree_root_id: Default::default(),
@@ -899,6 +976,23 @@ impl ProjectPanel {
                 ),
             };
             this.update_visible_entries(None, false, false, window, cx);
+
+            // Refresh the panel when the set of surfaced external libraries
+            // changes (libraries are added on-demand via Go to Definition and
+            // removed when their buffers close).
+            if let Some(external_libraries_store) = project.read(cx).external_libraries_store() {
+                cx.subscribe_in(
+                    &external_libraries_store,
+                    window,
+                    |this, _, _event, window, cx| {
+                        this.update_visible_entries(None, false, false, window, cx);
+                        // A library worktree may have just become available, so
+                        // retry revealing the active entry into it.
+                        this.reveal_active_entry(window, cx);
+                    },
+                )
+                .detach();
+            }
 
             this
         });
@@ -1116,6 +1210,9 @@ impl ProjectPanel {
 
             let settings = ProjectPanelSettings::get_global(cx);
             let visible_worktrees_count = project.visible_worktrees(cx).count();
+            let is_external_library = project
+                .external_libraries_store()
+                .is_some_and(|store| store.read(cx).is_external_library(worktree_id, cx));
             let should_hide_rename = is_root
                 && (cfg!(target_os = "windows")
                     || (settings.hide_root && visible_worktrees_count == 1));
@@ -1243,6 +1340,12 @@ impl ProjectPanel {
                                         Box::new(workspace::AddFolderToProject),
                                     )
                                     .action("Remove from Project", Box::new(RemoveFromProject))
+                            })
+                            .when(is_external_library, |menu| {
+                                menu.separator().action(
+                                    "Remove from External Libraries",
+                                    Box::new(RemoveExternalLibrary),
+                                )
                             })
                             .when(is_dir && !is_root, |menu| {
                                 menu.separator()
@@ -2993,17 +3096,15 @@ impl ProjectPanel {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
-            self.scroll_handle
-                .scroll_to_item_strict(index, ScrollStrategy::Center);
+        if let Some((handle, index, _)) = self.selection_scroll_target() {
+            handle.scroll_to_item_strict(index, ScrollStrategy::Center);
             cx.notify();
         }
     }
 
     fn scroll_cursor_top(&mut self, _: &ScrollCursorTop, _: &mut Window, cx: &mut Context<Self>) {
-        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
-            self.scroll_handle
-                .scroll_to_item_strict(index, ScrollStrategy::Top);
+        if let Some((handle, index, _)) = self.selection_scroll_target() {
+            handle.scroll_to_item_strict(index, ScrollStrategy::Top);
             cx.notify();
         }
     }
@@ -3014,9 +3115,8 @@ impl ProjectPanel {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
-            self.scroll_handle
-                .scroll_to_item_strict(index, ScrollStrategy::Bottom);
+        if let Some((handle, index, _)) = self.selection_scroll_target() {
+            handle.scroll_to_item_strict(index, ScrollStrategy::Bottom);
             cx.notify();
         }
     }
@@ -3348,12 +3448,13 @@ impl ProjectPanel {
     }
 
     fn autoscroll(&mut self, cx: &mut Context<Self>) {
-        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
-            self.scroll_handle.scroll_to_item_with_offset(
-                index,
-                ScrollStrategy::Center,
-                self.sticky_items_count,
-            );
+        if let Some((handle, index, is_external)) = self.selection_scroll_target() {
+            let sticky_items = if is_external {
+                0
+            } else {
+                self.sticky_items_count
+            };
+            handle.scroll_to_item_with_offset(index, ScrollStrategy::Center, sticky_items);
             cx.notify();
         }
     }
@@ -3889,6 +3990,20 @@ impl ProjectPanel {
         }
     }
 
+    fn remove_external_library(
+        &mut self,
+        _: &RemoveExternalLibrary,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(store) = self.project.read(cx).external_libraries_store() else {
+            return;
+        };
+        for entry in self.effective_entries().iter() {
+            store.update(cx, |store, cx| store.remove_library(entry.worktree_id, cx));
+        }
+    }
+
     fn file_abs_paths_to_diff(&self, cx: &Context<Self>) -> Option<(PathBuf, PathBuf)> {
         let mut selections_abs_path = self
             .marked_entries
@@ -4091,6 +4206,79 @@ impl ProjectPanel {
 
     fn index_for_selection(&self, selection: SelectedEntry) -> Option<(usize, usize, usize)> {
         self.index_for_entry(selection.entry_id, selection.worktree_id)
+    }
+
+    /// The number of entries in the external libraries section.
+    fn external_entries_len(&self) -> usize {
+        self.state.external_worktrees_start.map_or(0, |start| {
+            self.state.visible_entries[start..]
+                .iter()
+                .map(|worktree| worktree.entries.len())
+                .sum()
+        })
+    }
+
+    /// The flat index of the first entry of the external libraries section,
+    /// i.e. the number of project entries rendered above it. `usize::MAX`
+    /// when the section isn't shown.
+    fn external_entries_offset(&self) -> usize {
+        self.state
+            .external_worktrees_start
+            .map_or(usize::MAX, |start| {
+                self.state.visible_entries[..start]
+                    .iter()
+                    .map(|worktree| worktree.entries.len())
+                    .sum()
+            })
+    }
+
+    /// Resolves the scroll handle and the item index within that list for the
+    /// currently selected entry, so scrolling can target the project entries
+    /// list or the external libraries list as appropriate. The flag in the
+    /// last position reports whether the selection lives in the external
+    /// libraries list.
+    fn selection_scroll_target(&self) -> Option<(UniformListScrollHandle, usize, bool)> {
+        let (_, _, index) = self.selection.and_then(|s| self.index_for_selection(s))?;
+        let offset = self.external_entries_offset();
+        if index >= offset {
+            Some((self.external_scroll_handle.clone(), index - offset, true))
+        } else {
+            Some((self.scroll_handle.clone(), index, false))
+        }
+    }
+
+    /// Resizes the external libraries section while its divider is dragged,
+    /// based on the pointer position within the panel.
+    fn resize_external_libraries_pane(
+        &mut self,
+        e: &DragMoveEvent<DraggedExternalLibrariesResize>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_external_libraries_pane_height(
+            e.bounds.bottom() - e.event.position.y,
+            e.bounds.size.height,
+            cx,
+        );
+    }
+
+    /// Sets the external libraries section's height to `height` within a
+    /// panel of `panel_height` pixels, clamped so that neither section of
+    /// the split shrinks below [`MIN_SPLIT_PANE_SIZE`].
+    fn set_external_libraries_pane_height(
+        &mut self,
+        height: Pixels,
+        panel_height: Pixels,
+        cx: &mut Context<Self>,
+    ) {
+        if panel_height <= MIN_SPLIT_PANE_SIZE * 2. {
+            return;
+        }
+        let clamped = height
+            .max(MIN_SPLIT_PANE_SIZE)
+            .min(panel_height - MIN_SPLIT_PANE_SIZE);
+        self.external_libraries_pane_height = Some(clamped.as_f32() / panel_height.as_f32());
+        cx.notify();
     }
 
     fn disjoint_effective_entries_excluding_roots(&self, cx: &App) -> BTreeSet<SelectedEntry> {
@@ -4369,18 +4557,45 @@ impl ProjectPanel {
             .and_then(|worktree| worktree.read(cx).root_entry())
             .map(|entry| entry.id);
         let mut max_width_item = None;
+        let mut external_max_width_item = None;
 
-        let visible_worktrees: Vec<_> = project
+        let mut visible_worktrees: Vec<_> = project
             .visible_worktrees(cx)
             .map(|worktree| worktree.read(cx).snapshot())
             .collect();
-        let hide_root = settings.hide_root && visible_worktrees.len() == 1;
+        // Append the (non-visible) external library worktrees; they render in
+        // a separate section at the bottom of the panel. Remember where that
+        // section starts so rendering and navigation can treat both parts of
+        // the list differently.
+        let project_worktree_count = visible_worktrees.len();
+        let mut external_worktrees_start = None;
+        if settings.show_external_libraries
+            && let Some(store) = project.external_libraries_store()
+        {
+            for worktree in store.read(cx).worktrees() {
+                let snapshot = worktree.read(cx).snapshot();
+                if !visible_worktrees.iter().any(|w| w.id() == snapshot.id()) {
+                    if external_worktrees_start.is_none() {
+                        external_worktrees_start = Some(visible_worktrees.len());
+                    }
+                    visible_worktrees.push(snapshot);
+                }
+            }
+        }
+        let hide_root = settings.hide_root && project_worktree_count == 1;
         let hide_hidden = settings.hide_hidden;
 
         let visible_entries_task = cx.spawn_in(window, async move |this, cx| {
             let new_state = cx
                 .background_spawn(async move {
-                    for worktree_snapshot in visible_worktrees {
+                    for (worktree_ix, worktree_snapshot) in
+                        visible_worktrees.into_iter().enumerate()
+                    {
+                        let is_external_library =
+                            external_worktrees_start.is_some_and(|start| worktree_ix >= start);
+                        // Never hide the root of an external library: its name
+                        // labels the library in the external section.
+                        let hide_root = hide_root && !is_external_library;
                         let worktree_id = worktree_snapshot.id();
 
                         let mut new_entry_parent_id = None;
@@ -4554,6 +4769,11 @@ impl ProjectPanel {
                             let width_estimate =
                                 item_width_estimate(depth, chars, entry.canonical_path.is_some());
 
+                            let max_width_item = if is_external_library {
+                                &mut external_max_width_item
+                            } else {
+                                &mut max_width_item
+                            };
                             match max_width_item.as_mut() {
                                 Some((id, worktree_id, width)) => {
                                     if *width < width_estimate {
@@ -4563,7 +4783,7 @@ impl ProjectPanel {
                                     }
                                 }
                                 None => {
-                                    max_width_item =
+                                    *max_width_item =
                                         Some((entry.id, worktree_snapshot.id(), width_estimate))
                                 }
                             }
@@ -4601,26 +4821,17 @@ impl ProjectPanel {
                             index: OnceCell::new(),
                         })
                     }
-                    if let Some((project_entry_id, worktree_id, _)) = max_width_item {
-                        let mut visited_worktrees_length = 0;
-                        let index = new_state
-                            .visible_entries
-                            .iter()
-                            .find_map(|visible_entries| {
-                                if worktree_id == visible_entries.worktree_id {
-                                    visible_entries
-                                        .entries
-                                        .iter()
-                                        .position(|entry| entry.id == project_entry_id)
-                                } else {
-                                    visited_worktrees_length += visible_entries.entries.len();
-                                    None
-                                }
-                            });
-                        if let Some(index) = index {
-                            new_state.max_width_item_index = Some(visited_worktrees_length + index);
-                        }
-                    }
+                    let external_start =
+                        external_worktrees_start.unwrap_or(new_state.visible_entries.len());
+                    new_state.max_width_item_index = max_width_item_index_for(
+                        &new_state.visible_entries[..external_start],
+                        max_width_item,
+                    );
+                    new_state.external_max_width_item_index = max_width_item_index_for(
+                        &new_state.visible_entries[external_start..],
+                        external_max_width_item,
+                    );
+                    new_state.external_worktrees_start = external_worktrees_start;
                     new_state
                 })
                 .await;
@@ -4675,26 +4886,40 @@ impl ProjectPanel {
         cx: &mut Context<Self>,
     ) {
         self.project.update(cx, |project, cx| {
-            if let Some((worktree, expanded_dir_ids)) = project
-                .worktree_for_id(worktree_id, cx)
-                .zip(self.state.expanded_dir_ids.get_mut(&worktree_id))
-            {
-                project.expand_entry(worktree_id, entry_id, cx);
-                let worktree = worktree.read(cx);
+            let Some(worktree) = project.worktree_for_id(worktree_id, cx) else {
+                return;
+            };
+            // Initialize the worktree's expanded-dir tracking on demand. This
+            // normally happens inside `update_visible_entries`, but that builds
+            // entries in a background task — so for a newly-surfaced worktree
+            // (e.g. an external library revealed before its first build
+            // completes) the entry may not exist yet, which would silently skip
+            // the expand below. Seed it with the root entry, matching
+            // `update_visible_entries`.
+            let expanded_dir_ids = match self.state.expanded_dir_ids.entry(worktree_id) {
+                hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                hash_map::Entry::Vacant(entry) => {
+                    let Some(root_entry_id) = worktree.read(cx).root_entry().map(|e| e.id) else {
+                        return;
+                    };
+                    entry.insert(vec![root_entry_id])
+                }
+            };
+            project.expand_entry(worktree_id, entry_id, cx);
+            let worktree = worktree.read(cx);
 
-                if let Some(mut entry) = worktree.entry_for_id(entry_id) {
-                    loop {
-                        if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
-                            expanded_dir_ids.insert(ix, entry.id);
-                        }
+            if let Some(mut entry) = worktree.entry_for_id(entry_id) {
+                loop {
+                    if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
+                        expanded_dir_ids.insert(ix, entry.id);
+                    }
 
-                        if let Some(parent_entry) =
-                            entry.path.parent().and_then(|p| worktree.entry_for_path(p))
-                        {
-                            entry = parent_entry;
-                        } else {
-                            break;
-                        }
+                    if let Some(parent_entry) =
+                        entry.path.parent().and_then(|p| worktree.entry_for_path(p))
+                    {
+                        entry = parent_entry;
+                    } else {
+                        break;
                     }
                 }
             }
@@ -6877,6 +7102,81 @@ impl ProjectPanel {
         Ok(())
     }
 
+    /// Reveals the project's currently-active entry in the panel, translating
+    /// entries in single-file external worktrees (opened via the first Go to
+    /// Definition into a crate) to the corresponding library entry so they
+    /// reveal correctly. No-op unless `auto_reveal_entries` is enabled.
+    fn reveal_active_entry(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !ProjectPanelSettings::get_global(cx).auto_reveal_entries {
+            self.pending_reveal = None;
+            return;
+        }
+        let Some(entry_id) = self.project.read(cx).active_entry() else {
+            self.pending_reveal = None;
+            return;
+        };
+        self.reveal_entry_with_external_support(entry_id, true, window, cx);
+    }
+
+    /// Reveals `entry_id`, deferring it if the entry belongs to a single-file
+    /// external worktree whose library directory worktree hasn't been created
+    /// or scanned yet. When deferred, the entry is recorded in
+    /// [`Self::pending_reveal`] and retried on subsequent worktree updates.
+    /// Returns `true` when the reveal settled (succeeded or permanently
+    /// failed), and `false` when it was deferred.
+    fn reveal_entry_with_external_support(
+        &mut self,
+        entry_id: ProjectEntryId,
+        skip_ignored: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.is_external_entry_pending(entry_id, cx) {
+            // The library directory worktree either isn't created yet or
+            // hasn't scanned the active file. Defer the reveal until a later
+            // worktree update, without disturbing the current selection.
+            self.pending_reveal = Some((entry_id, skip_ignored));
+            cx.notify();
+            return false;
+        }
+        let resolved_id = self
+            .project
+            .read(cx)
+            .external_libraries_store()
+            .and_then(|store| store.read(cx).resolve_library_entry(entry_id, cx))
+            .unwrap_or(entry_id);
+        self.reveal_entry(self.project.clone(), resolved_id, skip_ignored, window, cx)
+            .ok();
+        self.pending_reveal = None;
+        true
+    }
+
+    /// Returns `true` if `entry_id` refers to a file opened via the first Go
+    /// to Definition into a crate (a single-file invisible worktree) whose
+    /// library directory worktree is expected but hasn't been created or
+    /// hasn't finished scanning the file. Ordinary invisible single-file
+    /// worktrees (files opened with `OpenVisible::None`) don't defer.
+    fn is_external_entry_pending(&self, entry_id: ProjectEntryId, cx: &App) -> bool {
+        let Some(store) = self.project.read(cx).external_libraries_store() else {
+            return false;
+        };
+        if store.read(cx).resolve_library_entry(entry_id, cx).is_some() {
+            return false;
+        }
+        let Some(worktree) = self.project.read(cx).worktree_for_entry(entry_id, cx) else {
+            return false;
+        };
+        let worktree = worktree.read(cx);
+        if worktree.is_visible() || !worktree.is_single_file() {
+            return false;
+        }
+        let Some(entry) = worktree.entry_for_id(entry_id) else {
+            return false;
+        };
+        let abs_path = worktree.absolutize(&entry.path);
+        store.read(cx).is_library_expected_for(&abs_path, cx)
+    }
+
     fn find_active_indent_guide(
         &self,
         indent_guides: &[IndentGuideLayout],
@@ -7119,12 +7419,15 @@ impl Render for ProjectPanel {
         let is_local = project.is_local();
 
         if has_worktree {
+            let external_item_count = self.external_entries_len();
             let item_count = self
                 .state
                 .visible_entries
                 .iter()
                 .map(|worktree| worktree.entries.len())
-                .sum();
+                .sum::<usize>()
+                - external_item_count;
+            let show_external_section = external_item_count > 0;
 
             fn handle_drag_move<T: 'static>(
                 this: &mut ProjectPanel,
@@ -7211,6 +7514,7 @@ impl Render for ProjectPanel {
                         this.refresh_drag_cursor_style(&event.modifiers, window, cx);
                     },
                 ))
+                .on_drag_move(cx.listener(Self::resize_external_libraries_pane))
                 .key_context(self.dispatch_context(window, cx))
                 .on_action(cx.listener(Self::scroll_up))
                 .on_action(cx.listener(Self::scroll_down))
@@ -7249,6 +7553,7 @@ impl Render for ProjectPanel {
                 .on_action(cx.listener(Self::unfold_directory))
                 .on_action(cx.listener(Self::fold_directory))
                 .on_action(cx.listener(Self::remove_from_project))
+                .on_action(cx.listener(Self::remove_external_library))
                 .on_action(cx.listener(Self::compare_marked_files))
                 .when(!project.is_read_only(cx), |el| {
                     el.on_action(cx.listener(Self::new_file))
@@ -7281,398 +7586,498 @@ impl Render for ProjectPanel {
                         .on_action(cx.listener(Self::download_from_remote))
                 })
                 .track_focus(&self.focus_handle(cx))
-                .child(
-                    v_flex()
-                        .child(
-                            uniform_list("entries", item_count, {
-                                cx.processor(|this, range: Range<usize>, window, cx| {
-                                    this.rendered_entries_len = range.end - range.start;
-                                    let mut items = Vec::with_capacity(this.rendered_entries_len);
-                                    let marked_selections: Arc<[SelectedEntry]> =
-                                        Arc::from(this.marked_entries.clone());
-                                    this.for_each_visible_entry(
+                .child({
+                    let project_entries_list = uniform_list("entries", item_count, {
+                        cx.processor(|this, range: Range<usize>, window, cx| {
+                            this.rendered_entries_len = range.end - range.start;
+                            let mut items = Vec::with_capacity(this.rendered_entries_len);
+                            let marked_selections: Arc<[SelectedEntry]> =
+                                Arc::from(this.marked_entries.clone());
+                            this.for_each_visible_entry(
+                                range,
+                                window,
+                                cx,
+                                &mut |id, details, window, cx| {
+                                    items.push(this.render_entry(
+                                        id,
+                                        details,
+                                        Arc::clone(&marked_selections),
+                                        window,
+                                        cx,
+                                    ));
+                                },
+                            );
+                            items
+                        })
+                    })
+                    .when(show_indent_guides, |list| {
+                        list.with_decoration(
+                            ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
+                                .with_compute_indents_fn(cx.entity(), |this, range, window, cx| {
+                                    let mut items =
+                                        SmallVec::with_capacity(range.end - range.start);
+                                    this.iter_visible_entries(
                                         range,
                                         window,
                                         cx,
-                                        &mut |id, details, window, cx| {
-                                            items.push(this.render_entry(
-                                                id,
-                                                details,
-                                                Arc::clone(&marked_selections),
-                                                window,
-                                                cx,
-                                            ));
+                                        &mut |entry, _, entries, _, _| {
+                                            let (depth, _) = Self::calculate_depth_and_difference(
+                                                entry, entries,
+                                            );
+                                            items.push(depth);
                                         },
                                     );
                                     items
                                 })
-                            })
-                            .when(show_indent_guides, |list| {
-                                list.with_decoration(
-                                    ui::indent_guides(
-                                        px(indent_size),
-                                        IndentGuideColors::panel(cx),
-                                    )
-                                    .with_compute_indents_fn(
-                                        cx.entity(),
-                                        |this, range, window, cx| {
-                                            let mut items =
-                                                SmallVec::with_capacity(range.end - range.start);
-                                            this.iter_visible_entries(
-                                                range,
-                                                window,
-                                                cx,
-                                                &mut |entry, _, entries, _, _| {
-                                                    let (depth, _) =
-                                                        Self::calculate_depth_and_difference(
-                                                            entry, entries,
-                                                        );
-                                                    items.push(depth);
-                                                },
-                                            );
-                                            items
-                                        },
-                                    )
-                                    .on_click(cx.listener(
-                                        |this,
-                                         active_indent_guide: &IndentGuideLayout,
-                                         window,
-                                         cx| {
-                                            if window.modifiers().secondary() {
-                                                let ix = active_indent_guide.offset.y;
-                                                let Some((target_entry, worktree)) = maybe!({
-                                                    let (worktree_id, entry) =
-                                                        this.entry_at_index(ix)?;
-                                                    let worktree = this
-                                                        .project
-                                                        .read(cx)
-                                                        .worktree_for_id(worktree_id, cx)?;
-                                                    let target_entry = worktree
-                                                        .read(cx)
-                                                        .entry_for_path(&entry.path.parent()?)?;
-                                                    Some((target_entry, worktree))
-                                                }) else {
-                                                    return;
-                                                };
+                                .on_click(cx.listener(
+                                    |this, active_indent_guide: &IndentGuideLayout, window, cx| {
+                                        if window.modifiers().secondary() {
+                                            let ix = active_indent_guide.offset.y;
+                                            let Some((target_entry, worktree)) = maybe!({
+                                                let (worktree_id, entry) =
+                                                    this.entry_at_index(ix)?;
+                                                let worktree = this
+                                                    .project
+                                                    .read(cx)
+                                                    .worktree_for_id(worktree_id, cx)?;
+                                                let target_entry = worktree
+                                                    .read(cx)
+                                                    .entry_for_path(&entry.path.parent()?)?;
+                                                Some((target_entry, worktree))
+                                            }) else {
+                                                return;
+                                            };
 
-                                                this.collapse_entry(
-                                                    target_entry.clone(),
-                                                    worktree,
-                                                    window,
-                                                    cx,
-                                                );
-                                            }
-                                        },
-                                    ))
-                                    .with_render_fn(
-                                        cx.entity(),
-                                        move |this, params, _, cx| {
-                                            const LEFT_OFFSET: Pixels =
-                                                ui::LIST_ITEM_INDENT_GUIDE_LEFT_OFFSET;
-                                            const PADDING_Y: Pixels = px(4.);
-                                            const HITBOX_OVERDRAW: Pixels = px(3.);
-
-                                            let active_indent_guide_index = this
-                                                .find_active_indent_guide(
-                                                    &params.indent_guides,
-                                                    cx,
-                                                );
-
-                                            let indent_size = params.indent_size;
-                                            let item_height = params.item_height;
-
-                                            params
-                                                .indent_guides
-                                                .into_iter()
-                                                .enumerate()
-                                                .map(|(idx, layout)| {
-                                                    let offset = if layout.continues_offscreen {
-                                                        px(0.)
-                                                    } else {
-                                                        PADDING_Y
-                                                    };
-                                                    let bounds = Bounds::new(
-                                                        point(
-                                                            layout.offset.x * indent_size
-                                                                + LEFT_OFFSET,
-                                                            layout.offset.y * item_height + offset,
-                                                        ),
-                                                        size(
-                                                            px(1.),
-                                                            layout.length * item_height
-                                                                - offset * 2.,
-                                                        ),
-                                                    );
-                                                    ui::RenderedIndentGuide {
-                                                        bounds,
-                                                        layout,
-                                                        is_active: Some(idx)
-                                                            == active_indent_guide_index,
-                                                        hitbox: Some(Bounds::new(
-                                                            point(
-                                                                bounds.origin.x - HITBOX_OVERDRAW,
-                                                                bounds.origin.y,
-                                                            ),
-                                                            size(
-                                                                bounds.size.width
-                                                                    + HITBOX_OVERDRAW * 2.,
-                                                                bounds.size.height,
-                                                            ),
-                                                        )),
-                                                    }
-                                                })
-                                                .collect()
-                                        },
-                                    ),
-                                )
-                            })
-                            .when(show_sticky_entries, |list| {
-                                let sticky_items = ui::sticky_items(
-                                    cx.entity(),
-                                    |this, range, window, cx| {
-                                        let mut items =
-                                            SmallVec::with_capacity(range.end - range.start);
-                                        this.iter_visible_entries(
-                                            range,
-                                            window,
-                                            cx,
-                                            &mut |entry, index, entries, _, _| {
-                                                let (depth, _) =
-                                                    Self::calculate_depth_and_difference(
-                                                        entry, entries,
-                                                    );
-                                                let candidate =
-                                                    StickyProjectPanelCandidate { index, depth };
-                                                items.push(candidate);
-                                            },
-                                        );
-                                        items
-                                    },
-                                    |this, marker_entry, window, cx| {
-                                        let sticky_entries =
-                                            this.render_sticky_entries(marker_entry, window, cx);
-                                        this.sticky_items_count = sticky_entries.len();
-                                        sticky_entries
-                                    },
-                                );
-                                list.with_decoration(if show_indent_guides {
-                                    sticky_items.with_decoration(
-                                        ui::indent_guides(
-                                            px(indent_size),
-                                            IndentGuideColors::panel(cx),
-                                        )
-                                        .with_render_fn(
-                                            cx.entity(),
-                                            move |_, params, _, _| {
-                                                const LEFT_OFFSET: Pixels =
-                                                    ui::LIST_ITEM_INDENT_GUIDE_LEFT_OFFSET;
-
-                                                let indent_size = params.indent_size;
-                                                let item_height = params.item_height;
-
-                                                params
-                                                    .indent_guides
-                                                    .into_iter()
-                                                    .map(|layout| {
-                                                        let bounds = Bounds::new(
-                                                            point(
-                                                                layout.offset.x * indent_size
-                                                                    + LEFT_OFFSET,
-                                                                layout.offset.y * item_height,
-                                                            ),
-                                                            size(
-                                                                px(1.),
-                                                                layout.length * item_height,
-                                                            ),
-                                                        );
-                                                        ui::RenderedIndentGuide {
-                                                            bounds,
-                                                            layout,
-                                                            is_active: false,
-                                                            hitbox: None,
-                                                        }
-                                                    })
-                                                    .collect()
-                                            },
-                                        ),
-                                    )
-                                } else {
-                                    sticky_items
-                                })
-                            })
-                            .with_sizing_behavior(ListSizingBehavior::Infer)
-                            .with_horizontal_sizing_behavior(if horizontal_scroll {
-                                ListHorizontalSizingBehavior::Unconstrained
-                            } else {
-                                ListHorizontalSizingBehavior::FitList
-                            })
-                            .when(horizontal_scroll, |list| {
-                                list.with_width_from_item(self.state.max_width_item_index)
-                            })
-                            .track_scroll(&self.scroll_handle),
-                        )
-                        .child(
-                            div()
-                                .id("project-panel-blank-area")
-                                .block_mouse_except_scroll()
-                                // `block_mouse_except_scroll` prevents the dock's own
-                                // focus-follows-mouse hover handler from seeing this area,
-                                // so handle it here directly.
-                                .focus_follows_mouse(
-                                    WorkspaceSettings::get_global(cx).focus_follows_mouse,
-                                    cx,
-                                )
-                                .flex_grow_1()
-                                .on_scroll_wheel({
-                                    let scroll_handle = self.scroll_handle.clone();
-                                    let entity_id = cx.entity().entity_id();
-                                    move |event, window, cx| {
-                                        let state = scroll_handle.0.borrow();
-                                        let base_handle = &state.base_handle;
-                                        let current_offset = base_handle.offset();
-                                        let max_offset = base_handle.max_offset();
-                                        let delta = event.delta.pixel_delta(window.line_height());
-                                        let new_offset = (current_offset + delta)
-                                            .clamp(&max_offset.neg(), &Point::default());
-
-                                        if new_offset != current_offset {
-                                            base_handle.set_offset(new_offset);
-                                            cx.notify(entity_id);
-                                        }
-                                    }
-                                })
-                                .when(
-                                    self.drag_target_entry.as_ref().is_some_and(
-                                        |entry| match entry {
-                                            DragTarget::Background => true,
-                                            DragTarget::Entry {
-                                                highlight_entry_id, ..
-                                            } => self.state.last_worktree_root_id.is_some_and(
-                                                |root_id| *highlight_entry_id == root_id,
-                                            ),
-                                        },
-                                    ),
-                                    |div| div.bg(cx.theme().colors().drop_target_background),
-                                )
-                                .on_drag_move::<ExternalPaths>(cx.listener(
-                                    move |this, event: &DragMoveEvent<ExternalPaths>, _, _| {
-                                        let Some(_last_root_id) = this.state.last_worktree_root_id
-                                        else {
-                                            return;
-                                        };
-                                        if event.bounds.contains(&event.event.position) {
-                                            this.drag_target_entry = Some(DragTarget::Background);
-                                        } else {
-                                            if this.drag_target_entry.as_ref().is_some_and(|e| {
-                                                matches!(e, DragTarget::Background)
-                                            }) {
-                                                this.drag_target_entry = None;
-                                            }
-                                        }
-                                    },
-                                ))
-                                .on_drag_move::<DraggedSelection>(cx.listener(
-                                    move |this, event: &DragMoveEvent<DraggedSelection>, _, cx| {
-                                        let Some(last_root_id) = this.state.last_worktree_root_id
-                                        else {
-                                            return;
-                                        };
-                                        if event.bounds.contains(&event.event.position) {
-                                            let drag_state = event.drag(cx);
-                                            if this.should_highlight_background_for_selection_drag(
-                                                &drag_state,
-                                                last_root_id,
-                                                cx,
-                                            ) {
-                                                this.drag_target_entry =
-                                                    Some(DragTarget::Background);
-                                            }
-                                        } else {
-                                            if this.drag_target_entry.as_ref().is_some_and(|e| {
-                                                matches!(e, DragTarget::Background)
-                                            }) {
-                                                this.drag_target_entry = None;
-                                            }
-                                        }
-                                    },
-                                ))
-                                .on_drop(cx.listener(
-                                    move |this, external_paths: &ExternalPaths, window, cx| {
-                                        this.clear_drag_state(cx);
-                                        if let Some(entry_id) = this.state.last_worktree_root_id {
-                                            this.drop_external_files(
-                                                external_paths.paths(),
-                                                entry_id,
+                                            this.collapse_entry(
+                                                target_entry.clone(),
+                                                worktree,
                                                 window,
                                                 cx,
                                             );
                                         }
-                                        cx.stop_propagation();
                                     },
                                 ))
-                                .on_drop(cx.listener(
-                                    move |this, selections: &DraggedSelection, window, cx| {
-                                        this.clear_drag_state(cx);
-                                        if let Some(entry_id) = this.state.last_worktree_root_id {
-                                            this.drag_onto(selections, entry_id, false, window, cx);
-                                        }
-                                        cx.stop_propagation();
-                                    },
-                                ))
-                                .on_click(cx.listener(|this, event, window, cx| {
-                                    if matches!(event, gpui::ClickEvent::Keyboard(_)) {
-                                        return;
-                                    }
-                                    cx.stop_propagation();
-                                    this.selection = None;
-                                    this.marked_entries.clear();
-                                    this.focus_handle(cx).focus(window, cx);
-                                }))
-                                .on_mouse_down(
-                                    MouseButton::Right,
-                                    cx.listener(move |this, event: &MouseDownEvent, window, cx| {
-                                        // When deploying the context menu anywhere below the last project entry,
-                                        // act as if the user clicked the root of the last worktree.
-                                        if let Some(entry_id) = this.state.last_worktree_root_id {
-                                            this.deploy_context_menu(
-                                                event.position,
-                                                entry_id,
-                                                window,
-                                                cx,
+                                .with_render_fn(cx.entity(), move |this, params, _, cx| {
+                                    const LEFT_OFFSET: Pixels =
+                                        ui::LIST_ITEM_INDENT_GUIDE_LEFT_OFFSET;
+                                    const PADDING_Y: Pixels = px(4.);
+                                    const HITBOX_OVERDRAW: Pixels = px(3.);
+
+                                    let active_indent_guide_index =
+                                        this.find_active_indent_guide(&params.indent_guides, cx);
+
+                                    let indent_size = params.indent_size;
+                                    let item_height = params.item_height;
+
+                                    params
+                                        .indent_guides
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(idx, layout)| {
+                                            let offset = if layout.continues_offscreen {
+                                                px(0.)
+                                            } else {
+                                                PADDING_Y
+                                            };
+                                            let bounds = Bounds::new(
+                                                point(
+                                                    layout.offset.x * indent_size + LEFT_OFFSET,
+                                                    layout.offset.y * item_height + offset,
+                                                ),
+                                                size(
+                                                    px(1.),
+                                                    layout.length * item_height - offset * 2.,
+                                                ),
                                             );
-                                        }
-                                    }),
-                                )
-                                .when(!project.is_read_only(cx), |el| {
-                                    el.on_click(cx.listener(
-                                        |this, event: &gpui::ClickEvent, window, cx| {
-                                            if event.click_count() > 1
-                                                && let Some(entry_id) =
-                                                    this.state.last_worktree_root_id
-                                            {
-                                                let project = this.project.read(cx);
-
-                                                let worktree_id = if let Some(worktree) =
-                                                    project.worktree_for_entry(entry_id, cx)
-                                                {
-                                                    worktree.read(cx).id()
-                                                } else {
-                                                    return;
-                                                };
-
-                                                this.selection = Some(SelectedEntry {
-                                                    worktree_id,
-                                                    entry_id,
-                                                });
-
-                                                this.new_file(&NewFile, window, cx);
+                                            ui::RenderedIndentGuide {
+                                                bounds,
+                                                layout,
+                                                is_active: Some(idx) == active_indent_guide_index,
+                                                hitbox: Some(Bounds::new(
+                                                    point(
+                                                        bounds.origin.x - HITBOX_OVERDRAW,
+                                                        bounds.origin.y,
+                                                    ),
+                                                    size(
+                                                        bounds.size.width + HITBOX_OVERDRAW * 2.,
+                                                        bounds.size.height,
+                                                    ),
+                                                )),
                                             }
-                                        },
-                                    ))
+                                        })
+                                        .collect()
                                 }),
                         )
-                        .size_full(),
-                )
+                    })
+                    .when(show_sticky_entries, |list| {
+                        let sticky_items = ui::sticky_items(
+                            cx.entity(),
+                            |this, range, window, cx| {
+                                let mut items = SmallVec::with_capacity(range.end - range.start);
+                                this.iter_visible_entries(
+                                    range,
+                                    window,
+                                    cx,
+                                    &mut |entry, index, entries, _, _| {
+                                        let (depth, _) =
+                                            Self::calculate_depth_and_difference(entry, entries);
+                                        let candidate =
+                                            StickyProjectPanelCandidate { index, depth };
+                                        items.push(candidate);
+                                    },
+                                );
+                                items
+                            },
+                            |this, marker_entry, window, cx| {
+                                let sticky_entries =
+                                    this.render_sticky_entries(marker_entry, window, cx);
+                                this.sticky_items_count = sticky_entries.len();
+                                sticky_entries
+                            },
+                        );
+                        list.with_decoration(if show_indent_guides {
+                            sticky_items.with_decoration(
+                                ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
+                                    .with_render_fn(cx.entity(), move |_, params, _, _| {
+                                        const LEFT_OFFSET: Pixels =
+                                            ui::LIST_ITEM_INDENT_GUIDE_LEFT_OFFSET;
+
+                                        let indent_size = params.indent_size;
+                                        let item_height = params.item_height;
+
+                                        params
+                                            .indent_guides
+                                            .into_iter()
+                                            .map(|layout| {
+                                                let bounds = Bounds::new(
+                                                    point(
+                                                        layout.offset.x * indent_size + LEFT_OFFSET,
+                                                        layout.offset.y * item_height,
+                                                    ),
+                                                    size(px(1.), layout.length * item_height),
+                                                );
+                                                ui::RenderedIndentGuide {
+                                                    bounds,
+                                                    layout,
+                                                    is_active: false,
+                                                    hitbox: None,
+                                                }
+                                            })
+                                            .collect()
+                                    }),
+                            )
+                        } else {
+                            sticky_items
+                        })
+                    })
+                    .with_sizing_behavior(ListSizingBehavior::Infer)
+                    .with_horizontal_sizing_behavior(if horizontal_scroll {
+                        ListHorizontalSizingBehavior::Unconstrained
+                    } else {
+                        ListHorizontalSizingBehavior::FitList
+                    })
+                    .when(horizontal_scroll, |list| {
+                        list.with_width_from_item(self.state.max_width_item_index)
+                    })
+                    .track_scroll(&self.scroll_handle);
+                    let blank_area = div()
+                        .id("project-panel-blank-area")
+                        .block_mouse_except_scroll()
+                        // `block_mouse_except_scroll` prevents the dock's own
+                        // focus-follows-mouse hover handler from seeing this area,
+                        // so handle it here directly.
+                        .focus_follows_mouse(
+                            WorkspaceSettings::get_global(cx).focus_follows_mouse,
+                            cx,
+                        )
+                        .flex_grow_1()
+                        .on_scroll_wheel({
+                            let scroll_handle = self.scroll_handle.clone();
+                            let entity_id = cx.entity().entity_id();
+                            move |event, window, cx| {
+                                let state = scroll_handle.0.borrow();
+                                let base_handle = &state.base_handle;
+                                let current_offset = base_handle.offset();
+                                let max_offset = base_handle.max_offset();
+                                let delta = event.delta.pixel_delta(window.line_height());
+                                let new_offset = (current_offset + delta)
+                                    .clamp(&max_offset.neg(), &Point::default());
+
+                                if new_offset != current_offset {
+                                    base_handle.set_offset(new_offset);
+                                    cx.notify(entity_id);
+                                }
+                            }
+                        })
+                        .when(
+                            self.drag_target_entry
+                                .as_ref()
+                                .is_some_and(|entry| match entry {
+                                    DragTarget::Background => true,
+                                    DragTarget::Entry {
+                                        highlight_entry_id, ..
+                                    } => self
+                                        .state
+                                        .last_worktree_root_id
+                                        .is_some_and(|root_id| *highlight_entry_id == root_id),
+                                }),
+                            |div| div.bg(cx.theme().colors().drop_target_background),
+                        )
+                        .on_drag_move::<ExternalPaths>(cx.listener(
+                            move |this, event: &DragMoveEvent<ExternalPaths>, _, _| {
+                                let Some(_last_root_id) = this.state.last_worktree_root_id else {
+                                    return;
+                                };
+                                if event.bounds.contains(&event.event.position) {
+                                    this.drag_target_entry = Some(DragTarget::Background);
+                                } else {
+                                    if this
+                                        .drag_target_entry
+                                        .as_ref()
+                                        .is_some_and(|e| matches!(e, DragTarget::Background))
+                                    {
+                                        this.drag_target_entry = None;
+                                    }
+                                }
+                            },
+                        ))
+                        .on_drag_move::<DraggedSelection>(cx.listener(
+                            move |this, event: &DragMoveEvent<DraggedSelection>, _, cx| {
+                                let Some(last_root_id) = this.state.last_worktree_root_id else {
+                                    return;
+                                };
+                                if event.bounds.contains(&event.event.position) {
+                                    let drag_state = event.drag(cx);
+                                    if this.should_highlight_background_for_selection_drag(
+                                        &drag_state,
+                                        last_root_id,
+                                        cx,
+                                    ) {
+                                        this.drag_target_entry = Some(DragTarget::Background);
+                                    }
+                                } else {
+                                    if this
+                                        .drag_target_entry
+                                        .as_ref()
+                                        .is_some_and(|e| matches!(e, DragTarget::Background))
+                                    {
+                                        this.drag_target_entry = None;
+                                    }
+                                }
+                            },
+                        ))
+                        .on_drop(cx.listener(
+                            move |this, external_paths: &ExternalPaths, window, cx| {
+                                this.clear_drag_state(cx);
+                                if let Some(entry_id) = this.state.last_worktree_root_id {
+                                    this.drop_external_files(
+                                        external_paths.paths(),
+                                        entry_id,
+                                        window,
+                                        cx,
+                                    );
+                                }
+                                cx.stop_propagation();
+                            },
+                        ))
+                        .on_drop(cx.listener(
+                            move |this, selections: &DraggedSelection, window, cx| {
+                                this.clear_drag_state(cx);
+                                if let Some(entry_id) = this.state.last_worktree_root_id {
+                                    this.drag_onto(selections, entry_id, false, window, cx);
+                                }
+                                cx.stop_propagation();
+                            },
+                        ))
+                        .on_click(cx.listener(|this, event, window, cx| {
+                            if matches!(event, gpui::ClickEvent::Keyboard(_)) {
+                                return;
+                            }
+                            cx.stop_propagation();
+                            this.selection = None;
+                            this.marked_entries.clear();
+                            this.focus_handle(cx).focus(window, cx);
+                        }))
+                        .on_mouse_down(
+                            MouseButton::Right,
+                            cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                                // When deploying the context menu anywhere below the last project entry,
+                                // act as if the user clicked the root of the last worktree.
+                                if let Some(entry_id) = this.state.last_worktree_root_id {
+                                    this.deploy_context_menu(event.position, entry_id, window, cx);
+                                }
+                            }),
+                        )
+                        .when(!project.is_read_only(cx), |el| {
+                            el.on_click(cx.listener(
+                                |this, event: &gpui::ClickEvent, window, cx| {
+                                    if event.click_count() > 1
+                                        && let Some(entry_id) = this.state.last_worktree_root_id
+                                    {
+                                        let project = this.project.read(cx);
+
+                                        let worktree_id = if let Some(worktree) =
+                                            project.worktree_for_entry(entry_id, cx)
+                                        {
+                                            worktree.read(cx).id()
+                                        } else {
+                                            return;
+                                        };
+
+                                        this.selection = Some(SelectedEntry {
+                                            worktree_id,
+                                            entry_id,
+                                        });
+
+                                        this.new_file(&NewFile, window, cx);
+                                    }
+                                },
+                            ))
+                        });
+
+                    let panel_body = if show_external_section {
+                        v_flex()
+                            .child(
+                                div()
+                                    .id("project-panel-entries-pane")
+                                    .min_h(MIN_SPLIT_PANE_SIZE)
+                                    .flex_1()
+                                    .overflow_hidden()
+                                    .child(
+                                        v_flex()
+                                            .child(project_entries_list)
+                                            .child(blank_area)
+                                            .size_full(),
+                                    ),
+                            )
+                            .child({
+                                let mut external_scrollbars =
+                                    Scrollbars::for_settings::<ProjectPanelScrollbarProxy>()
+                                        .tracked_scroll_handle(&self.external_scroll_handle);
+                                if horizontal_scroll {
+                                    external_scrollbars = external_scrollbars.with_track_along(
+                                        ScrollAxes::Horizontal,
+                                        cx.theme().colors().panel_background,
+                                    );
+                                }
+                                let external_pane = v_flex()
+                                    .id("project-panel-external-libraries")
+                                    .min_h(MIN_SPLIT_PANE_SIZE)
+                                    .overflow_hidden()
+                                    .map(|pane| match self.external_libraries_pane_height {
+                                        Some(fraction) => {
+                                            pane.h(gpui::relative(fraction)).flex_none()
+                                        }
+                                        None => pane.flex_1(),
+                                    })
+                                    .child(
+                                        div()
+                                            .id("external-libraries-resize-handle")
+                                            .w_full()
+                                            .h(px(6.))
+                                            .flex_none()
+                                            .flex()
+                                            .items_center()
+                                            .occlude()
+                                            .cursor_row_resize()
+                                            .on_drag(
+                                                DraggedExternalLibrariesResize,
+                                                |drag, _, _, cx| {
+                                                    cx.stop_propagation();
+                                                    cx.new(|_| drag.clone())
+                                                },
+                                            )
+                                            .on_mouse_up(
+                                                MouseButton::Left,
+                                                cx.listener(
+                                                    |this, e: &gpui::MouseUpEvent, _, cx| {
+                                                        if e.click_count == 2 {
+                                                            // Reset the split
+                                                            // to an even
+                                                            // divide.
+                                                            this.external_libraries_pane_height =
+                                                                None;
+                                                            cx.notify();
+                                                            cx.stop_propagation();
+                                                        }
+                                                    },
+                                                ),
+                                            )
+                                            .child(Divider::horizontal()),
+                                    )
+                                    .child(
+                                        h_flex()
+                                            .id("project-panel-external-libraries-header")
+                                            .h(px(26.))
+                                            .px_2()
+                                            .items_center()
+                                            .child(
+                                                Label::new("External Libraries")
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            ),
+                                    )
+                                    .child(
+                                        uniform_list(
+                                            "external-libraries-entries",
+                                            external_item_count,
+                                            cx.processor(
+                                                |this, range: Range<usize>, window, cx| {
+                                                    let external_offset =
+                                                        this.external_entries_offset();
+                                                    let mut items =
+                                                        Vec::with_capacity(range.end - range.start);
+                                                    let marked_selections: Arc<[SelectedEntry]> =
+                                                        Arc::from(this.marked_entries.clone());
+                                                    this.for_each_visible_entry(
+                                                        external_offset + range.start
+                                                            ..external_offset + range.end,
+                                                        window,
+                                                        cx,
+                                                        &mut |id, details, window, cx| {
+                                                            items.push(this.render_entry(
+                                                                id,
+                                                                details,
+                                                                Arc::clone(&marked_selections),
+                                                                window,
+                                                                cx,
+                                                            ));
+                                                        },
+                                                    );
+                                                    items
+                                                },
+                                            ),
+                                        )
+                                        .with_sizing_behavior(ListSizingBehavior::Infer)
+                                        .with_horizontal_sizing_behavior(if horizontal_scroll {
+                                            ListHorizontalSizingBehavior::Unconstrained
+                                        } else {
+                                            ListHorizontalSizingBehavior::FitList
+                                        })
+                                        .when(horizontal_scroll, |list| {
+                                            list.with_width_from_item(
+                                                self.state.external_max_width_item_index,
+                                            )
+                                        })
+                                        .track_scroll(&self.external_scroll_handle)
+                                        .flex_1(),
+                                    )
+                                    .custom_scrollbars(
+                                        external_scrollbars.notify_content(),
+                                        window,
+                                        cx,
+                                    );
+                                external_pane
+                            })
+                            .size_full()
+                    } else {
+                        v_flex()
+                            .child(project_entries_list)
+                            .child(blank_area)
+                            .size_full()
+                    };
+                    panel_body
+                })
                 .custom_scrollbars(
                     {
                         let mut scrollbars =

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,9 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, FolderIndicator, IntoGpui, ProjectPanelEntrySpacing, ProjectPanelSortMode,
-    ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
+    DockSide, ExternalLibrariesRemoval, FolderIndicator, IntoGpui, ProjectPanelEntrySpacing,
+    ProjectPanelSortMode, ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics,
+    ShowIndentGuides,
 };
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 
@@ -35,6 +36,8 @@ pub struct ProjectPanelSettings {
     pub sort_order: ProjectPanelSortOrder,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
+    pub show_external_libraries: bool,
+    pub external_libraries_removal: ExternalLibrariesRemoval,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -142,6 +145,10 @@ impl Settings for ProjectPanelSettings {
             sort_order: project_panel.sort_order.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
+            show_external_libraries: project_panel.show_external_libraries.unwrap(),
+            external_libraries_removal: project_panel
+                .external_libraries_removal
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -8,14 +8,17 @@ use git::{
 };
 use gpui::{Empty, Entity, TestAppContext, VisualTestContext};
 use language::{
-    Diagnostic, DiagnosticEntry, DiagnosticMessage, DiagnosticSourceKind, LanguageServerId,
-    PointUtf16, Unclipped,
+    BufferId, Diagnostic, DiagnosticEntry, DiagnosticMessage, DiagnosticSourceKind,
+    LanguageServerId, PointUtf16, Unclipped,
 };
 use menu::Cancel;
 use pretty_assertions::assert_eq;
 use project::{FakeFs, ProjectPath};
 use serde_json::json;
-use settings::{FolderIndicator, ProjectPanelAutoOpenSettings, SettingsStore, SplicingVec};
+use settings::{
+    ExternalLibrariesRemoval, FolderIndicator, ProjectPanelAutoOpenSettings, SettingsStore,
+    SplicingVec,
+};
 use smallvec::smallvec;
 use std::path::{Path, PathBuf};
 use util::{path, paths::PathStyle, rel_path::rel_path};
@@ -5674,11 +5677,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
     );
 
     for file_entry in [dir_1_file, dir_2_file, gitignored_dir_file] {
-        panel.update(cx, |panel, cx| {
-            panel.project.update(cx, |_, cx| {
-                cx.emit(project::Event::ActiveEntryChanged(Some(file_entry)))
-            })
-        });
+        set_active_project_entry(&panel, file_entry, cx);
         cx.run_until_parked();
         assert_eq!(
             visible_entries_as_strings(&panel, 0..20, cx),
@@ -5704,11 +5703,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
         })
     });
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(dir_1_file)))
-        })
-    });
+    set_active_project_entry(&panel, dir_1_file, cx);
     cx.run_until_parked();
     assert_eq!(
         visible_entries_as_strings(&panel, 0..20, cx),
@@ -5726,11 +5721,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
         "When auto reveal is enabled, not ignored dir_1 entry should be revealed"
     );
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(dir_2_file)))
-        })
-    });
+    set_active_project_entry(&panel, dir_2_file, cx);
     cx.run_until_parked();
     assert_eq!(
         visible_entries_as_strings(&panel, 0..20, cx),
@@ -5751,13 +5742,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
         "When auto reveal is enabled, not ignored dir_2 entry should be revealed"
     );
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(
-                gitignored_dir_file,
-            )))
-        })
-    });
+    set_active_project_entry(&panel, gitignored_dir_file, cx);
     cx.run_until_parked();
     assert_eq!(
         visible_entries_as_strings(&panel, 0..20, cx),
@@ -5806,11 +5791,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
         "When a gitignored entry is explicitly revealed, it should be shown in the project tree"
     );
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(dir_2_file)))
-        })
-    });
+    set_active_project_entry(&panel, dir_2_file, cx);
     cx.run_until_parked();
     assert_eq!(
         visible_entries_as_strings(&panel, 0..20, cx),
@@ -5834,13 +5815,7 @@ async fn test_autoreveal_and_gitignored_files(cx: &mut gpui::TestAppContext) {
         "After switching to dir_2_file, it should be selected and marked"
     );
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(
-                gitignored_dir_file,
-            )))
-        })
-    });
+    set_active_project_entry(&panel, gitignored_dir_file, cx);
     cx.run_until_parked();
     assert_eq!(
         visible_entries_as_strings(&panel, 0..20, cx),
@@ -5960,13 +5935,7 @@ async fn test_gitignored_and_always_included(cx: &mut gpui::TestAppContext) {
         })
     });
 
-    panel.update(cx, |panel, cx| {
-        panel.project.update(cx, |_, cx| {
-            cx.emit(project::Event::ActiveEntryChanged(Some(
-                always_included_but_ignored_dir_file,
-            )))
-        })
-    });
+    set_active_project_entry(&panel, always_included_but_ignored_dir_file, cx);
     cx.run_until_parked();
 
     assert_eq!(
@@ -6585,6 +6554,372 @@ async fn test_reveal_in_project_panel_fallback(cx: &mut gpui::TestAppContext) {
             panel.focus_handle(cx).is_focused(window),
             "Project panel should be focused even for an unsaved buffer."
         );
+    });
+}
+
+#[gpui::test]
+async fn test_reveal_active_entry_in_external_library(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    // `auto_reveal_entries` defaults to `true`; surface the external libraries
+    // section so the surfaced library worktree renders.
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .project_panel
+                    .get_or_insert_default()
+                    .show_external_libraries = Some(true);
+            });
+        })
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project", json!({ "main.py": "" })).await;
+    fs.insert_tree(
+        "/external_lib",
+        json!({
+            "Cargo.toml": "",
+            "src": { "lib.rs": "" },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &["v project", "      main.py"]
+    );
+
+    // Simulate the first Go to Definition into an external crate: a
+    // single-file invisible worktree is created at the target file.
+    let (single_file_worktree, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/external_lib/src/lib.rs", false, cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+    let external_entry = single_file_worktree.read_with(cx, |worktree, _| {
+        worktree
+            .snapshot()
+            .root_entry()
+            .expect("single-file worktree has a root file entry")
+            .id
+    });
+
+    let store = project.read_with(cx, |project, _| {
+        project
+            .external_libraries_store()
+            .expect("local project has an external libraries store")
+    });
+
+    // Mark the library root as pending, mirroring the real flow where the
+    // buffer's addition starts creating the library directory worktree before
+    // the editor activates.
+    store.update(cx, |store, _| {
+        store.mark_library_pending_for_test("/external_lib".into())
+    });
+
+    // The active entry becomes the external file. No library directory
+    // worktree has been surfaced yet, so the reveal must defer (and must not
+    // disturb the current selection).
+    let worktree_id = single_file_worktree.read_with(cx, |worktree, _| worktree.id());
+    project.update(cx, |project, cx| {
+        project.set_active_path(
+            Some(ProjectPath {
+                worktree_id,
+                path: rel_path("").into(),
+            }),
+            cx,
+        );
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &["v project", "      main.py"],
+        "external entry should not be revealed before its library is loaded"
+    );
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.pending_reveal),
+        Some((external_entry, true)),
+        "the reveal should be deferred until the library tree loads"
+    );
+
+    // Simulate the library directory worktree being surfaced and scanned.
+    let (library_worktree, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/external_lib", false, cx)
+        })
+        .await
+        .unwrap();
+    library_worktree
+        .read_with(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    let library_root =
+        library_worktree.read_with(cx, |worktree, _| worktree.abs_path().to_path_buf());
+    store.update(cx, |store, cx| {
+        store.register_library_worktree_for_test(library_root, library_worktree.clone(), cx)
+    });
+
+    // Surfacing the library emits `LibrariesChanged`, which retries the
+    // deferred reveal and should resolve + select the active file.
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v project",
+            "      main.py",
+            "v external_lib",
+            "    v src",
+            "          lib.rs  <== selected  <== marked",
+            "      Cargo.toml",
+        ],
+        "once the library tree is loaded the active file should be revealed"
+    );
+    assert_eq!(
+        panel.read_with(cx, |panel, _| panel.pending_reveal),
+        None,
+        "the deferred reveal should be cleared once it resolves"
+    );
+}
+
+/// Sets up a project at `/project` with a surfaced external library at
+/// `/external_lib` and returns the panel, the library worktree, the external
+/// libraries store and a visual test context for the panel's window.
+async fn external_libraries_test_harness(
+    cx: &mut gpui::TestAppContext,
+) -> (
+    Entity<ProjectPanel>,
+    Entity<worktree::Worktree>,
+    Entity<project::ExternalLibrariesStore>,
+    VisualTestContext,
+) {
+    init_test(cx);
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                let project_panel = settings.project_panel.get_or_insert_default();
+                project_panel.show_external_libraries = Some(true);
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project", json!({ "main.py": "" })).await;
+    fs.insert_tree(
+        "/external_lib",
+        json!({
+            "Cargo.toml": "",
+            "src": { "lib.rs": "" },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    let (library_worktree, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/external_lib", false, cx)
+        })
+        .await
+        .unwrap();
+    library_worktree
+        .read_with(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+
+    let store = project.read_with(cx, |project, _| {
+        project
+            .external_libraries_store()
+            .expect("local project has an external libraries store")
+    });
+    let library_root =
+        library_worktree.read_with(cx, |worktree, _| worktree.abs_path().to_path_buf());
+    store.update(cx, |store, cx| {
+        store.register_library_worktree_for_test(library_root, library_worktree.clone(), cx)
+    });
+
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(&mut cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    (panel, library_worktree, store, cx)
+}
+
+#[gpui::test]
+async fn test_external_library_removal_setting(cx: &mut gpui::TestAppContext) {
+    let (panel, library_worktree, store, mut cx) = external_libraries_test_harness(cx).await;
+
+    let set_removal = |cx: &mut VisualTestContext, removal| {
+        cx.update(|_, cx| {
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .project_panel
+                        .get_or_insert_default()
+                        .external_libraries_removal = Some(removal);
+                });
+            });
+        });
+    };
+
+    set_removal(&mut cx, ExternalLibrariesRemoval::ManualRemove);
+
+    let library_root =
+        library_worktree.read_with(&cx, |worktree, _| worktree.abs_path().to_path_buf());
+    let buffer_id = BufferId::new(1).unwrap();
+    store.update(&mut cx, |store, _| {
+        store.track_buffer_for_test(&library_root, buffer_id)
+    });
+
+    // With `manual_remove`, dropping the library's last buffer keeps the
+    // library listed.
+    store.update(&mut cx, |store, cx| {
+        store.simulate_buffer_dropped_for_test(buffer_id, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, &mut cx),
+        &[
+            "v project",
+            "      main.py",
+            "v external_lib",
+            "    > src",
+            "      Cargo.toml",
+        ],
+        "manual_remove should keep the library after its last buffer closes"
+    );
+
+    // Switching to `auto_remove` makes the next dropped buffer remove the
+    // library.
+    set_removal(&mut cx, ExternalLibrariesRemoval::AutoRemove);
+    let buffer_id = BufferId::new(2).unwrap();
+    store.update(&mut cx, |store, _| {
+        store.track_buffer_for_test(&library_root, buffer_id)
+    });
+    store.update(&mut cx, |store, cx| {
+        store.simulate_buffer_dropped_for_test(buffer_id, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, &mut cx),
+        &["v project", "      main.py"],
+        "auto_remove should drop the library once its last buffer closes"
+    );
+}
+
+#[gpui::test]
+async fn test_navigation_crosses_into_external_libraries(cx: &mut gpui::TestAppContext) {
+    let (panel, library_worktree, _store, mut cx) = external_libraries_test_harness(cx).await;
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, &mut cx),
+        &[
+            "v project",
+            "      main.py",
+            "v external_lib",
+            "    > src",
+            "      Cargo.toml",
+        ]
+    );
+    assert_eq!(
+        panel.read_with(&cx, |panel, _| panel.state.external_worktrees_start),
+        Some(1),
+        "the external section should start at the second worktree block"
+    );
+    assert_eq!(
+        panel.read_with(&cx, |panel, _| panel.external_entries_len()),
+        3,
+        "the external section should hold the library's three visible entries"
+    );
+
+    // Select the last project entry, then move down across the section
+    // boundary into the external libraries section.
+    panel.update_in(&mut cx, |panel, _, cx| {
+        let worktree = panel
+            .project
+            .read(cx)
+            .visible_worktrees(cx)
+            .next()
+            .expect("project worktree");
+        let entry = worktree
+            .read(cx)
+            .entry_for_path(rel_path("main.py"))
+            .expect("main.py entry");
+        panel.selection = Some(SelectedEntry {
+            worktree_id: worktree.read(cx).id(),
+            entry_id: entry.id,
+        });
+    });
+    panel.update_in(&mut cx, |panel, window, cx| {
+        panel.select_next(&SelectNext, window, cx)
+    });
+    let selection = panel.read_with(&cx, |panel, _| panel.selection);
+    let expected = library_worktree.read_with(&cx, |worktree, _| {
+        let root = worktree.root_entry().expect("library root entry");
+        SelectedEntry {
+            worktree_id: worktree.id(),
+            entry_id: root.id,
+        }
+    });
+    assert_eq!(
+        selection,
+        Some(expected),
+        "select_next should cross from the project entries into the external libraries section"
+    );
+
+    // And back up across the boundary.
+    panel.update_in(&mut cx, |panel, window, cx| {
+        panel.select_previous(&SelectPrevious, window, cx)
+    });
+    let selected_filename = panel.read_with(&cx, |panel, cx| {
+        panel
+            .selected_entry(cx)
+            .map(|(_, entry)| entry.path.file_name().unwrap().to_string())
+    });
+    assert_eq!(
+        selected_filename.as_deref(),
+        Some("main.py"),
+        "select_previous should cross back from the external libraries section"
+    );
+}
+
+#[gpui::test]
+async fn test_external_libraries_pane_resize(cx: &mut gpui::TestAppContext) {
+    let (panel, _library_worktree, _store, mut cx) = external_libraries_test_harness(cx).await;
+
+    panel.update_in(&mut cx, |panel, _, cx| {
+        assert_eq!(
+            panel.external_libraries_pane_height, None,
+            "the split should start out dividing the panel evenly"
+        );
+
+        // Dragging the divider to 150px above the bottom of a 600px panel
+        // sizes the external libraries section to a quarter of the panel.
+        panel.set_external_libraries_pane_height(px(150.), px(600.), cx);
+        assert_eq!(panel.external_libraries_pane_height, Some(0.25));
+
+        // Both sections keep a minimum size, so the height is clamped when
+        // the divider is dragged past either of them.
+        panel.set_external_libraries_pane_height(px(10.), px(600.), cx);
+        assert_eq!(panel.external_libraries_pane_height, Some(60. / 600.));
+        panel.set_external_libraries_pane_height(px(590.), px(600.), cx);
+        assert_eq!(panel.external_libraries_pane_height, Some(540. / 600.));
+
+        // Panels too small to fit two sections at the minimum size ignore
+        // resizing altogether.
+        panel.set_external_libraries_pane_height(px(10.), px(100.), cx);
+        assert_eq!(panel.external_libraries_pane_height, Some(540. / 600.));
     });
 }
 
@@ -10624,6 +10959,37 @@ fn mark_for(marks: &[(String, Option<DiagnosticMark>)], filename: &str) -> Optio
         .iter()
         .find(|(name, _)| name == filename)
         .and_then(|(_, mark)| *mark)
+}
+
+/// Sets the project's active entry by id, mirroring how the workspace drives
+/// `Project::set_active_path` in production (which both updates
+/// `project.active_entry()` and emits `ActiveEntryChanged`). Use this instead
+/// of emitting `ActiveEntryChanged` directly, since the panel's
+/// `reveal_active_entry` reads `project.active_entry()` rather than the event
+/// payload.
+fn set_active_project_entry(
+    panel: &Entity<ProjectPanel>,
+    entry_id: ProjectEntryId,
+    cx: &mut VisualTestContext,
+) {
+    panel.update(cx, |panel, cx| {
+        let project = panel.project.clone();
+        let project_path = {
+            let p = project.read(cx);
+            let worktree = p
+                .worktree_for_entry(entry_id, cx)
+                .expect("entry has a worktree");
+            let worktree_id = worktree.read(cx).id();
+            let path = worktree
+                .read(cx)
+                .entry_for_id(entry_id)
+                .expect("entry exists")
+                .path
+                .clone();
+            ProjectPath { worktree_id, path }
+        };
+        project.update(cx, |p, cx| p.set_active_path(Some(project_path), cx));
+    });
 }
 
 fn visible_entries_as_strings(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -853,6 +853,19 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// Whether to show an "External Libraries" section in the project panel,
+    /// listing the project's dependencies (e.g. Rust crates) so their source
+    /// can be browsed directly.
+    ///
+    /// Default: false
+    pub show_external_libraries: Option<bool>,
+    /// Controls when external libraries are removed from the project panel's
+    /// "External Libraries" section. With `auto_remove`, a library is removed
+    /// as soon as its last open buffer closes. With `manual_remove`, libraries
+    /// stay listed until removed via the context menu.
+    ///
+    /// Default: auto_remove
+    pub external_libraries_removal: Option<ExternalLibrariesRemoval>,
 }
 
 #[derive(
@@ -988,6 +1001,30 @@ impl From<ProjectPanelSortOrder> for util::paths::SortOrder {
             ProjectPanelSortOrder::Unicode => Self::Unicode,
         }
     }
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalLibrariesRemoval {
+    /// Remove a library automatically when its last open buffer closes.
+    #[default]
+    AutoRemove,
+    /// Keep libraries listed until they are removed manually via the
+    /// project panel's context menu.
+    ManualRemove,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5159,7 +5159,7 @@ fn window_and_layout_page() -> SettingsPage {
 }
 
 fn panels_page() -> SettingsPage {
-    fn project_panel_section() -> [SettingsPageItem; 29] {
+    fn project_panel_section() -> [SettingsPageItem; 31] {
         [
             SettingsPageItem::SectionHeader("Project Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -5541,6 +5541,54 @@ fn panels_page() -> SettingsPage {
                             .project_panel
                             .get_or_insert_default()
                             .git_status_indicator = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "External Libraries",
+                description: "Show an \"External Libraries\" section listing the project's dependencies \
+                     (e.g. Rust crates) so their source can be browsed in the project panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("project_panel.show_external_libraries"),
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .show_external_libraries
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .show_external_libraries = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "External Libraries Removal",
+                description: "When external libraries are removed from the project panel: automatically \
+                     when their last open buffer closes, or only manually via the context menu.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("project_panel.external_libraries_removal"),
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .external_libraries_removal
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .external_libraries_removal = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -575,6 +575,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortOrder>(render_dropdown)
+        .add_basic_renderer::<settings::ExternalLibrariesRemoval>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)
         .add_basic_renderer::<settings::FormatOnSave>(render_dropdown)
         .add_basic_renderer::<settings::LineEndingSetting>(render_dropdown)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4565,9 +4565,12 @@ impl Render for Pane {
                     pane.project
                         .update(cx, |project, cx| {
                             if let Some(entry_id) = entry_id
-                                && project
-                                    .worktree_for_entry(entry_id, cx)
-                                    .is_some_and(|worktree| worktree.read(cx).is_visible())
+                                && project.worktree_for_entry(entry_id, cx).is_some_and(
+                                    |worktree| {
+                                        let worktree = worktree.read(cx);
+                                        worktree.is_visible() || worktree.is_single_file()
+                                    },
+                                )
                             {
                                 return cx.emit(project::Event::RevealInProjectPanel(entry_id));
                             }


### PR DESCRIPTION
# Objective

- Fixes #11872
- When you use Go to Definition to navigate into a project dependency (e.g. a Rust crate from the cargo registry), the file opens from an invisible worktree and there is no way to browse the rest of that library's source from the project panel.

## Solution

- Add an "External Libraries" section to the project panel (below the project's files, in a resizable split with a draggable divider; double-click resets it; keyboard navigation moves across the boundary).
- The model is **on-demand**, not eager: `ExternalLibrariesStore` (crates/project) reacts to buffers opened in invisible worktrees — i.e. exactly what happens on Go to Definition into a dependency — resolves the enclosing package root (nearest `Cargo.toml`/`package.json`/`pyproject.toml`/`go.mod` ancestor), and creates a non-visible directory worktree for that library so its source tree becomes browsable. Subsequent navigations into the same library reuse that worktree; no core navigation code is touched.
- Library worktrees are created with `visible=false`, so they never leak into `visible_worktrees()` consumers (file finder, search, LSP rooting); the panel includes them explicitly, and the active entry is revealed/selected like a project file.
- Removal is governed by `project_panel.external_libraries_removal`: `"auto_remove"` (default) drops a library when its last open buffer closes; `"manual_remove"` keeps it listed until removed via the new `project_panel::RemoveExternalLibrary` context-menu action.
- Extensibility groundwork: a `DependencyLister` trait (`crates/language/src/dependency.rs`) plus a `RustDependencyLister` backed by `cargo metadata` (registry/git deps only; workspace members and path deps excluded), registered through the new `DependencyProvidersStore` — ready for TS/Python/Go providers to follow.
- Settings: `project_panel.show_external_libraries` (default `false`) and `project_panel.external_libraries_removal`, wired into the settings UI and the VS Code settings importer. Documented in `docs/src/project-panel.md`.

## Testing

- New gpui tests in `crates/project_panel/src/project_panel_tests.rs` (via a shared `external_libraries_test_harness`) covering:
  - reveal/selection of the active entry inside an external library, including the first-navigation case where the buffer still lives in a single-file worktree
  - library removal under both `auto_remove` and `manual_remove` settings
  - keyboard navigation crossing the boundary between project files and the section
  - resizing the section via the divider
- Manually exercised on Linux against a Rust workspace: navigation into registry, git, and path dependencies; expanding/collapsing library trees; toggling the setting; both removal modes.
- Reviewers can test by enabling `project_panel.show_external_libraries`, opening a Rust project, and running Go to Definition on e.g. a `serde` type — the crate should appear in the section, browse like a project tree, and disappear per the removal setting.
- Untested on macOS and Windows; divider drag and `cargo` discovery are worth a quick check there.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
<summary>Click to view showcase</summary>

TODO: Add a screenshot/GIF showing Go to Definition into a crate, the "External Libraries" section appearing with the crate's source tree, the resizable divider, and auto-removal when the last tab closes.

</details>

---

Release Notes:

- Added an "External Libraries" section to the project panel. When `project_panel.show_external_libraries` is enabled, using Go to Definition to navigate into a dependency (e.g. a Rust crate) surfaces that library's source tree in the project panel, where it can be browsed like project files. Libraries are removed automatically when their last open buffer closes (`"auto_remove"`, default) or manually via the context menu (`"manual_remove"`).
One note: the branch includes .agents/external-libraries/ planning docs (~1k lines) in the diff — you may want to drop them before opening the PR against zed-industries/zed.