### PR TITLE
sidebar: Add title renaming for Terminal Threads

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -40,8 +40,8 @@ use crate::ManageProfiles;
 use crate::agent_connection_store::AgentConnectionStore;
 use crate::completion_provider::{AgentContextSelection, AgentContextSource};
 use crate::terminal_thread_metadata_store::{
-    TerminalThreadCustomTitleChanged, TerminalThreadMetadata, TerminalThreadMetadataStore,
-    compose_terminal_thread_title, terminal_title_without_prefix,
+    TerminalThreadMetadata, TerminalThreadMetadataStore, compose_terminal_thread_title,
+    normalize_terminal_custom_title, terminal_title_without_prefix,
 };
 use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore, ThreadMetadataStoreEvent};
 use crate::{
@@ -1185,7 +1185,6 @@ pub struct AgentPanel {
     _draft_editor_observation: Option<Subscription>,
     _active_draft_reclaim_observation: Option<Subscription>,
     _thread_metadata_store_subscription: Subscription,
-    _terminal_thread_metadata_store_subscription: Option<Subscription>,
     last_context_source: Option<AgentContextSource>,
 
     is_active: bool,
@@ -1561,27 +1560,6 @@ impl AgentPanel {
             },
         );
 
-        let _terminal_thread_metadata_store_subscription =
-            TerminalThreadMetadataStore::try_global(cx).map(|store| {
-                cx.subscribe(&store, |this, _store, event, cx| {
-                    let TerminalThreadCustomTitleChanged {
-                        terminal_id,
-                        custom_title,
-                    } = event;
-                    let Some(terminal) = this.terminals.get(terminal_id) else {
-                        return;
-                    };
-                    let terminal_view = terminal.view.clone();
-                    let custom_title = custom_title.clone();
-                    cx.defer(move |cx| {
-                        terminal_view.update(cx, |terminal_view, cx| {
-                            terminal_view
-                                .set_custom_title(custom_title.map(|title| title.to_string()), cx);
-                        });
-                    });
-                })
-            });
-
         cx.on_release(|this, cx| {
             this.dismiss_all_terminal_notifications(cx);
         })
@@ -1621,7 +1599,6 @@ impl AgentPanel {
             _draft_editor_observation: None,
             _active_draft_reclaim_observation: None,
             _thread_metadata_store_subscription,
-            _terminal_thread_metadata_store_subscription,
             last_context_source: None,
             is_active: false,
         };
@@ -3394,6 +3371,26 @@ impl AgentPanel {
 
     pub fn has_terminal(&self, terminal_id: TerminalId) -> bool {
         self.terminals.contains_key(&terminal_id)
+    }
+
+    pub fn rename_terminal(
+        &mut self,
+        terminal_id: TerminalId,
+        title: SharedString,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(terminal) = self.terminals.get(&terminal_id) else {
+            return false;
+        };
+        let terminal_title = terminal.terminal_title(cx);
+        let custom_title = normalize_terminal_custom_title(terminal_title.as_ref(), title);
+        let terminal_view = terminal.view.clone();
+        cx.defer(move |cx| {
+            terminal_view.update(cx, |terminal_view, cx| {
+                terminal_view.set_custom_title(custom_title.map(|title| title.to_string()), cx);
+            });
+        });
+        true
     }
 
     pub fn terminals(&self, cx: &App) -> Vec<AgentPanelTerminalInfo> {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -40,8 +40,8 @@ use crate::ManageProfiles;
 use crate::agent_connection_store::AgentConnectionStore;
 use crate::completion_provider::{AgentContextSelection, AgentContextSource};
 use crate::terminal_thread_metadata_store::{
-    TerminalThreadMetadata, TerminalThreadMetadataStore, compose_terminal_thread_title,
-    terminal_title_without_prefix,
+    TerminalThreadCustomTitleChanged, TerminalThreadMetadata, TerminalThreadMetadataStore,
+    compose_terminal_thread_title, terminal_title_without_prefix,
 };
 use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore, ThreadMetadataStoreEvent};
 use crate::{
@@ -1185,6 +1185,7 @@ pub struct AgentPanel {
     _draft_editor_observation: Option<Subscription>,
     _active_draft_reclaim_observation: Option<Subscription>,
     _thread_metadata_store_subscription: Subscription,
+    _terminal_thread_metadata_store_subscription: Option<Subscription>,
     last_context_source: Option<AgentContextSource>,
 
     is_active: bool,
@@ -1560,6 +1561,27 @@ impl AgentPanel {
             },
         );
 
+        let _terminal_thread_metadata_store_subscription =
+            TerminalThreadMetadataStore::try_global(cx).map(|store| {
+                cx.subscribe(&store, |this, _store, event, cx| {
+                    let TerminalThreadCustomTitleChanged {
+                        terminal_id,
+                        custom_title,
+                    } = event;
+                    let Some(terminal) = this.terminals.get(terminal_id) else {
+                        return;
+                    };
+                    let terminal_view = terminal.view.clone();
+                    let custom_title = custom_title.clone();
+                    cx.defer(move |cx| {
+                        terminal_view.update(cx, |terminal_view, cx| {
+                            terminal_view
+                                .set_custom_title(custom_title.map(|title| title.to_string()), cx);
+                        });
+                    });
+                })
+            });
+
         cx.on_release(|this, cx| {
             this.dismiss_all_terminal_notifications(cx);
         })
@@ -1599,6 +1621,7 @@ impl AgentPanel {
             _draft_editor_observation: None,
             _active_draft_reclaim_observation: None,
             _thread_metadata_store_subscription,
+            _terminal_thread_metadata_store_subscription,
             last_context_source: None,
             is_active: false,
         };

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2612,17 +2612,15 @@ impl AgentPanel {
                 if initial_title.as_deref() == Some(new_title.as_str()) {
                     return;
                 }
-                let label = if new_title.trim().is_empty()
-                    || new_title == terminal_title_without_prefix(terminal_title.as_ref())
-                {
-                    None
-                } else {
-                    Some(new_title)
-                };
+                let custom_title = normalize_terminal_custom_title(
+                    terminal_title.as_ref(),
+                    SharedString::from(new_title),
+                );
 
                 cx.defer(move |cx| {
                     terminal_view.update(cx, |terminal_view, cx| {
-                        terminal_view.set_custom_title(label, cx);
+                        terminal_view
+                            .set_custom_title(custom_title.map(|title| title.to_string()), cx);
                     });
                 });
             }

--- a/crates/agent_ui/src/terminal_thread_metadata_store.rs
+++ b/crates/agent_ui/src/terminal_thread_metadata_store.rs
@@ -11,7 +11,7 @@ use db::{
     sqlez_macros::sql,
 };
 use futures::{FutureExt, future::Shared};
-use gpui::{AppContext as _, Entity, EventEmitter, Global, Task};
+use gpui::{AppContext as _, Entity, Global, Task};
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
 use ui::{App, Context, SharedString};
 use util::ResultExt as _;
@@ -78,12 +78,6 @@ impl TerminalThreadMetadata {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct TerminalThreadCustomTitleChanged {
-    pub terminal_id: TerminalId,
-    pub custom_title: Option<SharedString>,
-}
-
 pub(crate) fn compose_terminal_thread_title(
     terminal_title: &str,
     custom_title: Option<&str>,
@@ -103,6 +97,19 @@ pub(crate) fn terminal_title_without_prefix(title: &str) -> &str {
     terminal_title_prefix(title)
         .map(|prefix| &title[prefix.len()..])
         .unwrap_or(title)
+}
+
+pub(crate) fn normalize_terminal_custom_title(
+    terminal_title: &str,
+    edited_title: SharedString,
+) -> Option<SharedString> {
+    if edited_title.trim().is_empty()
+        || edited_title == terminal_title_without_prefix(terminal_title)
+    {
+        None
+    } else {
+        Some(edited_title)
+    }
 }
 
 pub fn terminal_title_prefix(title: &str) -> Option<&str> {
@@ -285,23 +292,13 @@ impl TerminalThreadMetadataStore {
         let Some(mut metadata) = self.entry(terminal_id).cloned() else {
             return;
         };
-        let custom_title = if title.trim().is_empty()
-            || title == terminal_title_without_prefix(metadata.title.as_ref())
-        {
-            None
-        } else {
-            Some(title)
-        };
+        let custom_title = normalize_terminal_custom_title(metadata.title.as_ref(), title);
         if metadata.custom_title == custom_title {
             return;
         }
 
-        metadata.custom_title = custom_title.clone();
+        metadata.custom_title = custom_title;
         self.save_internal(metadata);
-        cx.emit(TerminalThreadCustomTitleChanged {
-            terminal_id,
-            custom_title,
-        });
         cx.notify();
     }
 
@@ -480,8 +477,6 @@ impl TerminalThreadMetadataStore {
         );
     }
 }
-
-impl EventEmitter<TerminalThreadCustomTitleChanged> for TerminalThreadMetadataStore {}
 
 struct TerminalThreadMetadataDb(ThreadSafeConnection);
 

--- a/crates/agent_ui/src/terminal_thread_metadata_store.rs
+++ b/crates/agent_ui/src/terminal_thread_metadata_store.rs
@@ -11,7 +11,7 @@ use db::{
     sqlez_macros::sql,
 };
 use futures::{FutureExt, future::Shared};
-use gpui::{AppContext as _, Entity, Global, Task};
+use gpui::{AppContext as _, Entity, EventEmitter, Global, Task};
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
 use ui::{App, Context, SharedString};
 use util::ResultExt as _;
@@ -70,6 +70,18 @@ impl TerminalThreadMetadata {
             self.custom_title.as_ref().map(|title| title.as_ref()),
         )
     }
+
+    pub fn editable_title(&self) -> SharedString {
+        self.custom_title.clone().unwrap_or_else(|| {
+            SharedString::from(terminal_title_without_prefix(self.title.as_ref()).to_string())
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TerminalThreadCustomTitleChanged {
+    pub terminal_id: TerminalId,
+    pub custom_title: Option<SharedString>,
 }
 
 pub(crate) fn compose_terminal_thread_title(
@@ -264,6 +276,35 @@ impl TerminalThreadMetadataStore {
         cx.notify();
     }
 
+    pub fn rename_terminal(
+        &mut self,
+        terminal_id: TerminalId,
+        title: SharedString,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(mut metadata) = self.entry(terminal_id).cloned() else {
+            return;
+        };
+        let custom_title = if title.trim().is_empty()
+            || title == terminal_title_without_prefix(metadata.title.as_ref())
+        {
+            None
+        } else {
+            Some(title)
+        };
+        if metadata.custom_title == custom_title {
+            return;
+        }
+
+        metadata.custom_title = custom_title.clone();
+        self.save_internal(metadata);
+        cx.emit(TerminalThreadCustomTitleChanged {
+            terminal_id,
+            custom_title,
+        });
+        cx.notify();
+    }
+
     pub fn change_worktree_paths(
         &mut self,
         current_folder_paths: &PathList,
@@ -439,6 +480,8 @@ impl TerminalThreadMetadataStore {
         );
     }
 }
+
+impl EventEmitter<TerminalThreadCustomTitleChanged> for TerminalThreadMetadataStore {}
 
 struct TerminalThreadMetadataDb(ThreadSafeConnection);
 
@@ -657,6 +700,47 @@ mod tests {
 
         metadata.title = "Thinking".into();
         assert_eq!(metadata.display_title().as_ref(), "Fix bug");
+    }
+
+    #[gpui::test]
+    async fn test_rename_terminal_updates_stored_custom_title(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let metadata = metadata(
+            "⠋ Dev Server",
+            WorktreePaths::from_folder_paths(&PathList::default()),
+        );
+        let terminal_id = metadata.terminal_id;
+
+        cx.update(|cx| {
+            TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(metadata, cx);
+                store.rename_terminal(terminal_id, "Renamed Terminal".into(), cx);
+            });
+        });
+
+        cx.update(|cx| {
+            let store = TerminalThreadMetadataStore::global(cx);
+            let metadata = store
+                .read(cx)
+                .entry(terminal_id)
+                .expect("renamed terminal metadata should exist");
+            assert_eq!(metadata.custom_title.as_deref(), Some("Renamed Terminal"));
+            assert_eq!(metadata.display_title().as_ref(), "⠋ Renamed Terminal");
+        });
+
+        cx.update(|cx| {
+            TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.rename_terminal(terminal_id, "Dev Server".into(), cx);
+            });
+            let store = TerminalThreadMetadataStore::global(cx);
+            let metadata = store
+                .read(cx)
+                .entry(terminal_id)
+                .expect("renamed terminal metadata should exist");
+            assert_eq!(metadata.custom_title, None);
+            assert_eq!(metadata.display_title().as_ref(), "⠋ Dev Server");
+        });
     }
 
     #[gpui::test]

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3429,9 +3429,7 @@ impl Sidebar {
                         self.apply_thread_rename(thread_id, new_title, window, cx);
                     }
                     RenameTarget::Terminal(terminal_id) => {
-                        TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
-                            store.rename_terminal(terminal_id, new_title, cx);
-                        });
+                        self.apply_terminal_rename(terminal_id, new_title, cx);
                     }
                 }
             }
