### PR TITLE
Fall back to editor for non-image files with image extensions

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -1100,6 +1100,55 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    async fn test_non_image_file_with_image_extension_opens_in_editor(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            editor::init(cx);
+            crate::init(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.create_dir(Path::new("/root"))
+            .await
+            .expect("test root should be created");
+        fs.insert_file(
+            "/root/test.pam",
+            "Not a real image file\n".as_bytes().to_vec(),
+        )
+        .await;
+
+        let project = Project::test(fs, [Path::new("/root")], cx).await;
+
+        let worktree_id =
+            cx.update(|cx| project.read(cx).worktrees(cx).next().unwrap().read(cx).id());
+
+        let (workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::Workspace::test_new(project.clone(), window, cx)
+        });
+
+        let item = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    ProjectPath {
+                        worktree_id,
+                        path: rel_path("test.pam").into(),
+                    },
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .expect("test.pam should open");
+
+        assert!(
+            item.downcast::<editor::Editor>().is_some(),
+            "test.pam should open as Editor"
+        );
+    }
+
     fn test_image(red: u8) -> Arc<gpui::Image> {
         let bytes = format!("P3\n1 1\n255\n{red} 0 0\n").into_bytes();
         Arc::new(gpui::Image::from_bytes(gpui::ImageFormat::Pnm, bytes))

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -12,7 +12,7 @@ use gpui::{
 pub use image::ImageFormat;
 use image::{ExtendedColorType, GenericImageView, ImageReader};
 use language::{DiskState, File};
-use rpc::{AnyProtoClient, ErrorExt as _, TypedEnvelope, proto};
+use rpc::{AnyProtoClient, TypedEnvelope, proto};
 use std::future::Future;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
@@ -268,14 +268,14 @@ impl ProjectItem for ImageItem {
         project: &Entity<Project>,
         path: &ProjectPath,
         cx: &mut App,
-    ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+    ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
         if is_image_file(project, path, cx) {
             Some(cx.spawn({
                 let path = path.clone();
                 let project = project.clone();
                 async move |cx| {
                     project
-                        .update(cx, |project, cx| project.open_image(path, cx))
+                        .update(cx, |project, cx| project.try_open_image(path, cx))
                         .await
                 }
             }))
@@ -298,12 +298,12 @@ impl ProjectItem for ImageItem {
 }
 
 trait ImageStoreImpl {
-    fn open_image(
+    fn open_image_impl(
         &self,
         path: Arc<RelPath>,
         worktree: Entity<Worktree>,
         cx: &mut Context<ImageStore>,
-    ) -> Task<Result<Entity<ImageItem>>>;
+    ) -> Task<Result<ImageOpenOutcome>>;
 
     fn reload_images(
         &self,
@@ -337,6 +337,12 @@ struct LocalImageStore {
     _subscription: Subscription,
 }
 
+#[derive(Clone)]
+enum ImageOpenOutcome {
+    Opened(Entity<ImageItem>),
+    NotAnImage(Arc<anyhow::Error>),
+}
+
 pub struct ImageStore {
     state: Box<dyn ImageStoreImpl>,
     opened_images: HashMap<ImageId, WeakEntity<ImageItem>>,
@@ -344,7 +350,7 @@ pub struct ImageStore {
     #[allow(clippy::type_complexity)]
     loading_images_by_path: HashMap<
         ProjectPath,
-        postage::watch::Receiver<Option<Result<Entity<ImageItem>, Arc<anyhow::Error>>>>,
+        postage::watch::Receiver<Option<Result<ImageOpenOutcome, Arc<anyhow::Error>>>>,
     >,
 }
 
@@ -412,14 +418,42 @@ impl ImageStore {
             .find(|image| &image.read(cx).project_path(cx) == path)
     }
 
+    pub fn try_open_image(
+        &mut self,
+        project_path: ProjectPath,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Entity<ImageItem>>>> {
+        let task = self.open_image_impl(project_path, cx);
+        cx.background_spawn(async move {
+            match task.await? {
+                ImageOpenOutcome::Opened(image) => Ok(Some(image)),
+                ImageOpenOutcome::NotAnImage(_) => Ok(None),
+            }
+        })
+    }
+
     pub fn open_image(
         &mut self,
         project_path: ProjectPath,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<ImageItem>>> {
+        let task = self.open_image_impl(project_path, cx);
+        cx.background_spawn(async move {
+            match task.await? {
+                ImageOpenOutcome::Opened(image) => Ok(image),
+                ImageOpenOutcome::NotAnImage(e) => Err(anyhow::anyhow!("{:?}", e)),
+            }
+        })
+    }
+
+    fn open_image_impl(
+        &mut self,
+        project_path: ProjectPath,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<ImageOpenOutcome>> {
         let existing_image = self.get_by_path(&project_path, cx);
         if let Some(existing_image) = existing_image {
-            return Task::ready(Ok(existing_image));
+            return Task::ready(Ok(ImageOpenOutcome::Opened(existing_image)));
         }
 
         let Some(worktree) = self
@@ -440,21 +474,20 @@ impl ImageStore {
                 let (mut tx, rx) = postage::watch::channel();
                 entry.insert(rx.clone());
 
-                let load_image = self
-                    .state
-                    .open_image(project_path.path.clone(), worktree, cx);
-
+                let load_image =
+                    self.state
+                        .open_image_impl(project_path.path.clone(), worktree, cx);
                 cx.spawn(async move |this, cx| {
                     let load_result = load_image.await;
                     *tx.borrow_mut() = Some(this.update(cx, |this, _cx| {
                         // Record the fact that the image is no longer loading.
                         this.loading_images_by_path.remove(&project_path);
-                        let image = load_result.map_err(Arc::new)?;
-                        Ok(image)
+                        load_result.map_err(Arc::new)
                     })?);
                     anyhow::Ok(())
                 })
                 .detach();
+
                 rx
             }
         };
@@ -462,15 +495,15 @@ impl ImageStore {
         cx.background_spawn(async move {
             Self::wait_for_loading_image(loading_watch)
                 .await
-                .map_err(|e| e.cloned())
+                .map_err(|e| anyhow::anyhow!("{:?}", e))
         })
     }
 
-    pub async fn wait_for_loading_image(
+    async fn wait_for_loading_image(
         mut receiver: postage::watch::Receiver<
-            Option<Result<Entity<ImageItem>, Arc<anyhow::Error>>>,
+            Option<Result<ImageOpenOutcome, Arc<anyhow::Error>>>,
         >,
-    ) -> Result<Entity<ImageItem>, Arc<anyhow::Error>> {
+    ) -> Result<ImageOpenOutcome, Arc<anyhow::Error>> {
         loop {
             if let Some(result) = receiver.borrow().as_ref() {
                 match result {
@@ -648,12 +681,12 @@ impl RemoteImageStore {
 }
 
 impl ImageStoreImpl for Entity<LocalImageStore> {
-    fn open_image(
+    fn open_image_impl(
         &self,
         path: Arc<RelPath>,
         worktree: Entity<Worktree>,
         cx: &mut Context<ImageStore>,
-    ) -> Task<Result<Entity<ImageItem>>> {
+    ) -> Task<Result<ImageOpenOutcome>> {
         let this = self.clone();
 
         let load_file = worktree.update(cx, |worktree, cx| {
@@ -661,7 +694,28 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
         });
         cx.spawn(async move |image_store, cx| {
             let LoadedBinaryFile { file, content } = load_file.await?;
-            let image = create_gpui_image(content)?;
+            let format = match image::guess_format(&content) {
+                Ok(f) => f,
+                Err(image::ImageError::Unsupported(e)) => {
+                    return Ok(ImageOpenOutcome::NotAnImage(Arc::new(anyhow::anyhow!(e))));
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            let image = Arc::new(gpui::Image::from_bytes(
+                match format {
+                    image::ImageFormat::Png => gpui::ImageFormat::Png,
+                    image::ImageFormat::Jpeg => gpui::ImageFormat::Jpeg,
+                    image::ImageFormat::Gif => gpui::ImageFormat::Gif,
+                    image::ImageFormat::WebP => gpui::ImageFormat::Webp,
+                    image::ImageFormat::Bmp => gpui::ImageFormat::Bmp,
+                    image::ImageFormat::Ico => gpui::ImageFormat::Ico,
+                    image::ImageFormat::Tiff => gpui::ImageFormat::Tiff,
+                    image::ImageFormat::Pnm => gpui::ImageFormat::Pnm,
+                    format => anyhow::bail!("Image format {format:?} not supported"),
+                },
+                content,
+            ));
 
             let entity = cx.new(|cx| ImageItem {
                 id: cx.entity_id().as_non_zero_u64().into(),
@@ -692,7 +746,7 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
                 anyhow::Ok(())
             })?;
 
-            Ok(entity)
+            Ok(ImageOpenOutcome::Opened(entity))
         })
     }
 
@@ -721,12 +775,12 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
 }
 
 impl ImageStoreImpl for Entity<RemoteImageStore> {
-    fn open_image(
+    fn open_image_impl(
         &self,
         path: Arc<RelPath>,
         worktree: Entity<Worktree>,
         cx: &mut Context<ImageStore>,
-    ) -> Task<Result<Entity<ImageItem>>> {
+    ) -> Task<Result<ImageOpenOutcome>> {
         let worktree_id = worktree.read(cx).id().to_proto();
         let (project_id, client) = {
             let store = self.read(cx);
@@ -746,12 +800,10 @@ impl ImageStoreImpl for Entity<RemoteImageStore> {
             let image_id = ImageId::from(
                 NonZeroU64::new(response.image_id).context("invalid image_id in response")?,
             );
-
-            remote_store
-                .update(cx, |remote_store, cx| {
-                    remote_store.wait_for_remote_image(image_id, cx)
-                })
-                .await
+            let entity = remote_store
+                .update(cx, |store, cx| store.wait_for_remote_image(image_id, cx))
+                .await?;
+            Ok(ImageOpenOutcome::Opened(entity))
         })
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -193,7 +193,7 @@ pub trait ProjectItem: 'static {
         project: &Entity<Project>,
         path: &ProjectPath,
         cx: &mut App,
-    ) -> Option<Task<Result<Entity<Self>>>>
+    ) -> Option<Task<Result<Option<Entity<Self>>>>>
     where
         Self: Sized;
     fn entry_id(&self, cx: &App) -> Option<ProjectEntryId>;
@@ -3487,25 +3487,54 @@ impl Project {
         });
 
         let weak_project = cx.entity().downgrade();
-        cx.spawn(async move |_, cx| {
+        cx.spawn(async move |_, mut cx| {
             let image_item = open_image_task.await?;
-
-            // Check if metadata already exists (e.g., for remote images)
-            let needs_metadata =
-                cx.read_entity(&image_item, |item, _| item.image_metadata.is_none());
-
-            if needs_metadata {
-                let project = weak_project.upgrade().context("Project dropped")?;
-                let metadata =
-                    ImageItem::load_image_metadata(image_item.clone(), project, cx).await?;
-                image_item.update(cx, |image_item, cx| {
-                    image_item.image_metadata = Some(metadata);
-                    cx.emit(ImageItemEvent::MetadataUpdated);
-                });
-            }
-
-            Ok(image_item)
+            Self::ensure_image_metadata(image_item, weak_project, &mut cx).await
         })
+    }
+
+    pub fn try_open_image(
+        &mut self,
+        path: impl Into<ProjectPath>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Entity<ImageItem>>>> {
+        if self.is_disconnected(cx) {
+            return Task::ready(Err(anyhow!(ErrorCode::Disconnected)));
+        }
+
+        let open_image_task = self.image_store.update(cx, |image_store, cx| {
+            image_store.try_open_image(path.into(), cx)
+        });
+
+        let weak_project = cx.entity().downgrade();
+        cx.spawn(async move |_, mut cx| {
+            let Some(image_item) = open_image_task.await? else {
+                return Ok(None);
+            };
+            Self::ensure_image_metadata(image_item, weak_project, &mut cx)
+                .await
+                .map(Some)
+        })
+    }
+
+    async fn ensure_image_metadata(
+        image_item: Entity<ImageItem>,
+        weak_project: WeakEntity<Project>,
+        cx: &mut gpui::AsyncApp,
+    ) -> Result<Entity<ImageItem>> {
+        // Check if metadata already exists (e.g., for remote images)
+        let needs_metadata = cx.read_entity(&image_item, |item, _| item.image_metadata.is_none());
+
+        if needs_metadata {
+            let project = weak_project.upgrade().context("Project dropped")?;
+            let metadata = ImageItem::load_image_metadata(image_item.clone(), project, cx).await?;
+            image_item.update(cx, |image_item, cx| {
+                image_item.image_metadata = Some(metadata);
+                cx.emit(ImageItemEvent::MetadataUpdated);
+            });
+        }
+
+        Ok(image_item)
     }
 
     async fn send_buffer_ordered_messages(
@@ -6811,8 +6840,12 @@ impl ProjectItem for Buffer {
         project: &Entity<Project>,
         path: &ProjectPath,
         cx: &mut App,
-    ) -> Option<Task<Result<Entity<Self>>>> {
-        Some(project.update(cx, |project, cx| project.open_buffer(path.clone(), cx)))
+    ) -> Option<Task<Result<Option<Entity<Self>>>>> {
+        let task = project.update(cx, |project, cx| project.open_buffer(path.clone(), cx));
+        Some(cx.background_spawn(async move {
+            let buffer = task.await?;
+            Ok(Some(buffer))
+        }))
     }
 
     fn entry_id(&self, _cx: &App) -> Option<ProjectEntryId> {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1646,7 +1646,7 @@ impl project::ProjectItem for NotebookItem {
         project: &Entity<Project>,
         path: &ProjectPath,
         cx: &mut App,
-    ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+    ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
         let path = path.clone();
         let project = project.clone();
         let languages = project.read(cx).languages().clone();
@@ -1717,12 +1717,12 @@ impl project::ProjectItem for NotebookItem {
                     })
                     .context("Entry not found")?;
 
-                Ok(cx.new(|_| NotebookItem {
+                Ok(Some(cx.new(|_| NotebookItem {
                     project_path: path,
                     languages,
                     notebook,
                     id,
-                }))
+                })))
             }))
         } else {
             None
@@ -2153,7 +2153,8 @@ mod tests {
                 .expect("ipynb files should be openable as notebooks")
             })
             .await
-            .expect("notebook should parse");
+            .expect("notebook should parse")
+            .expect("notebook should be valid");
 
         // Don't render the notebook UI itself: its animated kernel status icon
         // schedules a new frame on every render, which makes `run_until_parked`
@@ -2266,7 +2267,8 @@ mod tests {
                     .expect("single-file .ipynb should open as a notebook")
             })
             .await
-            .expect("notebook should parse");
+            .expect("notebook should parse")
+            .expect("notebook should be valid");
 
         notebook_item.read_with(cx, |item, _| {
             assert_eq!(item.notebook.cells.len(), 1);
@@ -2306,7 +2308,8 @@ mod tests {
                     .expect("ipynb files should be openable as notebooks")
             })
             .await
-            .expect("notebook should parse");
+            .expect("notebook should parse")
+            .expect("notebook should be valid");
 
         // Held across the save: a save that bypasses the project writes the file
         // behind this buffer's back, leaving it stale.

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1473,7 +1473,7 @@ pub mod test {
             _project: &Entity<Project>,
             _path: &ProjectPath,
             _cx: &mut App,
-        ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+        ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
             None
         }
         fn entry_id(&self, _: &App) -> Option<ProjectEntryId> {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -9348,9 +9348,9 @@ mod tests {
                 _project: &Entity<Project>,
                 path: &ProjectPath,
                 cx: &mut App,
-            ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+            ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
                 let project_path = path.clone();
-                Some(cx.spawn(async move |cx| Ok(cx.new(|_| Self { project_path }))))
+                Some(cx.spawn(async move |cx| Ok(Some(cx.new(|_| Self { project_path })))))
             }
 
             fn entry_id(&self, _: &App) -> Option<ProjectEntryId> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -907,7 +907,7 @@ type BuildProjectItemForPathFn =
         &ProjectPath,
         &mut Window,
         &mut App,
-    ) -> Option<Task<Result<(Option<ProjectEntryId>, WorkspaceItemBuilder)>>>;
+    ) -> Option<Task<Result<Option<(Option<ProjectEntryId>, WorkspaceItemBuilder)>>>>;
 
 #[derive(Clone, Default)]
 struct ProjectItemRegistry {
@@ -944,7 +944,7 @@ impl ProjectItemRegistry {
                             entry_abs_path.as_deref().unwrap_or(&project_path.path.as_std_path())
                         )
                     }) {
-                        Ok(project_item) => {
+                        Ok(Some(project_item)) => {
                             let project_item = project_item;
                             let project_entry_id: Option<ProjectEntryId> =
                                 project_item.read_with(cx, project::ProjectItem::entry_id);
@@ -961,8 +961,9 @@ impl ProjectItemRegistry {
                                     })) as Box<dyn ItemHandle>
                                 },
                             ) as Box<_>;
-                            Ok((project_entry_id, build_workspace_item))
+                            Ok(Some((project_entry_id, build_workspace_item)))
                         }
+                        Ok(None) => Ok(None),
                         Err(e) => {
                             log::warn!("Failed to open a project item: {e:#}");
                             if e.error_code() == ErrorCode::Internal {
@@ -982,7 +983,7 @@ impl ProjectItemRegistry {
                                             },
                                         )
                                         as Box<_>;
-                                        return Ok((None, build_workspace_item));
+                                        return Ok(Some((None, build_workspace_item)));
                                     }
                                 }
                             }
@@ -1000,15 +1001,23 @@ impl ProjectItemRegistry {
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<(Option<ProjectEntryId>, WorkspaceItemBuilder)>> {
-        let Some(open_project_item) = self
-            .build_project_item_for_path_fns
-            .iter()
-            .rev()
-            .find_map(|open_project_item| open_project_item(project, path, window, cx))
-        else {
-            return Task::ready(Err(anyhow!("cannot open file {:?}", path.path)));
-        };
-        open_project_item
+        let build_fns = self.build_project_item_for_path_fns.clone();
+        let project = project.clone();
+        let path = path.clone();
+
+        window.spawn(cx, async move |cx| {
+            for build_fn in build_fns.into_iter().rev() {
+                let task = cx.update(|window, cx| build_fn(&project, &path, window, cx))?;
+                if let Some(task) = task {
+                    match task.await {
+                        Ok(Some(result)) => return Ok(result),
+                        Ok(None) => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+            Err(anyhow::anyhow!("cannot open file {:?}", path.path))
+        })
     }
 
     fn build_item<T: project::ProjectItem>(
@@ -17523,10 +17532,14 @@ mod tests {
                 _project: &Entity<Project>,
                 path: &ProjectPath,
                 cx: &mut App,
-            ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+            ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
                 if path.path.extension().unwrap() == "png" {
                     let project_path = path.clone();
-                    Some(cx.spawn(async move |cx| Ok(cx.new(|_| TestPngItem { project_path }))))
+                    Some(
+                        cx.spawn(async move |cx| {
+                            Ok(Some(cx.new(|_| TestPngItem { project_path })))
+                        }),
+                    )
                 } else {
                     None
                 }
@@ -17613,9 +17626,9 @@ mod tests {
                 _project: &Entity<Project>,
                 path: &ProjectPath,
                 cx: &mut App,
-            ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+            ) -> Option<Task<anyhow::Result<Option<Entity<Self>>>>> {
                 if path.path.extension().unwrap() == "ipynb" {
-                    Some(cx.spawn(async move |cx| Ok(cx.new(|_| TestIpynbItem {}))))
+                    Some(cx.spawn(async move |cx| Ok(Some(cx.new(|_| TestIpynbItem {})))))
                 } else {
                     None
                 }


### PR DESCRIPTION
Fixes #63449

This is a follow-up to #63455 and incorporates the maintainer feedback there.

Project item openers can now decline asynchronously without using an error as control flow. The image opener uses this when a file has an image extension but its contents aren't recognized as an image, allowing Workspace to try the next opener and fall back to the editor.

Image loading stores a mode-independent result so concurrent callers share the same image classification, while `open_image` and `try_open_image` can interpret a non-image result according to their respective semantics.

Added a regression test covering a text `test.pam` file opening in the editor.

Tested with:

* `cargo test -p image_viewer --lib`
* `cargo test -p workspace --lib register_project_item_tests`
* `cargo test -p repl --lib`
* `cargo check -p project`
* `./script/clippy -p project -p workspace -p image_viewer -p repl`
* `git diff --check`

Release Notes:

* Fixed non-image files with image extensions opening in the image viewer instead of the editor.
