### PR TITLE
agent_skills: Count description limit in characters, not bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -64,7 +64,7 @@ impl SkillLoadWarning {
                 actual_len,
                 max_len,
             } => format!(
-                "Skill description is {actual_len} bytes, exceeding the {max_len}-byte limit. The skill was loaded, but long descriptions may consume more model-context tokens."
+                "Skill description is {actual_len} characters, exceeding the {max_len}-character limit. The skill was loaded, but long descriptions may consume more model-context tokens."
             ),
         }
     }
@@ -330,9 +330,10 @@ fn validate_description_for_loading(
     }
 
     let mut warnings = Vec::new();
-    if description.len() > MAX_SKILL_DESCRIPTION_LEN {
+    let actual_len = description.chars().count();
+    if actual_len > MAX_SKILL_DESCRIPTION_LEN {
         warnings.push(SkillLoadWarning::DescriptionTooLong {
-            actual_len: description.len(),
+            actual_len,
             max_len: MAX_SKILL_DESCRIPTION_LEN,
         });
     }
@@ -416,13 +417,10 @@ fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
 /// by [`validate_name`].
 pub const MAX_SKILL_NAME_LEN: usize = 64;
 
-/// Maximum recommended length (in bytes) for a skill description. The
-/// create-skill UI enforces this as a hard limit, while the loader emits a
-/// warning and still loads longer descriptions.
-///
-/// Byte-based rather than char-based because that's what `.len()` returns
-/// and what every caller currently measures; the UI also surfaces this
-/// limit as a byte count so the editor's counter matches the validator.
+/// Maximum recommended length (in characters, as the Agent Skills
+/// specification measures it) for a skill description. The create-skill UI
+/// enforces this as a hard limit, while the loader emits a warning and still
+/// loads longer descriptions.
 pub const MAX_SKILL_DESCRIPTION_LEN: usize = 1024;
 
 /// Convert an arbitrary human-readable string into a valid skill name, or
@@ -532,9 +530,9 @@ pub fn validate_description(description: &str) -> Result<(), &'static str> {
     if description.trim().is_empty() {
         return Err("Skill description cannot be empty");
     }
-    if description.len() > MAX_SKILL_DESCRIPTION_LEN {
+    if description.chars().count() > MAX_SKILL_DESCRIPTION_LEN {
         return Err(formatcp!(
-            "Skill description must be at most {MAX_SKILL_DESCRIPTION_LEN} bytes"
+            "Skill description must be at most {MAX_SKILL_DESCRIPTION_LEN} characters"
         ));
     }
     Ok(())
@@ -1419,7 +1417,7 @@ Content.
 
         let result = parse_skill_file_content(&content);
         assert!(result.is_err());
-        let expected = format!("at most {MAX_SKILL_DESCRIPTION_LEN} bytes");
+        let expected = format!("at most {MAX_SKILL_DESCRIPTION_LEN} characters");
         assert!(result.unwrap_err().to_string().contains(&expected));
     }
 
@@ -2133,17 +2131,13 @@ description: A skill with no body content
     }
 
     #[test]
