### PR TITLE
editor: Speed up conflict block insertion

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1039,6 +1039,29 @@ impl DisplayMap {
     }
 
     #[instrument(skip_all)]
+    pub fn insert_above_blocks(
+        &mut self,
+        blocks: impl IntoIterator<Item = BlockProperties<Anchor>>,
+        cx: &mut Context<Self>,
+    ) -> Vec<CustomBlockId> {
+        let (self_wrap_snapshot, self_wrap_edits) = self.sync_through_wrap(cx);
+        Self::with_synced_companion_mut(
+            self.entity_id,
+            &self.companion,
+            cx,
+            |companion_view, _cx| {
+                self.block_map
+                    .write(
+                        self_wrap_snapshot.clone(),
+                        self_wrap_edits.clone(),
+                        companion_view,
+                    )
+                    .insert_above_blocks(blocks)
+            },
+        )
+    }
+
+    #[instrument(skip_all)]
     pub fn resize_blocks(&mut self, heights: HashMap<CustomBlockId, u32>, cx: &mut Context<Self>) {
         let (self_wrap_snapshot, self_wrap_edits) = self.sync_through_wrap(cx);
 

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -71,6 +71,14 @@ struct BlockMapInverseWriter<'a> {
     companion_writer: Box<BlockMapWriter<'a>>,
 }
 
+struct PreparedAboveInsertion {
+    ids: Vec<CustomBlockId>,
+    blocks: Vec<Arc<CustomBlock>>,
+    blocks_by_id: TreeMap<CustomBlockId, Arc<CustomBlock>>,
+    transforms: SumTree<Transform>,
+    next_block_id: usize,
+}
+
 #[derive(Clone)]
 pub struct BlockSnapshot {
     pub(super) wrap_snapshot: WrapSnapshot,
@@ -755,6 +763,13 @@ impl BlockMap {
             block_map: self,
             companion,
         }
+    }
+
+    fn apply_prepared_above_insertion(&mut self, prepared: PreparedAboveInsertion) {
+        self.custom_blocks = prepared.blocks;
+        self.custom_blocks_by_id = prepared.blocks_by_id;
+        *self.transforms.get_mut() = prepared.transforms;
+        self.next_block_id.store(prepared.next_block_id, SeqCst);
     }
 
     // Warning: doesn't sync the block map, use advisedly
@@ -1680,6 +1695,19 @@ fn push_isomorphic(tree: &mut SumTree<Transform>, rows: RowDelta, wrap_snapshot:
     }
 }
 
