### PR TITLE
agent_skills: Count description length in characters

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -4817,7 +4817,7 @@ mod internal_tests {
                 state.skill_loading_issues.iter().any(|issue| {
                     issue.kind == SkillLoadingIssueKind::DescriptionTooLong
                         && issue.path == skill_path
-                        && issue.message.to_string().contains("1024-byte limit")
+                        && issue.message.to_string().contains("1024-character limit")
                 }),
                 "expected a description-length warning issue, got {:?}",
                 state.skill_loading_issues
@@ -4838,7 +4838,7 @@ mod internal_tests {
                 available_skill
                     .warning
                     .as_ref()
-                    .is_some_and(|warning| warning.contains("1024-byte limit")),
+                    .is_some_and(|warning| warning.contains("1024-character limit")),
                 "available skill should expose warning text, got {:?}",
                 available_skill.warning
             );

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -64,7 +64,7 @@ impl SkillLoadWarning {
                 actual_len,
                 max_len,
             } => format!(
-                "Skill description is {actual_len} bytes, exceeding the {max_len}-byte limit. The skill was loaded, but long descriptions may consume more model-context tokens."
+                "Skill description is {actual_len} characters, exceeding the {max_len}-character limit. The skill was loaded, but long descriptions may consume more model-context tokens."
             ),
         }
     }
@@ -330,9 +330,10 @@ fn validate_description_for_loading(
     }
 
     let mut warnings = Vec::new();