-    fn validate_description_length_is_measured_in_bytes() {
-        // "é" is 2 bytes in UTF-8. A string of MAX/2 + 1 "é" characters has
-        // only ~MAX/2 + 1 chars but exceeds MAX bytes, so it must be
-        // rejected by a byte-based validator (and accepted by a char-based
-        // one). This regression-tests the byte semantics that strict
-        // validation and load-time warnings both rely on.
-        let chars = MAX_SKILL_DESCRIPTION_LEN / 2 + 1;
-        let description = "é".repeat(chars);
-        assert!(description.chars().count() <= MAX_SKILL_DESCRIPTION_LEN);
+    fn validate_description_length_is_measured_in_chars() {
+        // Multibyte text exceeds the limit in bytes long before it does in
+        // characters; the specification's limit is in characters.
+        let description = "中".repeat(MAX_SKILL_DESCRIPTION_LEN);
         assert!(description.len() > MAX_SKILL_DESCRIPTION_LEN);
-        assert!(validate_description(&description).is_err());
+        assert!(validate_description(&description).is_ok());
+        assert!(validate_description(&format!("{description}中")).is_err());
     }
 
     #[test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -11674,7 +11674,7 @@ impl ThreadView {
                     .gap_1()
                     .child(
                         Label::new(format!(
-                            "Ensure skill descriptions are at most {MAX_SKILL_DESCRIPTION_LEN} bytes; longer ones may consume more model-context tokens."
+                            "Ensure skill descriptions are at most {MAX_SKILL_DESCRIPTION_LEN} characters; longer ones may consume more model-context tokens."
                         ))
                         .size(LabelSize::Small)
                         .color(Color::Muted),

--- a/crates/settings_ui/src/pages/skill_creator.rs
+++ b/crates/settings_ui/src/pages/skill_creator.rs
@@ -402,7 +402,7 @@ impl SkillCreatorPage {
 
     fn recompute_description_error(&mut self, cx: &mut Context<Self>) {
         let description = self.current_description(cx);
-        self.description_length = description.len();
+        self.description_length = description.chars().count();
         let error = validate_description(&description).err();
         self.description_error = error;
         self.description_editor
@@ -1178,15 +1178,12 @@ fn derived_description_from_markdown(content: &str) -> Option<String> {
 }
 
 fn truncate_description(description: &str) -> String {
-    if description.len() <= MAX_SKILL_DESCRIPTION_LEN {
-        return description.to_string();
-    }
-
-    let mut end = MAX_SKILL_DESCRIPTION_LEN;
-    while !description.is_char_boundary(end) {
-        end -= 1;
-    }
-    description[..end].trim().to_string()
+    description
+        .chars()
+        .take(MAX_SKILL_DESCRIPTION_LEN)
+        .collect::<String>()
+        .trim()
+        .to_string()
 }
 
 /// Serialize the SKILL.md file to disk at `<skills_dir>/<name>/SKILL.md`.

--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -122,7 +122,7 @@ Step-by-step instructions for the agent...
 | Field                      | Required | Description                                                                                                                       |
 | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                     | Yes      | Lowercase letters, numbers, and hyphens only. Max 64 characters. Should match the folder name.                                    |
-| `description`              | Yes      | What the skill does and when to use it. Keep it under 1024 bytes; skills with longer descriptions still load, but with a warning. |
+| `description`              | Yes      | What the skill does and when to use it. Keep it under 1024 characters; skills with longer descriptions still load, but with a warning. |
 | `disable-model-invocation` | No       | Set to `true` to hide from the agent's catalog (invocable via slash command or @-mention only).                                   |
 
 > **Tip:** Write descriptions that help the agent recognize when a skill is relevant. Include specific task types and trigger phrases: "Use when handling PDFs, extracting text, or filling forms" is better than "Helps with PDFs."


### PR DESCRIPTION
Closes #63620

The [Agent Skills specification](https://agentskills.io/specification) limits `description` to 1024 characters, and the [reference validator](https://github.com/agentskills/agentskills/blob/main/skills-ref/src/skills_ref/validator.py) measures that with Python `len()`, which counts Unicode code points. Zed measured with `str::len()`, which counts UTF-8 bytes. A description of 342 CJK characters is 1026 bytes, so skills that pass the reference validator warned in the agent panel and were rejected by the create-skill and import flows.

The byte behaviour was never a deliberate choice. Before #56924 the loader checked `.len()` while its error message said "characters". #56924 documented the existing behaviour as byte-based and added a test locking it in, and #58356 reworded the messages to "bytes" to match. The doc comment's stated reason was that `.len()` returns bytes, and it also claimed the create-skill UI shows a matching byte counter; that field is written but never rendered.

This measures with `chars().count()` in the loader warning, the strict validator, the create-skill counter and the imported-skill truncation helper, and says "characters" in every message and in the docs. The aggregate `MAX_SKILL_DESCRIPTIONS_SIZE` byte cap is unchanged, so the model-context guard still exists separately from the spec rule.

The byte-semantics test is replaced with one that asserts 1024 CJK characters are accepted and 1025 are rejected.

Release Notes:

- Fixed the agent skill description limit counting UTF-8 bytes instead of characters, which rejected or warned about valid non-ASCII descriptions.
