### PR TITLE
project: Fix deleting directories in workspace edits

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2742,7 +2742,11 @@ impl FakeFs {
                 None
             }
             btree_map::Entry::Occupied(mut entry) => {
-                entry.get_mut().file_content(&path)?;
+                // A symlink is unlinked without being followed, so only a real
+                // directory is beyond the reach of `remove_file`.
+                if !entry.get().is_symlink() {
+                    entry.get_mut().file_content(&path)?;
+                }
                 Some(entry.remove())
             }
         };

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -706,6 +706,62 @@ async fn test_realfs_symlink_loop_metadata(executor: BackgroundExecutor) {
     // don't care about len or mtime on symlinks?
 }
 
+// `remove_file` unlinks a symlink rather than following it, so a symlink to a
+// directory is removed while the directory it names stays where it is.
+#[gpui::test]
+#[cfg(unix)]
+async fn test_realfs_remove_file_unlinks_a_symlink_to_a_directory(executor: BackgroundExecutor) {
+    let tempdir = TempDir::new().unwrap();
+    let fs = RealFs::new(None, executor);
+    let target = tempdir.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(target.join("kept.txt"), "kept").unwrap();
+    let link = tempdir.path().join("link");
+    gpui::block_on(fs.create_symlink(&link, target.clone())).unwrap();
+
+    gpui::block_on(fs.remove_file(&link, RemoveOptions::default()))
+        .expect("a symlink should be removable as a file");
+
+    assert!(fs.metadata(&link).await.unwrap().is_none());
+    assert_eq!(
+        std::fs::read_to_string(target.join("kept.txt")).unwrap(),
+        "kept"
+    );
+}
+
+#[gpui::test]
+async fn test_fake_fs_remove_file_unlinks_a_symlink_to_a_directory(executor: BackgroundExecutor) {
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "target": {
+                "kept.txt": "kept",
+            },
+        }),
+    )
+    .await;
+    fs.insert_symlink(path!("/root/link"), path!("/root/target").into())
+        .await;
+
+    fs.remove_file(Path::new(path!("/root/link")), RemoveOptions::default())
+        .await
+        .expect("a symlink should be removable as a file");
+
+    assert!(
+        fs.metadata(Path::new(path!("/root/link")))
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        fs.load(Path::new(path!("/root/target/kept.txt")))
+            .await
+            .unwrap(),
+        "kept"
+    );
+}
+
 #[gpui::test]
 async fn test_fake_fs_trash(executor: BackgroundExecutor) {
     let fs = FakeFs::new(executor.clone());

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3645,7 +3645,19 @@ impl LocalLspStore {
                             ignore_if_not_exists: options.ignore_if_not_exists.unwrap_or(false),
                         })
                         .unwrap_or_default();
-                    if abs_path.ends_with("/") {
+                    // A URI does not say whether it names a file or a directory,
+                    // and `Path::ends_with` compares whole components, so it never
+                    // matches a trailing slash. Ask the filesystem instead, or
+                    // deleting a directory tries to unlink it and fails. A symlink
+                    // is unlinked even when it points at a directory, so that the
+                    // directory it names survives.
+                    let is_dir = fs
+                        .metadata(&abs_path)
+                        .await
+                        .ok()
+                        .flatten()
+                        .is_some_and(|metadata| metadata.is_dir && !metadata.is_symlink);
+                    if is_dir {
                         fs.remove_dir(&abs_path, options).await?;
                     } else {
                         fs.remove_file(&abs_path, options).await?;

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8376,6 +8376,295 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
     );
 }
 
