### PR TITLE
Classify OpenAI subscription usage limits correctly

### DIFF
--- a/crates/language_model_core/src/chat_completion.rs
+++ b/crates/language_model_core/src/chat_completion.rs
@@ -74,6 +74,10 @@ where
 /// `{"error": {...}}` envelope.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResponseStreamError {
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default, rename = "type")]
+    pub error_type: Option<String>,
     pub message: String,
 }
 

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -379,15 +379,16 @@ impl LanguageModelCompletionError {
                 category,
                 ..
             } => {
-                status.is_some_and(|status| is_retryable_provider_status(provider, status))
-                    || matches!(
-                        category,
-                        ProviderErrorCategory::RateLimit
-                            | ProviderErrorCategory::Overloaded
-                            | ProviderErrorCategory::Timeout
-                            | ProviderErrorCategory::InternalServer
-                    )
-                    || retry_after.is_some()
+                *category != ProviderErrorCategory::PaymentRequired
+                    && (status.is_some_and(|status| is_retryable_provider_status(provider, status))
+                        || matches!(
+                            category,
+                            ProviderErrorCategory::RateLimit
+                                | ProviderErrorCategory::Overloaded
+                                | ProviderErrorCategory::Timeout
+                                | ProviderErrorCategory::InternalServer
+                        )
+                        || retry_after.is_some())
             }
             Self::ApiReadResponseError { .. } | Self::HttpSend { .. } => true,
             Self::DataRetentionConsentRequired { .. }

--- a/crates/open_ai/src/chat_completion_transport_tests.rs
+++ b/crates/open_ai/src/chat_completion_transport_tests.rs
@@ -4,6 +4,9 @@ use http_client::{
     FakeHttpClient, Response,
     http::{HeaderName, HeaderValue},
 };
+use language_model_core::{
+    LanguageModelCompletionError, LanguageModelProviderName, ProviderErrorCategory,
+};
 use serde_json::json;
 use std::sync::{Arc, Mutex};
 
