### PR TITLE
terminal_view: Add editor selection references when pasting into terminal agents

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1263,6 +1263,7 @@
       "paste": "terminal::Paste",
       "shift-insert": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
+      "ctrl-alt-v": "terminal::PasteText",
       "ctrl-enter": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],
       "alt-f": ["terminal::SendText", "\u001bf"],

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -846,18 +846,6 @@ pub fn selection_name(path: Option<&Path>, line_range: &RangeInclusive<u32>) -> 
     )
 }
 
-/// Formats a 0-based, inclusive line range as a 1-based path suffix: `:5` for a
-/// single line or `:5-9` for a span. Used for `path:line` mentions in text.
-pub fn line_range_suffix(line_range: &RangeInclusive<u32>) -> String {
-    let start = *line_range.start() + 1;
-    let end = *line_range.end() + 1;
-    if start == end {
-        format!(":{start}")
-    } else {
-        format!(":{start}-{end}")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use util::{path, uri};

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use acp_thread::{AcpThread, AcpThreadEvent, MentionUri, ThreadStatus, line_range_suffix};
+use acp_thread::{AcpThread, AcpThreadEvent, MentionUri, ThreadStatus};
 use agent::{ContextServerRegistry, SharedThread, ThreadStore};
 use agent_client_protocol::schema::v1 as acp;
 use agent_servers::AgentServer;
@@ -88,7 +88,10 @@ use settings::{NotifyWhenAgentWaiting, Settings, update_settings_file};
 
 use search::{BufferSearchBar, buffer_search::Deploy as DeployBufferSearch};
 use terminal::{Event as TerminalEvent, terminal_settings::TerminalSettings};
-use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
+use terminal_view::{
+    TerminalView, format_terminal_selection_reference, is_known_terminal_agent_command,
+    terminal_panel::TerminalPanel,
+};
 use text::OffsetRangeExt;
 use theme_settings::ThemeSettings;
 use ui::{
@@ -109,29 +112,6 @@ const LAST_USED_AGENT_KEY: &str = "agent_panel__last_used_external_agent";
 const LAST_CREATED_ENTRY_KIND_KEY: &str = "agent_panel__last_created_entry_kind";
 const TERMINAL_AGENT_TELEMETRY_ID: &str = "terminal";
 const TERMINAL_INIT_COMMAND_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
-const KNOWN_TERMINAL_AGENT_COMMANDS: &[&str] = &[
-    "agent", // Unfortunately, both Cursor cli + grok
-    "agy",
-    "aider",
-    "amp",
-    "claude",
-    "codex",
-    "copilot",
-    "crush",
-    "devin",
-    "droid",
-    "gemini",
-    "goose",
-    "grok",
-    "openhands",
-    "opencode",
-    "pi",
-    "qwen",
-];
-
-fn is_known_terminal_agent_command(command: &str) -> bool {
-    KNOWN_TERMINAL_AGENT_COMMANDS.contains(&command)
-}
 
 fn terminal_program_to_report(
     last_observed_program: &mut Option<String>,
@@ -769,7 +749,7 @@ fn format_selection_for_terminal(
 ) -> String {
     match selection {
         AgentContextSelection::Editor(ranges) => {
-            let path_style = project.read(cx).path_style(cx);
+            let project = project.read(cx);
             let mut parts: Vec<String> = Vec::new();
             for (buffer, range) in ranges {
                 let buffer = buffer.read(cx);
@@ -779,14 +759,13 @@ fn format_selection_for_terminal(
                 let snapshot = buffer.snapshot();
                 let point_range = range.to_point(&snapshot);
                 let line_range = point_range.start.row..=point_range.end.row;
-                let path = mention_path_for_terminal(
+                parts.push(format_terminal_selection_reference(
                     project,
                     &project_path,
+                    &line_range,
                     working_directory,
-                    path_style,
                     cx,
-                );
-                parts.push(format!("{path}{}", line_range_suffix(&line_range)));
+                ));
             }
             if parts.is_empty() {
                 String::new()
@@ -796,25 +775,6 @@ fn format_selection_for_terminal(
             }
         }
         AgentContextSelection::Terminal(texts) => texts.join("\n"),
-    }
-}
-
-/// Path for a terminal mention: relative to the terminal cwd if possible, else absolute.
-fn mention_path_for_terminal(
-    project: &Entity<Project>,
-    project_path: &ProjectPath,
-    working_directory: Option<&std::path::Path>,
-    path_style: util::paths::PathStyle,
-    cx: &App,
-) -> String {
-    let abs_path = project.read(cx).absolute_path(project_path, cx);
-    match (abs_path, working_directory) {
-        (Some(abs_path), Some(working_directory)) => path_style
-            .strip_prefix(&abs_path, working_directory)
-            .map(|relative| relative.display(path_style).into_owned())
-            .unwrap_or_else(|| abs_path.to_string_lossy().into_owned()),
-        (Some(abs_path), None) => abs_path.to_string_lossy().into_owned(),
-        (None, _) => project_path.path.display(path_style).into_owned(),
     }
 }
 
@@ -6910,14 +6870,6 @@ mod tests {
                 }
             });
         });
-    }
-
-    #[test]
-    fn test_is_known_terminal_agent_command() {
-        assert!(is_known_terminal_agent_command("claude"));
-        assert!(is_known_terminal_agent_command("codex"));
-        assert!(!is_known_terminal_agent_command("cargo"));
-        assert!(!is_known_terminal_agent_command("internal-agent"));
     }
 
     #[test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -67,7 +67,7 @@ use chrono::{DateTime, Utc};
 use client::UserStore;
 use cloud_api_types::Plan;
 use collections::HashMap;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, line_range_for_selection};
 use extension_host::ExtensionStore;
 use feature_flags::{CreateThreadToolFeatureFlag, FeatureFlagAppExt as _};
 
