### PR TITLE
gpui: Attribute frames the platform withheld from their draw, not their first invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -788,9 +788,16 @@ fn clear_trace_buffers() {
 pub struct FrameTiming {
     /// The window that was drawn.
     pub window_id: WindowId,
-    /// When the frame first became dirty (its first invalidation). `None` if
-    /// profiler tracing was not yet enabled when the invalidation occurred.
+    /// When the frame became dirty while the platform was presenting: its
+    /// first invalidation, or the draw start when the platform withheld
+    /// presentation of that invalidation (display asleep, window occluded or
+    /// minimized) — see `withheld_for`. `None` if the invalidation was not
+    /// observed.
     pub dirty_at: Option<Instant>,
+    /// How long the platform withheld presentation between the frame's first
+    /// invalidation and this draw, when it did. Time in here is not foreground
+    /// latency; `dirty_at` already excludes it.
+    pub withheld_for: Option<Duration>,
     /// Number of invalidations coalesced into this frame.
     pub invalidations: u64,
     /// When `Window::draw` started.
@@ -806,8 +813,8 @@ impl FrameTiming {
         self.draw_end.duration_since(self.draw_start)
     }
 
-    /// Time from the frame's first invalidation to the end of its draw, if the
-    /// first invalidation was observed.
+    /// Time from the frame becoming dirty while presentable (see `dirty_at`)
+    /// to the end of its draw, if the invalidation was observed.
     pub fn dirty_to_draw_duration(&self) -> Option<Duration> {
         self.dirty_at
             .map(|dirty_at| self.draw_end.duration_since(dirty_at))
@@ -883,6 +890,7 @@ enum WindowActivity {
     },
     Draw {
         started_at: Instant,
+        dirty: journal::ResolvedFrameDirty,
     },
 }
 
@@ -1011,19 +1019,22 @@ impl WindowProfiler {
         journal::end_foreground_turn();
     }
 
-    /// Records the beginning of a window draw.
-    pub fn begin_draw(&mut self) {
+    /// Records the beginning of a window draw. `dirty_at` is the frame's
+    /// first invalidation; the journal decides whether it counts as
+    /// foreground latency or was withheld by the platform.
+    pub fn begin_draw(&mut self, dirty_at: Option<Instant>) {
         journal::begin_foreground_turn();
         let started_at = Instant::now();
-        journal::record_frame_pending(self.window_id, started_at);
+        let dirty = journal::begin_draw(self.window_id, dirty_at, started_at);
         self.active_activities
-            .push(WindowActivity::Draw { started_at });
+            .push(WindowActivity::Draw { started_at, dirty });
     }
 
     /// Records the end of a window draw and returns the draw duration.
-    pub fn end_draw(&mut self, dirty_at: Option<Instant>, invalidations: u64) -> Duration {
+    pub fn end_draw(&mut self, invalidations: u64) -> Duration {
         let Some(WindowActivity::Draw {
             started_at: draw_start,
+            dirty,
         }) = self.active_activities.pop()
         else {
             debug_assert!(false, "draw activity must be the current window activity");
@@ -1034,7 +1045,8 @@ impl WindowProfiler {
         let draw_end = Instant::now();
         let frame_timing = FrameTiming {
             window_id: self.window_id,
-            dirty_at,
+            dirty_at: dirty.dirty_at,
+            withheld_for: dirty.withheld_for,
             invalidations,
             draw_start,
             draw_end,
@@ -1250,8 +1262,8 @@ mod tests {
         let dirty_at = Instant::now();
         let mut collector = FrameTimingCollector::new();
 
-        window_profiler.begin_draw();
-        window_profiler.end_draw(Some(dirty_at), 3);
+        window_profiler.begin_draw(Some(dirty_at));
+        window_profiler.end_draw(3);
         assert!(
             collector
                 .collect_unseen()
@@ -1261,8 +1273,8 @@ mod tests {
 
         set_trace_enabled(true);
         let mut collector = FrameTimingCollector::new();
-        window_profiler.begin_draw();
-        window_profiler.end_draw(Some(dirty_at), 3);
+        window_profiler.begin_draw(Some(dirty_at));
+        window_profiler.end_draw(3);
 
         let timing = collector
             .collect_unseen()
@@ -1334,8 +1346,8 @@ mod tests {
             WindowProfiler::new(window_id).expect("window profiler should initialize");
         let mut collector = FrameTimingCollector::new();
 
-        window_profiler.begin_draw();
-        window_profiler.end_draw(None, 0);
+        window_profiler.begin_draw(None);
+        window_profiler.end_draw(0);
         assert!(
             FRAME_TIMINGS
                 .lock()
@@ -1483,10 +1495,10 @@ mod tests {
         let mut window_profiler =
             WindowProfiler::new(WindowId::from(7)).expect("window profiler should initialize");
 
-        window_profiler.begin_draw();
+        window_profiler.begin_draw(None);
         begin_input_at(&mut window_profiler, Instant::now());
         window_profiler.end_input(true);
-        window_profiler.end_draw(None, 0);
+        window_profiler.end_draw(0);
 
         let snapshot = window_profiler.input_latency_snapshot();
         assert!(snapshot.latency_histogram.is_empty());
@@ -1574,6 +1586,7 @@ mod tests {
         window_profiler.record_draw_timing(FrameTiming {
             window_id: window_profiler.window_id,
             dirty_at: Some(draw_end - Duration::from_millis(4)),
+            withheld_for: None,
             invalidations: 1,
             draw_start: draw_end - Duration::from_millis(2),
             draw_end,

--- a/crates/gpui/src/profiler/hang.rs
+++ b/crates/gpui/src/profiler/hang.rs
@@ -99,9 +99,10 @@ pub struct SerializedHangIncident {
     /// [`HangDetector::first_present_at`]), otherwise `"steady"`.
     pub phase: &'static str,
     /// When the incident's active window started, in milliseconds since app
-    /// startup: the sealing frame's first invalidation, or the earliest
-    /// contributor's start when nothing was pending a repaint. Foreground
-    /// idle time between the previous frame and the cause is excluded.
+    /// startup: when the sealing frame became dirty while presentable, or the
+    /// earliest contributor's start when nothing was pending a repaint.
+    /// Foreground idle time between the previous frame and the cause is
+    /// excluded.
     pub start_ms: f64,
     /// Length of the active window in milliseconds: from the cause to the
     /// seal. Exceeds `stall_ms` when several stalls piled up on one frame.
@@ -112,8 +113,14 @@ pub struct SerializedHangIncident {
     /// incident.
     pub stall_ms: f64,
     /// For presentation-sealed incidents, how long the submitted frame had
-    /// been dirty, in milliseconds.
+    /// been dirty while the platform was presenting, in milliseconds: the
+    /// rerender latency a user could perceive.
     pub dirty_to_present_ms: Option<f64>,
+    /// For presentation-sealed incidents whose frame the platform withheld
+    /// (display asleep, window occluded or minimized), how long it was
+    /// withheld before this frame request, in milliseconds. Excluded from
+    /// `dirty_to_present_ms` and `active_ms`.
+    pub frame_withheld_ms: Option<f64>,
     /// What closed the incident: `"present"` or `"idle"`. This labels the
     /// boundary, not the hang's cause — the cause is the first contributor.
     pub sealed_by: &'static str,
@@ -263,6 +270,12 @@ impl SerializedHangIncident {
                 }
                 IntervalBoundary::Idle { .. } => None,
             },
+            frame_withheld_ms: match snapshot.boundary {
+                IntervalBoundary::Presented(presented) => {
+                    presented.frame.withheld_for.map(as_millis)
+                }
+                IntervalBoundary::Idle { .. } => None,
+            },
             sealed_by: match snapshot.boundary {
                 IntervalBoundary::Presented(_) => "present",
                 IntervalBoundary::Idle { .. } => "idle",
@@ -368,9 +381,9 @@ impl SerializedHangContributor {
 }
 
 impl HangIncident {
-    /// The incident's reporting window: from its earliest cause — the
-    /// sealing frame's first invalidation, or the earliest contributor's
-    /// start when no repaint was pending — to the seal. This trims
+    /// The incident's reporting window: from its earliest cause — when the
+    /// sealing frame became dirty while presentable, or the earliest
+    /// contributor's start when no repaint was pending — to the seal. This trims
     /// foreground-idle time between the previous frame and the cause, and
     /// may begin before the underlying snapshot when a contributor was
     /// already running at the previous seal.
@@ -449,7 +462,9 @@ mod tests {
         InputTiming, IntervalBoundary, PollSummary, PresentedFrame, SmallPollFlush,
         install_test_foreground_journal, record_present,
     };
-    use super::{HangDetector, HangIncident, SerializedHangContributor, SerializedHangIncident};
+    use super::{
+        HangDetector, HangIncident, SerializedHangContributor, SerializedHangIncident, as_millis,
+    };
 
     actions!(hang_test, [HangyAction]);
 
@@ -525,6 +540,7 @@ mod tests {
         let frame = FrameTiming {
             window_id,
             dirty_at: Some(at(100)),
+            withheld_for: None,
             invalidations: 3,
             draw_start: at(350),
             draw_end: at(380),
@@ -619,6 +635,49 @@ mod tests {
         assert_eq!(serialized.active_ms, 60.0);
         assert_eq!(serialized.stall_ms, 60.0);
         assert_eq!(serialized.busy_fraction, 1.0);
+        assert_eq!(serialized.frame_withheld_ms, None);
+    }
+
+    /// A frame the platform withheld (display asleep, window occluded) is
+    /// attributed from its draw: the hours it sat dirty appear only as
+    /// `frame_withheld_ms`, never in the active window or dirty-to-present.
+    #[test]
+    fn serialized_incident_excludes_a_withheld_frame_from_latency_fields() {
+        let startup = scheduler::Instant::now();
+        let at = |ms: u64| startup + Duration::from_millis(ms);
+        let window_id = WindowId::from(0x717D);
+        let withheld_for = Duration::from_secs(2 * 60 * 60);
+        let draw_start = at(10_000);
+        let snapshot = FrameSnapshot {
+            interval_start: at(9_990),
+            boundary: IntervalBoundary::Presented(PresentedFrame {
+                frame: FrameTiming {
+                    window_id,
+                    dirty_at: Some(draw_start),
+                    withheld_for: Some(withheld_for),
+                    invalidations: 4,
+                    draw_start,
+                    draw_end: at(10_030),
+                },
+                presentation: PresentTiming {
+                    window_id,
+                    present_start: at(10_030),
+                    present_end: at(10_035),
+                    animation_interval: None,
+                },
+            }),
+            events: vec![task_poll_event(at(9_990), at(10_005))],
+            small_polls: Vec::new(),
+            dropped_events: 0,
+            journal_discontinuous: false,
+        };
+        let incident = HangIncident::detect(snapshot, HANG_THRESHOLD, FRAME_BUDGET)
+            .expect("the poll crosses the threshold");
+        let serialized = SerializedHangIncident::convert(startup, &incident, 8, Some(startup));
+        assert_eq!(serialized.start_ms, 9_990.0);
+        assert_eq!(serialized.active_ms, 45.0);
+        assert_eq!(serialized.dirty_to_present_ms, Some(35.0));
+        assert_eq!(serialized.frame_withheld_ms, Some(as_millis(withheld_for)));
     }
 
     #[test]
@@ -732,6 +791,7 @@ mod tests {
                 frame: FrameTiming {
                     window_id,
                     dirty_at: Some(at(0)),
+                    withheld_for: None,
                     invalidations: 1,
                     draw_start: at(140),
                     draw_end: at(145),
@@ -816,6 +876,7 @@ mod tests {
                 frame: FrameTiming {
                     window_id,
                     dirty_at: Some(at(0)),
+                    withheld_for: None,
                     invalidations: 1,
                     draw_start: at(145),
                     draw_end: at(147),
@@ -887,6 +948,7 @@ mod tests {
                 ForegroundEvent::Draw(FrameTiming {
                     window_id,
                     dirty_at: Some(at(0)),
+                    withheld_for: None,
                     invalidations: 1,
                     draw_start: at(1),
                     draw_end: at(39),
@@ -930,6 +992,7 @@ mod tests {
                 frame: FrameTiming {
                     window_id,
                     dirty_at: Some(at(0)),
+                    withheld_for: None,
                     invalidations: 1,
                     draw_start: at(148),
                     draw_end: at(149),
@@ -1260,6 +1323,7 @@ mod tests {
         FrameTiming {
             window_id,
             dirty_at: Some(draw_end - Duration::from_millis(2)),
+            withheld_for: None,
             invalidations: 1,
             draw_start: draw_end - Duration::from_millis(1),
             draw_end,

--- a/crates/gpui/src/profiler/journal.rs
+++ b/crates/gpui/src/profiler/journal.rs
@@ -37,6 +37,11 @@ pub const TASK_POLL_FLOOR: Duration = Duration::from_micros(100);
 /// indefinitely. Expiry only unblocks: the open interval still seals at a
 /// real presentation or idle boundary, keeping a starving hang and the frame
 /// it starved in one interval.
+///
+/// The deadline also classifies the eventual frame (see
+/// [`ForegroundJournalWriter::begin_draw`]): a frame that crossed it while
+/// the foreground was idle was withheld by the platform, not starved by the
+/// foreground.
 pub const FRAME_DEADLINE: Duration = Duration::from_secs(1);
 
 // Backstop against pathological event storms within a single interval. At the
@@ -163,12 +168,24 @@ pub struct PresentedFrame {
 }
 
 impl PresentedFrame {
-    /// Time from the frame's first invalidation through platform submission.
+    /// Time from the frame becoming dirty while presentable through platform
+    /// submission (see [`FrameTiming::dirty_at`]).
     pub fn dirty_to_present_duration(&self) -> Option<Duration> {
         self.frame
             .dirty_at
             .map(|dirty_at| self.presentation.present_end.duration_since(dirty_at))
     }
+}
+
+/// How a window's dirty frame is attributed when it is finally drawn.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ResolvedFrameDirty {
+    /// When the frame became dirty while the platform was presenting: the
+    /// first invalidation, or the draw start when the frame was withheld.
+    pub dirty_at: Option<Instant>,
+    /// How long the platform withheld presentation of this frame, from its
+    /// first invalidation to the draw. `None` when the frame was not withheld.
+    pub withheld_for: Option<Duration>,
 }
 
 /// The semantic event that completed a foreground activity interval.
@@ -379,11 +396,25 @@ impl ForegroundRunnableCounter {
     }
 }
 
+/// One window's dirty frame as tracked by the writer.
+#[derive(Debug, Copy, Clone)]
+struct PendingFrame {
+    dirty_at: Instant,
+    /// Set once the frame crossed [`FRAME_DEADLINE`] at an idle turn end.
+    /// Expired frames no longer block idle boundaries.
+    expired: bool,
+    /// For expired frames: whether the deadline passed while the foreground
+    /// was idle (the platform withheld presentation) rather than during a
+    /// turn (the foreground starved the frame).
+    withheld: bool,
+}
+
 struct ForegroundJournalWriter {
     foreground_runnables: ForegroundRunnableCounter,
     publisher: JournalPublisher,
     turn_depth: usize,
-    pending_frames: HashMap<WindowId, Instant>,
+    outermost_turn_started_at: Option<Instant>,
+    pending_frames: HashMap<WindowId, PendingFrame>,
     retained_since_boundary: bool,
     small_polls: Option<SmallPollFlush>,
 }
@@ -394,6 +425,7 @@ impl ForegroundJournalWriter {
             foreground_runnables,
             publisher,
             turn_depth: 0,
+            outermost_turn_started_at: None,
             pending_frames: HashMap::new(),
             retained_since_boundary: false,
             small_polls: None,
@@ -401,6 +433,17 @@ impl ForegroundJournalWriter {
     }
 
     fn begin_turn(&mut self) {
+        if self.turn_depth == 0 {
+            self.begin_turn_at(Instant::now());
+        } else {
+            self.turn_depth += 1;
+        }
+    }
+
+    fn begin_turn_at(&mut self, started_at: Instant) {
+        if self.turn_depth == 0 {
+            self.outermost_turn_started_at = Some(started_at);
+        }
         self.turn_depth += 1;
     }
 
@@ -433,13 +476,79 @@ impl ForegroundJournalWriter {
         }));
     }
 
+    // Called only when the foreground is otherwise idle at the end of the
+    // outermost turn, so a frame crossing the deadline here is classified by
+    // when that turn began: after the deadline means the deadline passed with
+    // the foreground idle and nothing requesting a frame (the platform is
+    // withholding presentation, e.g. the display is asleep or the window is
+    // occluded); before it means the turn itself outlived the deadline (a
+    // hang starved the frame).
     fn has_unexpired_pending_frame(&mut self, now: Instant) -> bool {
-        if self.pending_frames.is_empty() {
-            return false;
+        let outermost_turn_started_at = self.outermost_turn_started_at;
+        let mut unexpired = false;
+        for frame in self.pending_frames.values_mut() {
+            if frame.expired {
+                continue;
+            }
+            if now.saturating_duration_since(frame.dirty_at) < FRAME_DEADLINE {
+                unexpired = true;
+                continue;
+            }
+            frame.expired = true;
+            frame.withheld =
+                Self::deadline_passed_while_idle(frame.dirty_at, outermost_turn_started_at);
         }
-        self.pending_frames
-            .retain(|_, dirty_at| now.saturating_duration_since(*dirty_at) < FRAME_DEADLINE);
-        !self.pending_frames.is_empty()
+        unexpired
+    }
+
+    fn deadline_passed_while_idle(
+        dirty_at: Instant,
+        outermost_turn_started_at: Option<Instant>,
+    ) -> bool {
+        outermost_turn_started_at.is_some_and(|started_at| {
+            started_at.saturating_duration_since(dirty_at) >= FRAME_DEADLINE
+        })
+    }
+
+    /// Resolves how the frame about to be drawn is attributed and marks the
+    /// window pending again from `draw_start`.
+    ///
+    /// `dirty_at` is the window's first invalidation. When the platform
+    /// withheld presentation of that invalidation — the frame crossed
+    /// [`FRAME_DEADLINE`] while the foreground was idle, either observed at an
+    /// idle turn end or implied by no turn having ended since the deadline —
+    /// presentability is taken to resume with this frame request, so the
+    /// resolved `dirty_at` is `draw_start` and the withheld stretch is
+    /// reported separately. Otherwise the first invalidation stands: the time
+    /// since it is foreground latency the user perceived.
+    fn begin_draw(
+        &mut self,
+        window_id: WindowId,
+        dirty_at: Option<Instant>,
+        draw_start: Instant,
+    ) -> ResolvedFrameDirty {
+        let withheld = match self.pending_frames.get(&window_id) {
+            Some(frame) if frame.expired => frame.withheld,
+            Some(frame) => {
+                draw_start.saturating_duration_since(frame.dirty_at) >= FRAME_DEADLINE
+                    && Self::deadline_passed_while_idle(
+                        frame.dirty_at,
+                        self.outermost_turn_started_at,
+                    )
+            }
+            None => false,
+        };
+        self.record_frame_pending(window_id, draw_start);
+        match (withheld, dirty_at) {
+            (true, Some(dirty_at)) => ResolvedFrameDirty {
+                dirty_at: Some(draw_start),
+                withheld_for: Some(draw_start.saturating_duration_since(dirty_at)),
+            },
+            _ => ResolvedFrameDirty {
+                dirty_at,
+                withheld_for: None,
+            },
+        }
     }
 
     fn fold_small_poll(&mut self, timing: TaskTiming) {
@@ -481,8 +590,8 @@ impl ForegroundJournalWriter {
 
     fn record_frame_pending(&mut self, window_id: WindowId, dirty_at: Instant) {
         let should_record = match self.pending_frames.get(&window_id) {
-            Some(previous_dirty_at) => {
-                dirty_at.saturating_duration_since(*previous_dirty_at) >= FRAME_DEADLINE
+            Some(previous) => {
+                dirty_at.saturating_duration_since(previous.dirty_at) >= FRAME_DEADLINE
             }
             None => true,
         };
@@ -490,7 +599,14 @@ impl ForegroundJournalWriter {
             return;
         }
 
-        self.pending_frames.insert(window_id, dirty_at);
+        self.pending_frames.insert(
+            window_id,
+            PendingFrame {
+                dirty_at,
+                expired: false,
+                withheld: false,
+            },
+        );
         self.record_frame_state(FrameStateChange::Pending {
             window_id,
             dirty_at,
@@ -663,6 +779,22 @@ pub(crate) fn record_present(timing: PresentTiming, frame: Option<FrameTiming>) 
 
 pub(crate) fn record_frame_pending(window_id: WindowId, dirty_at: Instant) {
     with_journal(|journal| journal.record_frame_pending(window_id, dirty_at));
+}
+
+/// Resolves the frame about to be drawn (see
+/// [`ForegroundJournalWriter::begin_draw`]). Without a journal on this thread
+/// the first invalidation stands as-is.
+pub(crate) fn begin_draw(
+    window_id: WindowId,
+    dirty_at: Option<Instant>,
+    draw_start: Instant,
+) -> ResolvedFrameDirty {
+    let mut resolved = ResolvedFrameDirty {
+        dirty_at,
+        withheld_for: None,
+    };
+    with_journal(|journal| resolved = journal.begin_draw(window_id, dirty_at, draw_start));
+    resolved
 }
 
 pub(crate) fn record_window_closed(window_id: WindowId) {
@@ -1112,6 +1244,7 @@ mod tests {
         let frame = FrameTiming {
             window_id: WindowId::from(1),
             dirty_at: Some(input.start),
+            withheld_for: None,
             invalidations: 1,
             draw_start: start + Duration::from_millis(3),
             draw_end: start + Duration::from_millis(4),
@@ -1414,6 +1547,126 @@ mod tests {
             &collector.collect_unseen().entries,
             event_end
         ));
+    }
+
+    /// A frame that crosses the deadline at an idle turn end was withheld by
+    /// the platform: nothing requested it while the foreground had nothing to
+    /// do. Its eventual draw is attributed from the draw itself, with the
+    /// withheld stretch reported separately.
+    #[test]
+    fn a_frame_expiring_while_the_foreground_is_idle_is_withheld() {
+        let start = Instant::now();
+        let window_id = WindowId::from(0xD1E1);
+        let (mut journal, _collector) = test_journal(ForegroundRunnableCounter::new());
+        journal.record_frame_pending(window_id, start);
+
+        // A short timer wake-up after the deadline observes the expiry.
+        let wake_up = start + FRAME_DEADLINE + Duration::from_millis(200);
+        journal.begin_turn_at(wake_up);
+        journal.end_turn(wake_up + Duration::from_micros(50));
+
+        // The display comes back much later and the platform asks for a frame.
+        let draw_start = start + Duration::from_secs(2 * 60 * 60);
+        journal.begin_turn_at(draw_start);
+        let resolved = journal.begin_draw(window_id, Some(start), draw_start);
+        assert_eq!(
+            resolved,
+            ResolvedFrameDirty {
+                dirty_at: Some(draw_start),
+                withheld_for: Some(draw_start.duration_since(start)),
+            }
+        );
+    }
+
+    /// A frame that crosses the deadline during a turn was starved by the
+    /// foreground, and the turn that follows the hang (the frame request)
+    /// must not reclassify it: its first invalidation is real latency.
+    #[test]
+    fn a_frame_expiring_during_a_long_turn_is_not_withheld() {
+        let start = Instant::now();
+        let window_id = WindowId::from(0xD1E2);
+        let (mut journal, _collector) = test_journal(ForegroundRunnableCounter::new());
+        journal.record_frame_pending(window_id, start);
+
+        let hang_start = start + Duration::from_millis(2);
+        let hang_end = start + FRAME_DEADLINE * 3;
+        journal.begin_turn_at(hang_start);
+        journal.end_turn(hang_end);
+
+        let draw_start = hang_end + Duration::from_millis(5);
+        journal.begin_turn_at(draw_start);
+        let resolved = journal.begin_draw(window_id, Some(start), draw_start);
+        assert_eq!(
+            resolved,
+            ResolvedFrameDirty {
+                dirty_at: Some(start),
+                withheld_for: None,
+            }
+        );
+    }
+
+    /// With no turn ending between the deadline and the draw, the frame
+    /// request's own turn decides: starting long after the deadline means the
+    /// foreground was idle throughout, so the frame was withheld.
+    #[test]
+    fn a_frame_pending_across_an_idle_stretch_without_turns_is_withheld() {
+        let start = Instant::now();
+        let window_id = WindowId::from(0xD1E3);
+        let (mut journal, _collector) = test_journal(ForegroundRunnableCounter::new());
+        journal.record_frame_pending(window_id, start);
+
+        let draw_start = start + Duration::from_secs(30 * 60);
+        journal.begin_turn_at(draw_start);
+        let resolved = journal.begin_draw(window_id, Some(start), draw_start);
+        assert_eq!(
+            resolved,
+            ResolvedFrameDirty {
+                dirty_at: Some(draw_start),
+                withheld_for: Some(draw_start.duration_since(start)),
+            }
+        );
+    }
+
+    /// A draw nested in a turn that began before the deadline is the hang
+    /// case even when no turn ended in between.
+    #[test]
+    fn a_frame_drawn_inside_a_turn_that_outlived_the_deadline_is_not_withheld() {
+        let start = Instant::now();
+        let window_id = WindowId::from(0xD1E4);
+        let (mut journal, _collector) = test_journal(ForegroundRunnableCounter::new());
+        journal.record_frame_pending(window_id, start);
+
+        journal.begin_turn_at(start + Duration::from_millis(1));
+        let draw_start = start + FRAME_DEADLINE * 2;
+        let resolved = journal.begin_draw(window_id, Some(start), draw_start);
+        assert_eq!(
+            resolved,
+            ResolvedFrameDirty {
+                dirty_at: Some(start),
+                withheld_for: None,
+            }
+        );
+    }
+
+    /// Ordinary frames are untouched: drawn before the deadline, the first
+    /// invalidation stands.
+    #[test]
+    fn a_frame_drawn_before_the_deadline_keeps_its_first_invalidation() {
+        let start = Instant::now();
+        let window_id = WindowId::from(0xD1E5);
+        let (mut journal, _collector) = test_journal(ForegroundRunnableCounter::new());
+        journal.record_frame_pending(window_id, start);
+
+        let draw_start = start + Duration::from_millis(12);
+        journal.begin_turn_at(draw_start);
+        let resolved = journal.begin_draw(window_id, Some(start), draw_start);
+        assert_eq!(
+            resolved,
+            ResolvedFrameDirty {
+                dirty_at: Some(start),
+                withheld_for: None,
+            }
+        );
     }
 
     /// One window presenting must not unblock idle boundaries while another
@@ -2687,7 +2940,17 @@ mod tests {
                 );
                 prop_assert_eq!(writer.turn_depth, model.turn_depth);
                 prop_assert_eq!(writer.retained_since_boundary, model.retained_since_boundary);
-                prop_assert_eq!(writer.pending_frames.len(), model.pending_frames.len());
+                // The writer retains expired frames (flagged) to classify their
+                // eventual draw; the model only tracks frames that still block
+                // idle boundaries.
+                prop_assert_eq!(
+                    writer
+                        .pending_frames
+                        .values()
+                        .filter(|frame| !frame.expired)
+                        .count(),
+                    model.pending_frames.len()
+                );
             }
         }
     }
@@ -2729,6 +2992,7 @@ mod tests {
         FrameTiming {
             window_id,
             dirty_at: Some(dirty_at),
+            withheld_for: None,
             invalidations: 1,
             draw_start: draw_end,
             draw_end,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2885,7 +2885,7 @@ impl Window {
         #[cfg(feature = "profiler")]
         let frame_dirty = self.invalidator.take_frame_dirty();
         #[cfg(feature = "profiler")]
-        self.window_profiler.begin_draw();
+        self.window_profiler.begin_draw(frame_dirty.dirty_at);
 
         // Set up the per-App arena for element allocation during this draw.
         // This ensures that multiple test Apps have isolated arenas.
@@ -3008,9 +3008,7 @@ impl Window {
 
         #[cfg(feature = "profiler")]
         {
-            let draw_duration = self
-                .window_profiler
-                .end_draw(frame_dirty.dirty_at, frame_dirty.invalidations);
+            let draw_duration = self.window_profiler.end_draw(frame_dirty.invalidations);
             self.debug_frame_overlay.record_frame(draw_duration);
         }
 


### PR DESCRIPTION
A window's first-invalidation timestamp (`FrameDirtyAccumulator::dirty_at`) survives until the frame is drawn. When the platform stops presenting — display asleep, window occluded or minimized — a periodic `cx.notify()` dirties the window and that timestamp sits for as long as the window stays hidden. The redraw when the display returns then reports a dirty-to-present spanning the whole hidden stretch, the hang incident's active window starts there too, and the `dirty_to_present` histogram behind `Frame Duration Report` absorbs the same value.

The foreground journal writer already has what distinguishes this from a hang: it sees when frames become dirty, when turns begin and end, and when the foreground is idle at a turn end. This PR makes it classify the frame:

- A pending frame that crosses `FRAME_DEADLINE` **while the foreground is idle** (observed at an idle turn end, or implied by no turn ending between the deadline and the frame request) was **withheld by the platform**.
- One that crosses it **during a turn** was **starved by the foreground** — a hang — and keeps its first invalidation.

`WindowProfiler::begin_draw` now asks the writer to resolve the frame. Withheld frames are attributed from the draw start (presentability resumed with the frame request) and carry the withheld stretch in `FrameTiming::withheld_for`. The resolved `dirty_at` flows to every consumer: the incident's `dirty_to_present_ms` and active window, the `Draw` contributor's `dirty_to_draw_ms`, and the `dirty_to_present` histogram. Serialized incidents gain `frame_withheld_ms` so the raw distance stays visible in telemetry.

Known approximation: if the foreground hangs *after* presentability resumes but before the draw runs, the resolved `dirty_at` is the draw start, so `dirty_to_present_ms` understates that hang; the hang itself is still a contributor. A real visibility signal from the platform (occlusion state, `WM_SHOWWINDOW`) could replace the idle-based inference later without changing consumers.

Tests: writer-level tests for withheld-at-idle-turn-end, starved-during-long-turn, withheld-with-no-turns, drawn-inside-a-long-turn, and ordinary frames; a serialization test that the withheld stretch stays out of `active_ms`/`dirty_to_present_ms`. The writer property test now compares unexpired frames only, since the writer retains expired ones (flagged) to classify their draw.

Release Notes:

- N/A
