### PR TITLE
gpui: capture-phase scroll wheel listener

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -377,6 +377,25 @@ impl Interactivity {
             }));
     }
 
+    /// Bind the given callback to scroll wheel events during the capture
+    /// phase, while the mouse is over this element. A handler here runs
+    /// before any element applies the scroll, so `cx.stop_propagation()`
+    /// consumes the event and nothing scrolls.
+    /// The imperative API equivalent to [`InteractiveElement::capture_scroll_wheel`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    pub fn capture_scroll_wheel(
+        &mut self,
+        listener: impl Fn(&ScrollWheelEvent, &mut Window, &mut App) + 'static,
+    ) {
+        self.scroll_wheel_listeners
+            .push(Box::new(move |event, phase, hitbox, window, cx| {
+                if phase == DispatchPhase::Capture && hitbox.should_handle_scroll(window) {
+                    (listener)(event, window, cx);
+                }
+            }));
+    }
+
     /// Bind the given callback to pinch gesture events during the bubble phase.
     ///
     /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
@@ -1022,6 +1041,21 @@ pub trait InteractiveElement: Sized {
         listener: impl Fn(&ScrollWheelEvent, &mut Window, &mut App) + 'static,
     ) -> Self {
         self.interactivity().on_scroll_wheel(listener);
+        self
+    }
+
+    /// Bind the given callback to scroll wheel events during the capture
+    /// phase, while the mouse is over this element. A handler here runs
+    /// before any element applies the scroll, so `cx.stop_propagation()`
+    /// consumes the event and nothing scrolls.
+    /// The fluent API equivalent to [`Interactivity::capture_scroll_wheel`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    fn capture_scroll_wheel(
+        mut self,
+        listener: impl Fn(&ScrollWheelEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.interactivity().capture_scroll_wheel(listener);
         self
     }
 

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -4347,9 +4347,12 @@ mod tests {
     use super::*;
     use crate::{
         AnyWindowHandle, AppContext as _, Context, InputEvent, Keystroke, MouseMoveEvent,
-        TestAppContext, canvas, util::FluentBuilder as _,
+        ScrollDelta, TestAppContext, canvas, util::FluentBuilder as _,
     };
-    use std::{cell::Cell, rc::Weak};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Weak,
+    };
 
     struct GroupHoverTestView {
         render_count: Rc<Cell<usize>>,
@@ -5449,5 +5452,57 @@ mod tests {
         assert_eq!(bounds("cell-0").origin.x, px(0.));
         assert_eq!(bounds("cell-1").origin.x, px(100.));
         assert_eq!(bounds("cell-2").origin.x, px(300.));
+    }
+
+    fn scroll_log_view(
+        log: Rc<RefCell<Vec<&'static str>>>,
+        stop: bool,
+    ) -> impl Fn(&mut Window, &mut App) -> AnyElement {
+        move |_, _| {
+            let capture_log = log.clone();
+            let bubble_log = log.clone();
+            div()
+                .size(px(100.))
+                .capture_scroll_wheel(move |_, _, cx| {
+                    capture_log.borrow_mut().push("outer capture");
+                    if stop {
+                        cx.stop_propagation();
+                    }
+                })
+                .child(
+                    div().size(px(50.)).on_scroll_wheel(move |_, _, _| {
+                        bubble_log.borrow_mut().push("inner bubble")
+                    }),
+                )
+                .into_any_element()
+        }
+    }
+
+    #[gpui::test]
+    fn capture_scroll_wheel_runs_before_the_bubble_listeners(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let scroll = ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-10.))),
+            ..Default::default()
+        };
+
+        cx.draw(
+            point(px(0.), px(0.)),
+            size(px(100.), px(100.)),
+            scroll_log_view(log.clone(), false),
+        );
+        cx.simulate_event(scroll.clone());
+        assert_eq!(*log.borrow(), ["outer capture", "inner bubble"]);
+
+        log.borrow_mut().clear();
+        cx.draw(
+            point(px(0.), px(0.)),
+            size(px(100.), px(100.)),
+            scroll_log_view(log.clone(), true),
+        );
+        cx.simulate_event(scroll);
+        assert_eq!(*log.borrow(), ["outer capture"]);
     }
 }


### PR DESCRIPTION
# Objective

Let an element see a scroll wheel event before any element applies the scroll. GPUIX, a React renderer for GPUI by @remorses, needs this for CSS `scroll-snap-type`. When the fingers lift after a fling, the handler predicts the landing point, starts a glide to the snap position, and consumes the OS momentum events so they cannot cancel the glide. It must see each event before the box scrolls with it.

One of the small PRs that came out of #63773. It stands on `main`.

## Solution

- `capture_scroll_wheel` on `Interactivity` and `InteractiveElement`. It pushes a scroll wheel listener that runs in the capture phase while the mouse is over the element. `cx.stop_propagation()` in the handler consumes the event, so nothing scrolls.
- The bubble-phase `on_scroll_wheel` stays as it is.

## Testing

- One new test in `crates/gpui/src/elements/div.rs`, `capture_scroll_wheel_runs_before_the_bubble_listeners`. An outer div captures, an inner div listens in the bubble phase. The log reads capture first, then bubble. With `stop_propagation` in the capture handler, the bubble listener never runs.
- `cargo test -p gpui`: 311 passed, 1 doc test passed. `cargo fmt --all -- --check` is clean.
- The GPUIX suite has scroll snap tests that send a fling through the test renderer and assert where the box lands.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
