### PR TITLE
settings: Improve wording on close pannel on toggle setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -9,7 +9,7 @@
   "theme": {
     "mode": "system",
     "light": "One Light",
-    "dark": "One Dark",
+    "dark": "One Dark"
   },
   "icon_theme": "Zed (Default)",
   // The name of a base set of key bindings to use.
@@ -63,7 +63,7 @@
   // The OpenType features to enable for text in the UI
   "ui_font_features": {
     // Disable ligatures:
-    "calt": false,
+    "calt": false
   },
   // The weight of the UI font in standard CSS units from 100 to 900.
   "ui_font_weight": 400,
@@ -93,7 +93,7 @@
     "border_size": 0.0,
     // Opacity of the inactive panes. 0 means transparent, 1 means opaque.
     // Values are clamped to the [0.0, 1.0] range.
-    "inactive_opacity": 1.0,
+    "inactive_opacity": 1.0
   },
   // Layout mode of the bottom dock. Defaults to "contained"
   //   choices: contained, full, left_aligned, right_aligned
@@ -109,12 +109,12 @@
     "left_padding": 0.2,
     // The relative width of the right padding of the central pane from the
     // workspace when the centered layout is used.
-    "right_padding": 0.2,
+    "right_padding": 0.2
   },
   // Image viewer settings
   "image_viewer": {
     // The unit for image file sizes: "binary" (KiB, MiB) or decimal (KB, MB)
-    "unit": "binary",
+    "unit": "binary"
   },
   // Markdown preview settings
   "markdown_preview": {
@@ -124,7 +124,7 @@
     "limit_content_width": true,
     // The maximum width, in pixels, of the rendered markdown content when
     // limit_content_width is enabled.
-    "max_width": 800,
+    "max_width": 800
   },
   // Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
   //
@@ -195,7 +195,7 @@
   // Whether toggling a panel (e.g. with its keyboard shortcut) also closes
   // the panel when it is already focused, instead of just moving focus back
   // to the editor.
-  "close_panel_on_toggle": false,
+  "close_panel_on_focus_toggle": false,
   // Relative size of the drop target in the editor that will open dropped file as a split pane (0-0.5)
   // E.g. 0.25 == If you drop onto the top/bottom quarter of the pane a new vertical split will be used
   //              If you drop onto the left/right quarter of the pane a new horizontal split will be used
@@ -290,7 +290,7 @@
   // Determines whether the focused panel follows the mouse location.
   "focus_follows_mouse": {
     "enabled": false,
-    "debounce_ms": 250,
+    "debounce_ms": 250
   },
   // Determines how snippets are sorted relative to other completion items.
   //
@@ -396,7 +396,7 @@
     // When true, enables drag and drop text selection in buffer.
     "enabled": true,
     // The delay in milliseconds that must elapse before drag and drop is allowed. Otherwise, a new text selection is created.
-    "delay": 300,
+    "delay": 300
   },
   // Whether and how to display code lenses from language servers.
   //
@@ -531,14 +531,14 @@
   // Visible characters used to render whitespace when show_whitespaces is enabled.
   "whitespace_map": {
     "space": "•",
-    "tab": "→",
+    "tab": "→"
   },
   // Settings related to calls in Zed
   "calls": {
     // Join calls with the microphone live by default
     "mute_on_join": false,
     // Share your project when you are the first to join a channel
-    "share_on_join": false,
+    "share_on_join": false
   },
   // Toolbar related settings
   "toolbar": {
@@ -551,7 +551,7 @@
     // Whether to show agent review buttons in the editor toolbar.
     "agent_review": true,
     // Whether to show code action buttons in the editor toolbar.
-    "code_actions": false,
+    "code_actions": false
   },
   // Whether to allow windows to tab together based on the user’s tabbing preference (macOS only).
   "use_system_window_tabs": false,
@@ -584,7 +584,7 @@
     // Whether to show the menus in the titlebar.
     "show_menus": false,
     // The layout of window control buttons in the title bar (Linux only).
-    "button_layout": "platform_default",
+    "button_layout": "platform_default"
   },
   "audio": {
     // Select specific output audio device.
@@ -594,7 +594,7 @@
     // Select specific input audio device.
     // `null` means use system default.
     // Any unrecognized input device will fall back to system default.
-    "experimental.input_audio_device": null,
+    "experimental.input_audio_device": null
   },
   // Scrollbar related settings
   "scrollbar": {
@@ -633,8 +633,8 @@
       // When false, forcefully disables the horizontal scrollbar. Otherwise, obey other settings.
       "horizontal": true,
       // When false, forcefully disables the vertical scrollbar. Otherwise, obey other settings.
-      "vertical": true,
-    },
+      "vertical": true
+    }
   },
   // Minimap related settings
   "minimap": {
@@ -682,7 +682,7 @@
     // 3. "gutter" or "none" to not highlight the current line in the minimap.
     "current_line_highlight": null,
     // Maximum number of columns to display in the minimap.
-    "max_width_columns": 80,
+    "max_width_columns": 80
   },
   // Enable middle-click paste on Linux.
   "middle_click_paste": true,
