### PR TITLE
workspace: Fix captured focus when opening modals

### DIFF
--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -164,8 +164,9 @@ impl ModalLayer {
                 return;
             }
         }
+        let previous_focus_handle = window.focused(cx);
         let new_modal = cx.new(|cx| build_view(window, cx));
-        self.show_modal(Box::new(new_modal), window, cx);
+        self.show_modal(Box::new(new_modal), previous_focus_handle, window, cx);
         cx.emit(ModalOpenedEvent);
     }
 
@@ -174,6 +175,7 @@ impl ModalLayer {
     fn show_modal(
         &mut self,
         modal: Box<dyn ModalViewHandle>,
+        previous_focus_handle: Option<FocusHandle>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -190,7 +192,7 @@ impl ModalLayer {
                     }
                 }),
             ],
-            previous_focus_handle: window.focused(cx),
+            previous_focus_handle,
             focus_handle,
         });
         cx.defer_in(window, move |_, window, cx| {
@@ -214,7 +216,8 @@ impl ModalLayer {
         let Some(modal) = self.stashed_modal.take() else {
             return false;
         };
-        self.show_modal(modal, window, cx);
+        let previous_focus_handle = window.focused(cx);
+        self.show_modal(modal, previous_focus_handle, window, cx);
         cx.emit(ModalOpenedEvent);
         true
     }

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -157,14 +157,15 @@ impl ModalLayer {
         // Opening a modal explicitly supersedes any reveal that was waiting for the
         // layer to become free.
         self.reveal_stash_when_free = false;
+        let mut previous_focus_handle = window.focused(cx);
         if let Some(active_modal) = &self.active_modal {
             let should_close = active_modal.modal.view().downcast::<V>().is_ok();
+            previous_focus_handle = active_modal.previous_focus_handle.clone();
             let did_close = self.hide_modal(window, cx);
             if should_close || !did_close {
                 return;
             }
         }
-        let previous_focus_handle = window.focused(cx);
         let new_modal = cx.new(|cx| build_view(window, cx));
         self.show_modal(Box::new(new_modal), previous_focus_handle, window, cx);
         cx.emit(ModalOpenedEvent);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15659,6 +15659,41 @@ mod tests {
         }
     }
 
+    // Steals focus for itself as soon as it's constructed, like a real `Picker`
+    // auto-focusing its query editor when built. This is what exposes the
+    // previous-focus capture-order bug: `previous_focus_handle` must be captured
+    // before `build_view` runs, not after, or it ends up capturing the modal's
+    // own (self-stolen) focus handle instead of whatever was focused before it.
+    struct FocusStealingTestModal(FocusHandle);
+
+    impl FocusStealingTestModal {
+        fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+            let focus_handle = cx.focus_handle();
+            window.focus(&focus_handle, cx);
+            Self(focus_handle)
+        }
+    }
+
+    impl EventEmitter<DismissEvent> for FocusStealingTestModal {}
+
+    impl Focusable for FocusStealingTestModal {
+        fn focus_handle(&self, _cx: &App) -> FocusHandle {
+            self.0.clone()
+        }
+    }
+
+    impl ModalView for FocusStealingTestModal {}
+
+    impl Render for FocusStealingTestModal {
+        fn render(
+            &mut self,
+            _window: &mut Window,
+            _cx: &mut Context<FocusStealingTestModal>,
+        ) -> impl IntoElement {
+            div().track_focus(&self.0)
+        }
+    }
+
     #[gpui::test]
     async fn test_reopen_last_picker(cx: &mut gpui::TestAppContext) {
         init_test(cx);
@@ -15818,6 +15853,58 @@ mod tests {
                 .is_some()),
             "reopen with an active modal that dismisses after the action should reveal the stash"
         );
+    }
+
+    #[gpui::test]
+    async fn test_modal_restores_focus_captured_before_construction(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        // Give focus to something representing whatever was focused before the
+        // modal was opened (e.g. a terminal panel, in the real bug this test guards).
+        let previously_focused_handle = workspace.update_in(cx, |_, window, cx| {
+            let handle = cx.focus_handle();
+            window.focus(&handle, cx);
+            handle
+        });
+        workspace.update_in(cx, |_, window, _cx| {
+            assert!(previously_focused_handle.is_focused(window));
+        });
+
+        // Open a modal whose construction steals focus for itself, mirroring a
+        // real `Picker` auto-focusing its query editor when built.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_modal(window, cx, FocusStealingTestModal::new);
+        });
+        cx.executor().run_until_parked();
+        assert!(workspace.read_with(cx, |workspace, cx| {
+            workspace
+                .active_modal::<FocusStealingTestModal>(cx)
+                .is_some()
+        }));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace
+                .modal_layer
+                .update(cx, |modal_layer, cx| modal_layer.hide_modal(window, cx));
+        });
+        cx.executor().run_until_parked();
+
+        // Focus should return to whatever was focused before the modal was
+        // opened, not to the modal's own (self-stolen) focus handle.
+        workspace.update_in(cx, |_, window, _cx| {
+            assert!(
+                previously_focused_handle.is_focused(window),
+                "dismissing the modal should restore focus to what was focused before it was \
+                 opened, even though the modal's own constructor stole focus for itself first"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15866,15 +15866,23 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
 
-        // Give focus to something representing whatever was focused before the
-        // modal was opened (e.g. a terminal panel, in the real bug this test guards).
-        let previously_focused_handle = workspace.update_in(cx, |_, window, cx| {
-            let handle = cx.focus_handle();
-            window.focus(&handle, cx);
-            handle
-        });
+        cx.executor().run_until_parked();
+
+        // Whatever the workspace naturally settles on focusing by default (e.g. the
+        // active pane's real focus target) represents "whatever was focused before
+        // the modal was opened" (a terminal panel, in the real bug this test guards).
+        // A hand-picked handle (a bare `cx.focus_handle()`, or the pane's own
+        // `Focusable::focus_handle`) doesn't survive the next render pass unless it's
+        // genuinely what the rendered tree tracks, so read the real default instead
+        // of fabricating one.
+        let previously_focused_handle = workspace
+            .update_in(cx, |_, window, cx| window.focused(cx))
+            .expect("workspace should focus something by default");
         workspace.update_in(cx, |_, window, _cx| {
-            assert!(previously_focused_handle.is_focused(window));
+            assert!(
+                previously_focused_handle.is_focused(window),
+                "the default focus target should still be focused on a second read"
+            );
         });
 
         // Open a modal whose construction steals focus for itself, mirroring a

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15659,41 +15659,6 @@ mod tests {
         }
     }
 
-    // Steals focus for itself as soon as it's constructed, like a real `Picker`
-    // auto-focusing its query editor when built. This is what exposes the
-    // previous-focus capture-order bug: `previous_focus_handle` must be captured
-    // before `build_view` runs, not after, or it ends up capturing the modal's
-    // own (self-stolen) focus handle instead of whatever was focused before it.
-    struct FocusStealingTestModal(FocusHandle);
-
-    impl FocusStealingTestModal {
-        fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-            let focus_handle = cx.focus_handle();
-            window.focus(&focus_handle, cx);
-            Self(focus_handle)
-        }
-    }
-
-    impl EventEmitter<DismissEvent> for FocusStealingTestModal {}
-
-    impl Focusable for FocusStealingTestModal {
-        fn focus_handle(&self, _cx: &App) -> FocusHandle {
-            self.0.clone()
-        }
-    }
-
-    impl ModalView for FocusStealingTestModal {}
-
-    impl Render for FocusStealingTestModal {
-        fn render(
-            &mut self,
-            _window: &mut Window,
-            _cx: &mut Context<FocusStealingTestModal>,
-        ) -> impl IntoElement {
-            div().track_focus(&self.0)
-        }
-    }
-
     #[gpui::test]
     async fn test_reopen_last_picker(cx: &mut gpui::TestAppContext) {
         init_test(cx);
@@ -15853,66 +15818,6 @@ mod tests {
                 .is_some()),
             "reopen with an active modal that dismisses after the action should reveal the stash"
         );
-    }
-
-    #[gpui::test]
-    async fn test_modal_restores_focus_captured_before_construction(
-        cx: &mut gpui::TestAppContext,
-    ) {
-        init_test(cx);
-
-        let fs = FakeFs::new(cx.executor());
-        let project = Project::test(fs, [], cx).await;
-        let (workspace, cx) =
-            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
-
-        cx.executor().run_until_parked();
-
-        // Whatever the workspace naturally settles on focusing by default (e.g. the
-        // active pane's real focus target) represents "whatever was focused before
-        // the modal was opened" (a terminal panel, in the real bug this test guards).
-        // A hand-picked handle (a bare `cx.focus_handle()`, or the pane's own
-        // `Focusable::focus_handle`) doesn't survive the next render pass unless it's
-        // genuinely what the rendered tree tracks, so read the real default instead
-        // of fabricating one.
-        let previously_focused_handle = workspace
-            .update_in(cx, |_, window, cx| window.focused(cx))
-            .expect("workspace should focus something by default");
-        workspace.update_in(cx, |_, window, _cx| {
-            assert!(
-                previously_focused_handle.is_focused(window),
-                "the default focus target should still be focused on a second read"
-            );
-        });
-
-        // Open a modal whose construction steals focus for itself, mirroring a
-        // real `Picker` auto-focusing its query editor when built.
-        workspace.update_in(cx, |workspace, window, cx| {
-            workspace.toggle_modal(window, cx, FocusStealingTestModal::new);
-        });
-        cx.executor().run_until_parked();
-        assert!(workspace.read_with(cx, |workspace, cx| {
-            workspace
-                .active_modal::<FocusStealingTestModal>(cx)
-                .is_some()
-        }));
-
-        workspace.update_in(cx, |workspace, window, cx| {
-            workspace
-                .modal_layer
-                .update(cx, |modal_layer, cx| modal_layer.hide_modal(window, cx));
-        });
-        cx.executor().run_until_parked();
-
-        // Focus should return to whatever was focused before the modal was
-        // opened, not to the modal's own (self-stolen) focus handle.
-        workspace.update_in(cx, |_, window, _cx| {
-            assert!(
-                previously_focused_handle.is_focused(window),
-                "dismissing the modal should restore focus to what was focused before it was \
-                 opened, even though the modal's own constructor stole focus for itself first"
-            );
-        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

- This PR fixes the captured focus in modals. 
- Fixes #63480 (and actually this was not specific to the task modal. it was generic and applied to all modals)

## Solution

- Previously when a modal was opened the `previous_focus_handle` was stealing the focus because it was captured in `show_modal`. The fix was to capture it before calling `show_modal` or `reveal_stashed_modal` and pass it to `show_modal`. That fixes the bug :) (yuhuu). 

## Testing

- Tested by running the build and trying to reproduce the bug. I couldn't reproduce it anymore. 
- For testing, a reviewer also needs to test the revelal stashed modal functionality. I did it with the file finder. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed previous window focus handle not being captured correctly when opening modals
