### PR TITLE
gpui: Smooth frame pacing in macOS Low Power Mode

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -760,6 +760,7 @@ pub struct App {
     pub(crate) reduce_motion: bool,
     /// Origin of the shared clock that phase-locks synced repeating animations.
     pub(crate) synced_animation_epoch: Instant,
+    low_power_mode_enabled: bool,
     /// Whether the app was created by [`Application::new_inaccessible`]. No
     /// accesskit APIs will be called when this flag is set.
     pub(crate) accessibility_force_disabled: bool,
@@ -795,6 +796,7 @@ impl App {
         let entities = EntityMap::new();
         let keyboard_layout = platform.keyboard_layout();
         let keyboard_mapper = platform.keyboard_mapper();
+        let low_power_mode_enabled = platform.low_power_mode_enabled();
 
         #[cfg(any(test, feature = "leak-detection"))]
         let _ref_counts = entities.ref_counts_drop_handle();
@@ -862,6 +864,7 @@ impl App {
                 cursor_hide_mode: CursorHideMode::default(),
                 reduce_motion: false,
                 synced_animation_epoch,
+                low_power_mode_enabled,
                 accessibility_force_disabled: false,
 
                 #[cfg(any(test, feature = "test-support", debug_assertions))]
@@ -911,6 +914,16 @@ impl App {
                     cx.system_wake_observers
                         .clone()
                         .retain(&(), move |callback| (callback)(cx));
+                }
+            }
+        }));
+
+        platform.on_low_power_mode_change(Box::new({
+            let app = Rc::downgrade(&app);
+            move || {
+                if let Some(app) = app.upgrade() {
+                    let low_power_mode_enabled = app.borrow().platform.low_power_mode_enabled();
+                    app.borrow_mut().low_power_mode_enabled = low_power_mode_enabled;
                 }
             }
         }));
