### PR TITLE
gpui_web: Bring the keyboard back after tapping outside a text input

### DIFF
--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -340,6 +340,7 @@ impl WebWindowInner {
                     == this.visual_viewport_height();
                 if completes_tap && viewport_stable {
                     let preserve_focused_input = should_preserve_focused_input(
+                        !this.ime_mirror.read_only(),
                         focused_input_accepted_text_before_tap,
                         this.focused_input_accepts_text(),
                         dispatch_result,
@@ -1282,11 +1283,13 @@ fn capslock_from_keyboard_event(event: &web_sys::KeyboardEvent) -> Capslock {
 }
 
 fn should_preserve_focused_input(
+    ime_session_live: bool,
     accepted_text_before_tap: bool,
     accepts_text_after_tap: bool,
     dispatch_result: Option<DispatchEventResult>,
 ) -> bool {
-    accepted_text_before_tap
+    ime_session_live
+        && accepted_text_before_tap
         && accepts_text_after_tap
         && dispatch_result.is_some_and(|result| result.default_prevented)
 }
@@ -1450,6 +1453,20 @@ mod tests {
         assert!(should_preserve_focused_input(
             true,
             true,
+            true,
+            Some(DispatchEventResult {
+                propagate: false,
+                default_prevented: true,
+            }),
+        ));
+    }
+
+    #[test]
+    fn tap_does_not_preserve_a_dismissed_ime_session() {
+        assert!(!should_preserve_focused_input(
+            false,
+            true,
+            true,
             Some(DispatchEventResult {
                 propagate: false,
                 default_prevented: true,
@@ -1466,8 +1483,23 @@ mod tests {
             })
         };
 
-        assert!(!should_preserve_focused_input(true, true, result(false),));
-        assert!(!should_preserve_focused_input(false, true, result(true),));
-        assert!(!should_preserve_focused_input(true, false, result(true),));
+        assert!(!should_preserve_focused_input(
+            true,
+            true,
+            true,
+            result(false)
+        ));
+        assert!(!should_preserve_focused_input(
+            true,
+            false,
+            true,
+            result(true)
+        ));
+        assert!(!should_preserve_focused_input(
+            true,
+            true,
+            false,
+            result(true)
+        ));
     }
 }


### PR DESCRIPTION
# Objective

On a touch device, tapping out of a text input and back into it leaves the software keyboard closed for good. Only a page reload brings it back. The draft text is still there, so nothing is lost, but the input can't be used again.

#63220 made a non-editable tap blur the IME mirror and mark it read-only specifically so "the keyboard can reopen after interacting with non-editable controls or dismissing it manually". At this point, `sync_virtual_keyboard` still supports this. 

#63533 then added `should_preserve_focused_input`, which skips `sync_virtual_keyboard` when the same input accepted text before and after a tap and the application prevented the default.

However, the tap out doesn't move GPUI's focus, only the mirror's, so the tap back in satisfies all three conditions and the sync that would open a new session never runs.

There's no issue for this; I hit it building a component library on `gpui`:  https://labcoder.github.io/gpui-ai/.

## Solution

`should_preserve_focused_input` takes the mirror's liveness as a fourth input, and the call site passes  !this.ime_mirror.read_only()`. There is nothing to preserve once an earlier tap has torn the session down.

I put the check in the function rather than the call sites so the existing unit tests cover it.

## Testing

* `cargo check -p gpui_web --target wasm32-unknown-unknown --all-targets`,
* `cargo fmt --check`
* clippy

All are clean on the file

Added `tap_does_not_preserve_a_dismissed_ime_session`  as a new test. Those tests compile for wasm32 but aren't executed by the wasm CI job, which is a `check`, so I also ran the guard standalone myself to confirm the new case fails without this change and passes with it.

**Reproducing it.** `hello_web` has no text input, so Zed's own example can't
show this. But I caught this in my own website: https://labcoder.github.io/gpui-ai/gallery/embed.html?story=prompt-bar&theme=dark&variant=empty
This is a specific link to the WASM embed you can try out on your phone. You can observe once the keyboard is dismissed it stays out.

1. On a phone, tap into a text input. The keyboard opens.
2. Tap anywhere that isn't a text input. The keyboard closes.
3. Tap the same input again. The keyboard does not return.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before — the keyboard doesn't come back</summary>

https://github.com/user-attachments/assets/18ad0313-1372-4567-97dd-1506d097ff4c
</details>

AI disclosure - I found this bug on my own gpui-ai component website and used an AI assistant to help me find where in GPUI or my own code this was happening and led me here. I implemented the fix myself since it's opinionated, but I also tested and verified the fix myself.

---

Release Notes:

- N/A
