### PR TITLE
gpui: add IsolatedLayout for layout inside a measure closure

### DIFF
--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -156,7 +156,7 @@ pub use subscription::*;
 pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
 use taffy::TaffyLayoutEngine;
-pub use taffy::{AvailableSpace, LayoutId};
+pub use taffy::{AvailableSpace, IsolatedLayout, LayoutId};
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
 pub use text_system::*;

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -71,16 +71,29 @@ impl IsolatedLayout {
 
     /// Run `f` with this tree in front of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, so calls that
-    /// straddle the two stay separate.
+    /// The window gets its own tree back when `f` returns, and also when `f`
+    /// panics, so a caught panic cannot leave the window on the wrong tree. A
+    /// reentered `enter` on the same value holds no tree any more and gives
+    /// the window a fresh one, so the window never sees `None`.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let outer = mem::replace(&mut window.layout_engine, self.0.take());
-        let result = f(window);
+        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
+        let outer = mem::replace(&mut window.layout_engine, Some(inner));
+        // The engines go back where they came from before the panic resumes,
+        // which is what makes the state safe to observe after a catch.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
         self.0 = mem::replace(&mut window.layout_engine, outer);
-        result
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
+    ///
+    /// Call it when a new layout of the content starts, before the first
+    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
+    /// nothing removes them, so a tree that is never cleared grows with each
+    /// pass for as long as the element lives.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();
@@ -959,5 +972,28 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
+    }
+
+    #[crate::test]
+    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
+            let mut layout = IsolatedLayout::new();
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                layout.enter(window, |_| panic!("a panic during an isolated layout"))
+            }));
+            assert!(caught.is_err());
+            // The window holds its own tree again and this value holds the
+            // isolated one, so the caller that caught the panic can go on.
+            assert!(window.layout_engine.is_some());
+            assert!(layout.0.is_some());
+            assert_eq!(layout.enter(window, |_| 7), 7);
+        })
+        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use collections::{FxHashMap, FxHashSet};
-use std::{fmt::Debug, ops::Range};
+use std::{fmt::Debug, mem, ops::Range};
 use taffy::{
     TaffyTree, TraversePartialTree as _,
     geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
@@ -35,6 +35,57 @@ pub struct TaffyLayoutEngine {
     absolute_outer_origins: FxHashMap<LayoutId, Point<f32>>,
     computed_layouts: FxHashSet<LayoutId>,
     layout_bounds_scratch_space: Vec<LayoutId>,
+}
+
+/// A layout tree of its own, for laying an element out while another tree computes.
+///
+/// Taffy computes one tree at a time. The measure closure of
+/// [`Window::request_measured_layout`] runs inside that computation, so an
+/// element that wants to measure a child there cannot use the window's tree.
+/// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
+/// in front of the window's tree for the duration of a closure.
+///
+/// With that, an element can size itself from content that the window's tree
+/// has not laid out yet. A panel that animates its height to the height of its
+/// content is the case this exists for.
+///
+/// The layout ids made inside `enter` belong to this tree and address a
+/// different node in any other tree. Every call that reads one has to run inside
+/// `enter`, which means the child's `prepaint` as well as its layout, because
+/// `prepaint` reads bounds. Two things break that rule: a child that calls
+/// `Window::defer_draw`, which prepaints after `enter` returns, and a child that
+/// keeps a layout id for a later frame.
+pub struct IsolatedLayout(Option<TaffyLayoutEngine>);
+
+impl Default for IsolatedLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsolatedLayout {
+    /// An empty tree.
+    pub fn new() -> Self {
+        Self(Some(TaffyLayoutEngine::new()))
+    }
+
+    /// Run `f` with this tree in front of the window's tree.
+    ///
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
+    pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
+        let outer = mem::replace(&mut window.layout_engine, self.0.take());
+        let result = f(window);
+        self.0 = mem::replace(&mut window.layout_engine, outer);
+        result
+    }
+
+    /// Drop everything this tree holds, keeping it usable for another frame.
+    pub fn clear(&mut self) {
+        if let Some(engine) = self.0.as_mut() {
+            engine.clear();
+        }
+    }
 }
 
 const EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by construction if possible";
