### PR TITLE
Add doc comments for OpenRouterProvider

### DIFF
--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -597,16 +597,24 @@ pub struct OpenRouterAvailableModel {
 #[with_fallible_options]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct OpenRouterProvider {
+    /// List of provider slugs to try in order (e.g. ["anthropic", "openai"]).
     order: Option<Vec<String>>,
+    /// Whether to allow backup providers when the primary is unavailable.
     #[serde(default = "default_true")]
     allow_fallbacks: bool,
+    /// Only use providers that support all parameters in your request.
     #[serde(default)]
     require_parameters: bool,
+    /// Control whether to use providers that may store data.
     #[serde(default)]
     data_collection: DataCollection,
+    /// List of provider slugs to allow for this request.
     only: Option<Vec<String>>,
+    /// List of provider slugs to skip for this request.
     ignore: Option<Vec<String>>,
+    /// List of quantization levels to filter by (e.g. ["int4", "int8"]).
     quantizations: Option<Vec<String>>,
+    /// Sort providers by price, throughput, or latency. Can be a string (e.g. "price") or an object with by and partition fields.
     sort: Option<String>,
 }
 


### PR DESCRIPTION
# Objective
Enable hover tooltips in for OpenRouterProvider settings to make them easier to edit in `settings.json` without going doc hunting

## Solution
Descriptions verbatim from
https://openrouter.ai/docs/guides/routing/provider-selection
added as doc comments mirroring existing (in-file) examples

## Testing
`settings_content` crate builds on my machine; this mostly needs verification for both:
- correctness (that I didn't swap any descriptions accidentally)
- welcome-ness (as this won't change affect the majority of users, but is nice for those it does)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior -- **caveat: I am currently unable to build the full project to do end-to-end behavior checking**
- [x] Performance impact has been considered and is acceptable