### PR TITLE
agent_ui: Add action to edit terminal thread title 

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -49,10 +49,10 @@ use crate::{
     NewNativeAgentThreadFromSummary,
 };
 use crate::{
-    AgentDiffPane, ConversationView, CopyThreadToClipboard, Follow, LoadThreadFromClipboard,
-    NewTerminalThread, NewThread, OpenActiveThreadAsMarkdown, OpenAgentDiff, ResetFastModeWarnings,
-    ResetTrialEndUpsell, ResetTrialUpsell, ShowAllSidebarThreadMetadata, ShowThreadMetadata,
-    ToggleNewThreadMenu, ToggleOptionsMenu,
+    AgentDiffPane, ConversationView, CopyThreadToClipboard, EditTerminalThreadTitle, Follow,
+    LoadThreadFromClipboard, NewTerminalThread, NewThread, OpenActiveThreadAsMarkdown,
+    OpenAgentDiff, ResetFastModeWarnings, ResetTrialEndUpsell, ResetTrialUpsell,
+    ShowAllSidebarThreadMetadata, ShowThreadMetadata, ToggleNewThreadMenu, ToggleOptionsMenu,
     conversation_view::{
         AcpThreadViewEvent, RootThreadUpdated, ThreadView, reset_fast_mode_warnings,
     },
@@ -6519,6 +6519,14 @@ impl Render for AgentPanel {
                 cx.stop_propagation();
                 this.new_terminal(None, AgentThreadSource::AgentPanel, window, cx);
             }))
+            .on_action(
+                cx.listener(|this, _: &EditTerminalThreadTitle, window, cx| {
+                    cx.stop_propagation();
+                    if let Some(terminal_id) = this.active_terminal_id() {
+                        this.edit_terminal_title(terminal_id, window, cx);
+                    }
+                }),
+            )
             .on_action(cx.listener(|this, _: &OpenSettings, window, cx| {
                 this.open_configuration(window, cx);
             }))
@@ -9803,6 +9811,78 @@ mod tests {
 
             panel.edit_terminal_title(terminal_id, window, cx);
             assert!(!panel.should_show_title_edit(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_edit_terminal_title_action_opens_and_focuses_editor(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_visible_panel(cx).await;
+        let terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Dev Server", true, window, cx)
+            })
+            .expect("test terminal should be inserted");
+        cx.run_until_parked();
+
+        cx.dispatch_action(EditTerminalThreadTitle);
+        cx.run_until_parked();
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert_eq!(panel.active_terminal_id(), Some(terminal_id));
+            assert!(panel.is_title_editor_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_edit_terminal_title_action_is_noop_for_agent_thread(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_visible_panel(cx).await;
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
+        });
+        cx.run_until_parked();
+
+        cx.dispatch_action(EditTerminalThreadTitle);
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, _cx| {
+            assert!(panel.active_terminal_id().is_none());
+            assert!(matches!(
+                panel.visible_surface(),
+                VisibleSurface::AgentThread(_)
+            ));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_edit_terminal_title_action_reuses_existing_editor(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_visible_panel(cx).await;
+        let terminal_id = panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Dev Server", true, window, cx)
+            })
+            .expect("test terminal should be inserted");
+        cx.run_until_parked();
+
+        cx.dispatch_action(EditTerminalThreadTitle);
+        cx.run_until_parked();
+        let first_editor_id = panel.read_with(&cx, |panel, _cx| {
+            panel
+                .terminals
+                .get(&terminal_id)
+                .and_then(|terminal| terminal.title_editor.as_ref())
+                .expect("terminal title editor should be active")
+                .entity_id()
+        });
+
+        cx.dispatch_action(EditTerminalThreadTitle);
+        cx.run_until_parked();
+        panel.read_with(&cx, |panel, _cx| {
+            let editor = panel
+                .terminals
+                .get(&terminal_id)
+                .and_then(|terminal| terminal.title_editor.as_ref())
+                .expect("terminal title editor should remain active");
+            assert_eq!(editor.entity_id(), first_editor_id);
         });
     }
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -326,6 +326,8 @@ actions!(
         ImportThreadsFromOtherChannels,
         /// Starts a new terminal thread.
         NewTerminalThread,
+        /// Edits the title of the active terminal thread.
+        EditTerminalThreadTitle,
     ]
 );
 

--- a/docs/src/ai/terminal-threads.md
+++ b/docs/src/ai/terminal-threads.md
@@ -56,6 +56,8 @@ You can also configure this from the Settings UI under **AI**, via the "Terminal
 
 The terminal title in the toolbar updates automatically to reflect the running shell or process. You can set a custom name by clicking the title or the pencil icon that appears on hover. In the Threads Sidebar, right-click a Terminal Thread and select **Rename Title**, or select it and press {#kb agent::RenameSelectedThread}.
 
+You can also edit the toolbar title with {#action agent::EditTerminalThreadTitle}. Map this action to a shortcut in your `keymap.json` if needed.
+
 ## Notifications {#terminal-thread-notifications}
 
 When a terminal produces a bell character while not in focus, Zed notifies you the same way it does when an agent finishes: with a visual pop-up and an optional sound. Clicking the notification brings the terminal into focus and clears the indicator.


### PR DESCRIPTION
## Summary

- Add `agent::EditTerminalThreadTitle` to open the existing inline title editor for the active Terminal Thread.
- Add focused tests for terminal, non-terminal, and repeat-invocation behavior.
- Document custom keymap assignment for the action.

## Testing

- `cargo test -p agent_ui agent_panel::tests::test_edit_terminal_title_action --lib`
- `cargo fmt --package agent_ui -- --check`
- `npx prettier --check src/ai/terminal-threads.md`
- Manually tested locally with a custom keymap binding.

Release Notes:

- Added a keymappable action to edit Terminal Thread titles.

---

### screenshots
<img width="1231" height="208" alt="Screenshot 2026-09-01 at 16 42 50" src="https://github.com/user-attachments/assets/cf56e281-2b97-4d24-8e41-264fff1693d1" />
