### PR TITLE
gpui: overscroll-behavior and a scroll range that follows the children

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -21,8 +21,8 @@ use crate::{
     FocusHandle, Global, GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId,
     IntoElement, IsZero, KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent,
     LayoutId, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
-    MouseMoveEvent, MousePressureEvent, MouseUpEvent, OngoingScroll, Overflow, ParentElement,
-    PinchEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Size, Style,
+    MouseMoveEvent, MousePressureEvent, MouseUpEvent, OngoingScroll, Overflow, Overscroll,
+    ParentElement, PinchEvent, Pixels, Point, Render, ScrollWheelEvent, SharedString, Size, Style,
     StyleRefinement, Styled, Task, TooltipId, Visibility, Window, WindowControlArea, point, px,
     size,
 };
@@ -1935,6 +1935,16 @@ impl Element for Div {
 
         let mut child_min = point(Pixels::MAX, Pixels::MAX);
         let mut child_max = Point::default();
+        let mut flow_child_edge: Option<Point<Pixels>> = None;
+        let mut absolute_child_edge: Option<Point<Pixels>> = None;
+        let mut note_child_edge = |edge: Point<Pixels>, absolute: bool| {
+            let slot = if absolute {
+                &mut absolute_child_edge
+            } else {
+                &mut flow_child_edge
+            };
+            *slot = Some(slot.map_or(edge, |max| max.max(&edge)));
+        };
         if let Some(handle) = self.interactivity.scroll_anchor.as_ref() {
             *handle.last_origin.borrow_mut() = bounds.origin - window.element_offset();
         }
@@ -1947,6 +1957,10 @@ impl Element for Div {
                 let child_bounds = window.layout_bounds(*child_layout_id);
                 child_min = child_min.min(&child_bounds.origin);
                 child_max = child_max.max(&child_bounds.bottom_right());
+                note_child_edge(
+                    child_bounds.bottom_right(),
+                    window.layout_position_is_absolute(*child_layout_id),
+                );
                 state.child_bounds.push(child_bounds);
             }
             (child_max - child_min).into()
@@ -1955,6 +1969,10 @@ impl Element for Div {
                 let child_bounds = window.layout_bounds(*child_layout_id);
                 child_min = child_min.min(&child_bounds.origin);
                 child_max = child_max.max(&child_bounds.bottom_right());
+                note_child_edge(
+                    child_bounds.bottom_right(),
+                    window.layout_position_is_absolute(*child_layout_id),
+                );
 
                 if has_prepaint_listener {
                     children_bounds.push(child_bounds);
@@ -1967,6 +1985,8 @@ impl Element for Div {
             scroll_handle.scroll_to_active_item();
         }
 
+        self.interactivity.flow_child_edge = flow_child_edge;
+        self.interactivity.absolute_child_edge = absolute_child_edge;
         self.interactivity.prepaint(
             global_id,
             inspector_id,
@@ -2091,6 +2111,16 @@ pub struct Interactivity {
     pub hovered: Option<bool>,
     pub(crate) tooltip_id: Option<TooltipId>,
     pub(crate) content_size: Size<Pixels>,
+    /// The furthest bottom right edge of an in-flow child, in window
+    /// pixels. The scroll range runs to this edge plus the end-side
+    /// padding, the CSS scrollable overflow.
+    pub(crate) flow_child_edge: Option<Point<Pixels>>,
+    /// The furthest bottom right edge of a `position: absolute` child.
+    /// The scroll range runs to this edge as is. CSS adds no end-side
+    /// padding after an absolutely positioned box.
+    pub(crate) absolute_child_edge: Option<Point<Pixels>>,
+    /// The scroll range this frame, from `clamp_scroll_position`.
+    pub(crate) scroll_max: Point<Pixels>,
     pub(crate) key_context: Option<KeyContext>,
     pub(crate) focusable: bool,
     pub(crate) tracked_focus_handle: Option<FocusHandle>,
@@ -2376,7 +2406,7 @@ impl Interactivity {
     }
 
     fn clamp_scroll_position(
-        &self,
+        &mut self,
         bounds: Bounds<Pixels>,
         style: &Style,
         window: &mut Window,
@@ -2414,10 +2444,22 @@ impl Interactivity {
             // 0.00000x pixels. As we generally don't benefit from a precision that
             // high for the maximum scroll, we round the scroll max to 2 decimal
             // places here.
-            let padded_content_size = self.content_size + padding_size;
-            let scroll_max = Point::from(padded_content_size - bounds.size)
-                .map(round_to_two_decimals)
-                .max(&Default::default());
+            let padded_flow_edge = self
+                .flow_child_edge
+                .map(|edge| edge + point(padding.right, padding.bottom));
+            let child_edge = match (padded_flow_edge, self.absolute_child_edge) {
+                (Some(flow), Some(absolute)) => Some(flow.max(&absolute)),
+                (edge, None) | (None, edge) => edge,
+            };
+            let scroll_max = match child_edge {
+                Some(edge) => (edge - bounds.bottom_right())
+                    .map(round_to_two_decimals)
+                    .max(&Default::default()),
+                None => Point::from(self.content_size + padding_size - bounds.size)
+                    .map(round_to_two_decimals)
+                    .max(&Default::default()),
+            };
+            self.scroll_max = scroll_max;
             // Clamp scroll offset in case scroll max is smaller now (e.g., if children
             // were removed or the bounds became larger).
             let mut scroll_offset = scroll_offset.borrow_mut();
@@ -3266,11 +3308,16 @@ impl Interactivity {
             let overflow = style.overflow;
             let allow_concurrent_scroll = style.allow_concurrent_scroll;
             let restrict_scroll_to_axis = style.restrict_scroll_to_axis;
+            let overscroll = style.overscroll_behavior;
+            let scroll_max = self.scroll_max;
             let line_height = window.line_height();
             let hitbox = hitbox.clone();
             let current_view = window.current_view();
             window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
-                if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
+                if phase == DispatchPhase::Bubble
+                    && hitbox.should_handle_scroll(window)
+                    && !window.scroll_wheel_taken()
+                {
                     let mut scroll_offset = scroll_offset.borrow_mut();
                     let old_scroll_offset = *scroll_offset;
                     let mut delta = event.delta.pixel_delta(line_height);
@@ -3309,10 +3356,16 @@ impl Interactivity {
                             delta_x = Pixels::ZERO;
                         }
                     }
-                    scroll_offset.y += delta_y;
-                    scroll_offset.x += delta_x;
-                    if *scroll_offset != old_scroll_offset {
+                    scroll_offset.y = (scroll_offset.y + delta_y).clamp(-scroll_max.y, px(0.));
+                    scroll_offset.x = (scroll_offset.x + delta_x).clamp(-scroll_max.x, px(0.));
+                    let scrolled = *scroll_offset != old_scroll_offset;
+                    if scrolled {
                         cx.notify(current_view);
+                    }
+                    let kept_x = !delta_x.is_zero() && overscroll.x != Overscroll::Auto;
+                    let kept_y = !delta_y.is_zero() && overscroll.y != Overscroll::Auto;
+                    if scrolled || kept_x || kept_y {
+                        window.take_scroll_wheel();
                     }
                 }
             });
@@ -4313,7 +4366,7 @@ mod tests {
     use super::*;
     use crate::{
         AnyWindowHandle, AppContext as _, Context, InputEvent, Keystroke, MouseMoveEvent,
-        TestAppContext, canvas, util::FluentBuilder as _,
+        ScrollDelta, TestAppContext, VisualTestContext, canvas, util::FluentBuilder as _,
     };
     use std::{cell::Cell, rc::Weak};
 
@@ -5415,5 +5468,163 @@ mod tests {
         assert_eq!(bounds("cell-0").origin.x, px(0.));
         assert_eq!(bounds("cell-1").origin.x, px(100.));
         assert_eq!(bounds("cell-2").origin.x, px(300.));
+    }
+
+    struct RenderWith(Box<dyn Fn(&mut Window, &mut App) -> AnyElement>);
+
+    impl Render for RenderWith {
+        fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            (self.0)(window, cx)
+        }
+    }
+
+    fn draw_view(
+        cx: &mut VisualTestContext,
+        render: impl Fn(&mut Window, &mut App) -> AnyElement + Clone + 'static,
+    ) {
+        cx.draw(
+            point(px(0.), px(0.)),
+            size(px(100.), px(100.)),
+            move |_, cx| {
+                let render = render.clone();
+                cx.new(|_| RenderWith(Box::new(render))).into_any_element()
+            },
+        );
+    }
+
+    fn wheel(dy: f32) -> ScrollWheelEvent {
+        ScrollWheelEvent {
+            position: point(px(10.), px(10.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(dy))),
+            ..Default::default()
+        }
+    }
+
+    fn draw_scroll_box(
+        cx: &mut VisualTestContext,
+        handle: &ScrollHandle,
+        child: impl Fn() -> Div + 'static,
+    ) {
+        let handle = handle.clone();
+        let child = Rc::new(child);
+        draw_view(cx, move |_, _| {
+            div()
+                .id("box")
+                .size(px(100.))
+                .p(px(10.))
+                .overflow_y_scroll()
+                .track_scroll(&handle)
+                .child(child())
+                .into_any_element()
+        });
+    }
+
+    #[gpui::test]
+    fn scroll_range_ends_after_the_bottom_padding(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let handle = ScrollHandle::new();
+        draw_scroll_box(cx, &handle, || div().w_full().h(px(200.)));
+        cx.simulate_event(wheel(-1000.));
+        assert_eq!(handle.offset().y, px(-120.));
+    }
+
+    #[gpui::test]
+    fn scroll_range_follows_a_child_with_a_margin(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let handle = ScrollHandle::new();
+        draw_scroll_box(cx, &handle, || div().w_full().mt(px(30.)).h(px(60.)));
+        cx.simulate_event(wheel(-1000.));
+        assert_eq!(handle.offset().y, px(-10.));
+    }
+
+    #[gpui::test]
+    fn scroll_range_ends_at_the_edge_of_an_absolute_child(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let handle = ScrollHandle::new();
+        draw_scroll_box(cx, &handle, || {
+            div().absolute().top(px(150.)).left_0().size(px(50.))
+        });
+        cx.simulate_event(wheel(-1000.));
+        assert_eq!(handle.offset().y, px(-100.));
+    }
+
+    struct NestedScroll {
+        outer: ScrollHandle,
+        inner: ScrollHandle,
+        overscroll: Overscroll,
+        outer_saw: Rc<Cell<usize>>,
+    }
+
+    impl NestedScroll {
+        fn new(overscroll: Overscroll) -> Self {
+            Self {
+                outer: ScrollHandle::new(),
+                inner: ScrollHandle::new(),
+                overscroll,
+                outer_saw: Rc::new(Cell::new(0)),
+            }
+        }
+
+        fn draw(&self, cx: &mut VisualTestContext) {
+            let outer = self.outer.clone();
+            let inner = self.inner.clone();
+            let overscroll = self.overscroll;
+            let outer_saw = self.outer_saw.clone();
+            draw_view(cx, move |_, _| {
+                let outer_saw = outer_saw.clone();
+                div()
+                    .id("outer")
+                    .size(px(100.))
+                    .overflow_y_scroll()
+                    .track_scroll(&outer)
+                    .on_scroll_wheel(move |_, _, _| outer_saw.set(outer_saw.get() + 1))
+                    .child(
+                        div()
+                            .id("inner")
+                            .w_full()
+                            .h(px(50.))
+                            .overflow_y_scroll()
+                            .overscroll_behavior(Overscroll::Auto, overscroll)
+                            .track_scroll(&inner)
+                            .child(div().w_full().h(px(100.))),
+                    )
+                    .child(div().w_full().h(px(200.)))
+                    .into_any_element()
+            });
+        }
+    }
+
+    #[gpui::test]
+    fn the_inner_scroll_container_scrolls_until_its_end(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let nested = NestedScroll::new(Overscroll::Auto);
+        nested.draw(cx);
+
+        cx.simulate_event(wheel(-30.));
+        assert_eq!(nested.inner.offset().y, px(-30.));
+        assert_eq!(nested.outer.offset().y, px(0.));
+
+        cx.simulate_event(wheel(-30.));
+        assert_eq!(nested.inner.offset().y, px(-50.));
+        assert_eq!(nested.outer.offset().y, px(0.));
+
+        cx.simulate_event(wheel(-30.));
+        assert_eq!(nested.inner.offset().y, px(-50.));
+        assert_eq!(nested.outer.offset().y, px(-30.));
+
+        assert_eq!(nested.outer_saw.get(), 3);
+    }
+
+    #[gpui::test]
+    fn overscroll_contain_keeps_the_wheel_at_the_end(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let nested = NestedScroll::new(Overscroll::Contain);
+        nested.draw(cx);
+
+        cx.simulate_event(wheel(-60.));
+        cx.simulate_event(wheel(-30.));
+        assert_eq!(nested.inner.offset().y, px(-50.));
+        assert_eq!(nested.outer.offset().y, px(0.));
+        assert_eq!(nested.outer_saw.get(), 2);
     }
 }

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1429,7 +1429,7 @@ impl std::fmt::Debug for ListItem {
 
 /// An offset into the list's items, in terms of the item index and the number
 /// of pixels off the top left of the item.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ListOffset {
     /// The index of an item in the list
     pub item_ix: usize,
@@ -1599,9 +1599,13 @@ impl Element for List {
         let hitbox_id = prepaint.hitbox.id;
         let mut accumulated_scroll_delta = ScrollDelta::default();
         window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
-            if phase == DispatchPhase::Bubble && hitbox_id.should_handle_scroll(window) {
+            if phase == DispatchPhase::Bubble
+                && hitbox_id.should_handle_scroll(window)
+                && !window.scroll_wheel_taken()
+            {
                 accumulated_scroll_delta = accumulated_scroll_delta.coalesce(event.delta);
                 let pixel_delta = accumulated_scroll_delta.pixel_delta(px(20.));
+                let before = list_state.logical_scroll_top();
                 list_state.0.borrow_mut().scroll(
                     &scroll_top,
                     height,
@@ -1609,7 +1613,10 @@ impl Element for List {
                     current_view,
                     window,
                     cx,
-                )
+                );
+                if list_state.logical_scroll_top() != before {
+                    window.take_scroll_wheel();
+                }
             }
         });
 

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -218,6 +218,10 @@ pub struct Style {
     /// Ideally we would match the web's behavior and not have a need for this, but right now we're adding this opt-in
     /// style property to limit the potential blast radius.
     pub restrict_scroll_to_axis: bool,
+    /// What happens to a wheel event this element could not scroll with, per
+    /// axis. CSS `overscroll-behavior`.
+    #[refineable]
+    pub overscroll_behavior: Point<Overscroll>,
 
     // Position properties
     /// What should the `position` value of this struct use as a base offset?
@@ -779,6 +783,7 @@ impl Default for Style {
             },
             allow_concurrent_scroll: false,
             restrict_scroll_to_axis: false,
+            overscroll_behavior: Point::default(),
             scrollbar_width: AbsoluteLength::default(),
             position: Position::Relative,
             inset: Edges::auto(),
@@ -1220,6 +1225,22 @@ pub enum Overflow {
     /// for a scrollbar. The amount of space reserved is controlled by the `scrollbar_width` property.
     /// Content that overflows this node should *not* contribute to the scroll region of its parent.
     Scroll,
+}
+
+/// Where a wheel event goes once a scroll container reaches its end on an
+/// axis. CSS `overscroll-behavior`.
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior>
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub enum Overscroll {
+    /// Past the end, the nearest scroll container around this one scrolls.
+    #[default]
+    Auto,
+    /// Past the end, nothing scrolls. Listeners still see the event.
+    Contain,
+    /// The same as `Contain`. CSS also drops the bounce effect, which GPUI
+    /// does not draw.
+    None,
 }
 
 /// The positioning strategy for this item.

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -2,7 +2,7 @@ use crate::{
     self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
     DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
     FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent, Length,
-    SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
+    Overscroll, SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
     TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
 pub use gpui_macros::{
@@ -493,6 +493,18 @@ pub trait Styled: Sized {
         Self: Sized,
     {
         self.style().background = Some(fill.into());
+        self
+    }
+
+    /// Sets where a wheel event goes once this element cannot scroll with
+    /// it, per axis. CSS `overscroll-behavior`.
+    fn overscroll_behavior(mut self, x: Overscroll, y: Overscroll) -> Self
+    where
+        Self: Sized,
+    {
+        let point = &mut self.style().overscroll_behavior;
+        point.x = Some(x);
+        point.y = Some(y);
         self
     }
 

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -342,6 +342,14 @@ impl TaffyLayoutEngine {
     // snapped independently, but the raw content-box origin can carry a
     // 1dp residual into descendants.
 
+    /// True when the node has `position: absolute`.
+    pub fn position_is_absolute(&self, id: LayoutId) -> bool {
+        self.taffy
+            .style(id.into())
+            .map(|style| style.position == taffy::style::Position::Absolute)
+            .unwrap_or(false)
+    }
+
     pub fn layout_bounds(&mut self, id: LayoutId, scale_factor: f32) -> Bounds<Pixels> {
         if let Some(layout) = self.absolute_layout_bounds.get(&id).cloned() {
             return layout;

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1223,6 +1223,7 @@ pub struct Window {
     /// The hitbox that has captured the pointer, if any.
     /// While captured, mouse events route to this hitbox regardless of hit testing.
     captured_hitbox: Option<HitboxId>,
+    scroll_wheel_taken: bool,
     #[cfg(any(feature = "inspector", debug_assertions))]
     inspector: Option<Entity<Inspector>>,
     #[cfg(feature = "profiler")]
@@ -2046,6 +2047,7 @@ impl Window {
             client_inset: None,
             image_cache_stack: Vec::new(),
             captured_hitbox: None,
+            scroll_wheel_taken: false,
             #[cfg(any(feature = "inspector", debug_assertions))]
             inspector: None,
             #[cfg(feature = "profiler")]
@@ -3846,6 +3848,21 @@ impl Window {
         self.requested_autoscroll.take()
     }
 
+    /// Marks the scroll wheel event now in dispatch as scrolled. A scroll
+    /// container calls this once it moved with the event, or once its
+    /// `overscroll_behavior` keeps the event on that axis. The containers
+    /// around it then leave the event alone, the way CSS chains a scroll
+    /// only past the end of the inner box. Listeners still see the event.
+    pub fn take_scroll_wheel(&mut self) {
+        self.scroll_wheel_taken = true;
+    }
+
+    /// Whether a scroll container inside already took the scroll wheel
+    /// event now in dispatch. See [`Self::take_scroll_wheel`].
+    pub fn scroll_wheel_taken(&self) -> bool {
+        self.scroll_wheel_taken
+    }
+
     /// Asynchronously load an asset, if the asset hasn't finished loading this will return None.
     /// Your view will be re-drawn once the asset has finished loading.
     ///
@@ -4905,6 +4922,18 @@ impl Window {
         bounds
     }
 
+    /// True when the layout node behind the given LayoutId has
+    /// `position: absolute`. The scroll range treats such a child by its
+    /// own edge, without the end-side padding that follows the in-flow
+    /// content, as CSS does.
+    pub fn layout_position_is_absolute(&mut self, layout_id: LayoutId) -> bool {
+        // The engine is only absent while a frame computes. A caller that
+        // lands here then gets the in-flow answer instead of a panic.
+        self.layout_engine
+            .as_ref()
+            .is_some_and(|engine| engine.position_is_absolute(layout_id))
+    }
+
     /// This method should be called during `prepaint`. You can use
     /// the returned [Hitbox] during `paint` or in an event handler
     /// to determine whether the inserted hitbox was the topmost.
@@ -5546,6 +5575,7 @@ impl Window {
     }
 
     fn dispatch_mouse_event(&mut self, event: &dyn Any, cx: &mut App) {
+        self.scroll_wheel_taken = false;
         let hit_test = self.rendered_frame.hit_test(self.mouse_position());
         if hit_test != self.mouse_hit_test {
             self.mouse_hit_test = hit_test;


### PR DESCRIPTION
# Objective

Two scroll changes a web-like layout needs.

- CSS `overscroll-behavior`. Today a wheel event scrolls every scroll container under the mouse at once. On the web the innermost container that can move takes the scroll, and the one around it moves only once the inner one is at its end. `contain` stops even that.
- A scroll range that follows the children. Today the range comes from `content_size` plus padding. CSS scrollable overflow runs to the furthest in-flow child plus the end-side padding, or to the edge of an absolutely positioned child with no padding after it. These differ when a child is absolutely positioned, has a margin, or when children overlap.

I need both for GPUIX, a React renderer for GPUI by @remorses. One of the small PRs that came out of #63773. It stands on `main`.

## Solution

- `Overscroll { Auto, Contain, None }` in style, `overscroll_behavior: Point<Overscroll>` on `Style`, and an `overscroll_behavior(x, y)` setter on `Styled`. `None` acts as `Contain`. CSS also drops the bounce effect, which GPUI does not draw.
- `Div` records the furthest bottom right edge of its in-flow children and of its `position: absolute` children. `clamp_scroll_position` takes the range from those edges, with the end-side padding only after the in-flow edge. It falls back to the old formula when there are no children. `Window::layout_position_is_absolute` and `TaffyLayoutEngine::position_is_absolute` tell the two apart.
- `Window::take_scroll_wheel` and `Window::scroll_wheel_taken`. A scroll container calls the first once it moved with the event, or once its axis says `Contain`. The containers around it check the second and leave the event alone. The flag resets at each mouse event dispatch. `Div`, `UniformList` and `List` use it.
- Wheel listeners still see every event. The keymap editor closes its context menu from an `on_scroll_wheel` on an ancestor of the table, and that keeps working.
- The wheel handler clamps the offset to the scroll range, so a fast wheel cannot leave the offset past the end until the next frame.

## Testing

- Five new tests in `crates/gpui/src/elements/div.rs`. Three check the scroll range: after the bottom padding, after a child with a top margin, at the edge of an absolute child. One scrolls a nested container: the inner one moves until its end, then the outer one moves, and the outer wheel listener sees all three events. One sets `contain` on the inner one and checks the outer one stays put.
- I ran the four tests that compile against `main` on `main`. All four fail there: the offset is not clamped, and the outer container moves on the first event.
- `cargo test -p gpui`: 315 passed, 1 doc test passed. `cargo check -p terminal_view` passes, it is the one crate outside gpui that calls `Interactivity::prepaint`. `cargo fmt --all -- --check` is clean.
- Performance: one extra `layout_position_is_absolute` call per child during prepaint.
- Behaviour change to review: nested scroll containers no longer move together. Today `allow_concurrent_scroll` decides which axis moves inside one container, and every container under the mouse moves. I kept the concurrent scroll branch as it is.
- Trackpad gestures on macOS against the `nested_scroll` example, sent as CGEvents with scroll and momentum phases. A fling in the inner container scrolls it to its end, then the outer one moves, in the same gesture. A fling in a `contain` container stops there. A drag without momentum does the same as a fling.
- Not done: gesture latching. Each event hit-tests the element under the pointer. In the test above the outer container moved, brought the `contain` box under the pointer, and the rest of the momentum scrolled that box. Chrome fixes the scroll chain at the start of a gesture. `main` hit-tests per event too, so this PR keeps that, and latching is a follow-up.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
