### PR TITLE
zed: Gate build script linker arguments on the target OS

### DIFF
--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -23,7 +23,10 @@ fn main() {
         }
     }
 
-    if cfg!(target_os = "macos") {
+    // `cfg!(target_os)` in a build script reflects the host that runs the
+    // script, not the target being built, so these macOS-only linker arguments
+    // were also passed when cross-compiling to another platform from a Mac.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
         println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
 
         // Weakly link ReplayKit to ensure Zed can be used on macOS 10.15+.


### PR DESCRIPTION
`cfg!(target_os = "macos")` in a build script is evaluated for the host that
runs the script, not for the target being built. Cross-compiling Zed from a Mac
therefore passed the macOS-only linker arguments (the weakly linked ReplayKit
and ScreenCaptureKit frameworks, the Swift rpath, `-ObjC`) to the other target,
where the linker fails on the missing frameworks.

Reading `CARGO_CFG_TARGET_OS` instead applies them to macOS targets only. Native
macOS builds are unaffected, since host and target agree there.

I ran into this cross-compiling to another Apple platform, but it applies to any
cross build started on a Mac.

Assisted by Claude.

Release Notes:

- N/A
