### PR TITLE
agent_ui: Hide manage skills command when AI is disabled

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -869,11 +869,10 @@ fn update_command_palette_filter(cx: &mut App) {
         // settings UI now. Applied after the disable-ai / agent-enabled
         // branches so it overrides the `show_namespace("assistant")` call
         // above without affecting the rest of that namespace's actions.
+        filter.hide_action_types(&manage_skills_action);
         if !disable_ai {
-            filter.hide_action_types(&manage_skills_action);
             filter.show_action_types(skill_creator_actions.iter());
         } else {
-            filter.show_action_types(manage_skills_action.iter());
             filter.hide_action_types(&skill_creator_actions);
         }
     });

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -865,10 +865,8 @@ fn update_command_palette_filter(cx: &mut App) {
             filter.show_namespace("multi_workspace");
         }
 
-        // Hide `agent: manage skills` — skills are surfaced through the
-        // settings UI now. Applied after the disable-ai / agent-enabled
-        // branches so it overrides the `show_namespace("assistant")` call
-        // above without affecting the rest of that namespace's actions.
+        // Skills are surfaced through the settings UI now, so this command
+        // should never appear in the palette.
         filter.hide_action_types(&manage_skills_action);
         if !disable_ai {
             filter.show_action_types(skill_creator_actions.iter());
@@ -1047,6 +1045,10 @@ mod tests {
                 !filter.is_hidden(&zed_actions::assistant::OpenProjectAgentsMdRules),
                 "OpenProjectAgentsMdRules should be visible by default"
             );
+            assert!(
+                filter.is_hidden(&zed_actions::assistant::ManageSkills),
+                "ManageSkills should be hidden even when AI is enabled"
+            );
         });
 
         // Disable agent
@@ -1122,6 +1124,29 @@ mod tests {
             assert!(
                 filter.is_hidden(&AcceptEditPrediction),
                 "EditPrediction should be hidden when provider is None"
+            );
+        });
+
+        // Disable AI entirely
+        cx.update(|cx| {
+            AgentSettings::override_global(agent_settings.clone(), cx);
+            DisableAiSettings::override_global(DisableAiSettings { disable_ai: true }, cx);
+            update_command_palette_filter(cx);
+        });
+
+        cx.update(|cx| {
+            let filter = CommandPaletteFilter::try_global(cx).unwrap();
+            assert!(
+                filter.is_hidden(&zed_actions::assistant::ManageSkills),
+                "ManageSkills should be hidden when AI is disabled"
+            );
+            assert!(
+                filter.is_hidden(&zed_actions::assistant::OpenSkillCreator),
+                "OpenSkillCreator should be hidden when AI is disabled"
+            );
+            assert!(
+                filter.is_hidden(&NewThread),
+                "NewThread should be hidden when AI is disabled"
             );
         });
     }


### PR DESCRIPTION
# Objective

Fixes #63495

When `"disable_ai": true` is set, `agent: manage skills` still appears in the command palette. The action was exposed by the `else` branch of the `disable_ai` check in `update_command_palette_filter`, which called `show_action_types` on it — overriding the `hide_namespace("agent")` applied when AI is disabled.

## Solution

Moved `filter.hide_action_types(&manage_skills_action)` out of the conditional so it applies regardless of the `disable_ai` setting. Skills are surfaced through the settings UI now, so the command should never appear in the palette.

Added test coverage in `test_agent_command_palette_visibility`:
- Asserts `ManageSkills` is hidden even when AI is enabled (the invariant).
- Asserts `ManageSkills`, `OpenSkillCreator`, and `NewThread` are hidden when AI is disabled.

## Testing

- `cargo test -p agent_ui` (398 passed)
- `./script/clippy -p agent_ui`
- `cargo fmt --check`
- Manual verification: set `"disable_ai": true`, open the command palette, filter `agent` — `agent: manage skills` should be absent.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (no unsafe blocks)
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed `agent: manage skills` still appearing in the command palette when AI is disabled