### PR TITLE
gpui_windows: Recover renderers after DirectX device loss

### DIFF
--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -60,7 +60,7 @@ impl Drop for DirectWriteComponents {
     }
 }
 
-struct GPUState {
+pub(crate) struct GPUState {
     device: ID3D11Device,
     device_context: ID3D11DeviceContext,
     sampler: Option<ID3D11SamplerState>,
@@ -110,7 +110,7 @@ impl GPUState {
                 ],
             };
             unsafe { device.CreateBlendState(&desc, Some(&mut blend_state)) }?;
-            blend_state.unwrap()
+            blend_state.context("CreateBlendState returned no DirectWrite blend state")?
         };
 
         let sampler = {
@@ -138,7 +138,7 @@ impl GPUState {
             )?;
             let mut shader = None;
             unsafe { device.CreateVertexShader(source.as_bytes(), None, Some(&mut shader)) }?;
-            shader.unwrap()
+            shader.context("CreateVertexShader returned no DirectWrite vertex shader")?
         };
 
         let pixel_shader = {
@@ -148,7 +148,7 @@ impl GPUState {
             )?;
             let mut shader = None;
             unsafe { device.CreatePixelShader(source.as_bytes(), None, Some(&mut shader)) }?;
-            shader.unwrap()
+            shader.context("CreatePixelShader returned no DirectWrite pixel shader")?
         };
 
         Ok(Self {
@@ -218,8 +218,14 @@ impl DirectWriteTextSystem {
         })
     }
 
-    pub(crate) fn handle_gpu_lost(&self, directx_devices: &DirectXDevices) -> Result<()> {
-        self.state.write().handle_gpu_lost(directx_devices)
+    pub(crate) fn build_gpu_recovery_candidate(
+        directx_devices: &DirectXDevices,
+    ) -> Result<GPUState> {
+        GPUState::new(directx_devices).context("Recreating GPU state for DirectWrite")
+    }
+
+    pub(crate) fn commit_gpu_recovery(&self, gpu_state: GPUState) {
+        self.state.write().gpu_state = gpu_state;
     }
 }
 
@@ -1278,13 +1284,6 @@ impl DirectWriteState {
             &components.locale,
         ));
         result
