### PR TITLE
markdown: Hide mermaid overlay controls until the first raster is ready

### DIFF
--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -709,7 +709,10 @@ pub(crate) fn render_mermaid_diagram(
                     })
                     .into_any_element()
             } else {
-                // No fallback — show the code so the user has something to look at
+                // No fallback — show the code so the user has something to look
+                // at. The overlay controls are deliberately omitted so they
+                // don't cover the "Rendering..." indicator; they appear once
+                // the first raster is ready.
                 container
                     .child(render_mermaid_code_view(&parsed.contents.contents))
                     .child(
@@ -726,15 +729,6 @@ pub(crate) fn render_mermaid_diagram(
                                 ),
                         ),
                     )
-                    .when(show_interactive, |container| {
-                        container.child(render_mermaid_overlay_controls(
-                            source_offset,
-                            code.to_string(),
-                            None,
-                            markdown,
-                            on_zoom,
-                        ))
-                    })
                     .into_any_element()
             }
         }


### PR DESCRIPTION
# Objective

In Markdown preview, while a Mermaid diagram is still rendering, the copy button would float over the "Rendering..." indicator.

## Solution

Don't render the overlay controls until the Mermaid diagram has rendered.

## Testing

I've tested it manually.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- In Markdown preview, fixed the Copy button overlapping the Mermaid diagram "Rendering..." text.
