### PR TITLE
project: Tell servers when an edit moves a file

### DIFF
--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -6,7 +6,7 @@ use crate::{
     InlayHintLabel, InlayHintLabelPart, InlayHintLabelPartTooltip, InlayHintTooltip, Location,
     LocationLink, LspAction, LspPullDiagnostics, MarkupContent, PrepareRenameResponse, ProjectPath,
     ProjectTransaction, PulledDiagnostics, ResolveState,
-    lsp_store::{LocalLspStore, LspDocumentLink, LspFoldingRange, LspStore},
+    lsp_store::{FileMoveNotifications, LocalLspStore, LspDocumentLink, LspFoldingRange, LspStore},
 };
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
@@ -1204,7 +1204,7 @@ impl LspCommand for PerformRename {
                 lsp_store,
                 edit,
                 self.push_to_history,
-                true,
+                FileMoveNotifications::Send,
                 lsp_server,
                 &mut cx,
             )

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1204,6 +1204,7 @@ impl LspCommand for PerformRename {
                 lsp_store,
                 edit,
                 self.push_to_history,
+                true,
                 lsp_server,
                 &mut cx,
             )

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -298,6 +298,16 @@ pub struct DocumentDiagnostics {
     version: Option<i32>,
 }
 
+/// Whether applying a workspace edit tells the language servers about the
+/// files it moves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FileMoveNotifications {
+    Send,
+    /// Used while applying what a server answered, so a reply that itself moves
+    /// a file cannot send the question round again.
+    Suppress,
+}
+
 pub struct LocalLspStore {
     weak: WeakEntity<LspStore>,
     pub worktree_store: Entity<WorktreeStore>,
@@ -3336,7 +3346,7 @@ impl LocalLspStore {
                     lsp_store.upgrade().context("project dropped")?,
                     edit.clone(),
                     push_to_history,
-                    true,
+                    FileMoveNotifications::Send,
                     language_server.clone(),
                     cx,
                 )
@@ -3523,16 +3533,11 @@ impl LocalLspStore {
     }
 
     /// Applies `edit`, which may move files as well as change their contents.
-    ///
-    /// `send_will_rename` asks the language servers what should change when a
-    /// file moves. It is off when this is already being called to apply what a
-    /// server answered, so that a reply which itself moves a file cannot send
-    /// the question round again.
     pub(crate) async fn deserialize_workspace_edit(
         this: Entity<LspStore>,
         edit: lsp::WorkspaceEdit,
         push_to_history: bool,
-        send_will_rename: bool,
+        file_moves: FileMoveNotifications,
         language_server: Arc<LanguageServer>,
         cx: &mut AsyncApp,
     ) -> Result<ProjectTransaction> {
@@ -3596,6 +3601,30 @@ impl LocalLspStore {
                         .to_file_path()
                         .map_err(|()| anyhow!("can't convert URI to path"))?;
 
+                    // Read from the filesystem rather than the worktree, so a
+                    // file the scan has not reached yet is still reported. A
+                    // symlink counts as a file, since moving one moves the link
+                    // and not what it points at.
+                    let move_to_report = match file_moves {
+                        FileMoveNotifications::Send => {
+                            let is_dir = fs
+                                .metadata(&source_abs_path)
+                                .await
+                                .ok()
+                                .flatten()
+                                .is_some_and(|metadata| metadata.is_dir && !metadata.is_symlink);
+                            this.update(cx, |this, cx| {
+                                let worktree_id = this
+                                    .worktree_store()
+                                    .read(cx)
+                                    .project_path_for_absolute_path(&source_abs_path, cx)?
+                                    .worktree_id;
+                                Some((worktree_id, is_dir))
+                            })
+                        }
+                        FileMoveNotifications::Suppress => None,
+                    };
+
                     // A server that registered `willRenameFiles` may be holding
                     // the text edits for this move rather than sending them here,
                     // to keep a client that asks as well from applying them twice.
@@ -3604,28 +3633,24 @@ impl LocalLspStore {
                     // is left behind. Asked before the move, as the spec says to
                     // and as the servers expect, since they answer from where the
                     // file is now.
-                    if send_will_rename {
-                        let renamed_entry = this.update(cx, |this, cx| {
-                            let worktree_store = this.worktree_store();
-                            let worktree_store = worktree_store.read(cx);
-                            let project_path = worktree_store
-                                .project_path_for_absolute_path(&source_abs_path, cx)?;
-                            let is_dir = worktree_store.entry_for_path(&project_path, cx)?.is_dir();
-                            Some((project_path.worktree_id, is_dir))
-                        });
-                        if let Some((worktree_id, is_dir)) = renamed_entry {
-                            let transaction = LspStore::will_rename_entry(
-                                this.downgrade(),
-                                worktree_id,
-                                &source_abs_path,
-                                &target_abs_path,
-                                is_dir,
-                                push_to_history,
-                                cx.clone(),
-                            )
-                            .await;
-                            project_transaction.0.extend(transaction.0);
-                        }
+                    if let Some((worktree_id, is_dir)) = move_to_report {
+                        let transaction = LspStore::will_rename_entry(
+                            this.downgrade(),
+                            worktree_id,
+                            &source_abs_path,
+                            &target_abs_path,
+                            is_dir,
+                            push_to_history,
+                            cx.clone(),
+                        )
+                        .await;
+                        // `extend` lets the later entry win, so an answer that
+                        // edits a buffer this workspace edit already edited
+                        // replaces that earlier transaction instead of joining
+                        // it, and undo would reach only half the change. A
+                        // server that withholds its edits until asked, which is
+                        // the only reason to ask, does not send both.
+                        project_transaction.0.extend(transaction.0);
                     }
 
                     // An LSP "rename symbol" can also rename the file, with the text edit
@@ -3662,7 +3687,24 @@ impl LocalLspStore {
                     };
 
                     fs.rename(&source_abs_path, &target_abs_path, options)
-                        .await?;
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "moving {source_abs_path:?} to {target_abs_path:?}. \
+                                 Any edits that came with the move are already applied"
+                            )
+                        })?;
+
+                    if let Some((worktree_id, is_dir)) = move_to_report {
+                        this.update(cx, |this, _| {
+                            this.did_rename_entry(
+                                worktree_id,
+                                &source_abs_path,
+                                &target_abs_path,
+                                is_dir,
+                            );
+                        });
+                    }
 
                     // Preserve the entry id across the rename so an open buffer follows it
                     // to the new path, instead of being stranded at the old path when the
@@ -3850,7 +3892,7 @@ impl LocalLspStore {
             this.clone(),
             params.edit,
             true,
-            true,
+            FileMoveNotifications::Send,
             language_server.clone(),
             cx,
         )
@@ -6087,7 +6129,7 @@ impl LspStore {
                         this.upgrade().context("no app present")?,
                         edit.clone(),
                         push_to_history,
-                        true,
+                        FileMoveNotifications::Send,
                         lang_server.clone(),
                         cx,
                     )
@@ -11103,7 +11145,7 @@ impl LspStore {
                                 this.upgrade()?,
                                 edit,
                                 push_to_history,
-                                false,
+                                FileMoveNotifications::Suppress,
                                 language_server.clone(),
                                 cx,
                             )

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3336,6 +3336,7 @@ impl LocalLspStore {
                     lsp_store.upgrade().context("project dropped")?,
                     edit.clone(),
                     push_to_history,
+                    true,
                     language_server.clone(),
                     cx,
                 )
@@ -3521,10 +3522,17 @@ impl LocalLspStore {
         })
     }
 
