### PR TITLE
Download wasi-sdk before cleaning the target directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         tool: nextest
     - name: steps::clear_target_dir_if_large
       run: ./script/clear-target-dir-if-larger-than 350 200
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:
@@ -78,8 +80,6 @@ jobs:
         path: ~/.rustup
     - name: steps::setup_linux
       run: ./script/linux
-    - name: steps::download_wasi_sdk
-      run: ./script/download-wasi-sdk
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -92,6 +92,8 @@ jobs:
         tool: nextest
     - name: steps::clear_target_dir_if_large
       run: ./script/clear-target-dir-if-larger-than 350 200
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -57,8 +57,6 @@ jobs:
         path: ~/.rustup
     - name: steps::setup_linux
       run: ./script/linux
-    - name: steps::download_wasi_sdk
-      run: ./script/download-wasi-sdk
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -71,6 +69,8 @@ jobs:
         tool: nextest
     - name: steps::clear_target_dir_if_large
       run: ./script/clear-target-dir-if-larger-than 350 200
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -394,8 +394,6 @@ jobs:
         path: ~/.rustup
     - name: steps::setup_linux
       run: ./script/linux
-    - name: steps::download_wasi_sdk
-      run: ./script/download-wasi-sdk
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -408,6 +406,8 @@ jobs:
         tool: nextest
     - name: steps::clear_target_dir_if_large
       run: ./script/clear-target-dir-if-larger-than 350 200
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:
@@ -463,6 +463,8 @@ jobs:
         tool: nextest
     - name: steps::clear_target_dir_if_large
       run: ./script/clear-target-dir-if-larger-than 350 200
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
       run: ./script/setup-sccache
       env:

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -626,16 +626,19 @@ fn run_platform_tests_impl(platform: Platform, filter_packages: bool, harden: bo
             .when(platform == Platform::Linux, |this| {
                 use_clang(this.add_step(steps::cache_rust_dependencies_namespace()))
             })
-            .when(
-                platform == Platform::Linux,
-                steps::install_linux_dependencies,
-            )
+            .when(platform == Platform::Linux, |job| {
+                job.add_step(steps::setup_linux())
+            })
             .add_step(steps::setup_node())
             .when(
                 platform == Platform::Linux || platform == Platform::Mac,
                 |job| job.add_step(steps::cargo_install_nextest()),
             )
             .add_step(steps::clear_target_dir_if_large(platform))
+            .when(
+                platform == Platform::Linux || platform == Platform::Mac,
+                |job| job.add_step(steps::download_wasi_sdk()),
+            )
             .add_step(steps::setup_sccache(platform))
             .when(filter_packages, |job| {
                 job.add_step(

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -322,7 +322,7 @@ pub fn setup_linux() -> Step<Run> {
     named::bash("./script/linux")
 }
 
-fn download_wasi_sdk() -> Step<Run> {
+pub(crate) fn download_wasi_sdk() -> Step<Run> {
     named::bash("./script/download-wasi-sdk")
 }
 


### PR DESCRIPTION
Fix flacks like https://github.com/zed-industries/zed/actions/runs/33546906778/job/99987145940?pr=63573

`test_extension_store_with_test_extension` gives the extension builder `target` as its cache at `crates/extension_host/src/extension_store_test.rs:801`.
`install_dev_extension` performs a real extension and grammar build at `crates/extension_host/src/extension_host.rs:1139`.
When `target/wasi-sdk` is absent (e.g. after `target/` cleanup), the builder downloads and extracts it at `crates/extension/src/extension_builder.rs:511`.

In the failed run, downloading and extracting the SDK consumed 59 seconds, grammar compilation began at 60 seconds, and the timeout fired immediately.

Release Notes:

- N/A
