### PR TITLE
 editor: Add sort descending, unique, and natural sort commands

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -836,12 +836,20 @@ actions!(
         SignatureHelpNext,
         /// Navigates to the previous signature in the signature help popup.
         SignatureHelpPrevious,
-        /// Sorts selected lines by length.
+        /// Sorts selected lines by length (ascending).
         SortLinesByLength,
+        /// Sorts selected lines by length (descending).
+        SortLinesByLengthDescending,
         /// Sorts selected lines case-insensitively.
         SortLinesCaseInsensitive,
-        /// Sorts selected lines case-sensitively.
+        /// Sorts selected lines case-sensitively (ascending).
         SortLinesCaseSensitive,
+        /// Sorts selected lines case-sensitively (descending).
+        SortLinesCaseSensitiveDescending,
+        /// Sorts selected lines case-sensitively and removes duplicates.
+        SortLinesCaseSensitiveUnique,
+        /// Sorts selected lines using natural ordering (numbers sorted numerically).
+        SortLinesNatural,
         /// Stops the language server for the current file.
         StopLanguageServer,
         /// Switches between source and header files.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5839,6 +5839,38 @@ impl Editor {
         self.manipulate_immutable_lines(window, cx, |lines| lines.sort())
     }
 
+    pub fn sort_lines_case_sensitive_descending(
+        &mut self,
+        _: &SortLinesCaseSensitiveDescending,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.manipulate_immutable_lines(window, cx, |lines| lines.sort_by(|a, b| b.cmp(a)))
+    }
+
+    pub fn sort_lines_case_sensitive_unique(
+        &mut self,
+        _: &SortLinesCaseSensitiveUnique,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.manipulate_immutable_lines(window, cx, |lines| {
+            lines.sort();
+            lines.dedup();
+        })
+    }
+
+    pub fn sort_lines_natural(
+        &mut self,
+        _: &SortLinesNatural,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.manipulate_immutable_lines(window, cx, |lines| {
+            lines.sort_by(|a, b| natural_cmp(a, b));
+        })
+    }
+
     pub fn sort_lines_by_length(
         &mut self,
         _: &SortLinesByLength,
@@ -5847,6 +5879,17 @@ impl Editor {
     ) {
         self.manipulate_immutable_lines(window, cx, |lines| {
             lines.sort_by_key(|&line| line.chars().count())
+        })
+    }
+
+    pub fn sort_lines_by_length_descending(
+        &mut self,
+        _: &SortLinesByLengthDescending,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.manipulate_immutable_lines(window, cx, |lines| {
+            lines.sort_by_key(|&line| Reverse(line.chars().count()))
         })
     }
 
@@ -12905,6 +12948,57 @@ struct LineManipulationResult {
     pub new_text: String,
     pub line_count_before: usize,
     pub line_count_after: usize,
+}
+
+fn natural_cmp(a: &str, b: &str) -> Ordering {
+    let mut a_chars = a.chars().peekable();
+    let mut b_chars = b.chars().peekable();
+
+    loop {
+        match (a_chars.peek(), b_chars.peek()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(&ac), Some(&bc)) => {
+                if ac.is_ascii_digit() && bc.is_ascii_digit() {
+                    let a_num = consume_digits(&mut a_chars);
+                    let b_num = consume_digits(&mut b_chars);
+                    let a_trimmed = a_num.trim_start_matches('0');
+                    let b_trimmed = b_num.trim_start_matches('0');
+                    let ord = a_trimmed
+                        .len()
+                        .cmp(&b_trimmed.len())
+                        .then_with(|| a_trimmed.cmp(&b_trimmed));
+                    match ord {
+                        Ordering::Equal => {}
+                        other => return other,
+                    }
+                } else {
+                    match ac.cmp(&bc) {
+                        Ordering::Equal => {
+                            a_chars.next();
+                            b_chars.next();
+                        }
+                        ord => return ord,
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn consume_digits(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+    std::iter::from_fn(|| {
+        chars
+            .peek()
+            .copied()
+            .filter(|c| c.is_ascii_digit())
+            .map(|c| {
+                chars.next();
+                c
+            })
+    })
+    .collect()
 }
 
 pub fn multibuffer_context_lines(cx: &App) -> u32 {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -7407,6 +7407,127 @@ async fn test_manipulate_immutable_lines_with_single_selection(cx: &mut TestAppC
 }
 
 #[gpui::test]
+async fn test_sort_lines_descending(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        «a
+        c
+        b
+        dˇ»
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.sort_lines_case_sensitive_descending(&SortLinesCaseSensitiveDescending, window, cx)
+    });
+    cx.assert_editor_state(indoc! {"
+        «d
+        c
+        b
+        aˇ»
+    "});
+}
+
+#[gpui::test]
+async fn test_sort_lines_by_length_descending(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        «a
+        ccc
+        bb
+        ddddˇ»
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.sort_lines_by_length_descending(&SortLinesByLengthDescending, window, cx)
+    });
+    cx.assert_editor_state(indoc! {"
+        «dddd
+        ccc
+        bb
+        aˇ»
+    "});
+}
+
+#[gpui::test]
+async fn test_sort_lines_case_sensitive_unique(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        «c
+        a
+        b
+        a
+        c
+        bˇ»
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.sort_lines_case_sensitive_unique(&SortLinesCaseSensitiveUnique, window, cx)
+    });
+    cx.assert_editor_state(indoc! {"
+        «a
+        b
+        cˇ»
+    "});
+}
+
+#[gpui::test]
+async fn test_sort_lines_natural(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc! {"
+        «file10
+        file2
+        file1
+        file20ˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.sort_lines_natural(&SortLinesNatural, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «file1
+        file2
+        file10
+        file20ˇ»
+    "});
+
+    // Mixed numeric and non-numeric
+    cx.set_state(indoc! {"
+        «z2
+        a10
+        a2
+        a1ˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.sort_lines_natural(&SortLinesNatural, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «a1
+        a2
+        a10
+        z2ˇ»
+    "});
+
+    // Leading zeros
+    cx.set_state(indoc! {"
+        «file01
+        file2
+        file001
+        file10ˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.sort_lines_natural(&SortLinesNatural, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «file001
+        file01
+        file2
+        file10ˇ»
+    "});
+}
+
+#[gpui::test]
 async fn test_unique_lines_multi_selection(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -596,8 +596,12 @@ impl EditorElement {
             register_action(editor, window, Editor::delete_line);
             register_action(editor, window, Editor::join_lines);
             register_action(editor, window, Editor::sort_lines_by_length);
+            register_action(editor, window, Editor::sort_lines_by_length_descending);
             register_action(editor, window, Editor::sort_lines_case_sensitive);
+            register_action(editor, window, Editor::sort_lines_case_sensitive_descending);
+            register_action(editor, window, Editor::sort_lines_case_sensitive_unique);
             register_action(editor, window, Editor::sort_lines_case_insensitive);
+            register_action(editor, window, Editor::sort_lines_natural);
             register_action(editor, window, Editor::unique_lines_case_insensitive);
             register_action(editor, window, Editor::unique_lines_case_sensitive);
             register_action(editor, window, Editor::reverse_lines);

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -3,7 +3,10 @@ use collections::{HashMap, HashSet};
 use command_palette_hooks::{CommandInterceptItem, CommandInterceptResult};
 use editor::{
     Bias, Editor, EditorSettings, SelectionEffects, ToPoint,
-    actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive},
+    actions::{
+        SortLinesCaseInsensitive, SortLinesCaseSensitive, SortLinesCaseSensitiveDescending,
+        SortLinesCaseSensitiveUnique, SortLinesNatural,
+    },
     display_map::ToDisplayPoint,
 };
 use futures::AsyncWriteExt as _;
@@ -1759,9 +1762,16 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
             .bang(DeleteMarks::AllLocal)
             .args(|_, args| Some(DeleteMarks::Marks(args).boxed_clone())),
         VimCommand::new(("sor", "t"), SortLinesCaseSensitive)
+            .bang(SortLinesCaseSensitiveDescending)
             .range(select_range)
             .default_range(CommandRange::buffer()),
         VimCommand::new(("sort i", ""), SortLinesCaseInsensitive)
+            .range(select_range)
+            .default_range(CommandRange::buffer()),
+        VimCommand::new(("sort u", ""), SortLinesCaseSensitiveUnique)
+            .range(select_range)
+            .default_range(CommandRange::buffer()),
+        VimCommand::new(("sort n", ""), SortLinesNatural)
             .range(select_range)
             .default_range(CommandRange::buffer()),
         VimCommand::str(("E", "xplore"), "project_panel::ToggleFocus"),


### PR DESCRIPTION
# Objective

Add missing sort line variants to the editor: descending (case-sensitive and by length), unique, and natural sort (numbers sorted numerically).

## Solution

- New actions: `SortLinesCaseSensitiveDescending`, `SortLinesByLengthDescending`, `SortLinesCaseSensitiveUnique`, `SortLinesNatural`
- `natural_cmp` comparator that handles numeric segments correctly, including leading zeros
- Vim `:sort` wired with `!` for descending, `:sort u` for unique, `:sort n` for natural

## Testing

- Unit tests for each new command (descending, by-length descending, unique, natural)
- Natural sort tested with mixed prefixes and leading zeros (`file01`, `file001`, `file2`, `file10`)
- Could not build locally (missing Xcode/Metal toolchain), relying on CI

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added sort lines descending, unique, and natural sort commands to the editor