@@ -3471,6 +3469,37 @@ impl Sidebar {
         if !found {
             ThreadMetadataStore::global(cx).update(cx, |store, cx| {
                 store.set_title_override(thread_id, title, cx);
+            });
+        }
+    }
+
+    fn apply_terminal_rename(
+        &mut self,
+        terminal_id: TerminalId,
+        title: SharedString,
+        cx: &mut Context<Self>,
+    ) {
+        let workspace = self.contents.entries.iter().find_map(|entry| {
+            let ListEntry::Terminal(terminal) = entry else {
+                return None;
+            };
+            (terminal.metadata.terminal_id == terminal_id).then(|| terminal.workspace.clone())
+        });
+        let renamed_live_terminal = match workspace {
+            Some(ThreadEntryWorkspace::Open(workspace)) => workspace
+                .read(cx)
+                .panel::<AgentPanel>(cx)
+                .is_some_and(|agent_panel| {
+                    agent_panel.update(cx, |agent_panel, cx| {
+                        agent_panel.rename_terminal(terminal_id, title.clone(), cx)
+                    })
+                }),
+            Some(ThreadEntryWorkspace::Closed { .. }) | None => false,
+        };
+
+        if !renamed_live_terminal {
+            TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.rename_terminal(terminal_id, title, cx);
             });
         }
     }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -93,6 +93,12 @@ gpui::actions!(
     ]
 );
 
