### PR TITLE
Handle reopened PRs on the community PR board

### DIFF
--- a/.github/workflows/community_pr_board.yml
+++ b/.github/workflows/community_pr_board.yml
@@ -1,11 +1,11 @@
 # Community PR Board — route labeled community PRs to a GitHub Project board
 #
-# When an area/platform label is added to a community PR (not staff, not bot),
-# the PR is added to the project board with a Track field set to the matching
-# review area group. Status transitions for assignment, re-request, and
-# comment events are handled here. Review-based status changes (approved →
-# "In Progress (us)", changes requested → "In Progress (author)") are handled
-# by built-in board automations.
+# When an area/platform label is added to or already present when reopening a
+# community PR (not staff, not bot), the PR is added to the project board with a
+# Track field set to the matching review area group. Status transitions for
+# assignment, re-request, and comment events are handled here. Review-based
+# status changes (approved → "In Progress (us)", changes requested → "In
+# Progress (author)") are handled by built-in board automations.
 #
 # See script/community-pr-track-mapping.json for the label→track mapping.
 
@@ -16,7 +16,7 @@ on:
   # Fork PRs must be supported, but this workflow only reads event metadata and
   # checks out scripts from the trusted default branch; it never executes PR code.
   pull_request_target:
-    types: [labeled, unlabeled, assigned, review_requested, edited]
+    types: [labeled, unlabeled, reopened, assigned, review_requested, edited]
   issue_comment:
     types: [created]
   workflow_dispatch:

--- a/script/github-community-pr-board.py
+++ b/script/github-community-pr-board.py
@@ -5,8 +5,8 @@ and surface signal fields (Size, Issue Linked, Contributor, Upvotes) that the
 board's views can filter and sort on.
 
 Reads the event payload dispatched by the GitHub Actions workflow and:
-- On `labeled`: adds the PR to the board (idempotent), sets the Track
-  field to the most specific matching track, and recomputes signal fields.
+- On `labeled` or `reopened`: adds the PR to the board (idempotent), sets the
+  Track field to the most specific matching track, and recomputes signal fields.
 - On `unlabeled`: re-resolves Track from remaining labels, or clears it
   if no area/platform labels remain (PR stays on the board for visibility).
   Signals are recomputed if the PR is on the board.
@@ -681,7 +681,7 @@ if __name__ == "__main__":
 
     print(f"Processing PR #{pr['number']}: action={action}")
 
-    if action in ("labeled", "unlabeled"):
+    if action in ("labeled", "unlabeled", "reopened"):
         project, project_item = sync_track_from_labels(pr, project_number)
         if project_item:
             recompute_signals(pr, project, project_item)


### PR DESCRIPTION
The particular edge case that is covered here is closing a community PR, then labeling it with an `area:`, and _then_ reopening it.

Release Notes:

- N/A