### PR TITLE
Relicense zlog, ztracing, and ztracing_macro under Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/gpui_shared_string/Cargo.toml
+++ b/crates/gpui_shared_string/Cargo.toml
@@ -3,6 +3,7 @@ name = "gpui_shared_string"
 version = "0.1.0"
 publish.workspace = true
 edition.workspace = true
+license = "Apache-2.0"
 
 [lib]
 path = "gpui_shared_string.rs"

--- a/crates/gpui_util/Cargo.toml
+++ b/crates/gpui_util/Cargo.toml
@@ -3,6 +3,7 @@ name = "gpui_util"
 version = "0.1.0"
 publish.workspace = true
 edition.workspace = true
+license = "Apache-2.0"
 
 [dependencies]
 log.workspace = true

--- a/crates/zlog/Cargo.toml
+++ b/crates/zlog/Cargo.toml
@@ -3,7 +3,7 @@ name = "zlog"
 version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 
 [lints]
 workspace = true

--- a/crates/zlog/LICENSE-APACHE
+++ b/crates/zlog/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/zlog/LICENSE-GPL
+++ b/crates/zlog/LICENSE-GPL
@@ -1,1 +1,0 @@
-../../LICENSE-GPL

--- a/crates/ztracing/Cargo.toml
+++ b/crates/ztracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "ztracing"
 version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 
 [lints]
 workspace = true

--- a/crates/ztracing/LICENSE-GPL
+++ b/crates/ztracing/LICENSE-GPL
@@ -1,1 +1,0 @@
-../../LICENSE-GPL

--- a/crates/ztracing_macro/Cargo.toml
+++ b/crates/ztracing_macro/Cargo.toml
@@ -3,7 +3,7 @@ name = "ztracing_macro"
 version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true

--- a/crates/ztracing_macro/LICENSE-GPL
+++ b/crates/ztracing_macro/LICENSE-GPL
@@ -1,1 +1,0 @@
-../../LICENSE-GPL


### PR DESCRIPTION
Relicenses `zlog`, `ztracing`, and `ztracing_macro` from GPL-3.0-or-later to Apache-2.0.

GPUI depends on `ztracing`, which depends on `zlog`, so these crates have to be non-copyleft for GPUI to ship as a permissively licensed project.

- Switched the `license` field to `Apache-2.0` in all three manifests.
- Added the `LICENSE-APACHE` symlink to `zlog`, and dropped the `LICENSE-GPL` symlinks from all three. `ztracing` and `ztracing_macro` already carried both symlinks; now the on-disk license matches the manifest.
- Declared `license = "Apache-2.0"` for `gpui_util`, which had a `LICENSE-APACHE` symlink but no `license` field. `script/check-licenses` doesn't catch that, since it only inspects symlinks.

No source changes; none of these crates carry GPL headers or in-source license references.

Checked the rest of the subtree while here: the only first-party crates reachable from `ztracing` via `cargo tree -e normal` are `collections`, `gpui_util`, `zlog`, and `ztracing_macro`, all Apache-2.0 now. Third-party deps (`tracing`, `tracing-subscriber`, `chrono`, `log`, `anyhow`, `tracy-client`) are MIT/Apache.

`script/check-licenses` passes.

Release Notes:

- N/A
