### PR TITLE
gpui_web: Disable native canvas touch callouts

### DIFF
--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -121,6 +121,7 @@ impl WebWindow {
             ("display", "block"),
             ("outline", "none"),
             ("touch-action", "none"),
+            ("-webkit-touch-callout", "none"),
         ] {
             style.set_property(property, value).map_err(|error| {
                 anyhow::anyhow!("Failed to set canvas {property} style: {error:?}")


### PR DESCRIPTION
On iOS, WebKit presents a native touch callout when a user long-presses a canvas. For GPUI Web this selected the full application canvas while GPUI independently selected the intended word, producing two pairs of selection handles, a native edit menu, and haptic feedback.

Set `-webkit-touch-callout: none` on the canvas created by `gpui_web`. GPUI already owns touch gesture recognition on this surface, so WebKit should not provide a competing canvas interaction.

Tested with:

- `cargo fmt --check --package gpui_web`
- `RUSTC_BOOTSTRAP=1 cargo check -p gpui_web --target wasm32-unknown-unknown`
- A Delta Web WASM build using the local Zed checkout
- Manual verification on an iPhone that long-press word selection no longer selects the full canvas

Release Notes:

- N/A
