### PR TITLE
Suggest the Emmet extension for supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/extensions_ui/src/extension_suggest.rs
+++ b/crates/extensions_ui/src/extension_suggest.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, OnceLock};
 
 use db::kvp::KeyValueStore;
 use editor::Editor;
-use extension_host::ExtensionStore;
+use extension_host::{ExtensionSettings, ExtensionStore};
 use gpui::{AppContext as _, Context, Entity, SharedString, Window};
-use language::Buffer;
+use language::{Buffer, LanguageName};
+use settings::Settings;
 use ui::prelude::*;
 use util::ResultExt;
 use util::rel_path::RelPath;
@@ -81,6 +82,40 @@ const SUGGESTIONS_BY_EXTENSION_ID: &[(&str, &[&str])] = &[
     ("zig", &["zig"]),
 ];
 
+struct OptionalExtensionSuggestion {
+    extension_id: &'static str,
+    languages: &'static [&'static str],
+}
+
+const OPTIONAL_EXTENSION_SUGGESTIONS: &[OptionalExtensionSuggestion] =
+    &[OptionalExtensionSuggestion {
+        extension_id: "emmet",
+        // Extension manifests are not available until installation, so keep this in sync with the
+        // languages in the Emmet extension's extension.toml.
+        languages: &[
+            "Angular",
+            "Blade",
+            "CSS",
+            "Django",
+            "ERB",
+            "Elixir",
+            "HEEx",
+            "HTML",
+            "HTML+ERB",
+            "JavaScript",
+            "Jinja2",
+            "LESS",
+            "Liquid",
+            "Nunjucks",
+            "PHP",
+            "SCSS",
+            "Statamic Antlers",
+            "TSX",
+            "Twig",
+            "Vue.js",
+        ],
+    }];
+
 fn suggested_extensions() -> &'static HashMap<&'static str, Arc<str>> {
     static SUGGESTIONS_BY_PATH_SUFFIX: OnceLock<HashMap<&str, Arc<str>>> = OnceLock::new();
     SUGGESTIONS_BY_PATH_SUFFIX.get_or_init(|| {
@@ -99,7 +134,7 @@ fn suggested_extensions() -> &'static HashMap<&'static str, Arc<str>> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 struct SuggestedExtension {
     pub extension_id: Arc<str>,
-    pub file_name_or_extension: Arc<str>,
+    pub display_name: Arc<str>,
 }
 
 /// Returns the suggested extension for the given [`Path`].
@@ -107,7 +142,7 @@ fn suggested_extension(path: &RelPath) -> Option<SuggestedExtension> {
     let file_extension: Option<Arc<str>> = path.extension().map(|extension| extension.into());
     let file_name: Option<Arc<str>> = path.file_name().map(|name| name.into());
 
-    let (file_name_or_extension, extension_id) = None
+    let (display_name, extension_id) = None
         // We suggest against file names first, as these suggestions will be more
         // specific than ones based on the file extension.
         .or_else(|| {
@@ -127,33 +162,104 @@ fn suggested_extension(path: &RelPath) -> Option<SuggestedExtension> {
 
     Some(SuggestedExtension {
         extension_id: extension_id.clone(),
-        file_name_or_extension,
+        display_name,
     })
 }
 
-fn language_extension_key(extension_id: &str) -> String {
+fn suggested_extension_for_language(
+    language_name: &LanguageName,
+    suggestions: &[OptionalExtensionSuggestion],
+    mut extension_is_eligible: impl FnMut(&str) -> bool,
+) -> Option<SuggestedExtension> {
+    suggestions
+        .iter()
+        .filter(|suggestion| suggestion.languages.contains(&language_name.as_ref()))
+        .find(|suggestion| extension_is_eligible(suggestion.extension_id))
+        .map(|suggestion| SuggestedExtension {
+            extension_id: suggestion.extension_id.into(),
+            display_name: language_name.as_ref().into(),
+        })
+}
+
+fn extension_suggestion_key(extension_id: &str) -> String {
     format!("{}_extension_suggest", extension_id)
 }
 
-pub(crate) fn suggest(buffer: Entity<Buffer>, window: &mut Window, cx: &mut Context<Workspace>) {
+pub(crate) fn suggest_for_path(
+    buffer: Entity<Buffer>,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
     let Some(file) = buffer.read(cx).file().cloned() else {
         return;
     };
 
     let Some(SuggestedExtension {
         extension_id,
-        file_name_or_extension,
+        display_name,
     }) = suggested_extension(file.path())
     else {
         return;
     };
 
-    let key = language_extension_key(&extension_id);
+    let key = extension_suggestion_key(&extension_id);
     let kvp = KeyValueStore::global(cx);
     let Ok(None) = kvp.read_kvp(&key) else {
         return;
     };
 
+    show_suggestion(buffer, extension_id, display_name, window, cx);
+}
+
+pub(crate) fn suggest_for_language(
+    buffer: Entity<Buffer>,
+    language_name: &LanguageName,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let extension_store = ExtensionStore::global(cx);
+    let extension_store = extension_store.read(cx);
+    let extension_settings = ExtensionSettings::get_global(cx);
+    let kvp = KeyValueStore::global(cx);
+
+    let Some(SuggestedExtension {
+        extension_id,
+        display_name,
+    }) = suggested_extension_for_language(
+        language_name,
+        OPTIONAL_EXTENSION_SUGGESTIONS,
+        |extension_id| {
+            !extension_store
+                .installed_extensions()
+                .contains_key(extension_id)
+                && !extension_store
+                    .outstanding_operations()
+                    .contains_key(extension_id)
+                && extension_settings
+                    .auto_install_extensions
+                    .get(extension_id)
+                    .copied()
+                    != Some(true)
+                && matches!(
+                    kvp.read_kvp(&extension_suggestion_key(extension_id)),
+                    Ok(None)
+                )
+        },
+    )
+    else {
+        return;
+    };
+
+    show_suggestion(buffer, extension_id, display_name, window, cx);
+}
+
+fn show_suggestion(
+    buffer: Entity<Buffer>,
+    extension_id: Arc<str>,
+    display_name: Arc<str>,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
     cx.on_next_frame(window, move |workspace, _, cx| {
         let Some(editor) = workspace.active_item_as::<Editor>(cx) else {
             return;
@@ -174,7 +280,7 @@ pub(crate) fn suggest(buffer: Entity<Buffer>, window: &mut Window, cx: &mut Cont
                 MessageNotification::new(
                     format!(
                         "Do you want to install the recommended '{}' extension for '{}' files?",
-                        extension_id, file_name_or_extension
+                        extension_id, display_name
                     ),
                     cx,
                 )
@@ -195,7 +301,7 @@ pub(crate) fn suggest(buffer: Entity<Buffer>, window: &mut Window, cx: &mut Cont
                 .secondary_icon(IconName::Close)
                 .secondary_icon_color(Color::Error)
                 .secondary_on_click(move |_window, cx| {
-                    let key = language_extension_key(&extension_id);
+                    let key = extension_suggestion_key(&extension_id);
                     let kvp = KeyValueStore::global(cx);
                     cx.background_spawn(async move {
                         kvp.write_kvp(key, "dismissed".to_string()).await.log_err()
@@ -218,35 +324,108 @@ mod tests {
             suggested_extension(rel_path("Cargo.toml")),
             Some(SuggestedExtension {
                 extension_id: "toml".into(),
-                file_name_or_extension: "toml".into()
+                display_name: "toml".into()
             })
         );
         assert_eq!(
             suggested_extension(rel_path("Cargo.lock")),
             Some(SuggestedExtension {
                 extension_id: "toml".into(),
-                file_name_or_extension: "Cargo.lock".into()
+                display_name: "Cargo.lock".into()
             })
         );
         assert_eq!(
             suggested_extension(rel_path("Dockerfile")),
             Some(SuggestedExtension {
                 extension_id: "dockerfile".into(),
-                file_name_or_extension: "Dockerfile".into()
+                display_name: "Dockerfile".into()
             })
         );
         assert_eq!(
             suggested_extension(rel_path("a/b/c/d/.gitignore")),
             Some(SuggestedExtension {
                 extension_id: "git-firefly".into(),
-                file_name_or_extension: ".gitignore".into()
+                display_name: ".gitignore".into()
             })
         );
         assert_eq!(
             suggested_extension(rel_path("a/b/c/d/test.gleam")),
             Some(SuggestedExtension {
                 extension_id: "gleam".into(),
-                file_name_or_extension: "gleam".into()
+                display_name: "gleam".into()
+            })
+        );
+    }
+
+    #[test]
+    fn test_suggested_extension_for_language() {
+        for language_name in [
+            "Angular",
+            "Blade",
+            "CSS",
+            "Django",
+            "ERB",
+            "Elixir",
+            "HEEx",
+            "HTML",
+            "HTML+ERB",
+            "JavaScript",
+            "Jinja2",
+            "LESS",
+            "Liquid",
+            "Nunjucks",
+            "PHP",
+            "SCSS",
+            "Statamic Antlers",
+            "TSX",
+            "Twig",
+            "Vue.js",
+        ] {
+            assert_eq!(
+                suggested_extension_for_language(
+                    &LanguageName::new(language_name),
+                    OPTIONAL_EXTENSION_SUGGESTIONS,
+                    |_| true,
+                ),
+                Some(SuggestedExtension {
+                    extension_id: "emmet".into(),
+                    display_name: language_name.into(),
+                })
+            );
+        }
+
+        assert_eq!(
+            suggested_extension_for_language(
+                &LanguageName::new("Rust"),
+                OPTIONAL_EXTENSION_SUGGESTIONS,
+                |_| true,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_suggested_extension_for_language_uses_first_eligible_suggestion() {
+        let suggestions = [
+            OptionalExtensionSuggestion {
+                extension_id: "first",
+                languages: &["HTML"],
+            },
+            OptionalExtensionSuggestion {
+                extension_id: "second",
+                languages: &["HTML"],
+            },
+        ];
+
+        assert_eq!(
+            suggested_extension_for_language(
+                &LanguageName::new("HTML"),
+                &suggestions,
+                |extension_id| extension_id != "first",
+            ),
+            Some(SuggestedExtension {
+                extension_id: "second".into(),
+                display_name: "HTML".into(),
             })
         );
     }

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -282,11 +282,25 @@ pub fn init(cx: &mut App) {
                 }
             });
 
-        cx.subscribe_in(workspace.project(), window, |_, _, event, window, cx| {
-            if let project::Event::LanguageNotFound(buffer) = event {
-                extension_suggest::suggest(buffer.clone(), window, cx);
-            }
-        })
+        cx.subscribe_in(
+            workspace.project(),
+            window,
+            |_, _, event, window, cx| match event {
+                project::Event::LanguageDetected {
+                    buffer,
+                    language_name,
+                } => extension_suggest::suggest_for_language(
+                    buffer.clone(),
+                    language_name,
+                    window,
+                    cx,
+                ),
+                project::Event::LanguageNotFound(buffer) => {
+                    extension_suggest::suggest_for_path(buffer.clone(), window, cx)
+                }
+                _ => {}
+            },
+        )
         .detach();
     })
     .detach();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -360,6 +360,10 @@ pub enum Event {
         notification_id: SharedString,
     },
     LanguageServerPrompt(LanguageServerPromptRequest),
+    LanguageDetected {
+        buffer: Entity<Buffer>,
+        language_name: LanguageName,
+    },
     LanguageNotFound(Entity<Buffer>),
     ActiveEntryChanged(Option<ProjectEntryId>),
     ActivateProjectPanel,
@@ -3702,10 +3706,14 @@ impl Project {
                 buffer,
                 new_language,
             } => {
-                let Some(_) = new_language else {
+                if let Some(language) = new_language {
+                    cx.emit(Event::LanguageDetected {
+                        buffer: buffer.clone(),
+                        language_name: language.name(),
+                    });
+                } else {
                     cx.emit(Event::LanguageNotFound(buffer.clone()));
-                    return;
-                };
+                }
             }
             LspStoreEvent::RefreshInlayHints { server_id } => cx.emit(Event::RefreshInlayHints {
                 server_id: *server_id,


### PR DESCRIPTION
## Objective

Fixes #32713.

The existing extension suggestion flow only runs when Zed cannot detect a language for a file. That works for language extensions, but it cannot recommend optional tooling such as Emmet after HTML, CSS, or another supported language has already been detected.

This PR extends the same suggestion flow to cover optional extensions associated with a detected language.

## Solution

Project now forwards successful language detection events with the buffer and detected language name. extensions_ui handles those events separately from the existing LanguageNotFound path:

- LanguageNotFound continues to use the existing filename and file-extension suggestions.
- LanguageDetected checks a new list of optional extension suggestions keyed by language.

Emmet is the first optional suggestion. Its entry includes all languages currently listed in the Emmet extension manifest. The list lives in the suggestion code because the full language-server configuration is not available from extension registry metadata before installation.

Before showing the notification, Zed skips an optional suggestion when the extension:

- is already installed;
- has an install, upgrade, or removal operation in progress;
- is explicitly configured for automatic installation; or
- was previously dismissed.

The existing notification UI and per-extension dismissal key are reused. Dismissing Emmet for one language also dismisses it for the other supported languages, so opening an HTML file and then a CSS file will not produce repeated prompts.

If multiple optional extensions support the same language in the future, the first eligible suggestion is selected in a stable order. Only one suggestion is shown for each language detection event, so this change does not require a new multi-extension UI.

## Scope

This PR does not:

- install Emmet automatically;
- change the extension manifest or registry schema;
- add a new notification component;
- change the existing filename and file-extension matching behavior; or
- modify the Emmet extension itself.

## Testing

- cargo test -p extensions_ui extension_suggest::tests -- --nocapture
- ./script/clippy -p extensions_ui

The tests cover the existing path-based matching, every language in the current Emmet manifest, unrelated languages, and selection of the first eligible suggestion.

## Self-Review Checklist

- [x] I have reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks, if any, have justifying comments
- [x] The content adheres to Zed UI standards
- [x] Tests cover the new and changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added a suggestion to install the Emmet extension when opening supported files.