@@ -1428,6 +1441,11 @@ impl App {
     /// Returns the current text rendering mode for the application.
     pub fn text_rendering_mode(&self) -> TextRenderingMode {
         self.text_rendering_mode.get()
+    }
+
+    /// Returns whether the operating system has enabled its low power mode.
+    pub fn low_power_mode_enabled(&self) -> bool {
+        self.low_power_mode_enabled
     }
 
     /// Writes data to the platform clipboard.

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -250,6 +250,13 @@ pub trait Platform: 'static {
     fn thermal_state(&self) -> ThermalState;
     fn on_thermal_state_change(&self, callback: Box<dyn FnMut()>);
 
+    /// Returns whether the operating system is conserving energy by reducing
+    /// the performance available to applications.
+    fn low_power_mode_enabled(&self) -> bool {
+        false
+    }
+    fn on_low_power_mode_change(&self, _callback: Box<dyn FnMut()>) {}
+
     /// Sets the application's process-wide identity and user-visible name.
     ///
     /// The identifier is used for platform identity mechanisms such as the

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1232,6 +1232,46 @@ pub(crate) struct InputRateTracker {
     sustain_duration: Duration,
 }
 
+const THIRTY_FPS_INTERVAL: Duration = Duration::from_micros(33333);
+const SIXTY_FPS_INTERVAL: Duration = Duration::from_micros(16667);
+const FRAME_INTERVAL_TOLERANCE: Duration = Duration::from_millis(1);
+
+/// Display-link timestamps can straddle a target interval by fractions of a
+/// millisecond. Accepting that callback preserves an even display-frame divisor
+/// instead of occasionally waiting for an additional refresh.
+fn frame_request_arrived_too_early(elapsed: Duration, minimum_interval: Duration) -> bool {
+    elapsed < minimum_interval.saturating_sub(FRAME_INTERVAL_TOLERANCE)
+}
+
+fn minimum_frame_interval(
+    should_throttle: bool,
+    inactive_without_high_rate_input: bool,
+    inactive_frame_interval: Option<Duration>,
+    thermal_state: ThermalState,
+    low_power_mode_enabled: bool,
+) -> Option<Duration> {
+    if !should_throttle {
+        None
+    } else if inactive_without_high_rate_input {
+        match (inactive_frame_interval, low_power_mode_enabled) {
+            (Some(inactive_frame_interval), true) => {
+                Some(inactive_frame_interval.max(THIRTY_FPS_INTERVAL))
+            }
+            (inactive_frame_interval, false) => inactive_frame_interval,
+            (None, true) => Some(THIRTY_FPS_INTERVAL),
+        }
+    } else if low_power_mode_enabled {
+        Some(THIRTY_FPS_INTERVAL)
+    } else if matches!(
+        thermal_state,
+        ThermalState::Critical | ThermalState::Serious
+    ) {
+        Some(SIXTY_FPS_INTERVAL)
+    } else {
+        None
+    }
+}
+
 impl Default for InputRateTracker {
     fn default() -> Self {
         Self {
@@ -1574,30 +1614,39 @@ impl Window {
                 let force_render =
                     mem::take(&mut deferred_force_render) || request_frame_options.force_render;
 
-                let thermal_state = handle
-                    .update(&mut cx, |_, _, cx| cx.thermal_state())
+                let power_state = handle
+                    .update(&mut cx, |_, _, cx| {
+                        (cx.thermal_state(), cx.low_power_mode_enabled())
+                    })
                     .log_err();
 
                 // Throttle frame rate based on conditions:
                 // - Thermal pressure (Serious/Critical): cap to ~60fps
-                // - Inactive window (not focused): cap to ~30fps to save energy
-                let min_frame_interval = if request_frame_options.require_presentation
-                    || (!request_frame_options.force_render
-                        && next_frame_callbacks.borrow().is_empty())
-                {
-                    None
-                } else if !active.get() && !input_rate_tracker.borrow_mut().is_high_rate() {
-                    inactive_frame_interval
-                } else if let Some(ThermalState::Critical | ThermalState::Serious) = thermal_state {
-                    Some(Duration::from_micros(16667))
-                } else {
-                    None
-                };
+                // - Low power mode: cap to ~30fps
+                // - Inactive window (not focused): use its configured frame interval
+                let should_throttle = !request_frame_options.require_presentation
+                    && (request_frame_options.force_render
+                        || !next_frame_callbacks.borrow().is_empty());
+                let inactive_without_high_rate_input = should_throttle
+                    && !active.get()
+                    && !input_rate_tracker.borrow_mut().is_high_rate();
+                let (thermal_state, low_power_mode_enabled) =
+                    power_state.unwrap_or((ThermalState::Nominal, false));
+                let min_frame_interval = minimum_frame_interval(
+                    should_throttle,
+                    inactive_without_high_rate_input,
+                    inactive_frame_interval,
+                    thermal_state,
+                    low_power_mode_enabled,
+                );
 
                 let now = Instant::now();
                 if let Some(min_interval) = min_frame_interval {
                     if let Some(last_frame) = last_frame_time.get()
-                        && now.duration_since(last_frame) < min_interval
+                        && frame_request_arrived_too_early(
+                            now.duration_since(last_frame),
+                            min_interval,
+                        )
                     {
                         // Don't lose a pending forced render to throttling.
                         deferred_force_render |= force_render;
@@ -6987,6 +7036,7 @@ mod tests {
         cell::{Cell, RefCell},
         path::PathBuf,
         rc::Rc,
+        time::Duration,
     };
 
     use crate::{
@@ -6994,9 +7044,41 @@ mod tests {
         ExternalDragPayload, ExternalPaths, FileDragPaths, FileDropEvent, FocusHandle,
         InputEvent as _, InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent,
         MouseMoveEvent, ParentElement, Pixels, Point, Render, RequestFrameOptions,
-        StatefulInteractiveElement as _, Styled, TestAppContext, Window, WindowAppearance,
-        WindowOptions, canvas, div, point, px, size,
+        StatefulInteractiveElement as _, Styled, TestAppContext, ThermalState, Window,
+        WindowAppearance, WindowOptions, canvas, div, point, px, size,
     };
+
+    #[test]
+    fn frame_throttle_accepts_display_link_rounding() {
+        assert!(!super::frame_request_arrived_too_early(
+            Duration::from_micros(16_666),
+            super::SIXTY_FPS_INTERVAL,
+        ));
+        assert!(!super::frame_request_arrived_too_early(
+            Duration::from_micros(33_332),
+            super::THIRTY_FPS_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn frame_throttle_rejects_an_extra_display_refresh() {
+        assert!(super::frame_request_arrived_too_early(
+            Duration::from_micros(8_333),
+            super::SIXTY_FPS_INTERVAL,
+        ));
+        assert!(super::frame_request_arrived_too_early(
+            Duration::from_micros(16_666),
+            super::THIRTY_FPS_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn low_power_mode_throttles_active_windows_to_thirty_fps() {
+        assert_eq!(
+            super::minimum_frame_interval(true, false, None, ThermalState::Nominal, true),
+            Some(super::THIRTY_FPS_INTERVAL)
+        );
+    }
 
     struct EmptyView;
 

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -152,6 +152,10 @@ unsafe fn build_classes() {
                 sel!(onThermalStateChange:),
                 on_thermal_state_change as extern "C" fn(&mut Object, Sel, id),
             );
+            decl.add_method(
+                sel!(onLowPowerModeChange:),
+                on_low_power_mode_change as extern "C" fn(&mut Object, Sel, id),
+            );
 
             decl.add_method(
                 sel!(onSystemWake:),
@@ -176,6 +180,7 @@ pub(crate) struct MacPlatformState {
     reopen: Option<Box<dyn FnMut()>>,
     on_keyboard_layout_change: Option<Box<dyn FnMut()>>,
     on_thermal_state_change: Option<Box<dyn FnMut()>>,
+    on_low_power_mode_change: Option<Box<dyn FnMut()>>,
     on_system_wake: Option<Box<dyn FnMut()>>,
     system_wake_observer_registered: bool,
     quit: Option<Box<dyn FnMut() -> bool>>,
@@ -232,6 +237,7 @@ impl MacPlatform {
             dock_menu: None,
             on_keyboard_layout_change: None,
             on_thermal_state_change: None,
+            on_low_power_mode_change: None,
             on_system_wake: None,
             system_wake_observer_registered: false,
             menus: None,
@@ -968,6 +974,10 @@ impl Platform for MacPlatform {
         self.0.lock().on_thermal_state_change = Some(callback);
     }
 
+    fn on_low_power_mode_change(&self, callback: Box<dyn FnMut()>) {
+        self.0.lock().on_low_power_mode_change = Some(callback);
+    }
+
     fn on_system_wake(&self, callback: Box<dyn FnMut()>) {
         let mut state = self.0.lock();
         state.on_system_wake = Some(callback);
@@ -998,6 +1008,19 @@ impl Platform for MacPlatform {
                 3 => ThermalState::Critical,
                 _ => ThermalState::Nominal,
             }
+        }
+    }
+
+    fn low_power_mode_enabled(&self) -> bool {
+        unsafe {
+            let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
+            let supported: BOOL =
+                msg_send![process_info, respondsToSelector: sel!(isLowPowerModeEnabled)];
+            if supported == NO {
+                return false;
+            }
+            let enabled: BOOL = msg_send![process_info, isLowPowerModeEnabled];
+            enabled != NO
         }
     }
 
@@ -1299,6 +1322,12 @@ extern "C" fn did_finish_launching(this: &mut Object, _: Sel, _: id) {
             name: thermal_name
             object: process_info
         ];
+        let low_power_name = ns_string("NSProcessInfoPowerStateDidChangeNotification");
+        let _: () = msg_send![notification_center, addObserver: this as id
+            selector: sel!(onLowPowerModeChange:)
+            name: low_power_name
+            object: process_info
+        ];
 
         let observer = this as *mut Object as id;
         let platform = get_mac_platform(this);
@@ -1388,6 +1417,28 @@ extern "C" fn on_thermal_state_change(this: &mut Object, _: Sel, _: id) {
                 .0
                 .lock()
                 .on_thermal_state_change
+                .get_or_insert(callback);
+        }
+    }
+}
+
+extern "C" fn on_low_power_mode_change(this: &mut Object, _: Sel, _: id) {
+    let platform = unsafe { get_mac_platform(this) };
+    let platform_ptr = platform as *const MacPlatform as *mut c_void;
+    unsafe {
+        DispatchQueue::main().exec_async_f(platform_ptr, on_low_power_mode_change);
+    }
+
+    extern "C" fn on_low_power_mode_change(context: *mut c_void) {
+        let platform = unsafe { &*(context as *const MacPlatform) };
+        let mut lock = platform.0.lock();
+        if let Some(mut callback) = lock.on_low_power_mode_change.take() {
+            drop(lock);
+            callback();
+            platform
+                .0
+                .lock()
+                .on_low_power_mode_change
                 .get_or_insert(callback);
         }
     }


### PR DESCRIPTION
# Objective

On macOS, Low Power Mode reduces the CPU and GPU performance available to applications. GPUI continued requesting animation frames at the normal cadence, so work that no longer fit inside every refresh produced irregular frame drops instead of a deliberate lower frame rate.

Frame throttling could also reject a display-link callback that arrived a fraction of a millisecond before the mathematically exact target interval. On a 120 Hz display, for example, a measured 16.666 ms interval missed a 16.667 ms threshold and delayed the frame until roughly 25 ms, intermittently turning a 60 fps cap into 40 fps.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved animation smoothness on macOS when Low Power Mode is enabled.
