### PR TITLE
Fix Wasm build

### DIFF
--- a/crates/fuzzy/src/fuzzy.rs
+++ b/crates/fuzzy/src/fuzzy.rs
@@ -4,7 +4,9 @@ mod paths;
 mod strings;
 
 pub use char_bag::CharBag;
-pub use paths::{
-    PathMatch, PathMatchCandidate, PathMatchCandidateSet, match_fixed_path_set, match_path_sets,
-};
-pub use strings::{StringMatch, StringMatchCandidate, match_strings};
+#[cfg(not(target_family = "wasm"))]
+pub use paths::match_path_sets;
+pub use paths::{PathMatch, PathMatchCandidate, PathMatchCandidateSet, match_fixed_path_set};
+#[cfg(not(target_family = "wasm"))]
+pub use strings::match_strings;
+pub use strings::{StringMatch, StringMatchCandidate};

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -1,11 +1,11 @@
+#[cfg(not(target_family = "wasm"))]
 use gpui::BackgroundExecutor;
 use path::{PathStyle, rel_path::RelPath};
+#[cfg(not(target_family = "wasm"))]
+use std::{cmp, sync::atomic};
 use std::{
-    cmp::{self, Ordering},
-    sync::{
-        Arc,
-        atomic::{self, AtomicBool},
-    },
+    cmp::Ordering,
+    sync::{Arc, atomic::AtomicBool},
 };
 
 use crate::{
@@ -139,6 +139,7 @@ pub fn match_fixed_path_set(
     results
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
     candidate_sets: &'a [Set],
     query: &str,
@@ -262,6 +263,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
 
 /// Compute the distance from a given path to some other path
 /// If there is no shared path, returns usize::MAX
+#[cfg(not(target_family = "wasm"))]
 fn distance_between_paths(path: &RelPath, relative_to: &RelPath) -> usize {
     let mut path_components = path.components();
     let mut relative_components = relative_to.components();
@@ -275,7 +277,7 @@ fn distance_between_paths(path: &RelPath, relative_to: &RelPath) -> usize {
     path_components.count() + relative_components.count() + 1
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use path::rel_path::RelPath;
 

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -1,16 +1,15 @@
-use crate::{
-    CharBag,
-    char_bag::simple_lowercase,
-    matcher::{MatchCandidate, Matcher},
-};
+use crate::{CharBag, matcher::MatchCandidate};
+#[cfg(not(target_family = "wasm"))]
+use crate::{char_bag::simple_lowercase, matcher::Matcher};
+#[cfg(not(target_family = "wasm"))]
 use gpui::BackgroundExecutor;
+#[cfg(not(target_family = "wasm"))]
 use std::{
     borrow::Borrow,
-    cmp::{self, Ordering},
-    iter,
-    ops::Range,
+    cmp,
     sync::atomic::{self, AtomicBool},
 };
+use std::{cmp::Ordering, iter, ops::Range};
 
 #[derive(Clone, Debug)]
 pub struct StringMatchCandidate {
@@ -114,6 +113,7 @@ impl Ord for StringMatch {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub async fn match_strings<T>(
     candidates: &[T],
     query: &str,

--- a/crates/fuzzy_nucleo/src/fuzzy_nucleo.rs
+++ b/crates/fuzzy_nucleo/src/fuzzy_nucleo.rs
@@ -5,9 +5,9 @@ mod strings;
 use fuzzy::CharBag;
 use nucleo::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
 
-pub use paths::{
-    PathMatch, PathMatchCandidate, PathMatchCandidateSet, match_fixed_path_set, match_path_sets,
-};
+#[cfg(not(target_family = "wasm"))]
+pub use paths::match_path_sets;
+pub use paths::{PathMatch, PathMatchCandidate, PathMatchCandidateSet, match_fixed_path_set};
 pub use strings::{StringMatch, StringMatchCandidate, match_strings, match_strings_async};
 
 pub(crate) struct Cancelled;

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_family = "wasm"))]
 use gpui::BackgroundExecutor;
 use path::{PathStyle, rel_path::RelPath};
 use std::{
@@ -261,6 +262,7 @@ pub fn match_fixed_path_set(
     results
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
     candidate_sets: &'a [Set],
     query: &str,

--- a/crates/fuzzy_nucleo/src/strings.rs
+++ b/crates/fuzzy_nucleo/src/strings.rs
@@ -97,6 +97,7 @@ impl Ord for StringMatch {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub async fn match_strings_async<T>(
     candidates: &[T],
     query: &str,
@@ -163,6 +164,26 @@ where
     let mut results = segment_results.concat();
     gpui_util::truncate_to_bottom_n_sorted_by(&mut results, max_results, &|a, b| b.cmp(a));
     results
+}
+
+#[cfg(target_family = "wasm")]
+pub async fn match_strings_async<T>(
+    candidates: &[T],
+    query: &str,
+    case: Case,
+    length_penalty: LengthPenalty,
+    max_results: usize,
+    cancel_flag: &AtomicBool,
+    _executor: BackgroundExecutor,
+) -> Vec<StringMatch>
+where
+    T: Borrow<StringMatchCandidate> + Sync,
+{
+    if cancel_flag.load(atomic::Ordering::Acquire) {
+        return Vec::new();
+    }
+
+    match_strings(candidates, query, case, length_penalty, max_results)
 }
 
 pub fn match_strings<T>(


### PR DESCRIPTION
gates some scheduler calls to be `cfg(not(wasm))` so they compile on web

---

Release Notes:

- N/A or Added/Fixed/Improved ...