+    /// Applies `edit`, which may move files as well as change their contents.
+    ///
+    /// `send_will_rename` asks the language servers what should change when a
+    /// file moves. It is off when this is already being called to apply what a
+    /// server answered, so that a reply which itself moves a file cannot send
+    /// the question round again.
     pub(crate) async fn deserialize_workspace_edit(
         this: Entity<LspStore>,
         edit: lsp::WorkspaceEdit,
         push_to_history: bool,
+        send_will_rename: bool,
         language_server: Arc<LanguageServer>,
         cx: &mut AsyncApp,
     ) -> Result<ProjectTransaction> {
@@ -3587,6 +3595,38 @@ impl LocalLspStore {
                         .new_uri
                         .to_file_path()
                         .map_err(|()| anyhow!("can't convert URI to path"))?;
+
+                    // A server that registered `willRenameFiles` may be holding
+                    // the text edits for this move rather than sending them here,
+                    // to keep a client that asks as well from applying them twice.
+                    // rust-analyzer does that for every module rename, so unless
+                    // we ask, the file moves and every reference to the old name
+                    // is left behind. Asked before the move, as the spec says to
+                    // and as the servers expect, since they answer from where the
+                    // file is now.
+                    if send_will_rename {
+                        let renamed_entry = this.update(cx, |this, cx| {
+                            let worktree_store = this.worktree_store();
+                            let worktree_store = worktree_store.read(cx);
+                            let project_path = worktree_store
+                                .project_path_for_absolute_path(&source_abs_path, cx)?;
+                            let is_dir = worktree_store.entry_for_path(&project_path, cx)?.is_dir();
+                            Some((project_path.worktree_id, is_dir))
+                        });
+                        if let Some((worktree_id, is_dir)) = renamed_entry {
+                            let transaction = LspStore::will_rename_entry(
+                                this.downgrade(),
+                                worktree_id,
+                                &source_abs_path,
+                                &target_abs_path,
+                                is_dir,
+                                push_to_history,
+                                cx.clone(),
+                            )
+                            .await;
+                            project_transaction.0.extend(transaction.0);
+                        }
+                    }
 
                     // An LSP "rename symbol" can also rename the file, with the text edit
                     // applied only to the in-memory buffer. Persist it before renaming, or
@@ -3809,6 +3849,7 @@ impl LocalLspStore {
         let transaction = Self::deserialize_workspace_edit(
             this.clone(),
             params.edit,
+            true,
             true,
             language_server.clone(),
             cx,
@@ -6046,6 +6087,7 @@ impl LspStore {
                         this.upgrade().context("no app present")?,
                         edit.clone(),
                         push_to_history,
+                        true,
                         lang_server.clone(),
                         cx,
                     )
@@ -10487,6 +10529,7 @@ impl LspStore {
             &old_abs_path,
             &new_abs_path,
             old_entry.is_dir(),
+            false,
             cx.clone(),
         )
         .await;
@@ -10997,12 +11040,18 @@ impl LspStore {
         });
     }
 
+    /// Asks every language server watching for it what should change when
+    /// `old_path` moves to `new_path`, and applies what they answer.
+    ///
+    /// Call this before the move. The servers answer from where the file is
+    /// now, and the spec has the request going out first.
     pub(super) fn will_rename_entry(
         this: WeakEntity<Self>,
         worktree_id: WorktreeId,
         old_path: &Path,
         new_path: &Path,
         is_dir: bool,
+        push_to_history: bool,
         cx: AsyncApp,
     ) -> Task<ProjectTransaction> {
         let old_uri = lsp::Uri::from_file_path(old_path)
@@ -11053,6 +11102,7 @@ impl LspStore {
                             LocalLspStore::deserialize_workspace_edit(
                                 this.upgrade()?,
                                 edit,
+                                push_to_history,
                                 false,
                                 language_server.clone(),
                                 cx,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2666,6 +2666,7 @@ impl Project {
                 &old_abs_path,
                 &new_abs_path,
                 is_dir,
+                false,
                 cx.clone(),
             )
             .await;

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8547,10 +8547,11 @@ async fn test_rename_that_also_renames_file(cx: &mut gpui::TestAppContext) {
     });
 }
 
-/// What rust-analyzer registers: it wants to be told before any Rust file, or
-/// any folder, moves.
-fn watched_rust_file_renames() -> lsp::FileOperationRegistrationOptions {
-    lsp::FileOperationRegistrationOptions {
+/// A server that answers renames. With `watch_renames` it also asks to be told
+/// before and after a Rust file moves, the way rust-analyzer asks to be told
+/// before one.
+fn rename_capabilities(watch_renames: bool) -> lsp::ServerCapabilities {
+    let watched = lsp::FileOperationRegistrationOptions {
         filters: vec![FileOperationFilter {
             scheme: Some("file".to_owned()),
             pattern: lsp::FileOperationPattern {
@@ -8559,18 +8560,14 @@ fn watched_rust_file_renames() -> lsp::FileOperationRegistrationOptions {
                 options: None,
             },
         }],
-    }
-}
-
-fn rename_capabilities(
-    will_rename: Option<lsp::FileOperationRegistrationOptions>,
-) -> lsp::ServerCapabilities {
+    };
     lsp::ServerCapabilities {
         rename_provider: Some(lsp::OneOf::Left(true)),
-        workspace: will_rename.map(|will_rename| lsp::WorkspaceServerCapabilities {
+        workspace: watch_renames.then(|| lsp::WorkspaceServerCapabilities {
             workspace_folders: None,
             file_operations: Some(lsp::WorkspaceFileOperationsServerCapabilities {
-                will_rename: Some(will_rename),
+                will_rename: Some(watched.clone()),
+                did_rename: Some(watched),
                 ..Default::default()
             }),
         }),
@@ -8603,7 +8600,7 @@ async fn test_workspace_edit_asks_what_the_move_changes(cx: &mut gpui::TestAppCo
     let mut fake_servers = language_registry.register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: rename_capabilities(Some(watched_rust_file_renames())),
+            capabilities: rename_capabilities(true),
             ..Default::default()
         },
     );
@@ -8678,6 +8675,20 @@ async fn test_workspace_edit_asks_what_the_move_changes(cx: &mut gpui::TestAppCo
         }
     });
 
+    let told_after_the_move = Arc::new(OnceLock::new());
+    fake_server.handle_notification::<DidRenameFiles, _>({
+        let told_after_the_move = told_after_the_move.clone();
+        move |params, _| {
+            assert_eq!(params.files.len(), 1);
+            told_after_the_move
+                .set((
+                    params.files[0].old_uri.clone(),
+                    params.files[0].new_uri.clone(),
+                ))
+                .ok();
+        }
+    });
+
     let transaction = project
         .update(cx, |project, cx| {
             project.perform_rename(buffer.clone(), 4, "glyphs".to_string(), cx)
@@ -8686,6 +8697,14 @@ async fn test_workspace_edit_asks_what_the_move_changes(cx: &mut gpui::TestAppCo
         .unwrap();
     cx.executor().run_until_parked();
 
+    assert_eq!(
+        told_after_the_move.get(),
+        Some(&(
+            uri!("file:///dir/clock.rs").to_owned(),
+            uri!("file:///dir/glyphs.rs").to_owned()
+        )),
+        "the server should have been told the move happened"
+    );
     assert_eq!(
         asked_before_the_move.get(),
         Some(&true),
@@ -8734,7 +8753,7 @@ async fn test_workspace_edit_does_not_ask_a_server_that_is_not_watching(
     let mut fake_servers = language_registry.register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: rename_capabilities(None),
+            capabilities: rename_capabilities(false),
             ..Default::default()
         },
     );
@@ -8811,7 +8830,7 @@ async fn test_workspace_edit_does_not_ask_about_the_moves_an_answer_makes(
     let mut fake_servers = language_registry.register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: rename_capabilities(Some(watched_rust_file_renames())),
+            capabilities: rename_capabilities(true),
             ..Default::default()
         },
     );

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8547,6 +8547,343 @@ async fn test_rename_that_also_renames_file(cx: &mut gpui::TestAppContext) {
     });
 }
 
+/// What rust-analyzer registers: it wants to be told before any Rust file, or
+/// any folder, moves.
+fn watched_rust_file_renames() -> lsp::FileOperationRegistrationOptions {
+    lsp::FileOperationRegistrationOptions {
+        filters: vec![FileOperationFilter {
+            scheme: Some("file".to_owned()),
+            pattern: lsp::FileOperationPattern {
+                glob: "**/*.rs".to_owned(),
+                matches: Some(lsp::FileOperationPatternKind::File),
+                options: None,
+            },
+        }],
+    }
+}
+
+fn rename_capabilities(
+    will_rename: Option<lsp::FileOperationRegistrationOptions>,
+) -> lsp::ServerCapabilities {
+    lsp::ServerCapabilities {
+        rename_provider: Some(lsp::OneOf::Left(true)),
+        workspace: will_rename.map(|will_rename| lsp::WorkspaceServerCapabilities {
+            workspace_folders: None,
+            file_operations: Some(lsp::WorkspaceFileOperationsServerCapabilities {
+                will_rename: Some(will_rename),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    }
+}
+
+// A server that registered `willRenameFiles` can answer a rename with the file
+// move alone and hold the edits for the references back, to stop a client that
+// asks as well from applying them twice. rust-analyzer does that for every
+// module rename. Unless the move asks, the file lands at its new name with
+// every reference to the old one left behind, and the crate stops compiling.
+#[gpui::test]
+async fn test_workspace_edit_asks_what_the_move_changes(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "main.rs": "mod clock;\nfn main() { clock::digit(); }",
+            "clock.rs": "pub fn digit() {}",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: rename_capabilities(Some(watched_rust_file_renames())),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    // The whole answer, in the shape rust-analyzer sends it. The file moves and
+    // nothing else is said.
+    fake_server.set_request_handler::<lsp::request::Rename, _, _>(|_params, _| async move {
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Operations(vec![
+                lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                    old_uri: Uri::from_file_path(path!("/dir/clock.rs")).unwrap(),
+                    new_uri: Uri::from_file_path(path!("/dir/glyphs.rs")).unwrap(),
+                    options: None,
+                    annotation_id: None,
+                })),
+            ])),
+            change_annotations: None,
+        }))
+    });
+
+    let asked_before_the_move = Arc::new(OnceLock::new());
+    fake_server.set_request_handler::<WillRenameFiles, _, _>({
+        let asked_before_the_move = asked_before_the_move.clone();
+        let fs = fs.clone();
+        move |params, _| {
+            let asked_before_the_move = asked_before_the_move.clone();
+            let fs = fs.clone();
+            async move {
+                assert_eq!(params.files.len(), 1);
+                assert_eq!(params.files[0].old_uri, uri!("file:///dir/clock.rs"));
+                assert_eq!(params.files[0].new_uri, uri!("file:///dir/glyphs.rs"));
+                // The edits below are worked out from where the file is now, so
+                // the question has to come before the move.
+                asked_before_the_move
+                    .set(fs.load(Path::new(path!("/dir/clock.rs"))).await.is_ok())
+                    .unwrap();
+                Ok(Some(lsp::WorkspaceEdit {
+                    changes: None,
+                    document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                        text_document: lsp::OptionalVersionedTextDocumentIdentifier {
+                            uri: Uri::from_file_path(path!("/dir/main.rs")).unwrap(),
+                            version: None,
+                        },
+                        edits: vec![
+                            lsp::Edit::Plain(lsp::TextEdit::new(
+                                lsp::Range::new(lsp::Position::new(0, 4), lsp::Position::new(0, 9)),
+                                "glyphs".to_string(),
+                            )),
+                            lsp::Edit::Plain(lsp::TextEdit::new(
+                                lsp::Range::new(
+                                    lsp::Position::new(1, 12),
+                                    lsp::Position::new(1, 17),
+                                ),
+                                "glyphs".to_string(),
+                            )),
+                        ],
+                    }])),
+                    change_annotations: None,
+                }))
+            }
+        }
+    });
+
+    let transaction = project
+        .update(cx, |project, cx| {
+            project.perform_rename(buffer.clone(), 4, "glyphs".to_string(), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        asked_before_the_move.get(),
+        Some(&true),
+        "the server should have been asked, and asked before the file moved"
+    );
+    assert_eq!(
+        buffer.read_with(cx, |buffer, _| buffer.text()),
+        "mod glyphs;\nfn main() { glyphs::digit(); }",
+        "the references the server sent back should have been applied"
+    );
+    assert!(fs.load(Path::new(path!("/dir/glyphs.rs"))).await.is_ok());
+    assert!(fs.load(Path::new(path!("/dir/clock.rs"))).await.is_err());
+
+    // The edits belong to the transaction this workspace edit produced, so undo
+    // reaches them, and the file it left renamed can be reported against them.
+    assert!(transaction.0.contains_key(&buffer));
+    buffer.update(cx, |buffer, cx| buffer.undo(cx));
+    assert_eq!(
+        buffer.read_with(cx, |buffer, _| buffer.text()),
+        "mod clock;\nfn main() { clock::digit(); }",
+        "undo should reach the edits that came back with the move"
+    );
+}
+
+// The question only goes to servers that asked for it. One that registered
+// nothing is not interested in the move and should not be interrupted by it.
+#[gpui::test]
+async fn test_workspace_edit_does_not_ask_a_server_that_is_not_watching(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "main.rs": "mod clock;\nfn main() { clock::digit(); }",
+            "clock.rs": "pub fn digit() {}",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: rename_capabilities(None),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    fake_server.set_request_handler::<lsp::request::Rename, _, _>(|_params, _| async move {
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Operations(vec![
+                lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                    old_uri: Uri::from_file_path(path!("/dir/clock.rs")).unwrap(),
+                    new_uri: Uri::from_file_path(path!("/dir/glyphs.rs")).unwrap(),
+                    options: None,
+                    annotation_id: None,
+                })),
+            ])),
+            change_annotations: None,
+        }))
+    });
+
+    let times_asked = Arc::new(atomic::AtomicUsize::new(0));
+    fake_server.set_request_handler::<WillRenameFiles, _, _>({
+        let times_asked = times_asked.clone();
+        move |_params, _| {
+            times_asked.fetch_add(1, atomic::Ordering::SeqCst);
+            async move { Ok(None) }
+        }
+    });
+
+    project
+        .update(cx, |project, cx| {
+            project.perform_rename(buffer.clone(), 4, "glyphs".to_string(), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(times_asked.load(atomic::Ordering::SeqCst), 0);
+    assert!(fs.load(Path::new(path!("/dir/glyphs.rs"))).await.is_ok());
+}
+
+// The answer to the question may itself move a file. Asking again about that
+// move would let a server keep the exchange going forever, so the moves an
+// answer makes are carried out without a further question.
+#[gpui::test]
+async fn test_workspace_edit_does_not_ask_about_the_moves_an_answer_makes(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "main.rs": "mod clock;\nfn main() { clock::digit(); }",
+            "clock.rs": "pub fn digit() {}",
+            "extra.rs": "pub fn extra() {}",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: rename_capabilities(Some(watched_rust_file_renames())),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    fake_server.set_request_handler::<lsp::request::Rename, _, _>(|_params, _| async move {
+        Ok(Some(lsp::WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Operations(vec![
+                lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(lsp::RenameFile {
+                    old_uri: Uri::from_file_path(path!("/dir/clock.rs")).unwrap(),
+                    new_uri: Uri::from_file_path(path!("/dir/glyphs.rs")).unwrap(),
+                    options: None,
+                    annotation_id: None,
+                })),
+            ])),
+            change_annotations: None,
+        }))
+    });
+
+    let times_asked = Arc::new(atomic::AtomicUsize::new(0));
+    fake_server.set_request_handler::<WillRenameFiles, _, _>({
+        let times_asked = times_asked.clone();
+        move |_params, _| {
+            times_asked.fetch_add(1, atomic::Ordering::SeqCst);
+            async move {
+                Ok(Some(lsp::WorkspaceEdit {
+                    changes: None,
+                    document_changes: Some(DocumentChanges::Operations(vec![
+                        lsp::DocumentChangeOperation::Op(lsp::ResourceOp::Rename(
+                            lsp::RenameFile {
+                                old_uri: Uri::from_file_path(path!("/dir/extra.rs")).unwrap(),
+                                new_uri: Uri::from_file_path(path!("/dir/spare.rs")).unwrap(),
+                                options: None,
+                                annotation_id: None,
+                            },
+                        )),
+                    ])),
+                    change_annotations: None,
+                }))
+            }
+        }
+    });
+
+    project
+        .update(cx, |project, cx| {
+            project.perform_rename(buffer.clone(), 4, "glyphs".to_string(), cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        times_asked.load(atomic::Ordering::SeqCst),
+        1,
+        "the move the answer made should not have been asked about"
+    );
+    // Both moves still happen. Not asking about the second one is not the same
+    // as refusing to make it.
+    assert!(fs.load(Path::new(path!("/dir/glyphs.rs"))).await.is_ok());
+    assert!(fs.load(Path::new(path!("/dir/spare.rs"))).await.is_ok());
+}
+
 #[gpui::test]
 async fn test_search(cx: &mut gpui::TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
# Objective

Renaming a Rust module renames the file but not any text reference. Every reference to the old name stays where it was, the crate stops compiling, and undo is no help because no text ever changed.

It's not rust-analyzer what loses those edits. Zed tells servers it supports `workspace/willRenameFiles`, so rust-analyzer leaves the reference edits out of the rename response on purpose and waits to be asked for them when the file moves. That is how it stops a client from applying them twice. Zed does ask when you rename a file from the project panel, but not when a workspace edit moves one, so for a module rename nobody ever asks.

The spec has the request going out in both cases. It is sent "before files are actually renamed as long as the rename is triggered from within the client either by a user action or by applying a workspace edit".

## Solution

A rename inside a workspace edit now asks before it moves the file, and folds the answer into the transaction the edit is building. That second part is what lets undo reach the edits. It also sends `didRenameFiles` afterwards, which this path never did, so a server that wants to reindex is told the move happened instead of waiting for the file watcher.

Only servers that registered for these get them. gopls, the other server that moves files during a rename, registers `didCreate` and nothing else, so it never sees the question and goes on sending its edits inline.

Both are off while a server's answer is being applied, so a reply that moves a file of its own cannot start the exchange again.

## Testing

I added three tests and checked each one fails against a deliberately broken implementation.

Ran it by hand on a small Rust crate. Renaming the module moves the file, updates the `mod` declaration and both call sites, and `cargo check` passes, where before it failed with E0583. Undo reverts all three edits but leaves the file renamed (which I have addressed in my proposed approach in #63483).

Also measured against rust-analyzer driven straight over LSP with Zed's client capabilities. The rename response carries the move and nothing else. Drop `fileOperations` from those capabilities, or ask `workspace/willRenameFiles`, and the three missing reference edits arrive. A rust-analyzer from five months earlier behaves the same, so this is not new.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/99cf3251-a2ab-4685-8c2e-61642402e52e

---

Release Notes:

- Fixed renaming a Rust module moving the file and leaving every reference to the old name behind.
