### PR TITLE
Allow extensions to register opt-in language servers

### DIFF
--- a/crates/edit_prediction_context/src/fake_definition_lsp.rs
+++ b/crates/edit_prediction_context/src/fake_definition_lsp.rs
@@ -23,6 +23,7 @@ pub fn register_fake_definition_server(
         language.name(),
         language::FakeLspAdapter {
             name: "fake-definition-lsp",
+            enabled_by_default: true,
             initialization_options: None,
             additional_initialization_options: HashMap::default(),
             additional_workspace_configuration: HashMap::default(),

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -50,14 +50,15 @@ impl fmt::Display for SchemaVersion {
 
 impl SchemaVersion {
     pub const ZERO: Self = Self(0);
+    pub const TWO: Self = Self(2);
 
     pub fn is_v0(&self) -> bool {
         self == &Self::ZERO
     }
 }
 
-// TODO: We should change this to just always be a Vec<PathBuf> once we bump the
-// extension.toml schema version to 2
+// TODO: We should change this to just always be a Vec<PathBuf> in a future
+// extension.toml schema version.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExtensionSnippets {
@@ -123,6 +124,15 @@ pub struct ExtensionManifest {
 }
 
 impl ExtensionManifest {
+    pub fn is_language_server_enabled_by_default(
+        &self,
+        language_server_name: &LanguageServerName,
+    ) -> bool {
+        self.language_servers
+            .get(language_server_name)
+            .is_none_or(LanguageServerManifestEntry::is_enabled_by_default)
+    }
+
     /// Returns the set of features provided by the extension.
     pub fn provides(&self) -> BTreeSet<ExtensionProvides> {
         let mut provides = BTreeSet::default();
@@ -335,6 +345,9 @@ pub struct LanguageServerManifestEntry {
     /// The list of languages this language server should work with.
     #[serde(default)]
     languages: Vec<LanguageName>,
+    /// Whether this language server is included by `"..."` in language settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_enabled: Option<bool>,
     #[serde(default)]
     pub language_ids: HashMap<LanguageName, String>,
     #[serde(default)]
@@ -342,6 +355,10 @@ pub struct LanguageServerManifestEntry {
 }
 
 impl LanguageServerManifestEntry {
+    pub fn is_enabled_by_default(&self) -> bool {
+        self.default_enabled.unwrap_or(true)
+    }
+
     /// Returns the list of languages for the language server.
     ///
     /// Prefer this over accessing the `language` or `languages` fields directly,
@@ -587,6 +604,42 @@ mod tests {
                 .is_ok()
         );
         assert!(manifest.allow_exec("docker", &["ps"]).is_err()); // wrong first arg
+    }
+
+    #[test]
+    fn test_language_server_is_enabled_by_default() {
+        let enabled: LanguageServerManifestEntry =
+            toml::from_str("").expect("language server manifest entry should parse");
+        assert!(enabled.is_enabled_by_default());
+        assert!(
+            !toml::to_string(&enabled)
+                .expect("language server manifest entry should serialize")
+                .contains("default_enabled")
+        );
+
+        let disabled: LanguageServerManifestEntry = toml::from_str("default_enabled = false")
+            .expect("language server manifest entry should parse");
+        assert!(!disabled.is_enabled_by_default());
+        assert!(
+            toml::to_string(&disabled)
+                .expect("language server manifest entry should serialize")
+                .contains("default_enabled = false")
+        );
+
+        let mut manifest = extension_manifest();
+        manifest
+            .language_servers
+            .insert("optional-language-server".into(), disabled);
+        assert!(
+            !manifest.is_language_server_enabled_by_default(&LanguageServerName::new_static(
+                "optional-language-server"
+            ))
+        );
+        assert!(
+            manifest.is_language_server_enabled_by_default(&LanguageServerName::new_static(
+                "unknown-language-server"
+            ))
+        );
     }
 
     #[test]

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -13,7 +13,7 @@ use cloud_api_types::ExtensionProvides;
 use extension::build_debug_adapter_schema_path;
 use extension::extension_builder::CompilationConcurrency;
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
-use extension::{ExtensionManifest, ExtensionSnippets};
+use extension::{ExtensionManifest, ExtensionSnippets, SchemaVersion};
 use http_client::Url;
 use language::LanguageConfig;
 use reqwest_client::ReqwestClient;
@@ -432,6 +432,11 @@ enum ExtensionManifestValidationError {
         as these are currently unsupported"
     )]
     LanguageModelProvidersUnsupported,
+    #[error(
+        "language server '{0}' uses `default_enabled`, which requires extension manifest \
+        schema version 2 or newer"
+    )]
+    LanguageServerDefaultEnabledRequiresSchemaVersionTwo(String),
 }
 
 fn validate_extension_manifest(
@@ -484,6 +489,25 @@ fn validate_extension_manifest(
 
     if !manifest.language_model_providers.is_empty() {
         return Err(ExtensionManifestValidationError::LanguageModelProvidersUnsupported);
+    }
+
+    if manifest.schema_version < SchemaVersion::TWO
+        && let Some(language_server_name) =
+            manifest
+                .language_servers
+                .iter()
+                .find_map(|(language_server_name, language_server)| {
+                    language_server
+                        .default_enabled
+                        .is_some()
+                        .then(|| language_server_name.to_string())
+                })
+    {
+        return Err(
+            ExtensionManifestValidationError::LanguageServerDefaultEnabledRequiresSchemaVersionTwo(
+                language_server_name,
+            ),
+        );
     }
 
     Ok(())
@@ -687,7 +711,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use cloud_api_types::ExtensionProvides;
-    use extension::{LanguageModelProviderManifestEntry, SchemaVersion};
+    use extension::{LanguageModelProviderManifestEntry, LanguageServerManifestEntry};
 
     use super::*;
 
@@ -719,6 +743,28 @@ mod tests {
     #[test]
     fn test_validate_manifest_valid() {
         assert!(validate_extension_manifest(&valid_manifest()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_manifest_language_server_default_enabled_requires_schema_version_two() {
+        let mut manifest = valid_manifest();
+        let mut language_server = LanguageServerManifestEntry::default();
+        language_server.default_enabled = Some(false);
+        manifest
+            .language_servers
+            .insert("optional-language-server".into(), language_server);
+
+        assert_eq!(
+            validate_extension_manifest(&manifest),
+            Err(
+                ExtensionManifestValidationError::LanguageServerDefaultEnabledRequiresSchemaVersionTwo(
+                    "optional-language-server".to_string(),
+                )
+            ),
+        );
+
+        manifest.schema_version = SchemaVersion::TWO;
+        assert!(validate_extension_manifest(&manifest).is_ok());
     }
 
     #[test]

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -103,7 +103,7 @@ async fn with_remote_sync_timeout<T>(
 }
 
 /// The current extension [`SchemaVersion`] supported by Zed.
-const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(1);
+const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion::TWO;
 
 /// Extensions that should no longer be loaded or downloaded.
 ///

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -7,7 +7,7 @@ use crate::{
         ExtensionVersion, HeadlessExtensionStore, LoadedExtension, STALE_UPLOAD_TTL,
         hash_directory_contents, remove_stale_uploads,
     },
-    load_plugin_queries, remote_sync_retry_delay,
+    load_plugin_queries, remote_sync_retry_delay, schema_version_range,
 };
 use async_compression::futures::bufread::GzipEncoder;
 use async_trait::async_trait;
@@ -54,6 +54,14 @@ use util::{rel_path::rel_path_buf, test::TempTree};
 #[ctor::ctor(unsafe)]
 fn init_logger() {
     zlog::init_test();
+}
+
+#[test]
+fn test_schema_version_range() {
+    assert_eq!(
+        schema_version_range(),
+        SchemaVersion::ZERO..=SchemaVersion::TWO
+    );
 }
 
 #[gpui::test]

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -333,6 +333,7 @@ pub type LanguageServerBinaryLocations = LocalBoxFuture<
 /// once at startup, and caches the results.
 pub struct CachedLspAdapter {
     pub name: LanguageServerName,
+    pub enabled_by_default: bool,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
     language_ids: HashMap<LanguageName, String>,
@@ -344,6 +345,7 @@ impl Debug for CachedLspAdapter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CachedLspAdapter")
             .field("name", &self.name)
+            .field("enabled_by_default", &self.enabled_by_default)
             .field(
                 "disk_based_diagnostic_sources",
                 &self.disk_based_diagnostic_sources,
@@ -360,12 +362,14 @@ impl Debug for CachedLspAdapter {
 impl CachedLspAdapter {
     pub fn new(adapter: Arc<dyn LspAdapter>) -> Arc<Self> {
         let name = adapter.name();
+        let enabled_by_default = adapter.is_enabled_by_default();
         let disk_based_diagnostic_sources = adapter.disk_based_diagnostic_sources();
         let disk_based_diagnostics_progress_token = adapter.disk_based_diagnostics_progress_token();
         let language_ids = adapter.language_ids();
 
         Arc::new(CachedLspAdapter {
             name,
+            enabled_by_default,
             disk_based_diagnostic_sources,
             disk_based_diagnostics_progress_token,
             language_ids,
@@ -682,6 +686,11 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
         false
     }
 
+    /// Whether this adapter is included by `"..."` in language settings.
+    fn is_enabled_by_default(&self) -> bool {
+        true
+    }
+
     /// True for the extension adapter and false otherwise.
     fn is_extension(&self) -> bool {
         false
@@ -917,6 +926,7 @@ pub struct LanguageScope {
 #[cfg(any(test, feature = "test-support"))]
 pub struct FakeLspAdapter {
     pub name: &'static str,
+    pub enabled_by_default: bool,
     pub initialization_options: Option<Value>,
     pub additional_initialization_options: HashMap<LanguageServerName, Value>,
     pub additional_workspace_configuration: HashMap<LanguageServerName, Value>,
@@ -1473,6 +1483,7 @@ impl Default for FakeLspAdapter {
     fn default() -> Self {
         Self {
             name: "the-fake-language-server",
+            enabled_by_default: true,
             capabilities: lsp::LanguageServer::full_capabilities(),
             initializer: None,
             disk_based_diagnostics_progress_token: None,
@@ -1586,6 +1597,10 @@ impl LspAdapter for FakeLspAdapter {
     ) -> Option<CodeLabel> {
         let label_for_completion = self.label_for_completion.as_ref()?;
         label_for_completion(item, language)
+    }
+
+    fn is_enabled_by_default(&self) -> bool {
+        self.enabled_by_default
     }
 
     fn is_extension(&self) -> bool {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -345,18 +345,21 @@ impl LanguageSettings {
         settings
     }
 
-    /// Returns the customized list of language servers from the list of
-    /// available language servers.
+    /// Returns the customized list of language servers, expanding `"..."` with
+    /// the provided language servers.
     pub fn customized_language_servers(
         &self,
-        available_language_servers: &[LanguageServerName],
+        language_servers_included_by_wildcard: &[LanguageServerName],
     ) -> Vec<LanguageServerName> {
-        Self::resolve_language_servers(&self.language_servers, available_language_servers)
+        Self::resolve_language_servers(
+            &self.language_servers,
+            language_servers_included_by_wildcard,
+        )
     }
 
     pub(crate) fn resolve_language_servers(
         configured_language_servers: &[ConfiguredLanguageServer],
-        available_language_servers: &[LanguageServerName],
+        language_servers_included_by_wildcard: &[LanguageServerName],
     ) -> Vec<LanguageServerName> {
         let (disabled_language_servers, enabled_language_servers): (
             Vec<LanguageServerName>,
@@ -372,7 +375,7 @@ impl LanguageSettings {
                 }
             });
 
-        let rest = available_language_servers
+        let rest = language_servers_included_by_wildcard
             .iter()
             .filter(|&available_language_server| {
                 !disabled_language_servers.contains(available_language_server)

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -273,6 +273,12 @@ impl LspAdapter for ExtensionLspAdapter {
         self.language_server_id.clone()
     }
 
+    fn is_enabled_by_default(&self) -> bool {
+        self.extension
+            .manifest()
+            .is_language_server_enabled_by_default(&self.language_server_id)
+    }
+
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         let code_action_kinds = self
             .extension

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -251,13 +251,14 @@ impl LanguageServerTree {
             return Default::default();
         }
         let available_lsp_adapters = self.languages.lsp_adapters(language_name);
-        let available_language_servers = available_lsp_adapters
+        let language_servers_enabled_by_default = available_lsp_adapters
             .iter()
-            .map(|lsp_adapter| lsp_adapter.name.clone())
+            .filter(|adapter| adapter.enabled_by_default)
+            .map(|adapter| adapter.name.clone())
             .collect::<Vec<_>>();
 
         let desired_language_servers =
-            settings.customized_language_servers(&available_language_servers);
+            settings.customized_language_servers(&language_servers_enabled_by_default);
         let adapters_with_settings = desired_language_servers
             .into_iter()
             .filter_map(|desired_adapter| {

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -3400,6 +3400,116 @@ async fn test_max_buffer_line_length_can_be_overridden(cx: &mut gpui::TestAppCon
 }
 
 #[gpui::test]
+async fn test_default_disabled_language_server_requires_explicit_opt_in(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({ "a.rs": "" })).await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    let mut default_language_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "default-language-server",
+            ..Default::default()
+        },
+    );
+    let mut optional_language_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            name: "optional-language-server",
+            enabled_by_default: false,
+            ..Default::default()
+        },
+    );
+    language_registry.add(rust_lang());
+
+    let (rust_buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/a.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let mut default_language_server = default_language_servers.next().await.unwrap();
+    assert_eq!(
+        default_language_server
+            .receive_notification::<lsp::notification::DidOpenTextDocument>()
+            .await
+            .text_document
+            .uri
+            .as_str(),
+        uri!("file:///dir/a.rs")
+    );
+    cx.run_until_parked();
+
+    let running_language_servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |lsp_store, cx| {
+            rust_buffer.update(cx, |buffer, cx| {
+                lsp_store
+                    .running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<HashSet<_>>()
+            })
+        })
+    });
+    assert_eq!(
+        running_language_servers,
+        HashSet::from_iter([LanguageServerName::new_static("default-language-server")])
+    );
+
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.languages_mut().insert(
+                    "Rust".into(),
+                    LanguageSettingsContent {
+                        language_servers: Some(vec![
+                            "optional-language-server".into(),
+                            "...".into(),
+                        ]),
+                        ..Default::default()
+                    },
+                );
+            });
+        })
+    });
+
+    let mut optional_language_server = optional_language_servers.next().await.unwrap();
+    assert_eq!(
+        optional_language_server
+            .receive_notification::<lsp::notification::DidOpenTextDocument>()
+            .await
+            .text_document
+            .uri
+            .as_str(),
+        uri!("file:///dir/a.rs")
+    );
+    cx.run_until_parked();
+
+    let running_language_servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |lsp_store, cx| {
+            rust_buffer.update(cx, |buffer, cx| {
+                lsp_store
+                    .running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, _)| adapter.name())
+                    .collect::<HashSet<_>>()
+            })
+        })
+    });
+    assert_eq!(
+        running_language_servers,
+        HashSet::from_iter([
+            LanguageServerName::new_static("default-language-server"),
+            LanguageServerName::new_static("optional-language-server"),
+        ])
+    );
+}
+
+#[gpui::test]
 async fn test_toggling_enable_language_server(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -124,9 +124,9 @@ In this example:
 
 - `intelephense` is set as the primary language server.
 - `phpactor`, `phptools` and `phpantom` are disabled (note the `!` prefix).
-- `"..."` expands to the rest of the language servers registered for PHP that are not already listed.
+- `"..."` expands to the rest of the default-enabled language servers registered for PHP that are not already listed.
 
-The `"..."` entry acts as a wildcard that includes any registered language server you haven't explicitly mentioned. Servers you list by name keep their position, and `"..."` fills in the remaining ones at that point in the list. Servers prefixed with `!` are excluded entirely. This means that if a new language server extension is installed or a new server is registered for a language, `"..."` will automatically include it. If you want full control over which servers are enabled, omit `"..."` — only the servers you list by name will be used.
+The `"..."` entry acts as a wildcard that includes any default-enabled registered language server you haven't explicitly mentioned. Servers you list by name keep their position, and `"..."` fills in the remaining ones at that point in the list. Servers prefixed with `!` are excluded entirely. This means that if a new default-enabled language server extension is installed or a new default-enabled server is registered for a language, `"..."` will automatically include it. Language servers that their extension marks as default-disabled must be listed explicitly to enable them. If you want full control over which servers are enabled, omit `"..."` — only the servers you list by name will be used.
 
 #### Examples
 
@@ -151,7 +151,7 @@ Suppose you're working with Ruby. The default configuration is:
 }
 ```
 
-When you override `language_servers` in your settings, your list **replaces** the default entirely. This means default-disabled servers like `kanayago` will be re-enabled by `"..."` unless you explicitly disable them again.
+When you override `language_servers` in your settings, your list **replaces** the default entirely. This means servers disabled by Zed's default settings, like `kanayago`, will be re-enabled by `"..."` unless you explicitly disable them again. Servers marked as default-disabled by their extension remain excluded from `"..."` and must be listed explicitly.
 
 | Configuration                                     | Result                                                                                  |
 | ------------------------------------------------- | --------------------------------------------------------------------------------------- |

--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -43,7 +43,7 @@ basic information about the extension:
 id = "my-extension"
 name = "My extension"
 version = "0.0.1"
-schema_version = 1
+schema_version = 2
 authors = ["Your Name <you@example.com>"]
 description = "Example extension"
 repository = "https://github.com/your-name/my-zed-extension"

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -477,9 +477,28 @@ An extension may provide any number of language servers. To provide a language s
 
 ```toml
 [language_servers.my-language-server]
-name = "My Language LSP"
+name = "My Language Server"
 languages = ["My Language"]
 ```
+
+Zed's default `language_servers` setting contains the `"..."` wildcard, which expands to all registered language servers that are enabled by default. As a result, a language server registered by an extension is normally selected without additional user configuration.
+
+With extension manifest schema version 2 or newer, an extension can exclude a language server from this wildcard expansion by setting `default_enabled = false`:
+
+```toml
+[language_servers.my-optional-language-server]
+name = "My Optional Language Server"
+languages = ["My Language"]
+default_enabled = false
+```
+
+The server remains registered, so users can opt in by explicitly including its ID in their language settings:
+
+```jsonc
+"language_servers": ["my-optional-language-server", "..."]
+```
+
+Here, the explicit ID enables the optional server, while `"..."` retains the other default-enabled language servers. To run only the optional server, omit `"..."`.
 
 Then, in the Rust code for your extension, implement the `language_server_command` method on your extension:
 


### PR DESCRIPTION
For the Julia extension (https://github.com/JuliaEditorSupport/zed-julia) I want to offer LanguageServer.jl alongside JETLS, because JETLS (the new language server) does not support older Julia versions, whereas LanguageServer.jl does, so some users may want to use LanguageServer.jl on an opt-in basis.
Previously, the language server wildcard expanded to every registered server, so an extension could not ship an alternative server without starting it for every user or relying on extension-specific defaults in Zed.

Add the `default_enabled` field to `language_servers` entries in extension manifest schema version `2`. Setting it to `false` keeps the server registered and available for explicit selection while excluding it from the "..." wildcard. Existing manifests and adapters remain enabled by default.

Propagate the flag from extension manifests through `ExtensionLspAdapter` and `CachedLspAdapter`, and pass only default-enabled server names to wildcard expansion. Explicitly configured names are still resolved against every registered adapter, so users can opt in without core-side settings.

Bump the supported extension schema to 2, reject `default_enabled` in older schemas during extension validation, and update the extension and language configuration documentation.

Release Notes:

- Added support for extension-provided opt-in language servers.