### PR TITLE
editor: Fix completion menu label overlapping documentation text

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1172,7 +1172,6 @@ impl CompletionsMenu {
                                     .start_slot::<AnyElement>(start_slot)
                                     .child(
                                         h_flex()
-                                            .min_w_0()
                                             .flex_grow_1()
                                             .when(left_aligned_suffix, |this| this.justify_start())
                                             .when(right_aligned_suffix, |this| {


### PR DESCRIPTION
Closes #63301

The completion label row set `min_w_0()`, which removes a flex item's automatic minimum size and lets it shrink below its own content width. The label inside is `flex_none` and never shrinks, so for long completion labels the text overflowed the row and, with GPUI's default `Overflow::Visible`, painted directly on top of the right-aligned documentation text.

Removing `min_w_0()` restores the row's automatic minimum so it no longer shrinks past the label. The documentation label already has `flex_shrink(1.0)`, `min_w_0()` and `truncate()`, so it is now the only element that gives way, shrinking and ellipsizing as intended.

The resulting layout is `[full label] [documentation, ellipsized when it overflows]`.

### Before

<img width="687" height="426" alt="Screenshot From 2026-09-02 00-48-03" src="https://github.com/user-attachments/assets/b734b632-fd05-4afc-8b02-b231922646ef" />


### After

<img width="853" height="526" alt="Screenshot From 2026-09-02 02-23-41" src="https://github.com/user-attachments/assets/60281115-5a8d-4f4e-bfe0-c037ff7244e3" />


Release Notes:

- Fixed completion menu labels overlapping the documentation text for long completion items