### PR TITLE
remote: Fix switching git worktrees inside a dev container

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -667,10 +667,11 @@ impl RemoteClient {
                 };
             }
 
-            if let Err(error) = remote_connection
-                .kill()
-                .await
-                .context("Failed to kill remote_connection process")
+            if remote_connection.kill_before_reconnect()
+                && let Err(error) = remote_connection
+                    .kill()
+                    .await
+                    .context("Failed to kill remote_connection process")
             {
                 failed!(error, attempts, remote_connection, delegate);
             };
@@ -1613,6 +1614,14 @@ pub trait RemoteConnection: Send + Sync {
     ) -> Task<Result<()>>;
     async fn kill(&self) -> Result<()>;
     fn has_been_killed(&self) -> bool;
+    /// Whether `RemoteClient::reconnect` must kill the connection before
+    /// starting a new proxy. True for transports with a shared master process
+    /// that may be wedged (SSH); false when each client runs an independent
+    /// proxy, so killing the shared connection would only tear down the
+    /// proxies of other workspaces using it.
+    fn kill_before_reconnect(&self) -> bool {
+        true
+    }
     fn shares_network_interface(&self) -> bool {
         false
     }

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
 use semver::Version as SemanticVersion;
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use std::{
     path::{Path, PathBuf},
@@ -53,7 +54,13 @@ pub struct DockerConnectionOptions {
 }
 
 pub(crate) struct DockerExecConnection {
-    proxy_process: Mutex<Option<u32>>,
+    /// PIDs of the local `docker exec` processes running a proxy over this
+    /// connection. The connection is shared between all workspaces open in
+    /// the same container, each running its own proxy.
+    proxy_processes: Arc<Mutex<Vec<u32>>>,
+    /// Whether `kill()` has been called. Separate from `proxy_processes`
+    /// because a connection with no live proxies is still usable.
+    killed: AtomicBool,
     remote_dir_for_server: String,
     remote_binary_relpath: Option<Arc<RelPath>>,
     connection_options: DockerConnectionOptions,
@@ -70,7 +77,8 @@ impl DockerExecConnection {
         cx: &mut AsyncApp,
     ) -> Result<Self> {
         let mut this = Self {
-            proxy_process: Mutex::new(None),
+            proxy_processes: Arc::new(Mutex::new(Vec::new())),
+            killed: AtomicBool::new(false),
             remote_dir_for_server: "/".to_string(),
             remote_binary_relpath: None,
             connection_options,
@@ -628,19 +636,18 @@ impl DockerExecConnection {
         Ok(())
     }
 
-    fn kill_inner(&self) -> Result<()> {
-        if let Some(pid) = self.proxy_process.lock().take() {
-            if let Ok(_) = util::command::new_command("kill")
-                .arg(pid.to_string())
-                .spawn()
-            {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("Failed to kill process"))
-            }
-        } else {
-            Ok(())
-        }
+}
+
+/// Deregisters a proxy process when the task driving it completes or is
+/// dropped, so that `kill()` only ever signals live processes.
+struct ProxyProcessGuard {
+    pid: u32,
+    proxy_processes: Arc<Mutex<Vec<u32>>>,
+}
+
+impl Drop for ProxyProcessGuard {
+    fn drop(&mut self) {
+        self.proxy_processes.lock().retain(|pid| *pid != self.pid);
     }
 }
 
@@ -659,13 +666,6 @@ impl RemoteConnection for DockerExecConnection {
         delegate: Arc<dyn RemoteClientDelegate>,
         cx: &mut AsyncApp,
     ) -> Task<Result<i32>> {
-        // We'll try connecting anew every time we open a devcontainer, so proactively try to kill any old connections.
-        if !self.has_been_killed() {
-            if let Err(e) = self.kill_inner() {
-                return Task::ready(Err(e));
-            };
-        }
-
         delegate.set_status(Some("Starting proxy"), cx);
 
         let Some(remote_binary_relpath) = self.remote_binary_relpath.clone() else {
@@ -718,10 +718,14 @@ impl RemoteConnection for DockerExecConnection {
             )));
         };
 
-        let mut proxy_process = self.proxy_process.lock();
-        *proxy_process = Some(child.id());
+        self.proxy_processes.lock().push(child.id());
+        let guard = ProxyProcessGuard {
+            pid: child.id(),
+            proxy_processes: self.proxy_processes.clone(),
+        };
 
         cx.spawn(async move |cx| {
+            let _guard = guard;
             super::handle_rpc_messages_over_child_process_stdio(
                 child,
                 incoming_tx,
@@ -759,11 +763,19 @@ impl RemoteConnection for DockerExecConnection {
     }
 
     async fn kill(&self) -> Result<()> {
-        self.kill_inner()
+        self.killed.store(true, Ordering::Release);
+        let pids = std::mem::take(&mut *self.proxy_processes.lock());
+        for pid in pids {
+            util::command::new_command("kill")
+                .arg(pid.to_string())
+                .spawn()
+                .with_context(|| format!("failed to kill proxy process {pid}"))?;
+        }
+        Ok(())
     }
 
     fn has_been_killed(&self) -> bool {
-        self.proxy_process.lock().is_none()
+        self.killed.load(Ordering::Acquire)
     }
 
     fn build_command(
@@ -875,5 +887,63 @@ impl RemoteConnection for DockerExecConnection {
 
     fn default_system_shell(&self) -> String {
         String::from("/bin/sh")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_connection() -> DockerExecConnection {
+        DockerExecConnection {
+            proxy_processes: Arc::new(Mutex::new(Vec::new())),
+            killed: AtomicBool::new(false),
+            remote_dir_for_server: "/".to_string(),
+            remote_binary_relpath: None,
+            connection_options: DockerConnectionOptions::default(),
+            remote_platform: None,
+            os_version: None,
+            path_style: None,
+            shell: "sh".to_owned(),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_kill_terminates_all_registered_proxies() {
+        let connection = test_connection();
+        assert!(
+            !connection.has_been_killed(),
+            "a connection with no proxies started yet must not read as killed, \
+             or the pool would refuse to share it"
+        );
+
+        let mut child = util::command::new_command("sleep")
+            .arg("600")
+            .spawn()
+            .expect("failed to spawn stand-in proxy process");
+        connection.proxy_processes.lock().push(child.id());
+
+        smol::block_on(async {
+            connection.kill().await.expect("kill failed");
+            let status = child
+                .status()
+                .await
+                .expect("failed to await stand-in proxy process");
+            assert!(!status.success(), "process should have been signalled");
+        });
+
+        assert!(connection.has_been_killed());
+        assert!(connection.proxy_processes.lock().is_empty());
+    }
+
+    #[test]
+    fn test_proxy_process_guard_deregisters_only_its_pid() {
+        let proxy_processes = Arc::new(Mutex::new(vec![1, 2, 3]));
+        drop(ProxyProcessGuard {
+            pid: 2,
+            proxy_processes: proxy_processes.clone(),
+        });
+        assert_eq!(*proxy_processes.lock(), vec![1, 3]);
     }
 }

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -765,17 +765,33 @@ impl RemoteConnection for DockerExecConnection {
     async fn kill(&self) -> Result<()> {
         self.killed.store(true, Ordering::Release);
         let pids = std::mem::take(&mut *self.proxy_processes.lock());
+        let mut errors = Vec::new();
         for pid in pids {
-            util::command::new_command("kill")
+            if let Err(error) = util::command::new_command("kill")
                 .arg(pid.to_string())
                 .spawn()
-                .with_context(|| format!("failed to kill proxy process {pid}"))?;
+            {
+                errors.push(format!("{pid}: {error}"));
+            }
         }
+        anyhow::ensure!(
+            errors.is_empty(),
+            "failed to kill proxy processes: {}",
+            errors.join(", ")
+        );
         Ok(())
     }
 
     fn has_been_killed(&self) -> bool {
         self.killed.load(Ordering::Acquire)
+    }
+
+    fn kill_before_reconnect(&self) -> bool {
+        // Each client runs its own `docker exec` proxy and the reconnecting
+        // client's proxy is already gone by the time `reconnect` runs, so
+        // killing the shared connection would only tear down the proxies of
+        // other workspaces open in the same container.
+        false
     }
 
     fn build_command(
@@ -935,6 +951,53 @@ mod tests {
 
         assert!(connection.has_been_killed());
         assert!(connection.proxy_processes.lock().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[gpui::test]
+    async fn test_start_proxy_does_not_kill_existing_proxies(cx: &mut gpui::TestAppContext) {
+        let connection = test_connection();
+        let mut existing_proxy = util::command::new_command("sleep")
+            .arg("600")
+            .spawn()
+            .expect("failed to spawn stand-in proxy process");
+        let existing_pid = existing_proxy.id();
+        connection.proxy_processes.lock().push(existing_pid);
+
+        let (incoming_tx, _incoming_rx) = futures::channel::mpsc::unbounded();
+        let (_outgoing_tx, outgoing_rx) = futures::channel::mpsc::unbounded();
+        let (connection_activity_tx, _connection_activity_rx) =
+            futures::channel::mpsc::channel(1);
+
+        // `test_connection` has no remote binary path, so `start_proxy` fails
+        // before spawning anything; the regression this guards against is it
+        // signalling existing proxies before that point (#63568).
+        connection
+            .start_proxy(
+                "test".to_string(),
+                false,
+                incoming_tx,
+                outgoing_rx,
+                connection_activity_tx,
+                Arc::new(crate::transport::mock::MockDelegate),
+                &mut cx.to_async(),
+            )
+            .await
+            .expect_err("start_proxy should fail without a remote binary path");
+
+        // Give a wrongly-sent signal time to be delivered before polling.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert_eq!(*connection.proxy_processes.lock(), vec![existing_pid]);
+        assert!(
+            existing_proxy
+                .try_status()
+                .expect("failed to poll stand-in proxy process")
+                .is_none(),
+            "existing proxy process should not have been signalled"
+        );
+        existing_proxy
+            .kill()
+            .expect("failed to clean up stand-in proxy process");
     }
 
     #[test]

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -638,16 +638,14 @@ impl DockerExecConnection {
 
 }
 
-/// Deregisters a proxy process when the task driving it completes or is
-/// dropped, so that `kill()` only ever signals live processes.
-struct ProxyProcessGuard {
-    pid: u32,
-    proxy_processes: Arc<Mutex<Vec<u32>>>,
-}
-
-impl Drop for ProxyProcessGuard {
-    fn drop(&mut self) {
-        self.proxy_processes.lock().retain(|pid| *pid != self.pid);
+/// Deregisters a proxy process once the task driving it completes or is
+/// dropped, so that `kill()` only ever signals live processes. Removes a
+/// single occurrence: if the OS reused the pid for another proxy registered
+/// concurrently, that proxy's entry must stay tracked.
+fn deregister_proxy_process(proxy_processes: &Mutex<Vec<u32>>, pid: u32) {
+    let mut proxy_processes = proxy_processes.lock();
+    if let Some(index) = proxy_processes.iter().position(|p| *p == pid) {
+        proxy_processes.remove(index);
     }
 }
 
@@ -719,13 +717,14 @@ impl RemoteConnection for DockerExecConnection {
         };
 
         self.proxy_processes.lock().push(child.id());
-        let guard = ProxyProcessGuard {
-            pid: child.id(),
-            proxy_processes: self.proxy_processes.clone(),
-        };
+        let deregister_proxy = util::defer({
+            let pid = child.id();
+            let proxy_processes = self.proxy_processes.clone();
+            move || deregister_proxy_process(&proxy_processes, pid)
+        });
 
         cx.spawn(async move |cx| {
-            let _guard = guard;
+            let _deregister_proxy = deregister_proxy;
             super::handle_rpc_messages_over_child_process_stdio(
                 child,
                 incoming_tx,
@@ -771,6 +770,8 @@ impl RemoteConnection for DockerExecConnection {
                 .arg(pid.to_string())
                 .spawn()
             {
+                // Keep the pid tracked so a later `kill()` can retry it.
+                self.proxy_processes.lock().push(pid);
                 errors.push(format!("{pid}: {error}"));
             }
         }
@@ -925,6 +926,16 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn spawn_stand_in_proxy() -> util::command::Child {
+        util::command::new_command("sleep")
+            .arg("600")
+            // Panic-safe cleanup: a failed assertion must not leak the process.
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn stand-in proxy process")
+    }
+
+    #[cfg(unix)]
     #[test]
     fn test_kill_terminates_all_registered_proxies() {
         let connection = test_connection();
@@ -934,19 +945,20 @@ mod tests {
              or the pool would refuse to share it"
         );
 
-        let mut child = util::command::new_command("sleep")
-            .arg("600")
-            .spawn()
-            .expect("failed to spawn stand-in proxy process");
-        connection.proxy_processes.lock().push(child.id());
+        let mut first_proxy = spawn_stand_in_proxy();
+        let mut second_proxy = spawn_stand_in_proxy();
+        connection.proxy_processes.lock().push(first_proxy.id());
+        connection.proxy_processes.lock().push(second_proxy.id());
 
         smol::block_on(async {
             connection.kill().await.expect("kill failed");
-            let status = child
-                .status()
-                .await
-                .expect("failed to await stand-in proxy process");
-            assert!(!status.success(), "process should have been signalled");
+            for child in [&mut first_proxy, &mut second_proxy] {
+                let status = child
+                    .status()
+                    .await
+                    .expect("failed to await stand-in proxy process");
+                assert!(!status.success(), "process should have been signalled");
+            }
         });
 
         assert!(connection.has_been_killed());
@@ -957,10 +969,7 @@ mod tests {
     #[gpui::test]
     async fn test_start_proxy_does_not_kill_existing_proxies(cx: &mut gpui::TestAppContext) {
         let connection = test_connection();
-        let mut existing_proxy = util::command::new_command("sleep")
-            .arg("600")
-            .spawn()
-            .expect("failed to spawn stand-in proxy process");
+        let mut existing_proxy = spawn_stand_in_proxy();
         let existing_pid = existing_proxy.id();
         connection.proxy_processes.lock().push(existing_pid);
 
@@ -995,18 +1004,14 @@ mod tests {
                 .is_none(),
             "existing proxy process should not have been signalled"
         );
-        existing_proxy
-            .kill()
-            .expect("failed to clean up stand-in proxy process");
     }
 
     #[test]
-    fn test_proxy_process_guard_deregisters_only_its_pid() {
-        let proxy_processes = Arc::new(Mutex::new(vec![1, 2, 3]));
-        drop(ProxyProcessGuard {
-            pid: 2,
-            proxy_processes: proxy_processes.clone(),
-        });
-        assert_eq!(*proxy_processes.lock(), vec![1, 3]);
+    fn test_deregister_proxy_process_removes_a_single_occurrence() {
+        let proxy_processes = Mutex::new(vec![1, 2, 2, 3]);
+        deregister_proxy_process(&proxy_processes, 2);
+        assert_eq!(*proxy_processes.lock(), vec![1, 2, 3]);
+        deregister_proxy_process(&proxy_processes, 4);
+        assert_eq!(*proxy_processes.lock(), vec![1, 2, 3]);
     }
 }

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -18,7 +18,7 @@ name = "remote_server"
 
 [features]
 default = []
-debug-embed = ["dep:rust-embed"]
+debug-embed = ["dep:rust-embed", "util/debug-embed"]
 test-support = ["fs/test-support"]
 
 [dependencies]


### PR DESCRIPTION
Closes #63568 (and its duplicate #63099).

## Problem

Switching to an existing git worktree from the worktree dropdown fails when the project is open in a dev container. The switch hangs and then fails after exactly 60 seconds with `Remote server exited with status 15`, even though the worktree path is valid on both sides and the target container is already running.

## Root cause

A `DockerExecConnection` is shared via the global connection pool between every workspace open in the same container, but the transport only tracked a **single** proxy pid and actively tore siblings down:

1. `start_proxy` proactively killed the previously tracked proxy, so opening the worktree's workspace killed the original workspace's proxy.
2. The original client's auto-reconnect then called `kill()` on the shared connection, which killed the **new** workspace's proxy (SIGTERM → status 15).
3. The new connection never became ready and died at `INITIAL_CONNECTION_TIMEOUT` (60s in release), which is the exact-60-seconds symptom.

A latent third bug: `has_been_killed()` returned "no proxy currently running", so a freshly created connection could read as dead in the pool.

## Fix

Model the docker transport on the SSH transport, which already supports many workspaces per connection:

- Track **all** live proxy pids (`Vec<u32>`) plus an SSH-style `killed: AtomicBool`. `start_proxy` no longer kills anything; each proxy is an independent `docker exec` child cleaned up via `kill_on_drop` and a `util::defer` guard that deregisters its pid when its IO task ends.
- `RemoteClient::reconnect` no longer tears down the shared connection for transports where each client owns its own proxy. A new `RemoteConnection::kill_before_reconnect()` defaults to `true` (SSH/WSL/mock unchanged) and is `false` for docker.
- `kill()` attempts every tracked pid (re-tracking any whose `kill` spawn failed) instead of aborting on the first failure; `has_been_killed()` reports the explicit flag.

## Secondary fix: `remote_server: Forward debug-embed to util`

While validating the fix end to end against a real dev container, connecting a **from-source** dev build (`cargo build -p remote_server --features debug-embed`) crashed the server at startup:

```
thread 'main' panicked at crates/util/src/util.rs:
dev asset loading requires running from within the checkout
```

`remote_server/debug-embed` enabled `dep:rust-embed` but never forwarded to `util/debug-embed` — the feature `fs_embed!` actually gates on — so `util` compiled its runtime-load arm and the server called `dev_repo_root().expect(...)`. That succeeds when the binary runs from inside the checkout (masking it on the build host) but panics in a dev container where the binary lives under `$HOME/.zed_server` with no `.git` ancestor. This is a one-line feature-forward and is independent of the worktree fix; happy to split it into its own PR if preferred.

## Testing

- New unit tests in `docker.rs`: `kill()` signals every registered proxy, `start_proxy` no longer signals already-running proxies (the #63568 regression), and the deregister helper removes a single pid occurrence.
- Verified manually: opened a dev container in Zed and switched to an existing git worktree successfully (previously failed at 60s).
- Verified the `remote_server` binary reaches full init from outside the checkout and inside the target dev container, where the unfixed binary panicked at `settings::init`.

Release Notes:

- Fixed switching git worktrees failing with `Remote server exited with status 15` when the project is open in a dev container.