@@ -772,5 +823,141 @@ mod tests {
             taffy_border.left,
             taffy::style::LengthPercentage::length(2.0)
         );
+    }
+}
+
+#[cfg(test)]
+mod isolated_layout_tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use crate::{
+        AnyElement, AnyWindowHandle, App, AppContext as _, AvailableSpace, Bounds, Context,
+        Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, IsolatedLayout,
+        LayoutId, ParentElement, Pixels, Render, Size, Style, Styled, TestAppContext, Window, div,
+        px, size,
+    };
+
+    /// An element that takes its size from content it measures during layout.
+    ///
+    /// The content is laid out in a tree of its own, because the measure closure
+    /// runs while the window's tree computes.
+    struct MeasureDuringLayout {
+        state: Rc<RefCell<(AnyElement, IsolatedLayout)>>,
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Element for MeasureDuringLayout {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            None
+        }
+
+        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            window: &mut Window,
+            _cx: &mut App,
+        ) -> (LayoutId, ()) {
+            let state = self.state.clone();
+            let layout_id = window.request_measured_layout(
+                Style::default(),
+                move |known: Size<Option<Pixels>>, available: Size<AvailableSpace>, window, cx| {
+                    let (content, layout) = &mut *state.borrow_mut();
+                    let width = known
+                        .width
+                        .map_or(available.width, AvailableSpace::Definite);
+                    layout.enter(window, |window| {
+                        content.layout_as_root(size(width, AvailableSpace::MaxContent), window, cx)
+                    })
+                },
+            );
+            (layout_id, ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+            self.bounds.set(bounds);
+        }
+
+        fn paint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _prepaint: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+        }
+    }
+
+    impl IntoElement for MeasureDuringLayout {
+        type Element = Self;
+
+        fn into_element(self) -> Self {
+            self
+        }
+    }
+
+    struct MeasureTestView {
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Render for MeasureTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            // Two children of 120 wrap into two rows of 30 at a width of 200, and
+            // sit on one row of 30 at max content.
+            let content = div()
+                .flex()
+                .flex_row()
+                .flex_wrap()
+                .child(div().w(px(120.)).h(px(30.)))
+                .child(div().w(px(120.)).h(px(30.)))
+                .into_any_element();
+
+            div()
+                .w(px(200.))
+                .flex()
+                .flex_col()
+                .child(MeasureDuringLayout {
+                    state: Rc::new(RefCell::new((content, IsolatedLayout::new()))),
+                    bounds: self.bounds.clone(),
+                })
+        }
+    }
+
+    #[crate::test]
+    fn measures_content_at_the_width_layout_resolved(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, cx| {
+            window.draw(cx).clear(cx)
+        })
+        .unwrap();
+
+        // The width reaches the measure closure, so the content wraps the way it
+        // will on screen. Without it the content would measure at max content and
+        // the element would stop at 30.
+        assert_eq!(bounds.get().size.height, px(60.));
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -43,7 +43,7 @@ pub struct TaffyLayoutEngine {
 /// [`Window::request_measured_layout`] runs inside that computation, so an
 /// element that wants to measure a child there cannot use the window's tree.
 /// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
-/// in front of the window's tree for the duration of a closure.
+/// in place of the window's tree for the duration of a closure.
 ///
 /// With that, an element can size itself from content that the window's tree
 /// has not laid out yet. A panel that animates its height to the height of its
@@ -69,23 +69,15 @@ impl IsolatedLayout {
         Self(Some(TaffyLayoutEngine::new()))
     }
 
-    /// Run `f` with this tree in front of the window's tree.
+    /// Run `f` with this tree in place of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, and also when `f`
-    /// panics, so a caught panic cannot leave the window on the wrong tree. A
-    /// reentered `enter` on the same value holds no tree any more and gives
-    /// the window a fresh one, so the window never sees `None`.
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
-        let outer = mem::replace(&mut window.layout_engine, Some(inner));
-        // The engines go back where they came from before the panic resumes,
-        // which is what makes the state safe to observe after a catch.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
-        self.0 = mem::replace(&mut window.layout_engine, outer);
-        match result {
-            Ok(value) => value,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        let result = f(window);
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        result
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
@@ -973,28 +965,5 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
-    }
-
-    #[crate::test]
-    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
-        let bounds = Rc::new(Cell::new(Bounds::default()));
-        let window = cx.add_window({
-            let bounds = bounds.clone();
-            move |_, _| MeasureTestView { bounds }
-        });
-
-        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
-            let mut layout = IsolatedLayout::new();
-            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                layout.enter(window, |_| panic!("a panic during an isolated layout"))
-            }));
-            assert!(caught.is_err());
-            // The window holds its own tree again and this value holds the
-            // isolated one, so the caller that caught the panic can go on.
-            assert!(window.layout_engine.is_some());
-            assert!(layout.0.is_some());
-            assert_eq!(layout.enter(window, |_| 7), 7);
-        })
-        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -90,10 +90,11 @@ impl IsolatedLayout {
 
     /// Drop everything this tree holds, keeping it usable for another frame.
     ///
-    /// Call it when a new layout of the content starts, before the first
-    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
-    /// nothing removes them, so a tree that is never cleared grows with each
-    /// pass for as long as the element lives.
+    /// Call it only between elements: after the old content element drops,
+    /// before the first `enter` with the new one. An element requests its
+    /// nodes once and reuses those ids in every later pass, so a clear while
+    /// the element lives makes its next layout panic on the dead ids. A tree
+    /// that lives exactly as long as one element never needs a clear.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1160,7 +1160,7 @@ pub struct Window {
     /// a given rem size.
     rem_size_override_stack: SmallVec<[Pixels; 8]>,
     pub(crate) viewport_size: Size<Pixels>,
-    layout_engine: Option<TaffyLayoutEngine>,
+    pub(crate) layout_engine: Option<TaffyLayoutEngine>,
     pub(crate) root: Option<AnyView>,
     pub(crate) element_id_stack: SmallVec<[ElementId; 32]>,
     pub(crate) text_style_stack: Vec<TextStyleRefinement>,


### PR DESCRIPTION
# Objective

Let an element lay out and measure a child while the window's layout is still running.

Taffy computes one tree at a time. The measure closure that `Window::request_measured_layout` takes runs inside that computation, so it cannot call `request_layout` or `compute_layout` on the window. A panel that animates its height to the height of its content needs exactly that: Taffy hands the closure the parent's width, and the content has to be measured at that width so text wraps the way it will on screen.

I hit this in GPUIX, a React renderer for GPUI by @remorses. Same change as remorses/zed#5.

This PR is the bottom of a stack. #63792, #63793 and #63773 build on it. The stack started as one PR, #63773, and I split it so each part gets its own review. #63773 lists the parts in order.

## Solution

- Add `IsolatedLayout`, a second `TaffyLayoutEngine`. `enter` swaps it in as the window's engine, runs the closure, and swaps the original back. `clear` drops the tree.
- Make `Window::layout_engine` `pub(crate)` so the swap can happen. No other change to `Window`.

Layout ids created inside `enter` belong to the isolated tree. Keeping one across frames, or using it with `Window::defer_draw`, is not supported.

## Testing

- One new test in `crates/gpui/src/taffy.rs`. It measures content inside `enter` at the width the outer layout resolved.
- `cargo test -p gpui` at this head: 311 passed, 1 doc test passed. `cargo fmt --all -- --check` is clean.
- Revert check: I changed `enter` to run the closure without the swap and rebuilt GPUIX. Its three `height: auto` tests and one React test then panic in the measure closure, where `Window::request_measured_layout` unwraps `layout_engine`. With the swap back, all pass.
- Performance: nothing runs unless an element calls `enter`. The second tree stays empty until then.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Screenshots

A `height: auto` animation in GPUIX at 0, 150, 300 and 500 ms. Both boxes hold the same words. The content is measured at each column's width inside the measure closure, so the narrow box wraps into more lines and grows taller. No height is written anywhere.

![height auto animation frames](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr1-height-strip.png)

---

Release Notes:

- N/A
