### PR TITLE
Prioritize terminal input over built-in bindings

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -37,10 +37,11 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
     DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalDragPayload, Font,
-    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
-    LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
-    RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
-    Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
+    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource,
+    KeyBinding, Keymap, LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority,
+    RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph,
+    ShapedRun, SharedString, Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea,
+    hash, point, px, size,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use anyhow::bail;
@@ -1548,6 +1549,18 @@ impl PlatformInputHandler {
         self.handler.replace_text_in_range(None, input, window, cx);
     }
 
+    pub fn intercept_keystroke(
+        &mut self,
+        keystroke: &crate::Keystroke,
+        bindings: &[KeyBinding],
+        pending: bool,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        self.handler
+            .intercept_keystroke(keystroke, bindings, pending, window, cx)
+    }
+
     pub fn compute_ime_candidate_bounds(
         marked_range: Option<Range<usize>>,
         selection: &UTF16Selection,
@@ -1832,6 +1845,18 @@ pub trait InputHandler: 'static {
     /// Returns whether this handler is accepting text input to be inserted.
     fn accepts_text_input(&mut self, _window: &mut Window, _cx: &mut App) -> bool {
         true
+    }
+
+    /// Allows an input handler to consume a keystroke before its resolved keybindings run.
+    fn intercept_keystroke(
+        &mut self,
+        _keystroke: &crate::Keystroke,
+        _bindings: &[KeyBinding],
+        _pending: bool,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> bool {
+        false
     }
 
     /// The contiguous range of text, in UTF-16 code units, that platform text

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5502,7 +5502,7 @@ impl Window {
 
         let match_result = self.rendered_frame.dispatch_tree.dispatch_key(
             currently_pending.keystrokes,
-            keystroke,
+            keystroke.clone(),
             &dispatch_path,
         );
 
@@ -5512,6 +5512,19 @@ impl Window {
         }
 
         if !match_result.pending.is_empty() {
+            if event.downcast_ref::<KeyDownEvent>().is_some()
+                && let Some(mut input_handler) = self.platform_window.take_input_handler()
+            {
+                input_handler.intercept_keystroke(
+                    &keystroke,
+                    &match_result.bindings,
+                    true,
+                    self,
+                    cx,
+                );
+                self.platform_window.set_input_handler(input_handler);
+            }
+
             currently_pending.timer.take();
             currently_pending.keystrokes = match_result.pending;
             currently_pending.focus = self.focus;
@@ -5579,6 +5592,23 @@ impl Window {
                     })
             })
             .unwrap_or(false);
+
+        if !skip_bindings && event.downcast_ref::<KeyDownEvent>().is_some() {
+            if let Some(mut input_handler) = self.platform_window.take_input_handler() {
+                let intercepted = input_handler.intercept_keystroke(
+                    &keystroke,
+                    &match_result.bindings,
+                    false,
+                    self,
+                    cx,
+                );
+                self.platform_window.set_input_handler(input_handler);
+                if intercepted {
+                    self.pending_input_changed(cx);
+                    return;
+                }
+            }
+        }
 
         if !skip_bindings {
             for binding in match_result.bindings {

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -3,10 +3,10 @@ use gpui::{
     AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, ContentMask, Context, DispatchPhase,
     Element, ElementId, Entity, FocusHandle, Font, FontFeatures, FontStyle, FontWeight,
     GlobalElementId, HighlightStyle, Hitbox, Hsla, InputHandler, InteractiveElement, Interactivity,
-    IntoElement, LayoutId, Length, ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels,
-    Point as GpuiPoint, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle,
-    UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window, div, fill, point, px, relative,
-    size,
+    IntoElement, KeyBinding, Keystroke, LayoutId, Length, ModifiersChangedEvent, MouseButton,
+    MouseMoveEvent, Pixels, Point as GpuiPoint, StatefulInteractiveElement, StrikethroughStyle,
+    Styled, TextRun, TextStyle, UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window,
+    div, fill, point, px, relative, size,
 };
 use itertools::Itertools;
 use language::CursorShape as EditorCursorShape;
@@ -1797,6 +1797,22 @@ struct TerminalInputHandler {
 }
 
 impl InputHandler for TerminalInputHandler {
+    fn intercept_keystroke(
+        &mut self,
+        keystroke: &Keystroke,
+        bindings: &[KeyBinding],
+        pending: bool,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        if !crate::terminal_input_can_preempt_bindings(bindings, pending) {
+            return false;
+        }
+
+        self.terminal_view
+            .update(cx, |view, cx| view.process_keystroke(keystroke, cx))
+    }
+
     fn selected_text_range(
         &mut self,
         _ignore_disabled_input: bool,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -10,9 +10,9 @@ use editor::{
 };
 use gpui::{
     Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, ExternalPaths,
-    FocusHandle, Focusable, Font, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent,
-    Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled, Subscription, Task, TaskExt,
-    WeakEntity, actions, anchored, deferred, div,
+    FocusHandle, Focusable, Font, KeyBinding, KeyContext, KeyDownEvent, Keystroke, MouseButton,
+    MouseDownEvent, Pixels, Point as GpuiPoint, Render, ScrollWheelEvent, Styled, Subscription,
+    Task, TaskExt, WeakEntity, actions, anchored, deferred, div,
 };
 use menu;
 use persistence::TerminalDb;
@@ -1324,6 +1324,13 @@ impl TerminalView {
     }
 }
 
+pub(crate) fn terminal_input_can_preempt_bindings(bindings: &[KeyBinding], pending: bool) -> bool {
+    !pending
+        && !bindings.iter().any(|binding| {
+            binding.predicate().is_some() || binding.meta().map_or(true, |meta| meta.0 == 0)
+        })
+}
+
 impl Render for TerminalView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // TODO: this should be moved out of render
@@ -2170,7 +2177,7 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, VisualTestContext};
+    use gpui::{KeyBindingMetaIndex, TestAppContext, VisualTestContext};
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
@@ -2178,6 +2185,26 @@ mod tests {
     use util::rel_path::RelPath;
     use workspace::item::test::{TestItem, TestProjectItem};
     use workspace::{AppState, MultiWorkspace, SelectedEntry};
+
+    actions!(test_only, [TerminalInputTestAction]);
+
+    #[test]
+    fn terminal_input_only_preempts_unqualified_builtins() {
+        let builtin = KeyBinding::new("ctrl-t", TerminalInputTestAction, None)
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(terminal_input_can_preempt_bindings(&[builtin], false));
+
+        let contextual = KeyBinding::new("ctrl-t", TerminalInputTestAction, Some("Terminal"))
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(!terminal_input_can_preempt_bindings(&[contextual], false));
+
+        let user = KeyBinding::new("ctrl-t", TerminalInputTestAction, None);
+        assert!(!terminal_input_can_preempt_bindings(&[user], false));
+
+        let builtin = KeyBinding::new("ctrl-t", TerminalInputTestAction, None)
+            .with_meta(KeyBindingMetaIndex(3));
+        assert!(!terminal_input_can_preempt_bindings(&[builtin], true));
+    }
 
     fn expected_drop_text(paths: &[PathBuf]) -> String {
         let mut text = String::new();


### PR DESCRIPTION
## Summary

When a terminal has focus, terminal applications should receive keystrokes that only match an unqualified built-in Zed binding. Contextual bindings and user keymap overrides still take precedence. Pending multi-stroke bindings are left alone.

The check runs in GPUI after keybindings are resolved and before actions are dispatched. It is connected to the terminal input handler, so IME and paste handling keep their existing path.

## Tests

- cargo check --target x86_64-pc-windows-msvc -p gpui --lib
- cargo check --target x86_64-pc-windows-msvc -p terminal_view --lib
- cargo test --target x86_64-pc-windows-msvc -p terminal_view --lib

Closes #26018