@@ -113,6 +116,59 @@ fn streaming_transport_does_not_synthesize_done_at_eof() {
         [ChatCompletionStreamEvent::Data(data)] => assert_eq!(data.get(), r#"{"chunk":1}"#),
         events => panic!("unexpected events: {events:?}"),
     }
+}
+
+#[test]
+fn streaming_transport_preserves_usage_limit_errors() {
+    let client = FakeHttpClient::create(|_| async move {
+        Ok(Response::builder()
+            .status(200)
+            .body(AsyncBody::from(concat!(
+                "data: {\"error\":{\"type\":\"usage_limit_reached\",",
+                "\"message\":\"The usage limit has been reached\"}}\n\n"
+            )))?)
+    });
+    let request = serde_json::from_value(json!({
+        "model": "custom/model",
+        "messages": [],
+        "stream": true
+    }))
+    .expect("valid chat completion request");
+
+    let error = block_on(async {
+        stream_completion(
+            client.as_ref(),
+            "Compatible Provider",
+            "https://example.com/v1",
+            "secret",
+            request,
+            &CustomHeaders::default(),
+        )
+        .await
+        .expect("streaming request")
+        .next()
+        .await
+        .expect("provider error event")
+        .expect_err("usage limit should reject the completion")
+    });
+    let error = error
+        .downcast_ref::<LanguageModelCompletionError>()
+        .expect("typed provider rejection");
+
+    assert!(!error.is_transient());
+    assert!(matches!(
+        error,
+        LanguageModelCompletionError::ProviderRejection {
+            provider,
+            status: None,
+            code: Some(code),
+            message,
+            category: ProviderErrorCategory::PaymentRequired,
+            ..
+        } if provider == &LanguageModelProviderName::from("Compatible Provider".to_string())
+            && code == "usage_limit_reached"
+            && message == "The usage limit has been reached"
+    ));
 }
 
 #[test]

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -1356,11 +1356,16 @@ fn completion_error_from_response_error(
     error: &ResponseError,
     provider: language_model_core::LanguageModelProviderName,
 ) -> LanguageModelCompletionError {
-    let category = response_error_category(error.code.as_deref(), None, &error.message);
+    let category = response_error_category(
+        error.code.as_deref(),
+        error.error_type.as_deref(),
+        None,
+        &error.message,
+    );
     LanguageModelCompletionError::from_provider_response(
         provider,
         None,
-        error.code.clone(),
+        error.code.clone().or_else(|| error.error_type.clone()),
         error.message.clone(),
         None,
         category,
@@ -1369,41 +1374,52 @@ fn completion_error_from_response_error(
 
 pub(crate) fn response_error_category(
     code: Option<&str>,
+    error_type: Option<&str>,
     status: Option<StatusCode>,
     message: &str,
 ) -> ProviderErrorCategory {
-    match code {
-        Some("context_length_exceeded" | "request_too_large") => {
+    code.and_then(response_error_category_from_discriminator)
+        .or_else(|| error_type.and_then(response_error_category_from_discriminator))
+        .unwrap_or_else(|| {
+            status
+                .map(|status| ProviderErrorCategory::from_http_status(status, message))
+                .unwrap_or(ProviderErrorCategory::Other)
+        })
+}
+
+fn response_error_category_from_discriminator(
+    discriminator: &str,
+) -> Option<ProviderErrorCategory> {
+    let category = match discriminator {
+        "context_length_exceeded" | "request_too_large" => {
             ProviderErrorCategory::PromptTooLarge { tokens: None }
         }
-        Some("invalid_encrypted_content") => ProviderErrorCategory::InvalidEncryptedContent,
-        Some("invalid_request_error") => ProviderErrorCategory::InvalidRequest,
-        Some("authentication_error") => ProviderErrorCategory::Authentication,
-        Some(
-            "billing_error"
-            | "payment_required_error"
-            | "credit_balance_exhausted"
-            | "insufficient_quota"
-            | "organization_spend_limit_exceeded"
-            | "project_spend_limit_exceeded"
-            | "organization_usage_limit_exceeded",
-        ) => ProviderErrorCategory::PaymentRequired,
-        Some("permission_error") => ProviderErrorCategory::Permission,
-        Some("cyber_policy" | "invalid_prompt") => ProviderErrorCategory::ContentPolicy,
-        Some("not_found_error") => ProviderErrorCategory::EndpointNotFound,
-        Some("conflict_error") => ProviderErrorCategory::Conflict,
-        Some("rate_limit_error" | "rate_limit_exceeded") => ProviderErrorCategory::RateLimit,
-        Some("timeout_error" | "request_timed_out") => ProviderErrorCategory::Timeout,
-        Some("api_error" | "internal_server_error" | "server_error") => {
+        "invalid_encrypted_content" => ProviderErrorCategory::InvalidEncryptedContent,
+        "invalid_request_error" => ProviderErrorCategory::InvalidRequest,
+        "authentication_error" => ProviderErrorCategory::Authentication,
+        "billing_error"
+        | "payment_required_error"
+        | "credit_balance_exhausted"
+        | "insufficient_quota"
+        | "organization_spend_limit_exceeded"
+        | "project_spend_limit_exceeded"
+        | "organization_usage_limit_exceeded"
+        | "usage_limit_reached" => ProviderErrorCategory::PaymentRequired,
+        "permission_error" => ProviderErrorCategory::Permission,
+        "cyber_policy" | "invalid_prompt" => ProviderErrorCategory::ContentPolicy,
+        "not_found_error" => ProviderErrorCategory::EndpointNotFound,
+        "conflict_error" => ProviderErrorCategory::Conflict,
+        "rate_limit_error" | "rate_limit_exceeded" => ProviderErrorCategory::RateLimit,
+        "timeout_error" | "request_timed_out" => ProviderErrorCategory::Timeout,
+        "api_error" | "internal_server_error" | "server_error" => {
             ProviderErrorCategory::InternalServer
         }
-        Some("overloaded_error" | "server_is_overloaded" | "slow_down") => {
+        "overloaded_error" | "server_is_overloaded" | "slow_down" => {
             ProviderErrorCategory::Overloaded
         }
-        Some(_) | None => status
-            .map(|status| ProviderErrorCategory::from_http_status(status, message))
-            .unwrap_or(ProviderErrorCategory::Other),
-    }
+        _ => return None,
+    };
+    Some(category)
 }
 
 fn response_error_message(error: &ResponseError) -> String {
@@ -2855,6 +2871,7 @@ mod tests {
                 status: Some("failed".into()),
                 error: Some(ResponseError {
                     code: Some("server_error".into()),
+                    error_type: None,
                     message: "The model failed to generate a response.".into(),
                     param: None,
                 }),
@@ -2948,6 +2965,35 @@ mod tests {
     }
 
     #[test]
+    fn responses_stream_preserves_and_classifies_type_without_code() {
+        let event = serde_json::from_value::<ResponsesStreamEvent>(json!({
+            "type": "error",
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "plan_type": "plus"
+            }
+        }))
+        .expect("nested usage limit error event");
+
+        let mut mapper = OpenAiResponseEventMapper::new(OPEN_AI_PROVIDER_ID);
+        let mapped = mapper.map_event(event);
+
+        assert_eq!(mapped.len(), 1);
+        let error = mapped.into_iter().next().unwrap().unwrap_err();
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::ProviderRejection {
+                code: Some(code),
+                message,
+                category: ProviderErrorCategory::PaymentRequired,
+                ..
+            } if code == "usage_limit_reached"
+                && message == "The usage limit has been reached"
+        ));
+    }
+
+    #[test]
     fn responses_stream_maps_billing_codes_to_payment_required() {
         for code in [
             "billing_error",
@@ -2959,7 +3005,7 @@ mod tests {
             "organization_usage_limit_exceeded",
         ] {
             assert_eq!(
-                response_error_category(Some(code), None, ""),
+                response_error_category(Some(code), None, None, ""),
                 ProviderErrorCategory::PaymentRequired,
                 "{code}"
             );
@@ -2967,9 +3013,22 @@ mod tests {
     }
 
     #[test]
+    fn responses_stream_uses_known_type_when_code_is_unknown() {
+        assert_eq!(
+            response_error_category(
+                Some("provider_specific_code"),
+                Some("usage_limit_reached"),
+                Some(StatusCode::TOO_MANY_REQUESTS),
+                "",
+            ),
+            ProviderErrorCategory::PaymentRequired
+        );
+    }
+
+    #[test]
     fn responses_stream_maps_invalid_prompt_to_content_policy() {
         assert_eq!(
-            response_error_category(Some("invalid_prompt"), None, ""),
+            response_error_category(Some("invalid_prompt"), None, None, ""),
             ProviderErrorCategory::ContentPolicy
         );
     }
@@ -2978,7 +3037,7 @@ mod tests {
     fn responses_stream_maps_overload_codes_to_overloaded() {
         for code in ["overloaded_error", "server_is_overloaded", "slow_down"] {
             assert_eq!(
-                response_error_category(Some(code), None, ""),
+                response_error_category(Some(code), None, None, ""),
                 ProviderErrorCategory::Overloaded,
                 "{code}"
             );
@@ -3021,6 +3080,7 @@ mod tests {
                 status: Some("failed".into()),
                 error: Some(ResponseError {
                     code: Some("context_length_exceeded".into()),
+                    error_type: None,
                     message: "Your input exceeds the context window of this model.".into(),
                     param: Some("input".into()),
                 }),

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -446,7 +446,8 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use language_model_core::{
-        LanguageModelCompletionError, OPEN_AI_PROVIDER_NAME, ProviderErrorCategory,
+        LanguageModelCompletionError, LanguageModelProviderName, OPEN_AI_PROVIDER_NAME,
+        ProviderErrorCategory,
     };
 
     use super::{Model, ReasoningEffort, RequestError, StatusCode};
@@ -548,6 +549,65 @@ mod tests {
                 ..
             } if code == "credit_balance_exhausted"
                 && message == "You have no credits remaining."
+        ));
+    }
+
+    #[test]
+    fn http_usage_limit_type_is_payment_required() {
+        let error = LanguageModelCompletionError::from(RequestError::HttpResponseError {
+            provider: OPEN_AI_PROVIDER_NAME.to_string(),
+            status_code: StatusCode::TOO_MANY_REQUESTS,
+            body: serde_json::json!({
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "plan_type": "plus"
+                }
+            })
+            .to_string(),
+            headers: Box::default(),
+        });
+
+        assert!(!error.is_transient());
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::ProviderRejection {
+                status: Some(StatusCode::TOO_MANY_REQUESTS),
+                code: Some(code),
+                message,
+                category: ProviderErrorCategory::PaymentRequired,
+                ..
+            } if code == "usage_limit_reached"
+                && message == "The usage limit has been reached"
+        ));
+    }
+
+    #[test]
+    fn http_unknown_error_type_is_preserved_for_compatible_provider() {
+        let error = LanguageModelCompletionError::from(RequestError::HttpResponseError {
+            provider: "Compatible Provider".to_string(),
+            status_code: StatusCode::BAD_REQUEST,
+            body: serde_json::json!({
+                "error": {
+                    "type": "provider_specific_error",
+                    "message": "Provider-specific rejection"
+                }
+            })
+            .to_string(),
+            headers: Box::default(),
+        });
+
+        assert!(matches!(
+            error,
+            LanguageModelCompletionError::ProviderRejection {
+                provider,
+                code: Some(code),
+                message,
+                category: ProviderErrorCategory::InvalidRequest,
+                ..
+            } if provider == LanguageModelProviderName::from("Compatible Provider".to_string())
+                && code == "provider_specific_error"
+                && message == "Provider-specific rejection"
         ));
     }
 
@@ -1034,24 +1094,46 @@ pub async fn stream_completion(
         &request,
     )
     .await?;
+    let provider_name =
+        language_model_core::LanguageModelProviderName::from(provider_name.to_string());
     Ok(events
-        .filter_map(|event| async move {
-            let value = match event {
-                Ok(ChatCompletionStreamEvent::Data(value)) => value,
-                Ok(ChatCompletionStreamEvent::Done) => return None,
-                Err(error) => return Some(Err(anyhow!(error))),
-            };
-            match serde_json::from_str::<ResponseStreamResult>(value.get()) {
-                Ok(ResponseStreamResult::Ok(response)) => Some(Ok(response)),
-                Ok(ResponseStreamResult::Err { error }) => Some(Err(anyhow!(error.message))),
-                Err(error) => {
-                    log::error!(
-                        "Failed to parse OpenAI response into ResponseStreamResult: `{}`\n\
-                        Response: `{}`",
-                        error,
-                        value,
-                    );
-                    Some(Err(anyhow!(error)))
+        .filter_map(move |event| {
+            let provider_name = provider_name.clone();
+            async move {
+                let value = match event {
+                    Ok(ChatCompletionStreamEvent::Data(value)) => value,
+                    Ok(ChatCompletionStreamEvent::Done) => return None,
+                    Err(error) => return Some(Err(anyhow!(error))),
+                };
+                match serde_json::from_str::<ResponseStreamResult>(value.get()) {
+                    Ok(ResponseStreamResult::Ok(response)) => Some(Ok(response)),
+                    Ok(ResponseStreamResult::Err { error }) => {
+                        let category = completion::response_error_category(
+                            error.code.as_deref(),
+                            error.error_type.as_deref(),
+                            None,
+                            &error.message,
+                        );
+                        Some(Err(anyhow!(
+                            language_model_core::LanguageModelCompletionError::from_provider_response(
+                                provider_name,
+                                None,
+                                error.code.or(error.error_type),
+                                error.message,
+                                None,
+                                category,
+                            )
+                        )))
+                    }
+                    Err(error) => {
+                        log::error!(
+                            "Failed to parse OpenAI response into ResponseStreamResult: `{}`\n\
+                            Response: `{}`",
+                            error,
+                            value,
+                        );
+                        Some(Err(anyhow!(error)))
+                    }
                 }
             }
         })
@@ -1195,13 +1277,14 @@ impl From<RequestError> for language_model_core::LanguageModelCompletionError {
                     let error = error_response.error;
                     let category = completion::response_error_category(
                         error.code.as_deref(),
+                        error.error_type.as_deref(),
                         Some(status_code),
                         &error.message,
                     );
                     Self::from_provider_response(
                         provider.into(),
                         Some(status_code),
-                        error.code,
+                        error.code.or(error.error_type),
                         error.message,
                         retry_after,
                         category,

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -393,6 +393,8 @@ pub enum CustomToolGrammarSyntax {
 pub struct ResponseError {
     #[serde(default)]
     pub code: Option<String>,
+    #[serde(default, rename = "type")]
+    pub error_type: Option<String>,
     pub message: String,
     #[serde(default)]
     pub param: Option<Value>,
@@ -414,6 +416,8 @@ pub struct GenericStreamErrorPayload {
 struct PartialResponseError {
     #[serde(default)]
     code: Option<String>,
+    #[serde(default, rename = "type")]
+    error_type: Option<String>,
     #[serde(default)]
     message: Option<String>,
     #[serde(default)]
@@ -425,6 +429,7 @@ impl GenericStreamErrorPayload {
         let nested = self.error.unwrap_or_default();
         ResponseError {
             code: self.top_level.code.or(nested.code),
+            error_type: self.top_level.error_type.or(nested.error_type),
             message: self
                 .top_level
                 .message


### PR DESCRIPTION
OpenAI's Codex endpoint reports an exhausted ChatGPT subscription with HTTP 429 and `error.type = "usage_limit_reached"`, but no `error.code`. The Responses parser discarded the type and classified the response from its status alone, making it appear to be transient request throttling.

This preserves `error.type` in both Responses and Chat Completions parsing, considers both OpenAI discriminator fields during classification, and falls back from the more-specific `error.code` to `error.type` when populating the existing provider rejection code. Usage-limit errors retain OpenAI's message and are not retried as transient 429s.

The regression coverage exercises initial HTTP failures, Responses stream errors, Chat Completions stream errors, unknown OpenAI-compatible provider types, and precedence when both code and type are present.

Release Notes:

- Fixed ChatGPT subscription usage limits being shown as temporary OpenAI request throttling.