@@ -710,7 +710,7 @@
     "min_line_number_digits": 4,
     // The width of the git diff hunk indicators in the gutter.
     // Use "default" to scale with font size, or {"custom": <pixels>} for a fixed width.
-    "git_gutter_width": "default",
+    "git_gutter_width": "default"
   },
   "indent_guides": {
     // Whether to show indent guides in the editor.
@@ -731,7 +731,7 @@
     //
     // 1. "disabled"
     // 2. "indent_aware"
-    "background_coloring": "disabled",
+    "background_coloring": "disabled"
   },
   // Whether the editor will scroll beyond the last line.
   "scroll_beyond_last_line": "one_page",
@@ -753,7 +753,7 @@
   "fast_scroll_sensitivity": 4.0,
   "sticky_scroll": {
     // Whether to stick scopes to the top of the editor.
-    "enabled": false,
+    "enabled": false
   },
   "relative_line_numbers": "disabled",
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
@@ -773,7 +773,7 @@
     // Whether to center the cursor on each search match when navigating.
     "center_on_match": false,
     // Start searching as you type in project search, without pressing Enter.
-    "search_on_type": true,
+    "search_on_type": true
   },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:
@@ -816,8 +816,8 @@
       "shift": false,
       "alt": false,
       "platform": false,
-      "function": false,
-    },
+      "function": false
+    }
   },
   // Whether to resize all the panels in a dock when resizing the dock.
   // Can be a combination of "left", "right" and "bottom".
@@ -877,7 +877,7 @@
       "show": null,
       // Whether to allow horizontal scrolling in the project panel.
       // When false, the view is locked to the leftmost position and long file names are clipped.
-      "horizontal_scroll": true,
+      "horizontal_scroll": true
     },
     // Which files containing diagnostic errors/warnings to mark in the project panel.
     // This setting can take the following three values:
@@ -900,7 +900,7 @@
       //    "always"
       // 2. Never show indent guides:
       //    "never"
-      "show": "always",
+      "show": "always"
     },
     // Sort order for entries in the project panel.
     // This setting can take three values:
@@ -945,8 +945,8 @@
       // Whether to automatically open files after pasting or duplicating them.
       "on_paste": true,
       // Whether to automatically open files dropped from external sources.
-      "on_drop": true,
-    },
+      "on_drop": true
+    }
   },
   "outline_panel": {
     // Whether to show the outline panel button in the status bar
@@ -986,7 +986,7 @@
       //    "always"
       // 2. Never show indent guides:
       //    "never"
-      "show": "always",
+      "show": "always"
     },
     // Scrollbar-related settings
     "scrollbar": {
@@ -1003,7 +1003,7 @@
       //    "always"
       // 5. Never show the scrollbar:
       //    "never"
-      "show": null,
+      "show": null
     },
     // Default depth to expand outline items in the current file.
     // Set to 0 to collapse all items that have children, 1 or higher to collapse items at that depth or deeper.
@@ -1012,7 +1012,7 @@
     // when a multi-buffer view (e.g. a diff or search results) is active,
     // showing only files and directories.
     // Does not affect single-file views.
-    "multi_buffer_hide_symbols": false,
+    "multi_buffer_hide_symbols": false
   },
   "collaboration_panel": {
     // Whether to show the collaboration panel button in the status bar.
@@ -1020,7 +1020,7 @@
     // Where to dock the collaboration panel. Can be 'left' or 'right'.
     "dock": "right",
     // Default width of the collaboration panel.
-    "default_width": 240,
+    "default_width": 240
   },
   "git_panel": {
     // Whether to show the git panel button in the status bar.
@@ -1097,7 +1097,7 @@
     //
     // Choices: project_diff, file_diff, view_file
     // Default: project_diff
-    "entry_primary_click_action": "project_diff",
+    "entry_primary_click_action": "project_diff"
   },
   "agent": {
     // Whether the inline assistant should use streaming tools, when available
@@ -1135,7 +1135,7 @@
       // The model to use.
       "model": "claude-sonnet-4",
       // Whether thinking is enabled.
-      "enable_thinking": false,
+      "enable_thinking": false
     },
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider
@@ -1198,7 +1198,7 @@
         //     { "pattern": "\\.key$" },
         //   ],
         // },