+// Applies a workspace edit built from `operations`, as a "rename symbol" on a
+// buffer opened from `buffer_path`, and reports whether the edit applied.
+async fn apply_rename_operations(
+    fs: Arc<FakeFs>,
+    buffer_path: &str,
+    operations: Vec<lsp::DocumentChangeOperation>,
+    cx: &mut gpui::TestAppContext,
+) -> Result<()> {
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(buffer_path, cx)
+        })
+        .await
+        .unwrap();
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    let response = project.update(cx, |project, cx| {
+        project.perform_rename(buffer.clone(), 0, "renamed".to_string(), cx)
+    });
+    fake_server
+        .set_request_handler::<lsp::request::Rename, _, _>(move |_params, _| {
+            let operations = operations.clone();
+            async move {
+                Ok(Some(lsp::WorkspaceEdit {
+                    changes: None,
+                    document_changes: Some(DocumentChanges::Operations(operations)),
+                    change_annotations: None,
+                }))
+            }
+        })
+        .next()
+        .await
+        .unwrap();
+    let result = response.await;
+    cx.executor().run_until_parked();
+    result.map(|_| ())
+}
+
+// A language server that renames a Go package, or anything else that empties a
+// directory, follows the rename with a delete of the directory left behind.
+#[gpui::test]
+async fn test_workspace_edit_deletes_a_directory(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one": {
+                "one.rs": "const ONE: usize = 1;",
+            },
+        }),
+    )
+    .await;
+
+    let result = apply_rename_operations(
+        fs.clone(),
+        path!("/dir/one/one.rs"),
+        vec![
+            lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                old_uri: Uri::from_file_path(path!("/dir/one/one.rs")).unwrap(),
+                new_uri: Uri::from_file_path(path!("/dir/two/one.rs")).unwrap(),
+                options: None,
+                annotation_id: None,
+            })),
+            lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(lsp::DeleteFile {
+                uri: Uri::from_file_path(path!("/dir/one")).unwrap(),
+                options: None,
+            })),
+        ],
+        cx,
+    )
+    .await;
+
+    result.expect("deleting the emptied directory should not fail the workspace edit");
+    assert!(
+        fs.metadata(Path::new(path!("/dir/one")))
+            .await
+            .unwrap()
+            .is_none(),
+        "the emptied directory should be gone"
+    );
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/two/one.rs"))).await.unwrap(),
+        "const ONE: usize = 1;",
+        "the renamed file should have survived the delete that followed it"
+    );
+}
+
+// A server that asks to delete a directory recursively means it, so the
+// contents go with it.
+#[gpui::test]
+async fn test_workspace_edit_deletes_a_directory_recursively(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "gone": {
+                "two.rs": "const TWO: usize = 2;",
+                "nested": {
+                    "deeper": {
+                        "three.rs": "const THREE: usize = 3;",
+                    },
+                },
+            },
+        }),
+    )
+    .await;
+
+    let result = apply_rename_operations(
+        fs.clone(),
+        path!("/dir/one.rs"),
+        vec![lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(
+            lsp::DeleteFile {
+                uri: Uri::from_file_path(path!("/dir/gone")).unwrap(),
+                options: Some(lsp::DeleteFileOptions {
+                    recursive: Some(true),
+                    ignore_if_not_exists: None,
+                    annotation_id: None,
+                }),
+            },
+        ))],
+        cx,
+    )
+    .await;
+
+    result.expect("a recursive delete should not fail the workspace edit");
+    assert!(
+        fs.metadata(Path::new(path!("/dir/gone")))
+            .await
+            .unwrap()
+            .is_none(),
+        "the directory and everything under it should be gone"
+    );
+    assert!(
+        fs.metadata(Path::new(path!("/dir/gone/nested/deeper/three.rs")))
+            .await
+            .unwrap()
+            .is_none(),
+        "including files nested well below the top"
+    );
+}
+
+// Without that flag a directory that still holds something is left where it is,
+// rather than being emptied on the server's behalf.
+#[gpui::test]
+async fn test_workspace_edit_will_not_delete_a_full_directory_on_its_own(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "kept": {
+                "two.rs": "const TWO: usize = 2;",
+            },
+        }),
+    )
+    .await;
+
+    let result = apply_rename_operations(
+        fs.clone(),
+        path!("/dir/one.rs"),
+        vec![lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(
+            lsp::DeleteFile {
+                uri: Uri::from_file_path(path!("/dir/kept")).unwrap(),
+                options: None,
+            },
+        ))],
+        cx,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "deleting a directory that still holds something should not quietly succeed"
+    );
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/kept/two.rs"))).await.unwrap(),
+        "const TWO: usize = 2;",
+        "the contents should still be there"
+    );
+}
+
+#[gpui::test]
+async fn test_workspace_edit_deletes_a_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "two.rs": "const TWO: usize = 2;",
+        }),
+    )
+    .await;
+
+    let result = apply_rename_operations(
+        fs.clone(),
+        path!("/dir/one.rs"),
+        vec![lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(
+            lsp::DeleteFile {
+                uri: Uri::from_file_path(path!("/dir/two.rs")).unwrap(),
+                options: None,
+            },
+        ))],
+        cx,
+    )
+    .await;
+
+    result.expect("deleting a file should not fail the workspace edit");
+    assert!(
+        fs.metadata(Path::new(path!("/dir/two.rs")))
+            .await
+            .unwrap()
+            .is_none(),
+        "the deleted file should be gone"
+    );
+}
+
+// A symlink reports the metadata of whatever it points at, so a symlink to a
+// directory has to be unlinked rather than removed as one, or the delete takes
+// the directory with it.
+#[gpui::test]
+async fn test_workspace_edit_deleting_a_symlink_spares_its_target(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "target": {
+                "kept.rs": "const KEPT: usize = 3;",
+            },
+        }),
+    )
+    .await;
+    fs.insert_symlink(path!("/dir/link"), path!("/dir/target").into())
+        .await;
+
+    let result = apply_rename_operations(
+        fs.clone(),
+        path!("/dir/one.rs"),
+        vec![lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Delete(
+            lsp::DeleteFile {
+                uri: Uri::from_file_path(path!("/dir/link")).unwrap(),
+                options: None,
+            },
+        ))],
+        cx,
+    )
+    .await;
+
+    result.expect("deleting a symlink should not fail the workspace edit");
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/target/kept.rs")))
+            .await
+            .unwrap(),
+        "const KEPT: usize = 3;",
+        "the directory the symlink pointed at should have survived"
+    );
+}
+
 // Regression test for https://github.com/zed-industries/zed/issues/59077:
 // a "rename symbol" whose workspace edit also renames the file used to swap the
 // two files' contents. The edited content must end up in the renamed file, and


