### PR TITLE
editor: reorder ordered lists after inserting items

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5314,9 +5314,10 @@ impl Editor {
             });
 
         let mut edits = Vec::new();
+        let mut ordered_list_indent_renumberings = Vec::new();
         let mut prev_edited_row = 0;
         let mut row_delta = 0;
-        for selection in &mut selections {
+        for (selection_index, selection) in selections.iter_mut().enumerate() {
             if selection.start.row != prev_edited_row {
                 row_delta = 0;
             }
@@ -5328,14 +5329,47 @@ impl Editor {
                 let settings = buffer.language_settings_at(cursor, cx);
                 if settings.indent_list_on_tab {
                     if let Some(language) = snapshot.language_scope_at(Point::new(cursor.row, 0)) {
-                        if input::is_list_prefix_row(
+                        let is_unordered_list = input::is_unordered_list_prefix_row(
                             MultiBufferRow(cursor.row),
                             &snapshot,
                             &language,
-                        ) {
+                        );
+                        let ordered_list_renumbering = (!is_unordered_list)
+                            .then(|| {
+                                let current_indent =
+                                    snapshot.indent_size_for_line(MultiBufferRow(cursor.row));
+                                let indent_kind = if settings.hard_tabs {
+                                    IndentKind::Tab
+                                } else {
+                                    IndentKind::Space
+                                };
+                                let indent_delta = Self::indent_delta_for_line(
+                                    current_indent,
+                                    indent_kind,
+                                    settings.tab_size.get(),
+                                );
+                                input::ordered_list_indent_renumbering(
+                                    cursor,
+                                    &snapshot,
+                                    &language,
+                                    indent_delta.chars().count(),
+                                )
+                            })
+                            .flatten();
+                        if is_unordered_list || ordered_list_renumbering.is_some() {
+                            let ordered_list_renumbering = (row_delta == 0)
+                                .then_some(ordered_list_renumbering)
+                                .flatten();
                             row_delta = Self::indent_selection(
                                 buffer, &snapshot, selection, &mut edits, row_delta, cx,
                             );
+                            if let Some(renumbering) = ordered_list_renumbering {
+                                ordered_list_indent_renumberings.push((
+                                    selection_index,
+                                    cursor.column >= renumbering.marker_end_column,
+                                    renumbering,
+                                ));
+                            }
                             continue;
                         }
                     }
@@ -5416,6 +5450,94 @@ impl Editor {
             edits.push((cursor..cursor, tab_size.chars().collect::<String>()));
             row_delta += tab_size.len;
         }
+
+        let selected_marker_ranges = ordered_list_indent_renumberings
+            .iter()
+            .map(|(_, _, renumbering)| renumbering.marker_range.clone())
+            .collect::<Vec<_>>();
+        let mut replacement_numbers: Vec<u32> =
+            Vec::with_capacity(ordered_list_indent_renumberings.len());
+        for current_index in 0..ordered_list_indent_renumberings.len() {
+            let current = &ordered_list_indent_renumberings[current_index].2;
+            let replacement_number = (0..current_index)
+                .rev()
+                .find(|previous_index| {
+                    let following_edits = &ordered_list_indent_renumberings[*previous_index]
+                        .2
+                        .following_edits;
+                    following_edits
+                        .iter()
+                        .position(|edit| edit.range == current.marker_range)
+                        .is_some_and(|position| {
+                            following_edits[..position]
+                                .iter()
+                                .all(|edit| selected_marker_ranges.contains(&edit.range))
+                        })
+                })
+                .and_then(|previous_index| replacement_numbers[previous_index].checked_add(1))
+                .unwrap_or(current.replacement_number);
+            replacement_numbers.push(replacement_number);
+        }
+
+        let mut coordinated_following_edits: Vec<(input::OrderedListRenumberEdit, u32)> =
+            Vec::new();
+        for ((selection_index, cursor_is_after_marker, renumbering), replacement_number) in
+            ordered_list_indent_renumberings
+                .into_iter()
+                .zip(replacement_numbers)
+        {
+            let replacement = renumbering
+                .format
+                .replace("{1}", &replacement_number.to_string());
+            if cursor_is_after_marker {
+                let selection = &mut selections[selection_index];
+                selection.start.column = Self::adjust_column_for_replacement(
+                    selection.start.column,
+                    renumbering.marker_len,
+                    replacement.len(),
+                );
+                selection.end.column = Self::adjust_column_for_replacement(
+                    selection.end.column,
+                    renumbering.marker_len,
+                    replacement.len(),
+                );
+            }
+            if replacement_number != renumbering.number {
+                edits.push((
+                    renumbering.marker_range.start.to_point(&snapshot)
+                        ..renumbering.marker_range.end.to_point(&snapshot),
+                    replacement,
+                ));
+            }
+
+            for edit in renumbering.following_edits {
+                if selected_marker_ranges.contains(&edit.range) {
+                    continue;
+                }
+                if let Some((_, count)) = coordinated_following_edits
+                    .iter_mut()
+                    .find(|(existing, _)| existing.range == edit.range)
+                {
+                    if let Some(incremented_count) = count.checked_add(1) {
+                        *count = incremented_count;
+                    }
+                } else {
+                    coordinated_following_edits.push((edit, 1));
+                }
+            }
+        }
+        edits.extend(
+            coordinated_following_edits
+                .into_iter()
+                .filter_map(|(edit, count)| {
+                    let number = edit.number.checked_sub(count)?;
+                    let replacement = edit.format.replace("{1}", &number.to_string());
+                    Some((
+                        edit.range.start.to_point(&snapshot)..edit.range.end.to_point(&snapshot),
+                        replacement,
+                    ))
+                }),
+        );
 
         self.transact(window, cx, |this, window, cx| {
             this.buffer.update(cx, |b, cx| b.edit(edits, None, cx));
@@ -5500,14 +5622,7 @@ impl Editor {
         let has_multiple_rows = start_row + 1 != end_row;
         for row in start_row..end_row {
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(row));
-            let indent_delta = match (current_indent.kind, indent_kind) {
-                (IndentKind::Space, IndentKind::Space) => {
-                    let columns_to_next_tab_stop = tab_size - (current_indent.len % tab_size);
-                    IndentSize::spaces(columns_to_next_tab_stop)
-                }
-                (IndentKind::Tab, IndentKind::Space) => IndentSize::spaces(tab_size),
-                (_, IndentKind::Tab) => IndentSize::tab(),
-            };
+            let indent_delta = Self::indent_delta_for_line(current_indent, indent_kind, tab_size);
 
             let start = if has_multiple_rows || current_indent.len < selection.start.column {
                 0
@@ -5534,6 +5649,32 @@ impl Editor {
             delta_for_start_row + delta_for_end_row
         } else {
             delta_for_end_row
+        }
+    }
+
+    fn indent_delta_for_line(
+        current_indent: IndentSize,
+        indent_kind: IndentKind,
+        tab_size: u32,
+    ) -> IndentSize {
+        match (current_indent.kind, indent_kind) {
+            (IndentKind::Space, IndentKind::Space) => {
+                let columns_to_next_tab_stop = tab_size - (current_indent.len % tab_size);
+                IndentSize::spaces(columns_to_next_tab_stop)
+            }
+            (IndentKind::Tab, IndentKind::Space) => IndentSize::spaces(tab_size),
+            (_, IndentKind::Tab) => IndentSize::tab(),
+        }
+    }
+
+    fn adjust_column_for_replacement(column: u32, old_len: usize, new_len: usize) -> u32 {
+        if let Some(added_len) = new_len.checked_sub(old_len) {
+            u32::try_from(added_len).map_or(column, |added_len| column.saturating_add(added_len))
+        } else if let Some(removed_len) = old_len.checked_sub(new_len) {
+            u32::try_from(removed_len)
+                .map_or(column, |removed_len| column.saturating_sub(removed_len))
+        } else {
+            column
         }
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42259,6 +42259,80 @@ async fn test_tab_list_indent(cx: &mut TestAppContext) {
     "};
     cx.assert_editor_state(expected.replace("$", " ").as_str());
 
+    cx.set_state(indoc! {"
+        1. first item
+        2. ˇsecond item
+        3. third item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    let expected = indoc! {"
+        1. first item
+        $$1. ˇsecond item
+        2. third item
+    "};
+    cx.assert_editor_state(expected.replace("$", " ").as_str());
+
+    cx.set_state(indoc! {"
+        1. first item
+          1. nested item
+        2. ˇsecond item
+        3. third item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+          1. nested item
+          2. ˇsecond item
+        2. third item
+    "});
+
+    cx.set_state(indoc! {"
+        9. first item
+        10. ˇsecond item
+        11. third item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        9. first item
+          1. ˇsecond item
+        10. third item
+    "});
+
+    cx.set_state(indoc! {"
+        1. first item
+        2. ˇsecond item
+        3. ˇthird item
+        4. fourth item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+          1. ˇsecond item
+          2. ˇthird item
+        2. fourth item
+    "});
+
+    cx.set_state(indoc! {"
+        1. first item
+        2. ˇsecond item
+        3. third item
+        4. ˇfourth item
+        5. fifth item
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+          1. ˇsecond item
+        2. third item
+          1. ˇfourth item
+        3. fifth item
+    "});
+
     // Case 4: With existing indentation - adds more indent
     let initial = indoc! {"
         $$- ˇitem

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42007,7 +42007,85 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         2. ˇem
     "});
 
-    // Case 4: Adding newline after (whitespace + marker + some whitespace) does NOT add marker
+    // Case 4: Inserting an item renumbers the following ordered list items
+    cx.set_state(indoc! {"
+        1. first itemˇ
+        2. second item
+        3. third item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+        2. ˇ
+        3. second item
+        4. third item
+    "});
+
+    // Case 5: Renumbering skips nested items
+    cx.set_state(indoc! {"
+        1. first itemˇ
+          1. nested item
+        2. second item
+          1. another nested item
+        3. third item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+        2. ˇ
+          1. nested item
+        3. second item
+          1. another nested item
+        4. third item
+    "});
+
+    // Case 6: Renumbering continues across blank lines in a loose list
+    cx.set_state(indoc! {"
+        1. first itemˇ
+
+        2. second item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+        2. ˇ
+
+        3. second item
+    "});
+
+    // Case 7: Multiple cursors coordinate renumbering in the same list
+    cx.set_state(indoc! {"
+        1. first itemˇ
+        2. second itemˇ
+        3. third item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+        2. ˇ
+        3. second item
+        4. ˇ
+        5. third item
+    "});
+
+    // Case 8: Renumbering stops at a discontinuity
+    cx.set_state(indoc! {"
+        1. first itemˇ
+        4. fourth item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+        2. ˇ
+        4. fourth item
+    "});
+
+    // Case 9: Adding newline after (whitespace + marker + some whitespace) does NOT add marker
     cx.set_state(indoc! {"
         1.  ˇ
     "});
@@ -42022,7 +42100,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         .as_str(),
     );
 
-    // Case 5: Adding newline with content adds marker preserving indentation
+    // Case 10: Adding newline with content adds marker preserving indentation
     cx.set_state(indoc! {"
         1. item
           2. indentedˇ
@@ -42035,7 +42113,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
           3. ˇ
     "});
 
-    // Case 6: Adding newline with cursor right after marker, unindents
+    // Case 11: Adding newline with cursor right after marker, unindents
     cx.set_state(indoc! {"
         1. item
           2. sub item
@@ -42051,7 +42129,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
     cx.wait_for_autoindent_applied().await;
 
-    // Case 7: Adding newline with cursor right after marker, removes marker
+    // Case 12: Adding newline with cursor right after marker, removes marker
     cx.assert_editor_state(indoc! {"
         1. item
           2. sub item
@@ -42065,7 +42143,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         ˇ
     "});
 
-    // Case 8: Cursor before or inside prefix does not add marker
+    // Case 13: Cursor before or inside prefix does not add marker
     cx.set_state(indoc! {"
         ˇ1. item
     "});
@@ -42085,6 +42163,30 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1
         ˇ. item
     "});
+}
+
+#[gpui::test]
+fn test_ordered_list_renumbering_stays_within_excerpt(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new_multibuffer(
+        cx,
+        ["«1. first item»\nhidden line\n«2. unrelated item»"],
+    );
+    cx.update_editor(|editor, _, cx| {
+        for buffer in editor.buffer().read(cx).all_buffers() {
+            buffer.update(cx, |buffer, cx| {
+                buffer.set_language(Some(markdown_language.clone()), cx)
+            });
+        }
+    });
+    cx.set_selections_state("1. first itemˇ\n2. unrelated item");
+
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.run_until_parked();
+
+    cx.assert_editor_state("1. first item\n2. ˇ\n2. unrelated item");
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -537,7 +537,7 @@ impl Editor {
         }
 
         self.transact(window, cx, |this, window, cx| {
-            let (edits_with_flags, selection_info): (Vec<_>, Vec<_>) = {
+            let (mut edits_with_flags, selection_data): (Vec<_>, Vec<_>) = {
                 let selections = this
                     .selections
                     .all::<MultiBufferOffset>(&this.display_snapshot(cx));
@@ -555,6 +555,7 @@ impl Editor {
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
+                        let mut ordered_list_continuation = None;
                         existing_indent =
                             logical_indent_for_newline(&start_point, &buffer, existing_indent);
                         let (delimiter, newline_config) = if let Some(language) = &language_scope {
@@ -633,6 +634,7 @@ impl Editor {
                                     &buffer,
                                     language,
                                     &mut newline_config,
+                                    &mut ordered_list_continuation,
                                 );
                             }) {
                                 delimiter = Some(list_delimiter);
@@ -701,7 +703,14 @@ impl Editor {
                                 }
                                 new_text.extend(additional_indent.chars());
                                 if let Some(delimiter) = &delimiter {
+                                    let delimiter_start = new_text.len();
                                     new_text.push_str(delimiter);
+                                    if let Some(ordered_list_continuation) =
+                                        &mut ordered_list_continuation
+                                    {
+                                        ordered_list_continuation.delimiter_range =
+                                            delimiter_start..new_text.len();
+                                    }
                                 }
                                 if let Some(extra_indent) = extra_line_additional_indent {
                                     new_text.push('\n');
@@ -735,11 +744,73 @@ impl Editor {
                         let new_selection = selection.map(|_| anchor);
                         (
                             ((edit_start..end, new_text), prevent_auto_indent),
-                            (newline_config.has_extra_line(), new_selection),
+                            (
+                                (newline_config.has_extra_line(), new_selection),
+                                ordered_list_continuation,
+                            ),
                         )
                     })
                     .unzip()
             };
+
+            let continuation_increments = selection_data
+                .iter()
+                .map(|(_, continuation)| {
+                    continuation.as_ref().and_then(|current_continuation| {
+                        selection_data
+                            .iter()
+                            .filter_map(|(_, continuation)| continuation.as_ref())
+                            .flat_map(|continuation| &continuation.following_edits)
+                            .filter(|edit| edit.range == current_continuation.marker_range)
+                            .try_fold(0_u32, |count, _| count.checked_add(1))
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for (((_, new_text), _), ((_, continuation), increment)) in edits_with_flags
+                .iter_mut()
+                .zip(selection_data.iter().zip(continuation_increments))
+            {
+                let (Some(continuation), Some(increment)) = (continuation, increment) else {
+                    continue;
+                };
+                let Some(number) = continuation.number.checked_add(increment) else {
+                    continue;
+                };
+                let delimiter = continuation.format.replace("{1}", &number.to_string());
+                if let (Some(before), Some(after)) = (
+                    new_text.get(..continuation.delimiter_range.start),
+                    new_text.get(continuation.delimiter_range.end..),
+                ) {
+                    *new_text = format!("{before}{delimiter}{after}");
+                }
+            }
+
+            let mut coordinated_following_edits: Vec<(OrderedListRenumberEdit, u32)> = Vec::new();
+            for (_, continuation) in &selection_data {
+                let Some(continuation) = continuation else {
+                    continue;
+                };
+                for edit in &continuation.following_edits {
+                    if let Some((_, count)) = coordinated_following_edits
+                        .iter_mut()
+                        .find(|(existing, _)| existing.range == edit.range)
+                    {
+                        if let Some(incremented_count) = count.checked_add(1) {
+                            *count = incremented_count;
+                        }
+                    } else {
+                        coordinated_following_edits.push((edit.clone(), 1));
+                    }
+                }
+            }
+            edits_with_flags.extend(coordinated_following_edits.into_iter().filter_map(
+                |(edit, count)| {
+                    let number = edit.number.checked_add(count)?;
+                    let replacement = edit.format.replace("{1}", &number.to_string());
+                    Some(((edit.range, replacement), true))
+                },
+            ));
 
             let mut auto_indent_edits = Vec::new();
             let mut edits = Vec::new();
@@ -758,9 +829,9 @@ impl Editor {
             }
 
             let buffer = this.buffer.read(cx).snapshot(cx);
-            let new_selections = selection_info
+            let new_selections = selection_data
                 .into_iter()
-                .map(|(extra_newline_inserted, new_selection)| {
+                .map(|((extra_newline_inserted, new_selection), _)| {
                     let mut cursor = new_selection.end.to_point(&buffer);
                     if extra_newline_inserted {
                         cursor.row -= 1;
@@ -2640,11 +2711,27 @@ fn logical_indent_for_newline(
         .unwrap_or(existing_indent)
 }
 
+struct OrderedListContinuation {
+    marker_range: Range<MultiBufferOffset>,
+    number: u32,
+    format: String,
+    delimiter_range: Range<usize>,
+    following_edits: Vec<OrderedListRenumberEdit>,
+}
+
+#[derive(Clone)]
+struct OrderedListRenumberEdit {
+    range: Range<MultiBufferOffset>,
+    number: u32,
+    format: String,
+}
+
 fn list_delimiter_for_newline(
     start_point: &Point,
     buffer: &MultiBufferSnapshot,
     language: &LanguageScope,
     newline_config: &mut NewlineConfig,
+    ordered_list_continuation: &mut Option<OrderedListContinuation>,
 ) -> Option<Arc<str>> {
     let (snapshot, range) = buffer.buffer_line_for_row(MultiBufferRow(start_point.row))?;
 
@@ -2736,9 +2823,27 @@ fn list_delimiter_for_newline(
 
             if has_content_after_marker && cursor_is_after_prefix {
                 let number: u32 = captures.get(1)?.as_str().parse().ok()?;
+                let next_number = number.checked_add(1)?;
+                let marker_start =
+                    buffer.point_to_offset(Point::new(start_point.row, num_of_whitespaces as u32));
+                let marker_end =
+                    buffer.point_to_offset(Point::new(start_point.row, end_of_prefix as u32));
+                *ordered_list_continuation = Some(OrderedListContinuation {
+                    marker_range: marker_start..marker_end,
+                    number: next_number,
+                    format: ordered_config.format.clone(),
+                    delimiter_range: 0..0,
+                    following_edits: ordered_list_renumber_edits(
+                        start_point,
+                        buffer,
+                        ordered_config,
+                        num_of_whitespaces,
+                        next_number,
+                    ),
+                });
                 let continuation = ordered_config
                     .format
-                    .replace("{1}", &(number + 1).to_string());
+                    .replace("{1}", &next_number.to_string());
                 return Some(continuation.into());
             }
 
@@ -2758,6 +2863,88 @@ fn list_delimiter_for_newline(
     }
 
     None
+}
+
+fn ordered_list_renumber_edits(
+    start_point: &Point,
+    buffer: &MultiBufferSnapshot,
+    ordered_config: &language::OrderedListConfig,
+    indentation_len: usize,
+    mut expected_number: u32,
+) -> Vec<OrderedListRenumberEdit> {
+    let Ok(regex) = Regex::new(&ordered_config.pattern) else {
+        return Vec::new();
+    };
+    let Some((_, excerpt_range)) = buffer.excerpt_containing(*start_point..*start_point) else {
+        return Vec::new();
+    };
+    let mut edits = Vec::new();
+
+    for row in start_point.row + 1..=buffer.max_point().row {
+        let row = MultiBufferRow(row);
+        let row_start = Point::new(row.0, 0);
+        if !buffer
+            .excerpt_containing(row_start..row_start)
+            .is_some_and(|(_, candidate)| candidate == excerpt_range)
+        {
+            break;
+        }
+        let line_len = buffer.line_len(row);
+        let line = buffer
+            .text_for_range(Point::new(row.0, 0)..Point::new(row.0, line_len))
+            .collect::<String>();
+        if line.chars().all(char::is_whitespace) {
+            continue;
+        }
+        let current_indentation_len = line.chars().take_while(|c| c.is_whitespace()).count();
+
+        if current_indentation_len < indentation_len {
+            break;
+        }
+        if current_indentation_len > indentation_len {
+            continue;
+        }
+
+        let candidate = line
+            .chars()
+            .skip(current_indentation_len)
+            .take(ORDERED_LIST_MAX_MARKER_LEN)
+            .collect::<String>();
+        let Some(captures) = regex.captures(&candidate) else {
+            break;
+        };
+        let Some(full_match) = captures.get(0) else {
+            break;
+        };
+        if full_match.start() != 0 {
+            break;
+        }
+        let Some(number) = captures
+            .get(1)
+            .and_then(|capture| capture.as_str().parse::<u32>().ok())
+        else {
+            break;
+        };
+        if number != expected_number {
+            break;
+        }
+        let Some(replacement_number) = number.checked_add(1) else {
+            break;
+        };
+        let start = buffer.point_to_offset(Point::new(row.0, current_indentation_len as u32));
+        let end = buffer.point_to_offset(Point::new(
+            row.0,
+            (current_indentation_len + full_match.len()) as u32,
+        ));
+        edits.push(OrderedListRenumberEdit {
+            range: start..end,
+            number,
+            format: ordered_config.format.clone(),
+        });
+        expected_number = replacement_number;
+    }
+
+    edits
 }
 
 impl EntityInputHandler for Editor {

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -2333,7 +2333,7 @@ impl Editor {
     }
 }
 
-pub(super) fn is_list_prefix_row(
+pub(super) fn is_unordered_list_prefix_row(
     row: MultiBufferRow,
     buffer: &MultiBufferSnapshot,
     language: &LanguageScope,
@@ -2369,7 +2369,7 @@ pub(super) fn is_list_prefix_row(
         .collect();
     if let Some(max_prefix_len) = all_prefixes.iter().map(|p| p.len()).max() {
         let candidate: String = snapshot
-            .chars_for_range(range.clone())
+            .chars_for_range(range)
             .skip(num_of_whitespaces)
             .take(max_prefix_len)
             .collect();
@@ -2378,21 +2378,6 @@ pub(super) fn is_list_prefix_row(
             .any(|prefix| candidate.starts_with(*prefix))
         {
             return true;
-        }
-    }
-
-    let ordered_list_candidate: String = snapshot
-        .chars_for_range(range)
-        .skip(num_of_whitespaces)
-        .take(ORDERED_LIST_MAX_MARKER_LEN)
-        .collect();
-    for ordered_config in language.ordered_list() {
-        let regex = match Regex::new(&ordered_config.pattern) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        if let Some(captures) = regex.captures(&ordered_list_candidate) {
-            return captures.get(0).is_some();
         }
     }
 
@@ -2720,10 +2705,32 @@ struct OrderedListContinuation {
 }
 
 #[derive(Clone)]
-struct OrderedListRenumberEdit {
-    range: Range<MultiBufferOffset>,
-    number: u32,
-    format: String,
+pub(super) struct OrderedListRenumberEdit {
+    pub(super) range: Range<MultiBufferOffset>,
+    pub(super) number: u32,
+    pub(super) format: String,
+}
+
+pub(super) struct OrderedListIndentRenumbering {
+    pub(super) marker_range: Range<MultiBufferOffset>,
+    pub(super) number: u32,
+    pub(super) replacement_number: u32,
+    pub(super) format: String,
+    pub(super) marker_len: usize,
+    pub(super) marker_end_column: u32,
+    pub(super) following_edits: Vec<OrderedListRenumberEdit>,
+}
+
+enum OrderedListRow {
+    Blank,
+    Other {
+        indentation_len: usize,
+    },
+    Item {
+        indentation_len: usize,
+        marker_len: usize,
+        number: u32,
+    },
 }
 
 fn list_delimiter_for_newline(
@@ -2837,6 +2844,7 @@ fn list_delimiter_for_newline(
                         start_point,
                         buffer,
                         ordered_config,
+                        &regex,
                         num_of_whitespaces,
                         next_number,
                     ),
@@ -2869,12 +2877,10 @@ fn ordered_list_renumber_edits(
     start_point: &Point,
     buffer: &MultiBufferSnapshot,
     ordered_config: &language::OrderedListConfig,
+    regex: &Regex,
     indentation_len: usize,
     mut expected_number: u32,
 ) -> Vec<OrderedListRenumberEdit> {
-    let Ok(regex) = Regex::new(&ordered_config.pattern) else {
-        return Vec::new();
-    };
     let Some((_, excerpt_range)) = buffer.excerpt_containing(*start_point..*start_point) else {
         return Vec::new();
     };
@@ -2889,14 +2895,23 @@ fn ordered_list_renumber_edits(
         {
             break;
         }
-        let line_len = buffer.line_len(row);
-        let line = buffer
-            .text_for_range(Point::new(row.0, 0)..Point::new(row.0, line_len))
-            .collect::<String>();
-        if line.chars().all(char::is_whitespace) {
-            continue;
-        }
-        let current_indentation_len = line.chars().take_while(|c| c.is_whitespace()).count();
+        let (current_indentation_len, marker_len, number) =
+            match ordered_list_row(row, buffer, regex) {
+                OrderedListRow::Blank => continue,
+                OrderedListRow::Other {
+                    indentation_len: current_indentation_len,
+                } => {
+                    if current_indentation_len > indentation_len {
+                        continue;
+                    }
+                    break;
+                }
+                OrderedListRow::Item {
+                    indentation_len: current_indentation_len,
+                    marker_len,
+                    number,
+                } => (current_indentation_len, marker_len, number),
+            };
 
         if current_indentation_len < indentation_len {
             break;
@@ -2904,27 +2919,6 @@ fn ordered_list_renumber_edits(
         if current_indentation_len > indentation_len {
             continue;
         }
-
-        let candidate = line
-            .chars()
-            .skip(current_indentation_len)
-            .take(ORDERED_LIST_MAX_MARKER_LEN)
-            .collect::<String>();
-        let Some(captures) = regex.captures(&candidate) else {
-            break;
-        };
-        let Some(full_match) = captures.get(0) else {
-            break;
-        };
-        if full_match.start() != 0 {
-            break;
-        }
-        let Some(number) = captures
-            .get(1)
-            .and_then(|capture| capture.as_str().parse::<u32>().ok())
-        else {
-            break;
-        };
         if number != expected_number {
             break;
         }
@@ -2934,7 +2928,7 @@ fn ordered_list_renumber_edits(
         let start = buffer.point_to_offset(Point::new(row.0, current_indentation_len as u32));
         let end = buffer.point_to_offset(Point::new(
             row.0,
-            (current_indentation_len + full_match.len()) as u32,
+            (current_indentation_len + marker_len) as u32,
         ));
         edits.push(OrderedListRenumberEdit {
             range: start..end,
@@ -2945,6 +2939,139 @@ fn ordered_list_renumber_edits(
     }
 
     edits
+}
+
+pub(super) fn ordered_list_indent_renumbering(
+    start_point: Point,
+    buffer: &MultiBufferSnapshot,
+    language: &LanguageScope,
+    added_indentation_len: usize,
+) -> Option<OrderedListIndentRenumbering> {
+    let row = MultiBufferRow(start_point.row);
+    let (_, excerpt_range) = buffer.excerpt_containing(start_point..start_point)?;
+
+    for ordered_config in language.ordered_list() {
+        let Ok(regex) = Regex::new(&ordered_config.pattern) else {
+            continue;
+        };
+        let OrderedListRow::Item {
+            indentation_len,
+            marker_len,
+            number,
+        } = ordered_list_row(row, buffer, &regex)
+        else {
+            continue;
+        };
+        let target_indentation_len = indentation_len.checked_add(added_indentation_len)?;
+        let mut replacement_number = 1;
+
+        for previous_row in (0..start_point.row).rev() {
+            let previous_row = MultiBufferRow(previous_row);
+            let previous_row_start = Point::new(previous_row.0, 0);
+            if !buffer
+                .excerpt_containing(previous_row_start..previous_row_start)
+                .is_some_and(|(_, candidate)| candidate == excerpt_range)
+            {
+                break;
+            }
+
+            match ordered_list_row(previous_row, buffer, &regex) {
+                OrderedListRow::Blank => continue,
+                OrderedListRow::Other {
+                    indentation_len: previous_indentation_len,
+                } => {
+                    if previous_indentation_len <= target_indentation_len {
+                        break;
+                    }
+                }
+                OrderedListRow::Item {
+                    indentation_len: previous_indentation_len,
+                    number: previous_number,
+                    ..
+                } => {
+                    if previous_indentation_len < target_indentation_len {
+                        break;
+                    }
+                    if previous_indentation_len == target_indentation_len {
+                        replacement_number = previous_number.checked_add(1)?;
+                        break;
+                    }
+                }
+            }
+        }
+
+        let marker_start = buffer.point_to_offset(Point::new(row.0, indentation_len as u32));
+        let marker_end =
+            buffer.point_to_offset(Point::new(row.0, (indentation_len + marker_len) as u32));
+        let marker_end_column = u32::try_from(indentation_len)
+            .ok()?
+            .checked_add(u32::try_from(marker_len).ok()?)?;
+
+        let following_edits = number
+            .checked_add(1)
+            .map_or_else(Vec::new, |expected_number| {
+                ordered_list_renumber_edits(
+                    &start_point,
+                    buffer,
+                    ordered_config,
+                    &regex,
+                    indentation_len,
+                    expected_number,
+                )
+            });
+
+        return Some(OrderedListIndentRenumbering {
+            marker_range: marker_start..marker_end,
+            number,
+            replacement_number,
+            format: ordered_config.format.clone(),
+            marker_len,
+            marker_end_column,
+            following_edits,
+        });
+    }
+
+    None
+}
+
+fn ordered_list_row(
+    row: MultiBufferRow,
+    buffer: &MultiBufferSnapshot,
+    regex: &Regex,
+) -> OrderedListRow {
+    let line_len = buffer.line_len(row);
+    let mut chars = buffer
+        .text_for_range(Point::new(row.0, 0)..Point::new(row.0, line_len))
+        .flat_map(str::chars)
+        .peekable();
+    let mut indentation_len = 0;
+    while let Some(character) = chars.next_if(|character| character.is_whitespace()) {
+        indentation_len += character.len_utf8();
+    }
+    let candidate = chars.take(ORDERED_LIST_MAX_MARKER_LEN).collect::<String>();
+    if candidate.is_empty() {
+        return OrderedListRow::Blank;
+    }
+    let Some(captures) = regex.captures(&candidate) else {
+        return OrderedListRow::Other { indentation_len };
+    };
+    let Some(full_match) = captures.get(0) else {
+        return OrderedListRow::Other { indentation_len };
+    };
+    if full_match.start() != 0 {
+        return OrderedListRow::Other { indentation_len };
+    }
+    let Some(number) = captures
+        .get(1)
+        .and_then(|capture| capture.as_str().parse::<u32>().ok())
+    else {
+        return OrderedListRow::Other { indentation_len };
+    };
+    OrderedListRow::Item {
+        indentation_len,
+        marker_len: full_match.len(),
+        number,
+    }
 }
 
 impl EntityInputHandler for Editor {


### PR DESCRIPTION
# Objective

Keep ordered Markdown list numbering consistent when inserting or indenting items.

Previously, inserting a new item renumbered only the new marker, leaving subsequent items unchanged. Indenting an item also preserved its old number and did not close the gap in the parent list.

## Solution

- Renumber subsequent ordered-list items when a new item is inserted.
- Renumber an indented item according to its new nesting level and decrement subsequent items in the parent list.
- Preserve existing nested lists and loose lists containing blank lines.
- Coordinate overlapping edits from multiple cursors.
- Stop renumbering at list discontinuities and excerpt boundaries.
- Preserve cursor positions when a replacement changes the marker width.
- Limit scanning to affected ordered lists, stopping at list boundaries and reading only indentation plus the bounded marker candidate.

## Testing

Automated testing on macOS:

- `cargo -q test -p editor --lib`
  - 993 passed, 1 ignored
- `cargo -q test -p editor test_tab -- --nocapture`
  - 16 passed
- `./script/clippy -p editor`
- `cargo fmt -p editor -- --check`

The tests cover:

- Inserting items into ordered lists
- Nested and loose lists
- Discontinuous numbering
- Excerpt boundaries
- Indenting into new and existing nested lists
- Changes in marker width
- Adjacent and non-adjacent multi-cursor edits

Reviewers can manually verify the behavior in a Markdown buffer by inserting a newline or pressing Tab on the second item of an ordered list.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase


https://github.com/user-attachments/assets/7c311d74-4451-4919-bc44-8bb25147ca82

---

Release Notes:

- Fixed ordered lists not renumbering following items when a new item is inserted.