-    if description.len() > MAX_SKILL_DESCRIPTION_LEN {
+    let description_len = description.chars().count();
+    if description_len > MAX_SKILL_DESCRIPTION_LEN {
         warnings.push(SkillLoadWarning::DescriptionTooLong {
-            actual_len: description.len(),
+            actual_len: description_len,
             max_len: MAX_SKILL_DESCRIPTION_LEN,
         });
     }
@@ -532,9 +533,9 @@ pub fn validate_description(description: &str) -> Result<(), &'static str> {
     if description.trim().is_empty() {
         return Err("Skill description cannot be empty");
     }
-    if description.len() > MAX_SKILL_DESCRIPTION_LEN {
+    if description.chars().count() > MAX_SKILL_DESCRIPTION_LEN {
         return Err(formatcp!(
-            "Skill description must be at most {MAX_SKILL_DESCRIPTION_LEN} bytes"
+            "Skill description must be at most {MAX_SKILL_DESCRIPTION_LEN} characters"
         ));
     }
     Ok(())
@@ -1375,7 +1376,7 @@ Content.
 
     #[test]
     fn test_parse_description_too_long_loads_with_warning() {
-        let long_desc = "a".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
+        let long_desc = "中".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
         let content = format!(
             r#"---
 name: test
@@ -1406,7 +1407,7 @@ Content.
 
     #[test]
     fn test_parse_skill_file_content_rejects_description_too_long() {
-        let long_desc = "a".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
+        let long_desc = "中".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
         let content = format!(
             r#"---
 name: test
@@ -1419,7 +1420,7 @@ Content.
 
         let result = parse_skill_file_content(&content);
         assert!(result.is_err());
-        let expected = format!("at most {MAX_SKILL_DESCRIPTION_LEN} bytes");
+        let expected = format!("at most {MAX_SKILL_DESCRIPTION_LEN} characters");
         assert!(result.unwrap_err().to_string().contains(&expected));
     }
 
@@ -2133,16 +2134,12 @@ description: A skill with no body content
     }
 
     #[test]
-    fn validate_description_length_is_measured_in_bytes() {
-        // "é" is 2 bytes in UTF-8. A string of MAX/2 + 1 "é" characters has
-        // only ~MAX/2 + 1 chars but exceeds MAX bytes, so it must be
-        // rejected by a byte-based validator (and accepted by a char-based
-        // one). This regression-tests the byte semantics that strict
-        // validation and load-time warnings both rely on.
-        let chars = MAX_SKILL_DESCRIPTION_LEN / 2 + 1;
-        let description = "é".repeat(chars);
-        assert!(description.chars().count() <= MAX_SKILL_DESCRIPTION_LEN);
+    fn validate_description_length_is_measured_in_characters() {
+        let description = "中".repeat(MAX_SKILL_DESCRIPTION_LEN);
         assert!(description.len() > MAX_SKILL_DESCRIPTION_LEN);
+        assert!(validate_description(&description).is_ok());
+
+        let description = "中".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
         assert!(validate_description(&description).is_err());
     }
 

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1371,6 +1371,30 @@ Content.
     }
 
     #[test]
+    fn test_parse_unicode_description_at_limit_loads_without_warning() {
+        let description = "中".repeat(MAX_SKILL_DESCRIPTION_LEN);
+        let content = format!(
+            r#"---
+name: test
+description: {description}
+---
+
+Content.
+"#
+        );
+
+        let skill = parse_skill_frontmatter(
+            Path::new("/skills/test/SKILL.md"),
+            &content,
+            SkillSource::Global,
+        )
+        .expect("descriptions at the character limit should load without a warning");
+
+        assert_eq!(skill.description, description);
+        assert!(skill.load_warnings.is_empty());
+    }
+
+    #[test]
     fn test_parse_description_too_long_loads_with_warning() {
         let long_desc = "中".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
         let content = format!(

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -417,13 +417,9 @@ fn extract_frontmatter(content: &str) -> Result<(SkillMetadata, &str)> {
 /// by [`validate_name`].
 pub const MAX_SKILL_NAME_LEN: usize = 64;
 
-/// Maximum recommended length (in bytes) for a skill description. The
+/// Maximum recommended length (in Unicode scalar values) for a skill description. The
 /// create-skill UI enforces this as a hard limit, while the loader emits a
 /// warning and still loads longer descriptions.
-///
-/// Byte-based rather than char-based because that's what `.len()` returns
-/// and what every caller currently measures; the UI also surfaces this
-/// limit as a byte count so the editor's counter matches the validator.
 pub const MAX_SKILL_DESCRIPTION_LEN: usize = 1024;
 
 /// Convert an arbitrary human-readable string into a valid skill name, or

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -11674,7 +11674,7 @@ impl ThreadView {
                     .gap_1()
                     .child(
                         Label::new(format!(
-                            "Ensure skill descriptions are at most {MAX_SKILL_DESCRIPTION_LEN} bytes; longer ones may consume more model-context tokens."
+                            "Ensure skill descriptions are at most {MAX_SKILL_DESCRIPTION_LEN} characters; longer ones may consume more model-context tokens."
                         ))
                         .size(LabelSize::Small)
                         .color(Color::Muted),

--- a/crates/settings_ui/src/pages/skill_creator.rs
+++ b/crates/settings_ui/src/pages/skill_creator.rs
@@ -402,7 +402,7 @@ impl SkillCreatorPage {
 
     fn recompute_description_error(&mut self, cx: &mut Context<Self>) {
         let description = self.current_description(cx);
-        self.description_length = description.len();
+        self.description_length = description.chars().count();
         let error = validate_description(&description).err();
         self.description_error = error;
         self.description_editor
@@ -1178,15 +1178,16 @@ fn derived_description_from_markdown(content: &str) -> Option<String> {
 }
 
 fn truncate_description(description: &str) -> String {
-    if description.len() <= MAX_SKILL_DESCRIPTION_LEN {
+    if description.chars().count() <= MAX_SKILL_DESCRIPTION_LEN {
         return description.to_string();
     }
 
-    let mut end = MAX_SKILL_DESCRIPTION_LEN;
-    while !description.is_char_boundary(end) {
-        end -= 1;
-    }
-    description[..end].trim().to_string()
+    description
+        .chars()
+        .take(MAX_SKILL_DESCRIPTION_LEN)
+        .collect::<String>()
+        .trim()
+        .to_string()
 }
 
 /// Serialize the SKILL.md file to disk at `<skills_dir>/<name>/SKILL.md`.
@@ -1539,6 +1540,15 @@ mod tests {
             message.contains("Skill name must contain only lowercase letters"),
             "error should come from shared skill metadata validation, got: {message}"
         );
+    }
+
+    #[test]
+    fn truncate_description_counts_unicode_characters() {
+        let description = "中".repeat(MAX_SKILL_DESCRIPTION_LEN + 1);
+        let truncated = truncate_description(&description);
+
+        assert_eq!(truncated.chars().count(), MAX_SKILL_DESCRIPTION_LEN);
+        assert_eq!(truncated, "中".repeat(MAX_SKILL_DESCRIPTION_LEN));
     }
 
     #[gpui::test]

--- a/crates/settings_ui/src/pages/skill_creator.rs
+++ b/crates/settings_ui/src/pages/skill_creator.rs
@@ -1178,14 +1178,7 @@ fn derived_description_from_markdown(content: &str) -> Option<String> {
 }
 
 fn truncate_description(description: &str) -> String {
-    if description.chars().count() <= MAX_SKILL_DESCRIPTION_LEN {
-        return description.to_string();
-    }
-
-    description
-        .chars()
-        .take(MAX_SKILL_DESCRIPTION_LEN)
-        .collect::<String>()
+    util::truncate(description, MAX_SKILL_DESCRIPTION_LEN)
         .trim()
         .to_string()
 }

--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -119,11 +119,11 @@ Step-by-step instructions for the agent...
 
 #### Frontmatter Fields {#frontmatter-fields}
 
-| Field                      | Required | Description                                                                                                                       |
-| -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                     | Yes      | Lowercase letters, numbers, and hyphens only. Max 64 characters. Should match the folder name.                                    |
-| `description`              | Yes      | What the skill does and when to use it. Keep it under 1024 bytes; skills with longer descriptions still load, but with a warning. |
-| `disable-model-invocation` | No       | Set to `true` to hide from the agent's catalog (invocable via slash command or @-mention only).                                   |
+| Field                      | Required | Description                                                                                                                              |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                     | Yes      | Lowercase letters, numbers, and hyphens only. Max 64 characters. Should match the folder name.                                           |
+| `description`              | Yes      | What the skill does and when to use it. Keep it at most 1024 characters; skills with longer descriptions still load, but with a warning. |
+| `disable-model-invocation` | No       | Set to `true` to hide from the agent's catalog (invocable via slash command or @-mention only).                                          |
 
 > **Tip:** Write descriptions that help the agent recognize when a skill is relevant. Include specific task types and trigger phrases: "Use when handling PDFs, extracting text, or filling forms" is better than "Helps with PDFs."
 


### PR DESCRIPTION
Closes #63620

Count Agent Skill descriptions by Unicode characters rather than UTF-8 bytes across validation, load-time warnings, the skill creator counter, and imported-description truncation. This aligns Zed with the Agent Skills specification and reference validator.

Testing:

- `cargo test -p agent_skills --lib`
- `cargo test -p settings_ui --lib`
- `cargo build -p zed`
- Manually verified that a 342-character CJK description containing 1,026 UTF-8 bytes can be saved successfully
- `./script/clippy -p agent_skills -p settings_ui --tests` is blocked by an unrelated existing `clippy::drain_collect` diagnostic in `crates/rpc/src/proto_client.rs`

<img width="667" height="210" alt="Successfully created Unicode test skill" src="https://github.com/user-attachments/assets/2427fce2-9f0f-462d-959f-e08ad160b3d1" />

Confirmed that the Codex agent panel discovers the skill and exposes it in command completion without a length warning.

<img width="953" height="367" alt="image" src="https://github.com/user-attachments/assets/8c100197-2e6e-4627-b3f8-862bdfaac918" />

Release Notes:

- Fixed valid multibyte Agent Skill descriptions being rejected for exceeding a byte-based length limit.