-      },
+      }
     },
     // When enabled, agent edits will be displayed in single-file editors for review
     "single_file_review": false,
@@ -1216,7 +1216,7 @@
       //   - A negative integer: compact once that many tokens remain in the
       //     context window (e.g. -20000 compacts once fewer than 20,000 remain).
       // 0 is not a valid threshold.
-      "threshold": "90%",
+      "threshold": "90%"
     },
     // When enabled, show voting thumbs for feedback on agent edits.
     "enable_feedback": true,
@@ -1249,8 +1249,8 @@
           "skill": true,
           "spawn_agent": true,
           "terminal": true,
-          "search_web": true,
-        },
+          "search_web": true
+        }
       },
       "ask": {
         "name": "Ask",
@@ -1271,14 +1271,14 @@
           "grep": true,
           "skill": true,
           "spawn_agent": true,
-          "search_web": true,
-        },
+          "search_web": true
+        }
       },
       "minimal": {
         "name": "Minimal",
         "enable_all_context_servers": false,
-        "tools": {},
-      },
+        "tools": {}
+      }
     },
     // Where to show notifications when the agent has either completed
     // its response, or else needs confirmation before it can run a
@@ -1335,7 +1335,7 @@
     // that offers to resolve conflicts using the agent.
     //
     // Default: true
-    "show_merge_conflict_indicator": true,
+    "show_merge_conflict_indicator": true
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
@@ -1398,7 +1398,7 @@
     // Whether or not to show pinned tabs in a separate row.
     // When enabled, pinned tabs appear in a top row and unpinned tabs in a bottom row.
     // When disabled, all tabs appear in a single row (default behavior).
-    "show_pinned_tabs_in_separate_row": false,
+    "show_pinned_tabs_in_separate_row": false
   },
   // Settings related to the editor's tabs
   "tabs": {
@@ -1437,7 +1437,7 @@
     //    "errors"
     // 3. Mark files with errors and warnings:
     //    "all"
-    "show_diagnostics": "off",
+    "show_diagnostics": "off"
   },
   // Settings related to preview tabs.
   "preview_tabs": {
@@ -1458,14 +1458,14 @@
     "enable_preview_file_from_code_navigation": true,
     // Whether to keep tabs in preview mode when code navigation is used to navigate away from them.
     // If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
-    "enable_keep_preview_on_code_navigation": false,
+    "enable_keep_preview_on_code_navigation": false
   },
   // Settings related to the call hierarchy picker.
   "call_hierarchy": {
     // Determines how much space the call hierarchy picker can take up in relation to the available window width.
     //
     // Default: medium
-    "modal_max_width": "medium",
+    "modal_max_width": "medium"
   },
   // Settings related to the file finder.
   "file_finder": {
@@ -1509,7 +1509,7 @@
     //   * "smart": Be smart and search for ignored when called from a gitignored worktree
     "include_ignored": "smart",
     // Whether to include text channels in file finder results.
-    "include_channels": false,
+    "include_channels": false
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.
@@ -1615,7 +1615,7 @@
     "metrics": true,
     // Allow sending requests to Anthropic models that cannot be offered with
     // Zero Data Retention
-    "anthropic_retention": false,
+    "anthropic_retention": false
   },
   // Whether to disable all AI features in Zed.
   //
@@ -1655,7 +1655,7 @@
       "enabled": true,
       // Minimum time to wait before pulling diagnostics from the language server(s).
       // 0 turns the debounce off.
-      "debounce_ms": 50,
+      "debounce_ms": 50
     },
     // Settings for inline diagnostics
     "inline": {
@@ -1673,8 +1673,8 @@
       "min_column": 0,
       // The minimum severity of the diagnostics to show inline.
       // Inherits editor's diagnostics' max severity settings when `null`.
-      "max_severity": null,
-    },
+      "max_severity": null
+    }
   },
   // Files or globs of files that will be excluded by Zed entirely. They will be skipped during file
   // scans, file searches, and not be displayed in the project file tree. Takes precedence over `file_scan_inclusions`.
@@ -1689,7 +1689,7 @@
     "**/.DS_Store",
     "**/Thumbs.db",
     "**/.classpath",
-    "**/.settings",
+    "**/.settings"
   ],
   // Files or globs of files that will be included by Zed, even when ignored by git. This is useful
   // for files that are not tracked by git, but are still important to your project. Note that globs
@@ -1752,18 +1752,18 @@
       // Whether or not to display the git commit summary on the same line.
       "show_commit_summary": false,
       // The minimum column number to show the inline blame information at