@@ -758,7 +758,7 @@ fn format_selection_for_terminal(
                 };
                 let snapshot = buffer.snapshot();
                 let point_range = range.to_point(&snapshot);
-                let line_range = point_range.start.row..=point_range.end.row;
+                let line_range = line_range_for_selection(point_range);
                 parts.push(format_terminal_selection_reference(
                     project,
                     &project_path,
@@ -9300,6 +9300,26 @@ mod tests {
         // Lines are 1-based and inclusive; the path is presented as
         // `<rel-path>:<start>-<end>`, with a trailing space.
         assert_eq!(pasted, "file.rs:2-3 ");
+
+        editor.update_in(&mut cx, |editor, window, cx| {
+            editor.change_selections(Default::default(), window, cx, |selections| {
+                selections.select_ranges([text::Point::new(1, 0)..text::Point::new(2, 0)]);
+            });
+        });
+        workspace.update_in(&mut cx, |_, window, cx| {
+            window.dispatch_action(AddSelectionToThread.boxed_clone(), cx);
+        });
+        cx.run_until_parked();
+
+        let pasted: String = terminal
+            .update(&mut cx, |terminal, _| terminal.take_input_log())
+            .into_iter()
+            .map(|bytes| String::from_utf8(bytes).expect("pasted bytes should be valid UTF-8"))
+            .collect();
+        assert_eq!(
+            pasted, "file.rs:2 ",
+            "a selection ending at column zero should exclude that row"
+        );
     }
 
     async fn setup_panel(cx: &mut TestAppContext) -> (Entity<AgentPanel>, VisualTestContext) {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -759,13 +759,16 @@ fn format_selection_for_terminal(
                 let snapshot = buffer.snapshot();
                 let point_range = range.to_point(&snapshot);
                 let line_range = line_range_for_selection(point_range);
-                parts.push(format_terminal_selection_reference(
+                let Some(reference) = format_terminal_selection_reference(
                     project,
                     &project_path,
                     &line_range,
                     working_directory,
                     cx,
-                ));
+                ) else {
+                    continue;
+                };
+                parts.push(reference);
             }
             if parts.is_empty() {
                 String::new()

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -8864,8 +8864,10 @@ pub(crate) mod tests {
                 conversation_view.project.clone(),
             )
         });
+        let buffer_text = "line one\nline two\nline three";
+        let selection_end = "line one\nline two\n".len();
         let buffer = project.update(cx, |project, cx| {
-            project.create_local_buffer("let a = 10 + 10;", None, false, cx)
+            project.create_local_buffer(buffer_text, None, false, cx)
         });
 
         workspace
@@ -8875,7 +8877,9 @@ pub(crate) mod tests {
                         Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx);
 
                     editor.change_selections(Default::default(), window, cx, |selections| {
-                        selections.select_ranges([MultiBufferOffset(8)..MultiBufferOffset(15)]);
+                        selections.select_ranges([
+                            MultiBufferOffset(0)..MultiBufferOffset(selection_end)
+                        ]);
                     });
 
                     editor
@@ -8899,12 +8903,27 @@ pub(crate) mod tests {
                 .unwrap();
             view.insert_selection(selection, window, cx);
         });
+        cx.run_until_parked();
 
         message_editor.read_with(cx, |editor, cx| {
             let text = editor.text(cx);
             let expected_txt = String::from("Can you review this snippet selection ");
 
             assert_eq!(text, expected_txt);
+            let mentions = editor.mention_set().read(cx).mentions();
+            assert_eq!(
+                mentions.len(),
+                1,
+                "expected exactly one mention, got {mentions:?}"
+            );
+            assert!(
+                mentions.contains(&MentionUri::Selection {
+                    abs_path: None,
+                    line_range: 0..=1,
+                    column: None,
+                }),
+                "a selection ending at column zero should exclude that row"
+            );
         })
     }
 

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -8,6 +8,7 @@ use collections::{HashMap, HashSet};
 use editor::{
     Anchor, Editor, EditorSnapshot, FoldPlaceholder, ToOffset,
     display_map::{Crease, CreaseId, CreaseMetadata, FoldId},
+    line_range_for_selection,
     scroll::Autoscroll,
 };
 use futures::{AsyncReadExt as _, FutureExt as _, future::Shared};
@@ -554,7 +555,7 @@ impl MentionSet {
                 .text_for_range(selection_range.clone())
                 .collect::<String>();
             let point_range = selection_range.to_point(&snapshot);
-            let line_range = point_range.start.row..=point_range.end.row;
+            let line_range = line_range_for_selection(point_range);
 
             let uri = MentionUri::Selection {
                 abs_path: abs_path.clone(),

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -400,7 +400,7 @@ impl Editor {
                     is_entire_line,
                     selection.range(),
                     &buffer,
-                    self.project.as_ref(),
+                    None,
                     cx,
                 ));
             }

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -1,6 +1,13 @@
 use super::*;
 use util::rel_path::RelPath;
 
