### PR TITLE
title_bar: Hide organization section when signed out

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1331,11 +1331,7 @@ impl TitleBar {
                         )
                         .separator()
                     })
-                    .map(|this| {
-                        if !is_signed_in {
-                            return this;
-                        }
-
+                    .when(is_signed_in, |this| {
                         let mut this = this.header("Organization");
 
                         for (organization, plan) in &organizations {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1332,6 +1332,10 @@ impl TitleBar {
                         .separator()
                     })
                     .map(|this| {
+                        if !is_signed_in {
+                            return this;
+                        }
+
                         let mut this = this.header("Organization");
 
                         for (organization, plan) in &organizations {


### PR DESCRIPTION
# Objective

- Fixes #63433
- Currently, when there is no logged in user, the Organization menu item shows up even though it should not.

## Solution

- This PR simply does an early return when there is no logged in user, which skips the logic to add the organization header into the menu drop down. 

## Testing

- Open a Zed window
- Sign out of Zed
- Click the menu bar chevron (top-right corner) and ensure that the Organization Menu item (like in image below is not there anymore.
- Login to make sure it does display properly when a user is logged in. 
- I tested this on a Windows Machine as I use that for development, but I believe the reproduction steps should be the same across Operating Systems. I don't have access to other operating systems, so that might be something that I'd need the communities help with to make sure everything is working properly. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments - Not Applicable
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior - Not Applicable.
- [ ] Performance impact has been considered and is acceptable - Not applicable

## Showcase

Before: Image is from the Original issue
<img width="438" height="458" alt="image" src="https://github.com/user-attachments/assets/c4852e86-1b68-42d8-ad79-68904214eed7" />

After:
https://github.com/user-attachments/assets/520f2564-36da-433b-9339-8c0210695ee0

---

Release Notes:

- Fixed issue where "Organization" section in dropdown menu was being rendered empty when no user was logged in. 
