### PR TITLE
nix: Include corgi patches in build sources

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -67,6 +67,7 @@ let
       relPath = lib.removePrefix root path;
       topLevelIncludes = [
         "crates"
+        "corgi-patches"
         "assets"
         "extensions"
         "script"
@@ -79,6 +80,10 @@ let
     in
     builtins.elem firstComp topLevelIncludes;
 
+  corgiPatches = builtins.path {
+    path = ../corgi-patches;
+    name = "corgi-patches";
+  };
   craneLib = crane.overrideToolchain rustToolchain;
   gpu-lib = if withGLES then libglvnd else vulkan-loader;
   commonArgs =
@@ -305,7 +310,20 @@ let
             drv;
       };
     };
-  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  cargoArtifacts = craneLib.buildDepsOnly (
+    builtins.removeAttrs commonArgs [ "src" ]
+    // {
+      dummySrc = craneLib.mkDummySrc {
+        inherit (commonArgs) src cargoLock;
+        # `scratch` is a local dependency of `cxx-build`, so its API is needed
+        # while Crane builds third-party dependencies.
+        extraDummyScript = ''
+          rm -rf $out/corgi-patches
+          cp --recursive ${corgiPatches} $out/corgi-patches
+        '';
+      };
+    }
+  );
 in
 craneLib.buildPackage (
   lib.recursiveUpdate commonArgs {


### PR DESCRIPTION
The local `scratch` override lives under `corgi-patches`, but the Nix build source filter omitted that directory. As a result, `nix develop` failed while loading the patched dependency.

Include `corgi-patches` in the filtered source and preserve the patch implementation in Crane's dummy dependency source. The latter is required because `cxx-build` calls `scratch::path` while dependency artifacts are built.

## Testing

- `nix fmt -- --ci nix/build.nix`
- `nix develop --command true`
- `nix develop --command cargo fmt --check`

Release Notes:

- N/A
