### PR TITLE
remote_servers: Dismiss picker on Open Folder click

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1198,6 +1198,7 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                 let Some(server_entry) = self.state.servers.get(*server) else {
                     return;
                 };
+                cx.emit(DismissEvent);
                 match server_entry {
                     RemoteEntry::Project {
                         connection, index, ..


### PR DESCRIPTION
# Objective

- Clicking "Open folder" on a remote server entry in the remote projects picker did not close the picker itself. The picker was staying underneath the new opened modal for folder/project picker. 

## Solution

- Emit `DismissEvent` immediately when `RemoteMatch::OpenFolder`  is confirmed. This mirrors the existing pattern in `open_remote_project_entry` which already dismisses immediately before proceeding with the async connect flow. 

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Fixed the remote projects picker not closing when opening a folder on a remote server
