### PR TITLE
gpui_linux: Disable IME in project panel when no input handler on Wayland

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1043,7 +1043,7 @@ impl WaylandWindowStatePtr {
             accepts_text_input
         } else {
             drop(state);
-            true
+            false
         };
         if Some(ime_enabled) == client.ime_enabled() {
             return;


### PR DESCRIPTION
# Objective

Fixes #63774

## Solution

On Wayland, the IME remained enabled when the focused control did not register a text input handler. This allowed IME to intercept ABC...Z character shortcuts in non-text UI, including the Project Panel outside filename editing. However Windows 11 doesn't have this problem.

Fixed it by treating a missing input handler as not accepting text input.

## Testing

I've tested on both Vim/Helix mode and normal mode with Vim/Helix keybinds. All clear now.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

[after.webm](https://github.com/user-attachments/assets/91743d71-05c5-49d2-b032-4aebc8e91496)

ABC...Z character shortcuts are not going to be intercepted by IME unexpectedly in project panel now.

---

Release Notes:

- Fixed IME remains enabled in project panel without a focused text input in Wayland #63774