-      "min_column": 0,
+      "min_column": 0
     },
     "blame": {
-      "show_avatar": true,
+      "show_avatar": true
     },
     // Control which information is shown in the branch picker.
     "branch_picker": {
-      "show_author_name": true,
+      "show_author_name": true
     },
     "file_diff": {
       // Whether newly opened file diffs show the full file instead of changes only.
-      "show_full_file": true,
+      "show_full_file": true
     },
     // How git hunks are displayed visually in the editor.
     // This setting can take two values:
@@ -1798,7 +1798,7 @@
     //   "my-worktrees" — <project>/my-worktrees/
     //
     // Trailing slashes are ignored.
-    "worktree_directory": "../worktrees",
+    "worktree_directory": "../worktrees"
   },
   // The list of custom Git hosting providers.
   "git_hosting_providers": [
@@ -1834,7 +1834,7 @@
       "**/secrets.yml",
       "**/.zed/settings.json", // zed project settings
       "/**/zed/settings.json", // zed user settings
-      "/**/zed/keymap.json",
+      "/**/zed/keymap.json"
     ],
     // When to show edit predictions previews in buffer.
     // This setting takes two possible values:
@@ -1858,33 +1858,33 @@
       "proxy": null,
       "proxy_no_verify": null,
       "enable_next_edit_suggestions": true,
-      "prediction_debounce": 75,
+      "prediction_debounce": 75
     },
     "codestral": {
       "api_url": "https://codestral.mistral.ai",
       "model": "codestral-latest",
       "max_tokens": 150,
-      "prediction_debounce": 150,
+      "prediction_debounce": 150
     },
     "ollama": {
       "api_url": "http://localhost:11434",
       "model": "qwen2.5-coder:7b-base",
       "prompt_format": "infer",
       "max_output_tokens": 64,
-      "prediction_debounce": 0,
+      "prediction_debounce": 0
     },
     "open_ai_compatible_api": {
       "api_url": "",
       "model": "",
       "prompt_format": "infer",
       "max_output_tokens": 64,
-      "prediction_debounce": 0,
+      "prediction_debounce": 0
     },
     "zed": {
-      "prediction_debounce": 0,
+      "prediction_debounce": 0
     },
     "mercury": {
-      "prediction_debounce": 0,
+      "prediction_debounce": 0
     },
     // Controls whether Zed may collect training data when using Zed's Edit Predictions.
     // Data is only captured when the project is detected as open source.
@@ -1893,7 +1893,7 @@
     //     or false if no preference has been stored.
     //   - "yes": allow data collection for files in open-source projects.
     //   - "no": never allow data collection.
-    "allow_data_collection": "default",
+    "allow_data_collection": "default"
   },
   // Settings specific to journaling
   "journal": {
@@ -1903,7 +1903,7 @@
     // May take 2 values:
     // 1. hour12
     // 2. hour24
-    "hour_format": "hour12",
+    "hour_format": "hour12"
   },
   // Status bar-related settings.
   "status_bar": {
@@ -1918,7 +1918,7 @@
     // Whether to show active line endings button in the status bar.
     "line_endings_button": false,
     // Control when to show the active encoding in the status bar.
-    "active_encoding_button": "non_utf8",
+    "active_encoding_button": "non_utf8"
   },
   // Settings specific to the terminal
   "terminal": {
@@ -2056,8 +2056,8 @@
         // Preferred Conda manager to use when activating Conda environments.
         // Values: "auto", "conda", "mamba", "micromamba"
         // Default: "auto"
-        "conda_manager": "auto",
-      },
+        "conda_manager": "auto"
+      }
     },
     "toolbar": {
       // Whether to display the terminal title in its toolbar's breadcrumbs.
@@ -2065,7 +2065,7 @@
       //
       // The shell running in the terminal needs to be configured to emit the title.
       // Example: `echo -e "\e]2;New Title\007";`
-      "breadcrumbs": false,
+      "breadcrumbs": false
     },
     // Scrollbar-related settings
     "scrollbar": {
@@ -2082,7 +2082,7 @@
       //    "always"
       // 5. Never show the scrollbar:
       //    "never"
-      "show": null,
+      "show": null
     },
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
@@ -2159,8 +2159,8 @@
         "    )",
         "    # optional line/column suffix (included in path for PathWithPosition::parse_str)",
         "    (:+[0-9]+(:[0-9]+)?|:?\\([0-9]+([,:]?[0-9]+)?\\))?",
-        ")",
-      ],
+        ")"
+      ]
     ],
     // Timeout for hover and Cmd-click path hyperlink discovery in milliseconds. Specifying a
     // timeout of `0` will disable path hyperlinking in terminal.
@@ -2168,7 +2168,7 @@
     // Whether to show a badge on the terminal panel icon with the count of open terminals.
     "show_count_badge": false,
     // Whether to invoke the OS-specific alert sound when the terminal bell (BEL character) is printed.
