### PR TITLE
corgi: Use globs for extra-inputs

### DIFF
--- a/corgi.toml
+++ b/corgi.toml
@@ -1,3 +1,5 @@
+corgi_version = "0.1.43"
+
 # corgi build configuration for Zed.
 # Corgi source and documentation: https://github.com/ConradIrwin/corgi
 #
@@ -53,26 +55,31 @@ profiles = ["release"]
 # Reads a package's actions perform that corgi's sandbox does not grant by
 # default. By default only a package's own `.rs` files (plus its manifest) are
 # readable, so non-`.rs` files a build script or macro reads must be listed even
-# when they live inside the package. Paths are relative to the named package's
-# root and are granted and hashed as inputs.
+# when they live inside the package. Entries are glob patterns relative to the
+# named package's root, and every file they match is granted and hashed as an
+# input. A pattern selects files, never directories: `dir/**` is how you take
+# everything under a directory, and `dir/*` takes only what sits directly in it.
 [extra-inputs]
 # Own non-.rs files read at build time (protobufs, bindgen headers, doc/data).
-proto = ["proto"]
-livekit_api = ["vendored/protocol"]
+proto = ["proto/**"]
+livekit_api = ["vendored/protocol/**"]
 media = ["src/bindings.h"]
 gpui = ["README.md"]
 git = ["src/checkpoint.gitignore"]
 git_ui = ["src/commit_message_prompt.txt"]
-editor = ["../grammars/src"]
-edit_prediction = ["license_patterns"]
-agent_skills = ["builtin"]
-agent_settings = ["src/prompts"]
-json_schema_store = ["src/schemas"]
+editor = ["../grammars/src/**"]
+edit_prediction = ["license_patterns/**"]
+agent_skills = ["builtin/**"]
+agent_settings = ["src/prompts/**"]
+json_schema_store = ["src/schemas/**"]
 prettier = ["src/prettier_server.js"]
-zed = ["resources"]
+zed = ["resources/**"]
+zed_extension_api = ["wit/**"]
+gpui_wgpu = ["src/*.wgsl"]
 # Cross-package reads (and, for gpui_apple, its own metal shader source).
-extension_host = ["../extension_api/wit"]
-gpui_apple = ["../gpui/src", "src/shaders.metal"]
+extension_host = ["../extension_api/wit/**"]
+gpui_apple = ["../gpui/src/**", "src/shaders.metal"]
+eval_cli = ["../zed/Cargo.toml"]
 prompt_store = ["../git_ui/src/commit_message_prompt.txt"]
 release_channel = ["../zed/RELEASE_CHANNEL"]
 cli = ["../../script/uninstall.sh"]
@@ -80,4 +87,4 @@ remote_server = ["../zed/Cargo.toml"]
 # `../zed/Cargo.toml`: build.rs reads it for ZED_PKG_VERSION. `../grammars/src`
 # and `src/prompts` are embedded in release builds; dev builds read them at
 # runtime via fs_embed.
-edit_prediction_cli = ["../zed/Cargo.toml", "../grammars/src", "src/prompts"]
+edit_prediction_cli = ["../zed/Cargo.toml", "../grammars/src/**", "src/prompts/**"]


### PR DESCRIPTION
Corgi 0.1.43 changes how `[extra-inputs]` in `corgi.toml` is read: entries are glob patterns rather than plain paths, and they select files rather than directories. Handing corgi a bare directory name used to mean "everything under here, hashed as a tree"; now it matches nothing and reports that appending `/**` is the fix. This updates each directory entry accordingly, and rewords the section comment to describe the new rules.

The practical gain is that the readable set and the hashed set are now exactly the same set of files. Each matched file is granted to the sandbox individually and hashed under its workspace-relative path, so adding, removing, or renaming a file that a pattern covers changes the package's source hash even when no file's contents changed. Reading a file that no pattern matches is denied rather than silently allowed because it happened to sit inside a granted directory.

Three reads that corgi has been denying all along now have entries. `eval_cli`'s build script reads `crates/zed/Cargo.toml`, `gpui_wgpu` includes its WGSL shaders through `include_str!`, and `zed_extension_api` includes its own `wit` tree through `wit_bindgen::generate!`. Each of those units fails on `main` today under `corgi check --workspace`. The last one could not be declared at all until corgi 0.1.43, because `[extra-inputs]` is keyed by package name and this workspace resolves three packages named `zed_extension_api` — the member at 0.8.0 plus published 0.1.0 and 0.7.0 that extensions depend on — so the declaration reached the published copies and failed the workspace-escape check. Corgi now applies extra inputs only to local packages, which is safe because a registry package is hashed as a whole directory and reads its own root freely.

`corgi_version` is pinned to 0.1.43 so everyone picks up the matching corgi automatically; older corgi releases cannot read these entries.

Testing:

- `corgi check --workspace` passes with no failing units, which it did not do before this change.
- `corgi build -p zed` links the binary.
- `corgi check --workspace --all-targets` goes from 16 failing units to 13. The remaining 13 are pre-existing undeclared reads in test targets (font files under `assets/`, `test_data` fixtures and similar) that this change does not attempt to fix.

Release Notes:

- N/A
