### PR TITLE
workspace: Prompt before replacing a window with dirty buffers

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -72,8 +72,9 @@ use util::{
     rel_path::{RelPath, RelPathBuf},
 };
 use workspace::{
-    DraggedSelection, OpenInTerminal, OpenMode, OpenOptions, OpenVisible, PreviewTabsSettings,
-    SelectedEntry, SplitDirection, Workspace, WorkspaceSettings, copy_file_permalink,
+    DraggedSelection, MultiWorkspace, OpenInTerminal, OpenMode, OpenOptions, OpenVisible,
+    PreviewTabsSettings, SelectedEntry, SplitDirection, Workspace, WorkspaceSettings,
+    copy_file_permalink,
     dock::{DockPosition, Panel, PanelEvent},
     focus_follows_mouse::FocusFollowsMouse as _,
     notifications::{DetachAndPromptErr, NotifyResultExt, NotifyTaskExt},
@@ -7738,7 +7739,22 @@ impl Render for ProjectPanel {
                         .on_drop(cx.listener(
                             move |this, external_paths: &ExternalPaths, window, cx| {
                                 this.clear_drag_state(cx);
-                                if let Some(task) = this
+                                if let Some(handle) =
+                                    window.window_handle().downcast::<MultiWorkspace>()
+                                {
+                                    handle
+                                        .update(cx, |multi_workspace, window, cx| {
+                                            multi_workspace
+                                                .open_project(
+                                                    external_paths.paths().to_owned(),
+                                                    OpenMode::Activate,
+                                                    window,
+                                                    cx,
+                                                )
+                                                .detach_and_log_err(cx);
+                                        })
+                                        .log_err();
+                                } else if let Some(task) = this
                                     .workspace
                                     .update(cx, |workspace, cx| {
                                         workspace.open_workspace_for_paths(

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -1,6 +1,6 @@
 use crate::{
-    NewFile, Open, OpenMode, PathList, RecentWorkspace, SerializedWorkspaceLocation,
-    ToggleWorkspaceSidebar, Workspace, WorkspaceSettings,
+    MultiWorkspace, NewFile, Open, OpenMode, PathList, RecentWorkspace,
+    SerializedWorkspaceLocation, ToggleWorkspaceSidebar, Workspace, WorkspaceSettings,
     item::{Item, ItemEvent},
     persistence::WorkspaceDb,
 };
@@ -311,13 +311,25 @@ impl WelcomePage {
                         DefaultOpenBehavior::ExistingWindow => OpenMode::Activate,
                         DefaultOpenBehavior::NewWindow => OpenMode::NewWindow,
                     };
-                    self.workspace
-                        .update(cx, |workspace, cx| {
-                            workspace
-                                .open_workspace_for_paths(open_mode, paths, window, cx)
-                                .detach_and_log_err(cx);
-                        })
-                        .log_err();
+                    if open_mode != OpenMode::NewWindow
+                        && let Some(handle) = window.window_handle().downcast::<MultiWorkspace>()
+                    {
+                        handle
+                            .update(cx, |multi_workspace, window, cx| {
+                                multi_workspace
+                                    .open_project(paths, open_mode, window, cx)
+                                    .detach_and_log_err(cx);
+                            })
+                            .log_err();
+                    } else {
+                        self.workspace
+                            .update(cx, |workspace, cx| {
+                                workspace
+                                    .open_workspace_for_paths(open_mode, paths, window, cx)
+                                    .detach_and_log_err(cx);
+                            })
+                            .log_err();
+                    }
                 } else {
                     use zed_actions::OpenRecent;
                     window.dispatch_action(OpenRecent::default().boxed_clone(), cx);


### PR DESCRIPTION

# Objective

Opening a project from the welcome view's recent projects list, or by dropping a
folder onto the project panel, could silently discard unsaved buffers.


---

Release Notes:

- Fixed unsaved buffers being silently discarded when opening a recent project
  from the welcome view or dropping a folder onto the project panel.