### PR DESCRIPTION
# Objective

As I was working on #5369, I noticed that a workspace edit that asks for a directory to be deleted always fails. Whatever the edit did before that point has already happened, so you are left with a half-applied change that isn't undoable.

Any language server that sends a delete for a directory runs into this. The one I hit it with is gopls. Renaming a Go package moves the file out and then asks for the emptied directory to go. However, the directory stays empty, and nothing is undoable, because the delete fails.

## Solution

`Path::ends_with` compares whole path components, so the old check never matched a trailing slash and no delete was ever recognized as a directory. We now ask the filesystem what the path is instead. Symlinks still go through `remove_file`, so they are unlinked rather than followed.

This also makes the `recursive` option mean something. It was parsed and forwarded already, but the branch using it was unreachable, so a server asking for a recursive delete got nothing. It now gets one.

Also, `FakeFs::remove_file` rejected symlinks, which `RealFs` allows. That is why this touches two crates.

## Testing

I have added 7 tests. I checked each one fails against a deliberately broken implementation.

Reproduced by hand with a Go project where one package imports another, renaming the package in its `package` clause.

Tested on macOS. The fix does not depend on which error a platform returns, since it checks what the path is before removing it.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed workspace edits failing when a language server asks for a directory to be deleted, such as renaming a Go package.