-    }
-
-    fn handle_gpu_lost(&mut self, directx_devices: &DirectXDevices) -> Result<()> {
-        try_to_recover_from_device_lost(|| {
-            GPUState::new(directx_devices).context("Recreating GPU state for DirectWrite")
-        })
-        .map(|gpu_state| self.gpu_state = gpu_state)
     }
 }
 

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -17,8 +17,8 @@ use gpui::{
 pub(crate) struct DirectXAtlas(Mutex<DirectXAtlasState>);
 
 struct DirectXAtlasState {
-    device: ID3D11Device,
-    device_context: ID3D11DeviceContext,
+    device: Option<ID3D11Device>,
+    device_context: Option<ID3D11DeviceContext>,
     monochrome_textures: AtlasTextureList<DirectXAtlasTexture>,
     polychrome_textures: AtlasTextureList<DirectXAtlasTexture>,
     subpixel_textures: AtlasTextureList<DirectXAtlasTexture>,
@@ -37,8 +37,19 @@ struct DirectXAtlasTexture {
 impl DirectXAtlas {
     pub(crate) fn new(device: &ID3D11Device, device_context: &ID3D11DeviceContext) -> Self {
         DirectXAtlas(Mutex::new(DirectXAtlasState {
-            device: device.clone(),
-            device_context: device_context.clone(),
+            device: Some(device.clone()),
+            device_context: Some(device_context.clone()),
+            monochrome_textures: Default::default(),
+            polychrome_textures: Default::default(),
+            subpixel_textures: Default::default(),
+            tiles_by_key: Default::default(),
+        }))
+    }
+
+    pub(crate) fn new_suspended() -> Self {
+        DirectXAtlas(Mutex::new(DirectXAtlasState {
+            device: None,
+            device_context: None,
             monochrome_textures: Default::default(),
             polychrome_textures: Default::default(),
             subpixel_textures: Default::default(),
@@ -49,10 +60,19 @@ impl DirectXAtlas {
     pub(crate) fn get_texture_view(
         &self,
         id: AtlasTextureId,
-    ) -> [Option<ID3D11ShaderResourceView>; 1] {
+    ) -> anyhow::Result<[Option<ID3D11ShaderResourceView>; 1]> {
         let lock = self.0.lock();
-        let tex = lock.texture(id);
-        tex.view.clone()
+        let tex = lock
+            .texture(id)
+            .ok_or_else(|| anyhow::anyhow!("atlas texture is unavailable after device loss"))?;
+        Ok(tex.view.clone())
+    }
+
+    pub(crate) fn suspend(&self) {
+        let mut lock = self.0.lock();
+        lock.device = None;
+        lock.device_context = None;
+        lock.clear_textures();
     }
 
     pub(crate) fn handle_device_lost(
@@ -61,12 +81,18 @@ impl DirectXAtlas {
         device_context: &ID3D11DeviceContext,
     ) {
         let mut lock = self.0.lock();
-        lock.device = device.clone();
-        lock.device_context = device_context.clone();
-        lock.monochrome_textures = AtlasTextureList::default();
-        lock.polychrome_textures = AtlasTextureList::default();
-        lock.subpixel_textures = AtlasTextureList::default();
-        lock.tiles_by_key.clear();
+        lock.device = Some(device.clone());
+        lock.device_context = Some(device_context.clone());
+        lock.clear_textures();
+    }
+}
+
+impl DirectXAtlasState {
+    fn clear_textures(&mut self) {
+        self.monochrome_textures = AtlasTextureList::default();
+        self.polychrome_textures = AtlasTextureList::default();
+        self.subpixel_textures = AtlasTextureList::default();
+        self.tiles_by_key.clear();
     }
 }
 
@@ -79,6 +105,10 @@ impl PlatformAtlas for DirectXAtlas {
         >,
     ) -> anyhow::Result<Option<AtlasTile>> {
         let mut lock = self.0.lock();
+        let device_context = lock
+            .device_context
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("atlas is suspended after device loss"))?;
         if let Some(tile) = lock.tiles_by_key.get(key) {
             Ok(Some(*tile))
         } else {
@@ -88,8 +118,10 @@ impl PlatformAtlas for DirectXAtlas {
             let tile = lock
                 .allocate(size, key.texture_kind())
                 .ok_or_else(|| anyhow::anyhow!("failed to allocate"))?;
-            let texture = lock.texture(tile.texture_id);
-            texture.upload(&lock.device_context, tile.bounds, &bytes);
+            let texture = lock
+                .texture(tile.texture_id)
+                .ok_or_else(|| anyhow::anyhow!("allocated atlas texture is missing"))?;
+            texture.upload(&device_context, tile.bounds, &bytes);
             lock.tiles_by_key.insert(key.clone(), tile);
             Ok(Some(tile))
         }
@@ -156,6 +188,7 @@ impl DirectXAtlasState {
         min_size: Size<DevicePixels>,
         kind: AtlasTextureKind,
     ) -> Option<&mut DirectXAtlasTexture> {
+        let device = self.device.as_ref()?;
         const DEFAULT_ATLAS_SIZE: Size<DevicePixels> = Size {
             width: DevicePixels(1024),
             height: DevicePixels(1024),
@@ -206,11 +239,11 @@ impl DirectXAtlasState {
         unsafe {
             // This only returns None if the device is lost, which we will recreate later.
             // So it's ok to return None here.
-            self.device
+            device
                 .CreateTexture2D(&texture_desc, None, Some(&mut texture))
                 .ok()?;
         }
-        let texture = texture.unwrap();
+        let texture = texture?;
 
         let texture_list = match kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
@@ -220,10 +253,10 @@ impl DirectXAtlasState {
         let index = texture_list.free_list.pop();
         let view = unsafe {
             let mut view = None;
-            self.device
+            device
                 .CreateShaderResourceView(&texture, None, Some(&mut view))
                 .ok()?;
-            [view]
+            [Some(view?)]
         };
         let atlas_texture = DirectXAtlasTexture {
             id: AtlasTextureId {
@@ -238,24 +271,30 @@ impl DirectXAtlasState {
         };
         if let Some(ix) = index {
             texture_list.textures[ix] = Some(atlas_texture);
-            texture_list.textures.get_mut(ix).unwrap().as_mut()
+            texture_list.textures.get_mut(ix)?.as_mut()
         } else {
             texture_list.textures.push(Some(atlas_texture));
-            texture_list.textures.last_mut().unwrap().as_mut()
+            texture_list.textures.last_mut()?.as_mut()
         }
     }
 
-    fn texture(&self, id: AtlasTextureId) -> &DirectXAtlasTexture {
+    fn texture(&self, id: AtlasTextureId) -> Option<&DirectXAtlasTexture> {
         match id.kind {
-            AtlasTextureKind::Monochrome => &self.monochrome_textures[id.index as usize]
-                .as_ref()
-                .unwrap(),
-            AtlasTextureKind::Polychrome => &self.polychrome_textures[id.index as usize]
-                .as_ref()
-                .unwrap(),
-            AtlasTextureKind::Subpixel => {
-                &self.subpixel_textures[id.index as usize].as_ref().unwrap()
-            }
+            AtlasTextureKind::Monochrome => self
+                .monochrome_textures
+                .textures
+                .get(id.index as usize)?
+                .as_ref(),
+            AtlasTextureKind::Polychrome => self
+                .polychrome_textures
+                .textures
+                .get(id.index as usize)?
+                .as_ref(),
+            AtlasTextureKind::Subpixel => self
+                .subpixel_textures
+                .textures
+                .get(id.index as usize)?
+                .as_ref(),
         }
     }
 }

--- a/crates/gpui_windows/src/directx_devices.rs
+++ b/crates/gpui_windows/src/directx_devices.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use gpui_util::ResultExt;
-use itertools::Itertools;
 use windows::Win32::{
     Foundation::HMODULE,
     Graphics::{
@@ -20,20 +19,6 @@ use windows::Win32::{
     },
 };
 use windows::core::Interface;
-
-pub(crate) fn try_to_recover_from_device_lost<T>(mut f: impl FnMut() -> Result<T>) -> Result<T> {
-    (0..5)
-        .map(|i| {
-            if i > 0 {
-                // Add a small delay before retrying
-                std::thread::sleep(std::time::Duration::from_millis(100 + i * 10));
-            }
-            f()
-        })
-        .find_or_last(Result::is_ok)
-        .unwrap()
-        .context("DirectXRenderer failed to recover from lost device after multiple attempts")
-}
 
 #[derive(Clone)]
 pub(crate) struct DirectXDevices {

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -3,6 +3,9 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+#[cfg(debug_assertions)]
+use std::sync::Mutex as StdMutex;
+
 use anyhow::{Context, Result};
 use gpui_util::ResultExt;
 use windows::{
@@ -28,6 +31,139 @@ const RENDER_TARGET_FORMAT: DXGI_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 // This configuration is used for MSAA rendering on paths only, and it's guaranteed to be supported by DirectX 11.
 const PATH_MULTISAMPLE_COUNT: u32 = 4;
 const MAX_INSTANCE_BUFFER_SIZE: usize = 256 * 1024 * 1024;
+#[cfg(any(debug_assertions, test))]
+const DEVICE_RECOVERY_FAILURE_STAGES: [&str; 7] = [
+    "renderer-devices",
+    "resources",
+    "global-elements",
+    "pipelines",
+    "direct-composition",
+    "composition-swapchain",
+    "atlas-commit",
+];
+
+#[cfg(any(debug_assertions, test))]
+struct InjectedDeviceRecoveryFailure {
+    stage: String,
+    count: usize,
+}
+
+#[cfg(any(debug_assertions, test))]
+#[derive(Default)]
+struct InjectedDeviceRecoveryAttempts {
+    generation: Option<u64>,
+    attempts: usize,
+}
+
+#[cfg(any(debug_assertions, test))]
+impl InjectedDeviceRecoveryAttempts {
+    fn next_failure(&mut self, generation: u64, failure_count: usize) -> Option<usize> {
+        if self.generation != Some(generation) {
+            self.generation = Some(generation);
+            self.attempts = 0;
+        }
+        self.attempts += 1;
+        (self.attempts <= failure_count).then_some(self.attempts)
+    }
+}
+
+#[cfg(any(debug_assertions, test))]
+fn parse_injected_device_recovery_failure(value: &str) -> Option<InjectedDeviceRecoveryFailure> {
+    let (stage, count) = value.rsplit_once(':')?;
+    if !DEVICE_RECOVERY_FAILURE_STAGES.contains(&stage) {
+        return None;
+    }
+    Some(InjectedDeviceRecoveryFailure {
+        stage: stage.to_owned(),
+        count: count.parse().ok()?,
+    })
+}
+
+#[cfg(debug_assertions)]
+fn maybe_inject_device_recovery_failure(stage: &str, generation: u64) -> Result<()> {
+    static CONFIG: OnceLock<Option<InjectedDeviceRecoveryFailure>> = OnceLock::new();
+    static MATCHING_ATTEMPTS: OnceLock<StdMutex<InjectedDeviceRecoveryAttempts>> = OnceLock::new();
+
+    let Some(config) = CONFIG
+        .get_or_init(|| {
+            let value = std::env::var("GPUI_TEST_DEVICE_RECOVERY_FAILURE").ok()?;
+            let config = parse_injected_device_recovery_failure(&value);
+            if config.is_none() {
+                eprintln!(
+                    "gpui_device_loss_test invalid GPUI_TEST_DEVICE_RECOVERY_FAILURE={value:?}; expected <stage>:<count>, stage one of {}",
+                    DEVICE_RECOVERY_FAILURE_STAGES.join(",")
+                );
+            }
+            config
+        })
+        .as_ref()
+    else {
+        return Ok(());
+    };
+
+    if config.stage != stage {
+        return Ok(());
+    }
+
+    let mut matching_attempts = MATCHING_ATTEMPTS
+        .get_or_init(|| StdMutex::new(InjectedDeviceRecoveryAttempts::default()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(attempt) = matching_attempts.next_failure(generation, config.count) else {
+        return Ok(());
+    };
+    eprintln!(
+        "gpui_device_loss_test generation={generation} stage={stage} attempt={attempt} result=injected_failure"
+    );
+    anyhow::bail!(
+        "injected DirectX device recovery failure at stage {stage} ({attempt}/{})",
+        config.count
+    );
+}
+
+#[cfg(not(debug_assertions))]
+fn maybe_inject_device_recovery_failure(_stage: &str, _generation: u64) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod device_recovery_injection_tests {
+    use super::{
+        DEVICE_RECOVERY_FAILURE_STAGES, InjectedDeviceRecoveryAttempts,
+        parse_injected_device_recovery_failure,
+    };
+
+    #[test]
+    fn parses_stage_and_count_from_the_right() {
+        let config = parse_injected_device_recovery_failure("resources:7").unwrap();
+        assert_eq!(config.stage, "resources");
+        assert_eq!(config.count, 7);
+        assert!(parse_injected_device_recovery_failure(":7").is_none());
+        assert!(parse_injected_device_recovery_failure("unknown:7").is_none());
+        assert!(parse_injected_device_recovery_failure("resources:nope").is_none());
+        assert!(parse_injected_device_recovery_failure("resources").is_none());
+    }
+
+    #[test]
+    fn accepts_every_recovery_candidate_stage() {
+        for stage in DEVICE_RECOVERY_FAILURE_STAGES {
+            let config = parse_injected_device_recovery_failure(&format!("{stage}:1")).unwrap();
+            assert_eq!(config.stage, stage);
+            assert_eq!(config.count, 1);
+        }
+    }
+
+    #[test]
+    fn failure_budget_resets_for_each_generation() {
+        let mut attempts = InjectedDeviceRecoveryAttempts::default();
+        assert_eq!(attempts.next_failure(7, 2), Some(1));
+        assert_eq!(attempts.next_failure(7, 2), Some(2));
+        assert_eq!(attempts.next_failure(7, 2), None);
+        assert_eq!(attempts.next_failure(8, 2), Some(1));
+        assert_eq!(attempts.next_failure(8, 2), Some(2));
+        assert_eq!(attempts.next_failure(8, 2), None);
+    }
+}
 
 pub(crate) struct FontInfo {
     pub gamma_ratios: [f32; 4],
@@ -39,21 +175,64 @@ pub(crate) struct FontInfo {
 pub(crate) struct DirectXRenderer {
     hwnd: HWND,
     atlas: Arc<DirectXAtlas>,
-    devices: Option<DirectXRendererDevices>,
-    resources: Option<DirectXResources>,
-    globals: DirectXGlobalElements,
-    pipelines: DirectXRenderPipelines,
-    direct_composition: Option<DirectComposition>,
+    active: Option<DirectXRendererState>,
     font_info: &'static FontInfo,
-
     width: u32,
     height: u32,
+    disable_direct_composition: bool,
+    recovery_generation: u64,
+    drawable: bool,
+    #[cfg(debug_assertions)]
+    test_recovery_present_generation: Option<u64>,
+}
 
-    /// Whether we want to skip drwaing due to device lost events.
-    ///
-    /// In that case we want to discard the first frame that we draw as we got reset in the middle of a frame
-    /// meaning we lost all the allocated gpu textures and scene resources.
-    skip_draws: bool,
+struct DirectXRendererState {
+    devices: DirectXRendererDevices,
+    resources: DirectXResources,
+    globals: DirectXGlobalElements,
+    pipelines: DirectXRenderPipelines,
+    _direct_composition: Option<DirectComposition>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct DirectXRendererRecoverySnapshot {
+    pub(crate) generation: u64,
+    pub(crate) hwnd: HWND,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) disable_direct_composition: bool,
+}
+
+pub(crate) struct DirectXRendererRecoveryCandidate {
+    snapshot: DirectXRendererRecoverySnapshot,
+    state: DirectXRendererState,
+}
+
+pub(crate) struct DirectXRendererSuspendedState(Option<DirectXRendererState>);
+
+impl DirectXRendererSuspendedState {
+    pub(crate) fn release(self) {
+        let Some(state) = self.0 else {
+            return;
+        };
+        // SAFETY: this detached state owns every COM object below, and the
+        // window renderer can no longer issue commands through its context.
+        unsafe {
+            state.devices.device_context.OMSetRenderTargets(None, None);
+            state.devices.device_context.ClearState();
+            state.devices.device_context.Flush();
+        }
+        #[cfg(debug_assertions)]
+        report_live_objects(&state.devices.device)
+            .context("Failed to report live objects after device loss")
+            .log_err();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DirectXRendererRecoveryCommit {
+    Active,
+    Stale,
 }
 
 /// Direct3D objects
@@ -174,8 +353,14 @@ impl DirectXRenderer {
         let direct_composition = if disable_direct_composition {
             None
         } else {
-            let composition = DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), hwnd)
-                .context("Creating DirectComposition")?;
+            let composition = DirectComposition::new(
+                devices
+                    .dxgi_device
+                    .as_ref()
+                    .context("DXGI device missing for DirectComposition")?,
+                hwnd,
+            )
+            .context("Creating DirectComposition")?;
             composition
                 .set_swap_chain(&resources.swap_chain)
                 .context("Setting swap chain for DirectComposition")?;
@@ -185,32 +370,63 @@ impl DirectXRenderer {
         Ok(DirectXRenderer {
             hwnd,
             atlas,
-            devices: Some(devices),
-            resources: Some(resources),
-            globals,
-            pipelines,
-            direct_composition,
+            active: Some(DirectXRendererState {
+                devices,
+                resources,
+                globals,
+                pipelines,
+                _direct_composition: direct_composition,
+            }),
             font_info: Self::get_font_info(),
             width: 1,
             height: 1,
-            skip_draws: false,
+            disable_direct_composition,
+            recovery_generation: 0,
+            drawable: true,
+            #[cfg(debug_assertions)]
+            test_recovery_present_generation: None,
         })
+    }
+
+    pub(crate) fn new_suspended(
+        hwnd: HWND,
+        disable_direct_composition: bool,
+        recovery_generation: u64,
+    ) -> Self {
+        Self {
+            hwnd,
+            atlas: Arc::new(DirectXAtlas::new_suspended()),
+            active: None,
+            font_info: Self::get_font_info(),
+            width: 1,
+            height: 1,
+            disable_direct_composition,
+            recovery_generation,
+            drawable: false,
+            #[cfg(debug_assertions)]
+            test_recovery_present_generation: None,
+        }
     }
 
     pub(crate) fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.atlas.clone()
     }
 
+    pub(crate) fn is_suspended(&self) -> bool {
+        self.active.is_none()
+    }
+
     fn pre_draw(&self, clear_color: &[f32; 4]) -> Result<()> {
-        let resources = self.resources.as_ref().expect("resources missing");
-        let device_context = &self
-            .devices
-            .as_ref()
-            .expect("devices missing")
-            .device_context;
+        let active = self.active.as_ref().context("renderer is suspended")?;
+        let resources = &active.resources;
+        let device_context = &active.devices.device_context;
         update_buffer(
             device_context,
-            self.globals.global_params_buffer.as_ref().unwrap(),
+            active
+                .globals
+                .global_params_buffer
+                .as_ref()
+                .context("global params buffer missing")?,
             &[GlobalParams {
                 gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [resources.viewport.Width, resources.viewport.Height],
@@ -231,100 +447,158 @@ impl DirectXRenderer {
             device_context
                 .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
             device_context.RSSetViewports(Some(slice::from_ref(&resources.viewport)));
-            device_context
-                .VSSetConstantBuffers(0, Some(slice::from_ref(&self.globals.global_params_buffer)));
-            device_context
-                .VSSetConstantBuffers(1, Some(slice::from_ref(&self.globals.batch_params_buffer)));
-            device_context
-                .PSSetConstantBuffers(0, Some(slice::from_ref(&self.globals.global_params_buffer)));
+            device_context.VSSetConstantBuffers(
+                0,
+                Some(slice::from_ref(&active.globals.global_params_buffer)),
+            );
+            device_context.VSSetConstantBuffers(
+                1,
+                Some(slice::from_ref(&active.globals.batch_params_buffer)),
+            );
+            device_context.PSSetConstantBuffers(
+                0,
+                Some(slice::from_ref(&active.globals.global_params_buffer)),
+            );
         }
         Ok(())
     }
 
     #[inline]
     fn present(&mut self) -> Result<()> {
-        let result = unsafe {
-            self.resources
-                .as_ref()
-                .expect("resources missing")
-                .swap_chain
-                .Present(0, DXGI_PRESENT(0))
-        };
-        result.ok().context("Presenting swap chain failed")
+        let active = self.active.as_ref().context("renderer is suspended")?;
+        // SAFETY: the swap chain belongs to this active renderer state and is
+        // presented only from its window thread.
+        let result = unsafe { active.resources.swap_chain.Present(0, DXGI_PRESENT(0)) };
+        result.ok().context("Presenting swap chain failed")?;
+        #[cfg(debug_assertions)]
+        if let Some(generation) = self.test_recovery_present_generation.take()
+            && std::env::var_os("GPUI_TEST_DEVICE_RECOVERY_FAILURE").is_some()
+        {
+            eprintln!(
+                "gpui_device_loss_test generation={generation} window={:?} result=presented",
+                self.hwnd
+            );
+        }
+        Ok(())
     }
 
-    pub(crate) fn handle_device_lost(&mut self, directx_devices: &DirectXDevices) -> Result<()> {
-        try_to_recover_from_device_lost(|| {
-            self.handle_device_lost_impl(directx_devices)
-                .context("DirectXRenderer handling device lost")
+    pub(crate) fn suspend(&mut self, generation: u64) -> Option<DirectXRendererSuspendedState> {
+        if generation < self.recovery_generation
+            || (generation == self.recovery_generation && self.active.is_some())
+        {
+            return None;
+        }
+
+        self.recovery_generation = generation;
+        self.drawable = false;
+        #[cfg(debug_assertions)]
+        {
+            self.test_recovery_present_generation = None;
+        }
+        self.atlas.suspend();
+        Some(DirectXRendererSuspendedState(self.active.take()))
+    }
+
+    pub(crate) fn recovery_snapshot(
+        &self,
+        generation: u64,
+    ) -> Option<DirectXRendererRecoverySnapshot> {
+        if self.active.is_some() || self.recovery_generation != generation {
+            return None;
+        }
+        Some(DirectXRendererRecoverySnapshot {
+            generation,
+            hwnd: self.hwnd,
+            width: self.width,
+            height: self.height,
+            disable_direct_composition: self.disable_direct_composition,
         })
     }
 
-    fn handle_device_lost_impl(&mut self, directx_devices: &DirectXDevices) -> Result<()> {
-        let disable_direct_composition = self.direct_composition.is_none();
-
-        unsafe {
-            #[cfg(debug_assertions)]
-            if let Some(devices) = &self.devices {
-                report_live_objects(&devices.device)
-                    .context("Failed to report live objects after device lost")
-                    .log_err();
-            }
-
-            self.resources.take();
-            if let Some(devices) = &self.devices {
-                devices.device_context.OMSetRenderTargets(None, None);
-                devices.device_context.ClearState();
-                devices.device_context.Flush();
-                #[cfg(debug_assertions)]
-                report_live_objects(&devices.device)
-                    .context("Failed to report live objects after device lost")
-                    .log_err();
-            }
-
-            self.direct_composition.take();
-            self.devices.take();
-        }
-
-        let devices = DirectXRendererDevices::new(directx_devices, disable_direct_composition)
-            .context("Recreating DirectX devices")?;
+    pub(crate) fn build_recovery_candidate(
+        snapshot: DirectXRendererRecoverySnapshot,
+        directx_devices: &DirectXDevices,
+    ) -> Result<DirectXRendererRecoveryCandidate> {
+        maybe_inject_device_recovery_failure("renderer-devices", snapshot.generation)?;
+        let devices =
+            DirectXRendererDevices::new(directx_devices, snapshot.disable_direct_composition)
+                .context("Recreating DirectX devices")?;
+        maybe_inject_device_recovery_failure("resources", snapshot.generation)?;
         let resources = DirectXResources::new(
             &devices,
-            self.width,
-            self.height,
-            self.hwnd,
-            disable_direct_composition,
+            snapshot.width,
+            snapshot.height,
+            snapshot.hwnd,
+            snapshot.disable_direct_composition,
         )
         .context("Creating DirectX resources")?;
+        maybe_inject_device_recovery_failure("global-elements", snapshot.generation)?;
         let globals = DirectXGlobalElements::new(&devices.device)
             .context("Creating DirectXGlobalElements")?;
+        maybe_inject_device_recovery_failure("pipelines", snapshot.generation)?;
         let pipelines = DirectXRenderPipelines::new(&devices.device)
             .context("Creating DirectXRenderPipelines")?;
 
-        let direct_composition = if disable_direct_composition {
+        let direct_composition = if snapshot.disable_direct_composition {
             None
         } else {
-            let composition =
-                DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), self.hwnd)?;
+            maybe_inject_device_recovery_failure("direct-composition", snapshot.generation)?;
+            let composition = DirectComposition::new(
+                devices
+                    .dxgi_device
+                    .as_ref()
+                    .context("DXGI device missing for DirectComposition")?,
+                snapshot.hwnd,
+            )?;
+            maybe_inject_device_recovery_failure("composition-swapchain", snapshot.generation)?;
             composition.set_swap_chain(&resources.swap_chain)?;
             Some(composition)
         };
 
-        self.atlas
-            .handle_device_lost(&devices.device, &devices.device_context);
-
+        maybe_inject_device_recovery_failure("atlas-commit", snapshot.generation)?;
+        // SAFETY: the render-target view and context were created together in
+        // this unpublished candidate and remain alive for the call.
         unsafe {
             devices
                 .device_context
                 .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
         }
-        self.devices = Some(devices);
-        self.resources = Some(resources);
-        self.globals = globals;
-        self.pipelines = pipelines;
-        self.direct_composition = direct_composition;
-        self.skip_draws = true;
-        Ok(())
+        Ok(DirectXRendererRecoveryCandidate {
+            snapshot,
+            state: DirectXRendererState {
+                devices,
+                resources,
+                globals,
+                pipelines,
+                _direct_composition: direct_composition,
+            },
+        })
+    }
+
+    pub(crate) fn commit_recovery(
+        &mut self,
+        candidate: DirectXRendererRecoveryCandidate,
+    ) -> DirectXRendererRecoveryCommit {
+        let snapshot = candidate.snapshot;
+        if self.recovery_generation != snapshot.generation
+            || self.width != snapshot.width
+            || self.height != snapshot.height
+            || self.active.is_some()
+        {
+            return DirectXRendererRecoveryCommit::Stale;
+        }
+
+        self.atlas.handle_device_lost(
+            &candidate.state.devices.device,
+            &candidate.state.devices.device_context,
+        );
+        self.active = Some(candidate.state);
+        self.drawable = false;
+        #[cfg(debug_assertions)]
+        {
+            self.test_recovery_present_generation = Some(snapshot.generation);
+        }
+        DirectXRendererRecoveryCommit::Active
     }
 
     pub(crate) fn draw(
@@ -332,9 +606,7 @@ impl DirectXRenderer {
         scene: &Scene,
         background_appearance: WindowBackgroundAppearance,
     ) -> Result<()> {
-        if self.skip_draws {
-            // skip drawing this frame, we just recovered from a device lost event
-            // and so likely do not have the textures anymore that are required for drawing
+        if self.active.is_none() || !self.drawable {
             return Ok(());
         }
         self.render(scene, background_appearance)?;
@@ -358,9 +630,9 @@ impl DirectXRenderer {
         self.upload_scene_buffers(scene)?;
 
         let annotation = self
-            .devices
+            .active
             .as_ref()
-            .and_then(|devices| devices.annotation.clone())
+            .and_then(|active| active.devices.annotation.clone())
             .filter(|annotation| unsafe { annotation.GetStatus().as_bool() });
         for batch in scene.batches() {
             let _annotation = annotation
@@ -415,19 +687,19 @@ impl DirectXRenderer {
         scene: &Scene,
         background_appearance: WindowBackgroundAppearance,
     ) -> Result<image::RgbaImage> {
-        // A pending device-lost recovery (`skip_draws`) leaves the atlas holding
-        // tile references from the previous device; drawing before the forced
-        // re-render rebuilds them panics in `DirectXAtlasState::texture`.
+        // A suspended renderer has no complete device-bound bundle, and a
+        // recovered renderer is not drawable until a forced frame has rebuilt
+        // its atlas textures.
         anyhow::ensure!(
-            !self.skip_draws,
+            self.active.is_some() && self.drawable,
             "render_to_image unavailable while recovering from a lost device"
         );
         self.render(scene, background_appearance)?;
 
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let device = &devices.device;
-        let context = &devices.device_context;
-        let resources = self.resources.as_ref().context("resources missing")?;
+        let active = self.active.as_ref().context("renderer is suspended")?;
+        let device = &active.devices.device;
+        let context = &active.devices.device_context;
+        let resources = &active.resources;
         let render_target = resources
             .render_target
             .as_ref()
@@ -491,46 +763,69 @@ impl DirectXRenderer {
         self.width = width;
         self.height = height;
 
+        let Some(mut active) = self.active.take() else {
+            return Ok(());
+        };
+
         // Clear the render target before resizing
-        let devices = self.devices.as_ref().context("devices missing")?;
-        unsafe { devices.device_context.OMSetRenderTargets(None, None) };
-        let resources = self.resources.as_mut().context("resources missing")?;
-        resources.render_target.take();
-        resources.render_target_view.take();
+        // SAFETY: the context belongs to `active`; unbinding does not retain
+        // either optional view that is dropped immediately below.
+        unsafe { active.devices.device_context.OMSetRenderTargets(None, None) };
+        active.resources.render_target.take();
+        active.resources.render_target_view.take();
 
         // Resizing the swap chain requires a call to the underlying DXGI adapter, which can return the device removed error.
         // The app might have moved to a monitor that's attached to a different graphics device.
         // When a graphics device is removed or reset, the desktop resolution often changes, resulting in a window size change.
         // But here we just return the error, because we are handling device lost scenarios elsewhere.
-        unsafe {
-            resources
-                .swap_chain
-                .ResizeBuffers(
-                    BUFFER_COUNT as u32,
-                    width,
-                    height,
-                    RENDER_TARGET_FORMAT,
-                    DXGI_SWAP_CHAIN_FLAG(0),
-                )
-                .context("Failed to resize swap chain")?;
+        let result = (|| {
+            // SAFETY: `active` exclusively owns the swap chain, all bound
+            // targets were released above, and the dimensions are nonzero.
+            unsafe {
+                active
+                    .resources
+                    .swap_chain
+                    .ResizeBuffers(
+                        BUFFER_COUNT as u32,
+                        width,
+                        height,
+                        RENDER_TARGET_FORMAT,
+                        DXGI_SWAP_CHAIN_FLAG(0),
+                    )
+                    .context("Failed to resize swap chain")?;
+            }
+
+            active
+                .resources
+                .recreate_resources(&active.devices, width, height)?;
+
+            // SAFETY: resource recreation produced this view for the active
+            // device context and both remain alive in `active`.
+            unsafe {
+                active.devices.device_context.OMSetRenderTargets(
+                    Some(slice::from_ref(&active.resources.render_target_view)),
+                    None,
+                );
+            }
+            Ok(())
+        })();
+
+        if let Err(error) = result {
+            self.drawable = false;
+            self.atlas.suspend();
+            return Err(error);
         }
 
-        resources.recreate_resources(devices, width, height)?;
-
-        unsafe {
-            devices
-                .device_context
-                .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
-        }
-
+        self.active = Some(active);
         Ok(())
     }
 
     fn upload_scene_buffers(&mut self, scene: &Scene) -> Result<()> {
-        let devices = self.devices.as_ref().context("devices missing")?;
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        let devices = &active.devices;
 
         if !scene.shadows.is_empty() {
-            self.pipelines.shadow_pipeline.update_buffer(
+            active.pipelines.shadow_pipeline.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.shadows,
@@ -538,7 +833,7 @@ impl DirectXRenderer {
         }
 
         if !scene.quads.is_empty() {
-            self.pipelines.quad_pipeline.update_buffer(
+            active.pipelines.quad_pipeline.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.quads,
@@ -546,7 +841,7 @@ impl DirectXRenderer {
         }
 
         if !scene.underlines.is_empty() {
-            self.pipelines.underline_pipeline.update_buffer(
+            active.pipelines.underline_pipeline.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.underlines,
@@ -554,7 +849,7 @@ impl DirectXRenderer {
         }
 
         if !scene.monochrome_sprites.is_empty() {
-            self.pipelines.mono_sprites.update_buffer(
+            active.pipelines.mono_sprites.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.monochrome_sprites,
@@ -562,7 +857,7 @@ impl DirectXRenderer {
         }
 
         if !scene.subpixel_sprites.is_empty() {
-            self.pipelines.subpixel_sprites.update_buffer(
+            active.pipelines.subpixel_sprites.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.subpixel_sprites,
@@ -570,7 +865,7 @@ impl DirectXRenderer {
         }
 
         if !scene.polychrome_sprites.is_empty() {
-            self.pipelines.poly_sprites.update_buffer(
+            active.pipelines.poly_sprites.update_buffer(
                 &devices.device,
                 &devices.device_context,
                 &scene.polychrome_sprites,
@@ -584,10 +879,11 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        self.pipelines.shadow_pipeline.draw_range(
-            &devices.device_context,
-            self.globals
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.shadow_pipeline.draw_range(
+            &active.devices.device_context,
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
@@ -600,10 +896,11 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        self.pipelines.quad_pipeline.draw_range(
-            &devices.device_context,
-            self.globals
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.quad_pipeline.draw_range(
+            &active.devices.device_context,
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
@@ -617,12 +914,16 @@ impl DirectXRenderer {
             return Ok(());
         }
 
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        let devices = &active.devices;
+        let resources = &active.resources;
         // Clear intermediate MSAA texture
         unsafe {
             devices.device_context.ClearRenderTargetView(
-                resources.path_intermediate_msaa_view.as_ref().unwrap(),
+                resources
+                    .path_intermediate_msaa_view
+                    .as_ref()
+                    .context("path MSAA render target view missing")?,
                 &[0.0; 4],
             );
             // Set intermediate MSAA texture as render target
@@ -644,13 +945,13 @@ impl DirectXRenderer {
             }));
         }
 
-        self.pipelines.path_rasterization_pipeline.update_buffer(
+        active.pipelines.path_rasterization_pipeline.update_buffer(
             &devices.device,
             &devices.device_context,
             &vertices,
         )?;
 
-        self.pipelines.path_rasterization_pipeline.draw(
+        active.pipelines.path_rasterization_pipeline.draw(
             &devices.device_context,
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
             vertices.len() as u32,
@@ -687,7 +988,10 @@ impl DirectXRenderer {
         // disjoint, so we can copy each path's bounds individually. If this
         // batch combines different draw orders, we perform a single copy
         // for a minimal spanning rect.
-        let sprites = if paths.last().unwrap().order == first_path.order {
+        let sprites = if paths
+            .last()
+            .is_some_and(|path| path.order == first_path.order)
+        {
             paths
                 .iter()
                 .map(|path| PathSprite {
@@ -702,19 +1006,20 @@ impl DirectXRenderer {
             vec![PathSprite { bounds }]
         };
 
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let resources = self.resources.as_ref().context("resources missing")?;
-        self.pipelines.path_sprite_pipeline.update_buffer(
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        let devices = &active.devices;
+        let resources = &active.resources;
+        active.pipelines.path_sprite_pipeline.update_buffer(
             &devices.device,
             &devices.device_context,
             &sprites,
         )?;
 
         // Draw the sprites with the path texture
-        self.pipelines.path_sprite_pipeline.draw_with_texture(
+        active.pipelines.path_sprite_pipeline.draw_with_texture(
             &devices.device_context,
             slice::from_ref(&resources.path_intermediate_srv),
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&active.globals.sampler),
             sprites.len() as u32,
         )
     }
@@ -723,10 +1028,11 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        self.pipelines.underline_pipeline.draw_range(
-            &devices.device_context,
-            self.globals
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.underline_pipeline.draw_range(
+            &active.devices.device_context,
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
@@ -744,16 +1050,17 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let texture_view = self.atlas.get_texture_view(texture_id);
-        self.pipelines.mono_sprites.draw_range_with_texture(
-            &devices.device_context,
+        let texture_view = self.atlas.get_texture_view(texture_id)?;
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.mono_sprites.draw_range_with_texture(
+            &active.devices.device_context,
             &texture_view,
-            self.globals
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&active.globals.sampler),
             start as u32,
             len as u32,
         )
@@ -768,16 +1075,17 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let texture_view = self.atlas.get_texture_view(texture_id);
-        self.pipelines.subpixel_sprites.draw_range_with_texture(
-            &devices.device_context,
+        let texture_view = self.atlas.get_texture_view(texture_id)?;
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.subpixel_sprites.draw_range_with_texture(
+            &active.devices.device_context,
             &texture_view,
-            self.globals
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&active.globals.sampler),
             start as u32,
             len as u32,
         )
@@ -792,16 +1100,17 @@ impl DirectXRenderer {
         if len == 0 {
             return Ok(());
         }
-        let devices = self.devices.as_ref().context("devices missing")?;
-        let texture_view = self.atlas.get_texture_view(texture_id);
-        self.pipelines.poly_sprites.draw_range_with_texture(
-            &devices.device_context,
+        let texture_view = self.atlas.get_texture_view(texture_id)?;
+        let active = self.active.as_mut().context("renderer is suspended")?;
+        active.pipelines.poly_sprites.draw_range_with_texture(
+            &active.devices.device_context,
             &texture_view,
-            self.globals
+            active
+                .globals
                 .batch_params_buffer
                 .as_ref()
                 .context("batch params buffer missing")?,
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&active.globals.sampler),
             start as u32,
             len as u32,
         )
@@ -815,7 +1124,11 @@ impl DirectXRenderer {
     }
 
     pub(crate) fn gpu_specs(&self) -> Result<GpuSpecs> {
-        let devices = self.devices.as_ref().context("devices missing")?;
+        let devices = &self
+            .active
+            .as_ref()
+            .context("renderer is suspended")?
+            .devices;
         let desc = unsafe { devices.adapter.GetDesc1() }?;
         let is_software_emulated = (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE.0 as u32) != 0;
         let device_name = String::from_utf16_lossy(&desc.Description)
@@ -860,7 +1173,9 @@ impl DirectXRenderer {
     }
 
     pub(crate) fn mark_drawable(&mut self) {
-        self.skip_draws = false;
+        if self.active.is_some() {
+            self.drawable = true;
+        }
     }
 }
 
@@ -1278,8 +1593,8 @@ struct PathSprite {
 impl Drop for DirectXRenderer {
     fn drop(&mut self) {
         #[cfg(debug_assertions)]
-        if let Some(devices) = &self.devices {
-            report_live_objects(&devices.device).ok();
+        if let Some(active) = &self.active {
+            report_live_objects(&active.devices.device).ok();
         }
     }
 }
@@ -1421,13 +1736,19 @@ fn create_path_intermediate_texture(
             MiscFlags: 0,
         };
         device.CreateTexture2D(&desc, None, Some(&mut output))?;
-        output.unwrap()
+        output.context("CreateTexture2D returned no path intermediate texture")?
     };
 
     let mut shader_resource_view = None;
     unsafe { device.CreateShaderResourceView(&texture, None, Some(&mut shader_resource_view))? };
 
-    Ok((texture, Some(shader_resource_view.unwrap())))
+    Ok((
+        texture,
+        Some(
+            shader_resource_view
+                .context("CreateShaderResourceView returned no path intermediate view")?,
+        ),
+    ))
 }
 
 #[inline]
@@ -1454,11 +1775,14 @@ fn create_path_intermediate_msaa_texture_and_view(
             MiscFlags: 0,
         };
         device.CreateTexture2D(&desc, None, Some(&mut output))?;
-        output.unwrap()
+        output.context("CreateTexture2D returned no path MSAA texture")?
     };
     let mut msaa_view = None;
     unsafe { device.CreateRenderTargetView(&msaa_texture, None, Some(&mut msaa_view))? };
-    Ok((msaa_texture, Some(msaa_view.unwrap())))
+    Ok((
+        msaa_texture,
+        Some(msaa_view.context("CreateRenderTargetView returned no path MSAA view")?),
+    ))
 }
 
 #[inline]
@@ -1478,7 +1802,7 @@ fn set_rasterizer_state(device: &ID3D11Device, device_context: &ID3D11DeviceCont
     let rasterizer_state = unsafe {
         let mut state = None;
         device.CreateRasterizerState(&desc, Some(&mut state))?;
-        state.unwrap()
+        state.context("CreateRasterizerState returned no state")?
     };
     unsafe { device_context.RSSetState(&rasterizer_state) };
     Ok(())
@@ -1499,7 +1823,7 @@ fn create_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
     unsafe {
         let mut state = None;
         device.CreateBlendState(&desc, Some(&mut state))?;
-        Ok(state.unwrap())
+        state.context("CreateBlendState returned no state")
     }
 }
 
@@ -1520,7 +1844,7 @@ fn create_blend_state_for_subpixel_rendering(device: &ID3D11Device) -> Result<ID
     unsafe {
         let mut state = None;
         device.CreateBlendState(&desc, Some(&mut state))?;
-        Ok(state.unwrap())
+        state.context("CreateBlendState for subpixel rendering returned no state")
     }
 }
 
@@ -1540,7 +1864,7 @@ fn create_blend_state_for_path_rasterization(device: &ID3D11Device) -> Result<ID
     unsafe {
         let mut state = None;
         device.CreateBlendState(&desc, Some(&mut state))?;
-        Ok(state.unwrap())
+        state.context("CreateBlendState for path rasterization returned no state")
     }
 }
 
@@ -1560,7 +1884,7 @@ fn create_blend_state_for_path_sprite(device: &ID3D11Device) -> Result<ID3D11Ble
     unsafe {
         let mut state = None;
         device.CreateBlendState(&desc, Some(&mut state))?;
-        Ok(state.unwrap())
+        state.context("CreateBlendState for path sprites returned no state")
     }
 }
 
@@ -1569,7 +1893,7 @@ fn create_vertex_shader(device: &ID3D11Device, bytes: &[u8]) -> Result<ID3D11Ver
     unsafe {
         let mut shader = None;
         device.CreateVertexShader(bytes, None, Some(&mut shader))?;
-        Ok(shader.unwrap())
+        shader.context("CreateVertexShader returned no shader")
     }
 }
 
@@ -1578,7 +1902,7 @@ fn create_fragment_shader(device: &ID3D11Device, bytes: &[u8]) -> Result<ID3D11P
     unsafe {
         let mut shader = None;
         device.CreatePixelShader(bytes, None, Some(&mut shader))?;
-        Ok(shader.unwrap())
+        shader.context("CreatePixelShader returned no shader")
     }
 }
 
@@ -1614,7 +1938,7 @@ fn create_buffer(
     };
     let mut buffer = None;
     unsafe { device.CreateBuffer(&desc, None, Some(&mut buffer)) }?;
-    Ok(buffer.unwrap())
+    buffer.context("CreateBuffer returned no buffer")
 }
 
 #[inline]

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -161,7 +161,11 @@ impl WindowsWindowInner {
             WM_SHOWWINDOW => self.handle_window_visibility_changed(handle, wparam),
             WM_GPUI_CURSOR_STYLE_CHANGED => self.handle_cursor_changed(lparam),
             WM_GPUI_FORCE_UPDATE_WINDOW => self.draw_window(handle, true),
-            WM_GPUI_GPU_DEVICE_LOST => self.handle_device_lost(lparam),
+            WM_GPUI_GPU_DEVICE_LOST => self.handle_device_recovery(handle, wparam, lparam),
+            WM_NCDESTROY => {
+                self.state.destroyed.set(true);
+                None
+            }
             DM_POINTERHITTEST => self.handle_dm_pointer_hit_test(wparam),
             WM_GETOBJECT => self.handle_wm_getobject(wparam, lparam),
             _ => None,
@@ -1268,23 +1272,118 @@ impl WindowsWindowInner {
         None
     }
 
-    fn handle_device_lost(&self, lparam: LPARAM) -> Option<isize> {
-        let devices = lparam.0 as *const DirectXDevices;
-        let devices = unsafe { &*devices };
-        if let Err(err) = self
-            .state
-            .renderer
-            .borrow_mut()
-            .handle_device_lost(&devices)
-        {
-            panic!("Device lost: {err}");
+    fn handle_device_recovery(
+        &self,
+        handle: HWND,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> Option<isize> {
+        if wparam.0 != self.validation_number || lparam.0 == 0 {
+            log::error!("gpui_device_loss invalid window recovery message");
+            return Some(0);
         }
-        // Make sure the first `draw_window` after recovery (whether it comes
-        // from the forced WM_GPUI_FORCE_UPDATE_WINDOW or a stray WM_PAINT in
-        // between) is treated as a forced render so it both clears
-        // `skip_draws` and bypasses the view cache.
-        self.state.force_render_pending.set(true);
+
+        let request = lparam.0 as *mut WindowDeviceRecoveryRequest;
+        // SAFETY: the validation token was checked above. The coordinator
+        // sends a pointer to a live stack request with synchronous
+        // `SendMessageW`, so it remains valid for this handler call.
+        let (generation, action) = unsafe {
+            let request = &*request;
+            (request.generation, request.action.clone())
+        };
+
+        let outcome = if self.state.destroyed.get() {
+            WindowDeviceRecoveryOutcome::Destroyed
+        } else {
+            match action {
+                WindowDeviceRecoveryAction::Suspend => self.suspend_renderer(generation),
+                WindowDeviceRecoveryAction::Recover(devices) => {
+                    self.recover_renderer(handle, generation, &devices)
+                }
+            }
+        };
+        // SAFETY: this is the same live synchronous request validated above;
+        // the sender reads the outcome only after `SendMessageW` returns.
+        unsafe { (*request).outcome = Some(outcome) };
         Some(0)
+    }
+
+    fn suspend_renderer(&self, generation: u64) -> WindowDeviceRecoveryOutcome {
+        let suspended = {
+            let Ok(mut renderer) = self.state.renderer.try_borrow_mut() else {
+                // The vsync-owned coordinator keeps this window pending and
+                // retries on its next tick after the current draw, present, or
+                // resize releases the renderer borrow.
+                return WindowDeviceRecoveryOutcome::Deferred;
+            };
+            renderer.suspend(generation)
+        };
+
+        let Some(suspended) = suspended else {
+            return WindowDeviceRecoveryOutcome::Stale;
+        };
+        suspended.release();
+        WindowDeviceRecoveryOutcome::Suspended
+    }
+
+    fn recover_renderer(
+        &self,
+        handle: HWND,
+        generation: u64,
+        devices: &DirectXDevices,
+    ) -> WindowDeviceRecoveryOutcome {
+        let snapshot = {
+            let Ok(renderer) = self.state.renderer.try_borrow() else {
+                return WindowDeviceRecoveryOutcome::Deferred;
+            };
+            let Some(snapshot) = renderer.recovery_snapshot(generation) else {
+                return WindowDeviceRecoveryOutcome::Stale;
+            };
+            snapshot
+        };
+
+        let candidate = match DirectXRenderer::build_recovery_candidate(snapshot, devices) {
+            Ok(candidate) => candidate,
+            Err(error) => {
+                return WindowDeviceRecoveryOutcome::Failed(format!(
+                    "window={:?} size={}x{} direct_composition={} error={error:#}",
+                    snapshot.hwnd,
+                    snapshot.width,
+                    snapshot.height,
+                    !snapshot.disable_direct_composition,
+                ));
+            }
+        };
+        if self.state.destroyed.get() {
+            return WindowDeviceRecoveryOutcome::Destroyed;
+        }
+
+        let commit = {
+            let Ok(mut renderer) = self.state.renderer.try_borrow_mut() else {
+                return WindowDeviceRecoveryOutcome::Deferred;
+            };
+            // This flag must be visible before the renderer becomes active. A
+            // normal WM_PAINT can arrive before the forced-update message.
+            self.state.force_render_pending.set(true);
+            renderer.commit_recovery(candidate)
+        };
+        if commit == DirectXRendererRecoveryCommit::Stale {
+            return WindowDeviceRecoveryOutcome::Stale;
+        }
+
+        // SAFETY: `handle` originated from this window procedure, the posted
+        // message contains no borrowed memory, and an invalidated handle is
+        // reported as a normal Win32 error.
+        unsafe {
+            PostMessageW(
+                Some(handle),
+                WM_GPUI_FORCE_UPDATE_WINDOW,
+                WPARAM(self.validation_number),
+                LPARAM(0),
+            )
+            .log_err();
+        }
+        WindowDeviceRecoveryOutcome::Active
     }
 
     fn handle_dm_pointer_hit_test(&self, wparam: WPARAM) -> Option<isize> {
@@ -1308,6 +1407,16 @@ impl WindowsWindowInner {
             unsafe { ValidateRect(Some(handle), None).ok().log_err() };
             return Some(0);
         };
+        let suspended = match self.state.renderer.try_borrow() {
+            Ok(renderer) => renderer.is_suspended(),
+            Err(_) => true,
+        };
+        if suspended {
+            // SAFETY: `handle` is the window currently dispatching this paint
+            // message; no pointer data crosses the FFI boundary.
+            unsafe { ValidateRect(Some(handle), None).ok().log_err() };
+            return Some(0);
+        }
         let mut request_frame = self.state.callbacks.request_frame.take()?;
 
         self.state.direct_manipulation.update();

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -8,13 +8,14 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context as _, Result, anyhow};
 use futures::channel::oneshot::{self, Receiver};
 use gpui_util::{ResultExt, get_powershell, new_std_command};
 use itertools::Itertools;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 use windows::{
     UI::ViewManagement::UISettings,
@@ -45,12 +46,157 @@ pub struct WindowsPlatform {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     invalidate_devices: Arc<AtomicBool>,
+    device_recovery: Arc<Mutex<SharedDeviceRecovery>>,
     handle: HWND,
     suspend_resume_notification: RefCell<Option<HPOWERNOTIFY>>,
     disable_direct_composition: bool,
     has_package_identity: bool,
     app_identity: RefCell<Option<(String, String)>>,
     system_notifications: RefCell<SystemNotificationState>,
+}
+
+#[derive(Default)]
+struct SharedDeviceRecovery {
+    generation: u64,
+    last_generation: u64,
+    new_windows: Vec<SafeHwnd>,
+}
+
+#[derive(Clone)]
+pub(crate) enum WindowDeviceRecoveryAction {
+    Suspend,
+    Recover(DirectXDevices),
+}
+
+pub(crate) struct WindowDeviceRecoveryRequest {
+    pub(crate) generation: u64,
+    pub(crate) action: WindowDeviceRecoveryAction,
+    pub(crate) outcome: Option<WindowDeviceRecoveryOutcome>,
+}
+
+#[derive(Debug)]
+pub(crate) enum WindowDeviceRecoveryOutcome {
+    Suspended,
+    Active,
+    Deferred,
+    Stale,
+    Destroyed,
+    Failed(String),
+}
+
+struct GlobalDeviceRecoveryRequest {
+    directx_devices: DirectXDevices,
+    text_system: Arc<DirectWriteTextSystem>,
+    gpu_state: Option<GPUState>,
+    published: bool,
+}
+
+const DEVICE_RECOVERY_RETRY_DELAYS_MS: [u64; 8] = [0, 100, 250, 500, 1000, 2000, 4000, 8000];
+
+#[cfg(any(debug_assertions, test))]
+fn parse_injected_device_loss_vsyncs(value: &str) -> Vec<u64> {
+    value
+        .split(',')
+        .filter_map(|value| value.trim().parse::<u64>().ok())
+        .collect()
+}
+
+fn window_recovery_retry_delay(attempts: usize) -> Option<Duration> {
+    DEVICE_RECOVERY_RETRY_DELAYS_MS
+        .get(attempts)
+        .copied()
+        .map(Duration::from_millis)
+}
+
+fn take_device_invalidation(recovery_active: bool, invalidate_devices: &AtomicBool) -> bool {
+    !recovery_active && invalidate_devices.fetch_and(false, Ordering::Acquire)
+}
+
+struct DeviceRecovery {
+    generation: u64,
+    started_at: Instant,
+    phase: DeviceRecoveryPhase,
+    windows: Vec<DeviceRecoveryWindow>,
+}
+
+enum DeviceRecoveryPhase {
+    Suspending,
+    RecreateGlobal {
+        attempts: usize,
+        next_attempt: Instant,
+    },
+    RecoverWindows {
+        devices: DirectXDevices,
+    },
+}
+
+struct DeviceRecoveryWindow {
+    hwnd: SafeHwnd,
+    suspended: bool,
+    attempts: usize,
+    next_attempt: Instant,
+    outcome: DeviceRecoveryWindowOutcome,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeviceRecoveryWindowOutcome {
+    Pending,
+    Active,
+    Destroyed,
+    Exhausted,
+}
+
+impl DeviceRecoveryWindow {
+    fn new(hwnd: SafeHwnd, suspended: bool, now: Instant) -> Self {
+        Self {
+            hwnd,
+            suspended,
+            attempts: 0,
+            next_attempt: now,
+            outcome: DeviceRecoveryWindowOutcome::Pending,
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.outcome,
+            DeviceRecoveryWindowOutcome::Active
+                | DeviceRecoveryWindowOutcome::Destroyed
+                | DeviceRecoveryWindowOutcome::Exhausted
+        )
+    }
+
+    fn next_attempt_number(&self) -> usize {
+        self.attempts + 1
+    }
+
+    fn record_active(&mut self) {
+        self.attempts += 1;
+        self.outcome = DeviceRecoveryWindowOutcome::Active;
+    }
+
+    fn record_destroyed(&mut self) {
+        self.outcome = DeviceRecoveryWindowOutcome::Destroyed;
+    }
+
+    fn record_deferred(&mut self, now: Instant) {
+        self.next_attempt = now;
+    }
+
+    fn record_retryable_failure(&mut self, now: Instant) -> bool {
+        self.attempts += 1;
+        let Some(delay) = window_recovery_retry_delay(self.attempts) else {
+            self.outcome = DeviceRecoveryWindowOutcome::Exhausted;
+            return true;
+        };
+        self.next_attempt = now + delay;
+        false
+    }
+
+    fn reset_for_recovery(&mut self, now: Instant) {
+        self.attempts = 0;
+        self.next_attempt = now;
+    }
 }
 
 struct WindowsPlatformInner {
@@ -208,6 +354,7 @@ impl WindowsPlatform {
             has_package_identity: has_package_identity(),
             drop_target_helper,
             invalidate_devices: Arc::new(AtomicBool::new(false)),
+            device_recovery: Arc::new(Mutex::new(SharedDeviceRecovery::default())),
             app_identity: RefCell::new(None),
             system_notifications: RefCell::new(SystemNotificationState::new()),
         })
@@ -231,7 +378,7 @@ impl WindowsPlatform {
             });
     }
 
-    fn generate_creation_info(&self) -> WindowCreationInfo {
+    fn generate_creation_info(&self, recovery_generation: u64) -> WindowCreationInfo {
         WindowCreationInfo {
             icon: self.icon,
             executor: self.foreground_executor.clone(),
@@ -242,7 +389,12 @@ impl WindowsPlatform {
             main_receiver: self.inner.main_receiver.clone(),
             platform_window_handle: self.handle,
             disable_direct_composition: self.disable_direct_composition,
-            directx_devices: self.inner.state.directx_devices.borrow().clone().unwrap(),
+            directx_devices: if recovery_generation == 0 {
+                self.inner.state.directx_devices.borrow().clone()
+            } else {
+                None
+            },
+            recovery_generation,
             invalidate_devices: self.invalidate_devices.clone(),
             draw_coordinator: self.inner.state.draw_coordinator.clone(),
         }
@@ -322,25 +474,65 @@ impl WindowsPlatform {
         let all_windows = Arc::downgrade(&self.raw_window_handles);
         let text_system = Arc::downgrade(direct_write_text_system);
         let invalidate_devices = self.invalidate_devices.clone();
+        let shared_recovery = self.device_recovery.clone();
+        #[cfg(debug_assertions)]
+        let injected_device_loss_vsyncs = std::env::var("GPUI_TEST_DEVICE_LOSS_AT_VSYNCS")
+            .ok()
+            .map(|value| parse_injected_device_loss_vsyncs(&value))
+            .unwrap_or_default();
 
         std::thread::Builder::new()
             .name("VSyncProvider".to_owned())
             .spawn(move || {
                 let vsync_provider = VSyncProvider::new();
+                let mut recovery = None;
+                #[cfg(debug_assertions)]
+                let mut vsync_count = 0u64;
                 loop {
                     vsync_provider.wait_for_vsync();
-                    if check_device_lost(&directx_device.device)
-                        || invalidate_devices.fetch_and(false, Ordering::Acquire)
+                    #[cfg(debug_assertions)]
+                    let inject_device_loss = {
+                        vsync_count += 1;
+                        injected_device_loss_vsyncs.contains(&vsync_count)
+                    };
+                    #[cfg(not(debug_assertions))]
+                    let inject_device_loss = false;
+                    #[cfg(debug_assertions)]
+                    if inject_device_loss {
+                        log::warn!(
+                            "injecting synthetic DirectX device-loss recovery at vsync {vsync_count}"
+                        );
+                    }
+                    // Preserve resize failures raised during recovery. Once
+                    // the active generation completes, the retained flag
+                    // starts a follow-up generation rather than leaving a
+                    // window suspended indefinitely.
+                    let devices_invalidated =
+                        take_device_invalidation(recovery.is_some(), &invalidate_devices);
+                    if recovery.is_none()
+                        && (check_device_lost(&directx_device.device)
+                            || devices_invalidated
+                            || inject_device_loss)
                     {
-                        if let Err(err) = handle_gpu_device_lost(
-                            &mut directx_device,
+                        recovery = DeviceRecovery::start(
+                            &shared_recovery,
+                            &all_windows,
+                            &directx_device,
+                            Instant::now(),
+                        );
+                    }
+                    if recovery.as_mut().is_some_and(|recovery| {
+                        recovery.advance(
                             platform_window.as_raw(),
                             validation_number,
                             &all_windows,
                             &text_system,
-                        ) {
-                            panic!("Device lost: {err}");
-                        }
+                            &shared_recovery,
+                            &mut directx_device,
+                            Instant::now(),
+                        )
+                    }) {
+                        recovery = None;
                     }
                     let Some(all_windows) = all_windows.upgrade() else {
                         break;
@@ -580,9 +772,18 @@ impl Platform for WindowsPlatform {
         handle: AnyWindowHandle,
         options: WindowParams,
     ) -> Result<Box<dyn PlatformWindow>> {
-        let window = WindowsWindow::new(handle, options, self.generate_creation_info())?;
+        let mut device_recovery = self.device_recovery.lock();
+        let recovery_generation = device_recovery.generation;
+        let window = WindowsWindow::new(
+            handle,
+            options,
+            self.generate_creation_info(recovery_generation),
+        )?;
         let handle = window.get_raw_handle();
         self.raw_window_handles.write().push(handle.into());
+        if recovery_generation != 0 {
+            device_recovery.new_windows.push(handle.into());
+        }
 
         Ok(Box::new(window))
     }
@@ -1030,7 +1231,7 @@ impl WindowsPlatformInner {
             WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD => self.run_foreground_task(),
             WM_GPUI_DOCK_MENU_ACTION => self.handle_dock_action_event(lparam.0 as _),
             WM_GPUI_KEYBOARD_LAYOUT_CHANGED => self.handle_keyboard_layout_change(),
-            WM_GPUI_GPU_DEVICE_LOST => self.handle_device_lost(lparam),
+            WM_GPUI_GPU_DEVICE_LOST => self.publish_device_recovery(lparam),
             WM_GPUI_END_SESSION => self.handle_end_session(),
             _ => unreachable!(),
         }
@@ -1170,12 +1371,33 @@ impl WindowsPlatformInner {
         Some(1)
     }
 
-    fn handle_device_lost(&self, lparam: LPARAM) -> Option<isize> {
-        let directx_devices = lparam.0 as *const DirectXDevices;
-        let directx_devices = unsafe { &*directx_devices };
-        self.state.directx_devices.borrow_mut().take();
-        *self.state.directx_devices.borrow_mut() = Some(directx_devices.clone());
+    fn publish_device_recovery(&self, lparam: LPARAM) -> Option<isize> {
+        if lparam.0 == 0 {
+            log::error!("gpui_device_loss invalid global recovery message");
+            return Some(0);
+        }
+        let request = lparam.0 as *mut GlobalDeviceRecoveryRequest;
+        // SAFETY: the platform coordinator sends this live stack request with
+        // synchronous `SendMessageW`; the call cannot return until this
+        // handler releases the borrow.
+        let (directx_devices, text_system, gpu_state) = unsafe {
+            let request = &mut *request;
+            (
+                request.directx_devices.clone(),
+                request.text_system.clone(),
+                request.gpu_state.take(),
+            )
+        };
+        let Some(gpu_state) = gpu_state else {
+            log::error!("gpui_device_loss missing DirectWrite recovery candidate");
+            return Some(0);
+        };
 
+        text_system.commit_gpu_recovery(gpu_state);
+        *self.state.directx_devices.borrow_mut() = Some(directx_devices);
+        // SAFETY: this is the same live synchronous request validated above;
+        // the sender reads `published` only after the handler returns.
+        unsafe { (*request).published = true };
         Some(0)
     }
 }
@@ -1205,7 +1427,8 @@ pub(crate) struct WindowCreationInfo {
     pub(crate) main_receiver: PriorityQueueReceiver<RunnableVariant>,
     pub(crate) platform_window_handle: HWND,
     pub(crate) disable_direct_composition: bool,
-    pub(crate) directx_devices: DirectXDevices,
+    pub(crate) directx_devices: Option<DirectXDevices>,
+    pub(crate) recovery_generation: u64,
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     pub(crate) invalidate_devices: Arc<AtomicBool>,
@@ -1429,65 +1652,393 @@ fn check_device_lost(device: &ID3D11Device) -> bool {
     match device_state {
         Ok(_) => false,
         Err(err) => {
-            log::error!("DirectX device lost detected: {:?}", err);
+            log::error!(
+                "gpui_device_loss removed_hresult=0x{:08x} error={err:?}",
+                err.code().0 as u32
+            );
             true
         }
     }
 }
 
-fn handle_gpu_device_lost(
-    directx_devices: &mut DirectXDevices,
+fn adapter_diagnostics(devices: &DirectXDevices) -> String {
+    // SAFETY: `adapter` is an owned COM interface and `GetDesc1` writes into
+    // the result value managed by the Windows binding.
+    let Ok(description) = (unsafe { devices.adapter.GetDesc1() }) else {
+        return "adapter=unknown".to_owned();
+    };
+    let name = String::from_utf16_lossy(&description.Description)
+        .trim_matches(char::from(0))
+        .to_owned();
+    format!(
+        "adapter={name:?} vendor=0x{:04x} device=0x{:04x} luid={:08x}:{:08x}",
+        description.VendorId,
+        description.DeviceId,
+        description.AdapterLuid.HighPart as u32,
+        description.AdapterLuid.LowPart,
+    )
+}
+
+impl DeviceRecovery {
+    fn start(
+        shared_recovery: &Arc<Mutex<SharedDeviceRecovery>>,
+        all_windows: &std::sync::Weak<RwLock<SmallVec<[SafeHwnd; 4]>>>,
+        current_devices: &DirectXDevices,
+        now: Instant,
+    ) -> Option<Self> {
+        let all_windows = all_windows.upgrade()?;
+        let mut shared = shared_recovery.lock();
+        shared.last_generation = shared.last_generation.wrapping_add(1).max(1);
+        shared.generation = shared.last_generation;
+        shared.new_windows.clear();
+        let generation = shared.generation;
+        let windows = all_windows
+            .read()
+            .iter()
+            .copied()
+            .map(|hwnd| DeviceRecoveryWindow::new(hwnd, false, now))
+            .collect::<Vec<_>>();
+        drop(shared);
+
+        log::error!(
+            "gpui_device_loss generation={generation} detected windows={} {}",
+            windows.len(),
+            adapter_diagnostics(current_devices),
+        );
+        Some(Self {
+            generation,
+            started_at: now,
+            phase: DeviceRecoveryPhase::Suspending,
+            windows,
+        })
+    }
+
+    fn advance(
+        &mut self,
+        platform_window: HWND,
+        validation_number: usize,
+        all_windows: &std::sync::Weak<RwLock<SmallVec<[SafeHwnd; 4]>>>,
+        text_system: &std::sync::Weak<DirectWriteTextSystem>,
+        shared_recovery: &Arc<Mutex<SharedDeviceRecovery>>,
+        current_devices: &mut DirectXDevices,
+        now: Instant,
+    ) -> bool {
+        self.add_new_windows(shared_recovery, now);
+        let Some(all_windows) = all_windows.upgrade() else {
+            self.finish(shared_recovery);
+            return true;
+        };
+        let live_windows = all_windows
+            .read()
+            .iter()
+            .map(|window| window.as_raw())
+            .collect::<Vec<_>>();
+        for window in &mut self.windows {
+            if !live_windows.contains(&window.hwnd.as_raw()) {
+                window.record_destroyed();
+            }
+        }
+        drop(all_windows);
+
+        if matches!(self.phase, DeviceRecoveryPhase::Suspending) {
+            for window in &mut self.windows {
+                if window.suspended || window.outcome == DeviceRecoveryWindowOutcome::Destroyed {
+                    continue;
+                }
+                match send_window_device_recovery(
+                    window.hwnd,
+                    validation_number,
+                    self.generation,
+                    WindowDeviceRecoveryAction::Suspend,
+                ) {
+                    WindowDeviceRecoveryOutcome::Suspended => window.suspended = true,
+                    WindowDeviceRecoveryOutcome::Destroyed => window.record_destroyed(),
+                    WindowDeviceRecoveryOutcome::Deferred => {}
+                    outcome => log::warn!(
+                        "gpui_device_loss generation={} window={:?} suspend={outcome:?}",
+                        self.generation,
+                        window.hwnd.as_raw()
+                    ),
+                }
+            }
+            if self.windows.iter().all(|window| {
+                window.suspended || window.outcome == DeviceRecoveryWindowOutcome::Destroyed
+            }) {
+                self.phase = DeviceRecoveryPhase::RecreateGlobal {
+                    attempts: 0,
+                    next_attempt: now,
+                };
+            }
+        }
+
+        let should_recreate_global = match &self.phase {
+            DeviceRecoveryPhase::RecreateGlobal { next_attempt, .. } => now >= *next_attempt,
+            _ => false,
+        };
+        if should_recreate_global {
+            let attempt = match &self.phase {
+                DeviceRecoveryPhase::RecreateGlobal { attempts, .. } => *attempts + 1,
+                _ => unreachable!(),
+            };
+            let candidate = DirectXDevices::new()
+                .context("recreating global DirectX devices")
+                .and_then(|devices| {
+                    DirectWriteTextSystem::build_gpu_recovery_candidate(&devices)
+                        .map(|gpu_state| (devices, gpu_state))
+                });
+
+            match candidate {
+                Ok((devices, gpu_state)) => {
+                    let Some(text_system) = text_system.upgrade() else {
+                        self.finish(shared_recovery);
+                        return true;
+                    };
+                    if publish_global_device_recovery(
+                        platform_window,
+                        validation_number,
+                        devices.clone(),
+                        text_system,
+                        gpu_state,
+                    ) {
+                        log::info!(
+                            "gpui_device_loss generation={} global_attempt={} active elapsed_ms={} {}",
+                            self.generation,
+                            attempt,
+                            self.started_at.elapsed().as_millis(),
+                            adapter_diagnostics(&devices),
+                        );
+                        *current_devices = devices.clone();
+                        for window in &mut self.windows {
+                            window.reset_for_recovery(now);
+                        }
+                        self.phase = DeviceRecoveryPhase::RecoverWindows { devices };
+                    } else {
+                        self.schedule_global_retry(now, attempt);
+                    }
+                }
+                Err(error) => {
+                    log::error!(
+                        "gpui_device_loss generation={} global_attempt={} failed: {error:#}",
+                        self.generation,
+                        attempt
+                    );
+                    self.schedule_global_retry(now, attempt);
+                }
+            }
+        }
+
+        let recovery_devices = match &self.phase {
+            DeviceRecoveryPhase::RecoverWindows { devices } => Some(devices.clone()),
+            _ => None,
+        };
+        if let Some(devices) = recovery_devices {
+            for window in &mut self.windows {
+                if window.outcome != DeviceRecoveryWindowOutcome::Pending
+                    || now < window.next_attempt
+                {
+                    continue;
+                }
+
+                let attempt = window.next_attempt_number();
+                let outcome = send_window_device_recovery(
+                    window.hwnd,
+                    validation_number,
+                    self.generation,
+                    WindowDeviceRecoveryAction::Recover(devices.clone()),
+                );
+                match outcome {
+                    WindowDeviceRecoveryOutcome::Active => {
+                        window.record_active();
+                        #[cfg(debug_assertions)]
+                        if std::env::var_os("GPUI_TEST_DEVICE_RECOVERY_FAILURE").is_some() {
+                            eprintln!(
+                                "gpui_device_loss_test generation={} window={:?} attempt={} result=active",
+                                self.generation,
+                                window.hwnd.as_raw(),
+                                attempt
+                            );
+                        }
+                        log::info!(
+                            "gpui_device_loss generation={} window={:?} attempt={} active",
+                            self.generation,
+                            window.hwnd.as_raw(),
+                            attempt
+                        );
+                    }
+                    WindowDeviceRecoveryOutcome::Destroyed => window.record_destroyed(),
+                    WindowDeviceRecoveryOutcome::Deferred => window.record_deferred(now),
+                    WindowDeviceRecoveryOutcome::Failed(error) => {
+                        log::error!(
+                            "gpui_device_loss generation={} window={:?} attempt={} failed: {}",
+                            self.generation,
+                            window.hwnd.as_raw(),
+                            attempt,
+                            error
+                        );
+                        if window.record_retryable_failure(now) {
+                            log::error!(
+                                "gpui_device_loss generation={} window={:?} attempt={} exhausted",
+                                self.generation,
+                                window.hwnd.as_raw(),
+                                attempt
+                            );
+                            #[cfg(debug_assertions)]
+                            if std::env::var_os("GPUI_TEST_DEVICE_RECOVERY_FAILURE").is_some() {
+                                eprintln!(
+                                    "gpui_device_loss_test generation={} window={:?} attempt={} result=exhausted",
+                                    self.generation,
+                                    window.hwnd.as_raw(),
+                                    attempt
+                                );
+                            }
+                        }
+                    }
+                    WindowDeviceRecoveryOutcome::Stale => {
+                        log::warn!(
+                            "gpui_device_loss generation={} window={:?} attempt={} stale candidate",
+                            self.generation,
+                            window.hwnd.as_raw(),
+                            attempt
+                        );
+                        // A live resize or generation race invalidates this
+                        // candidate without proving the replacement device is
+                        // bad. Retry on the next vsync without consuming one of
+                        // the eight device-recovery attempts.
+                        window.record_deferred(now);
+                    }
+                    WindowDeviceRecoveryOutcome::Suspended => {}
+                }
+            }
+
+            if self.windows.iter().all(DeviceRecoveryWindow::is_terminal) {
+                let mut shared = shared_recovery.lock();
+                if shared.generation != self.generation {
+                    return true;
+                }
+                if shared.new_windows.is_empty() {
+                    shared.generation = 0;
+                    log::info!(
+                        "gpui_device_loss generation={} complete elapsed_ms={}",
+                        self.generation,
+                        self.started_at.elapsed().as_millis()
+                    );
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn add_new_windows(
+        &mut self,
+        shared_recovery: &Arc<Mutex<SharedDeviceRecovery>>,
+        now: Instant,
+    ) {
+        let new_windows = {
+            let mut shared = shared_recovery.lock();
+            if shared.generation != self.generation {
+                return;
+            }
+            std::mem::take(&mut shared.new_windows)
+        };
+        for hwnd in new_windows {
+            if let Some(window) = self
+                .windows
+                .iter_mut()
+                .find(|window| window.hwnd.as_raw() == hwnd.as_raw())
+            {
+                // Windows can recycle a destroyed HWND before this recovery
+                // generation finishes. A queued new window with the same raw
+                // handle owns a new suspended renderer, so replace the old
+                // terminal record instead of discarding it as a duplicate.
+                if window.is_terminal() {
+                    *window = DeviceRecoveryWindow::new(hwnd, true, now);
+                }
+                continue;
+            }
+            self.windows
+                .push(DeviceRecoveryWindow::new(hwnd, true, now));
+        }
+    }
+
+    fn schedule_global_retry(&mut self, now: Instant, attempt: usize) {
+        let delay_index = attempt.min(DEVICE_RECOVERY_RETRY_DELAYS_MS.len() - 1);
+        self.phase = DeviceRecoveryPhase::RecreateGlobal {
+            attempts: attempt,
+            next_attempt: now + Duration::from_millis(DEVICE_RECOVERY_RETRY_DELAYS_MS[delay_index]),
+        };
+    }
+
+    fn finish(&self, shared_recovery: &Arc<Mutex<SharedDeviceRecovery>>) {
+        let mut shared = shared_recovery.lock();
+        if shared.generation == self.generation {
+            shared.generation = 0;
+            shared.new_windows.clear();
+        }
+    }
+}
+
+fn send_window_device_recovery(
+    hwnd: SafeHwnd,
+    validation_number: usize,
+    generation: u64,
+    action: WindowDeviceRecoveryAction,
+) -> WindowDeviceRecoveryOutcome {
+    // SAFETY: the raw handle is used only as an identifier for the Win32
+    // validity query; no application memory is dereferenced.
+    if !unsafe { IsWindow(Some(hwnd.as_raw())).as_bool() } {
+        return WindowDeviceRecoveryOutcome::Destroyed;
+    }
+    let mut request = WindowDeviceRecoveryRequest {
+        generation,
+        action,
+        outcome: None,
+    };
+    // SAFETY: `SendMessageW` is synchronous, so `request` remains live while
+    // the validated GPUI window procedure reads it and writes its outcome.
+    unsafe {
+        SendMessageW(
+            hwnd.as_raw(),
+            WM_GPUI_GPU_DEVICE_LOST,
+            Some(WPARAM(validation_number)),
+            Some(LPARAM(&raw mut request as *mut _ as isize)),
+        );
+    }
+    request.outcome.unwrap_or_else(|| {
+        // SAFETY: the raw handle is used only for a validity query after the
+        // synchronous send; no application memory is dereferenced.
+        if unsafe { IsWindow(Some(hwnd.as_raw())).as_bool() } {
+            WindowDeviceRecoveryOutcome::Deferred
+        } else {
+            WindowDeviceRecoveryOutcome::Destroyed
+        }
+    })
+}
+
+fn publish_global_device_recovery(
     platform_window: HWND,
     validation_number: usize,
-    all_windows: &std::sync::Weak<RwLock<SmallVec<[SafeHwnd; 4]>>>,
-    text_system: &std::sync::Weak<DirectWriteTextSystem>,
-) -> Result<()> {
-    // Here we wait a bit to ensure the system has time to recover from the device lost state.
-    // If we don't wait, the final drawing result will be blank.
-    std::thread::sleep(std::time::Duration::from_millis(350));
-
-    *directx_devices = try_to_recover_from_device_lost(|| {
-        DirectXDevices::new().context("Failed to recreate new DirectX devices after device lost")
-    })?;
-    log::info!("DirectX devices successfully recreated.");
-
-    let lparam = LPARAM(directx_devices as *const _ as _);
+    directx_devices: DirectXDevices,
+    text_system: Arc<DirectWriteTextSystem>,
+    gpu_state: GPUState,
+) -> bool {
+    let mut request = GlobalDeviceRecoveryRequest {
+        directx_devices,
+        text_system,
+        gpu_state: Some(gpu_state),
+        published: false,
+    };
+    // SAFETY: `SendMessageW` is synchronous, so `request` remains live while
+    // the validated platform window procedure consumes its candidate state.
     unsafe {
         SendMessageW(
             platform_window,
             WM_GPUI_GPU_DEVICE_LOST,
             Some(WPARAM(validation_number)),
-            Some(lparam),
+            Some(LPARAM(&raw mut request as *mut _ as isize)),
         );
     }
-
-    if let Some(text_system) = text_system.upgrade() {
-        text_system.handle_gpu_lost(&directx_devices)?;
-    }
-    if let Some(all_windows) = all_windows.upgrade() {
-        for window in all_windows.read().iter() {
-            unsafe {
-                SendMessageW(
-                    window.as_raw(),
-                    WM_GPUI_GPU_DEVICE_LOST,
-                    Some(WPARAM(validation_number)),
-                    Some(lparam),
-                );
-            }
-        }
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        for window in all_windows.read().iter() {
-            unsafe {
-                SendMessageW(
-                    window.as_raw(),
-                    WM_GPUI_FORCE_UPDATE_WINDOW,
-                    Some(WPARAM(validation_number)),
-                    None,
-                );
-            }
-        }
-    }
-    Ok(())
+    request.published
 }
 
 const PLATFORM_WINDOW_CLASS_NAME: PCWSTR = w!("Zed::PlatformWindow");
@@ -1566,11 +2117,20 @@ unsafe extern "system" fn window_procedure(
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
 
     use crate::{read_from_clipboard, write_to_clipboard};
     use gpui::ClipboardItem;
+    use parking_lot::Mutex;
+    use windows::Win32::Foundation::HWND;
 
-    use super::encode_restart_arguments;
+    use super::{
+        DeviceRecovery, DeviceRecoveryPhase, DeviceRecoveryWindow, DeviceRecoveryWindowOutcome,
+        SafeHwnd, SharedDeviceRecovery, encode_restart_arguments,
+        parse_injected_device_loss_vsyncs, take_device_invalidation, window_recovery_retry_delay,
+    };
 
     #[test]
     fn test_encode_restart_arguments() {
@@ -1586,6 +2146,113 @@ mod tests {
             encode_restart_arguments(&[OsString::from(r"C:\")]),
             OsStr::new(r#""C:\\""#)
         );
+    }
+
+    #[test]
+    fn parses_synthetic_device_loss_vsyncs() {
+        assert_eq!(
+            parse_injected_device_loss_vsyncs("30, 90,broken,120"),
+            [30, 90, 120]
+        );
+    }
+
+    #[test]
+    fn window_recovery_has_eight_bounded_attempts() {
+        let delays = (0..8)
+            .map(|attempts| window_recovery_retry_delay(attempts).unwrap().as_millis())
+            .collect::<Vec<_>>();
+        assert_eq!(delays, [0, 100, 250, 500, 1000, 2000, 4000, 8000]);
+        assert!(window_recovery_retry_delay(8).is_none());
+    }
+    #[test]
+    fn retryable_window_failure_exhausts_on_attempt_eight() {
+        let now = Instant::now();
+        let mut window = DeviceRecoveryWindow::new(SafeHwnd::from(HWND::default()), true, now);
+
+        for attempt in 1..8 {
+            assert_eq!(window.next_attempt_number(), attempt);
+            assert!(!window.record_retryable_failure(now));
+            assert_eq!(window.attempts, attempt);
+            assert_eq!(window.outcome, DeviceRecoveryWindowOutcome::Pending);
+            assert_eq!(
+                window.next_attempt,
+                now + window_recovery_retry_delay(attempt).unwrap()
+            );
+        }
+
+        assert_eq!(window.next_attempt_number(), 8);
+        assert!(window.record_retryable_failure(now));
+        assert_eq!(window.attempts, 8);
+        assert_eq!(window.outcome, DeviceRecoveryWindowOutcome::Exhausted);
+        assert!(window.is_terminal());
+    }
+
+    #[test]
+    fn deferred_window_recovery_does_not_consume_an_attempt() {
+        let now = Instant::now();
+        let later = now + Duration::from_secs(1);
+        let mut window = DeviceRecoveryWindow::new(SafeHwnd::from(HWND::default()), true, now);
+        assert!(!window.record_retryable_failure(now));
+        assert_eq!(window.attempts, 1);
+
+        window.record_deferred(later);
+
+        assert_eq!(window.attempts, 1);
+        assert_eq!(window.next_attempt, later);
+        assert_eq!(window.outcome, DeviceRecoveryWindowOutcome::Pending);
+    }
+
+    #[test]
+    fn device_invalidation_is_retained_until_recovery_finishes() {
+        let invalidated = AtomicBool::new(true);
+
+        assert!(!take_device_invalidation(true, &invalidated));
+        assert!(invalidated.load(Ordering::Acquire));
+        assert!(take_device_invalidation(false, &invalidated));
+        assert!(!invalidated.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn active_and_destroyed_windows_are_terminal() {
+        let now = Instant::now();
+        let mut active = DeviceRecoveryWindow::new(SafeHwnd::from(HWND::default()), true, now);
+        active.record_active();
+        assert_eq!(active.attempts, 1);
+        assert_eq!(active.outcome, DeviceRecoveryWindowOutcome::Active);
+        assert!(active.is_terminal());
+
+        let mut destroyed = DeviceRecoveryWindow::new(SafeHwnd::from(HWND::default()), true, now);
+        destroyed.record_destroyed();
+        assert_eq!(destroyed.attempts, 0);
+        assert_eq!(destroyed.outcome, DeviceRecoveryWindowOutcome::Destroyed);
+        assert!(destroyed.is_terminal());
+    }
+
+    #[test]
+    fn recycled_window_handle_replaces_terminal_recovery_record() {
+        let now = Instant::now();
+        let hwnd = SafeHwnd::from(HWND::default());
+        let mut old_window = DeviceRecoveryWindow::new(hwnd, true, now);
+        old_window.record_active();
+        let mut recovery = DeviceRecovery {
+            generation: 7,
+            started_at: now,
+            phase: DeviceRecoveryPhase::Suspending,
+            windows: vec![old_window],
+        };
+        let shared = Arc::new(Mutex::new(SharedDeviceRecovery {
+            generation: 7,
+            last_generation: 7,
+            new_windows: vec![hwnd],
+        }));
+
+        recovery.add_new_windows(&shared, now + Duration::from_secs(1));
+
+        assert_eq!(recovery.windows.len(), 1);
+        let replacement = &recovery.windows[0];
+        assert!(replacement.suspended);
+        assert_eq!(replacement.attempts, 0);
+        assert_eq!(replacement.outcome, DeviceRecoveryWindowOutcome::Pending);
     }
 
     #[test]

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -71,6 +71,7 @@ pub struct WindowsWindowState {
     /// and when a forced render was requested while another draw was in
     /// progress and had to be deferred.
     pub force_render_pending: Cell<bool>,
+    pub destroyed: Cell<bool>,
 
     pub click_state: ClickState,
     pub current_cursor: Cell<Option<HCURSOR>>,
@@ -110,7 +111,8 @@ pub(crate) struct WindowsWindowInner {
 impl WindowsWindowState {
     fn new(
         hwnd: HWND,
-        directx_devices: &DirectXDevices,
+        directx_devices: Option<&DirectXDevices>,
+        recovery_generation: u64,
         window_params: &CREATESTRUCTW,
         current_cursor: Option<HCURSOR>,
         cursor_visible: Arc<AtomicBool>,
@@ -139,8 +141,12 @@ impl WindowsWindowState {
         };
         let border_offset = WindowBorderOffset::default();
         let restore_from_minimized = None;
-        let renderer = DirectXRenderer::new(hwnd, directx_devices, disable_direct_composition)
-            .context("Creating DirectX renderer")?;
+        let renderer = if let Some(directx_devices) = directx_devices {
+            DirectXRenderer::new(hwnd, directx_devices, disable_direct_composition)
+                .context("Creating DirectX renderer")?
+        } else {
+            DirectXRenderer::new_suspended(hwnd, disable_direct_composition, recovery_generation)
+        };
         let callbacks = Callbacks::default();
         let input_handler = None;
         let pending_surrogate = None;
@@ -174,6 +180,7 @@ impl WindowsWindowState {
             hovered: Cell::new(hovered),
             renderer: RefCell::new(renderer),
             force_render_pending: Cell::new(false),
+            destroyed: Cell::new(false),
             click_state,
             current_cursor: Cell::new(current_cursor),
             cursor_visible,
@@ -252,7 +259,8 @@ impl WindowsWindowInner {
     fn new(context: &mut WindowCreateContext, hwnd: HWND, cs: &CREATESTRUCTW) -> Result<Rc<Self>> {
         let state = WindowsWindowState::new(
             hwnd,
-            &context.directx_devices,
+            context.directx_devices.as_ref(),
+            context.recovery_generation,
             cs,
             context.current_cursor,
             context.cursor_visible.clone(),
@@ -407,7 +415,8 @@ struct WindowCreateContext {
     platform_window_handle: HWND,
     appearance: WindowAppearance,
     disable_direct_composition: bool,
-    directx_devices: DirectXDevices,
+    directx_devices: Option<DirectXDevices>,
+    recovery_generation: u64,
     invalidate_devices: Arc<AtomicBool>,
     draw_coordinator: Rc<DrawCoordinator>,
     parent_hwnd: Option<HWND>,
@@ -436,6 +445,7 @@ impl WindowsWindow {
             platform_window_handle,
             disable_direct_composition,
             directx_devices,
+            recovery_generation,
             invalidate_devices,
             draw_coordinator,
         } = creation_info;
@@ -521,6 +531,7 @@ impl WindowsWindow {
             appearance,
             disable_direct_composition,
             directx_devices,
+            recovery_generation,
             invalidate_devices,
             draw_coordinator,
             parent_hwnd,

--- a/script/test-gpui-windows-device-loss.ps1
+++ b/script/test-gpui-windows-device-loss.ps1
@@ -1,0 +1,384 @@
+#!/usr/bin/env pwsh
+# Exercise GPUI's real Windows vsync and renderer-recovery path without changing
+# the installed display driver. Each scenario launches an existing GPUI example,
+# waits for its structured recovery result, verifies that the process is still
+# alive, and stops only that exact child process.
+#
+# This test needs an interactive Windows desktop and therefore is not part of
+# the parallel nextest suite.
+#
+# Usage:
+#   ./script/test-gpui-windows-device-loss.ps1
+#   ./script/test-gpui-windows-device-loss.ps1 -NoBuild
+#   ./script/test-gpui-windows-device-loss.ps1 -EvidenceDirectory D:/tmp/gpui-device-loss
+
+[CmdletBinding()]
+param(
+    [switch]$NoBuild,
+    [ValidateRange(10, 120)]
+    [int]$TimeoutSeconds = 35,
+    [string]$EvidenceDirectory
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+    throw "This integration test requires Windows."
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$cargo = if ($env:CARGO) { $env:CARGO } else { "cargo" }
+$environmentNames = @(
+    "GPUI_TEST_DEVICE_LOSS_AT_VSYNCS",
+    "GPUI_TEST_DEVICE_RECOVERY_FAILURE",
+    "GPUI_DISABLE_DIRECT_COMPOSITION"
+)
+
+function Set-ScenarioEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]$Scenario
+    )
+
+    $env:GPUI_TEST_DEVICE_LOSS_AT_VSYNCS = $Scenario.DeviceLossVsyncs
+    $env:GPUI_TEST_DEVICE_RECOVERY_FAILURE = $Scenario.RecoveryFailure
+    if ($Scenario.DisableDirectComposition) {
+        $env:GPUI_DISABLE_DIRECT_COMPOSITION = "true"
+    }
+    else {
+        Remove-Item Env:GPUI_DISABLE_DIRECT_COMPOSITION -ErrorAction SilentlyContinue
+    }
+}
+
+function Restore-Environment {
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$OriginalEnvironment
+    )
+
+    foreach ($name in $environmentNames) {
+        $value = $OriginalEnvironment[$name]
+        if ($null -eq $value) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item "Env:$name" $value
+        }
+    }
+}
+
+function Test-ExpectedPatterns {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Log,
+        [Parameter(Mandatory = $true)][string[]]$ExpectedPatterns
+    )
+
+    foreach ($pattern in $ExpectedPatterns) {
+        if (-not [regex]::IsMatch($Log, $pattern)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Get-InjectedFailurePatterns {
+    param(
+        [Parameter(Mandatory = $true)][string]$Stage,
+        [Parameter(Mandatory = $true)][int]$Count,
+        [int[]]$Generations = @(1)
+    )
+
+    $escapedStage = [regex]::Escape($Stage)
+    foreach ($generation in $Generations) {
+        foreach ($attempt in 1..$Count) {
+            "generation=$generation stage=$escapedStage attempt=$attempt result=injected_failure"
+        }
+    }
+}
+
+function Test-ExpectedActiveWindows {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Log,
+        [Parameter(Mandatory = $true)][int]$Generation,
+        [Parameter(Mandatory = $true)][int]$ExpectedCount,
+        [Parameter(Mandatory = $true)][int[]]$ExpectedAttempts
+    )
+
+    $windowResults = [regex]::Matches(
+        $Log,
+        "generation=$Generation window=(?<window>HWND\([^)]+\)) attempt=(?<attempt>\d+) result=active"
+    )
+    $windows = @(
+        $windowResults |
+            ForEach-Object { $_.Groups["window"].Value } |
+            Sort-Object -Unique
+    )
+    $attempts = @(
+        $windowResults |
+            ForEach-Object { [int]$_.Groups["attempt"].Value } |
+            Sort-Object
+    )
+    $expectedAttemptsSorted = @($ExpectedAttempts | Sort-Object)
+
+    return $windowResults.Count -eq $ExpectedCount `
+        -and $windows.Count -eq $ExpectedCount `
+        -and ($attempts -join ",") -eq ($expectedAttemptsSorted -join ",")
+}
+
+function Test-ExpectedPresentedWindows {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Log,
+        [Parameter(Mandatory = $true)][int]$Generation,
+        [Parameter(Mandatory = $true)][int]$ExpectedCount
+    )
+
+    $presentResults = [regex]::Matches(
+        $Log,
+        "generation=$Generation window=(?<window>HWND\([^)]+\)) result=presented"
+    )
+    $windows = @(
+        $presentResults |
+            ForEach-Object { $_.Groups["window"].Value } |
+            Sort-Object -Unique
+    )
+    return $presentResults.Count -eq $ExpectedCount -and $windows.Count -eq $ExpectedCount
+}
+
+Push-Location $repoRoot
+try {
+    if (-not $NoBuild) {
+        Write-Host "==> Building gpui device-loss examples"
+        & $cargo build -p gpui --example hello_world --example on_window_close_quit
+        if ($LASTEXITCODE -ne 0) {
+            throw "cargo build failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    $metadata = & $cargo metadata --format-version 1 --no-deps | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo metadata failed with exit code $LASTEXITCODE"
+    }
+    $examplePaths = @{
+        hello_world = Join-Path $metadata.target_directory "debug/examples/hello_world.exe"
+        on_window_close_quit = Join-Path $metadata.target_directory "debug/examples/on_window_close_quit.exe"
+    }
+    foreach ($examplePath in $examplePaths.Values) {
+        if (-not (Test-Path -LiteralPath $examplePath)) {
+            throw "GPUI example was not found at $examplePath; run without -NoBuild"
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($EvidenceDirectory)) {
+        $EvidenceDirectory = Join-Path ([System.IO.Path]::GetTempPath()) (
+            "zed-gpui-device-loss-" + [guid]::NewGuid().ToString("N")
+        )
+    }
+    $EvidenceDirectory = [System.IO.Path]::GetFullPath($EvidenceDirectory)
+    New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
+
+    $singleFailureStages = @(
+        "renderer-devices",
+        "resources",
+        "global-elements",
+        "pipelines",
+        "direct-composition",
+        "composition-swapchain",
+        "atlas-commit"
+    )
+    $scenarios = @(
+        foreach ($stage in $singleFailureStages) {
+            [pscustomobject]@{
+                Name = "recover-after-one-$stage-failure"
+                Example = "hello_world"
+                DeviceLossVsyncs = "30"
+                RecoveryFailure = "${stage}:1"
+                DisableDirectComposition = $false
+                ExpectedPatterns = @(
+                    Get-InjectedFailurePatterns -Stage $stage -Count 1
+                    "generation=1 window=.* attempt=2 result=active"
+                    "generation=1 window=.* result=presented"
+                )
+            }
+        }
+        [pscustomobject]@{
+            Name = "recover-two-windows"
+            Example = "on_window_close_quit"
+            DeviceLossVsyncs = "30"
+            RecoveryFailure = "resources:1"
+            DisableDirectComposition = $false
+            ExpectedPatterns = @(
+                Get-InjectedFailurePatterns -Stage "resources" -Count 1
+            )
+            ExpectedActiveWindowCount = 2
+            ExpectedActiveAttempts = @(1, 2)
+            ExpectedPresentedWindowCount = 2
+        },
+        [pscustomobject]@{
+            Name = "recover-on-final-attempt"
+            Example = "hello_world"
+            DeviceLossVsyncs = "30"
+            RecoveryFailure = "resources:7"
+            DisableDirectComposition = $false
+            ExpectedPatterns = @(
+                Get-InjectedFailurePatterns -Stage "resources" -Count 7
+                "generation=1 window=.* attempt=8 result=active"
+                "generation=1 window=.* result=presented"
+            )
+        },
+        [pscustomobject]@{
+            Name = "exhaust-without-abort"
+            Example = "hello_world"
+            DeviceLossVsyncs = "30"
+            RecoveryFailure = "resources:8"
+            DisableDirectComposition = $false
+            ExpectedPatterns = @(
+                Get-InjectedFailurePatterns -Stage "resources" -Count 8
+                "generation=1 window=.* attempt=8 result=exhausted"
+            )
+        },
+        [pscustomobject]@{
+            Name = "reset-budget-for-next-generation"
+            Example = "hello_world"
+            DeviceLossVsyncs = "30,180"
+            RecoveryFailure = "resources:1"
+            DisableDirectComposition = $false
+            ExpectedPatterns = @(
+                Get-InjectedFailurePatterns -Stage "resources" -Count 1 -Generations @(1, 2)
+                "generation=1 window=.* attempt=2 result=active",
+                "generation=2 window=.* attempt=2 result=active",
+                "generation=1 window=.* result=presented",
+                "generation=2 window=.* result=presented"
+            )
+        },
+        [pscustomobject]@{
+            Name = "recover-without-direct-composition"
+            Example = "hello_world"
+            DeviceLossVsyncs = "30"
+            RecoveryFailure = "resources:1"
+            DisableDirectComposition = $true
+            ExpectedPatterns = @(
+                Get-InjectedFailurePatterns -Stage "resources" -Count 1
+                "generation=1 window=.* attempt=2 result=active"
+                "generation=1 window=.* result=presented"
+            )
+        }
+    )
+
+    $originalEnvironment = @{}
+    foreach ($name in $environmentNames) {
+        $originalEnvironment[$name] = [Environment]::GetEnvironmentVariable(
+            $name,
+            [EnvironmentVariableTarget]::Process
+        )
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    foreach ($scenario in $scenarios) {
+        $standardOutputPath = Join-Path $EvidenceDirectory "$($scenario.Name).stdout.log"
+        $standardErrorPath = Join-Path $EvidenceDirectory "$($scenario.Name).stderr.log"
+        $process = $null
+        $matched = $false
+        $startedAt = [DateTimeOffset]::UtcNow
+
+        try {
+            Set-ScenarioEnvironment $scenario
+            Write-Host "==> $($scenario.Name)"
+            $process = Start-Process `
+                -FilePath $examplePaths[$scenario.Example] `
+                -RedirectStandardOutput $standardOutputPath `
+                -RedirectStandardError $standardErrorPath `
+                -PassThru
+
+            $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+            while ([DateTimeOffset]::UtcNow -lt $deadline) {
+                $log = ""
+                if (Test-Path -LiteralPath $standardErrorPath) {
+                    # Normalize any pipeline values before binding to
+                    # Test-ExpectedPatterns' string parameter.
+                    $log = @(
+                        Get-Content -Raw -LiteralPath $standardErrorPath -ErrorAction SilentlyContinue
+                    ) -join [Environment]::NewLine
+                }
+                $matched = Test-ExpectedPatterns $log $scenario.ExpectedPatterns
+                if (
+                    $matched `
+                    -and $null -ne $scenario.PSObject.Properties["ExpectedActiveWindowCount"]
+                ) {
+                    $matched = Test-ExpectedActiveWindows `
+                        -Log $log `
+                        -Generation 1 `
+                        -ExpectedCount $scenario.ExpectedActiveWindowCount `
+                        -ExpectedAttempts $scenario.ExpectedActiveAttempts
+                }
+                if (
+                    $matched `
+                    -and $null -ne $scenario.PSObject.Properties["ExpectedPresentedWindowCount"]
+                ) {
+                    $matched = Test-ExpectedPresentedWindows `
+                        -Log $log `
+                        -Generation 1 `
+                        -ExpectedCount $scenario.ExpectedPresentedWindowCount
+                }
+                if ($matched) {
+                    break
+                }
+                if ($process.HasExited) {
+                    break
+                }
+                Start-Sleep -Milliseconds 100
+            }
+
+            $elapsedMilliseconds = [int]([DateTimeOffset]::UtcNow - $startedAt).TotalMilliseconds
+            if (-not $matched) {
+                $exitDescription = if ($process.HasExited) {
+                    "exited with code $($process.ExitCode)"
+                }
+                else {
+                    "did not report the expected result within $TimeoutSeconds seconds"
+                }
+                throw "$($scenario.Name) $exitDescription; evidence: $standardErrorPath"
+            }
+            if ($process.HasExited) {
+                throw "$($scenario.Name) reported success but then exited with code $($process.ExitCode)"
+            }
+
+            $results.Add([pscustomobject]@{
+                scenario = $scenario.Name
+                example = $scenario.Example
+                device_loss_vsyncs = $scenario.DeviceLossVsyncs
+                recovery_failure = $scenario.RecoveryFailure
+                direct_composition = -not $scenario.DisableDirectComposition
+                elapsed_ms = $elapsedMilliseconds
+                alive_at_result = $true
+                result = "passed"
+            })
+            Write-Host "    passed in $elapsedMilliseconds ms; process alive at result"
+        }
+        finally {
+            try {
+                if ($null -ne $process -and -not $process.HasExited) {
+                    try {
+                        $process.Kill()
+                    }
+                    catch {
+                        if (-not $process.HasExited) {
+                            throw
+                        }
+                    }
+                    if (-not $process.WaitForExit(5000)) {
+                        throw "failed to stop owned $($scenario.Example) process $($process.Id)"
+                    }
+                }
+            }
+            finally {
+                Restore-Environment $originalEnvironment
+            }
+        }
+    }
+
+    $resultPath = Join-Path $EvidenceDirectory "results.json"
+    $results | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $resultPath -Encoding utf8NoBOM
+    Write-Host "==> All GPUI Windows device-loss scenarios passed"
+    Write-Host "    Evidence: $resultPath"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
# Objective

Closes #52085

Prevent a recoverable DirectX device removal or reset from aborting the process inside the Windows window procedure.

We reproduced the same fatal callback path without changing the installed driver: a debug-only fault injector enters the real vsync and `WM_GPUI_GPU_DEVICE_LOST` path, then forces window recovery to fail. The existing handler panics after its recovery attempts; Windows terminates the process with `0xC0000409`.

## Solution

- Give every Windows renderer one atomic state: a complete active bundle or suspended. No partially rebuilt device, swapchain, pipeline, target, or atlas becomes visible.
- Suspend every live window before publishing replacement global DirectX and DirectWrite state. Windows created during that generation start suspended.
- Build each window candidate off to the side, then commit it only if the recovery generation, drawable size, and lifetime still match.
- Retry from normal vsync deadlines (`0, 100, 250, 500, 1000, 2000, 4000, 8000 ms`) without sleeping the vsync thread. Exhaustion leaves the window suspended and the process alive.
- Make renderer re-entry explicit. Recovery messages use `try_borrow_mut` and return deferred; the vsync-owned coordinator retries the pending window after the active draw, present, or resize releases its borrow.
- Force the first recovered frame before publishing the active bundle, so it cannot replay atlas tiles from the removed device. Offscreen rendering is likewise rejected while recovery is suspended.
- Add generation, window, attempt, size, compositor mode, adapter, and chained Windows-error diagnostics under the stable `gpui_device_loss` prefix.
- Replace the fixed 350 ms post-loss sleep with immediate global recovery and non-blocking retry deadlines. Global creation keeps retrying with an 8 s cap; each window gets eight failed candidate attempts, while stale resize races do not spend that budget.

This follows Microsoft's lost-device contract rather than inventing a new renderer lifecycle. Direct3D 11 requires replacing the device and every device-dependent resource, including swapchains. DirectComposition likewise requires a new DXGI device, DirectComposition device, and content; its pending commands are committed atomically. Win2D exposes the same transition as `DeviceLost` followed by `CreateResources(NewDevice)`. GPUI's extra machinery handles its multi-window and re-entrant Win32 shape: unpublished candidates, generation/size/lifetime validation, and a required fresh first frame keep old device state from crossing the recovery boundary.

Sources: [Microsoft's Direct3D 11 device-loss guidance](https://learn.microsoft.com/en-us/windows/uwp/gaming/handling-device-lost-scenarios), [DirectComposition device-state contract](https://learn.microsoft.com/en-us/windows/win32/api/dcomp/nf-dcomp-idcompositiondevice-checkdevicestate), [atomic DirectComposition commits](https://learn.microsoft.com/en-us/windows/win32/api/dcomp/nf-dcomp-idcompositiondevice2-commit), and [Win2D device-loss handling](https://microsoft.github.io/Win2D/WinUI3/html/HandlingDeviceLost.htm).

### Deterministic test seam

Debug builds accept:

- `GPUI_TEST_DEVICE_LOSS_AT_VSYNCS=<n>[,<n>...]`
- `GPUI_TEST_DEVICE_RECOVERY_FAILURE=<stage>:<count>`

The seam is inert outside debug builds. It injects at the real vsync and recovery boundaries; it does not install, reset, disable, or otherwise touch a display driver.

Unit tests cover trigger parsing, all seven candidate stages, a fresh failure budget per generation, deferred attempts, retry deadlines, exact eight-attempt exhaustion, active/destroyed terminal states, and recycled HWND registration. They are ordinary inline Rust tests next to the private recovery types and run in Zed's Windows `cargo nextest` job.

`script/test-gpui-windows-device-loss.ps1` is the native integration test. It builds two existing GPUI examples, launches one owned process per scenario, waits for structured `gpui_device_loss_test` records, asserts that the process is still alive at the expected terminal result, requires every recovered window's forced fresh frame to complete a successful `Present()`, and stops that exact child through its process handle. It is intentionally separate from nextest because it needs an interactive Windows desktop and a real DirectX/DirectComposition window.

<details>
<summary>Related work and scope boundaries</summary>

- [#34374](https://github.com/zed-industries/zed/pull/34374) introduced the DirectX 11 backend and its device-loss recovery. This PR keeps that recovery entry point but makes publication atomic and failure nonfatal.
- [#42114](https://github.com/zed-industries/zed/pull/42114) removed unsound `ManuallyDrop` bookkeeping and deliberately panicked when recovery could not complete. This PR preserves the sound ownership model while replacing the panic with an explicit suspended state and bounded retries.
- [#55878](https://github.com/zed-industries/zed/pull/55878) fixed stale atlas replay after a successful recovery by forcing a full first frame. This PR keeps that invariant, moves the forced-frame flag before active-state publication, and also prevents atlas access while recovery is incomplete.
- [#50898](https://github.com/zed-industries/zed/pull/50898) made the Linux wgpu renderer recover from device loss, and [#52389](https://github.com/zed-industries/zed/pull/52389) forced its first recovered scene to rebuild. The forced-scene invariant is shared here. The recovery implementation is not: Windows owns DirectX/DirectWrite globals, per-HWND swapchains, and synchronous window messages that the wgpu path does not have.
- [#36798](https://github.com/zed-industries/zed/issues/36798) records the same `DXGI_ERROR_DEVICE_HUNG`/device-recovery family and a later atlas index panic. The atlas symptom was addressed by #55878; this PR addresses the remaining partial-recovery and fatal-exhaustion path.
- [#49956](https://github.com/zed-industries/zed/issues/49956) is primarily a remote-host report, so this PR must not claim to fix it. Its attached log is useful corroboration: failed resize, missing render target, repeated device recreation, and a later hang are the inconsistent intermediate state this PR prevents.
- [#50972](https://github.com/zed-industries/zed/discussions/50972) proposes WARP for machines that cannot acquire a hardware adapter. That is an initial adapter-selection/fallback problem, not recovery of existing windows after a removed device. WARP remains compatible with this state machine but is not needed to fix the reproduced failure.
- [#61469](https://github.com/zed-industries/zed/issues/61469) is now addressed by [#63489](https://github.com/zed-industries/zed/pull/63489), which adds bounded outer-loop paint and input fairness. It does not enter device loss or rebuild DirectX state. The exact submitted #63489 head cherry-picks cleanly over this branch and passes this PR's full 12-scenario recovery harness. The fixes remain separate because their triggers and state are unrelated.
- [#63182](https://github.com/zed-industries/zed/pull/63182) makes Windows frame scheduling demand-driven and adds lifecycle-safe per-window request state. It touches device-recovery wakeup and overlapping Windows files, but solves idle scheduling rather than rebuilding removed DirectX state. Neither PR should absorb the other; whichever lands second should rebase and rerun its Windows gates.
- [#60295](https://github.com/zed-industries/zed/pull/60295) is already in this branch's base and prevents re-entrant draw corruption. This recovery code respects that invariant by deferring renderer borrows; it does not replace or extend the arena/draw-coordinator fix.

</details>

## Testing

Before, against public injector-only baseline commit [`16ce921398`](https://github.com/railapex/zed/commit/16ce9213980e664ef52efc92c21519f0497d719f):

```powershell
$env:GPUI_TEST_DEVICE_LOSS_AT_VSYNCS = '30'
$env:GPUI_TEST_DEVICE_RECOVERY_FAILURE = 'resources:8'
./target/debug/examples/hello_world.exe
```

Three consecutive runs entered the existing fatal handler and exited `0xC0000409` with:

```text
Device lost: DirectXRenderer failed to recover from lost device after multiple attempts
```

After:

- `resources:8`: eight failures, final `result=exhausted`; process remained alive with the window suspended.
- `resources:7`: attempt eight reached `result=active`.
- vsyncs `30,180` plus `resources:1`: both generations failed once and recovered on attempt two, proving the failure budget resets.

The submitted native integration test reproduces those checks with one command:

```powershell
./script/test-gpui-windows-device-loss.ps1
```

The reviewed implementation passed all twelve scenarios twice. After the final upstream rebase and squash, the exact final head passed all twelve again. Every recovered window completed a successful post-recovery `Present()`.

<details>
<summary>Native recovery scenario coverage</summary>

- Each of the seven candidate-construction stages failed once, then became active on attempt two.
- Two distinct HWNDs recovered in one generation, on attempts one and two.
- DirectComposition, `resources:7`: active on attempt eight.
- DirectComposition, `resources:8`: exhausted on attempt eight and suspended.
- DirectComposition, vsyncs `30,180` plus `resources:1`: generations one and two independently active on attempt two.
- DirectComposition disabled, `resources:1`: active on attempt two.

</details>

Tested Zed base `ef075910c99ce2c8fd07da4174e7c3bb71513f35`, fork head `ec6123c7e9`:

- `cargo fmt -p gpui_windows --check`: pass
- `cargo test -p gpui_windows --features test-support -- --skip test_clipboard`: 18 passed, 1 clipboard test filtered
- `script/clippy.ps1 -p gpui_windows`: pass
- `cargo build -p gpui --example hello_world --example on_window_close_quit`: pass
- `script/test-gpui-windows-device-loss.ps1`: 12 scenarios passed at the final squashed head, after two earlier full passes of the same implementation; every recovered window completed a successful post-recovery `Present()`, every owned process was alive at its expected result, and each was terminated through its process handle afterward
- injector-only baseline `16ce921398`, `resources:8`: three consecutive `0xC0000409` exits with the original fatal-handler message
- combined with exact submitted [#63489](https://github.com/zed-industries/zed/pull/63489) head `cf61a7492e` over the final squashed head: clean cherry-pick; `present_starvation` check, formatting, 18 focused tests, canonical release Clippy, and all 12 native recovery scenarios passed

Coverage boundary: the Rust tests run in normal Windows CI. The native script requires an interactive Windows desktop, so it is submitted and repeatable but not part of the parallel nextest job. It exercises the real vsync, window-message, DirectX, and DirectComposition paths, but injects the loss rather than servicing a physical display driver. No driver was installed, reset, disabled, or otherwise changed. The seam proves the software recovery state machine; it does not claim coverage of every adapter, driver, or Windows build.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability.
- [x] Unsafe blocks added or changed by this PR have justifying comments.
- [x] This PR does not change UI or icons.
- [x] Tests cover the new and changed behavior.
- [x] Performance impact is acceptable: parsing is debug-only; recovery work runs only after device removal; normal vsync does not sleep or allocate recovery candidates.

---

Release Notes:

- Fixed a Windows crash when a DirectX graphics device is removed or reset.