+#[derive(Clone, Debug, PartialEq, gpui::Action)]
+#[action(namespace = agents_sidebar, no_json, no_register)]
+struct RenameTerminalThread {
+    terminal_id: TerminalId,
+}
+
 gpui::actions!(
     dev,
     [
@@ -402,6 +408,28 @@ enum ListEntry {
     },
     Thread(Arc<ThreadEntry>),
     Terminal(TerminalEntry),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RenameTarget {
+    Thread(ThreadId),
+    Terminal(TerminalId),
+}
+
+impl RenameTarget {
+    fn from_entry(entry: &ListEntry) -> Option<(Self, SharedString)> {
+        match entry {
+            ListEntry::Thread(thread) => Some((
+                Self::Thread(thread.metadata.thread_id),
+                thread.metadata.display_title(),
+            )),
+            ListEntry::Terminal(terminal) => Some((
+                Self::Terminal(terminal.metadata.terminal_id),
+                terminal.metadata.editable_title(),
+            )),
+            ListEntry::ProjectHeader { .. } => None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -736,7 +764,7 @@ pub struct Sidebar {
     width: Pixels,
     focus_handle: FocusHandle,
     filter_editor: Entity<Editor>,
-    thread_rename_editor: Entity<Editor>,
+    rename_editor: Entity<Editor>,
     list_state: ListState,
     contents: SidebarContents,
     /// The index of the list item that currently has the keyboard focus
@@ -746,11 +774,11 @@ pub struct Sidebar {
     /// Tracks which sidebar entry is currently active (highlighted).
     active_entry: Option<ActiveEntry>,
     hovered_thread_index: Option<usize>,
-    renaming_thread_id: Option<ThreadId>,
+    rename_target: Option<RenameTarget>,
     /// Threads in the database-backed regeneration path need their own loading
     /// state because they do not have a live `agent::Thread` to report it.
     regenerating_titles: HashSet<ThreadId>,
-    /// start_renaming_thread must seed current title into the title editor
+    /// Starting a rename must seed the current title into the title editor,
     /// so this prevents that BufferEdited event from being interpreted as user input.
     suppress_next_rename_edit: bool,
 
@@ -808,7 +836,7 @@ impl Sidebar {
             editor.set_placeholder_text("Search threads…", window, cx);
             editor
         });
-        let thread_rename_editor = cx.new(|cx| Editor::single_line(window, cx));
+        let rename_editor = cx.new(|cx| Editor::single_line(window, cx));
 
         cx.subscribe_in(
             &multi_workspace,
@@ -843,10 +871,10 @@ impl Sidebar {
         .detach();
 
         cx.subscribe_in(
-            &thread_rename_editor,
+            &rename_editor,
             window,
             |this, title_editor, event, window, cx| {
-                this.handle_thread_rename_editor_event(title_editor, event, window, cx);
+                this.handle_rename_editor_event(title_editor, event, window, cx);
             },
         )
         .detach();
@@ -891,13 +919,13 @@ impl Sidebar {
             width: DEFAULT_WIDTH,
             focus_handle,
             filter_editor,
-            thread_rename_editor,
+            rename_editor,
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)),
             contents: SidebarContents::default(),
             selection: None,
             active_entry: None,
             hovered_thread_index: None,
-            renaming_thread_id: None,
+            rename_target: None,
             regenerating_titles: HashSet::new(),
             suppress_next_rename_edit: false,
 
@@ -3244,16 +3272,13 @@ impl Sidebar {
 
         let is_archived_search_focused = matches!(&self.view, SidebarView::Archive(archive) if archive.read(cx).is_filter_editor_focused(window, cx));
 
-        let is_renaming_thread = self
-            .thread_rename_editor
-            .focus_handle(cx)
-            .is_focused(window);
+        let is_renaming = self.rename_editor.focus_handle(cx).is_focused(window);
 
         let identifier = if self.filter_editor.focus_handle(cx).is_focused(window)
             || is_archived_search_focused
         {
             "searching"
-        } else if is_renaming_thread {
+        } else if is_renaming {
             "editing"
         } else {
             "not_searching"
@@ -3279,8 +3304,8 @@ impl Sidebar {
     }
 
     fn cancel(&mut self, _: &Cancel, window: &mut Window, cx: &mut Context<Self>) {
-        if self.renaming_thread_id.is_some() {
-            self.finish_thread_rename(window, cx);
+        if self.rename_target.is_some() {
+            self.finish_entry_rename(window, cx);
             return;
         }
 
@@ -3344,23 +3369,30 @@ impl Sidebar {
         !self.filter_editor.read(cx).text(cx).is_empty()
     }
 
-    fn start_renaming_thread(
+    fn start_renaming_entry(
         &mut self,
         ix: usize,
-        thread_id: ThreadId,
+        target: RenameTarget,
         title: SharedString,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.renaming_thread_id.is_some() && self.renaming_thread_id != Some(thread_id) {
-            self.finish_thread_rename(window, cx);
+        if self.rename_target == Some(target) {
+            self.rename_editor.update(cx, |editor, cx| {
+                editor.select_all(&editor::actions::SelectAll, window, cx);
+                editor.focus_handle(cx).focus(window, cx);
+            });
+            return;
+        }
+        if self.rename_target.is_some() {
+            self.finish_entry_rename(window, cx);
         }
 
         self.selection = Some(ix);
-        self.renaming_thread_id = Some(thread_id);
+        self.rename_target = Some(target);
         self.suppress_next_rename_edit = true;
         self.list_state.scroll_to_reveal_item(ix);
-        self.thread_rename_editor.update(cx, |editor, cx| {
+        self.rename_editor.update(cx, |editor, cx| {
             editor.set_text(title, window, cx);
             editor.select_all(&editor::actions::SelectAll, window, cx);
             editor.focus_handle(cx).focus(window, cx);
@@ -3368,7 +3400,7 @@ impl Sidebar {
         cx.notify();
     }
 
-    fn handle_thread_rename_editor_event(
+    fn handle_rename_editor_event(
         &mut self,
         title_editor: &Entity<Editor>,
         event: &editor::EditorEvent,
@@ -3385,16 +3417,26 @@ impl Sidebar {
                     return;
                 }
                 let new_title = title_editor.read(cx).text(cx);
-                if new_title.is_empty() {
-                    return;
-                }
-                let Some(thread_id) = self.renaming_thread_id else {
+                let Some(target) = self.rename_target else {
                     return;
                 };
-                self.apply_thread_rename(thread_id, SharedString::from(new_title), window, cx);
+                if matches!(target, RenameTarget::Thread(_)) && new_title.is_empty() {
+                    return;
+                }
+                let new_title = SharedString::from(new_title);
+                match target {
+                    RenameTarget::Thread(thread_id) => {
+                        self.apply_thread_rename(thread_id, new_title, window, cx);
+                    }
+                    RenameTarget::Terminal(terminal_id) => {
+                        TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                            store.rename_terminal(terminal_id, new_title, cx);
+                        });
+                    }
+                }
             }
             editor::EditorEvent::Blurred => {
-                self.finish_thread_rename(window, cx);
+                self.finish_entry_rename(window, cx);
             }
             _ => {}
         }
@@ -3433,8 +3475,8 @@ impl Sidebar {
         }
     }
 
-    fn finish_thread_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
-        if self.renaming_thread_id.take().is_none() {
+    fn finish_entry_rename(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.rename_target.take().is_none() {
             return false;
         }
         self.focus_handle.focus(window, cx);
@@ -3516,7 +3558,7 @@ impl Sidebar {
     }
 
     fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
-        if self.finish_thread_rename(window, cx) {
+        if self.finish_entry_rename(window, cx) {
             return;
         }
 
@@ -5677,12 +5719,40 @@ impl Sidebar {
         let Some(ix) = self.selection else {
             return;
         };
-        let Some(ListEntry::Thread(thread)) = self.contents.entries.get(ix) else {
+        let Some((target, title)) = self
+            .contents
+            .entries
+            .get(ix)
+            .and_then(RenameTarget::from_entry)
+        else {
             return;
         };
-        let thread_id = thread.metadata.thread_id;
-        let title = thread.metadata.display_title();
-        self.start_renaming_thread(ix, thread_id, title, window, cx);
+        self.start_renaming_entry(ix, target, title, window, cx);
+    }
+
+    fn rename_terminal_thread(
+        &mut self,
+        action: &RenameTerminalThread,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some((ix, terminal)) =
+            self.contents
+                .entries
+                .iter()
+                .enumerate()
+                .find_map(|(ix, entry)| {
+                    let ListEntry::Terminal(terminal) = entry else {
+                        return None;
+                    };
+                    (terminal.metadata.terminal_id == action.terminal_id).then_some((ix, terminal))
+                })
+        else {
+            return;
+        };
+        let target = RenameTarget::Terminal(action.terminal_id);
+        let title = terminal.metadata.editable_title();
+        self.start_renaming_entry(ix, target, title, window, cx);
     }
 
     fn record_thread_access(&mut self, id: &ThreadId) {
@@ -6100,6 +6170,28 @@ impl Sidebar {
         window.focus(&focus, cx);
     }
 
+    fn render_rename_title_editor(&self, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .h_full()
+            .min_w_0()
+            .flex_1()
+            .capture_action(
+                cx.listener(|this, _: &editor::actions::Newline, window, cx| {
+                    this.finish_entry_rename(window, cx);
+                }),
+            )
+            .on_action(cx.listener(|this, _: &Confirm, window, cx| {
+                this.finish_entry_rename(window, cx);
+            }))
+            .on_action(
+                cx.listener(|this, _: &editor::actions::Cancel, window, cx| {
+                    this.finish_entry_rename(window, cx);
+                }),
+            )
+            .child(self.rename_editor.clone())
+            .into_any_element()
+    }
+
     fn render_thread(
         &self,
         ix: usize,
@@ -6122,12 +6214,13 @@ impl Sidebar {
             thread.status,
             AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation
         );
-        let is_renaming = self.renaming_thread_id == Some(thread.metadata.thread_id);
+        let is_renaming =
+            self.rename_target == Some(RenameTarget::Thread(thread.metadata.thread_id));
 
         let thread_id_for_actions = thread.metadata.thread_id;
         let session_id_for_delete = thread.metadata.session_id.clone();
         let focus_handle = self.focus_handle.clone();
-        let title_editor = self.thread_rename_editor.clone();
+        let rename_title_editor = is_renaming.then(|| self.render_rename_title_editor(cx));
 
         let id = SharedString::from(format!("thread-entry-{}", ix));
 
@@ -6193,27 +6286,8 @@ impl Sidebar {
                 }
                 cx.notify();
             }))
-            .when(is_renaming, |this| {
-                this.is_truncated(false).title_slot(
-                    div()
-                        .h_full()
-                        .min_w_0()
-                        .flex_1()
-                        .capture_action(cx.listener(
-                            |this, _: &editor::actions::Newline, window, cx| {
-                                this.finish_thread_rename(window, cx);
-                            },
-                        ))
-                        .on_action(cx.listener(|this, _: &Confirm, window, cx| {
-                            this.finish_thread_rename(window, cx);
-                        }))
-                        .on_action(
-                            cx.listener(|this, _: &editor::actions::Cancel, window, cx| {
-                                this.finish_thread_rename(window, cx);
-                            }),
-                        )
-                        .child(title_editor),
-                )
+            .when_some(rename_title_editor, |this, title_editor| {
+                this.is_truncated(false).title_slot(title_editor)
             })
             .when(is_hovered && !is_renaming, |this| {
                 let rename_button = IconButton::new(("rename-thread", ix), IconName::Pencil)
@@ -6232,9 +6306,9 @@ impl Sidebar {
                     .on_click({
                         let title = title.clone();
                         cx.listener(move |this, _, window, cx| {
-                            this.start_renaming_thread(
+                            this.start_renaming_entry(
                                 ix,
-                                thread_id_for_actions,
+                                RenameTarget::Thread(thread_id_for_actions),
                                 title.clone(),
                                 window,
                                 cx,
@@ -6374,9 +6448,9 @@ impl Sidebar {
                             move |window, cx| {
                                 sidebar
                                     .update(cx, |sidebar, cx| {
-                                        sidebar.start_renaming_thread(
+                                        sidebar.start_renaming_entry(
                                             ix,
-                                            thread_id,
+                                            RenameTarget::Thread(thread_id),
                                             rename_title.clone(),
                                             window,
                                             cx,
@@ -6485,6 +6559,9 @@ impl Sidebar {
             cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
         );
         let is_remote = terminal.workspace.is_remote(cx);
+        let is_renaming =
+            self.rename_target == Some(RenameTarget::Terminal(terminal.metadata.terminal_id));
+        let rename_title_editor = is_renaming.then(|| self.render_rename_title_editor(cx));
 
         let display_title = terminal.metadata.display_title();
         let (icon_char, title, highlight_positions) =
@@ -6493,7 +6570,7 @@ impl Sidebar {
                 None => (None, display_title, terminal.highlight_positions.clone()),
             };
 
-        ThreadItem::new(id, title)
+        let terminal_item = ThreadItem::new(id, title)
             .base_bg(sidebar_bg)
             .icon(IconName::Terminal)
             .when_some(icon_char, |this, icon_char| this.icon_char(icon_char))
@@ -6513,7 +6590,10 @@ impl Sidebar {
                 }
                 cx.notify();
             }))
-            .when(is_hovered, |this| {
+            .when_some(rename_title_editor, |this, title_editor| {
+                this.is_truncated(false).title_slot(title_editor)
+            })
+            .when(is_hovered && !is_renaming, |this| {
                 this.action_slot(
                     IconButton::new("close-terminal", IconName::Close)
                         .icon_size(IconSize::Small)
@@ -6546,7 +6626,21 @@ impl Sidebar {
                         cx,
                     );
                 }
-            }))
+            }));
+
+        let context_menu_id = SharedString::from(format!("terminal-context-menu-{ix}"));
+        let terminal_id = terminal.metadata.terminal_id;
+
+        right_click_menu(context_menu_id)
+            .trigger(move |_, _, _| terminal_item)
+            .menu(move |window, cx| {
+                ContextMenu::build(window, cx, move |menu, _window, _cx| {
+                    menu.action(
+                        "Rename Title",
+                        RenameTerminalThread { terminal_id }.boxed_clone(),
+                    )
+                })
+            })
             .into_any_element()
     }
 
@@ -7790,6 +7884,7 @@ impl Render for Sidebar {
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::archive_selected_thread))
             .on_action(cx.listener(Self::rename_selected_thread))
+            .on_action(cx.listener(Self::rename_terminal_thread))
             .on_action(cx.listener(Self::new_thread_in_group))
             .on_action(cx.listener(Self::new_terminal_thread))
             .on_action(cx.listener(Self::toggle_archive))

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -93,12 +93,6 @@ gpui::actions!(
     ]
 );
 
-#[derive(Clone, Debug, PartialEq, gpui::Action)]
-#[action(namespace = agents_sidebar, no_json, no_register)]
-struct RenameTerminalThread {
-    terminal_id: TerminalId,
-}
-
 gpui::actions!(
     dev,
     [
@@ -5759,31 +5753,6 @@ impl Sidebar {
         self.start_renaming_entry(ix, target, title, window, cx);
     }
 
-    fn rename_terminal_thread(
-        &mut self,
-        action: &RenameTerminalThread,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let Some((ix, terminal)) =
-            self.contents
-                .entries
-                .iter()
-                .enumerate()
-                .find_map(|(ix, entry)| {
-                    let ListEntry::Terminal(terminal) = entry else {
-                        return None;
-                    };
-                    (terminal.metadata.terminal_id == action.terminal_id).then_some((ix, terminal))
-                })
-        else {
-            return;
-        };
-        let target = RenameTarget::Terminal(action.terminal_id);
-        let title = terminal.metadata.editable_title();
-        self.start_renaming_entry(ix, target, title, window, cx);
-    }
-
     fn record_thread_access(&mut self, id: &ThreadId) {
         self.thread_last_accessed.insert(*id, Utc::now());
     }
@@ -6659,15 +6628,28 @@ impl Sidebar {
 
         let context_menu_id = SharedString::from(format!("terminal-context-menu-{ix}"));
         let terminal_id = terminal.metadata.terminal_id;
+        let rename_title = terminal.metadata.editable_title();
+        let sidebar = cx.weak_entity();
 
         right_click_menu(context_menu_id)
             .trigger(move |_, _, _| terminal_item)
             .menu(move |window, cx| {
+                let sidebar = sidebar.clone();
+                let rename_title = rename_title.clone();
                 ContextMenu::build(window, cx, move |menu, _window, _cx| {
-                    menu.action(
-                        "Rename Title",
-                        RenameTerminalThread { terminal_id }.boxed_clone(),
-                    )
+                    menu.entry("Rename Title", None, move |window, cx| {
+                        sidebar
+                            .update(cx, |sidebar, cx| {
+                                sidebar.start_renaming_entry(
+                                    ix,
+                                    RenameTarget::Terminal(terminal_id),
+                                    rename_title.clone(),
+                                    window,
+                                    cx,
+                                );
+                            })
+                            .ok();
+                    })
                 })
             })
             .into_any_element()
@@ -7913,7 +7895,6 @@ impl Render for Sidebar {
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::archive_selected_thread))
             .on_action(cx.listener(Self::rename_selected_thread))
-            .on_action(cx.listener(Self::rename_terminal_thread))
             .on_action(cx.listener(Self::new_thread_in_group))
             .on_action(cx.listener(Self::new_terminal_thread))
             .on_action(cx.listener(Self::toggle_archive))

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3473,25 +3473,21 @@ impl Sidebar {
         title: SharedString,
         cx: &mut Context<Self>,
     ) {
-        let workspace = self.contents.entries.iter().find_map(|entry| {
-            let ListEntry::Terminal(terminal) = entry else {
-                return None;
-            };
-            (terminal.metadata.terminal_id == terminal_id).then(|| terminal.workspace.clone())
-        });
-        let renamed_live_terminal = match workspace {
-            Some(ThreadEntryWorkspace::Open(workspace)) => workspace
-                .read(cx)
-                .panel::<AgentPanel>(cx)
-                .is_some_and(|agent_panel| {
-                    agent_panel.update(cx, |agent_panel, cx| {
+        let mut found = false;
+        if let Some(multi_workspace) = self.multi_workspace.upgrade() {
+            let workspaces: Vec<_> = multi_workspace.read(cx).workspaces().cloned().collect();
+            for workspace in workspaces {
+                if let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx)
+                    && agent_panel.update(cx, |agent_panel, cx| {
                         agent_panel.rename_terminal(terminal_id, title.clone(), cx)
                     })
-                }),
-            Some(ThreadEntryWorkspace::Closed { .. }) | None => false,
-        };
+                {
+                    found = true;
+                }
+            }
+        }
 
-        if !renamed_live_terminal {
+        if !found {
             TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
                 store.rename_terminal(terminal_id, title, cx);
             });

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -5262,7 +5262,7 @@ async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut Tes
 }
 
 #[gpui::test]
-async fn test_terminal_context_menu_action_renames_terminal(cx: &mut TestAppContext) {
+async fn test_rename_selected_thread_action_renames_terminal(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
@@ -5275,8 +5275,26 @@ async fn test_terminal_context_menu_action_renames_terminal(cx: &mut TestAppCont
         .expect("test terminal should be inserted");
     cx.run_until_parked();
 
+    let entry_ix = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .position(|entry| {
+                matches!(
+                    entry,
+                    ListEntry::Terminal(terminal)
+                        if terminal.metadata.terminal_id == terminal_id
+                )
+            })
+            .expect("sidebar should have a terminal entry")
+    });
+
     focus_sidebar(&sidebar, cx);
-    cx.dispatch_action(RenameTerminalThread { terminal_id });
+    sidebar.update_in(cx, |sidebar, _window, _cx| {
+        sidebar.selection = Some(entry_ix);
+    });
+    cx.dispatch_action(RenameSelectedThread);
     cx.run_until_parked();
 
     let renamed_title = "Renamed Terminal";

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -24,7 +24,23 @@ use std::{
 };
 use util::{path_list::PathList, rel_path::rel_path};
 
+fn use_unique_metadata_databases(cx: &mut TestAppContext) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_TEST_DATABASE: AtomicUsize = AtomicUsize::new(0);
+    let test_database_id = NEXT_TEST_DATABASE.fetch_add(1, Ordering::SeqCst);
+    cx.update(|cx| {
+        cx.set_global(agent_ui::thread_metadata_store::TestMetadataDbName(
+            format!("SIDEBAR_THREAD_METADATA_{test_database_id}"),
+        ));
+        cx.set_global(TestTerminalMetadataDbName(format!(
+            "SIDEBAR_TERMINAL_THREAD_METADATA_{test_database_id}"
+        )));
+    });
+}
+
 fn init_test(cx: &mut TestAppContext) {
+    use_unique_metadata_databases(cx);
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
@@ -488,6 +504,27 @@ fn save_draft_metadata_with_main_paths(
 fn focus_sidebar(sidebar: &Entity<Sidebar>, cx: &mut gpui::VisualTestContext) {
     sidebar.update_in(cx, |_, window, cx| {
         cx.focus_self(window);
+    });
+    cx.run_until_parked();
+}
+
+fn enter_renamed_title(
+    sidebar: &Entity<Sidebar>,
+    target: RenameTarget,
+    renamed_title: &str,
+    cx: &mut gpui::VisualTestContext,
+) {
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert_eq!(sidebar.rename_target, Some(target));
+    });
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.rename_editor.update(cx, |editor, cx| {
+            editor.set_text(renamed_title, window, cx);
+        });
+    });
+    cx.run_until_parked();
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.finish_entry_rename(window, cx);
     });
     cx.run_until_parked();
 }
@@ -1721,6 +1758,7 @@ async fn init_test_project_with_agent_panel(
     worktree_path: &str,
     cx: &mut TestAppContext,
 ) -> Entity<project::Project> {
+    use_unique_metadata_databases(cx);
     agent_ui::test_support::init_test(cx);
     cx.update(|cx| {
         cx.set_global(agent_ui::MaxIdleRetainedThreads(1));
@@ -5080,17 +5118,17 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
 
     let renamed_title = "abcdefghijklmnopqrstuvwxyé renamed";
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.start_renaming_thread(entry_ix, thread_id, title, window, cx);
+        sidebar.start_renaming_entry(entry_ix, RenameTarget::Thread(thread_id), title, window, cx);
     });
     cx.run_until_parked();
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.thread_rename_editor.update(cx, |editor, cx| {
+        sidebar.rename_editor.update(cx, |editor, cx| {
             editor.set_text(renamed_title, window, cx);
         });
     });
     cx.run_until_parked();
     sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.finish_thread_rename(window, cx);
+        sidebar.finish_entry_rename(window, cx);
     });
     cx.run_until_parked();
 
@@ -5210,25 +5248,8 @@ async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut Tes
     cx.dispatch_action(RenameSelectedThread);
     cx.run_until_parked();
 
-    sidebar.read_with(cx, |sidebar, _cx| {
-        assert_eq!(
-            sidebar.renaming_thread_id,
-            Some(thread_id),
-            "dispatching RenameSelectedThread should start renaming the selected thread"
-        );
-    });
-
     let renamed_title = "Renamed via action";
-    sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.thread_rename_editor.update(cx, |editor, cx| {
-            editor.set_text(renamed_title, window, cx);
-        });
-    });
-    cx.run_until_parked();
-    sidebar.update_in(cx, |sidebar, window, cx| {
-        sidebar.finish_thread_rename(window, cx);
-    });
-    cx.run_until_parked();
+    enter_renamed_title(&sidebar, RenameTarget::Thread(thread_id), renamed_title, cx);
 
     let metadata = cx.update(|_, cx| {
         ThreadMetadataStore::global(cx)
@@ -5238,6 +5259,54 @@ async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut Tes
             .expect("thread metadata should exist")
     });
     assert_eq!(metadata.title_override.as_deref(), Some(renamed_title));
+}
+
+#[gpui::test]
+async fn test_terminal_context_menu_action_renames_terminal(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let terminal_id = panel
+        .update_in(cx, |panel, window, cx| {
+            panel.insert_test_terminal("Dev Server", true, window, cx)
+        })
+        .expect("test terminal should be inserted");
+    cx.run_until_parked();
+
+    focus_sidebar(&sidebar, cx);
+    cx.dispatch_action(RenameTerminalThread { terminal_id });
+    cx.run_until_parked();
+
+    let renamed_title = "Renamed Terminal";
+    enter_renamed_title(
+        &sidebar,
+        RenameTarget::Terminal(terminal_id),
+        renamed_title,
+        cx,
+    );
+
+    panel.read_with(cx, |panel, cx| {
+        let terminal = panel
+            .terminals(cx)
+            .into_iter()
+            .find(|terminal| terminal.id == terminal_id)
+            .expect("terminal should remain open after renaming");
+        assert_eq!(terminal.custom_title.as_deref(), Some(renamed_title));
+    });
+    sidebar.read_with(cx, |_sidebar, cx| {
+        let metadata = TerminalThreadMetadataStore::global(cx)
+            .read(cx)
+            .entry(terminal_id)
+            .cloned()
+            .expect("renamed terminal metadata should exist");
+        assert_eq!(metadata.custom_title.as_deref(), Some(renamed_title));
+    });
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [my-project]", "  Renamed Terminal  <== selected"]
+    );
 }
 
 #[gpui::test]

--- a/docs/src/ai/terminal-threads.md
+++ b/docs/src/ai/terminal-threads.md
@@ -54,7 +54,7 @@ You can also configure this from the Settings UI under **AI**, via the "Terminal
 
 ## Terminal Thread Titles {#terminal-thread-titles}
 
-The terminal title in the toolbar updates automatically to reflect the running shell or process. You can also set a custom name by clicking the title or the pencil icon that appears on hover.
+The terminal title in the toolbar updates automatically to reflect the running shell or process. You can set a custom name by clicking the title or the pencil icon that appears on hover. In the Threads Sidebar, right-click a Terminal Thread and select **Rename Title**, or select it and press {#kb agent::RenameSelectedThread}.
 
 ## Notifications {#terminal-thread-notifications}
 


### PR DESCRIPTION
The Agent Panel already lets users rename Terminal Threads. This adds the same option to the Threads Sidebar. A rename in either place updates the other.

<p>
<img width="321" height="89" alt="image" src="https://github.com/user-attachments/assets/189a8598-f0da-4622-a5b0-b6a18a5750b7" />
</p>
<p>
<img width="324" height="77" alt="image" src="https://github.com/user-attachments/assets/2fc9f7aa-c791-4568-8729-fd3a78322d63" />
</p>

Release Notes:

- Added support for renaming Terminal Threads from the Threads Sidebar.