### PR TITLE
gpui: lay list rows out inside the horizontal padding

### DIFF
--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1052,7 +1052,7 @@ impl StateInner {
 
         let available_item_space = size(
             available_width.map_or(AvailableSpace::MaxContent, |width| {
-                AvailableSpace::Definite(width)
+                AvailableSpace::Definite(width - padding.left - padding.right)
             }),
             AvailableSpace::MinContent,
         );
@@ -1257,10 +1257,11 @@ impl StateInner {
         window: &mut Window,
         cx: &mut App,
     ) -> Result<LayoutItemsResponse, ListOffset> {
+        let item_width = bounds.size.width - padding.left - padding.right;
         window.transact(|window| {
             match self.measuring_behavior {
                 ListMeasuringBehavior::Measure(has_measured) if !has_measured => {
-                    self.layout_all_items(bounds.size.width, render_item, window, cx);
+                    self.layout_all_items(item_width, render_item, window, cx);
                 }
                 _ => {}
             }
@@ -1279,7 +1280,7 @@ impl StateInner {
 
             // Only paint the visible items, if there is actually any space for them (taking padding into account)
             if bounds.size.height > padding.top + padding.bottom {
-                let mut item_origin = bounds.origin + Point::new(px(0.), padding.top);
+                let mut item_origin = bounds.origin + Point::new(padding.left, padding.top);
                 item_origin.y -= layout_response.scroll_top.offset_in_item;
                 for item in &mut layout_response.item_layouts {
                     window.with_content_mask(Some(ContentMask { bounds }), |window| {
@@ -1308,10 +1309,8 @@ impl StateInner {
                                     };
                                     let size = prev_item.size().unwrap_or_else(|| {
                                         let mut element = render_item(cursor.start().0, window, cx);
-                                        let item_available_size = size(
-                                            bounds.size.width.into(),
-                                            AvailableSpace::MinContent,
-                                        );
+                                        let item_available_size =
+                                            size(item_width.into(), AvailableSpace::MinContent);
                                         element.layout_as_root(item_available_size, window, cx)
                                     });
                                     item_ix = cursor.start().0;
@@ -1339,7 +1338,7 @@ impl StateInner {
                                 let size = item.size().unwrap_or_else(|| {
                                     let mut item = render_item(cursor.start().0, window, cx);
                                     let item_available_size =
-                                        size(bounds.size.width.into(), AvailableSpace::MinContent);
+                                        size(item_width.into(), AvailableSpace::MinContent);
                                     item.layout_as_root(item_available_size, window, cx)
                                 });
                                 height -= size.height;
@@ -1484,7 +1483,8 @@ impl Element for List {
                         window,
                         cx,
                     );
-                    let max_element_width = layout_response.max_item_width;
+                    let max_element_width =
+                        layout_response.max_item_width + padding.left + padding.right;
 
                     let summary = state.items.summary();
                     let total_height = summary.height;


### PR DESCRIPTION
This PR fixes a small bug in the `list` element which reads padding on both axes (X & Y) but only applies the values set for the Y axis and the X axis values end up being ignored.

Right now Zed works around this bug by manually setting the horizontal padding to `8` (here's an exmple: https://github.com/zed-industries/zed/blob/main/crates/settings_ui/src/settings_ui.rs#L3616).

I ran `cargo test -p gpui` to make sure my changes didn't break any existing test.

P.S.: this description was re-written by me because I used AI to write the original version of it.