### PR TITLE
ui: Allow hiding keybinding labels

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use gpui::{
     Action, Anchor, AnyElement, App, Bounds, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, Role,
-    Size, Subscription, TaskExt, anchored, canvas, prelude::*, px, relative,
+    Focusable, Global, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
+    Role, Size, Subscription, TaskExt, anchored, canvas, prelude::*, px, relative,
 };
 use menu::{SelectChild, SelectFirst, SelectLast, SelectNext, SelectParent, SelectPrevious};
 use std::{
@@ -209,6 +209,10 @@ impl From<ContextMenuEntry> for ContextMenuItem {
     }
 }
 
+struct ContextMenuKeybindingLabelVisibility(bool);
+
+impl Global for ContextMenuKeybindingLabelVisibility {}
+
 pub struct ContextMenu {
     builder: Option<Rc<dyn Fn(Self, &mut Window, &mut Context<Self>) -> Self>>,
     items: Vec<ContextMenuItem>,
@@ -270,6 +274,20 @@ impl EventEmitter<DismissEvent> for ContextMenu {}
 impl FluentBuilder for ContextMenu {}
 
 impl ContextMenu {
+    /// Sets whether context menus render visible keybinding labels.
+    ///
+    /// Registered keybindings and their accessibility metadata remain available
+    /// when labels are hidden.
+    pub fn set_keybinding_labels_visible(cx: &mut App, visible: bool) {
+        cx.set_global(ContextMenuKeybindingLabelVisibility(visible));
+        cx.refresh_windows();
+    }
+
+    fn keybinding_labels_visible(cx: &App) -> bool {
+        cx.try_global::<ContextMenuKeybindingLabelVisibility>()
+            .map_or(true, |visibility| visibility.0)
+    }
+
     pub fn new(
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -1461,6 +1479,7 @@ impl ContextMenu {
         &self,
         ix: usize,
         item: &ContextMenuItem,
+        keybinding_labels_visible: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
@@ -1499,7 +1518,14 @@ impl ContextMenu {
                 .child(Label::new(label.clone()))
                 .into_any_element(),
             ContextMenuItem::Entry(entry) => self
-                .render_menu_entry(ix, entry, is_active_descendant(true), window, cx)
+                .render_menu_entry(
+                    ix,
+                    entry,
+                    is_active_descendant(true),
+                    keybinding_labels_visible,
+                    window,
+                    cx,
+                )
                 .into_any_element(),
             ContextMenuItem::CustomEntry {
                 entry_render,
@@ -1818,6 +1844,7 @@ impl ContextMenu {
         ix: usize,
         entry: &ContextMenuEntry,
         is_active_descendant: bool,
+        keybinding_labels_visible: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
@@ -2079,20 +2106,22 @@ impl ContextMenu {
                             .justify_between()
                             .child(label_element)
                             .debug_selector(|| format!("MENU_ITEM-{}", label))
-                            .children(action.as_ref().map(|action| {
-                                let binding = self
-                                    .action_context
-                                    .as_ref()
-                                    .map(|focus| KeyBinding::for_action_in(&**action, focus, cx))
-                                    .unwrap_or_else(|| KeyBinding::for_action(&**action, cx));
+                            .when(keybinding_labels_visible, |parent| {
+                                parent.children(action.as_ref().map(|action| {
+                                    let binding = self
+                                        .action_context
+                                        .as_ref()
+                                        .map(|focus| {
+                                            KeyBinding::for_action_in(&**action, focus, cx)
+                                        })
+                                        .unwrap_or_else(|| KeyBinding::for_action(&**action, cx));
 
-                                div()
-                                    .ml_4()
-                                    .child(binding.disabled(*disabled))
-                                    .when(*disabled && documentation_aside.is_some(), |parent| {
-                                        parent.invisible()
-                                    })
-                            }))
+                                    div().ml_4().child(binding.disabled(*disabled)).when(
+                                        *disabled && documentation_aside.is_some(),
+                                        |parent| parent.invisible(),
+                                    )
+                                }))
+                            })
                             .when(*disabled && documentation_aside.is_some(), |parent| {
                                 parent.child(
                                     Icon::new(IconName::Info)
@@ -2195,6 +2224,7 @@ impl Render for ContextMenu {
         let theme_settings = theme::theme_settings(cx);
         let ui_font_size = theme_settings.ui_font_size(cx);
         let ui_font_family = theme_settings.ui_font(cx).family.clone();
+        let keybinding_labels_visible = Self::keybinding_labels_visible(cx);
         // Menus can be deferred from inside elements that override the text
         // style (e.g. the editor with a custom `buffer_line_height`), so always
         // apply the default line height to render the same everywhere.
@@ -2360,14 +2390,17 @@ impl Render for ContextMenu {
                             }
                             el
                         })
-                        .child(
-                            List::new().children(
-                                self.items
-                                    .iter()
-                                    .enumerate()
-                                    .map(|(ix, item)| self.render_menu_item(ix, item, window, cx)),
-                            ),
-                        ),
+                        .child(List::new().children(self.items.iter().enumerate().map(
+                            |(ix, item)| {
+                                self.render_menu_item(
+                                    ix,
+                                    item,
+                                    keybinding_labels_visible,
+                                    window,
+                                    cx,
+                                )
+                            },
+                        ))),
                 )
         };
 
@@ -2443,6 +2476,69 @@ mod tests {
     use gpui::TestAppContext;
 
     use super::*;
+
+    #[gpui::test]
+    fn can_hide_keybinding_labels_without_disabling_bindings(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            cx.bind_keys([
+                gpui::KeyBinding::new("ctrl-r", RootAction, None),
+                gpui::KeyBinding::new("ctrl-n", NestedAction, None),
+            ]);
+        });
+
+        let (context_menu, cx) = cx.add_window_view(|window, cx| {
+            ContextMenu::new(window, cx, |menu, _, _| {
+                menu.action("Root action", Box::new(RootAction))
+                    .submenu("Submenu", |menu, _, _| {
+                        menu.action("Nested action", Box::new(NestedAction))
+                    })
+            })
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("KEY_BINDING-r").is_some(),
+            "context menus should show keybinding labels by default"
+        );
+
+        cx.update(|_, cx| ContextMenu::set_keybinding_labels_visible(cx, false));
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("KEY_BINDING-r").is_none(),
+            "the context menu should omit its keybinding label"
+        );
+        assert!(
+            cx.update(|window, _| {
+                window
+                    .highest_precedence_binding_for_action(&RootAction)
+                    .is_some()
+            }),
+            "hiding labels should not unregister their keybindings"
+        );
+
+        context_menu.update_in(cx, |context_menu, window, cx| {
+            context_menu.selected_index = Some(1);
+            context_menu.confirm(&menu::Confirm, window, cx);
+        });
+        // One frame measures the trigger and menu bounds; the next positions the submenu.
+        for _ in 0..2 {
+            cx.update(|window, _| window.refresh());
+            cx.run_until_parked();
+        }
+
+        assert!(
+            cx.debug_bounds("MENU_ITEM-Nested action").is_some(),
+            "the submenu should be open"
+        );
+        assert!(
+            cx.debug_bounds("KEY_BINDING-n").is_none(),
+            "submenus should inherit the application label visibility"
+        );
+    }
 
     #[gpui::test]
     fn can_navigate_back_over_headers(cx: &mut TestAppContext) {
@@ -2531,4 +2627,6 @@ mod tests {
             );
         });
     }
+
+    gpui::actions!(context_menu_tests, [RootAction, NestedAction]);
 }

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use gpui::{
     Action, Anchor, AnyElement, App, Bounds, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, Global, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
-    Role, Size, Subscription, TaskExt, anchored, canvas, prelude::*, px, relative,
+    Focusable, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, Role,
+    Size, Subscription, TaskExt, anchored, canvas, prelude::*, px, relative,
 };
 use menu::{SelectChild, SelectFirst, SelectLast, SelectNext, SelectParent, SelectPrevious};
 use std::{
@@ -209,10 +209,6 @@ impl From<ContextMenuEntry> for ContextMenuItem {
     }
 }
 
-struct ContextMenuKeybindingLabelVisibility(bool);
-
-impl Global for ContextMenuKeybindingLabelVisibility {}
-
 pub struct ContextMenu {
     builder: Option<Rc<dyn Fn(Self, &mut Window, &mut Context<Self>) -> Self>>,
     items: Vec<ContextMenuItem>,
@@ -274,20 +270,6 @@ impl EventEmitter<DismissEvent> for ContextMenu {}
 impl FluentBuilder for ContextMenu {}
 
 impl ContextMenu {
-    /// Sets whether context menus render visible keybinding labels.
-    ///
-    /// Registered keybindings and their accessibility metadata remain available
-    /// when labels are hidden.
-    pub fn set_keybinding_labels_visible(cx: &mut App, visible: bool) {
-        cx.set_global(ContextMenuKeybindingLabelVisibility(visible));
-        cx.refresh_windows();
-    }
-
-    fn keybinding_labels_visible(cx: &App) -> bool {
-        cx.try_global::<ContextMenuKeybindingLabelVisibility>()
-            .map_or(true, |visibility| visibility.0)
-    }
-
     pub fn new(
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -1479,7 +1461,6 @@ impl ContextMenu {
         &self,
         ix: usize,
         item: &ContextMenuItem,
-        keybinding_labels_visible: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
@@ -1518,14 +1499,7 @@ impl ContextMenu {
                 .child(Label::new(label.clone()))
                 .into_any_element(),
             ContextMenuItem::Entry(entry) => self
-                .render_menu_entry(
-                    ix,
-                    entry,
-                    is_active_descendant(true),
-                    keybinding_labels_visible,
-                    window,
-                    cx,
-                )
+                .render_menu_entry(ix, entry, is_active_descendant(true), window, cx)
                 .into_any_element(),
             ContextMenuItem::CustomEntry {
                 entry_render,
@@ -1844,7 +1818,6 @@ impl ContextMenu {
         ix: usize,
         entry: &ContextMenuEntry,
         is_active_descendant: bool,
-        keybinding_labels_visible: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
@@ -2106,22 +2079,20 @@ impl ContextMenu {
                             .justify_between()
                             .child(label_element)
                             .debug_selector(|| format!("MENU_ITEM-{}", label))
-                            .when(keybinding_labels_visible, |parent| {
-                                parent.children(action.as_ref().map(|action| {
-                                    let binding = self
-                                        .action_context
-                                        .as_ref()
-                                        .map(|focus| {
-                                            KeyBinding::for_action_in(&**action, focus, cx)
-                                        })
-                                        .unwrap_or_else(|| KeyBinding::for_action(&**action, cx));
+                            .children(action.as_ref().map(|action| {
+                                let binding = self
+                                    .action_context
+                                    .as_ref()
+                                    .map(|focus| KeyBinding::for_action_in(&**action, focus, cx))
+                                    .unwrap_or_else(|| KeyBinding::for_action(&**action, cx));
 
-                                    div().ml_4().child(binding.disabled(*disabled)).when(
-                                        *disabled && documentation_aside.is_some(),
-                                        |parent| parent.invisible(),
-                                    )
-                                }))
-                            })
+                                div()
+                                    .ml_4()
+                                    .child(binding.disabled(*disabled))
+                                    .when(*disabled && documentation_aside.is_some(), |parent| {
+                                        parent.invisible()
+                                    })
+                            }))
                             .when(*disabled && documentation_aside.is_some(), |parent| {
                                 parent.child(
                                     Icon::new(IconName::Info)
@@ -2224,7 +2195,6 @@ impl Render for ContextMenu {
         let theme_settings = theme::theme_settings(cx);
         let ui_font_size = theme_settings.ui_font_size(cx);
         let ui_font_family = theme_settings.ui_font(cx).family.clone();
-        let keybinding_labels_visible = Self::keybinding_labels_visible(cx);
         // Menus can be deferred from inside elements that override the text
         // style (e.g. the editor with a custom `buffer_line_height`), so always
         // apply the default line height to render the same everywhere.
@@ -2390,17 +2360,14 @@ impl Render for ContextMenu {
                             }
                             el
                         })
-                        .child(List::new().children(self.items.iter().enumerate().map(
-                            |(ix, item)| {
-                                self.render_menu_item(
-                                    ix,
-                                    item,
-                                    keybinding_labels_visible,
-                                    window,
-                                    cx,
-                                )
-                            },
-                        ))),
+                        .child(
+                            List::new().children(
+                                self.items
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(ix, item)| self.render_menu_item(ix, item, window, cx)),
+                            ),
+                        ),
                 )
         };
 
@@ -2476,69 +2443,6 @@ mod tests {
     use gpui::TestAppContext;
 
     use super::*;
-
-    #[gpui::test]
-    fn can_hide_keybinding_labels_without_disabling_bindings(cx: &mut TestAppContext) {
-        cx.update(|cx| {
-            let settings_store = settings::SettingsStore::test(cx);
-            cx.set_global(settings_store);
-            theme_settings::init(theme::LoadThemes::JustBase, cx);
-            cx.bind_keys([
-                gpui::KeyBinding::new("ctrl-r", RootAction, None),
-                gpui::KeyBinding::new("ctrl-n", NestedAction, None),
-            ]);
-        });
-
-        let (context_menu, cx) = cx.add_window_view(|window, cx| {
-            ContextMenu::new(window, cx, |menu, _, _| {
-                menu.action("Root action", Box::new(RootAction))
-                    .submenu("Submenu", |menu, _, _| {
-                        menu.action("Nested action", Box::new(NestedAction))
-                    })
-            })
-        });
-        cx.run_until_parked();
-
-        assert!(
-            cx.debug_bounds("KEY_BINDING-r").is_some(),
-            "context menus should show keybinding labels by default"
-        );
-
-        cx.update(|_, cx| ContextMenu::set_keybinding_labels_visible(cx, false));
-        cx.run_until_parked();
-
-        assert!(
-            cx.debug_bounds("KEY_BINDING-r").is_none(),
-            "the context menu should omit its keybinding label"
-        );
-        assert!(
-            cx.update(|window, _| {
-                window
-                    .highest_precedence_binding_for_action(&RootAction)
-                    .is_some()
-            }),
-            "hiding labels should not unregister their keybindings"
-        );
-
-        context_menu.update_in(cx, |context_menu, window, cx| {
-            context_menu.selected_index = Some(1);
-            context_menu.confirm(&menu::Confirm, window, cx);
-        });
-        // One frame measures the trigger and menu bounds; the next positions the submenu.
-        for _ in 0..2 {
-            cx.update(|window, _| window.refresh());
-            cx.run_until_parked();
-        }
-
-        assert!(
-            cx.debug_bounds("MENU_ITEM-Nested action").is_some(),
-            "the submenu should be open"
-        );
-        assert!(
-            cx.debug_bounds("KEY_BINDING-n").is_none(),
-            "submenus should inherit the application label visibility"
-        );
-    }
 
     #[gpui::test]
     fn can_navigate_back_over_headers(cx: &mut TestAppContext) {
@@ -2627,6 +2531,4 @@ mod tests {
             );
         });
     }
-
-    gpui::actions!(context_menu_tests, [RootAction, NestedAction]);
 }

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -60,6 +60,12 @@ impl Global for VimStyle {}
 struct KeyBindingVisibility(bool);
 impl Global for KeyBindingVisibility {}
 
+impl Default for KeyBindingVisibility {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
 impl KeyBinding {
     /// Returns the highest precedence keybinding for an action. This is the last binding added to
     /// the keymap. User bindings are added after built-in bindings so that they take precedence.
@@ -98,9 +104,8 @@ impl KeyBinding {
         cx.refresh_windows();
     }
 
-    fn default_visibility(cx: &App) -> bool {
-        cx.try_global::<KeyBindingVisibility>()
-            .map_or(true, |visibility| visibility.0)
+    fn default_visibility(cx: &mut App) -> bool {
+        cx.default_global::<KeyBindingVisibility>().0
     }
 
     pub fn new(action: &dyn Action, focus_handle: Option<FocusHandle>, cx: &App) -> Self {

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -52,7 +52,6 @@ pub struct KeyBinding {
     vim_mode: bool,
     /// Indicates whether the keybinding is currently disabled.
     disabled: bool,
-    visible: Option<bool>,
 }
 
 struct VimStyle(bool);
@@ -93,8 +92,7 @@ impl KeyBinding {
         cx.try_global::<VimStyle>().is_some_and(|g| g.0)
     }
 
-    /// Sets the visibility inherited by keybindings without a per-instance
-    /// override.
+    /// Sets the application-wide visibility of keybindings.
     pub fn set_default_visibility(cx: &mut App, visible: bool) {
         cx.set_global(KeyBindingVisibility(visible));
         cx.refresh_windows();
@@ -115,7 +113,6 @@ impl KeyBinding {
             vim_mode: KeyBinding::is_vim_mode(cx),
             platform_style: PlatformStyle::platform(),
             disabled: false,
-            visible: None,
         }
     }
 
@@ -126,7 +123,6 @@ impl KeyBinding {
             vim_mode,
             platform_style: PlatformStyle::platform(),
             disabled: false,
-            visible: None,
         }
     }
 
@@ -146,12 +142,6 @@ impl KeyBinding {
     /// Disabled keybinds will be rendered in a dimmed state.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
-        self
-    }
-
-    /// Sets whether this keybinding is rendered.
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
         self
     }
 
@@ -223,7 +213,7 @@ fn render_key(
 
 impl RenderOnce for KeyBinding {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        if !self.visible.unwrap_or_else(|| Self::default_visibility(cx)) {
+        if !Self::default_visibility(cx) {
             return gpui::Empty.into_any_element();
         }
 

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -52,10 +52,14 @@ pub struct KeyBinding {
     vim_mode: bool,
     /// Indicates whether the keybinding is currently disabled.
     disabled: bool,
+    visible: Option<bool>,
 }
 
 struct VimStyle(bool);
 impl Global for VimStyle {}
+
+struct KeyBindingVisibility(bool);
+impl Global for KeyBindingVisibility {}
 
 impl KeyBinding {
     /// Returns the highest precedence keybinding for an action. This is the last binding added to
@@ -89,6 +93,18 @@ impl KeyBinding {
         cx.try_global::<VimStyle>().is_some_and(|g| g.0)
     }
 
+    /// Sets the visibility inherited by keybindings without a per-instance
+    /// override.
+    pub fn set_default_visibility(cx: &mut App, visible: bool) {
+        cx.set_global(KeyBindingVisibility(visible));
+        cx.refresh_windows();
+    }
+
+    fn default_visibility(cx: &App) -> bool {
+        cx.try_global::<KeyBindingVisibility>()
+            .map_or(true, |visibility| visibility.0)
+    }
+
     pub fn new(action: &dyn Action, focus_handle: Option<FocusHandle>, cx: &App) -> Self {
         Self {
             source: Source::Action {
@@ -99,6 +115,7 @@ impl KeyBinding {
             vim_mode: KeyBinding::is_vim_mode(cx),
             platform_style: PlatformStyle::platform(),
             disabled: false,
+            visible: None,
         }
     }
 
@@ -109,6 +126,7 @@ impl KeyBinding {
             vim_mode,
             platform_style: PlatformStyle::platform(),
             disabled: false,
+            visible: None,
         }
     }
 
@@ -128,6 +146,12 @@ impl KeyBinding {
     /// Disabled keybinds will be rendered in a dimmed state.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// Sets whether this keybinding is rendered.
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.visible = Some(visible);
         self
     }
 
@@ -199,6 +223,10 @@ fn render_key(
 
 impl RenderOnce for KeyBinding {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        if !self.visible.unwrap_or_else(|| Self::default_visibility(cx)) {
+            return gpui::Empty.into_any_element();
+        }
+
         let render_keybinding = |keystrokes: &[KeybindingKeystroke]| {
             let color = self.disabled.then_some(Color::Disabled);
 


### PR DESCRIPTION
`KeyBinding` elements currently always render their shortcut labels. Applications with a touch-oriented interface cannot remove those keyboard-only visual affordances without changing each consumer or unregistering the shortcuts themselves.

This adds an application-wide visibility policy to the reusable `KeyBinding` component, so context menus and other consumers follow the same setting. Registered keybindings and `aria-keyshortcuts` remain intact, and labels remain visible by default.

## Testing

- `cargo nextest run -p ui --lib`
- `cargo fmt --check`
- The final unused-override cleanup was not rerun because `nix develop` currently fails while building the existing `zed-editor-deps` derivation: `corgi-patches/scratch/Cargo.toml` is absent from its Nix source.

Release Notes:

- N/A
