### PR TITLE
terminal: Prioritize input in focused terminals

### DIFF
--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -524,6 +524,28 @@ impl<'a, T: 'static> Context<'a, T> {
         )
     }
 
+    /// Register a callback to be invoked before keybindings are resolved for a keystroke.
+    /// Calling `cx.stop_propagation()` prevents action dispatch and later key event handlers.
+    pub fn intercept_keystrokes(
+        &mut self,
+        mut f: impl FnMut(&mut T, &KeystrokeEvent, &mut Window, &mut Context<T>) + 'static,
+    ) -> Subscription {
+        let view = self.weak_entity();
+        let (subscription, activate) = self.keystroke_interceptors.insert(
+            (),
+            Box::new(move |event, window, cx| {
+                if let Some(view) = view.upgrade() {
+                    view.update(cx, |view, cx| f(view, event, window, cx));
+                    true
+                } else {
+                    false
+                }
+            }),
+        );
+        activate();
+        subscription
+    }
+
     /// Register a callback to be invoked when the window's pending input changes.
     pub fn observe_pending_input(
         &self,

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -445,7 +445,7 @@ impl DispatchTree {
         }
     }
 
-    fn bindings_for_input(
+    pub(crate) fn bindings_for_input(
         &self,
         input: &[Keystroke],
         dispatch_path: &SmallVec<[DispatchNodeId; 32]>,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6029,6 +6029,17 @@ impl Window {
             .possible_next_bindings_for_input(input, &self.context_stack())
     }
 
+    /// Returns the bindings that match the input and whether a longer binding is pending.
+    pub fn bindings_for_input(&self, input: &[Keystroke]) -> (Vec<KeyBinding>, bool) {
+        let node_id = self.focus_node_id_in_rendered_frame(self.focus);
+        let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
+        let (bindings, pending, _) = self
+            .rendered_frame
+            .dispatch_tree
+            .bindings_for_input(input, &dispatch_path);
+        (bindings.into_vec(), pending)
+    }
+
     fn context_stack_for_focus_handle(
         &self,
         focus_handle: &FocusHandle,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -10,9 +10,9 @@ use editor::{
 };
 use gpui::{
     Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, ExternalPaths,
-    FocusHandle, Focusable, Font, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent,
-    Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled, Subscription, Task, TaskExt,
-    WeakEntity, actions, anchored, deferred, div,
+    FocusHandle, Focusable, Font, KeyBinding, KeyContext, KeyDownEvent, Keystroke, KeystrokeEvent,
+    MouseButton, MouseDownEvent, Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled,
+    Subscription, Task, TaskExt, WeakEntity, actions, anchored, deferred, div,
 };
 use menu;
 use persistence::TerminalDb;
@@ -273,6 +273,7 @@ impl TerminalView {
         let subscriptions = vec![
             focus_in,
             focus_out,
+            cx.intercept_keystrokes(Self::intercept_keystroke),
             cx.observe(&blink_manager, |_, _, cx| cx.notify()),
             cx.observe_global::<SettingsStore>(Self::settings_changed),
         ];
@@ -1265,6 +1266,26 @@ impl ScrollbarVisibility for TerminalScrollbarSettingsWrapper {
 }
 
 impl TerminalView {
+    fn intercept_keystroke(
+        &mut self,
+        event: &KeystrokeEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.focus_handle.is_focused(window) {
+            return;
+        }
+
+        let (bindings, pending) = window.bindings_for_input(std::slice::from_ref(&event.keystroke));
+        if !terminal_input_can_preempt_bindings(&bindings, pending) {
+            return;
+        }
+
+        if self.process_keystroke(&event.keystroke, cx) {
+            cx.stop_propagation();
+        }
+    }
+
     /// Attempts to process a keystroke in the terminal. Returns true if handled.
     ///
     /// In vi mode, explicitly triggers a re-render because vi navigation (like j/k)
@@ -1322,6 +1343,13 @@ impl TerminalView {
         });
         cx.notify();
     }
+}
+
+fn terminal_input_can_preempt_bindings(bindings: &[KeyBinding], pending: bool) -> bool {
+    !pending
+        && !bindings.iter().any(|binding| {
+            binding.predicate().is_some() || binding.meta().map_or(true, |meta| meta.0 == 0)
+        })
 }
 
 impl Render for TerminalView {
@@ -2170,7 +2198,7 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, VisualTestContext};
+    use gpui::{KeyBindingMetaIndex, TestAppContext, VisualTestContext};
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
@@ -2178,6 +2206,26 @@ mod tests {
     use util::rel_path::RelPath;
     use workspace::item::test::{TestItem, TestProjectItem};
     use workspace::{AppState, MultiWorkspace, SelectedEntry};
+
+    actions!(test_only, [TerminalInputTestAction]);
+
+    #[test]
+    fn terminal_input_only_preempts_unqualified_builtins() {
+        let builtin = KeyBinding::new("ctrl-t", TerminalInputTestAction, None)
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(terminal_input_can_preempt_bindings(&[builtin], false));
+
+        let contextual = KeyBinding::new("ctrl-t", TerminalInputTestAction, Some("Terminal"))
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(!terminal_input_can_preempt_bindings(&[contextual], false));
+
+        let user = KeyBinding::new("ctrl-t", TerminalInputTestAction, None);
+        assert!(!terminal_input_can_preempt_bindings(&[user], false));
+
+        let builtin = KeyBinding::new("ctrl-t", TerminalInputTestAction, None)
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(!terminal_input_can_preempt_bindings(&[builtin], true));
+    }
 
     fn expected_drop_text(paths: &[PathBuf]) -> String {
         let mut text = String::new();


### PR DESCRIPTION
## Summary

- Let a focused terminal receive a keystroke before an unqualified built-in keybinding handles it.
- Keep user keybindings, contextual bindings, and multi-key prefixes ahead of terminal input.
- Add a regression test for the precedence rules.

Fixes #26018.

## Why

Zed currently resolves global keybindings before the terminal gets a chance to process input. That makes common terminal shortcuts such as `Ctrl-T` trigger Zed actions instead of reaching tools running in the terminal. This moves the terminal decision into GPUI's pre-dispatch phase while preserving explicit keybinding choices.

## Testing

- `cargo fmt --check`
- `cargo test -p gpui --lib --offline` (278 passed)
- `cargo test -p terminal_view --lib` (91 passed)
- `cargo test -p terminal_view terminal_input_only_preempts_unqualified_builtins --lib --offline` (1 passed)
- `cargo check -p gpui -p terminal_view --offline`