-    "bell": "off",
+    "bell": "off"
   },
   "code_actions_on_format": {},
   // Settings related to running tasks.
@@ -2184,7 +2184,7 @@
     // * Zed task from history (e.g. one-off task was spawned before)
     //
     // Default: true
-    "prefer_lsp": true,
+    "prefer_lsp": true
   },
   // An object whose keys are language names, and whose values
   // are arrays of filenames or extensions of files that should
@@ -2203,10 +2203,10 @@
       "**/.zed/*.json",
       "**/.vscode/**/*.json",
       "**/{zed,Zed}/{settings,keymap,tasks,debug}.json",
-      "tsconfig*.json",
+      "tsconfig*.json"
     ],
     "Markdown": [".rules", ".cursorrules", ".windsurfrules", ".clinerules"],
-    "Shell Script": [".env.*"],
+    "Shell Script": [".env.*"]
   },
   // Settings for which version of Node.js and NPM to use when installing
   // language servers and Copilot.
@@ -2222,14 +2222,14 @@
     // `path`, but not `npm_path`, Zed will assume that `npm` is located at
     // `${path}/../npm`.
     "path": null,
-    "npm_path": null,
+    "npm_path": null
   },
   // The extensions that Zed should automatically install on startup.
   //
   // If you don't want any of these extensions, add this field to your settings
   // and change the value to `false`.
   "auto_install_extensions": {
-    "html": true,
+    "html": true
   },
   // The capabilities granted to extensions.
   //
@@ -2237,7 +2237,7 @@
   "granted_extension_capabilities": [
     { "kind": "process:exec", "command": "*", "args": ["**"] },
     { "kind": "download_file", "host": "*", "path": ["**"] },
-    { "kind": "npm:install", "package": "*" },
+    { "kind": "npm:install", "package": "*" }
   ],
   // Controls how completions are processed for this language.
   "completions": {
@@ -2288,7 +2288,7 @@
     // 4. "replace_suffix"
     //   Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like
     //   `"insert"` otherwise.
-    "lsp_insert_mode": "replace_suffix",
+    "lsp_insert_mode": "replace_suffix"
   },
   // Different settings for specific languages.
   "languages": {
@@ -2297,125 +2297,125 @@
       "language_servers": ["astro-language-server", "..."],
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-astro"],
-      },
+        "plugins": ["prettier-plugin-astro"]
+      }
     },
     "Blade": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "C": {
       "use_on_type_format": false,
       "prettier": {
-        "allowed": false,
-      },
+        "allowed": false
+      }
     },
     "C++": {
       "use_on_type_format": false,
       "prettier": {
-        "allowed": false,
-      },
+        "allowed": false
+      }
     },
     "CSharp": {
-      "language_servers": ["roslyn", "!csharp-ls", "!omnisharp", "..."],
+      "language_servers": ["roslyn", "!csharp-ls", "!omnisharp", "..."]
     },
     "CSS": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "Dart": {
       "format_on_save": "on",
-      "tab_size": 2,
+      "tab_size": 2
     },
     "Diff": {
       "show_edit_predictions": false,
       "remove_trailing_whitespace_on_save": false,
-      "ensure_final_newline_on_save": false,
+      "ensure_final_newline_on_save": false
     },
     "EEx": {
       "format_on_save": "on",
-      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."]
     },
     "Elixir": {
       "format_on_save": "on",
-      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "!emmet-language-server", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "!emmet-language-server", "..."]
     },
     "Elm": {
       "format_on_save": "on",
-      "tab_size": 4,
+      "tab_size": 4
     },
     "Erlang": {
-      "language_servers": ["erlang-ls", "!elp", "..."],
+      "language_servers": ["erlang-ls", "!elp", "..."]
     },
     "Git Commit": {
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width",
-      "preferred_line_length": 72,
+      "preferred_line_length": 72
     },
     "Go": {
       "format_on_save": "on",
       "hard_tabs": true,
       "code_actions_on_format": {
-        "source.organizeImports": true,
+        "source.organizeImports": true
       },
-      "debuggers": ["Delve"],
+      "debuggers": ["Delve"]
     },
     "GraphQL": {
       "format_on_save": "on",
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "HEEx": {
       "format_on_save": "on",
-      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."],
+      "language_servers": ["elixir-ls", "!expert", "!dexter", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "HTML+ERB": {
-      "language_servers": ["herb", "!ruby-lsp", "..."],
+      "language_servers": ["herb", "!ruby-lsp", "..."]
     },
     "Java": {
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-java"],
-      },
+        "plugins": ["prettier-plugin-java"]
+      }
     },
     "JavaScript": {
       "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "JSON": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "JSONC": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "JS+ERB": {
-      "language_servers": ["!ruby-lsp", "..."],
+      "language_servers": ["!ruby-lsp", "..."]
     },
     "Kotlin": {
       "format_on_save": "on",
-      "language_servers": ["!kotlin-language-server", "kotlin-lsp", "..."],
+      "language_servers": ["!kotlin-language-server", "kotlin-lsp", "..."]
     },
     "LaTeX": {
       "formatter": "language_server",
       "language_servers": ["texlab", "..."],
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-latex"],
-      },
+        "plugins": ["prettier-plugin-latex"]
+      }
     },
     "Markdown": {
       "use_on_type_format": false,
@@ -2423,41 +2423,41 @@
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width",
       "completions": {
-        "words": "disabled",
+        "words": "disabled"
       },
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "PHP": {
       "language_servers": ["phpactor", "!intelephense", "!phptools", "!phpantom", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["@prettier/plugin-php"],
-        "parser": "php",
-      },
+        "parser": "php"
+      }
     },
     "Plain Text": {
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width",
       "completions": {
-        "words": "disabled",
-      },
+        "words": "disabled"
+      }
     },
     "Proto": {
-      "language_servers": ["buf", "!protols", "!protobuf-language-server", "..."],
+      "language_servers": ["buf", "!protols", "!protobuf-language-server", "..."]
     },
     "Python": {
       "code_actions_on_format": {
-        "source.organizeImports.ruff": true,
+        "source.organizeImports.ruff": true
       },
       "formatter": {
         "language_server": {
-          "name": "ruff",
-        },
+          "name": "ruff"
+        }
       },
       "debuggers": ["Debugpy"],
