### PR TITLE
gpui_windows: Prevent paint and input starvation under sustained messages

### DIFF
--- a/crates/gpui/examples/README.md
+++ b/crates/gpui/examples/README.md
@@ -69,4 +69,5 @@ best starting point for new applications:
 - `list_example` demonstrates bottom-aligned list state and scrollbar behavior.
 - `ownership_post` supports the ownership and data-flow documentation.
 - `paths_bench` is a path rendering benchmark.
+- `present_starvation` is a focused Windows present-starvation reproduction.
 - `tree` renders a deep tree of nested elements.

--- a/crates/gpui/examples/present_starvation.rs
+++ b/crates/gpui/examples/present_starvation.rs
@@ -1,0 +1,236 @@
+#[cfg(target_os = "windows")]
+mod windows_repro {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use gpui::*;
+    use gpui_platform::application;
+    use raw_window_handle::RawWindowHandle;
+
+    const WM_NULL: u32 = 0x0000;
+    const WM_KEYDOWN: u32 = 0x0100;
+    const WM_KEYUP: u32 = 0x0101;
+    const VK_A: usize = 0x41;
+    const A_SCAN_CODE: u32 = 0x1e;
+
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        fn PostMessageW(window: isize, message: u32, wparam: usize, lparam: isize) -> i32;
+    }
+
+    fn post_message(window: isize, message: u32, wparam: usize, lparam: u32) -> bool {
+        // SAFETY: `window` comes from GPUI's live Win32 platform window, and the message
+        // parameters contain integers only. Failure is reported by the return value.
+        (unsafe { PostMessageW(window, message, wparam, lparam as i32 as isize) }) != 0
+    }
+
+    fn post_key_message(window: isize, message: u32, lparam: u32, cancelled: &AtomicBool) -> bool {
+        let deadline = Instant::now() + Duration::from_millis(250);
+        while !cancelled.load(Ordering::Acquire) && Instant::now() < deadline {
+            if post_message(window, message, VK_A, lparam) {
+                return true;
+            }
+            thread::yield_now();
+        }
+        false
+    }
+
+    fn sleep_while_running(duration: Duration, cancelled: &AtomicBool) -> bool {
+        let deadline = Instant::now() + duration;
+        while !cancelled.load(Ordering::Acquire) {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return true;
+            }
+            thread::sleep(remaining.min(Duration::from_millis(10)));
+        }
+        false
+    }
+
+    struct StressController {
+        cancelled: Arc<AtomicBool>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl Drop for StressController {
+        fn drop(&mut self) {
+            self.cancelled.store(true, Ordering::Release);
+            if let Some(thread) = self.thread.take()
+                && thread.join().is_err()
+            {
+                eprintln!("stress thread panicked");
+            }
+        }
+    }
+
+    // Posted WM_KEYDOWN reaches GPUI's keyboard handler while WM_NULL keeps the
+    // posted-message FIFO continuously busy. Input-class fairness is tested separately.
+    fn start_stress(window: isize) -> StressController {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let thread_cancelled = cancelled.clone();
+        let thread = thread::spawn(move || {
+            if !sleep_while_running(Duration::from_secs(1), &thread_cancelled) {
+                return;
+            }
+
+            let flood_running = Arc::new(AtomicBool::new(true));
+            let flood_running_thread = flood_running.clone();
+            let flood_cancelled = thread_cancelled.clone();
+            let flood = thread::spawn(move || {
+                while !flood_cancelled.load(Ordering::Acquire)
+                    && flood_running_thread.load(Ordering::Acquire)
+                {
+                    for _ in 0..16 {
+                        if flood_cancelled.load(Ordering::Acquire) {
+                            break;
+                        }
+                        if !post_message(window, WM_NULL, 0, 0) {
+                            thread::yield_now();
+                            break;
+                        }
+                    }
+                    thread::yield_now();
+                }
+            });
+
+            let started = Instant::now();
+            let mut key_count = 0;
+            while !thread_cancelled.load(Ordering::Acquire)
+                && started.elapsed() < Duration::from_secs(8)
+            {
+                let previous_state = if key_count == 0 { 0 } else { 1 << 30 };
+                if !post_key_message(
+                    window,
+                    WM_KEYDOWN,
+                    1 | (A_SCAN_CODE << 16) | previous_state,
+                    &thread_cancelled,
+                ) {
+                    break;
+                }
+                key_count += 1;
+                if !sleep_while_running(Duration::from_millis(17), &thread_cancelled) {
+                    break;
+                }
+            }
+
+            flood_running.store(false, Ordering::Release);
+            if flood.join().is_err() {
+                eprintln!("message-flood thread panicked");
+            }
+
+            if !thread_cancelled.load(Ordering::Acquire) {
+                post_key_message(
+                    window,
+                    WM_KEYUP,
+                    1 | (A_SCAN_CODE << 16) | (1 << 30) | (1 << 31),
+                    &thread_cancelled,
+                );
+            }
+        });
+
+        StressController {
+            cancelled,
+            thread: Some(thread),
+        }
+    }
+
+    struct PresentStarvation {
+        focus_handle: FocusHandle,
+        key_count: usize,
+        _stress_controller: Option<StressController>,
+    }
+
+    impl PresentStarvation {
+        fn new(
+            window: &mut Window,
+            cx: &mut Context<Self>,
+            stress_controller: Option<StressController>,
+        ) -> Self {
+            let focus_handle = cx.focus_handle();
+            window.focus(&focus_handle, cx);
+            Self {
+                focus_handle,
+                key_count: 0,
+                _stress_controller: stress_controller,
+            }
+        }
+    }
+
+    impl Render for PresentStarvation {
+        fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .track_focus(&self.focus_handle)
+                .on_key_down(cx.listener(|this, _, _, cx| {
+                    this.key_count += 1;
+                    cx.notify();
+                }))
+                .size_full()
+                .flex()
+                .flex_col()
+                .justify_center()
+                .items_center()
+                .gap_2()
+                .bg(if self.key_count.is_multiple_of(2) {
+                    rgb(0x173b57)
+                } else {
+                    rgb(0x8a2d2d)
+                })
+                .text_color(rgb(0xffffff))
+                .child("Windows present-starvation reproduction")
+                .child(format!("Dispatched keys: {}", self.key_count))
+                .child("The baseline freezes during the eight-second stress, then catches up.")
+        }
+    }
+
+    pub fn run() {
+        application().run(|cx: &mut App| {
+            cx.on_window_closed(|cx, _window_id| {
+                if cx.windows().is_empty() {
+                    cx.quit();
+                }
+            })
+            .detach();
+
+            let result = cx.open_window(WindowOptions::default(), |window, cx| {
+                let stress_controller = if let Ok(handle) =
+                    raw_window_handle::HasWindowHandle::window_handle(window)
+                    && let RawWindowHandle::Win32(handle) = handle.as_raw()
+                {
+                    let native_window = handle.hwnd.get();
+                    let stress_controller = start_stress(native_window);
+                    let cancelled = stress_controller.cancelled.clone();
+                    window.on_window_should_close(cx, move |_, _| {
+                        cancelled.store(true, Ordering::Release);
+                        true
+                    });
+                    Some(stress_controller)
+                } else {
+                    None
+                };
+                cx.new(|cx| PresentStarvation::new(window, cx, stress_controller))
+            });
+            if let Err(error) = result {
+                eprintln!("failed to open reproduction window: {error:#}");
+                cx.quit();
+                return;
+            }
+            cx.activate(true);
+        });
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    windows_repro::run();
+}
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("present_starvation is a Windows-only reproduction");
+}

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -8,6 +8,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context as _, Result, anyhow};
@@ -445,18 +446,67 @@ impl Platform for WindowsPlatform {
     }
 
     fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {
+        // A 1 ms interval stays below a 240 Hz frame period while capping empty
+        // supplemental probes at 1,000 per second.
+        const FAIRNESS_PROBE_INTERVAL: Duration = Duration::from_millis(1);
+        // Leave headroom for 1 kHz input even when the outer loop cannot run one
+        // probe per millisecond, but keep the supplemental batch finite.
+        const MAX_INPUTS_PER_PROBE: usize = 4;
+
         on_finish_launching();
         if !self.headless {
             self.begin_vsync_thread();
         }
 
         let mut msg = MSG::default();
+        let mut next_fairness_probe = Instant::now() + FAIRNESS_PROBE_INTERVAL;
         unsafe {
-            while GetMessageW(&mut msg, None, 0, 0).as_bool() {
+            'message_loop: while GetMessageW(&mut msg, None, 0, 0).as_bool() {
                 if translate_accelerator(&msg).is_none() {
                     _ = TranslateMessage(&msg);
                     DispatchMessageW(&msg);
                 }
+
+                // Windows selects posted work before hardware input and synthesized
+                // WM_PAINT. Periodically service one of each before continuous posted
+                // traffic can starve either, while bounding the supplemental work.
+                let now = Instant::now();
+                if msg.message == WM_PAINT {
+                    next_fairness_probe = now + FAIRNESS_PROBE_INTERVAL;
+                    continue;
+                }
+                if now < next_fairness_probe {
+                    continue;
+                }
+
+                let mut supplemental_msg = MSG::default();
+                if PeekMessageW(&mut supplemental_msg, None, 0, 0, PM_REMOVE | PM_QS_PAINT)
+                    .as_bool()
+                {
+                    if supplemental_msg.message == WM_QUIT {
+                        break 'message_loop;
+                    }
+                    if translate_accelerator(&supplemental_msg).is_none() {
+                        _ = TranslateMessage(&supplemental_msg);
+                        DispatchMessageW(&supplemental_msg);
+                    }
+                }
+
+                for _ in 0..MAX_INPUTS_PER_PROBE {
+                    if !PeekMessageW(&mut supplemental_msg, None, 0, 0, PM_REMOVE | PM_QS_INPUT)
+                        .as_bool()
+                    {
+                        break;
+                    }
+                    if supplemental_msg.message == WM_QUIT {
+                        break 'message_loop;
+                    }
+                    if translate_accelerator(&supplemental_msg).is_none() {
+                        _ = TranslateMessage(&supplemental_msg);
+                        DispatchMessageW(&supplemental_msg);
+                    }
+                }
+                next_fairness_probe = Instant::now() + FAIRNESS_PROBE_INTERVAL;
             }
         }
 


### PR DESCRIPTION
## Objective

Fixes #61469.

On Windows, GPUI can keep processing queued work while a visible window stops presenting. The vsync thread invalidates the window, but Windows synthesizes `WM_PAINT` only after higher-priority sent, posted, and input work has drained. A continuously busy posted queue can therefore starve both pending paint and hardware input.

The original report uses held-key input. #61632 demonstrates the same synthesized-paint mechanism with high-polling mouse input. In the controlled matrix below, isolated 60 Hz key and 1 kHz mouse input are healthy on the frozen base. Saturated posted traffic is the deterministic trigger: it starves paint, and when combined with 1 kHz mouse motion it also starves the input queue. A keydown-only draw request fixes one symptom but leaves the queue-level failure.

## Solution

After dispatching a normally retrieved message, the outer Windows message loop runs a bounded fairness probe at most once per millisecond:

1. Dispatch at most one pending paint-class message.
2. Dispatch at most four pending input-class messages.
3. Return to the normal blocking `GetMessageW` path.

The one-millisecond interval is shorter than a 240 Hz frame period and caps an idle queue at 1,000 supplemental probe batches per second. Four input messages per batch gives a 1 kHz device headroom when the outer loop does not regain control exactly once per millisecond. The queued messages selected by each probe stay finite, so the fairness policy does not add an unbounded queue drain. As documented by Win32, `PeekMessageW` can dispatch pending nonqueued sent messages before returning; the quota is not a hard bound on callbacks or CPU work. This was measured at 1 kHz; it is not a claim about higher input rates, and the policy has an idealized selection ceiling of roughly 4,000 input messages per second under simultaneous posted saturation.

Both filtered paths retain the normal accelerator, translation, dispatch, and `WM_QUIT` handling. The change does not call `UpdateWindow`, draw synchronously from an input/vsync thread, post another per-vsync signal into the busy FIFO, or change GPUI's invalidation and request-frame path.

This follows established message-pump practice rather than introducing a new Win32 primitive. Microsoft documents both the normal queue ordering and class-filtered retrieval with `PM_QS_PAINT` and `PM_QS_INPUT`. GPUI's existing `run_foreground_task` pump already selects those two classes. SDL's current Windows pump independently uses a one-millisecond deadline plus a finite new-message allowance to prevent an endless drain, while Chromium interleaves bounded native-message and application-work turns to prevent posted work from starving paint and timers. The exact one-paint/four-input weighting here is the GPUI-specific policy established by the matrix below.

Sources: [Win32 `PeekMessageW`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagew), [SDL Windows message pump](https://github.com/libsdl-org/SDL/blob/main/src/video/windows/SDL_windowsevents.c#L2613-L2666), and [Chromium's Windows message pump](https://chromium.googlesource.com/chromium/src/+/HEAD/base/message_loop/message_pump_win.cc#228).

## Testing

The source-only [deterministic Windows matrix harness](https://github.com/railapex/zed-61469-present-starvation-harness) contains the exact six-phase fixture, isolated build stager, randomized runner, integrity gates, methodology, and reference aggregate. It excludes binaries, symbols, ETLs, raw logs, machine inventory, and capture-machine privacy policy.

The external Windows fixture keeps animation demand constant and records GPUI platform-draw attempts after message delivery. Each row ran three times in a rotated order against the same frozen base and byte-identical profiler fixture. All 12 runs passed their provenance, foreground, input-restoration, exit, and process-cleanup integrity checks.

Median rates for the deterministic saturated-posted phases:

| Implementation | Key + posted: present / key | Mouse + posted: present / mouse | Posted only: present |
|---|---:|---:|---:|
| Frozen main | 0.502 / 59.975 Hz | 1.000 / 269.426 Hz | 0.750 Hz |
| Rebased #61632 | 11.795 / 59.980 Hz | 8.748 / 0 Hz | 12.247 Hz |
| Paint-only fairness | 144.065 / 59.985 Hz | 143.941 / 0 Hz | 143.963 Hz |
| This change | 143.807 / 59.982 Hz | 143.956 / 998.343 Hz | 143.961 Hz |

The paint-only row is intentional: it shows that selecting paint alone can restore frame cadence while the same posted queue still blocks hardware input. This change was the only row to pass all 22 predeclared presentation and input gates in all three runs.

For this change, the worst mouse-plus-posted maximum gap was 9.196 ms and the worst posted-only maximum gap was 11.354 ms. One key-plus-posted run recorded a 76.538 ms maximum gap; the corresponding control phases also had maxima up to 77.115 ms, so the data does not support claiming that every isolated gap stayed below one frame period. The rate, mean, p99, input, and integrity gates passed.

The profiler event is an internal GPUI platform-draw-attempt oracle. It does not prove that `IDXGISwapChain::Present` ran or succeeded. Matched ETW/PresentMon captures are the external DXGI check.

A single clean-boot A/C/D/I run produced four complete, zero-loss scheduler ETLs plus matching PresentMon DXGI data. Rates are presents/input dispatch per second; parentheses show the maximum present gap:

| Implementation | Control present | Key + posted: present / key | Mouse + posted: present / mouse | Posted only: present |
|---|---:|---:|---:|---:|
| Frozen main | 143.951 | 0.502 / 59.980 (3969.732 ms) | 7.497 / 985.343 (521.739 ms) | 28.743 (711.396 ms) |
| Key-handler draw request | 142.972 | 60.720 / 59.967 (17.506 ms) | 0.750 / 154.457 (3983.250 ms) | 0.500 (3917.660 ms) |
| Rebased #61632 | 143.975 | 8.282 / 59.978 (167.848 ms) | 10.997 / 3.749 (149.073 ms) | 9.248 (159.190 ms) |
| This change | 144.449 | 144.054 / 59.981 (8.035 ms) | 143.957 / 999.948 (8.131 ms) | 144.208 (7.822 ms) |

Frozen main, the narrow key fix, and rebased #61632 each failed the predeclared behavior gates. This exact PR source passed every integrity, presentation, and input gate. The ETLs and matching symbols remain private and can be supplied to maintainers after manual privacy review.

Supplemental checks:

- a saturated-queue quit probe exited normally in 113.759 ms with 9,996 queued messages; no forced kill was needed;
- an exact-policy two-window probe kept both windows at their requested cadence, closed one window in 3.182 ms under active posted flood, kept presenting the survivor, and exited normally;
- an integration worktree combining this policy with Windows device-loss recovery changes passed all 12 injected recovery scenarios, including two windows, final-attempt recovery, exhausted retries without abort, a new device generation, and the non-DirectComposition path; the evidence records source, platform blob, executable hashes, and scenario results.

Validation at the PR head:

- `cargo fmt --all -- --check`
- `cargo check --locked -p gpui --example present_starvation`
- `cargo test --locked -p gpui_windows --features test-support` — 9 passed
- `script/clippy -p gpui_windows -p gpui` using the repository's canonical release/all-target/all-feature configuration

Bare `cargo test -p gpui_windows` has an existing feature mismatch on unchanged main: crate-local `cfg(test)` exposes `render_to_image`, while the dependency build of `gpui` hides the corresponding trait method unless `test-support` is enabled. This PR does not change that test configuration.

## Limits

- Nested or modal loops owned by Windows, COM, or third-party code do not pass through this outer loop and remain outside this change.
- `run_foreground_task` has its own existing local pump. It already selects one paint, drains input, and posts a task-dispatched message to return control; changing that separate reentrant path is not needed for #61469 and would enlarge the regression surface.
- Translating a selected `WM_KEYDOWN` can post `WM_CHAR` behind an existing posted backlog. This change does not promise keydown/character adjacency during an artificial saturated posted flood.
- The included example is a focused manual paint-starvation reproduction. It posts `WM_KEYDOWN` plus `WM_NULL`; hardware-input fairness is verified by the external `SendInput` matrix rather than asserted by the example.

### Related work

- #61632 correctly identifies synthesized-`WM_PAINT` starvation. Its custom per-vsync posted message can make progress during pure input load because posted work outranks input, then calls `UpdateWindow`. Under a saturated posted FIFO, that signal queues behind the traffic causing starvation. The table reports both approaches under the same workloads; it is not a general performance comparison outside this queue shape.
- #63182 makes Windows frame generation demand-driven. That is compatible, but it retains invalidation-based paint delivery and does not give synthesized `WM_PAINT` or hardware input progress through a continuously busy posted queue, so it is not folded into this delivery fix.
- #60295 is already in the frozen base. It hardens nested Windows draws against reentrancy. This change keeps those guards and does not add another draw path.
- #50883 reported similar held-key terminal symptoms but did not establish this queue mechanism. #61469 and the matched fixture are the causal evidence used here.
- #32588 concerned unnecessary presentation of unchanged Windows contents. This change does not schedule frames or make input trigger unconditional drawing; it services paint Windows already considers pending.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Windows frames and input freezing while the message queue remains busy.