### PR TITLE
git_ui: Show absolute path tooltip for Git panel entries

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8018,6 +8018,18 @@ impl GitPanel {
         })
     }
 
+    fn format_display_path(&self, repo: &Repository, path: &RepoPath) -> String {
+        let abs_path = repo.work_directory_abs_path.join(path.as_std_path());
+        if let Ok(relative_to_home) = abs_path.strip_prefix(util::paths::home_dir()) {
+            Path::new("~")
+                .join(relative_to_home)
+                .to_string_lossy()
+                .to_string()
+        } else {
+            abs_path.to_string_lossy().into_owned()
+        }
+    }
+
     fn deploy_entry_context_menu(
         &mut self,
         position: Point<Pixels>,
@@ -8335,6 +8347,8 @@ impl GitPanel {
 
         let id_for_diff_stat = id.clone();
 
+        let path = self.format_display_path(repo, &entry.repo_path);
+
         h_flex()
             .id(id)
             .h(self.list_item_height())
@@ -8350,6 +8364,8 @@ impl GitPanel {
             .bg(base_bg)
             .hover(|s| s.bg(hover_bg))
             .active(|s| s.bg(active_bg))
+            .tooltip_show_delay(Duration::from_millis(1500))
+            .tooltip(Tooltip::text(path))
             .child(name_row)
             .when(GitPanelSettings::get_global(cx).diff_stats, |el| {
                 el.when_some(entry.diff_stat, move |this, stat| {
@@ -8513,13 +8529,16 @@ impl GitPanel {
             IconName::Folder
         };
 
-        let stage_status = if let Some(repo) = &self.active_repository {
-            self.stage_status_for_directory(entry, repo.read(cx))
+        let (stage_status, path) = if let Some(repo) = &self.active_repository {
+            (
+                self.stage_status_for_directory(entry, repo.read(cx)),
+                self.format_display_path(repo.read(cx), &entry.key.path),
+            )
         } else {
             util::debug_panic!(
                 "Won't have entries to render without an active repository in Git Panel"
             );
-            StageStatus::PartiallyStaged
+            (StageStatus::PartiallyStaged, String::new())
         };
 
         let stage_intent = StageIntent::for_section(entry.key.section);
@@ -8574,6 +8593,8 @@ impl GitPanel {
             .when(selected && self.focus_handle.is_focused(window), |el| {
                 el.border_color(cx.theme().colors().panel_focused_border)
             })
+            .tooltip_show_delay(Duration::from_millis(1500))
+            .tooltip(Tooltip::text(path))
             .bg(base_bg)
             .hover(|s| s.bg(hover_bg))
             .active(|s| s.bg(active_bg))

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -47,7 +47,7 @@ use git::{
     TrashUntrackedFiles, UnstageAll, ViewFile, parse_git_remote_url,
 };
 use gpui::{
-    AbsoluteLength, Action, Anchor, AnyElement, AsyncApp, AsyncWindowContext, ClickEvent,
+    AbsoluteLength, Action, Anchor, AnyElement, AnyView, AsyncApp, AsyncWindowContext, ClickEvent,
     ClipboardItem, DismissEvent, Empty, Entity, EventEmitter, FocusHandle, Focusable, KeyContext,
     MouseButton, MouseDownEvent, Pixels, Point, PromptLevel, ScrollStrategy, Subscription, Task,
     TaskExt, TextStyle, UniformListScrollHandle, WeakEntity, actions, anchored, deferred,
@@ -8018,16 +8018,24 @@ impl GitPanel {
         })
     }
 
-    fn format_display_path(&self, repo: &Repository, path: &RepoPath) -> String {
-        let abs_path = repo.work_directory_abs_path.join(path.as_std_path());
-        if let Ok(relative_to_home) = abs_path.strip_prefix(util::paths::home_dir()) {
-            Path::new("~")
-                .join(relative_to_home)
-                .to_string_lossy()
-                .to_string()
-        } else {
-            abs_path.to_string_lossy().into_owned()
-        }
+    fn format_display_path(
+        work_dir: Arc<Path>,
+        repo_path: RepoPath,
+    ) -> Box<dyn Fn(&mut Window, &mut App) -> AnyView> {
+        Box::new(move |_window: &mut Window, cx: &mut App| {
+            let abs_path = work_dir.join(repo_path.as_std_path());
+            let display_path =
+                if let Ok(relative_to_home) = abs_path.strip_prefix(util::paths::home_dir()) {
+                    Path::new("~")
+                        .join(relative_to_home)
+                        .to_string_lossy()
+                        .to_string()
+                } else {
+                    abs_path.to_string_lossy().into_owned()
+                };
+
+            Tooltip::simple(display_path, cx)
+        })
     }
 
     fn deploy_entry_context_menu(
@@ -8347,8 +8355,6 @@ impl GitPanel {
 
         let id_for_diff_stat = id.clone();
 
-        let path = self.format_display_path(repo, &entry.repo_path);
-
         h_flex()
             .id(id)
             .h(self.list_item_height())
@@ -8365,7 +8371,10 @@ impl GitPanel {
             .hover(|s| s.bg(hover_bg))
             .active(|s| s.bg(active_bg))
             .tooltip_show_delay(Duration::from_millis(1500))
-            .tooltip(Tooltip::text(path))
+            .tooltip(Self::format_display_path(
+                repo.work_directory_abs_path.clone(),
+                entry.repo_path.clone(),
+            ))
             .child(name_row)
             .when(GitPanelSettings::get_global(cx).diff_stats, |el| {
                 el.when_some(entry.diff_stat, move |this, stat| {
@@ -8529,16 +8538,23 @@ impl GitPanel {
             IconName::Folder
         };
 
-        let (stage_status, path) = if let Some(repo) = &self.active_repository {
+        let (stage_status, tool_tip) = if let Some(repo) = &self.active_repository {
             (
                 self.stage_status_for_directory(entry, repo.read(cx)),
-                self.format_display_path(repo.read(cx), &entry.key.path),
+                Self::format_display_path(
+                    repo.read(cx).work_directory_abs_path.clone(),
+                    entry.key.path.clone(),
+                ),
             )
         } else {
             util::debug_panic!(
                 "Won't have entries to render without an active repository in Git Panel"
             );
-            (StageStatus::PartiallyStaged, String::new())
+            (
+                StageStatus::PartiallyStaged,
+                Box::new(|_window: &mut Window, cx: &mut App| Tooltip::simple(String::new(), cx))
+                    as Box<dyn Fn(&mut Window, &mut App) -> AnyView>,
+            )
         };
 
         let stage_intent = StageIntent::for_section(entry.key.section);
@@ -8594,7 +8610,7 @@ impl GitPanel {
                 el.border_color(cx.theme().colors().panel_focused_border)
             })
             .tooltip_show_delay(Duration::from_millis(1500))
-            .tooltip(Tooltip::text(path))
+            .tooltip(tool_tip)
             .bg(base_bg)
             .hover(|s| s.bg(hover_bg))
             .active(|s| s.bg(active_bg))


### PR DESCRIPTION
# Objective
Git panel rows only show a file's name (or a possibly-compacted directory name in tree view) — there's no way to see the entry's full path without leaving the panel. This makes it hard to disambiguate same-named files in different directories, or to quickly confirm exactly which file on disk a row corresponds to.

similar to pr:[63299](https://github.com/zed-industries/zed/pull/63299)

## Solution

- Added GitPanel::format_display_path, which resolves a repo-relative RepoPath to its absolute filesystem path (via Repository::work_directory_abs_path) and formats it for display, abbreviating the user's home directory with ~ — consistent with the existing convention already used elsewhere in git_panel.rs (the "where would you like to initialize this repository" prompt).
- Wired a .tooltip() onto both file rows (render_status_entry) and folder rows (render_directory_entry), shown after a short hover delay (tooltip_show_delay).
- For folder rows, consolidated the existing self.active_repository lookup (previously only used for stage_status) into a single if let that now also produces the display path, avoiding a duplicate Option check/debug_panic!.

## Testing

- Manually tested with a local debug build (cargo build --profile dbg for full debug info): hovered over file and folder rows at various tree depths and confirmed the tooltip shows the correct ~-abbreviated absolute path, and falls back to the full absolute path when the repo lives outside the home directory.
- Not covered by automated tests yet — this is UI-only hover behavior, so a test would need to exercise tooltip rendering specifically. Flagging as a gap rather than skipping it silently.
- Reviewers: the easiest way to check this is to open a repo with nested changed files/folders in the Git panel and hover both a file row and a collapsed-folder row.

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A, no unsafe code
- [ ] The content adheres to Zed's UI standards (UX/UI and icon guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

screenshot:
<img width="416" height="759" alt="image" src="https://github.com/user-attachments/assets/b0fa0c8e-27d7-4241-b619-24e814b7b6b2" />
<img width="416" height="610" alt="image" src="https://github.com/user-attachments/assets/d6d142b0-d0d9-4b8d-a600-5c5c66b9247b" />


---

Release Notes:

- Added a tooltip showing the file's absolute path when hovering over an entry in the Git panel