-      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."],
+      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."]
     },
     "Ruby": {
       "language_servers": [
@@ -2468,117 +2468,117 @@
         "!steep",
         "!kanayago",
         "!fuzzy-ruby-server",
-        "...",
-      ],
+        "..."
+      ]
     },
     "Rust": {
       "format_on_save": "on",
-      "debuggers": ["CodeLLDB"],
+      "debuggers": ["CodeLLDB"]
     },
     "SCSS": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "Starlark": {
       "format_on_save": "on",
-      "language_servers": ["starpls", "!buck2-lsp", "!tilt", "..."],
+      "language_servers": ["starpls", "!buck2-lsp", "!tilt", "..."]
     },
     "Svelte": {
       "language_servers": ["svelte-language-server", "..."],
       "prettier": {
         "allowed": true,
-        "plugins": ["prettier-plugin-svelte"],
-      },
+        "plugins": ["prettier-plugin-svelte"]
+      }
     },
     "TSX": {
       "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "Twig": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "TypeScript": {
       "language_servers": ["!typescript-language-server", "vtsls", "..."],
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "SystemVerilog": {
       "language_servers": ["slang", "!verible", "!veridian", "!svls", "..."],
-      "use_on_type_format": false,
+      "use_on_type_format": false
     },
     "Vue.js": {
       "language_servers": ["vue-language-server", "vtsls", "..."],
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "XML": {
       "prettier": {
         "allowed": true,
-        "plugins": ["@prettier/plugin-xml"],
-      },
+        "plugins": ["@prettier/plugin-xml"]
+      }
     },
     "YAML": {
       "prettier": {
-        "allowed": true,
-      },
+        "allowed": true
+      }
     },
     "YAML+ERB": {
-      "language_servers": ["!ruby-lsp", "..."],
+      "language_servers": ["!ruby-lsp", "..."]
     },
     "Zig": {
       "format_on_save": "on",
-      "language_servers": ["zls", "..."],
-    },
+      "language_servers": ["zls", "..."]
+    }
   },
   // Different settings for specific language models.
   "language_models": {
     "anthropic": {
-      "api_url": "https://api.anthropic.com",
+      "api_url": "https://api.anthropic.com"
     },
     "anthropic_compatible": {},
     "bedrock": {},
     "google": {
-      "api_url": "https://generativelanguage.googleapis.com",
+      "api_url": "https://generativelanguage.googleapis.com"
     },
     "ollama": {
-      "api_url": "http://localhost:11434",
+      "api_url": "http://localhost:11434"
     },
     "llama.cpp": {
-      "api_url": "http://localhost:8080",
+      "api_url": "http://localhost:8080"
     },
     "openai": {
-      "api_url": "https://api.openai.com/v1",
+      "api_url": "https://api.openai.com/v1"
     },
     "openai_compatible": {},
     "opencode": {
-      "api_url": "https://opencode.ai/zen",
+      "api_url": "https://opencode.ai/zen"
     },
     "open_router": {
-      "api_url": "https://openrouter.ai/api/v1",
+      "api_url": "https://openrouter.ai/api/v1"
     },
     "lmstudio": {
-      "api_url": "http://localhost:1234/api/v0",
+      "api_url": "http://localhost:1234/api/v0"
     },
     "deepseek": {
-      "api_url": "https://api.deepseek.com/v1",
+      "api_url": "https://api.deepseek.com/v1"
     },
     "mistral": {
-      "api_url": "https://api.mistral.ai/v1",
+      "api_url": "https://api.mistral.ai/v1"
     },
     "vercel_ai_gateway": {
-      "api_url": "https://ai-gateway.vercel.sh/v1",
+      "api_url": "https://ai-gateway.vercel.sh/v1"
     },
     "x_ai": {
-      "api_url": "https://api.x.ai/v1",
+      "api_url": "https://api.x.ai/v1"
     },
-    "zed.dev": {},
+    "zed.dev": {}
   },
   "session": {
     // Whether or not to restore unsaved buffers on restart.
@@ -2593,7 +2593,7 @@
     // language and MCP servers are downloaded and started automatically.
     //
     // Default: false
-    "trust_all_worktrees": false,
+    "trust_all_worktrees": false
   },
   // Zed's Prettier integration settings.
   // Allows to enable/disable formatting with Prettier
