### PR TITLE
ui: Expose keybinding visibility

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -116,7 +116,8 @@ impl KeyBinding {
         cx.refresh_windows();
     }
 
-    fn default_visibility(cx: &mut App) -> bool {
+    /// Returns whether keybindings are visible application-wide.
+    pub fn default_visibility(cx: &mut App) -> bool {
         cx.default_global::<KeyBindingVisibility>().0
     }
 


### PR DESCRIPTION
`KeyBinding::set_default_visibility` lets applications suppress keybinding labels, but the current visibility value is private to `KeyBinding::render`. Applications that compose related modifier hints from lower-level UI elements cannot follow the same presentation policy.

Expose the existing visibility query without changing its behavior. This lets those callers omit their complete hint, including accompanying text and spacing, while sharing the same application-wide source of truth.

Release Notes:

- N/A
