### PR TITLE
gpui: expose the window redraw mark to tests

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2527,6 +2527,14 @@ impl Window {
         self.on_next_frame(move |_, cx| cx.notify(entity));
     }
 
+    /// Whether the window will paint on the next frame. The test harness
+    /// paints only on demand, so a test reads this after an event to check
+    /// that a handler asked for a paint.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn needs_paint(&self) -> bool {
+        self.invalidator.is_dirty()
+    }
+
     /// Runs all callbacks scheduled via [`Self::on_next_frame`], returning how many ran.
     ///
     /// Tests have no platform frame loop, so this simulates the delivery of the


### PR DESCRIPTION
# Objective

Let a test assert that an event handler asked the window to redraw.

GPUIX, a React renderer for GPUI by @remorses, glides to a scroll snap position one step per painted frame, and the live window only paints when something asks. A test dispatches the lift of a fling and asserts that the handler asked for a paint. The test harness paints on demand, so the dirty mark on the invalidator is the only trace of that request.

One of the small PRs that came out of #63773. It stands on `main`.

## Solution

- `Window::needs_paint()` under `cfg(any(test, feature = "test-support"))`. It returns `self.invalidator.is_dirty()`.
- `TestWindow` also records frame requests, in `frame_scheduled` and `frame_wake_count`. The mark here is true only inside the update closure that dispatched the event, which is how GPUIX reads it. A read on `VisualTestContext` would serve more tests. Say so if you prefer that shape.

## Testing

- `cargo test -p gpui`: 310 passed, 1 doc test passed. `cargo fmt --all -- --check` is clean.
- No test is new in gpui. The method is a getter for tests. GPUIX reads it in its scroll snap tests.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
