### PR TITLE
Fix repo docs

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -128,7 +128,8 @@ Use this when Zed is using a lot of CPU. It is not useful for hangs.
   On Ubuntu (derivatives) run `sudo apt install linux-tools`.
 
 - Perf record:
-  Run `sudo perf record -p <pid you just found>`, wait a few seconds to gather data, then press Ctrl+C. You should now have a `perf.data` file.
+  Run `sudo perf record -g --call-graph dwarf -p <pid you just found>`, wait a few seconds to gather data, then press Ctrl+C. You should now have a `perf.data` file.
+  The `--call-graph dwarf` part records the callers of every sampled function: without it, the profile shows isolated hot symbols with no way to tell who invoked them, which is rarely enough to act on.
 
 - Make the output file user owned:
   run `sudo chown $USER:$USER perf.data`

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -61,12 +61,39 @@ if (includesIssueUrl) {
   );
 }
 
-const readmeModified = danger.git.modified_files.includes("README.md") || danger.git.created_files.includes("README.md");
+const SELF_REVIEW_MARKER = "Remove this line to confirm you've reviewed this PR before submitting.";
+
+const readmeModified =
+  danger.git.modified_files.includes("README.md") || danger.git.created_files.includes("README.md");
 if (readmeModified) {
   schedule(async () => {
     const readmeDiff = await danger.git.diffForFile("README.md");
-    if (readmeDiff && readmeDiff.added.includes("Remove this line to confirm you've reviewed this PR before submitting.")) {
-      fail("Please self-review your PR before submitting — README.md contains a line that asks to be removed which you should have spotted.");
+    if (readmeDiff && readmeDiff.added.includes(SELF_REVIEW_MARKER)) {
+      fail(
+        "Please self-review your PR before submitting — README.md contains a line that asks to be removed which you should have spotted.",
+      );
+    }
+  });
+}
+
+if (danger.git.deleted_files.includes(".rules")) {
+  fail(
+    [
+      "This PR deletes `.rules`, which contains the mandatory agent self-review rule (the `> [!IMPORTANT]` README marker rule).",
+      "If the deletion is intentional, move that rule to another rules file in the same PR.",
+    ].join("\n"),
+  );
+} else if (danger.git.modified_files.includes(".rules")) {
+  schedule(async () => {
+    const rulesDiff = await danger.git.diffForFile(".rules");
+    if (rulesDiff && rulesDiff.removed.includes(SELF_REVIEW_MARKER) && !rulesDiff.added.includes(SELF_REVIEW_MARKER)) {
+      fail(
+        [
+          "This PR removes the mandatory agent self-review rule from `.rules` (the `> [!IMPORTANT]` README marker rule).",
+          "It has been dropped by accident before and had to be restored in https://github.com/zed-industries/zed/pull/63384.",
+          "If changing it is intentional, keep an equivalent rule containing the same marker text in `.rules`.",
+        ].join("\n"),
+      );
     }
   });
 }


### PR DESCRIPTION
* ensures The Rule cannot be accidentall removed
* fixes the perf command example to capture call graphs, to avoid round-trips like https://github.com/zed-industries/zed/issues/59689#issuecomment-5453623044 (samples without call graphs are not quite usable for investigating bugs like these)


Release Notes:

- N/A
