### PR TITLE
editor: Clear IME composition when the editor loses focus

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10754,6 +10754,10 @@ impl Editor {
     }
 
     pub fn handle_blur(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Losing focus ends the IME session, so a composition left marked here would
+        // otherwise be treated as still active once focus returns, making the next
+        // IME edit target a stale range.
+        self.unmark_text(window, cx);
         self.blink_manager.update(cx, BlinkManager::disable);
         self.buffer
             .update(cx, |buffer, cx| buffer.remove_active_selections(cx));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -535,6 +535,58 @@ fn test_ime_composition(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_ime_composition_is_cleared_on_blur(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let buffer = cx.new(|cx| {
+        let mut buffer = language::Buffer::local("abcde", cx);
+        buffer.set_group_interval(Duration::ZERO);
+        buffer
+    });
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer.clone(), window, cx));
+    let elsewhere = cx.update(|_, cx| cx.focus_handle());
+
+    // Focus events are only dispatched for an active window.
+    cx.update(|window, _| window.activate_window());
+    cx.run_until_parked();
+
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+        editor.replace_and_mark_text_in_range(Some(0..1), "à", None, window, cx);
+        assert_eq!(
+            editor.marked_text_ranges(cx),
+            Some(vec![
+                MultiBufferOffsetUtf16(OffsetUtf16(0))..MultiBufferOffsetUtf16(OffsetUtf16(1))
+            ])
+        );
+    });
+    cx.run_until_parked();
+
+    // Clicking away ends the IME session at the platform layer, so the editor must
+    // not keep treating the previously marked range as an active composition.
+    cx.update(|window, cx| window.focus(&elsewhere, cx));
+    cx.run_until_parked();
+
+    editor.update_in(cx, |editor, _window, cx| {
+        assert_eq!(editor.marked_text_ranges(cx), None);
+    });
+
+    // Returning to the editor and pressing backspace must delete the character
+    // before the cursor rather than replacing the stale marked range.
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+    });
+    cx.run_until_parked();
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.backspace(&Default::default(), window, cx);
+        assert_eq!(editor.text(cx), "bcde");
+    });
+}
+
+#[gpui::test]
 fn test_selection_with_mouse(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
# Objective

- `Editor::handle_blur` did not clear the marked range, so a composition abandoned when focus moved was still reported as active afterwards. The next IME edit then targeted that stale range.
- Inside the editor, `unmark_text` was only reached from `undo`, `redo`, `replace_text_in_range` and `replace_and_mark_text_in_range` — never from the blur path.
- On macOS this has a second effect. AppKit treats the whole GPUI window as one `NSView`, so a focus change inside it need not be visible to the platform, and the input session can stay open. While AppKit believes a session is active it delivers keystrokes to `insertText:` as text, which is how backspace ends up arriving as U+0008 instead of being dispatched as an action. I could only reproduce this by opening a file through the CLI mid-composition; `cmd-p` and switching applications did not trigger it.

## Solution

- Call `unmark_text` from `Editor::handle_blur`. The editor stops reporting a composition that is no longer being composed, and AppKit closes the session.

## Testing

- Added `test_ime_composition_is_cleared_on_blur`: mark a range, move focus away, assert `marked_text_ranges` is `None`, then return focus and assert backspace deletes the character before the cursor rather than replacing the stale range.
- Verified on macOS with the Apple 2-set Korean IME, on an instrumented build logging `insert_text`, `set_marked_text` and `unmark_text`. Reproduction: type continuously in a prompt, open a file via the CLI so an editor takes focus mid-composition, then press backspace.

  Two separate runs, each on its own instrumented build:

  | | #63412, 659 log lines | this change, 308 log lines |
  |---|---|---|
  | `insert_text` receiving U+0008 | 22 | 0 |
  | `insert_text` receiving U+001B | 1 | 0 |
  | backspace | does not delete | deletes normally |
  | replacement at a stale offset | observed (offset 7030, belonging to a different buffer) | not observed |

  The left column is a build of #63412 and not of `main`: that PR filters these characters out at the `insertText:` boundary, so they still arrive and are discarded there. On `main` the same 22 U+0008 would reach the buffer and render as empty boxes. This change was measured on its own, with no filter present.

  Filtering at the boundary stops the empty box, but backspace and escape carry no `key_char` (`crates/gpui_macos/src/events.rs:372`) and are therefore routed to the IME (`crates/gpui_macos/src/window.rs:2480`); discarding the text there removes the delete along with the insertion, leaving both keys dead. Clearing the composition state instead means the control characters are never generated, and the keys are dispatched as actions again.

## Out of scope

A composition already in flight when focus moves still lands in the newly focused editor — visible in the same run as writes at offsets 1742–1750. Clearing the marked range invalidates stale coordinates but does not cancel the composition itself; that needs the AppKit input session torn down, which is a larger change. Happy to file it separately.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed IME composition state persisting after an editor lost focus