+fn above_custom_transform(block: Arc<CustomBlock>) -> Transform {
+    Transform {
+        summary: TransformSummary {
+            input_rows: WrapRow(0),
+            output_rows: BlockRow(block.height.unwrap_or(0)),
+            longest_row: BlockRow(0),
+            longest_row_chars: 0,
+            has_replacement_blocks: false,
+        },
+        block: Some(Block::Custom(block)),
+    }
+}
+
 impl BlockPoint {
     pub fn new(row: BlockRow, column: u32) -> Self {
         Self(Point::new(row.0, column))
@@ -1817,6 +1845,359 @@ impl BlockMapWriter<'_> {
         &mut self,
         blocks: impl IntoIterator<Item = BlockProperties<Anchor>>,
     ) -> Vec<CustomBlockId> {
+        self.insert_generic(blocks.into_iter().collect())
+    }
+
+    pub fn insert_above_blocks(
+        &mut self,
+        blocks: impl IntoIterator<Item = BlockProperties<Anchor>>,
+    ) -> Vec<CustomBlockId> {
+        let blocks = blocks.into_iter().collect::<Vec<_>>();
+        if blocks.is_empty() {
+            return Vec::new();
+        }
+        let companion_blocks = match self.companion.as_ref() {
+            Some(companion) if companion.inverse.is_some() => {
+                let wrap_snapshot = self.block_map.wrap_snapshot.borrow();
+                let buffer = wrap_snapshot.buffer_snapshot();
+                Some(
+                    blocks
+                        .iter()
+                        .map(|block| {
+                            balancing_block(
+                                block,
+                                buffer,
+                                companion.companion_wrap_snapshot.buffer(),
+                                companion.display_map_id,
+                                companion.companion,
+                            )
+                        })
+                        .collect::<Option<Vec<_>>>(),
+                )
+            }
+            _ => None,
+        };
+        let companion_blocks = match companion_blocks {
+            Some(Some(companion_blocks)) if companion_blocks.len() == blocks.len() => {
+                Some(companion_blocks)
+            }
+            Some(_) => return self.insert_generic(blocks),
+            None => None,
+        };
+
+        if !self.can_insert_above_blocks(&blocks)
+            || companion_blocks.as_ref().is_some_and(|companion_blocks| {
+                self.companion
+                    .as_ref()
+                    .and_then(|companion| companion.inverse.as_ref())
+                    .is_none_or(|inverse| {
+                        !inverse
+                            .companion_writer
+                            .can_insert_above_blocks(companion_blocks)
+                    })
+            })
+        {
+            return self.insert_generic(blocks);
+        }
+
+        let Some(prepared) = self.prepare_above_blocks(&blocks) else {
+            return self.insert_generic(blocks);
+        };
+        let companion_prepared = match companion_blocks.as_ref() {
+            Some(companion_blocks) => {
+                let Some(inverse) = self
+                    .companion
+                    .as_ref()
+                    .and_then(|companion| companion.inverse.as_ref())
+                else {
+                    return self.insert_generic(blocks);
+                };
+                let Some(prepared) = inverse
+                    .companion_writer
+                    .prepare_above_blocks(companion_blocks)
+                else {
+                    return self.insert_generic(blocks);
+                };
+                if prepared.ids.len() != blocks.len() {
+                    return self.insert_generic(blocks);
+                }
+                Some(prepared)
+            }
+            None => None,
+        };
+
+        let ids = prepared.ids.clone();
+        if let Some(companion_prepared) = companion_prepared {
+            let companion_ids = companion_prepared.ids.clone();
+            let Some(companion) = &mut self.companion else {
+                return self.insert_generic(blocks);
+            };
+            let Some(inverse) = &mut companion.inverse else {
+                return self.insert_generic(blocks);
+            };
+            let balancing_blocks = companion
+                .companion
+                .custom_block_to_balancing_block(companion.display_map_id);
+            // Acquire this before publishing either map so a borrow violation cannot leave the
+            // primary and companion states only partially committed.
+            let mut balancing_blocks = balancing_blocks.borrow_mut();
+            let mut prepared_balancing_blocks = balancing_blocks.clone();
+            prepared_balancing_blocks.extend(ids.iter().copied().zip(companion_ids));
+
+            self.block_map.apply_prepared_above_insertion(prepared);
+            inverse
+                .companion_writer
+                .block_map
+                .apply_prepared_above_insertion(companion_prepared);
+            *balancing_blocks = prepared_balancing_blocks;
+        } else {
+            self.block_map.apply_prepared_above_insertion(prepared);
+        }
+        ids
+    }
+
+    fn can_insert_above_blocks(&self, blocks: &[BlockProperties<Anchor>]) -> bool {
+        let wrap_snapshot = self.block_map.wrap_snapshot.borrow();
+        let buffer = wrap_snapshot.buffer_snapshot();
+        let Some(mut rows) = blocks
+            .iter()
+            .map(|block| {
+                let BlockPlacement::Above(anchor) = &block.placement else {
+                    return None;
+                };
+                let point = anchor.to_point(buffer);
+                if wrap_snapshot.intersects_fold(Point::new(point.row, 0)) {
+                    return None;
+                }
+                Some(
+                    wrap_snapshot
+                        .make_wrap_point(Point::new(point.row, 0), Bias::Left)
+                        .row(),
+                )
+            })
+            .collect::<Option<Vec<_>>>()
+        else {
+            return false;
+        };
+        rows.sort_unstable();
+        rows.dedup();
+        if self.block_map.transforms.borrow().summary().input_rows
+            != wrap_snapshot.max_point().row() + WrapRow(1)
+        {
+            return false;
+        }
+
+        let transforms = self.block_map.transforms.borrow();
+        let mut cursor = transforms.cursor::<WrapRow>(());
+        let Some(first_row) = rows.first() else {
+            return true;
+        };
+        let last_row = rows.last().copied().unwrap_or(*first_row);
+        cursor.seek(first_row, Bias::Left);
+        while let Some(transform) = cursor.item() {
+            if *cursor.start() > last_row {
+                break;
+            }
+            if transform.block.as_ref().is_some_and(Block::is_replacement) {
+                let start = *cursor.start();
+                let end = start + transform.summary.input_rows;
+                let row_index = rows.partition_point(|row| *row < start);
+                if rows.get(row_index).is_some_and(|row| *row < end) {
+                    return false;
+                }
+            }
+            // Same-row Above blocks require a priority merge, and Near blocks must move after the
+            // new Above blocks. Leave both order-sensitive cases to the generic rebuild.
+            if let Some(Block::Custom(block)) = transform.block.as_ref() {
+                match block.placement.to_wrap_row(&wrap_snapshot) {
+                    Some(BlockPlacement::Above(row) | BlockPlacement::Near(row))
+                        if rows.binary_search(&row).is_ok() =>
+                    {
+                        return false;
+                    }
+                    _ => {}
+                }
+            }
+            cursor.next();
+        }
+        true
+    }
+
+    fn prepare_above_blocks(
+        &self,
+        blocks: &[BlockProperties<Anchor>],
+    ) -> Option<PreparedAboveInsertion> {
+        let wrap_snapshot = self.block_map.wrap_snapshot.borrow().clone();
+        let buffer = wrap_snapshot.buffer_snapshot();
+        let mut ids = Vec::with_capacity(blocks.len());
+        let mut custom_blocks = Vec::with_capacity(blocks.len());
+        let mut additions = Vec::with_capacity(blocks.len());
+        let first_block_id = self.block_map.next_block_id.load(SeqCst);
+        let next_block_id = first_block_id.checked_add(blocks.len())?;
+        for (index, block) in blocks.iter().enumerate() {
+            let BlockPlacement::Above(anchor) = &block.placement else {
+                return None;
+            };
+            let point = anchor.to_point(buffer);
+            let wrap_row = wrap_snapshot
+                .make_wrap_point(Point::new(point.row, 0), Bias::Left)
+                .row();
+            let id = CustomBlockId(first_block_id + index);
+            let custom_block = Arc::new(CustomBlock {
+                id,
+                placement: block.placement.clone(),
+                height: block.height,
+                style: block.style,
+                render: Arc::new(Mutex::new(block.render.clone())),
+                priority: block.priority,
+            });
+            ids.push(id);
+            custom_blocks.push(custom_block.clone());
+            additions.push((wrap_row, custom_block));
+        }
+        additions.sort_unstable_by(|(row_a, block_a), (row_b, block_b)| {
+            row_a
+                .cmp(row_b)
+                .then_with(|| block_a.priority.cmp(&block_b.priority))
+                .then_with(|| block_a.id.cmp(&block_b.id))
+        });
+
+        let transforms = self.block_map.transforms.borrow();
+        let mut cursor = transforms.cursor::<WrapRow>(());
+        let mut new_transforms = SumTree::default();
+        let mut addition_index = 0;
+
+        while let Some((addition_row, _)) = additions.get(addition_index) {
+            new_transforms.append(cursor.slice(addition_row, Bias::Left), ());
+            let cursor_start = *cursor.start();
+            let transform = cursor.item()?;
+            let cursor_end = cursor_start + transform.summary.input_rows;
+
+            if cursor_end <= *addition_row {
+                new_transforms.push(transform.clone(), ());
+                cursor.next();
+                continue;
+            }
+
+            if cursor_start < *addition_row {
+                if transform.block.is_some() {
+                    return None;
+                }
+                let mut segment_start = cursor_start;
+                while let Some((row, _)) = additions.get(addition_index)
+                    && *row < cursor_end
+                {
+                    push_isomorphic(&mut new_transforms, *row - segment_start, &wrap_snapshot);
+                    let row = *row;
+                    while additions
+                        .get(addition_index)
+                        .is_some_and(|(addition_row, _)| *addition_row == row)
+                    {
+                        new_transforms.push(
+                            above_custom_transform(additions[addition_index].1.clone()),
+                            (),
+                        );
+                        addition_index += 1;
+                    }
+                    segment_start = row;
+                }
+                push_isomorphic(
+                    &mut new_transforms,
+                    cursor_end - segment_start,
+                    &wrap_snapshot,
+                );
+                cursor.next();
+                continue;
+            }
+
+            while let Some(transform) = cursor.item()
+                && transform.summary.input_rows == WrapRow(0)
+            {
+                if let Some(Block::Custom(existing_block)) = transform.block.as_ref()
+                    && matches!(
+                        existing_block.placement.to_wrap_row(&wrap_snapshot),
+                        Some(BlockPlacement::Above(row)) if row == *addition_row
+                    )
+                {
+                    while let Some((row, new_block)) = additions.get(addition_index)
+                        && *row == *addition_row
+                        && (new_block.priority, new_block.id)
+                            < (existing_block.priority, existing_block.id)
+                    {
+                        new_transforms.push(above_custom_transform(new_block.clone()), ());
+                        addition_index += 1;
+                    }
+                }
+                new_transforms.push(transform.clone(), ());
+                cursor.next();
+            }
+            while additions
+                .get(addition_index)
+                .is_some_and(|(row, _)| *row == *addition_row)
+            {
+                new_transforms.push(
+                    above_custom_transform(additions[addition_index].1.clone()),
+                    (),
+                );
+                addition_index += 1;
+            }
+        }
+
+        new_transforms.append(cursor.suffix(), ());
+        if addition_index != additions.len()
+            || new_transforms.summary().input_rows != wrap_snapshot.max_point().row() + WrapRow(1)
+        {
+            return None;
+        }
+        let mut blocks_by_id = self.block_map.custom_blocks_by_id.clone();
+        for block in &custom_blocks {
+            blocks_by_id.insert(block.id, block.clone());
+        }
+        custom_blocks.sort_unstable_by(|block_a, block_b| {
+            block_a
+                .placement
+                .cmp(&block_b.placement, buffer)
+                .then_with(|| block_a.id.cmp(&block_b.id))
+        });
+        let mut existing_blocks = self.block_map.custom_blocks.iter().cloned().peekable();
+        let mut added_blocks = custom_blocks.into_iter().peekable();
+        let mut merged_blocks =
+            Vec::with_capacity(self.block_map.custom_blocks.len() + blocks.len());
+        loop {
+            match (existing_blocks.peek(), added_blocks.peek()) {
+                (Some(existing), Some(added))
+                    if existing.placement.cmp(&added.placement, buffer).is_le() =>
+                {
+                    if let Some(existing) = existing_blocks.next() {
+                        merged_blocks.push(existing);
+                    }
+                }
+                (Some(_), Some(_)) => {
+                    if let Some(added) = added_blocks.next() {
+                        merged_blocks.push(added);
+                    }
+                }
+                (Some(_), None) => {
+                    merged_blocks.extend(existing_blocks);
+                    break;
+                }
+                (None, Some(_)) => {
+                    merged_blocks.extend(added_blocks);
+                    break;
+                }
+                (None, None) => break,
+            }
+        }
+        Some(PreparedAboveInsertion {
+            ids,
+            blocks: merged_blocks,
+            blocks_by_id,
+            transforms: new_transforms,
+            next_block_id,
+        })
+    }
+
+    fn insert_generic(&mut self, blocks: Vec<BlockProperties<Anchor>>) -> Vec<CustomBlockId> {
         let blocks = blocks.into_iter();
         let mut ids = Vec::with_capacity(blocks.size_hint().1.unwrap_or(0));
         let mut edits = Patch::default();
@@ -3228,6 +3609,187 @@ mod tests {
             HashSet::from_iter([block_a, block_d]),
             "blocks B and C anchored to folded lines are dropped, A (fold-start line) and D (past the fold) stay",
         );
+    }
+
+    #[gpui::test]
+    fn test_insert_above_blocks_matches_generic_insertion(cx: &mut gpui::TestAppContext) {
+        cx.update(init_test);
+
+        let buffer = cx.update(|cx| MultiBuffer::build_simple("aaa\nbbb\nccc\nddd", cx));
+        let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot(cx));
+        let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
+        let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
+        let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
+        let (_, wraps_snapshot) =
+            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let blocks = [
+            (Point::new(3, 3), 3, 1),
+            (Point::new(1, 0), 2, 2),
+            (Point::new(1, 2), 1, 0),
+            (Point::new(0, 0), 1, 1),
+        ]
+        .map(|(point, height, priority)| BlockProperties {
+            style: BlockStyle::Sticky,
+            placement: BlockPlacement::Above(buffer_snapshot.anchor_after(point)),
+            height: Some(height),
+            render: Arc::new(|_| div().into_any()),
+            priority,
+        });
+        let existing_blocks = [BlockProperties {
+            style: BlockStyle::Fixed,
+            placement: BlockPlacement::Below(buffer_snapshot.anchor_after(Point::new(0, 0))),
+            height: Some(1),
+            render: Arc::new(|_| div().into_any()),
+            priority: 0,
+        }];
+
+        let mut generic_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+        generic_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert(existing_blocks.clone());
+        let generic_ids = generic_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert(blocks.clone());
+        let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
+
+        let mut specialized_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+        specialized_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert(existing_blocks);
+        let specialized_ids = {
+            let mut writer =
+                specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
+            assert!(writer.can_insert_above_blocks(&blocks));
+            writer.insert_above_blocks(blocks)
+        };
+        let specialized_snapshot =
+            specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
+
+        assert_eq!(specialized_ids, generic_ids);
+        assert_block_snapshots_eq(
+            &specialized_snapshot,
+            &generic_snapshot,
+            wraps_snapshot.max_point().row(),
+        );
+
+        let additional_block = BlockProperties {
+            style: BlockStyle::Sticky,
+            placement: BlockPlacement::Above(buffer_snapshot.anchor_after(Point::new(1, 0))),
+            height: Some(1),
+            render: Arc::new(|_| div().into_any()),
+            priority: 1,
+        };
+        generic_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert([additional_block.clone()]);
+        {
+            let mut writer =
+                specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
+            assert!(!writer.can_insert_above_blocks(std::slice::from_ref(&additional_block)));
+            writer.insert_above_blocks([additional_block]);
+        }
+        let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
+        let specialized_snapshot =
+            specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
+        assert_block_snapshots_eq(
+            &specialized_snapshot,
+            &generic_snapshot,
+            wraps_snapshot.max_point().row(),
+        );
+    }
+
+    #[gpui::test]
+    fn test_insert_above_blocks_falls_back_at_replacement_start(cx: &mut gpui::TestAppContext) {
+        cx.update(init_test);
+
+        let buffer = cx.update(|cx| MultiBuffer::build_simple("aaa\nbbb\nccc\nddd", cx));
+        let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot(cx));
+        let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
+        let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
+        let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
+        let (_, wraps_snapshot) =
+            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let replacement = BlockProperties {
+            style: BlockStyle::Fixed,
+            placement: BlockPlacement::Replace(
+                buffer_snapshot.anchor_after(Point::new(2, 0))
+                    ..=buffer_snapshot.anchor_before(Point::new(2, 3)),
+            ),
+            height: Some(1),
+            render: Arc::new(|_| div().into_any()),
+            priority: 0,
+        };
+        let blocks = [
+            BlockProperties {
+                style: BlockStyle::Sticky,
+                placement: BlockPlacement::Above(buffer_snapshot.anchor_after(Point::new(2, 0))),
+                height: Some(2),
+                render: Arc::new(|_| div().into_any()),
+                priority: 1,
+            },
+            BlockProperties {
+                style: BlockStyle::Sticky,
+                placement: BlockPlacement::Above(buffer_snapshot.anchor_after(Point::new(3, 0))),
+                height: Some(3),
+                render: Arc::new(|_| div().into_any()),
+                priority: 0,
+            },
+        ];
+
+        let mut generic_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+        generic_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert([replacement.clone()]);
+        let generic_ids = generic_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert(blocks.clone());
+        let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
+
+        let mut specialized_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+        specialized_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert([replacement]);
+        let specialized_ids = {
+            let mut writer =
+                specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
+            assert!(!writer.can_insert_above_blocks(&blocks));
+            writer.insert_above_blocks(blocks)
+        };
+        let specialized_snapshot =
+            specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
+
+        assert_eq!(specialized_ids, generic_ids);
+        assert_block_snapshots_eq(
+            &specialized_snapshot,
+            &generic_snapshot,
+            wraps_snapshot.max_point().row(),
+        );
+    }
+
+    fn assert_block_snapshots_eq(
+        actual: &BlockSnapshot,
+        expected: &BlockSnapshot,
+        max_wrap_row: WrapRow,
+    ) {
+        assert_eq!(actual.text(), expected.text());
+        assert_eq!(actual.max_point(), expected.max_point());
+        for row in 0..=max_wrap_row.0 {
+            let point = WrapPoint::new(WrapRow(row), 0);
+            assert_eq!(
+                actual.to_block_point(point),
+                expected.to_block_point(point),
+                "different mapping for wrap row {row}"
+            );
+        }
+        let actual_blocks = actual
+            .blocks_in_range(BlockRow(0)..actual.max_point().row() + BlockRow(1))
+            .map(|(row, block)| (row, block.id()))
+            .collect::<Vec<_>>();
+        let expected_blocks = expected
+            .blocks_in_range(BlockRow(0)..expected.max_point().row() + BlockRow(1))
+            .map(|(row, block)| (row, block.id()))
+            .collect::<Vec<_>>();
+        assert_eq!(actual_blocks, expected_blocks);
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -3615,93 +3615,161 @@ mod tests {
     fn test_insert_above_blocks_matches_generic_insertion(
         cx: &mut gpui::TestAppContext,
         #[strategy = proptest::collection::vec(
-            (0u32..8, 0u32..4, proptest::option::of(0u32..5), 0usize..4),
+            (0usize..20, 0u32..4, proptest::option::of(0u32..5), 0usize..4),
             1..24,
         )]
-        additions: Vec<(u32, u32, Option<u32>, usize)>,
+        additions: Vec<(usize, u32, Option<u32>, usize)>,
         #[strategy = proptest::collection::vec(
-            (0u32..8, proptest::bool::ANY, proptest::option::of(0u32..5), 0usize..4),
+            (0usize..8, proptest::bool::ANY, proptest::option::of(0u32..5), 0usize..4),
             0..16,
         )]