@@ -2611,11 +2611,11 @@
     // "singleQuote": true
     // Forces Prettier integration to use a specific parser name when formatting files with the language
     // when set to a non-empty string.
-    "parser": "",
+    "parser": ""
   },
   // Settings for auto-closing of JSX tags.
   "jsx_tag_auto_close": {
-    "enabled": true,
+    "enabled": true
   },
   // LSP Specific settings.
   "lsp": {
@@ -2636,9 +2636,9 @@
     // Specify the DAP name as a key here.
     "CodeLLDB": {
       "env": {
-        "RUST_LOG": "info",
-      },
-    },
+        "RUST_LOG": "info"
+      }
+    }
   },
   // Common language server settings.
   "global_lsp_settings": {
@@ -2657,7 +2657,7 @@
     "notifications": {
       // Timeout in milliseconds for automatically dismissing language server notifications.
       // Set to 0 to disable auto-dismiss.
-      "dismiss_timeout_ms": 5000,
+      "dismiss_timeout_ms": 5000
     },
     // Rules for highlighting semantic tokens. User-defined rules are prepended to the default
     // rules (viewable via "Show Default Semantic Token Rules"), so they take precedence.
@@ -2688,12 +2688,12 @@
     // ]
     //
     // Default rules are viewable via the "zed: show default semantic token rules" action.
-    "semantic_token_rules": [],
+    "semantic_token_rules": []
   },
   // Jupyter settings
   "jupyter": {
     "enabled": true,
-    "kernel_selections": {},
+    "kernel_selections": {}
     // Specify the language name as the key and the kernel name as the value.
     // "kernel_selections": {
     //    "python": "conda-base"
@@ -2713,7 +2713,7 @@
     "output_max_height_lines": 0,
     // Maximum number of columns of output to display before scaling images.
     // Set to 0 to disable output width limits.
-    "output_max_width_columns": 0,
+    "output_max_width_columns": 0
   },
   // Vim settings
   "vim": {
@@ -2735,15 +2735,15 @@
       "replace": "underline",
       "visual": "block",
       // Set to "inherit" to use the editor's cursor_shape.
-      "insert": "inherit",
-    },
+      "insert": "inherit"
+    }
   },
   // Which-key popup settings
   "which_key": {
     // Whether to show the which-key popup when holding down key combinations.
     "enabled": false,
     // Delay in milliseconds before showing the which-key popup.
-    "delay_ms": 1000,
+    "delay_ms": 1000
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.
@@ -2759,9 +2759,9 @@
     // "theme": "Andromeda"
     "instrumentation": {
       "performance_profiler": {
-        "enabled": true,
-      },
-    },
+        "enabled": true
+      }
+    }
   },
   // Settings overrides to use when using Zed Stable.
   // Mostly useful for developers who are managing multiple instances of Zed.
@@ -2774,9 +2774,9 @@
     // "theme": "Andromeda"
     "instrumentation": {
       "performance_profiler": {
-        "enabled": true,
-      },
-    },
+        "enabled": true
+      }
+    }
   },
   // Settings overrides to use when using Linux.
   "linux": {},
@@ -2786,9 +2786,9 @@
   "windows": {
     "languages": {
       "PHP": {
-        "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."],
-      },
-    },
+        "language_servers": ["intelephense", "!phpactor", "!phptools", "!phpantom", "..."]
+      }
+    }
   },
   // Whether to show full labels in line indicator or short ones
   //
