### PR TITLE
terminal: Never signal our own process group when releasing a PTY

### DIFF
--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -148,7 +148,7 @@ impl PtyProcessInfo {
 
     #[cfg(unix)]
     pub(crate) fn kill_current_process(&self) -> bool {
-        let Some(pid) = self.pid_getter.pid() else {
+        let Some(pid) = self.pid_getter.pid().filter(|pid| pid.as_u32() != 0) else {
             return false;
         };
         unsafe { libc::killpg(pid.as_u32() as i32, libc::SIGKILL) == 0 }
@@ -166,6 +166,12 @@ impl PtyProcessInfo {
     #[cfg(unix)]
     pub(crate) fn terminate_child_process(&self) -> bool {
         let pid = self.pid_getter.fallback_pid();
+        // `killpg(0, ...)` signals the caller's own process group, so a PTY
+        // without a local child process (a remote PTY, say) would terminate
+        // the application itself.
+        if pid.as_u32() == 0 {
+            return false;
+        }
         unsafe { libc::killpg(pid.as_u32() as i32, libc::SIGTERM) == 0 }
     }
 


### PR DESCRIPTION
`PtyProcessInfo::terminate_child_process` passes the PTY's fallback pid to
`killpg` without checking it. A PTY that has no local child process reports
`0`, and `killpg(0, ...)` signals *the caller's own process group*, so
releasing such a PTY terminates the application itself.

`release_pty_resources` runs from `Terminal::drop`, so this happens whenever
such a terminal is closed.

I hit this while running Zed against a PTY that lives on a remote host, where
there is no local child process to signal. It should be reachable by any
`TerminalBuilder` consumer whose pty reports no child pid.

`kill_current_process` is guarded the same way; it cannot return `0` today, but
the guard keeps the invariant local to the call.

Assisted by Claude.

Release Notes:

- Fixed closing a terminal whose PTY has no local child process terminating Zed
