### PR TITLE
Fix misaligned borders around avatars with fractional display scale

### DIFF
--- a/crates/ui/src/components/avatar.rs
+++ b/crates/ui/src/components/avatar.rs
@@ -89,7 +89,7 @@ impl RenderOnce for Avatar {
             })
             .child(
                 self.image
-                    .size(image_size)
+                    .size_full()
                     .rounded_full()
                     .bg(cx.theme().colors().element_disabled)
                     .with_fallback(|| {


### PR DESCRIPTION
Before and after:

https://github.com/user-attachments/assets/b165d525-c368-4245-a246-2522e67ff3a0

---

Release Notes:

- N/A