@@ -2858,7 +2858,7 @@
     "dock": "bottom",
     "log_dap_communications": true,
     "format_dap_log_messages": true,
-    "button": true,
+    "button": true
   },
   // Configures any number of settings profiles that are temporarily applied
   // when selected from `settings profile selector: toggle`.
@@ -2905,7 +2905,7 @@
     // tasks. Enabling this may lead to increased memory usage, hence it's
     // disabled by default for regular builds.
     "performance_profiler": {
-      "enabled": false,
-    },
-  },
+      "enabled": false
+    }
+  }
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1045,7 +1045,7 @@ impl VsCodeSettings {
             cli_default_open_behavior: None,
             default_open_behavior: None,
             close_on_file_delete: None,
-            close_panel_on_toggle: None,
+            close_panel_on_focus_toggle: None,
             command_aliases: Default::default(),
             confirm_quit: self.read_enum("window.confirmBeforeClose", |s| match s {
                 "always" | "keyboardOnly" => Some(true),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -140,7 +140,7 @@ pub struct WorkspaceSettingsContent {
     /// to the editor.
     ///
     /// Default: false
-    pub close_panel_on_toggle: Option<bool>,
+    pub close_panel_on_focus_toggle: Option<bool>,
     /// Controls whether Zed or the window manager or compositor draws window decorations on Linux.
     ///
     /// Default: client

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4495,7 +4495,7 @@ impl Workspace {
 
     /// Focus the panel of the given type if it isn't already focused. If it is
     /// already focused, then transfer focus back to the workspace center.
-    /// When the `close_panel_on_toggle` setting is enabled, also closes the
+    /// When the `close_panel_on_focus_toggle` setting is enabled, also closes the
     /// panel when transferring focus back to the center.
     pub fn toggle_panel_focus<T: Panel>(
         &mut self,
@@ -4508,7 +4508,7 @@ impl Workspace {
             did_focus_panel
         });
 
-        if !did_focus_panel && WorkspaceSettings::get_global(cx).close_panel_on_toggle {
+        if !did_focus_panel && WorkspaceSettings::get_global(cx).close_panel_on_focus_toggle {
             self.close_panel::<T>(window, cx);
         }
 
@@ -14033,7 +14033,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_close_panel_on_toggle(cx: &mut gpui::TestAppContext) {
+    async fn test_close_panel_on_focus_toggle(cx: &mut gpui::TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());
 
@@ -14053,10 +14053,10 @@ mod tests {
             pane.add_item(Box::new(item), true, true, None, window, cx);
         });
 
-        // Enable close_panel_on_toggle
+        // Enable close_panel_on_focus_toggle
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings(cx, |settings| {
-                settings.workspace.close_panel_on_toggle = Some(true);
+                settings.workspace.close_panel_on_focus_toggle = Some(true);
             });
         });
 
@@ -14124,7 +14124,7 @@ mod tests {
         // from a focused panel moves focus to center but leaves the dock open.
         cx.update_global(|store: &mut SettingsStore, cx| {
             store.update_user_settings(cx, |settings| {
-                settings.workspace.close_panel_on_toggle = Some(false);
+                settings.workspace.close_panel_on_focus_toggle = Some(false);
             });
         });
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -37,7 +37,7 @@ pub struct WorkspaceSettings {
     pub text_rendering_mode: settings::TextRenderingMode,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
-    pub close_panel_on_toggle: bool,
+    pub close_panel_on_focus_toggle: bool,
     pub use_system_window_tabs: bool,
     pub fullscreen_mode: settings::FullscreenMode,
     pub zoomed_padding: bool,
@@ -139,7 +139,7 @@ impl Settings for WorkspaceSettings {
                 .map(Into::into)
                 .collect(),
             close_on_file_delete: workspace.close_on_file_delete.unwrap(),
-            close_panel_on_toggle: workspace.close_panel_on_toggle.unwrap(),
+            close_panel_on_focus_toggle: workspace.close_panel_on_focus_toggle.unwrap(),
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             fullscreen_mode: workspace.fullscreen_mode.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),


### PR DESCRIPTION
# Objective

- While working on #63458 and discussing on the issue we realized that the `close_panel_on_toggle` setting doesn't represent / doesn't say exactly what it does. the setting is there for when `ToggleFocus` commands are sent not when `Toggle` commands are sent to panels. 

## Solution

- The solution was to rename it to something more representative. My idea was to introduce the `focus` wording in the setting. So the new setting becomes `close_panel_on_focus_toggle`. 

## Testing

Tests were changed accordingly to use the new setting. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Renamed the `close_panel_on_toggle` setting to `close_panel_on_focus_toggle`, since it only applies to the focus-toggle action: closing a panel that was already visible and focused when focus moves away from it
