### PR TITLE
editor: Warn when undo leaves a file renamed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5619,6 +5619,7 @@ dependencies = [
  "markdown",
  "menu",
  "multi_buffer",
+ "notifications",
  "ordered-float 2.10.1",
  "parking_lot",
  "pretty_assertions",

--- a/crates/agent/src/tools/apply_code_action_tool.rs
+++ b/crates/agent/src/tools/apply_code_action_tool.rs
@@ -118,7 +118,7 @@ impl AgentTool for ApplyCodeActionTool {
                 .await
                 .map_err(|e| format!("Failed to apply code action '{title}': {e}"))?;
 
-            if transaction.0.is_empty() {
+            if transaction.buffers.is_empty() {
                 return Ok(format!(
                     "Code action '{title}' was applied but made no changes.",
                 ));
@@ -126,10 +126,10 @@ impl AgentTool for ApplyCodeActionTool {
 
             let mut output = format!(
                 "Applied code action '{title}'. Modified {} file(s):\n",
-                transaction.0.len()
+                transaction.buffers.len()
             );
 
-            for (buffer, _) in &transaction.0 {
+            for (buffer, _) in &transaction.buffers {
                 buffer.read_with(cx, |buffer, cx| {
                     let path = buffer
                         .file()

--- a/crates/agent/src/tools/rename_tool.rs
+++ b/crates/agent/src/tools/rename_tool.rs
@@ -89,14 +89,14 @@ impl AgentTool for RenameTool {
                 .await
                 .map_err(|e| format!("Rename failed: {e}"))?;
 
-            if transaction.0.is_empty() {
+            if transaction.buffers.is_empty() {
                 return Ok(format!(
                     "No changes were made. The language server could not rename '{}'.",
                     input.symbol.symbol_name
                 ));
             }
 
-            let buffers = transaction.0.keys().cloned().collect::<HashSet<_>>();
+            let buffers = transaction.buffers.keys().cloned().collect::<HashSet<_>>();
             project
                 .update(cx, |project, cx| project.save_buffers(buffers, cx))
                 .await
@@ -106,10 +106,10 @@ impl AgentTool for RenameTool {
                 "Renamed `{}` to `{}` in {} file(s):\n",
                 input.symbol.symbol_name,
                 input.new_name,
-                transaction.0.len()
+                transaction.buffers.len()
             );
 
-            for (buffer, _) in &transaction.0 {
+            for (buffer, _) in &transaction.buffers {
                 buffer.read_with(cx, |buffer, cx| {
                     let path = buffer
                         .file()

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -63,6 +63,7 @@ lsp.workspace = true
 markdown.workspace = true
 menu.workspace = true
 multi_buffer.workspace = true
+notifications.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true
 pretty_assertions.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23,6 +23,7 @@ mod document_links;
 mod document_symbols;
 mod editor_settings;
 mod element;
+mod file_rename_toast;
 mod fold;
 mod folding_ranges;
 mod git;
@@ -3555,6 +3556,18 @@ impl Editor {
             return;
         }
 
+        // Tracked here as well as in `open_project_transaction`, because the
+        // branch below skips that call when every edited buffer is already open.
+        // A workspace edit a server pushes on its own takes that branch, and it
+        // is exactly the case worth reporting.
+        if !transaction.file_renames.is_empty() {
+            workspace.update(cx, |workspace, cx| {
+                workspace.project().update(cx, |project, cx| {
+                    project.track_file_renames(&transaction, cx);
+                })
+            });
+        }
+
         let edited_buffers_already_open = {
             let other_editors: Vec<Entity<Editor>> = workspace
                 .read(cx)
@@ -3597,6 +3610,16 @@ impl Editor {
         title: String,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
+        // Remembered before the transaction is split up, so undoing any of the
+        // buffer transactions it produced can report the files it moved.
+        if !transaction.file_renames.is_empty() {
+            workspace.update(cx, |workspace, cx| {
+                workspace.project().update(cx, |project, cx| {
+                    project.track_file_renames(&transaction, cx);
+                })
+            })?;
+        }
+
         let mut entries = transaction.buffers.into_iter().collect::<Vec<_>>();
         cx.update(|_, cx| {
             entries.sort_unstable_by_key(|(buffer, _)| {
@@ -7851,6 +7874,11 @@ impl Editor {
             return;
         }
 
+        // Captured before the undo, because these are the transactions it is
+        // about to remove. Afterwards they are gone from the history and there
+        // is no way to ask what they were.
+        let before = self.transactions_at_top_of_undo_stacks(cx);
+
         if let Some(transaction_id) = self.buffer.update(cx, |buffer, cx| buffer.undo(cx)) {
             let transaction = self.selection_history.transaction(transaction_id);
             if transaction.is_none() {
@@ -7869,7 +7897,69 @@ impl Editor {
             );
             cx.emit(EditorEvent::Edited { transaction_id });
             cx.emit(EditorEvent::TransactionUndone { transaction_id });
+            // A multibuffer undo only touches the buffers named in one history
+            // entry, so comparing against the state afterwards separates the
+            // buffers that were actually undone from those that were not.
+            let after = self.transactions_at_top_of_undo_stacks(cx);
+            let undone = before
+                .into_iter()
+                .filter(|(buffer_id, transaction_id)| after.get(buffer_id) != Some(transaction_id))
+                .collect::<Vec<_>>();
+            self.report_file_renames_left_behind(undone, window, cx);
         }
+    }
+
+    /// The transaction sitting on top of each of this editor's buffers' undo
+    /// stacks, which is what an undo will remove.
+    ///
+    /// A multibuffer undo can remove a range of transactions rather than only
+    /// the top one, so a rename recorded further down the stack is missed here.
+    /// That costs a notification rather than correctness, which is the right way
+    /// round for a guess.
+    fn transactions_at_top_of_undo_stacks(
+        &self,
+        cx: &App,
+    ) -> HashMap<text::BufferId, TransactionId> {
+        self.buffer
+            .read(cx)
+            .all_buffers()
+            .into_iter()
+            .filter_map(|buffer| {
+                let buffer = buffer.read(cx);
+                Some((
+                    buffer.remote_id(),
+                    buffer.peek_undo_stack()?.transaction_id(),
+                ))
+            })
+            .collect()
+    }
+
+    /// An LSP rename can move a file as well as edit it. Undo reverts the text
+    /// but leaves the file where the rename put it, so the two disagree until
+    /// someone does something about it. Rather than guess, say so and offer.
+    fn report_file_renames_left_behind(
+        &mut self,
+        undone: Vec<(text::BufferId, TransactionId)>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project) = self.project.clone() else {
+            return;
+        };
+        let Some(workspace) = self.workspace() else {
+            return;
+        };
+        let renames = project.read_with(cx, |project, _| {
+            undone.into_iter().find_map(|(buffer_id, transaction_id)| {
+                project.file_renames_for_transaction(buffer_id, transaction_id)
+            })
+        });
+        let Some(renames) = renames else {
+            return;
+        };
+        crate::file_rename_toast::show_files_left_renamed_toast(
+            &workspace, project, renames, window, cx,
+        );
     }
 
     pub fn redo(&mut self, _: &Redo, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3551,7 +3551,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if transaction.0.is_empty() {
+        if transaction.buffers.is_empty() {
             return;
         }
 
@@ -3564,7 +3564,7 @@ impl Editor {
                 .filter(|editor| editor.entity_id() != cx.entity_id())
                 .collect();
 
-            transaction.0.keys().all(|buffer| {
+            transaction.buffers.keys().all(|buffer| {
                 other_editors.iter().any(|editor| {
                     let multi_buffer = editor.read(cx).buffer();
                     multi_buffer.read(cx).is_singleton()
@@ -3597,7 +3597,7 @@ impl Editor {
         title: String,
         cx: &mut AsyncWindowContext,
     ) -> Result<()> {
-        let mut entries = transaction.0.into_iter().collect::<Vec<_>>();
+        let mut entries = transaction.buffers.into_iter().collect::<Vec<_>>();
         cx.update(|_, cx| {
             entries.sort_unstable_by_key(|(buffer, _)| {
                 buffer.read(cx).file().map(|f| f.path().clone())
@@ -8432,7 +8432,7 @@ impl Editor {
                 if let Some(transaction) = transaction
                     && !buffer.is_singleton()
                 {
-                    buffer.push_transaction(&transaction.0, cx);
+                    buffer.push_transaction(&transaction.buffers, cx);
                 }
                 cx.notify();
             });
@@ -8503,7 +8503,7 @@ impl Editor {
                 if let Some(transaction) = transaction
                     && !buffer.is_singleton()
                 {
-                    buffer.push_transaction(&transaction.0, cx);
+                    buffer.push_transaction(&transaction.buffers, cx);
                 }
                 cx.notify();
             });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -35688,7 +35688,7 @@ async fn test_apply_code_lens_actions_with_commands(cx: &mut gpui::TestAppContex
     // Applying the code lens command returns a project transaction containing the edits
     // sent by the language server in its `workspaceEdit` request.
     let transaction = apply.await.unwrap();
-    assert!(transaction.0.contains_key(&buffer));
+    assert!(transaction.buffers.contains_key(&buffer));
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "Xa");
         buffer.undo(cx);

--- a/crates/editor/src/file_rename_toast.rs
+++ b/crates/editor/src/file_rename_toast.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use gpui::{App, Entity};
+use notifications::status_toast::StatusToast;
+use project::{FileRename, Project};
+use ui::prelude::*;
+use workspace::Workspace;
+
+/// Tells the user that undoing a rename left its files under their new names,
+/// and offers to move them back.
+///
+/// The move is not part of the undo. A workspace edit becomes one buffer
+/// transaction per file it touched, and those are undone independently, so
+/// there is no single point at which the edit is "undone" and the files can
+/// safely follow. Asking is the honest way out of that.
+///
+/// Redo has no counterpart. Once the files have been moved back the record of
+/// where the edit put them is dropped, so redoing the text leaves the files
+/// where the user just asked for them to be. Offering to move them forward
+/// again would mean tracking a second direction, which is more than this is
+/// trying to do.
+pub fn show_files_left_renamed_toast(
+    workspace: &Entity<Workspace>,
+    project: Entity<Project>,
+    renames: Arc<Vec<FileRename>>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let message = match renames.as_slice() {
+        [rename] => format!(
+            "Undo reverted the text. `{}` is still named `{}`.",
+            rename.old_path.path.as_unix_str(),
+            rename.new_path.path.as_unix_str()
+        ),
+        renames => format!(
+            "Undo reverted the text. {} files are still under their new names.",
+            renames.len()
+        ),
+    };
+
+    let project = project.downgrade();
+    let status_toast = StatusToast::new(message, cx, move |this, _cx| {
+        this.icon(
+            Icon::new(IconName::Undo)
+                .size(IconSize::Small)
+                .color(Color::Muted),
+        )
+        .action("Move back", move |_window, cx| {
+            if let Some(project) = project.upgrade() {
+                project
+                    .update(cx, |project, cx| {
+                        project.move_renamed_files_back(renames.clone(), cx)
+                    })
+                    .detach_and_log_err(cx);
+            }
+        })
+        .dismiss_button(true)
+        // The default is to disappear after ten seconds. This one offers to
+        // repair a state the user did not ask for, so it waits to be answered.
+        .auto_dismiss(false)
+    });
+
+    workspace.update(cx, |workspace, cx| {
+        workspace.toggle_status_toast(status_toast, cx);
+    });
+    let _ = window;
+}

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1060,7 +1060,7 @@ impl Item for Editor {
                 if let Some(transaction) = transaction
                     && !buffer.is_singleton()
                 {
-                    buffer.push_transaction(&transaction.0, cx);
+                    buffer.push_transaction(&transaction.buffers, cx);
                 }
             });
             Ok(())

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -97,14 +97,44 @@ pub enum BufferStoreEvent {
 }
 
 #[derive(Default, Debug, Clone)]
-pub struct ProjectTransaction(pub HashMap<Entity<Buffer>, language::Transaction>);
+pub struct ProjectTransaction {
+    pub buffers: HashMap<Entity<Buffer>, language::Transaction>,
+    /// Files moved by this transaction's workspace edit, in the order they were
+    /// applied. An LSP rename can move a file as well as edit its contents, and
+    /// consumers that only look at the buffers cannot tell that it happened.
+    pub file_renames: Vec<FileRename>,
+}
+
+/// A file moved while applying a workspace edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRename {
+    /// The entry that moved, rather than the path it sat at. By the time anyone
+    /// acts on this, something unrelated may occupy either end of the move.
+    pub entry_id: ProjectEntryId,
+    pub old_path: ProjectPath,
+    pub new_path: ProjectPath,
+}
+
+impl ProjectTransaction {
+    /// Folds another transaction into this one. Both the buffer edits and the
+    /// file renames have to be carried over, or the moves would be dropped
+    /// while the edits that came with them are kept.
+    pub fn merge(&mut self, other: Self) {
+        self.buffers.extend(other.buffers);
+        self.file_renames.extend(other.file_renames);
+    }
+}
 
 impl PartialEq for ProjectTransaction {
     fn eq(&self, other: &Self) -> bool {
-        self.0.len() == other.0.len()
-            && self.0.iter().all(|(buffer, transaction)| {
-                other.0.get(buffer).is_some_and(|t| t.id == transaction.id)
+        self.buffers.len() == other.buffers.len()
+            && self.buffers.iter().all(|(buffer, transaction)| {
+                other
+                    .buffers
+                    .get(buffer)
+                    .is_some_and(|t| t.id == transaction.id)
             })
+            && self.file_renames == other.file_renames
     }
 }
 
@@ -276,10 +306,24 @@ impl RemoteBufferStore {
                     .update(cx, |this, cx| this.wait_for_remote_buffer(buffer_id, cx))?
                     .await?;
                 let transaction = language::proto::deserialize_transaction(transaction)?;
-                project_transaction.0.insert(buffer, transaction);
+                project_transaction.buffers.insert(buffer, transaction);
             }
 
-            for (buffer, transaction) in &project_transaction.0 {
+            for rename in message.file_renames {
+                let (Some(old_path), Some(new_path)) = (
+                    rename.old_path.and_then(ProjectPath::from_proto),
+                    rename.new_path.and_then(ProjectPath::from_proto),
+                ) else {
+                    continue;
+                };
+                project_transaction.file_renames.push(FileRename {
+                    entry_id: ProjectEntryId::from_proto(rename.entry_id),
+                    old_path,
+                    new_path,
+                });
+            }
+
+            for (buffer, transaction) in &project_transaction.buffers {
                 buffer
                     .update(cx, |buffer, _| {
                         buffer.wait_for_edits(transaction.edit_ids.iter().copied())
@@ -809,7 +853,7 @@ impl LocalBufferStore {
                         if !push_to_history {
                             buffer.forget_transaction(transaction.id);
                         }
-                        project_transaction.0.insert(cx.entity(), transaction);
+                        project_transaction.buffers.insert(cx.entity(), transaction);
                     }
                 });
             }
@@ -1763,8 +1807,17 @@ impl BufferStore {
         let mut serialized_transaction = proto::ProjectTransaction {
             buffer_ids: Default::default(),
             transactions: Default::default(),
+            file_renames: project_transaction
+                .file_renames
+                .iter()
+                .map(|rename| proto::FileRename {
+                    old_path: Some(rename.old_path.to_proto()),
+                    new_path: Some(rename.new_path.to_proto()),
+                    entry_id: rename.entry_id.to_proto(),
+                })
+                .collect(),
         };
-        for (buffer, transaction) in project_transaction.0 {
+        for (buffer, transaction) in project_transaction.buffers {
             self.create_buffer_for_peer(&buffer, peer_id, cx)
                 .detach_and_log_err(cx);
             serialized_transaction

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1579,7 +1579,7 @@ impl LocalLspStore {
                     buffer.forget_transaction(formatting_transaction.id);
                 }
                 project_transaction
-                    .0
+                    .buffers
                     .insert(cx.entity(), formatting_transaction);
             });
 
@@ -2321,7 +2321,8 @@ impl LocalLspStore {
                             .unwrap_or_default()
                     })?;
 
-                    if let Some(transaction) = project_transaction_command.0.remove(&buffer.handle)
+                    if let Some(transaction) =
+                        project_transaction_command.buffers.remove(&buffer.handle)
                     {
                         zlog::trace!(
                             logger =>
@@ -2346,12 +2347,12 @@ impl LocalLspStore {
                         });
                     }
 
-                    if project_transaction_command.0.is_empty() {
+                    if project_transaction_command.buffers.is_empty() {
                         continue;
                     }
 
                     let mut extra_buffers = String::new();
-                    for buffer in project_transaction_command.0.keys() {
+                    for buffer in project_transaction_command.buffers.keys() {
                         buffer.read_with(cx, |b, cx| {
                             let Some(path) = b.project_path(cx) else {
                                 return;
@@ -3319,7 +3320,7 @@ impl LocalLspStore {
                     cx,
                 )
                 .await?;
-                project_transaction.0.extend(new.0);
+                project_transaction.merge(new);
             }
 
             let Some(command) = action.lsp_action.command() else {
@@ -3362,11 +3363,10 @@ impl LocalLspStore {
 
             lsp_store.update(cx, |this, _| {
                 if let LspStoreMode::Local(mode) = &mut this.mode {
-                    project_transaction.0.extend(
+                    project_transaction.merge(
                         mode.last_workspace_edits_by_language_server
                             .remove(&language_server.server_id())
-                            .unwrap_or_default()
-                            .0,
+                            .unwrap_or_default(),
                     )
                 }
             })?;
@@ -3600,8 +3600,67 @@ impl LocalLspStore {
                         create_parents: true,
                     };
 
+                    // Resolved before the move, while the entry is still at the
+                    // source. `refresh_entry` below carries the id across, so it
+                    // still names this file afterwards.
+                    let moved_entry = this.update(cx, |this, cx| {
+                        let worktree_store = this.worktree_store();
+                        let worktree_store = worktree_store.read(cx);
+                        let old_path =
+                            worktree_store.project_path_for_absolute_path(&source_abs_path, cx)?;
+                        let new_path =
+                            worktree_store.project_path_for_absolute_path(&target_abs_path, cx)?;
+                        // Only a rename within one worktree keeps its entry id,
+                        // through the `refresh_entry` call below. Across
+                        // worktrees the watcher mints a new one, so the id
+                        // recorded here would name nothing by the time anyone
+                        // used it. Better to record no move than one that cannot
+                        // be acted on.
+                        if old_path.worktree_id != new_path.worktree_id {
+                            return None;
+                        }
+                        let entry_id = worktree_store.entry_for_path(&old_path, cx)?.id;
+                        Some((entry_id, old_path, new_path))
+                    });
+
+                    let ignore_if_exists = options.ignore_if_exists;
                     fs.rename(&source_abs_path, &target_abs_path, options)
                         .await?;
+
+                    // `Fs::rename` reports success without moving anything when
+                    // `ignore_if_exists` is set and the target is already there,
+                    // and a move that did not happen must not be recorded as one.
+                    let moved = if ignore_if_exists {
+                        match fs.metadata(&source_abs_path).await {
+                            // The source is still there, so nothing moved.
+                            Ok(Some(_)) => false,
+                            Ok(None) => true,
+                            // Claiming a move that did not happen is worse than
+                            // missing one, so an unreadable source is treated as
+                            // "did not move".
+                            Err(error) => {
+                                log::warn!(
+                                    "could not tell whether {source_abs_path:?} moved, \
+                                     leaving the rename unrecorded: {error}"
+                                );
+                                false
+                            }
+                        }
+                    } else {
+                        true
+                    };
+
+                    // Recorded before anything that can fail, so a later error
+                    // cannot leave the file moved with no record of it.
+                    if moved && let Some((entry_id, old_path, new_path)) = moved_entry {
+                        project_transaction
+                            .file_renames
+                            .push(crate::buffer_store::FileRename {
+                                entry_id,
+                                old_path,
+                                new_path,
+                            });
+                    }
 
                     // Preserve the entry id across the rename so an open buffer follows it
                     // to the new path, instead of being stranded at the old path when the
@@ -3766,7 +3825,9 @@ impl LocalLspStore {
                         })
                     });
                     if let Some(transaction) = transaction {
-                        project_transaction.0.insert(buffer_to_edit, transaction);
+                        project_transaction
+                            .buffers
+                            .insert(buffer_to_edit, transaction);
                     }
                 }
             }
@@ -11040,9 +11101,7 @@ impl LspStore {
                 // Await on tasks sequentially so that the order of application of edits is deterministic
                 // (at least with regards to the order of registration of language servers)
                 if let Some(transaction) = task.await {
-                    for (buffer, buffer_transaction) in transaction.0 {
-                        merged_transaction.0.insert(buffer, buffer_transaction);
-                    }
+                    merged_transaction.merge(transaction);
                 }
             }
             merged_transaction

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -123,7 +123,7 @@ pub use snippet_provider;
 use snippet_provider::SnippetProvider;
 use std::{
     borrow::Cow,
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     ffi::OsString,
     future::Future,
     ops::{Not as _, Range},
@@ -136,7 +136,7 @@ use std::{
 
 use task_store::TaskStore;
 use terminals::Terminals;
-use text::{Anchor, BufferId, Point, Rope};
+use text::{Anchor, BufferId, Point, Rope, TransactionId};
 use toolchain_store::EmptyToolchainStore;
 use util::{
     ResultExt as _, maybe,
@@ -163,7 +163,7 @@ pub use task_inventory::{
     Inventory, TaskContexts, TaskSourceKind,
 };
 
-pub use buffer_store::ProjectTransaction;
+pub use buffer_store::{FileRename, ProjectTransaction};
 pub use lsp_command::{CallHierarchyItem, IncomingCall, OutgoingCall};
 pub use lsp_store::{
     DiagnosticSummary, InvalidationStrategy, LanguageServerLogType, LanguageServerProgress,
@@ -172,6 +172,11 @@ pub use lsp_store::{
 };
 pub use toolchain_store::{ToolchainStore, Toolchains};
 const MAX_PROJECT_SEARCH_HISTORY_SIZE: usize = 500;
+
+/// How many workspace edits are kept available for the editor to report their
+/// file moves. Renames are rare, so this only needs to outlast the edits a user
+/// is realistically going to walk back.
+const MAX_TRACKED_FILE_RENAMES: usize = 64;
 
 #[derive(Clone, Copy, Debug)]
 pub struct LocalProjectFlags {
@@ -215,6 +220,17 @@ pub enum OpenedBufferEvent {
 /// Can be either local (for the project opened on the same host) or remote.(for collab projects, browsed by multiple remote users).
 pub struct Project {
     active_entry: Option<ProjectEntryId>,
+    /// Files moved by workspace edits, against the buffer transaction the same
+    /// edit produced. Undoing that transaction reverts the text but leaves the
+    /// file where the edit put it, so this is what lets the editor say so.
+    ///
+    /// Keyed per buffer because a buffer's transaction ids are only unique
+    /// within that buffer. Bounded because a transaction stays undoable for as
+    /// long as it is in a buffer's history, which has no bound of its own.
+    file_renames: HashMap<(BufferId, TransactionId), Arc<Vec<FileRename>>>,
+    /// One entry per workspace edit, not per key, so that the budget below
+    /// counts edits rather than the files each one happened to touch.
+    file_rename_order: VecDeque<Arc<Vec<FileRename>>>,
     buffer_ordered_messages_tx: mpsc::UnboundedSender<BufferOrderedMessage>,
     languages: Arc<LanguageRegistry>,
     dap_store: Entity<DapStore>,
@@ -1374,6 +1390,8 @@ impl Project {
                 client_subscriptions: Vec::new(),
                 _subscriptions: vec![cx.on_release(Self::release)],
                 active_entry: None,
+                file_renames: HashMap::default(),
+                file_rename_order: VecDeque::new(),
                 snippets,
                 languages,
                 collab_client: client,
@@ -1622,6 +1640,8 @@ impl Project {
                     }),
                 ],
                 active_entry: None,
+                file_renames: HashMap::default(),
+                file_rename_order: VecDeque::new(),
                 snippets,
                 languages,
                 collab_client: client,
@@ -1897,6 +1917,8 @@ impl Project {
                 lsp_store: lsp_store.clone(),
                 context_server_store,
                 active_entry: None,
+                file_renames: HashMap::default(),
+                file_rename_order: VecDeque::new(),
                 collaborators: Default::default(),
                 join_project_response_message_id: response.message_id,
                 languages,
@@ -2622,6 +2644,132 @@ impl Project {
         self.worktree_store.update(cx, |worktree_store, cx| {
             worktree_store.copy_entry(entry_id, new_project_path, cx)
         })
+    }
+
+    /// Remembers the files a workspace edit moved, against every buffer
+    /// transaction that edit produced.
+    ///
+    /// Undoing any of those transactions reverts the text and leaves the file
+    /// where the edit put it, which is the state the editor asks the user about.
+    pub fn track_file_renames(&mut self, transaction: &ProjectTransaction, cx: &App) {
+        // A move with no buffer edits has no transaction to hang off, so no undo
+        // can ever reach it. Recording it anyway would occupy a slot in the
+        // budget below for something that can never be reported.
+        if transaction.file_renames.is_empty() || transaction.buffers.is_empty() {
+            return;
+        }
+        let renames = Arc::new(transaction.file_renames.clone());
+        for (buffer, buffer_transaction) in &transaction.buffers {
+            let key = (buffer.read(cx).remote_id(), buffer_transaction.id);
+            self.file_renames.insert(key, renames.clone());
+        }
+        self.file_rename_order.push_back(renames);
+
+        // Evicting whole edits, rather than individual keys, is what stops an
+        // edit that touched a hundred files from evicting itself as it is being
+        // recorded. Which of its own keys survived would have depended on
+        // `HashMap` iteration order.
+        while self.file_rename_order.len() > MAX_TRACKED_FILE_RENAMES
+            && let Some(oldest) = self.file_rename_order.pop_front()
+        {
+            self.file_renames
+                .retain(|_, tracked| !Arc::ptr_eq(tracked, &oldest));
+        }
+    }
+
+    /// The files moved by the workspace edit that produced `transaction_id` in
+    /// `buffer_id`, if that edit moved any.
+    pub fn file_renames_for_transaction(
+        &self,
+        buffer_id: BufferId,
+        transaction_id: TransactionId,
+    ) -> Option<Arc<Vec<FileRename>>> {
+        self.file_renames.get(&(buffer_id, transaction_id)).cloned()
+    }
+
+    /// Moves the files in `renames` back to where they were before the edit.
+    ///
+    /// This is only ever called because someone asked for it, so unlike the
+    /// forward path it reports what it could not do rather than logging and
+    /// carrying on.
+    /// Moves the files in `renames` back to where they were before the edit.
+    ///
+    /// This goes through [`Self::rename_entry`], so the language servers are
+    /// told about the move and may update references to match, exactly as they
+    /// would for a rename done from the project panel. That is deliberate: the
+    /// user asked for this move, so it should behave like any other one they
+    /// ask for. It is also the only behaviour available on a remote project,
+    /// where the host runs `willRenameFiles` on its side regardless.
+    ///
+    /// Doing this automatically as part of undo would be a different matter,
+    /// since the edits come back applied with `push_to_history: false` and the
+    /// user never asked for them.
+    ///
+    /// Called only because someone clicked, so unlike the forward path it
+    /// reports what it could not do rather than logging and carrying on.
+    pub fn move_renamed_files_back(
+        &mut self,
+        renames: Arc<Vec<FileRename>>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        let fs = self.fs.clone();
+        cx.spawn(async move |project, cx| {
+            let mut failures = Vec::new();
+            // Reversed, so a chain like a -> b -> c unwinds cleanly.
+            for rename in renames.iter().rev() {
+                // The entry is followed rather than the path it sits at, so a
+                // file created at either end of the move since is left alone.
+                // A missing entry means the file was deleted, and moving it back
+                // is not something to attempt.
+                let entry_exists = project.read_with(cx, |project, cx| {
+                    project
+                        .worktree_store
+                        .read(cx)
+                        .worktree_and_entry_for_id(rename.entry_id, cx)
+                        .is_some()
+                })?;
+                if !entry_exists {
+                    failures.push(format!("{} is gone", rename.new_path.path.as_unix_str()));
+                    continue;
+                }
+
+                let renamed = project
+                    .update(cx, |project, cx| {
+                        project.rename_entry(rename.entry_id, rename.old_path.clone(), cx)
+                    })?
+                    .await;
+                if let Err(error) = renamed {
+                    failures.push(format!("{}: {error}", rename.old_path.path.as_unix_str()));
+                } else {
+                    remove_directory_left_empty(&fs, &project, rename, cx).await;
+                }
+            }
+            // The record described where the edit put these files, and it no
+            // longer does. Leaving it would offer the same move again on the
+            // next undo, when there is nothing left to move.
+            project
+                .update(cx, |project, _| {
+                    project.forget_file_renames(&renames);
+                })
+                .ok();
+
+            anyhow::ensure!(
+                failures.is_empty(),
+                "could not move {} file(s) back: {}",
+                failures.len(),
+                failures.join(", ")
+            );
+            Ok(())
+        })
+    }
+
+    /// Drops the record of `renames`, once the files are no longer where it says
+    /// they are.
+    fn forget_file_renames(&mut self, renames: &Arc<Vec<FileRename>>) {
+        self.file_renames
+            .retain(|_, tracked| !Arc::ptr_eq(tracked, renames));
+        self.file_rename_order
+            .retain(|tracked| !Arc::ptr_eq(tracked, renames));
     }
 
     /// Renames the project entry with given `entry_id`.
@@ -6975,4 +7123,61 @@ fn provide_inline_values(
     }
 
     variables
+}
+
+/// Removes the directory a moved-back file has just left, when nothing else
+/// ended up inside it. The edit created that directory to hold the file, and
+/// moving back already recreates the directory the edit emptied, so leaving
+/// this one behind would keep a trace of a move that no longer exists.
+///
+/// A directory that still holds something is left alone, and so is a worktree
+/// root. Failing to remove it is not worth reporting, since the file is back
+/// where it belongs either way.
+async fn remove_directory_left_empty(
+    fs: &Arc<dyn Fs>,
+    project: &WeakEntity<Project>,
+    rename: &FileRename,
+    cx: &mut AsyncApp,
+) {
+    let Some(parent) = rename.new_path.path.parent() else {
+        return;
+    };
+    if parent.is_empty() {
+        return;
+    }
+    let Ok(Some(abs_path)) = project.read_with(cx, |project, cx| {
+        Some(
+            project
+                .worktree_for_id(rename.new_path.worktree_id, cx)?
+                .read(cx)
+                .absolutize(parent),
+        )
+    }) else {
+        return;
+    };
+
+    match fs.read_dir(&abs_path).await {
+        Ok(mut entries) => {
+            if entries.next().await.is_some() {
+                return;
+            }
+        }
+        Err(error) => {
+            log::warn!("could not tell whether {abs_path:?} was left empty: {error}");
+            return;
+        }
+    }
+
+    if let Err(error) = fs
+        .remove_dir(
+            &abs_path,
+            RemoveOptions {
+                recursive: false,
+                ignore_if_not_exists: true,
+            },
+        )
+        .await
+    {
+        log::warn!("could not remove the emptied directory {abs_path:?}: {error}");
+    }
 }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -6279,7 +6279,7 @@ async fn test_apply_code_actions_with_commands(cx: &mut gpui::TestAppContext) {
     // Applying the code action returns a project transaction containing the edits
     // sent by the language server in its `workspaceEdit` request.
     let transaction = apply.await.unwrap();
-    assert!(transaction.0.contains_key(&buffer));
+    assert!(transaction.buffers.contains_key(&buffer));
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "Xa");
         buffer.undo(cx);
@@ -8356,7 +8356,7 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
         .next()
         .await
         .unwrap();
-    let mut transaction = response.await.unwrap().0;
+    let mut transaction = response.await.unwrap().buffers;
     assert_eq!(transaction.len(), 2);
     assert_eq!(
         transaction

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8376,6 +8376,566 @@ async fn test_rename(cx: &mut gpui::TestAppContext) {
     );
 }
 
+// A "rename symbol" whose workspace edit also moves the file records the move on
+// the transaction. Undo reverts only the text, so this record is what lets the
+// editor tell the user the file is still under its new name.
+#[gpui::test]
+async fn test_rename_records_the_file_it_moved(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let (buffer, project_transaction) =
+        perform_file_moving_rename_into(&project, path!("/dir/three.rs"), cx).await;
+
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let moved_entry_id = project.read_with(cx, |project, cx| {
+        project
+            .entry_for_path(
+                &ProjectPath {
+                    worktree_id,
+                    path: rel_path("three.rs").into(),
+                },
+                cx,
+            )
+            .unwrap()
+            .id
+    });
+
+    // The entry is named, not just the paths, so that acting on this later
+    // follows the file rather than whatever occupies the path by then.
+    assert_eq!(
+        project_transaction.file_renames,
+        vec![FileRename {
+            entry_id: moved_entry_id,
+            old_path: ProjectPath {
+                worktree_id,
+                path: rel_path("one.rs").into(),
+            },
+            new_path: ProjectPath {
+                worktree_id,
+                path: rel_path("three.rs").into(),
+            },
+        }],
+    );
+
+    // Tracked against every buffer transaction the edit produced, because undo
+    // is driven from whichever buffer the user happens to be in.
+    let transaction_id = project_transaction
+        .buffers
+        .values()
+        .next()
+        .expect("the rename should have edited a buffer")
+        .id;
+    let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+    project.update(cx, |project, cx| {
+        project.track_file_renames(&project_transaction, cx);
+    });
+    let tracked = project.read_with(cx, |project, _| {
+        project.file_renames_for_transaction(buffer_id, transaction_id)
+    });
+    assert_eq!(
+        tracked.as_deref(),
+        Some(&project_transaction.file_renames),
+        "the moves should be reachable from the transaction that carried them"
+    );
+}
+
+// Moving the files back is a separate, user-initiated step. It must not go
+// through the request half of the file operations protocol, because those edits
+// would land on top of the text the undo restored and could not be undone in
+// turn. The notification half still has to be sent.
+#[gpui::test]
+async fn test_moving_renamed_files_back(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let (_buffer, project_transaction) =
+        perform_file_moving_rename_into(&project, path!("/dir/three.rs"), cx).await;
+
+    assert!(
+        fs.load(Path::new(path!("/dir/three.rs"))).await.is_ok(),
+        "precondition: the rename moved the file"
+    );
+
+    let renames = Arc::new(project_transaction.file_renames.clone());
+    project
+        .update(cx, |project, cx| {
+            project.move_renamed_files_back(renames, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(
+        fs.load(Path::new(path!("/dir/one.rs"))).await.is_ok(),
+        "the file should be back under its original name"
+    );
+    assert!(
+        fs.load(Path::new(path!("/dir/three.rs"))).await.is_err(),
+        "the file should no longer be under the renamed path"
+    );
+}
+
+// The edit created a directory to hold the file it moved. Moving back already
+// recreates the directory the edit emptied, so the one it created goes too.
+#[gpui::test]
+async fn test_moving_back_removes_the_directory_it_emptied(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let (_buffer, project_transaction) =
+        perform_file_moving_rename_into(&project, path!("/dir/moved/one.rs"), cx).await;
+
+    assert!(
+        fs.load(Path::new(path!("/dir/moved/one.rs"))).await.is_ok(),
+        "precondition: the rename moved the file into a directory it created"
+    );
+
+    let renames = Arc::new(project_transaction.file_renames.clone());
+    project
+        .update(cx, |project, cx| {
+            project.move_renamed_files_back(renames, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(
+        fs.load(Path::new(path!("/dir/one.rs"))).await.is_ok(),
+        "the file should be back where it started"
+    );
+    assert!(
+        fs.metadata(Path::new(path!("/dir/moved")))
+            .await
+            .unwrap()
+            .is_none(),
+        "the directory the edit created should be gone with it"
+    );
+}
+
+// Only a directory left with nothing in it is removed, since anything else in
+// there was not put there by the edit.
+#[gpui::test]
+async fn test_moving_back_keeps_a_directory_that_still_holds_something(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "moved": {
+                "kept.rs": "const KEPT: usize = 3;",
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let (_buffer, project_transaction) =
+        perform_file_moving_rename_into(&project, path!("/dir/moved/one.rs"), cx).await;
+
+    let renames = Arc::new(project_transaction.file_renames.clone());
+    project
+        .update(cx, |project, cx| {
+            project.move_renamed_files_back(renames, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/moved/kept.rs")))
+            .await
+            .unwrap(),
+        "const KEPT: usize = 3;",
+        "a directory that still holds something should be left alone"
+    );
+}
+
+// Moving back follows the entry that moved, so a file created at the path it
+// vacated is left alone.
+#[gpui::test]
+async fn test_moving_renamed_files_back_ignores_a_new_file_at_that_path(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let (_buffer, project_transaction) =
+        perform_file_moving_rename_into(&project, path!("/dir/three.rs"), cx).await;
+
+    // The renamed file is moved on again outside the editor, and something
+    // unrelated takes the path it vacated.
+    fs.rename(
+        Path::new(path!("/dir/three.rs")),
+        Path::new(path!("/dir/four.rs")),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+    fs.save(
+        Path::new(path!("/dir/three.rs")),
+        &"const BRAND_NEW: usize = 7;".into(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+
+    let renames = Arc::new(project_transaction.file_renames.clone());
+    project
+        .update(cx, |project, cx| {
+            project.move_renamed_files_back(renames, cx)
+        })
+        .await
+        .ok();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/three.rs"))).await.unwrap(),
+        "const BRAND_NEW: usize = 7;",
+        "a file this edit never renamed must be left where it is"
+    );
+    // The entry that moved is the one that came back, wherever it had got to,
+    // and it brought its own contents rather than the newcomer's.
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/one.rs"))).await.unwrap(),
+        "const THREE: usize = 1;",
+        "the file that was renamed should be the one moved back"
+    );
+    assert!(
+        fs.load(Path::new(path!("/dir/four.rs"))).await.is_err(),
+        "the renamed file should have left the path it had moved on to"
+    );
+}
+
+// `Fs::rename` reports success without moving anything when `ignoreIfExists` is
+// set and the target already exists. Recording that as a move would point a
+// later "move back" at a file the rename never touched.
+#[gpui::test]
+async fn test_rename_that_did_not_move_is_not_recorded(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "three.rs": "const UNRELATED: usize = 9;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/one.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    let response = project.update(cx, |project, cx| {
+        project.perform_rename(buffer.clone(), 7, "THREE".to_string(), cx)
+    });
+    fake_server
+        .set_request_handler::<lsp::request::Rename, _, _>(|_params, _| async move {
+            Ok(Some(lsp::WorkspaceEdit {
+                changes: None,
+                document_changes: Some(DocumentChanges::Operations(vec![
+                    lsp::DocumentChangeOperation::Edit(lsp::TextDocumentEdit {
+                        text_document: lsp::OptionalVersionedTextDocumentIdentifier {
+                            uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                            version: None,
+                        },
+                        edits: vec![lsp::Edit::Plain(lsp::TextEdit::new(
+                            lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
+                            "THREE".to_string(),
+                        ))],
+                    }),
+                    lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                        old_uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                        new_uri: Uri::from_file_path(path!("/dir/three.rs")).unwrap(),
+                        options: Some(lsp::RenameFileOptions {
+                            overwrite: None,
+                            ignore_if_exists: Some(true),
+                        }),
+                        annotation_id: None,
+                    })),
+                ])),
+                change_annotations: None,
+            }))
+        })
+        .next()
+        .await
+        .unwrap();
+    let project_transaction = response.await.unwrap();
+    cx.executor().run_until_parked();
+
+    assert!(
+        project_transaction.file_renames.is_empty(),
+        "a rename that moved nothing must not be recorded as a move"
+    );
+    assert_eq!(
+        fs.load(Path::new(path!("/dir/three.rs"))).await.unwrap(),
+        "const UNRELATED: usize = 9;",
+        "the pre-existing file should be untouched"
+    );
+    assert!(
+        fs.load(Path::new(path!("/dir/one.rs"))).await.is_ok(),
+        "the file that never moved should still be where it was"
+    );
+}
+
+// An edit spanning several files is tracked against every buffer it touched, so
+// undoing in any of them can report the move. The budget for how many edits are
+// kept is per edit, not per file, or a wide rename would trim its own entries as
+// it recorded them.
+#[gpui::test]
+async fn test_a_rename_across_files_is_tracked_from_each_of_them(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "one.rs": "const ONE: usize = 1;",
+            "two.rs": "const TWO: usize = one::ONE;",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/one.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    let response = project.update(cx, |project, cx| {
+        project.perform_rename(buffer.clone(), 7, "THREE".to_string(), cx)
+    });
+    fake_server
+        .set_request_handler::<lsp::request::Rename, _, _>(|_params, _| async move {
+            Ok(Some(lsp::WorkspaceEdit {
+                changes: None,
+                document_changes: Some(DocumentChanges::Operations(vec![
+                    lsp::DocumentChangeOperation::Edit(lsp::TextDocumentEdit {
+                        text_document: lsp::OptionalVersionedTextDocumentIdentifier {
+                            uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                            version: None,
+                        },
+                        edits: vec![lsp::Edit::Plain(lsp::TextEdit::new(
+                            lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
+                            "THREE".to_string(),
+                        ))],
+                    }),
+                    lsp::DocumentChangeOperation::Edit(lsp::TextDocumentEdit {
+                        text_document: lsp::OptionalVersionedTextDocumentIdentifier {
+                            uri: Uri::from_file_path(path!("/dir/two.rs")).unwrap(),
+                            version: None,
+                        },
+                        edits: vec![lsp::Edit::Plain(lsp::TextEdit::new(
+                            lsp::Range::new(lsp::Position::new(0, 24), lsp::Position::new(0, 27)),
+                            "THREE".to_string(),
+                        ))],
+                    }),
+                    lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                        old_uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                        new_uri: Uri::from_file_path(path!("/dir/three.rs")).unwrap(),
+                        options: None,
+                        annotation_id: None,
+                    })),
+                ])),
+                change_annotations: None,
+            }))
+        })
+        .next()
+        .await
+        .unwrap();
+    let project_transaction = response.await.unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        project_transaction.buffers.len(),
+        2,
+        "precondition: the rename should have edited both files"
+    );
+
+    project.update(cx, |project, cx| {
+        project.track_file_renames(&project_transaction, cx);
+    });
+
+    let keys = project.read_with(cx, |_, cx| {
+        project_transaction
+            .buffers
+            .iter()
+            .map(|(buffer, transaction)| (buffer.read(cx).remote_id(), transaction.id))
+            .collect::<Vec<_>>()
+    });
+    for (buffer_id, transaction_id) in keys {
+        assert!(
+            project
+                .read_with(cx, |project, _| project
+                    .file_renames_for_transaction(buffer_id, transaction_id))
+                .is_some(),
+            "the move should be reachable from every buffer the edit touched"
+        );
+    }
+}
+
+/// Runs a "rename symbol" whose workspace edit both edits `one.rs` and moves it
+/// to `new_abs_path`, which is the shape this issue is about.
+async fn perform_file_moving_rename_into(
+    project: &Entity<Project>,
+    new_abs_path: &str,
+    cx: &mut gpui::TestAppContext,
+) -> (Entity<Buffer>, ProjectTransaction) {
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/one.rs"), cx)
+        })
+        .await
+        .unwrap();
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    let response = project.update(cx, |project, cx| {
+        project.perform_rename(buffer.clone(), 7, "THREE".to_string(), cx)
+    });
+    let new_abs_path = new_abs_path.to_owned();
+    fake_server
+        .set_request_handler::<lsp::request::Rename, _, _>(move |_params, _| {
+            let new_abs_path = new_abs_path.clone();
+            async move {
+                Ok(Some(lsp::WorkspaceEdit {
+                    changes: None,
+                    document_changes: Some(DocumentChanges::Operations(vec![
+                        lsp::DocumentChangeOperation::Edit(lsp::TextDocumentEdit {
+                            text_document: lsp::OptionalVersionedTextDocumentIdentifier {
+                                uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                                version: None,
+                            },
+                            edits: vec![lsp::Edit::Plain(lsp::TextEdit::new(
+                                lsp::Range::new(lsp::Position::new(0, 6), lsp::Position::new(0, 9)),
+                                "THREE".to_string(),
+                            ))],
+                        }),
+                        lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(
+                            lsp::RenameFile {
+                                old_uri: Uri::from_file_path(path!("/dir/one.rs")).unwrap(),
+                                new_uri: Uri::from_file_path(&new_abs_path).unwrap(),
+                                options: None,
+                                annotation_id: None,
+                            },
+                        )),
+                    ])),
+                    change_annotations: None,
+                }))
+            }
+        })
+        .next()
+        .await
+        .unwrap();
+    let project_transaction = response.await.unwrap();
+    cx.executor().run_until_parked();
+    (buffer, project_transaction)
+}
+
 // Regression test for https://github.com/zed-industries/zed/issues/59077:
 // a "rename symbol" whose workspace edit also renames the file used to swap the
 // two files' contents. The edited content must end up in the renamed file, and

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -186,6 +186,13 @@ message Operation {
 message ProjectTransaction {
   repeated uint64 buffer_ids = 1;
   repeated Transaction transactions = 2;
+  repeated FileRename file_renames = 3;
+}
+
+message FileRename {
+  ProjectPath old_path = 1;
+  ProjectPath new_path = 2;
+  uint64 entry_id = 3;
 }
 
 message Transaction {

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -4387,7 +4387,7 @@ async fn test_remote_apply_code_action_skips_unadvertised_command(
         })
         .await
         .expect("Unadvertised command must not be forwarded to executeCommand");
-    assert_eq!(transaction.0.len(), 0);
+    assert_eq!(transaction.buffers.len(), 0);
 }
 
 #[gpui::test]


### PR DESCRIPTION
# Objective

Fixes #5369.

Renaming a symbol can rename the file too. Undoing changes the text back in the editor, and also offers to move the file back.

## Solution

Undo reverts the text, a toast reports that the file is still renamed, and "Move back" moves it if that is what you wanted. Moving back takes the same path as a rename from the project panel, so language servers hear about it, and it removes the directory the file leaves behind if nothing else is in it.

The reason I have taken this approach is that moving the file back automatically is not as straightforward as it may seem.

The file can't simply follow the undo. One workspace edit becomes a separate undo entry in each file it touched, and those are undone one at a time, so there is no moment when the whole edit is undone and the file can safely move. Undo one file while another is still redone and the same code disagrees about where its file lives.

I have left two gaps:
- A rename across worktrees isn't recorded, because the entry id doesn't survive the move.
- Redo has no equivalent notification.

## Testing

I checked each of the tests fails against a deliberately broken implementation.

Verified by hand with gopls, where renaming a Go package both moves the file and edits the files that import it. That actually needs #63481, or the edit fails before you reach the undo.

Worth knowing that rust-analyzer sends only a rename and no text edits for a Rust module rename, so there is nothing to undo and no toast. That is the other half of #5369 and it is upstream.

Tested on macOS.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/33c5e4d0-b6ed-4bd3-bf39-e616d8c6a755

---

Release Notes:

- Added a notification when undoing a rename leaves the file under its new name, with an action to move it back.