### PR TITLE
Locate Visual Studio via vswhere in bundle-windows.ps1

### DIFF
--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -41,7 +41,16 @@ function Get-VSArch {
 }
 
 Push-Location
-& "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1" -Arch (Get-VSArch -Arch $Architecture) -HostArch (Get-VSArch -Arch $OSArchitecture)
+$vsDevShell = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1"
+if (-not (Test-Path $vsDevShell)) {
+    # Fall back to whatever VS edition is installed (Professional, Enterprise,
+    # BuildTools, or a custom location) — e.g. GitHub's windows-2022 runner
+    # images ship Enterprise, not Community.
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    $vsDevShell = Join-Path $vsPath "Common7\Tools\Launch-VsDevShell.ps1"
+}
+& $vsDevShell -Arch (Get-VSArch -Arch $Architecture) -HostArch (Get-VSArch -Arch $OSArchitecture)
 Pop-Location
 
 $target = "$Architecture-pc-windows-msvc"


### PR DESCRIPTION
## What this PR does

Makes `script/bundle-windows.ps1` work with **any Visual Studio 2022 edition** — Enterprise, Professional, BuildTools, or a custom install location — instead of only Community. This lets Zed be bundled on machines and CI environments that don't have VS Community, such as GitHub's standard hosted Windows runners.

## Why

The script hardcodes the Community edition's dev-shell path and fails immediately when it doesn't exist. GitHub's `windows-2022` runner images, for example, ship VS **Enterprise**, so bundling on a stock hosted runner dies at startup:

```
The term 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' is not
recognized as a name of a cmdlet, function, script file, or executable program.
```

## How

When the Community `Launch-VsDevShell.ps1` is missing, fall back to `vswhere.exe` (shipped with every Visual Studio 2022 installation) to locate the newest installed edition that has the C++ toolset, and use its dev shell instead. No behavior change for machines where Community is installed.

## Testing

Bundled Zed on a stock `windows-2022` GitHub Actions runner: fails before this change, succeeds after it.

Release Notes:

- N/A