### PR TITLE
cloud_api: Add notification update message

### DIFF
--- a/crates/client/src/llm_token.rs
+++ b/crates/client/src/llm_token.rs
@@ -132,6 +132,7 @@ impl RefreshLlmTokenListener {
             MessageToClient::UserUpdated => {
                 this.update(cx, |this, cx| this.refresh(TokenRefreshMode::Refresh, cx));
             }
+            MessageToClient::NotificationsUpdated => {}
         }
     }
 }

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -902,29 +902,29 @@ impl UserStore {
     }
 
     fn handle_message_to_client(this: WeakEntity<Self>, message: &MessageToClient, cx: &App) {
-        cx.spawn(async move |cx| {
-            match message {
-                MessageToClient::UserUpdated => {
-                    let (cloud_client, system_id) = cx
-                        .update(|cx| {
-                            this.read_with(cx, |this, _cx| {
-                                this.client.upgrade().map(|client| {
-                                    let system_id =
-                                        client.telemetry().system_id().map(|id| id.to_string());
-                                    (client.cloud_client(), system_id)
-                                })
-                            })
-                        })?
-                        .ok_or(anyhow::anyhow!("Failed to get Cloud client"))?;
+        match message {
+            MessageToClient::UserUpdated => {}
+            MessageToClient::NotificationsUpdated => return,
+        }
 
-                    let response = cloud_client.get_authenticated_user(system_id).await?;
-                    cx.update(|cx| {
-                        this.update(cx, |this, cx| {
-                            this.update_authenticated_user(response, cx);
+        cx.spawn(async move |cx| {
+            let (cloud_client, system_id) = cx
+                .update(|cx| {
+                    this.read_with(cx, |this, _cx| {
+                        this.client.upgrade().map(|client| {
+                            let system_id = client.telemetry().system_id().map(|id| id.to_string());
+                            (client.cloud_client(), system_id)
                         })
-                    })?;
-                }
-            }
+                    })
+                })?
+                .ok_or(anyhow::anyhow!("Failed to get Cloud client"))?;
+
+            let response = cloud_client.get_authenticated_user(system_id).await?;
+            cx.update(|cx| {
+                this.update(cx, |this, cx| {
+                    this.update_authenticated_user(response, cx);
+                })
+            })?;
 
             anyhow::Ok(())
         })

--- a/crates/cloud_api_types/src/websocket_protocol.rs
+++ b/crates/cloud_api_types/src/websocket_protocol.rs
@@ -8,10 +8,12 @@ pub const PROTOCOL_VERSION: u32 = 0;
 pub const PROTOCOL_VERSION_HEADER_NAME: &str = "x-zed-protocol-version";
 
 /// A message from Cloud to the Zed client.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessageToClient {
     /// The user was updated and should be refreshed.
     UserUpdated,
+    /// The user's notifications were updated.
+    NotificationsUpdated,
 }
 
 impl MessageToClient {
@@ -24,5 +26,32 @@ impl MessageToClient {
 
     pub fn deserialize(data: &[u8]) -> Result<Self> {
         ciborium::from_reader(data).context("failed to deserialize message")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notifications_updated_message_round_trips() -> Result<()> {
+        let message = MessageToClient::NotificationsUpdated;
+
+        assert_eq!(
+            MessageToClient::deserialize(&message.serialize()?)?,
+            message
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn notifications_updated_message_uses_the_expected_wire_format() -> Result<()> {
+        assert_eq!(
+            MessageToClient::NotificationsUpdated.serialize()?,
+            b"\x74NotificationsUpdated"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Allow Cloud to send notification invalidations. Add `NotificationsUpdated` to the `cloud_api_types` protocol and handle it explicitly as a no-op in the existing user and LLM token listeners. 

Release Notes:

- N/A