+pub enum ClipboardTextSource<'a> {
+    Existing {
+        project: Option<&'a Entity<Project>>,
+    },
+    Removed,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ClipboardSelection {
     /// The number of bytes in this selection.
@@ -21,22 +28,25 @@ impl ClipboardSelection {
         is_entire_line: bool,
         range: Range<Point>,
         buffer: &MultiBufferSnapshot,
-        project: Option<&Entity<Project>>,
+        text_source: ClipboardTextSource<'_>,
         cx: &App,
     ) -> Self {
         let first_line_indent = buffer
             .indent_size_for_line(MultiBufferRow(range.start.row))
             .len;
 
-        let file_path = util::maybe!({
-            let project = project?.read(cx);
-            let file = buffer.file_at(range.start)?;
-            let project_path = ProjectPath {
-                worktree_id: file.worktree_id(cx),
-                path: file.path().clone(),
-            };
-            project.absolute_path(&project_path, cx)
-        });
+        let file_path = match text_source {
+            ClipboardTextSource::Existing { project } => util::maybe!({
+                let project = project?.read(cx);
+                let file = buffer.file_at(range.start)?;
+                let project_path = ProjectPath {
+                    worktree_id: file.worktree_id(cx),
+                    path: file.path().clone(),
+                };
+                project.absolute_path(&project_path, cx)
+            }),
+            ClipboardTextSource::Removed => None,
+        };
 
         let line_range = if file_path.is_some() {
             buffer
@@ -400,7 +410,7 @@ impl Editor {
                     is_entire_line,
                     selection.range(),
                     &buffer,
-                    None,
+                    ClipboardTextSource::Removed,
                     cx,
                 ));
             }
@@ -668,7 +678,9 @@ impl Editor {
                 is_entire_line,
                 start..end,
                 &buffer,
-                self.project.as_ref(),
+                ClipboardTextSource::Existing {
+                    project: self.project.as_ref(),
+                },
                 cx,
             ));
         }

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -41,7 +41,7 @@ impl ClipboardSelection {
         let line_range = if file_path.is_some() {
             buffer
                 .range_to_buffer_range(range)
-                .map(|(_, buffer_range)| buffer_range.start.row..=buffer_range.end.row)
+                .map(|(_, buffer_range)| line_range_for_selection(buffer_range))
         } else {
             None
         };

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -72,7 +72,7 @@ mod rewrap;
 mod selection;
 
 pub(crate) use actions::*;
-pub use clipboard::ClipboardSelection;
+pub use clipboard::{ClipboardSelection, ClipboardTextSource};
 pub use code_actions::CodeActionProvider;
 use collections::TypeIdHashMap;
 pub use completions::CompletionProvider;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1207,6 +1207,16 @@ struct AccentData {
     overrides: Vec<SharedString>,
 }
 
+/// Excludes an end row at column zero because selection ranges use exclusive endpoints.
+pub fn line_range_for_selection(range: Range<Point>) -> RangeInclusive<u32> {
+    let end_row = if range.end.column == 0 && range.end.row > range.start.row {
+        range.end.row - 1
+    } else {
+        range.end.row
+    };
+    range.start.row..=end_row
+}
+
 fn debounce_value(debounce_ms: u64) -> Option<Duration> {
     if debounce_ms > 0 {
         Some(Duration::from_millis(debounce_ms))
@@ -8972,14 +8982,9 @@ impl Editor {
                     Some((buffer, point..point))
                 })?;
 
-            let start_line = range.start.row + 1;
-            let end_line = range.end.row + 1;
-
-            let end_line = if range.end.column == 0 && end_line > start_line {
-                end_line - 1
-            } else {
-                end_line
-            };
+            let line_range = line_range_for_selection(range);
+            let start_line = line_range.start() + 1;
+            let end_line = line_range.end() + 1;
 
             let project = self.project()?.read(cx);
             let file = buffer.file()?;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10572,6 +10572,54 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
         "line range should use original file rows 2-4, excluding the column-zero endpoint, not multibuffer rows 0-2"
     );
 
+    editor.update_in(cx, |editor, _window, cx| {
+        editor.set_wrap_width(Some(20.0.into()), cx);
+    });
+    cx.run_until_parked();
+    editor.update_in(cx, |editor, window, cx| {
+        let display_snapshot = editor.display_snapshot(cx);
+        let start = DisplayPoint::new(DisplayRow(0), 0);
+        let end = Point::new(0, "third line".len() as u32).to_display_point(&display_snapshot);
+        assert!(end.row() > start.row(), "expected the first line to wrap");
+
+        editor.select(
+            SelectPhase::Begin {
+                position: start,
+                add: false,
+                click_count: 1,
+            },
+            window,
+            cx,
+        );
+        editor.select(
+            SelectPhase::Update {
+                position: end,
+                goal_column: end.column(),
+                scroll_delta: gpui::Point::default(),
+            },
+            window,
+            cx,
+        );
+        editor.select(SelectPhase::End, window, cx);
+        editor.copy(&Copy, window, cx);
+    });
+
+    let wrapped_clipboard_selections: Vec<ClipboardSelection> = cx
+        .read_from_clipboard()
+        .and_then(|item| item.entries().first().cloned())
+        .and_then(|entry| match entry {
+            gpui::ClipboardEntry::String(text) => text.metadata_json(),
+            _ => None,
+        })
+        .expect("should have clipboard selections");
+    assert_eq!(
+        wrapped_clipboard_selections
+            .first()
+            .and_then(|selection| selection.line_range.clone()),
+        Some(2..=2),
+        "soft-wrapped display rows should remain one logical buffer row"
+    );
+
     editor.update_in(cx, |editor, window, cx| editor.cut(&Cut, window, cx));
     let cut_source_locations = cx.read_from_clipboard().and_then(|item| {
         item.entries().first().and_then(|entry| match entry {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10571,6 +10571,26 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
         Some(2..=4),
         "line range should use original file rows 2-4, excluding the column-zero endpoint, not multibuffer rows 0-2"
     );
+
+    editor.update_in(cx, |editor, window, cx| editor.cut(&Cut, window, cx));
+    let cut_source_locations = cx.read_from_clipboard().and_then(|item| {
+        item.entries().first().and_then(|entry| match entry {
+            gpui::ClipboardEntry::String(text) => text
+                .metadata_json::<Vec<ClipboardSelection>>()
+                .map(|selections| {
+                    selections
+                        .into_iter()
+                        .map(|selection| (selection.file_path, selection.line_range))
+                        .collect::<Vec<_>>()
+                }),
+            _ => None,
+        })
+    });
+    assert_eq!(
+        cut_source_locations,
+        Some(vec![(None, None)]),
+        "cut text should not retain its source location after it is removed"
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10568,8 +10568,8 @@ async fn test_clipboard_line_numbers_from_multibuffer(cx: &mut TestAppContext) {
     let selection = &selections[0];
     assert_eq!(
         selection.line_range,
-        Some(2..=5),
-        "line range should be from original file (rows 2-5), not multibuffer rows (0-2)"
+        Some(2..=4),
+        "line range should use original file rows 2-4, excluding the column-zero endpoint, not multibuffer rows 0-2"
     );
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1065,6 +1065,8 @@ impl TerminalBuilder {
             pending_cwd_boundary: None,
             #[cfg(any(test, feature = "test-support"))]
             input_log: Vec::new(),
+            #[cfg(any(test, feature = "test-support"))]
+            foreground_process_command_for_test: None,
             #[cfg(test)]
             suppress_hyperlink_throttle_once: false,
             #[cfg(any(test, feature = "test-support"))]
@@ -1364,6 +1366,8 @@ impl TerminalBuilder {
                 pending_cwd_boundary: None,
                 #[cfg(any(test, feature = "test-support"))]
                 input_log: Vec::new(),
+                #[cfg(any(test, feature = "test-support"))]
+                foreground_process_command_for_test: None,
                 #[cfg(test)]
                 suppress_hyperlink_throttle_once: false,
                 #[cfg(any(test, feature = "test-support"))]
@@ -1544,6 +1548,8 @@ pub struct Terminal {
     pending_cwd_boundary: Option<i32>,
     #[cfg(any(test, feature = "test-support"))]
     input_log: Vec<Vec<u8>>,
+    #[cfg(any(test, feature = "test-support"))]
+    foreground_process_command_for_test: Option<String>,
     #[cfg(test)]
     suppress_hyperlink_throttle_once: bool,
     #[cfg(any(test, feature = "test-support"))]
@@ -2888,6 +2894,11 @@ impl Terminal {
 
     /// Normalizes the command name of the foreground process, if one is known.
     pub fn foreground_process_command_name(&self) -> Option<String> {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(command) = &self.foreground_process_command_for_test {
+            return Some(command.clone());
+        }
+
         match &self.terminal_type {
             TerminalType::Pty { info, .. } => info
                 .current
@@ -2896,6 +2907,11 @@ impl Terminal {
                 .and_then(|process| foreground_process_command_from_argv(&process.argv)),
             TerminalType::DisplayOnly => None,
         }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_foreground_process_command_for_test(&mut self, command: impl Into<String>) {
+        self.foreground_process_command_for_test = Some(command.into());
     }
 
     /// Returns the working directory of the process that's connected to the PTY.

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -107,7 +107,7 @@ pub fn format_terminal_selection_reference(
     line_range: &RangeInclusive<u32>,
     working_directory: Option<&Path>,
     cx: &App,
-) -> String {
+) -> Option<String> {
     let path_style = project.path_style(cx);
     let absolute_path = project.absolute_path(project_path, cx);
     let path = match (absolute_path, working_directory) {
@@ -120,11 +120,14 @@ pub fn format_terminal_selection_reference(
     };
     let start_line = line_range.start() + 1;
     let end_line = line_range.end() + 1;
-    if start_line == end_line {
+    let reference = if start_line == end_line {
         format!("{path}:{start_line}")
     } else {
         format!("{path}:{start_line}-{end_line}")
-    }
+    };
+    shlex::try_quote(&reference)
+        .ok()
+        .map(|reference| reference.into_owned())
 }
 
 /// Event to transmit the scroll from the element to the view
@@ -1203,16 +1206,8 @@ fn format_clipboard_selection_for_terminal_agent(
         return None;
     }
     let project_path = project.project_path_for_absolute_path(file_path, cx)?;
-    Some(format!(
-        "{} ",
-        format_terminal_selection_reference(
-            project,
-            &project_path,
-            line_range,
-            working_directory,
-            cx,
-        )
-    ))
+    format_terminal_selection_reference(project, &project_path, line_range, working_directory, cx)
+        .map(|reference| format!("{reference} "))
 }
 
 fn terminal_rerun_override(task: &TaskId) -> zed_actions::Rerun {
@@ -2313,6 +2308,11 @@ mod tests {
         let (project, _workspace) = init_test(cx).await;
         let (worktree, _) = create_folder_wt(project.clone(), "/project", cx).await;
         let file_entry = create_file_in_worktree(worktree.clone(), "main.rs", cx).await;
+        let spaced_file_entry = create_file_in_worktree(worktree.clone(), "my file.rs", cx).await;
+        let quoted_file_entry =
+            create_file_in_worktree(worktree.clone(), "reader's notes.rs", cx).await;
+        let shell_file_entry = create_file_in_worktree(worktree.clone(), "$(notes).rs", cx).await;
+        let unicode_file_entry = create_file_in_worktree(worktree.clone(), "日本.rs", cx).await;
 
         let selection = editor::ClipboardSelection {
             len: 12,
@@ -2340,7 +2340,7 @@ mod tests {
                     Some(Path::new("/project")),
                     cx,
                 ),
-                "main.rs:5"
+                Some("main.rs:5".to_string())
             );
             assert_eq!(
                 format_clipboard_selection_for_terminal_agent(
@@ -2352,6 +2352,47 @@ mod tests {
                 ),
                 Some("main.rs:10-42 ".to_string())
             );
+
+            let spaced_path_clipboard = ClipboardItem::new_string_with_json_metadata(
+                "selected text".to_string(),
+                vec![editor::ClipboardSelection {
+                    file_path: Some(PathBuf::from("/project/my file.rs")),
+                    ..selection.clone()
+                }],
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &spaced_path_clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                Some("'my file.rs:10-42' ".to_string())
+            );
+
+            for (file_entry, expected_reference) in [
+                (&spaced_file_entry, "my file.rs:10-42"),
+                (&quoted_file_entry, "reader's notes.rs:10-42"),
+                (&shell_file_entry, "$(notes).rs:10-42"),
+                (&unicode_file_entry, "日本.rs:10-42"),
+            ] {
+                let project_path = ProjectPath {
+                    worktree_id: worktree.read(cx).id(),
+                    path: file_entry.path.clone(),
+                };
+                let reference = format_terminal_selection_reference(
+                    project,
+                    &project_path,
+                    &(9..=41),
+                    Some(Path::new("/project")),
+                    cx,
+                );
+                assert_eq!(
+                    reference.as_deref().and_then(shlex::split),
+                    Some(vec![expected_reference.to_string()])
+                );
+            }
             assert_eq!(
                 format_clipboard_selection_for_terminal_agent(
                     &clipboard,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -9,10 +9,10 @@ use editor::{
     ui_scrollbar_settings_from_raw,
 };
 use gpui::{
-    Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, ExternalPaths,
-    FocusHandle, Focusable, Font, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent,
-    Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled, Subscription, Task, TaskExt,
-    WeakEntity, actions, anchored, deferred, div,
+    Action, AnyElement, App, ClipboardEntry, ClipboardItem, DismissEvent, Entity, EventEmitter,
+    ExternalPaths, FocusHandle, Focusable, Font, KeyContext, KeyDownEvent, Keystroke, MouseButton,
+    MouseDownEvent, Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled, Subscription,
+    Task, TaskExt, WeakEntity, actions, anchored, deferred, div,
 };
 use menu;
 use persistence::TerminalDb;
@@ -25,7 +25,7 @@ use settings::{
 use std::{
     any::Any,
     cmp,
-    ops::Range as StdRange,
+    ops::{Range as StdRange, RangeInclusive},
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -76,6 +76,56 @@ fn viewport_line_for_point(point: Point, display_offset: usize) -> Option<usize>
 }
 
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+
+const KNOWN_TERMINAL_AGENT_COMMANDS: &[&str] = &[
+    "agent", // Cursor CLI and Grok both use this command.
+    "agy",
+    "aider",
+    "amp",
+    "claude",
+    "codex",
+    "copilot",
+    "crush",
+    "devin",
+    "droid",
+    "gemini",
+    "goose",
+    "grok",
+    "openhands",
+    "opencode",
+    "pi",
+    "qwen",
+];
+
+pub fn is_known_terminal_agent_command(command: &str) -> bool {
+    KNOWN_TERMINAL_AGENT_COMMANDS.contains(&command)
+}
+
+pub fn format_terminal_selection_reference(
+    project: &Project,
+    project_path: &project::ProjectPath,
+    line_range: &RangeInclusive<u32>,
+    working_directory: Option<&Path>,
+    cx: &App,
+) -> String {
+    let path_style = project.path_style(cx);
+    let absolute_path = project.absolute_path(project_path, cx);
+    let path = match (absolute_path, working_directory) {
+        (Some(absolute_path), Some(working_directory)) => path_style
+            .strip_prefix(&absolute_path, working_directory)
+            .map(|relative| relative.display(path_style).into_owned())
+            .unwrap_or_else(|| absolute_path.to_string_lossy().into_owned()),
+        (Some(absolute_path), None) => absolute_path.to_string_lossy().into_owned(),
+        (None, _) => project_path.path.display(path_style).into_owned(),
+    };
+    let start_line = line_range.start() + 1;
+    let end_line = line_range.end() + 1;
+    if start_line == end_line {
+        format!("{path}:{start_line}")
+    } else {
+        format!("{path}:{start_line}-{end_line}")
+    }
+}
 
 /// Event to transmit the scroll from the element to the view
 #[derive(Clone, Debug, PartialEq)]
@@ -914,6 +964,30 @@ impl TerminalView {
             return;
         };
 
+        let (foreground_process_command, working_directory) = {
+            let terminal = self.terminal.read(cx);
+            (
+                terminal.foreground_process_command_name(),
+                terminal.working_directory(),
+            )
+        };
+        let selection_reference = self.project.upgrade().and_then(|project| {
+            format_clipboard_selection_for_terminal_agent(
+                &clipboard,
+                foreground_process_command.as_deref(),
+                project.read(cx),
+                working_directory.as_deref(),
+                cx,
+            )
+        });
+
+        if let Some(selection_reference) = selection_reference {
+            self.terminal.update(cx, |terminal, _| {
+                terminal.paste(&selection_reference);
+            });
+            return;
+        }
+
         match clipboard.entries().first() {
             Some(ClipboardEntry::Image(image)) if !image.bytes.is_empty() => {
                 self.forward_ctrl_v(cx);
@@ -1103,6 +1177,42 @@ impl TerminalView {
                 }),
         )
     }
+}
+
+fn format_clipboard_selection_for_terminal_agent(
+    clipboard: &ClipboardItem,
+    foreground_process_command: Option<&str>,
+    project: &Project,
+    working_directory: Option<&Path>,
+    cx: &App,
+) -> Option<String> {
+    if !foreground_process_command.is_some_and(is_known_terminal_agent_command) {
+        return None;
+    }
+
+    let selections = clipboard.entries().iter().find_map(|entry| match entry {
+        ClipboardEntry::String(text) => text.metadata_json::<Vec<editor::ClipboardSelection>>(),
+        _ => None,
+    })?;
+    let [selection] = selections.as_slice() else {
+        return None;
+    };
+    let file_path = selection.file_path.as_deref()?;
+    let line_range = selection.line_range.as_ref()?;
+    if line_range.start() == line_range.end() {
+        return None;
+    }
+    let project_path = project.project_path_for_absolute_path(file_path, cx)?;
+    Some(format!(
+        "{} ",
+        format_terminal_selection_reference(
+            project,
+            &project_path,
+            line_range,
+            working_directory,
+            cx,
+        )
+    ))
 }
 
 fn terminal_rerun_override(task: &TaskId) -> zed_actions::Rerun {
@@ -2170,7 +2280,7 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, VisualTestContext};
+    use gpui::{ClipboardItem, TestAppContext, VisualTestContext};
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
@@ -2187,6 +2297,133 @@ mod tests {
         }
         text.push(' ');
         text
+    }
+
+    #[test]
+    fn test_is_known_terminal_agent_command() {
+        assert!(is_known_terminal_agent_command("claude"));
+        assert!(is_known_terminal_agent_command("codex"));
+        assert!(is_known_terminal_agent_command("opencode"));
+        assert!(!is_known_terminal_agent_command("cargo"));
+        assert!(!is_known_terminal_agent_command("internal-agent"));
+    }
+
+    #[gpui::test]
+    async fn test_format_clipboard_selection_for_terminal_agent(cx: &mut TestAppContext) {
+        let (project, _workspace) = init_test(cx).await;
+        let (worktree, _) = create_folder_wt(project.clone(), "/project", cx).await;
+        let file_entry = create_file_in_worktree(worktree.clone(), "main.rs", cx).await;
+
+        let selection = editor::ClipboardSelection {
+            len: 12,
+            is_entire_line: false,
+            first_line_indent: 0,
+            file_path: Some(PathBuf::from("/project/main.rs")),
+            line_range: Some(9..=41),
+        };
+        let clipboard = ClipboardItem::new_string_with_json_metadata(
+            "selected text".to_string(),
+            vec![selection.clone()],
+        );
+
+        cx.read(|cx| {
+            let project = project.read(cx);
+            let project_path = ProjectPath {
+                worktree_id: worktree.read(cx).id(),
+                path: file_entry.path.clone(),
+            };
+            assert_eq!(
+                format_terminal_selection_reference(
+                    project,
+                    &project_path,
+                    &(4..=4),
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                "main.rs:5"
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                Some("main.rs:10-42 ".to_string())
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/other")),
+                    cx,
+                ),
+                Some("/project/main.rs:10-42 ".to_string())
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &clipboard,
+                    Some("zsh"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                None
+            );
+
+            let single_line_clipboard = ClipboardItem::new_string_with_json_metadata(
+                "selected text".to_string(),
+                vec![editor::ClipboardSelection {
+                    line_range: Some(9..=9),
+                    ..selection.clone()
+                }],
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &single_line_clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                None
+            );
+
+            let multiple_selection_clipboard = ClipboardItem::new_string_with_json_metadata(
+                "selected text".to_string(),
+                vec![selection.clone(), selection.clone()],
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &multiple_selection_clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                None
+            );
+
+            let external_file_clipboard = ClipboardItem::new_string_with_json_metadata(
+                "selected text".to_string(),
+                vec![editor::ClipboardSelection {
+                    file_path: Some(PathBuf::from("/other/main.rs")),
+                    ..selection
+                }],
+            );
+            assert_eq!(
+                format_clipboard_selection_for_terminal_agent(
+                    &external_file_clipboard,
+                    Some("codex"),
+                    project,
+                    Some(Path::new("/project")),
+                    cx,
+                ),
+                None
+            );
+        });
     }
 
     fn assert_drop_writes_to_terminal(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2360,7 +2360,10 @@ mod tests {
                     Some(Path::new("/other")),
                     cx,
                 ),
-                Some("/project/main.rs:10-42 ".to_string())
+                Some(format!(
+                    "{}:10-42 ",
+                    Path::new("/project").join("main.rs").display()
+                ))
             );
             assert_eq!(
                 format_clipboard_selection_for_terminal_agent(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2528,6 +2528,65 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_paste_selection_reference_wiring(cx: &mut TestAppContext) {
+        let (project, _workspace, window_handle) = init_test_with_window(cx).await;
+        let (worktree, _) = create_folder_wt(project.clone(), "/project", cx).await;
+        create_file_in_worktree(worktree, "main.rs", cx).await;
+        let (_pane, terminal, terminal_view) =
+            add_display_only_terminal(&project, window_handle, true, cx);
+
+        let clipboard = ClipboardItem::new_string_with_json_metadata(
+            "selected text".to_string(),
+            vec![editor::ClipboardSelection {
+                len: 12,
+                is_entire_line: false,
+                first_line_indent: 0,
+                file_path: Some(PathBuf::from("/project/main.rs")),
+                line_range: Some(9..=41),
+            }],
+        );
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+            cx.write_to_clipboard(clipboard.clone());
+            terminal.update(cx, |terminal, _| {
+                terminal.set_foreground_process_command_for_test("codex");
+                terminal.take_input_log();
+            });
+            terminal_view.update(cx, |terminal_view, cx| {
+                terminal_view.paste(&Paste, window, cx);
+            });
+            assert_eq!(
+                terminal.update(cx, |terminal, _| terminal.take_input_log()),
+                vec![b"/project/main.rs:10-42 ".to_vec()]
+            );
+
+            terminal.update(cx, |terminal, _| {
+                terminal.set_foreground_process_command_for_test("zsh");
+            });
+            terminal_view.update(cx, |terminal_view, cx| {
+                terminal_view.paste(&Paste, window, cx);
+            });
+            assert_eq!(
+                terminal.update(cx, |terminal, _| terminal.take_input_log()),
+                vec![b"selected text".to_vec()]
+            );
+
+            terminal.update(cx, |terminal, _| {
+                terminal.set_foreground_process_command_for_test("codex");
+            });
+            terminal_view.update(cx, |terminal_view, cx| {
+                terminal_view.paste_text(&PasteText, window, cx);
+            });
+            assert_eq!(
+                terminal.update(cx, |terminal, _| terminal.take_input_log()),
+                vec![b"selected text".to_vec()]
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn shift_up_scrolls_history_in_normal_screen(cx: &mut TestAppContext) {
         let (project, _workspace, window_handle) = init_test_with_window(cx).await;
         cx.update(load_default_keymap);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2393,6 +2393,10 @@ mod tests {
                     Some(vec![expected_reference.to_string()])
                 );
             }
+            let absolute_reference =
+                format!("{}:10-42", Path::new("/project").join("main.rs").display());
+            let expected_absolute_reference = shlex::try_quote(&absolute_reference)
+                .expect("selection reference should be shell-quotable");
             assert_eq!(
                 format_clipboard_selection_for_terminal_agent(
                     &clipboard,
@@ -2401,10 +2405,7 @@ mod tests {
                     Some(Path::new("/other")),
                     cx,
                 ),
-                Some(format!(
-                    "{}:10-42 ",
-                    Path::new("/project").join("main.rs").display()
-                ))
+                Some(format!("{expected_absolute_reference} "))
             );
             assert_eq!(
                 format_clipboard_selection_for_terminal_agent(
@@ -2557,9 +2558,13 @@ mod tests {
             terminal_view.update(cx, |terminal_view, cx| {
                 terminal_view.paste(&Paste, window, cx);
             });
+            let absolute_reference =
+                format!("{}:10-42", Path::new("/project").join("main.rs").display());
+            let expected_absolute_reference = shlex::try_quote(&absolute_reference)
+                .expect("selection reference should be shell-quotable");
             assert_eq!(
                 terminal.update(cx, |terminal, _| terminal.take_input_log()),
-                vec![b"/project/main.rs:10-42 ".to_vec()]
+                vec![format!("{expected_absolute_reference} ").into_bytes()]
             );
 
             terminal.update(cx, |terminal, _| {

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -396,6 +396,7 @@ mod test {
     use indoc::indoc;
     use language::{LanguageName, language_settings::LanguageSettingsContent};
     use settings::{SettingsStore, UseSystemClipboard};
+    use util::path;
 
     #[gpui::test]
     async fn test_paste(cx: &mut gpui::TestAppContext) {
@@ -567,7 +568,7 @@ mod test {
         });
         assert_eq!(
             source_locations,
-            Some(vec![(Some("/root/dir/file.rs".into()), Some(1..=1))])
+            Some(vec![(Some(path!("/root/dir/file.rs").into()), Some(1..=1))])
         );
         cx.simulate_keystrokes("d d p");
         cx.assert_state(

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -391,6 +391,7 @@ mod test {
         state::{Mode, Register},
         test::{NeovimBackedTestContext, VimTestContext},
     };
+    use editor::ClipboardSelection;
     use gpui::ClipboardItem;
     use indoc::indoc;
     use language::{LanguageName, language_settings::LanguageSettingsContent};
@@ -551,6 +552,23 @@ mod test {
             cx.read_from_clipboard().map(|item| item.text().unwrap()),
             Some("jumps".into())
         );
+        let source_locations = cx.read_from_clipboard().and_then(|item| {
+            item.entries().first().and_then(|entry| match entry {
+                gpui::ClipboardEntry::String(text) => text
+                    .metadata_json::<Vec<ClipboardSelection>>()
+                    .map(|selections| {
+                        selections
+                            .into_iter()
+                            .map(|selection| (selection.file_path, selection.line_range))
+                            .collect::<Vec<_>>()
+                    }),
+                _ => None,
+            })
+        });
+        assert_eq!(
+            source_locations,
+            Some(vec![(Some("/root/dir/file.rs".into()), Some(1..=1))])
+        );
         cx.simulate_keystrokes("d d p");
         cx.assert_state(
             indoc! {"
@@ -572,6 +590,36 @@ mod test {
                 test-copˇyfox jjumpsumps over"},
             Mode::Normal,
         );
+    }
+
+    #[gpui::test]
+    async fn test_delete_system_clipboard_omits_source_location(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.vim.get_or_insert_default().use_system_clipboard =
+                    Some(UseSystemClipboard::Always)
+            });
+        });
+
+        cx.set_state("one\ntˇwo\nthree", Mode::Normal);
+        cx.simulate_keystrokes("d d");
+
+        let source_locations = cx.read_from_clipboard().and_then(|item| {
+            item.entries().first().and_then(|entry| match entry {
+                gpui::ClipboardEntry::String(text) => text
+                    .metadata_json::<Vec<ClipboardSelection>>()
+                    .map(|selections| {
+                        selections
+                            .into_iter()
+                            .map(|selection| (selection.file_path, selection.line_range))
+                            .collect::<Vec<_>>()
+                    }),
+                _ => None,
+            })
+        });
+        assert_eq!(source_locations, Some(vec![(None, None)]));
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -200,7 +200,7 @@ impl Vim {
                     false,
                     start..end,
                     &buffer,
-                    editor.project(),
+                    if is_yank { editor.project() } else { None },
                     cx,
                 ));
             }

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -7,7 +7,7 @@ use crate::{
     state::{Mode, Register},
 };
 use collections::HashMap;
-use editor::{ClipboardSelection, Editor, HighlightKey, SelectionEffects};
+use editor::{ClipboardSelection, ClipboardTextSource, Editor, HighlightKey, SelectionEffects};
 use gpui::Context;
 use gpui::Window;
 use language::Point;
@@ -200,7 +200,13 @@ impl Vim {
                     false,
                     start..end,
                     &buffer,
-                    if is_yank { editor.project() } else { None },
+                    if is_yank {
+                        ClipboardTextSource::Existing {
+                            project: editor.project(),
+                        }
+                    } else {
+                        ClipboardTextSource::Removed
+                    },
                     cx,
                 ));
             }


### PR DESCRIPTION
When a supported terminal agent is the foreground process, pasting a single multi-line selection from a project file inserts a reference such as `src/main.rs:10-42`. The path is relative to the terminal's working directory when possible and absolute otherwise.

All other clipboard content follows the existing paste behavior. "Paste Text" inserts the original text, and Linux now binds it to `ctrl-alt-v`, matching the existing raw-paste shortcut on Windows.

Single-line selection in a terminal agent:
<img width="637" height="76" alt="Single-line selection pasted into a terminal agent" src="https://github.com/user-attachments/assets/767f2245-c604-4d08-a03b-d9fce011c8e6" />

Multi-line selection in a terminal agent:
<img width="652" height="79" alt="Multi-line selection pasted into a terminal agent as a file and line reference" src="https://github.com/user-attachments/assets/0cd5664e-adc3-4a79-8994-1e17d45f4297" />

Paste in a regular terminal:
<img width="655" height="109" alt="Selection pasted as text into a regular terminal" src="https://github.com/user-attachments/assets/3ad5cd1c-444a-4805-9748-412914ac9ac9" />

Release Notes:

- Added file and line references when pasting multi-line editor selections into terminal agents.