-        existing: Vec<(u32, bool, Option<u32>, usize)>,
+        existing: Vec<(usize, bool, Option<u32>, usize)>,
+        #[strategy = proptest::collection::vec(
+            (1usize..4, 1usize..4),
+            4,
+        )]
+        hunk_lengths: Vec<(usize, usize)>,
     ) {
         cx.update(init_test);
 
-        let text = vec!["aaa"; 16].join("\n");
-        let buffer = cx.new(|cx| Buffer::local(&text, cx));
-        let diff = cx.new(|cx| {
-            BufferDiff::new_with_base_text(
-                &format!("deleted\n{text}"),
-                &buffer.read(cx).text_snapshot(),
-                cx,
-            )
-        });
-        let base_buffer = diff.read_with(cx, |diff, _| diff.base_text_buffer().clone());
-        let multibuffer = cx.new(|cx| {
-            let mut multibuffer = MultiBuffer::new(Capability::ReadWrite);
-            multibuffer.set_excerpts_for_buffer(
-                buffer.clone(),
-                [Point::zero()..buffer.read(cx).max_point()],
-                0,
-                cx,
-            );
-            multibuffer.add_diff(diff.clone(), cx);
-            multibuffer
-        });
-        let companion_multibuffer = cx.new(|cx| {
-            let mut multibuffer = MultiBuffer::new(Capability::ReadWrite);
-            multibuffer.set_excerpts_for_buffer(
-                base_buffer.clone(),
-                [Point::zero()..base_buffer.read(cx).max_point()],
-                0,
-                cx,
-            );
-            multibuffer.add_inverted_diff(diff.clone(), buffer.clone(), cx);
-            multibuffer
-        });
+        let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));
+        let companion_multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));
+        let mut insertion_points = Vec::new();
+        let mut existing_points = Vec::new();
+        for (file, sections) in hunk_lengths.chunks_exact(2).enumerate() {
+            let mut lines = Vec::new();
+            let mut base_lines = Vec::new();
+            let mut ranges = Vec::new();
+            let mut base_ranges = Vec::new();
+            let mut insertion_rows = Vec::new();
+            let mut existing_rows = Vec::new();
+            for (section, &(deleted, inserted)) in sections.iter().enumerate() {
+                let start = lines.len();
+                let base_start = base_lines.len();
+                let common = |line| format!("file {file} section {section} common {line}");
+                lines.extend([common(0), common(1), common(2), common(3)]);
+                base_lines.extend([common(0), common(1)]);
+                base_lines.extend(
+                    (0..deleted)
+                        .map(|line| format!("file {file} section {section} deleted {line}")),
+                );
+                base_lines.extend([common(2), common(3), common(4), common(5)]);
+                lines.extend(
+                    (0..inserted)
+                        .map(|line| format!("file {file} section {section} inserted {line}")),
+                );
+                lines.extend([common(4), common(5)]);
+                ranges.push(
+                    Point::new(start as u32, 0)
+                        ..Point::new((lines.len() - 1) as u32, common(5).len() as u32),
+                );
+                base_ranges.push(
+                    Point::new(base_start as u32, 0)
+                        ..Point::new((base_lines.len() - 1) as u32, common(5).len() as u32),
+                );
+                // Exercise excerpt starts, deletion spacers, and inserted rows that collapse to
+                // the same companion position. Keep preexisting blocks on separate common rows.
+                insertion_rows.extend([
+                    start,
+                    start + 2,
+                    start + 4,
+                    start + 4 + inserted - 1,
+                    start + 4 + inserted,
+                ]);
+                existing_rows.extend([start + 1, start + 5 + inserted]);
+                for gap in 0..2 {
+                    let line = format!("file {file} section {section} omitted {gap}");
+                    lines.push(line.clone());
+                    base_lines.push(line);
+                }
+            }
+            let buffer = cx.new(|cx| Buffer::local(lines.join("\n"), cx));
+            let diff = cx.new(|cx| {
+                BufferDiff::new_with_base_text(
+                    &base_lines.join("\n"),
+                    &buffer.read(cx).text_snapshot(),
+                    cx,
+                )
+            });
+            diff.read_with(cx, |diff, cx| {
+                assert_eq!(
+                    diff.snapshot(cx)
+                        .hunks(&buffer.read(cx).text_snapshot())
+                        .count(),
+                    4,
+                );
+            });
+            let base_buffer = diff.read_with(cx, |diff, _| diff.base_text_buffer().clone());
+            multibuffer.update(cx, |multibuffer, cx| {
+                multibuffer.set_excerpts_for_buffer(buffer.clone(), ranges, 0, cx);
+                multibuffer.add_diff(diff.clone(), cx);
+            });
+            companion_multibuffer.update(cx, |multibuffer, cx| {
+                multibuffer.set_excerpts_for_buffer(base_buffer, base_ranges, 0, cx);
+                multibuffer.add_inverted_diff(diff, buffer.clone(), cx);
+            });
+            insertion_points.extend(insertion_rows.into_iter().map(|row| (buffer.clone(), row)));
+            existing_points.extend(existing_rows.into_iter().map(|row| (buffer.clone(), row)));
+        }
         let buffer_snapshot = cx.update(|cx| multibuffer.read(cx).snapshot(cx));
+        assert_eq!(buffer_snapshot.excerpts().count(), 4);
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
         let (_, wraps_snapshot) =
             cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
         let companion_buffer_snapshot = cx.update(|cx| companion_multibuffer.read(cx).snapshot(cx));
+        assert_eq!(companion_buffer_snapshot.excerpts().count(), 4);
         let (_, inlay_snapshot) = InlayMap::new(companion_buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
         let (_, companion_wraps_snapshot) =
             cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
-        // Separate existing Above blocks from new ones so every generated case exercises the fast
-        // path, rather than passing only because it fell back to generic insertion.
-        let blocks = additions
-            .into_iter()
-            .map(|(row, column, height, priority)| BlockProperties {
-                style: BlockStyle::Sticky,
-                placement: BlockPlacement::Above(
-                    buffer_snapshot.anchor_after(Point::new(row * 2, column)),
-                ),
-                height,
-                render: Arc::new(|_| div().into_any()),
-                priority,
-            })
-            .collect::<Vec<_>>();
-        let existing_blocks = existing
-            .into_iter()
-            .map(|(row, above, height, priority)| {
-                let anchor = buffer_snapshot.anchor_after(Point::new(row * 2 + 1, 0));
-                BlockProperties {
-                    style: BlockStyle::Fixed,
-                    placement: if above {
-                        BlockPlacement::Above(anchor)
-                    } else {
-                        BlockPlacement::Below(anchor)
-                    },
-                    height,
-                    render: Arc::new(|_| div().into_any()),
-                    priority,
-                }
-            })
-            .collect::<Vec<_>>();
+        let blocks = cx.update(|cx| {
+            additions
+                .into_iter()
+                .map(|(index, column, height, priority)| {
+                    let (buffer, row) = &insertion_points[index];
+                    let anchor = buffer
+                        .read(cx)
+                        .anchor_after(Point::new(*row as u32, column));
+                    BlockProperties {
+                        style: BlockStyle::Sticky,
+                        placement: BlockPlacement::Above(
+                            buffer_snapshot
+                                .anchor_in_excerpt(anchor)
+                                .expect("included row"),
+                        ),
+                        height,
+                        render: Arc::new(|_| div().into_any()),
+                        priority,
+                    }
+                })
+                .collect::<Vec<_>>()
+        });
+        let existing_blocks = cx.update(|cx| {
+            existing
+                .into_iter()
+                .map(|(index, above, height, priority)| {
+                    let (buffer, row) = &existing_points[index];
+                    let anchor = buffer.read(cx).anchor_after(Point::new(*row as u32, 0));
+                    let anchor = buffer_snapshot
+                        .anchor_in_excerpt(anchor)
+                        .expect("included row");
+                    BlockProperties {
+                        style: BlockStyle::Fixed,
+                        placement: if above {
+                            BlockPlacement::Above(anchor)
+                        } else {
+                            BlockPlacement::Below(anchor)
+                        },
+                        height,
+                        render: Arc::new(|_| div().into_any()),
+                        priority,
+                    }
+                })
+                .collect::<Vec<_>>()
+        });
 
         let additional_block = BlockProperties {
             style: BlockStyle::Sticky,
@@ -3837,10 +3905,12 @@ mod tests {
                         )),
                     )
                     .snapshot;
-                assert!(
+                assert_eq!(
                     snapshot
                         .blocks_in_range(BlockRow(0)..snapshot.max_point().row() + BlockRow(1))
-                        .any(|(_, block)| matches!(block, Block::Spacer { .. }))
+                        .filter(|(_, block)| matches!(block, Block::Spacer { .. }))
+                        .count(),
+                    4,
                 );
                 let companion_snapshot = companion_block_map
                     .read(
@@ -3854,6 +3924,15 @@ mod tests {
                         )),
                     )
                     .snapshot;
+                assert_eq!(
+                    companion_snapshot
+                        .blocks_in_range(
+                            BlockRow(0)..companion_snapshot.max_point().row() + BlockRow(1)
+                        )
+                        .filter(|(_, block)| matches!(block, Block::Spacer { .. }))
+                        .count(),
+                    4,
+                );
                 results.push([(snapshot, ids.clone()), (companion_snapshot, companion_ids)]);
             }
             results

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -3611,7 +3611,10 @@ mod tests {
         );
     }
 
