### PR TITLE
grammars: Distinguish control-flow keyword highlighting in Go

### DIFF
--- a/crates/grammars/src/go/highlights.scm
+++ b/crates/grammars/src/go/highlights.scm
@@ -101,32 +101,36 @@
 ] @operator
 
 [
-  "break"
-  "case"
   "chan"
   "const"
+  "func"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "struct"
+  "type"
+  "var"
+] @keyword
+
+
+[
+  "break"
+  "case"
   "continue"
   "default"
   "defer"
   "else"
   "fallthrough"
   "for"
-  "func"
   "go"
   "goto"
   "if"
-  "import"
-  "interface"
-  "map"
-  "package"
   "range"
   "return"
   "select"
-  "struct"
   "switch"
-  "type"
-  "var"
-] @keyword
+] @keyword.control
 
 [
   (interpreted_string_literal)

--- a/crates/grammars/src/go/highlights.scm
+++ b/crates/grammars/src/go/highlights.scm
@@ -113,7 +113,6 @@
   "var"
 ] @keyword
 
-
 [
   "break"
   "case"


### PR DESCRIPTION
# Objective
- Improve Go's syntax highlighting by distinguishing control-flow keywords from other keywords, in the same way it was done for other languages.

## Solution

- Split keywords in `highlights.scm` into two groups: `keyword.control` and `keyword`. This change affects tree-sitter highlighting, enabling `Semantic Tokens` can override it.

## Testing

- Tested locally on Windows using a development build, with `Semantic Tokens` disabled. Opened a Go file with a theme that assigns different colors to `keyword` and `keyword.control`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

- Screenshot showing a build without this change and one with it side by side
<img width="930" height="154" alt="after" src="https://github.com/user-attachments/assets/bf3f612f-0ffc-40e4-b4c3-7002fff49fb7" />


Release Notes:
- Improved Go syntax highlighting by separating control-flow keywords from regular keywords