-    #[gpui::property_test]
+    #[gpui::property_test(config = proptest::test_runner::Config {
+        cases: 32,
+        ..Default::default()
+    })]
     fn test_insert_above_blocks_matches_generic_insertion(
         cx: &mut gpui::TestAppContext,
         #[strategy = proptest::collection::vec(

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -3628,12 +3628,48 @@ mod tests {
         cx.update(init_test);
 
         let text = vec!["aaa"; 16].join("\n");
-        let buffer = cx.update(|cx| MultiBuffer::build_simple(&text, cx));
-        let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot(cx));
+        let buffer = cx.new(|cx| Buffer::local(&text, cx));
+        let diff = cx.new(|cx| {
+            BufferDiff::new_with_base_text(
+                &format!("deleted\n{text}"),
+                &buffer.read(cx).text_snapshot(),
+                cx,
+            )
+        });
+        let base_buffer = diff.read_with(cx, |diff, _| diff.base_text_buffer().clone());
+        let multibuffer = cx.new(|cx| {
+            let mut multibuffer = MultiBuffer::new(Capability::ReadWrite);
+            multibuffer.set_excerpts_for_buffer(
+                buffer.clone(),
+                [Point::zero()..buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multibuffer.add_diff(diff.clone(), cx);
+            multibuffer
+        });
+        let companion_multibuffer = cx.new(|cx| {
+            let mut multibuffer = MultiBuffer::new(Capability::ReadWrite);
+            multibuffer.set_excerpts_for_buffer(
+                base_buffer.clone(),
+                [Point::zero()..base_buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multibuffer.add_inverted_diff(diff.clone(), buffer.clone(), cx);
+            multibuffer
+        });
+        let buffer_snapshot = cx.update(|cx| multibuffer.read(cx).snapshot(cx));
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
         let (_, wraps_snapshot) =
+            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let companion_buffer_snapshot = cx.update(|cx| companion_multibuffer.read(cx).snapshot(cx));
+        let (_, inlay_snapshot) = InlayMap::new(companion_buffer_snapshot.clone());
+        let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
+        let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
+        let (_, companion_wraps_snapshot) =
             cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
         // Separate existing Above blocks from new ones so every generated case exercises the fast
         // path, rather than passing only because it fell back to generic insertion.
@@ -3667,57 +3703,6 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let mut generic_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
-        generic_map
-            .write(wraps_snapshot.clone(), Default::default(), None)
-            .insert(existing_blocks.clone());
-        let generic_ids = generic_map
-            .write(wraps_snapshot.clone(), Default::default(), None)
-            .insert(blocks.clone());
-        let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
-
-        let mut individual_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
-        individual_map
-            .write(wraps_snapshot.clone(), Default::default(), None)
-            .insert(existing_blocks.clone());
-        let mut individual_ids = Vec::new();
-        for block in &blocks {
-            individual_ids.extend(
-                individual_map
-                    .write(wraps_snapshot.clone(), Default::default(), None)
-                    .insert([block.clone()]),
-            );
-        }
-        let individual_snapshot =
-            individual_map.read(wraps_snapshot.clone(), Default::default(), None);
-
-        let mut specialized_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
-        specialized_map
-            .write(wraps_snapshot.clone(), Default::default(), None)
-            .insert(existing_blocks);
-        let specialized_ids = {
-            let mut writer =
-                specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
-            assert!(writer.can_insert_above_blocks(&blocks));
-            assert!(writer.prepare_above_blocks(&blocks).is_some());
-            writer.insert_above_blocks(blocks.clone())
-        };
-        let specialized_snapshot =
-            specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
-
-        assert_eq!(specialized_ids, generic_ids);
-        assert_eq!(specialized_ids, individual_ids);
-        assert_block_snapshots_eq(
-            &specialized_snapshot,
-            &generic_snapshot,
-            wraps_snapshot.max_point().row(),
-        );
-        assert_block_snapshots_eq(
-            &specialized_snapshot,
-            &individual_snapshot,
-            wraps_snapshot.max_point().row(),
-        );
-
         let additional_block = BlockProperties {
             style: BlockStyle::Sticky,
             placement: blocks
@@ -3729,23 +3714,168 @@ mod tests {
             render: Arc::new(|_| div().into_any()),
             priority: 1,
         };
-        generic_map
-            .write(wraps_snapshot.clone(), Default::default(), None)
-            .insert([additional_block.clone()]);
-        {
-            let mut writer =
-                specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
-            assert!(!writer.can_insert_above_blocks(std::slice::from_ref(&additional_block)));
-            writer.insert_above_blocks([additional_block]);
+        enum Insertion {
+            Bulk,
+            Generic,
+            Individual,
         }
-        let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
-        let specialized_snapshot =
-            specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
-        assert_block_snapshots_eq(
-            &specialized_snapshot,
-            &generic_snapshot,
-            wraps_snapshot.max_point().row(),
-        );
+        let run = |insertion, cx: &App| {
+            let companion = Companion::new(multibuffer.entity_id());
+            let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+            let mut companion_block_map = BlockMap::new(companion_wraps_snapshot.clone(), 1, 1);
+            let mut ids = Vec::new();
+            let mut results = Vec::new();
+            for (stage, batch) in [
+                existing_blocks.as_slice(),
+                blocks.as_slice(),
+                std::slice::from_ref(&additional_block),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let edits = if stage == 0 {
+                    Patch::new(vec![Edit {
+                        old: WrapRow(0)..wraps_snapshot.max_point().row() + WrapRow(1),
+                        new: WrapRow(0)..wraps_snapshot.max_point().row() + WrapRow(1),
+                    }])
+                } else {
+                    Patch::default()
+                };
+                let companion_edits = if stage == 0 {
+                    Patch::new(vec![Edit {
+                        old: WrapRow(0)..companion_wraps_snapshot.max_point().row() + WrapRow(1),
+                        new: WrapRow(0)..companion_wraps_snapshot.max_point().row() + WrapRow(1),
+                    }])
+                } else {
+                    Patch::default()
+                };
+                let mut writer = block_map.write(
+                    wraps_snapshot.clone(),
+                    edits,
+                    Some(CompanionViewMut::new(
+                        multibuffer.entity_id(),
+                        companion_multibuffer.entity_id(),
+                        &companion_wraps_snapshot,
+                        &companion_edits,
+                        companion_multibuffer.read(cx),
+                        &companion,
+                        &mut companion_block_map,
+                    )),
+                );
+                if stage == 0 {
+                    ids.extend(writer.insert(batch.iter().cloned()));
+                    continue;
+                }
+                match insertion {
+                    Insertion::Bulk => {
+                        if stage == 1 {
+                            assert!(writer.can_insert_above_blocks(batch));
+                            assert!(writer.prepare_above_blocks(batch).is_some());
+                            let balancing_blocks = batch
+                                .iter()
+                                .map(|block| {
+                                    balancing_block(
+                                        block,
+                                        &buffer_snapshot,
+                                        &companion_buffer_snapshot,
+                                        multibuffer.entity_id(),
+                                        &companion,
+                                    )
+                                })
+                                .collect::<Option<Vec<_>>>()
+                                .expect("every block must have a companion");
+                            let inverse = writer
+                                .companion
+                                .as_ref()
+                                .and_then(|companion| companion.inverse.as_ref())
+                                .expect("paired writer");
+                            assert!(
+                                inverse
+                                    .companion_writer
+                                    .can_insert_above_blocks(&balancing_blocks)
+                            );
+                            assert!(
+                                inverse
+                                    .companion_writer
+                                    .prepare_above_blocks(&balancing_blocks)
+                                    .is_some()
+                            );
+                        } else {
+                            assert!(!writer.can_insert_above_blocks(batch));
+                        }
+                        ids.extend(writer.insert_above_blocks(batch.iter().cloned()));
+                    }
+                    Insertion::Generic => ids.extend(writer.insert(batch.iter().cloned())),
+                    Insertion::Individual => {
+                        for block in batch {
+                            ids.extend(writer.insert([block.clone()]));
+                        }
+                    }
+                }
+                drop(writer);
+                let mapping = companion
+                    .custom_block_to_balancing_block(multibuffer.entity_id())
+                    .borrow();
+                assert_eq!(mapping.len(), ids.len());
+                let companion_ids = ids
+                    .iter()
+                    .map(|id| *mapping.get(id).expect("balancing block ID"))
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    companion_ids.iter().collect::<HashSet<_>>().len(),
+                    ids.len()
+                );
+                let snapshot = block_map
+                    .read(
+                        wraps_snapshot.clone(),
+                        Patch::default(),
+                        Some(CompanionView::new(
+                            multibuffer.entity_id(),
+                            &companion_wraps_snapshot,
+                            &Patch::default(),
+                            &companion,
+                        )),
+                    )
+                    .snapshot;
+                assert!(
+                    snapshot
+                        .blocks_in_range(BlockRow(0)..snapshot.max_point().row() + BlockRow(1))
+                        .any(|(_, block)| matches!(block, Block::Spacer { .. }))
+                );
+                let companion_snapshot = companion_block_map
+                    .read(
+                        companion_wraps_snapshot.clone(),
+                        Patch::default(),
+                        Some(CompanionView::new(
+                            companion_multibuffer.entity_id(),
+                            &wraps_snapshot,
+                            &Patch::default(),
+                            &companion,
+                        )),
+                    )
+                    .snapshot;
+                results.push([(snapshot, ids.clone()), (companion_snapshot, companion_ids)]);
+            }
+            results
+        };
+        cx.update(|cx| {
+            let bulk = run(Insertion::Bulk, cx);
+            for reference in [run(Insertion::Generic, cx), run(Insertion::Individual, cx)] {
+                assert_eq!(bulk.len(), reference.len());
+                for (actual, expected) in bulk.iter().zip(&reference) {
+                    for ((actual, actual_ids), (expected, expected_ids)) in
+                        actual.iter().zip(expected)
+                    {
+                        assert_block_snapshots_with_ids_eq(
+                            actual,
+                            actual_ids,
+                            expected,
+                            expected_ids,
+                        );
+                    }
+                }
+            }
+        });
     }
 
     #[gpui::test]
@@ -3814,6 +3944,66 @@ mod tests {
             &generic_snapshot,
             wraps_snapshot.max_point().row(),
         );
+    }
+
+    fn assert_block_snapshots_with_ids_eq(
+        actual: &BlockSnapshot,
+        actual_ids: &[CustomBlockId],
+        expected: &BlockSnapshot,
+        expected_ids: &[CustomBlockId],
+    ) {
+        assert_eq!(actual.text(), expected.text());
+        assert_eq!(actual.max_point(), expected.max_point());
+        for row in 0..=actual.wrap_snapshot.max_point().row().0 {
+            let point = WrapPoint::new(WrapRow(row), 0);
+            assert_eq!(actual.to_block_point(point), expected.to_block_point(point));
+        }
+
+        // Generic syncs can allocate new spacer IDs, shifting subsequent custom IDs. Compare
+        // custom blocks by insertion order, while checking spacer placement and height, not IDs.
+        let blocks = |snapshot: &BlockSnapshot, ids: &[CustomBlockId]| {
+            snapshot
+                .blocks_in_range(BlockRow(0)..snapshot.max_point().row() + BlockRow(1))
+                .map(|(row, block)| {
+                    let index = match block {
+                        Block::Custom(block) => Some(
+                            ids.iter()
+                                .position(|id| *id == block.id)
+                                .expect("known block"),
+                        ),
+                        _ => None,
+                    };
+                    (
+                        row,
+                        std::mem::discriminant(block),
+                        index,
+                        block.height(),
+                        block.style(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(blocks(actual, actual_ids), blocks(expected, expected_ids));
+        assert_eq!(actual_ids.len(), expected_ids.len());
+        for (actual_id, expected_id) in actual_ids.iter().zip(expected_ids) {
+            let actual_block = actual
+                .custom_blocks_by_id
+                .get(actual_id)
+                .expect("known block");
+            let expected_block = expected
+                .custom_blocks_by_id
+                .get(expected_id)
+                .expect("known block");
+            assert_eq!(
+                actual_block.placement.to_wrap_row(&actual.wrap_snapshot),
+                expected_block
+                    .placement
+                    .to_wrap_row(&expected.wrap_snapshot),
+            );
+            assert_eq!(actual_block.height, expected_block.height);
+            assert_eq!(actual_block.priority, expected_block.priority);
+            assert_eq!(actual_block.style, expected_block.style);
+        }
     }
 
     fn assert_block_snapshots_eq(

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -3611,37 +3611,61 @@ mod tests {
         );
     }
 
-    #[gpui::test]
-    fn test_insert_above_blocks_matches_generic_insertion(cx: &mut gpui::TestAppContext) {
+    #[gpui::property_test]
+    fn test_insert_above_blocks_matches_generic_insertion(
+        cx: &mut gpui::TestAppContext,
+        #[strategy = proptest::collection::vec(
+            (0u32..8, 0u32..4, proptest::option::of(0u32..5), 0usize..4),
+            1..24,
+        )]
+        additions: Vec<(u32, u32, Option<u32>, usize)>,
+        #[strategy = proptest::collection::vec(
+            (0u32..8, proptest::bool::ANY, proptest::option::of(0u32..5), 0usize..4),
+            0..16,
+        )]
+        existing: Vec<(u32, bool, Option<u32>, usize)>,
+    ) {
         cx.update(init_test);
 
-        let buffer = cx.update(|cx| MultiBuffer::build_simple("aaa\nbbb\nccc\nddd", cx));
+        let text = vec!["aaa"; 16].join("\n");
+        let buffer = cx.update(|cx| MultiBuffer::build_simple(&text, cx));
         let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot(cx));
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
         let (_, wraps_snapshot) =
             cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
-        let blocks = [
-            (Point::new(3, 3), 3, 1),
-            (Point::new(1, 0), 2, 2),
-            (Point::new(1, 2), 1, 0),
-            (Point::new(0, 0), 1, 1),
-        ]
-        .map(|(point, height, priority)| BlockProperties {
-            style: BlockStyle::Sticky,
-            placement: BlockPlacement::Above(buffer_snapshot.anchor_after(point)),
-            height: Some(height),
-            render: Arc::new(|_| div().into_any()),
-            priority,
-        });
-        let existing_blocks = [BlockProperties {
-            style: BlockStyle::Fixed,
-            placement: BlockPlacement::Below(buffer_snapshot.anchor_after(Point::new(0, 0))),
-            height: Some(1),
-            render: Arc::new(|_| div().into_any()),
-            priority: 0,
-        }];
+        // Separate existing Above blocks from new ones so every generated case exercises the fast
+        // path, rather than passing only because it fell back to generic insertion.
+        let blocks = additions
+            .into_iter()
+            .map(|(row, column, height, priority)| BlockProperties {
+                style: BlockStyle::Sticky,
+                placement: BlockPlacement::Above(
+                    buffer_snapshot.anchor_after(Point::new(row * 2, column)),
+                ),
+                height,
+                render: Arc::new(|_| div().into_any()),
+                priority,
+            })
+            .collect::<Vec<_>>();
+        let existing_blocks = existing
+            .into_iter()
+            .map(|(row, above, height, priority)| {
+                let anchor = buffer_snapshot.anchor_after(Point::new(row * 2 + 1, 0));
+                BlockProperties {
+                    style: BlockStyle::Fixed,
+                    placement: if above {
+                        BlockPlacement::Above(anchor)
+                    } else {
+                        BlockPlacement::Below(anchor)
+                    },
+                    height,
+                    render: Arc::new(|_| div().into_any()),
+                    priority,
+                }
+            })
+            .collect::<Vec<_>>();
 
         let mut generic_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
         generic_map
@@ -3652,6 +3676,21 @@ mod tests {
             .insert(blocks.clone());
         let generic_snapshot = generic_map.read(wraps_snapshot.clone(), Default::default(), None);
 
+        let mut individual_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
+        individual_map
+            .write(wraps_snapshot.clone(), Default::default(), None)
+            .insert(existing_blocks.clone());
+        let mut individual_ids = Vec::new();
+        for block in &blocks {
+            individual_ids.extend(
+                individual_map
+                    .write(wraps_snapshot.clone(), Default::default(), None)
+                    .insert([block.clone()]),
+            );
+        }
+        let individual_snapshot =
+            individual_map.read(wraps_snapshot.clone(), Default::default(), None);
+
         let mut specialized_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
         specialized_map
             .write(wraps_snapshot.clone(), Default::default(), None)
@@ -3660,21 +3699,32 @@ mod tests {
             let mut writer =
                 specialized_map.write(wraps_snapshot.clone(), Default::default(), None);
             assert!(writer.can_insert_above_blocks(&blocks));
-            writer.insert_above_blocks(blocks)
+            assert!(writer.prepare_above_blocks(&blocks).is_some());
+            writer.insert_above_blocks(blocks.clone())
         };
         let specialized_snapshot =
             specialized_map.read(wraps_snapshot.clone(), Default::default(), None);
 
         assert_eq!(specialized_ids, generic_ids);
+        assert_eq!(specialized_ids, individual_ids);
         assert_block_snapshots_eq(
             &specialized_snapshot,
             &generic_snapshot,
             wraps_snapshot.max_point().row(),
         );
+        assert_block_snapshots_eq(
+            &specialized_snapshot,
+            &individual_snapshot,
+            wraps_snapshot.max_point().row(),
+        );
 
         let additional_block = BlockProperties {
             style: BlockStyle::Sticky,
-            placement: BlockPlacement::Above(buffer_snapshot.anchor_after(Point::new(1, 0))),
+            placement: blocks
+                .first()
+                .expect("nonempty generated batch")
+                .placement
+                .clone(),
             height: Some(1),
             render: Arc::new(|_| div().into_any()),
             priority: 1,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8701,6 +8701,22 @@ impl Editor {
         blocks
     }
 
+    pub fn insert_above_blocks(
+        &mut self,
+        blocks: impl IntoIterator<Item = BlockProperties<Anchor>>,
+        autoscroll: Option<Autoscroll>,
+        cx: &mut Context<Self>,
+    ) -> Vec<CustomBlockId> {
+        let blocks = self.display_map.update(cx, |display_map, cx| {
+            display_map.insert_above_blocks(blocks, cx)
+        });
+        if let Some(autoscroll) = autoscroll {
+            self.request_autoscroll(autoscroll, cx);
+        }
+        cx.notify();
+        blocks
+    }
+
     pub fn resize_blocks(
         &mut self,
         heights: HashMap<CustomBlockId, u32>,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1020,7 +1020,7 @@ pub struct Editor {
     show_indent_guides: Option<bool>,
     buffers_with_disabled_indent_guides: HashSet<BufferId>,
     highlight_order: usize,
-    highlighted_rows: TypeIdHashMap<RowHighlights>,
+    highlighted_rows: TypeIdHashMap<Vec<RowHighlight>>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     navigation_overlays: HashMap<NavigationOverlayKey, Arc<[NavigationTargetOverlay]>>,
     gutter_highlights: TypeIdHashMap<GutterHighlight>,
@@ -1523,12 +1523,6 @@ struct RowHighlight {
     color: fn(&App) -> Hsla,
     options: RowHighlightOptions,
     type_id: TypeId,
-}
-
-#[derive(Default)]
-struct RowHighlights {
-    ranges: Vec<RowHighlight>,
-    has_diff_base_anchors: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -9111,9 +9105,6 @@ impl Editor {
     ) {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
-        row_highlights.has_diff_base_anchors |=
-            range.start.diff_base_anchor().is_some() || range.end.diff_base_anchor().is_some();
-        let row_highlights = &mut row_highlights.ranges;
         let ix = row_highlights.binary_search_by(|highlight| {
             Ordering::Equal
                 .then_with(|| highlight.range.start.cmp(&range.start, &snapshot))
@@ -9193,7 +9184,7 @@ impl Editor {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
         let mut ranges_to_remove = ranges_to_remove.iter().peekable();
-        row_highlights.ranges.retain(|highlight| {
+        row_highlights.retain(|highlight| {
             while let Some(range_to_remove) = ranges_to_remove.peek() {
                 match range_to_remove.end.cmp(&highlight.range.start, &snapshot) {
                     Ordering::Less | Ordering::Equal => {
@@ -9226,7 +9217,7 @@ impl Editor {
     ) -> impl 'a + Iterator<Item = (Range<Anchor>, Hsla)> {
         self.highlighted_rows
             .get(&TypeId::of::<T>())
-            .map_or(&[] as &[_], |highlights| highlights.ranges.as_slice())
+            .map_or(&[] as &[_], |highlights| highlights.as_slice())
             .iter()
             .map(|highlight| (highlight.range.clone(), (highlight.color)(cx)))
     }
@@ -9265,40 +9256,34 @@ impl Editor {
         self.highlighted_rows
             .values()
             .flat_map(|highlighted_rows| {
-                let ranges = highlighted_rows.ranges.as_slice();
-                let (start_index, end_index) = if highlighted_rows.has_diff_base_anchors {
-                    (0, ranges.len())
-                } else {
-                    // Diff-base anchor ordering depends on the current diff snapshot, while regular
-                    // buffer anchors preserve their ordering across edits.
-                    let start_index = ranges.partition_point(|highlight| {
-                        highlight
-                            .range
-                            .end
-                            .cmp(&anchor_range.start, buffer_snapshot)
-                            .is_lt()
-                    });
-                    let end_index = ranges.partition_point(|highlight| {
-                        highlight
-                            .range
-                            .start
-                            .cmp(&anchor_range.end, buffer_snapshot)
-                            .is_le()
-                    });
-                    (start_index, end_index)
-                };
-                ranges[start_index..end_index].iter().filter(|highlight| {
+                let start_index = highlighted_rows.partition_point(|highlight| {
                     highlight
                         .range
                         .end
                         .cmp(&anchor_range.start, buffer_snapshot)
-                        .is_ge()
-                        && highlight
+                        .is_lt()
+                });
+                let end_index = highlighted_rows.partition_point(|highlight| {
+                    highlight
+                        .range
+                        .start
+                        .cmp(&anchor_range.end, buffer_snapshot)
+                        .is_le()
+                });
+                highlighted_rows[start_index..end_index]
+                    .iter()
+                    .filter(|highlight| {
+                        highlight
                             .range
-                            .start
-                            .cmp(&anchor_range.end, buffer_snapshot)
-                            .is_le()
-                })
+                            .end
+                            .cmp(&anchor_range.start, buffer_snapshot)
+                            .is_ge()
+                            && highlight
+                                .range
+                                .start
+                                .cmp(&anchor_range.end, buffer_snapshot)
+                                .is_le()
+                    })
             })
             .fold(
                 BTreeMap::<DisplayRow, LineHighlight>::new(),
@@ -9361,7 +9346,7 @@ impl Editor {
     ) -> Option<DisplayRow> {
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.ranges.iter())
+            .flat_map(|highlighted_rows| highlighted_rows.iter())
             .filter_map(|highlight| {
                 if highlight.options.autoscroll {
                     Some(highlight.range.start.to_display_point(snapshot).row())
@@ -9835,7 +9820,7 @@ impl Editor {
         let current_execution_position = self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .and_then(|lines| lines.ranges.last().map(|line| line.range.end));
+            .and_then(|lines| lines.last().map(|line| line.range.end));
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
             let inline_values = editor

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1020,7 +1020,7 @@ pub struct Editor {
     show_indent_guides: Option<bool>,
     buffers_with_disabled_indent_guides: HashSet<BufferId>,
     highlight_order: usize,
-    highlighted_rows: TypeIdHashMap<Vec<RowHighlight>>,
+    highlighted_rows: TypeIdHashMap<RowHighlights>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     navigation_overlays: HashMap<NavigationOverlayKey, Arc<[NavigationTargetOverlay]>>,
     gutter_highlights: TypeIdHashMap<GutterHighlight>,
@@ -1523,6 +1523,12 @@ struct RowHighlight {
     color: fn(&App) -> Hsla,
     options: RowHighlightOptions,
     type_id: TypeId,
+}
+
+#[derive(Default)]
+struct RowHighlights {
+    ranges: Vec<RowHighlight>,
+    has_diff_base_anchors: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -9105,6 +9111,9 @@ impl Editor {
     ) {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
+        row_highlights.has_diff_base_anchors |=
+            range.start.diff_base_anchor().is_some() || range.end.diff_base_anchor().is_some();
+        let row_highlights = &mut row_highlights.ranges;
         let ix = row_highlights.binary_search_by(|highlight| {
             Ordering::Equal
                 .then_with(|| highlight.range.start.cmp(&range.start, &snapshot))
@@ -9184,7 +9193,7 @@ impl Editor {
         let snapshot = self.buffer().read(cx).snapshot(cx);
         let row_highlights = self.highlighted_rows.entry(TypeId::of::<T>()).or_default();
         let mut ranges_to_remove = ranges_to_remove.iter().peekable();
-        row_highlights.retain(|highlight| {
+        row_highlights.ranges.retain(|highlight| {
             while let Some(range_to_remove) = ranges_to_remove.peek() {
                 match range_to_remove.end.cmp(&highlight.range.start, &snapshot) {
                     Ordering::Less | Ordering::Equal => {
@@ -9217,7 +9226,7 @@ impl Editor {
     ) -> impl 'a + Iterator<Item = (Range<Anchor>, Hsla)> {
         self.highlighted_rows
             .get(&TypeId::of::<T>())
-            .map_or(&[] as &[_], |vec| vec.as_slice())
+            .map_or(&[] as &[_], |highlights| highlights.ranges.as_slice())
             .iter()
             .map(|highlight| (highlight.range.clone(), (highlight.color)(cx)))
     }
@@ -9231,21 +9240,81 @@ impl Editor {
         cx: &mut App,
     ) -> BTreeMap<DisplayRow, LineHighlight> {
         let snapshot = self.snapshot(window, cx);
+        let max_row = snapshot.max_point().row();
+        self.highlighted_display_rows_in_range(
+            Anchor::Min..Anchor::Max,
+            DisplayRow(0)..max_row.next_row(),
+            &snapshot.display_snapshot,
+            cx,
+        )
+    }
+
+    pub fn highlighted_display_rows_in_range(
+        &self,
+        anchor_range: Range<Anchor>,
+        display_row_range: Range<DisplayRow>,
+        snapshot: &DisplaySnapshot,
+        cx: &App,
+    ) -> BTreeMap<DisplayRow, LineHighlight> {
+        if display_row_range.is_empty() {
+            return BTreeMap::default();
+        }
+
+        let buffer_snapshot = snapshot.buffer_snapshot();
         let mut used_highlight_orders = HashMap::default();
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.iter())
+            .flat_map(|highlighted_rows| {
+                let ranges = highlighted_rows.ranges.as_slice();
+                let (start_index, end_index) = if highlighted_rows.has_diff_base_anchors {
+                    (0, ranges.len())
+                } else {
+                    // Diff-base anchor ordering depends on the current diff snapshot, while regular
+                    // buffer anchors preserve their ordering across edits.
+                    let start_index = ranges.partition_point(|highlight| {
+                        highlight
+                            .range
+                            .end
+                            .cmp(&anchor_range.start, buffer_snapshot)
+                            .is_lt()
+                    });
+                    let end_index = ranges.partition_point(|highlight| {
+                        highlight
+                            .range
+                            .start
+                            .cmp(&anchor_range.end, buffer_snapshot)
+                            .is_le()
+                    });
+                    (start_index, end_index)
+                };
+                ranges[start_index..end_index].iter().filter(|highlight| {
+                    highlight
+                        .range
+                        .end
+                        .cmp(&anchor_range.start, buffer_snapshot)
+                        .is_ge()
+                        && highlight
+                            .range
+                            .start
+                            .cmp(&anchor_range.end, buffer_snapshot)
+                            .is_le()
+                })
+            })
             .fold(
                 BTreeMap::<DisplayRow, LineHighlight>::new(),
                 |mut unique_rows, highlight| {
-                    let start = highlight.range.start.to_display_point(&snapshot);
-                    let end = highlight.range.end.to_display_point(&snapshot);
-                    let start_row = start.row().0;
-                    let end_row = if !highlight.range.end.is_max() && end.column() == 0 {
+                    let start = highlight.range.start.to_display_point(snapshot);
+                    let end = highlight.range.end.to_display_point(snapshot);
+                    let start_row = start.row().0.max(display_row_range.start.0);
+                    let mut end_row = if !highlight.range.end.is_max() && end.column() == 0 {
                         end.row().0.saturating_sub(1)
                     } else {
                         end.row().0
                     };
+                    end_row = end_row.min(display_row_range.end.0.saturating_sub(1));
+                    if start_row > end_row {
+                        return unique_rows;
+                    }
                     let mut header_rows = snapshot
                         .blocks_in_range(
                             DisplayRow(start_row)..DisplayRow(end_row.saturating_add(1)),
@@ -9292,7 +9361,7 @@ impl Editor {
     ) -> Option<DisplayRow> {
         self.highlighted_rows
             .values()
-            .flat_map(|highlighted_rows| highlighted_rows.iter())
+            .flat_map(|highlighted_rows| highlighted_rows.ranges.iter())
             .filter_map(|highlight| {
                 if highlight.options.autoscroll {
                     Some(highlight.range.start.to_display_point(snapshot).row())
@@ -9766,7 +9835,7 @@ impl Editor {
         let current_execution_position = self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .and_then(|lines| lines.last().map(|line| line.range.end));
+            .and_then(|lines| lines.ranges.last().map(|line| line.range.end));
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
             let inline_values = editor

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -84,6 +84,108 @@ fn display_ranges(editor: &Editor, cx: &mut Context<'_, Editor>) -> Vec<Range<Di
         .display_ranges(&editor.display_snapshot(cx))
 }
 
+#[gpui::test]
+fn test_highlighted_display_rows_in_range(cx: &mut TestAppContext) {
+    struct FirstHighlight;
+    struct SecondHighlight;
+
+    init_test(cx, |_| {});
+    let buffer = cx.new(|cx| language::Buffer::local(sample_text(8, 3, 'a'), cx));
+    let editor = cx.add_window(|window, cx| Editor::for_buffer(buffer, None, window, cx));
+
+    assert!(
+        editor
+            .update(cx, |editor, window, cx| {
+                let buffer = editor.buffer().read(cx).snapshot(cx);
+                editor.highlight_rows::<FirstHighlight>(
+                    buffer.anchor_before(Point::new(0, 0))..buffer.anchor_before(Point::new(6, 0)),
+                    |cx| cx.theme().colors().editor_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(0, 0))..buffer.anchor_before(Point::new(1, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(3, 0))..buffer.anchor_before(Point::new(4, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                editor.highlight_rows::<SecondHighlight>(
+                    buffer.anchor_before(Point::new(6, 0))..buffer.anchor_before(Point::new(7, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+
+                let display_row_range = DisplayRow(2)..DisplayRow(5);
+                let expected = editor
+                    .highlighted_display_rows(window, cx)
+                    .into_iter()
+                    .filter(|(row, _)| display_row_range.contains(row))
+                    .collect::<BTreeMap<_, _>>();
+                let snapshot = editor.snapshot(window, cx);
+                let actual = editor.highlighted_display_rows_in_range(
+                    buffer.anchor_before(Point::new(2, 0))..buffer.anchor_before(Point::new(5, 0)),
+                    display_row_range,
+                    &snapshot.display_snapshot,
+                    cx,
+                );
+
+                assert_eq!(actual, expected);
+
+                let highlight_start = buffer.anchor_before(Point::new(2, 0));
+                let Some(block_id) = editor
+                    .insert_blocks(
+                        [BlockProperties {
+                            style: BlockStyle::Fixed,
+                            placement: BlockPlacement::Above(highlight_start),
+                            height: Some(1),
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        }],
+                        None,
+                        cx,
+                    )
+                    .into_iter()
+                    .next()
+                else {
+                    panic!("expected an inserted block");
+                };
+                editor.highlight_rows::<SecondHighlight>(
+                    highlight_start..buffer.anchor_before(Point::new(4, 0)),
+                    |cx| cx.theme().colors().editor_highlighted_line_background,
+                    RowHighlightOptions::default(),
+                    cx,
+                );
+                let Some(block_row) = editor.row_for_block(block_id, cx) else {
+                    panic!("expected an inserted block row");
+                };
+                let display_row_range = block_row..block_row.next_row();
+                let expected = editor
+                    .highlighted_display_rows(window, cx)
+                    .into_iter()
+                    .filter(|(row, _)| display_row_range.contains(row))
+                    .collect::<BTreeMap<_, _>>();
+                let snapshot = editor.snapshot(window, cx);
+                let actual = editor.highlighted_display_rows_in_range(
+                    buffer.anchor_before(Point::new(1, 0))..highlight_start,
+                    display_row_range,
+                    &snapshot.display_snapshot,
+                    cx,
+                );
+
+                assert!(!expected.is_empty());
+                assert_eq!(actual, expected);
+            })
+            .is_ok()
+    );
+}
+
 #[cfg(any(test, feature = "test-support"))]
 pub mod property_test;
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8215,9 +8215,13 @@ impl Element for EditorElement {
                         )
                     };
 
-                    let mut highlighted_rows = self
-                        .editor
-                        .update(cx, |editor, cx| editor.highlighted_display_rows(window, cx));
+                    let mut highlighted_rows =
+                        self.editor.read(cx).highlighted_display_rows_in_range(
+                            start_anchor..end_anchor,
+                            start_row..end_row,
+                            &snapshot.display_snapshot,
+                            cx,
+                        );
 
                     let mut highlighted_ranges = self
                         .editor_with_selections(cx)

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1158,7 +1158,7 @@ impl Item for Editor {
         if self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .is_some_and(|lines| !lines.ranges.is_empty())
+            .is_some_and(|lines| !lines.is_empty())
             && let Some(breakpoint_store) = self.breakpoint_store.as_ref()
         {
             breakpoint_store.update(cx, |store, _cx| {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1158,7 +1158,7 @@ impl Item for Editor {
         if self
             .highlighted_rows
             .get(&TypeId::of::<ActiveDebugLine>())
-            .is_some_and(|lines| !lines.is_empty())
+            .is_some_and(|lines| !lines.ranges.is_empty())
             && let Some(breakpoint_store) = self.breakpoint_store.as_ref()
         {
             breakpoint_store.update(cx, |store, _cx| {

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -4804,6 +4804,198 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_bulk_above_block_lifecycle_between_split_views(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+        use unindent::Unindent as _;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Split).await;
+        let base_text = "
+            bbb
+            ccc
+        "
+        .unindent();
+        let current_text = "
+            aaa
+            bbb
+            ccc
+        "
+        .unindent();
+        let (buffer, diff) = buffer_with_diff(&base_text, &current_text, &mut cx);
+        editor.update(cx, |editor, cx| {
+            editor.update_excerpts_for_path(
+                PathKey::sorted(0),
+                buffer.clone(),
+                vec![Point::new(0, 0)..buffer.read(cx).max_point()],
+                0,
+                diff.clone(),
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let rhs_editor = editor.read_with(cx, |editor, _| editor.rhs_editor.clone());
+        let lhs_editor =
+            editor.read_with(cx, |editor, _| editor.lhs.as_ref().unwrap().editor.clone());
+        let lhs_seed_id = lhs_editor.update(cx, |editor, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            editor.insert_blocks(
+                [BlockProperties {
+                    placement: BlockPlacement::Near(snapshot.anchor_before(Point::new(1, 0))),
+                    height: Some(1),
+                    style: BlockStyle::Fixed,
+                    render: Arc::new(|_| div().into_any()),
+                    priority: 0,
+                }],
+                None,
+                cx,
+            )[0]
+        });
+        let rhs_block_ids = rhs_editor.update(cx, |editor, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            editor.insert_above_blocks(
+                [
+                    BlockProperties {
+                        placement: BlockPlacement::Above(snapshot.anchor_before(Point::new(1, 0))),
+                        height: Some(2),
+                        style: BlockStyle::Fixed,
+                        render: Arc::new(|_| div().into_any()),
+                        priority: 1,
+                    },
+                    BlockProperties {
+                        placement: BlockPlacement::Above(snapshot.anchor_before(Point::new(2, 0))),
+                        height: Some(3),
+                        style: BlockStyle::Fixed,
+                        render: Arc::new(|_| div().into_any()),
+                        priority: 0,
+                    },
+                ],
+                None,
+                cx,
+            )
+        });
+        assert_eq!(rhs_block_ids.len(), 2);
+
+        let balancing_block_ids = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let companion = lhs_editor
+                .display_map
+                .read(cx)
+                .companion()
+                .unwrap()
+                .read(cx);
+            let mapping = companion
+                .custom_block_to_balancing_block(rhs_editor.read(cx).display_map.entity_id())
+                .borrow();
+            assert_eq!(mapping.len(), 2);
+            rhs_block_ids
+                .iter()
+                .map(|block_id| *mapping.get(block_id).unwrap())
+                .collect::<Vec<_>>()
+        });
+        assert!(!balancing_block_ids.contains(&lhs_seed_id));
+
+        let get_block_height = |editor: &Entity<crate::Editor>,
+                                block_id: crate::CustomBlockId,
+                                cx: &mut VisualTestContext| {
+            editor.update_in(cx, |editor, window, cx| {
+                let snapshot = editor.snapshot(window, cx);
+                snapshot
+                    .block_for_id(crate::BlockId::Custom(block_id))
+                    .map(|block| block.height())
+            })
+        };
+        assert_eq!(
+            get_block_height(&rhs_editor, rhs_block_ids[0], &mut cx),
+            Some(2)
+        );
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[0], &mut cx),
+            Some(2)
+        );
+        assert_eq!(
+            get_block_height(&rhs_editor, rhs_block_ids[1], &mut cx),
+            Some(3)
+        );
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[1], &mut cx),
+            Some(3)
+        );
+
+        rhs_editor.update(cx, |editor, cx| {
+            editor.resize_blocks(
+                HashMap::from_iter([(rhs_block_ids[0], 4), (rhs_block_ids[1], 5)]),
+                None,
+                cx,
+            );
+        });
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[0], &mut cx),
+            Some(4)
+        );
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[1], &mut cx),
+            Some(5)
+        );
+
+        rhs_editor.update(cx, |editor, cx| {
+            editor.remove_blocks(HashSet::from_iter([rhs_block_ids[0]]), None, cx);
+        });
+        assert_eq!(
+            get_block_height(&rhs_editor, rhs_block_ids[0], &mut cx),
+            None
+        );
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[0], &mut cx),
+            None
+        );
+        assert_eq!(
+            get_block_height(&rhs_editor, rhs_block_ids[1], &mut cx),
+            Some(5)
+        );
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[1], &mut cx),
+            Some(5)
+        );
+        lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let companion = lhs_editor
+                .display_map
+                .read(cx)
+                .companion()
+                .unwrap()
+                .read(cx);
+            let mapping = companion
+                .custom_block_to_balancing_block(rhs_editor.read(cx).display_map.entity_id())
+                .borrow();
+            assert_eq!(mapping.len(), 1);
+            assert_eq!(
+                mapping.get(&rhs_block_ids[1]),
+                Some(&balancing_block_ids[1])
+            );
+        });
+
+        rhs_editor.update(cx, |editor, cx| {
+            editor.remove_blocks(HashSet::from_iter([rhs_block_ids[1]]), None, cx);
+        });
+        assert_eq!(
+            get_block_height(&lhs_editor, balancing_block_ids[1], &mut cx),
+            None
+        );
+        lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let companion = lhs_editor
+                .display_map
+                .read(cx)
+                .companion()
+                .unwrap()
+                .read(cx);
+            assert!(
+                companion
+                    .custom_block_to_balancing_block(rhs_editor.read(cx).display_map.entity_id())
+                    .borrow()
+                    .is_empty()
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_custom_block_deletion_and_resplit_sync(cx: &mut gpui::TestAppContext) {
         use rope::Point;
         use unindent::Unindent as _;

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -271,7 +271,7 @@ fn conflicts_updated(
             })
         }
     }
-    let new_block_ids = editor.insert_blocks(blocks, None, cx);
+    let new_block_ids = editor.insert_above_blocks(blocks, None, cx);
 
     let Some(conflict_addon) = editor.addon_mut::<ConflictAddon>() else {
         return;

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -237,25 +237,39 @@ fn conflicts_updated(
     // Add new highlights and blocks
     let editor_handle = cx.weak_entity();
     let new_conflicts = &conflict_set.conflicts[event.new_range.clone()];
+    let mut converted_ranges = snapshot
+        .ordered_buffer_anchor_ranges_to_anchor_ranges(new_conflicts.iter().flat_map(|conflict| {
+            [
+                conflict.range.start..conflict.range.start,
+                conflict.range.clone(),
+                conflict.ours.clone(),
+                conflict.theirs.clone(),
+            ]
+        }))
+        .into_iter();
     let mut blocks = Vec::new();
     for conflict in new_conflicts {
-        update_conflict_highlighting(editor, conflict, &snapshot, cx);
+        let block_anchor = converted_ranges.next().flatten().map(|range| range.start);
+        let outer = converted_ranges.next().flatten();
+        let ours = converted_ranges.next().flatten();
+        let theirs = converted_ranges.next().flatten();
+        if let (Some(outer), Some(ours), Some(theirs)) = (outer, ours, theirs) {
+            update_conflict_highlighting(editor, conflict, outer, ours, theirs, cx);
+        }
 
-        let Some(anchor) = snapshot.anchor_in_excerpt(conflict.range.start) else {
-            continue;
-        };
-
-        let editor_handle = editor_handle.clone();
-        blocks.push(BlockProperties {
-            placement: BlockPlacement::Above(anchor),
-            height: Some(1),
-            style: BlockStyle::Sticky,
-            render: Arc::new({
-                let conflict = conflict.clone();
-                move |cx| render_conflict_buttons(&conflict, editor_handle.clone(), cx)
-            }),
-            priority: 0,
-        })
+        if let Some(anchor) = block_anchor {
+            let editor_handle = editor_handle.clone();
+            blocks.push(BlockProperties {
+                placement: BlockPlacement::Above(anchor),
+                height: Some(1),
+                style: BlockStyle::Sticky,
+                render: Arc::new({
+                    let conflict = conflict.clone();
+                    move |cx| render_conflict_buttons(&conflict, editor_handle.clone(), cx)
+                }),
+                priority: 0,
+            })
+        }
     }
     let new_block_ids = editor.insert_blocks(blocks, None, cx);
 
@@ -279,14 +293,12 @@ fn conflicts_updated(
 fn update_conflict_highlighting(
     editor: &mut Editor,
     conflict: &ConflictRegion,
-    buffer: &editor::MultiBufferSnapshot,
+    outer: Range<editor::Anchor>,
+    ours: Range<editor::Anchor>,
+    theirs: Range<editor::Anchor>,
     cx: &mut Context<Editor>,
-) -> Option<()> {
+) {
     log::debug!("update conflict highlighting for {conflict:?}");
-
-    let outer = buffer.buffer_anchor_range_to_anchor_range(conflict.range.clone())?;
-    let ours = buffer.buffer_anchor_range_to_anchor_range(conflict.ours.clone())?;
-    let theirs = buffer.buffer_anchor_range_to_anchor_range(conflict.theirs.clone())?;
 
     let ours_background = |cx: &App| cx.theme().colors().version_control_conflict_marker_ours;
     let theirs_background = |cx: &App| cx.theme().colors().version_control_conflict_marker_theirs;
@@ -318,8 +330,6 @@ fn update_conflict_highlighting(
         options,
         cx,
     );
-
-    Some(())
 }
 
 fn render_conflict_buttons(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5382,6 +5382,97 @@ impl MultiBufferSnapshot {
         None
     }
 
+    /// Converts ranges from one buffer in start-anchor order without restarting the excerpt scan
+    /// for every range. Unordered or mixed-buffer input falls back to independent conversions.
+    pub fn ordered_buffer_anchor_ranges_to_anchor_ranges(
+        &self,
+        text_anchor_ranges: impl IntoIterator<Item = Range<text::Anchor>>,
+    ) -> Vec<Option<Range<Anchor>>> {
+        let text_anchor_ranges = text_anchor_ranges.into_iter().collect::<Vec<_>>();
+        let Some(first_range) = text_anchor_ranges.first() else {
+            return Vec::new();
+        };
+        let buffer_id = first_range.start.buffer_id;
+        let ranges_share_buffer = text_anchor_ranges
+            .iter()
+            .all(|range| range.start.buffer_id == buffer_id && range.end.buffer_id == buffer_id);
+        if !ranges_share_buffer {
+            return text_anchor_ranges
+                .into_iter()
+                .map(|range| self.buffer_anchor_range_to_anchor_range(range))
+                .collect();
+        }
+
+        let Some(buffer_state) = self.buffers.get(&buffer_id) else {
+            return vec![None; text_anchor_ranges.len()];
+        };
+        let buffer_snapshot = &buffer_state.buffer_snapshot;
+        let ranges_are_ordered = text_anchor_ranges.windows(2).all(|ranges| {
+            ranges[0]
+                .start
+                .cmp(&ranges[1].start, buffer_snapshot)
+                .is_le()
+        });
+        if !ranges_are_ordered {
+            return text_anchor_ranges
+                .into_iter()
+                .map(|range| self.buffer_anchor_range_to_anchor_range(range))
+                .collect();
+        }
+
+        let path_key = buffer_state.path_key.clone();
+        let mut cursor = self.excerpts.cursor::<PathKey>(());
+        cursor.seek_forward(&path_key, Bias::Left);
+        let excerpts = iter::from_fn(move || {
+            let excerpt = cursor.item()?;
+            if excerpt.path_key != path_key {
+                return None;
+            }
+            cursor.next();
+            Some(excerpt)
+        })
+        .collect::<Vec<_>>();
+        let mut first_candidate_index = 0;
+        text_anchor_ranges
+            .into_iter()
+            .map(|range| {
+                while let Some(excerpt) = excerpts.get(first_candidate_index) {
+                    let buffer_snapshot = excerpt.buffer_snapshot(self);
+                    if excerpt
+                        .range
+                        .context
+                        .end
+                        .cmp(&range.start, buffer_snapshot)
+                        .is_lt()
+                    {
+                        first_candidate_index += 1;
+                        continue;
+                    }
+                    break;
+                }
+
+                for excerpt in &excerpts[first_candidate_index..] {
+                    let buffer_snapshot = excerpt.buffer_snapshot(self);
+                    if excerpt
+                        .range
+                        .context
+                        .start
+                        .cmp(&range.start, buffer_snapshot)
+                        .is_gt()
+                    {
+                        break;
+                    }
+                    if excerpt.range.contains(&range.start, buffer_snapshot)
+                        && excerpt.range.contains(&range.end, buffer_snapshot)
+                    {
+                        return Some(Anchor::range_in_buffer(excerpt.path_key_index, range));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
     /// Returns a buffer anchor and its buffer snapshot for the given anchor, if it is in the multibuffer.
     pub fn anchor_to_buffer_anchor(
         &self,

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1166,6 +1166,76 @@ fn test_remove_excerpts_for_paths(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_ordered_buffer_anchor_ranges_to_anchor_ranges(cx: &mut App) {
+    let buffer = cx.new(|cx| Buffer::local(sample_text(12, 3, 'a'), cx));
+    let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));
+    multibuffer.update(cx, |multibuffer, cx| {
+        multibuffer.set_excerpts_for_path(
+            PathKey::for_buffer(&buffer, cx),
+            buffer.clone(),
+            [
+                Point::new(1, 0)..Point::new(1, 3),
+                Point::new(5, 0)..Point::new(5, 3),
+                Point::new(9, 0)..Point::new(9, 3),
+            ],
+            0,
+            cx,
+        );
+    });
+
+    let buffer_snapshot = buffer.read(cx).snapshot();
+    let ranges = [
+        buffer_snapshot.anchor_before(Point::new(1, 0))
+            ..buffer_snapshot.anchor_before(Point::new(1, 0)),
+        buffer_snapshot.anchor_before(Point::new(1, 1))
+            ..buffer_snapshot.anchor_after(Point::new(1, 2)),
+        buffer_snapshot.anchor_before(Point::new(3, 0))
+            ..buffer_snapshot.anchor_after(Point::new(3, 2)),
+        buffer_snapshot.anchor_before(Point::new(5, 0))
+            ..buffer_snapshot.anchor_after(Point::new(5, 3)),
+        buffer_snapshot.anchor_before(Point::new(9, 1))
+            ..buffer_snapshot.anchor_after(Point::new(9, 2)),
+    ];
+    let snapshot = multibuffer.read(cx).snapshot(cx);
+    let expected = ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(ranges.clone()),
+        expected
+    );
+
+    let unordered_ranges = ranges.clone().into_iter().rev().collect::<Vec<_>>();
+    let expected = unordered_ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(unordered_ranges),
+        expected
+    );
+
+    let other_buffer = cx.new(|cx| Buffer::local("other", cx));
+    let other_snapshot = other_buffer.read(cx).snapshot();
+    let mixed_buffer_ranges = vec![
+        other_snapshot.anchor_before(Point::zero())..other_snapshot.anchor_after(Point::new(0, 5)),
+        ranges[0].clone(),
+    ];
+    let expected = mixed_buffer_ranges
+        .iter()
+        .cloned()
+        .map(|range| snapshot.buffer_anchor_range_to_anchor_range(range))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        snapshot.ordered_buffer_anchor_ranges_to_anchor_ranges(mixed_buffer_ranges),
+        expected
+    );
+}
+
+#[gpui::test]
 fn test_expand_excerpts(cx: &mut App) {
     let buffer = cx.new(|cx| Buffer::local(sample_text(20, 3, 'a'), cx));
     let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadWrite));

--- a/script/generate-merge-conflict-benchmark
+++ b/script/generate-merge-conflict-benchmark
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+PRESETS = {
+    "small": (2, 8, 16 * 1024),
+    "medium": (32, 64, 128 * 1024),
+    "severe": (128, 256, 512 * 1024),
+}
+
+
+def run_git(
+    repository: Path, *arguments: str, expect_failure: bool = False
+) -> subprocess.CompletedProcess:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_AUTHOR_NAME": "Zed Benchmark",
+            "GIT_AUTHOR_EMAIL": "benchmark@zed.dev",
+            "GIT_COMMITTER_NAME": "Zed Benchmark",
+            "GIT_COMMITTER_EMAIL": "benchmark@zed.dev",
+        }
+    )
+    result = subprocess.run(
+        ["git", "-C", repository, *arguments],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if expect_failure:
+        if result.returncode == 0:
+            raise RuntimeError(f"git {' '.join(arguments)} unexpectedly succeeded")
+    elif result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {stderr}")
+    return result
+
+
+def unchanged_separator(region_index: int) -> str:
+    return "".join(
+        f"// unchanged separator {region_index:04d} {line_index:02d}\n"
+        for line_index in range(10)
+    )
+
+
+def conflict_file(
+    file_index: int, region_count: int, variant: str, padding: int
+) -> str:
+    chunks = [
+        f"// Synthetic merge-conflict workload: file {file_index:04d}, variant {variant}\n"
+    ]
+    for region_index in range(region_count):
+        value = f"{variant}-file-{file_index:04d}-region-{region_index:04d}-"
+        chunks.append(
+            f'pub const VALUE_{region_index:04d}: &str = "{value}{"x" * padding}";\n'
+        )
+        chunks.append(unchanged_separator(region_index))
+    return "".join(chunks)
+
+
+def padding_for_target_size(file_index: int, region_count: int, target_size: int) -> int:
+    unpadded_ours = conflict_file(file_index, region_count, "ours", 0)
+    unpadded_theirs = conflict_file(file_index, region_count, "theirs", 0)
+    marker_overhead = region_count * len(
+        "<<<<<<< HEAD\n=======\n>>>>>>> conflict-side\n"
+    )
+    shared_separator_size = sum(
+        len(unchanged_separator(region_index))
+        for region_index in range(region_count)
+    )
+    minimum_size = (
+        len(unpadded_ours)
+        + len(unpadded_theirs)
+        - shared_separator_size
+        + marker_overhead
+    )
+    if target_size < minimum_size:
+        raise ValueError(
+            f"target size {target_size} is too small for {region_count} regions; "
+            f"minimum is approximately {minimum_size} bytes"
+        )
+    return (target_size - minimum_size) // (2 * region_count)
+
+
+def write_variant(
+    repository: Path,
+    file_count: int,
+    region_count: int,
+    target_size: int,
+    variant: str,
+) -> None:
+    for file_index in range(file_count):
+        path = (
+            repository
+            / "conflicts"
+            / f"module_{file_index:04d}"
+            / f"generated_conflict_{file_index:04d}.rs"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        padding = padding_for_target_size(file_index, region_count, target_size)
+        path.write_text(
+            conflict_file(file_index, region_count, variant, padding),
+            encoding="utf-8",
+        )
+
+
+def validate(repository: Path, file_count: int, region_count: int) -> tuple[int, int]:
+    merge_head = run_git(repository, "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    if not merge_head.stdout.strip():
+        raise RuntimeError("MERGE_HEAD is missing")
+
+    unresolved_output = run_git(
+        repository, "diff", "--name-only", "--diff-filter=U", "-z"
+    ).stdout
+    unresolved_paths = [
+        Path(path.decode()) for path in unresolved_output.split(b"\0") if path
+    ]
+    if len(unresolved_paths) != file_count:
+        raise RuntimeError(
+            f"expected {file_count} unresolved paths, found {len(unresolved_paths)}"
+        )
+
+    total_bytes = 0
+    for relative_path in unresolved_paths:
+        contents = (repository / relative_path).read_bytes()
+        total_bytes += len(contents)
+        marker_counts = (
+            contents.count(b"<<<<<<< "),
+            contents.count(b"======="),
+            contents.count(b">>>>>>> "),
+        )
+        if marker_counts != (region_count, region_count, region_count):
+            raise RuntimeError(
+                f"{relative_path} has marker counts {marker_counts}, "
+                f"expected {(region_count, region_count, region_count)}"
+            )
+
+    status_entries = [
+        entry
+        for entry in run_git(
+            repository, "status", "--porcelain=v1", "-z"
+        ).stdout.split(b"\0")
+        if entry
+    ]
+    if len(status_entries) != file_count or any(
+        not entry.startswith(b"UU ") for entry in status_entries
+    ):
+        raise RuntimeError("the repository contains unexpected status entries")
+
+    return len(unresolved_paths), total_bytes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a deterministic unresolved Git merge for Zed performance testing."
+    )
+    parser.add_argument("destination", type=Path)
+    parser.add_argument(
+        "--preset", choices=PRESETS, default="medium", help="workload size"
+    )
+    arguments = parser.parse_args()
+
+    file_count, region_count, target_size = PRESETS[arguments.preset]
+    destination = arguments.destination.expanduser().resolve()
+    try:
+        destination.mkdir(parents=True, exist_ok=False)
+        run_git(destination, "init", "-b", "main")
+
+        write_variant(destination, file_count, region_count, target_size, "base")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "base")
+
+        run_git(destination, "switch", "-c", "conflict-side")
+        write_variant(destination, file_count, region_count, target_size, "theirs")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "theirs")
+
+        run_git(destination, "switch", "main")
+        write_variant(destination, file_count, region_count, target_size, "ours")
+        run_git(destination, "add", "conflicts")
+        run_git(destination, "commit", "-m", "ours")
+
+        run_git(destination, "merge", "conflict-side", expect_failure=True)
+        unresolved_count, total_bytes = validate(
+            destination, file_count, region_count
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"repository: {destination}")
+    print(f"preset: {arguments.preset}")
+    print(f"unresolved files: {unresolved_count}")
+    print(f"conflict regions per file: {region_count}")
+    print(f"total conflict regions: {unresolved_count * region_count}")
+    print(f"working tree bytes: {total_bytes}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add a specialized bulk path for inserting `Above` blocks without repeatedly rebuilding the block-map transform tree.
- Prepare primary and companion block-map state before committing either side, preserving balancing-block ID correspondence through resize and removal.
- Fall back to the generic insertion path for folds, replacements, unsupported placements, and order-sensitive existing blocks.
- Use bulk insertion for merge-conflict action blocks.

This is stacked on #63395.

## Performance

On the severe synthetic workload of 128 conflicted files with 256 conflicts per file, same-binary A/B measurement reduced:

- summed foreground block insertion from 5.91 seconds to 1.77 seconds (70%);
- median per-file insertion from 46.1 ms to 13.8 ms;
- p95 per-file insertion from 52.2 ms to 16.2 ms;
- end-to-end project-diff refresh from 11.50 seconds to 7.31 seconds (36%).

## Validation

- `cargo test -p editor test_insert_above_blocks`
- `cargo test -p editor test_bulk_above_block_lifecycle_between_split_views`
- `./script/clippy -p editor -p git_ui`
- `git diff --check`
- Same-binary release-fast A/B runs against the severe synthetic merge-conflict fixture

Release Notes:

- Improved performance when opening large merge conflicts.
