### PR TITLE
gpui: add corner shapes

### DIFF
--- a/crates/gpui/src/debug_overlay.rs
+++ b/crates/gpui/src/debug_overlay.rs
@@ -225,6 +225,7 @@ fn solid_quad(
         border_color: transparent_black(),
         corner_radii: Corners::default(),
         border_widths: Edges::default(),
+        corner_shapes: Corners::default(),
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2249,6 +2249,79 @@ impl Anchor {
     }
 }
 
+/// The shape of one corner, as the curvature of a superellipse.
+///
+/// This is the number CSS `corner-shape: superellipse()` takes. 1 is a
+/// circle, 2 a squircle, 0 a straight bevel and infinity a square corner.
+/// Negative values curve inward: -1 is a scoop and negative infinity a notch.
+/// The corner radius still sets the size; the shape only bends the curve.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[repr(transparent)]
+pub struct CornerShape(pub f32);
+
+impl CornerShape {
+    /// A quarter circle. The default.
+    pub const ROUND: Self = Self(1.0);
+    /// Between round and square.
+    pub const SQUIRCLE: Self = Self(2.0);
+    /// A plain square corner, whatever the radius.
+    pub const SQUARE: Self = Self(f32::INFINITY);
+    /// A straight cut across the corner.
+    pub const BEVEL: Self = Self(0.0);
+    /// A quarter circle bitten out of the corner.
+    pub const SCOOP: Self = Self(-1.0);
+    /// A square bitten out of the corner.
+    pub const NOTCH: Self = Self(f32::NEG_INFINITY);
+
+    /// Where the inner edge of the border meets the two straight inner edges
+    /// at this corner, as distances from the corner along the horizontal edge
+    /// and along the vertical edge.
+    ///
+    /// This follows css-borders-4 "Rendering corner-shape". Each end of the
+    /// curve moves inward along a normal by the width of its own edge, and two
+    /// different widths tilt the normals so the border grows evenly from one
+    /// end to the other. A concave bite therefore moves each end by the width
+    /// of the other edge.
+    pub(crate) fn inner_curve_ends(
+        self,
+        radius: f32,
+        horizontal_width: f32,
+        vertical_width: f32,
+    ) -> (f32, f32) {
+        let mut half_corner = 0.5f32.powf(1.0 / self.0.abs().exp2());
+        if self.0 < 0.0 {
+            half_corner = 1.0 - half_corner;
+        }
+        let control = (half_corner / (std::f32::consts::SQRT_2 - 1.0)
+            - 1.0 / std::f32::consts::SQRT_2)
+            .clamp(0.0, 1.0);
+        let mut start_control = control;
+        let inset_diff = (vertical_width - horizontal_width).clamp(-radius, radius);
+        if inset_diff != 0.0 {
+            let s = (2.0 * radius * radius - inset_diff * inset_diff).sqrt();
+            let bevel_control = (s - inset_diff) / (2.0 * s);
+            start_control = if self.0 < 0.0 {
+                bevel_control * 2.0 * control
+            } else {
+                1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control)
+            };
+        }
+        let end_control = 2.0 * control - start_control;
+        let start_normal_x = (1.0 - start_control) / (1.0 - start_control).hypot(start_control);
+        let end_normal_y = (1.0 - end_control) / end_control.hypot(1.0 - end_control);
+        (
+            radius + horizontal_width * start_normal_x,
+            radius + vertical_width * end_normal_y,
+        )
+    }
+}
+
+impl Default for CornerShape {
+    fn default() -> Self {
+        Self::ROUND
+    }
+}
+
 /// Represents the corners of a box in a 2D space, such as border radius.
 ///
 /// Each field represents the size of the corner on one side of the box: `top_left`, `top_right`, `bottom_right`, and `bottom_left`.

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -156,7 +156,7 @@ pub use subscription::*;
 pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
 use taffy::TaffyLayoutEngine;
-pub use taffy::{AvailableSpace, LayoutId};
+pub use taffy::{AvailableSpace, IsolatedLayout, LayoutId};
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
 pub use text_system::*;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -541,6 +541,8 @@ pub struct Quad {
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
+    /// The curvature of each corner. See [`crate::CornerShape`].
+    pub corner_shapes: Corners<f32>,
 }
 
 impl From<Quad> for Primitive {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use crate::{
-    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
-    CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
-    point, px, quad, rems, size,
+    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, CornerShape,
+    Corners, CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement,
+    Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels,
+    Point, PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window,
+    black, phi, point, px, quad, rems, size,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -287,6 +287,10 @@ pub struct Style {
     /// The radius of the corners of this element
     #[refineable]
     pub corner_radii: Corners<AbsoluteLength>,
+
+    /// The shape of each corner. Round unless set.
+    #[refineable]
+    pub corner_shapes: Corners<CornerShape>,
 
     /// Box shadow of the element
     pub box_shadow: Vec<BoxShadow>,
@@ -727,14 +731,17 @@ impl Style {
                 None => Hsla::default(),
             };
             border_color.a = 0.;
-            window.paint_quad(quad(
-                bounds,
-                corner_radii,
-                background_color.unwrap_or_default(),
-                Edges::default(),
-                border_color,
-                self.border_style,
-            ));
+            window.paint_quad(
+                quad(
+                    bounds,
+                    corner_radii,
+                    background_color.unwrap_or_default(),
+                    Edges::default(),
+                    border_color,
+                    self.border_style,
+                )
+                .corner_shapes(self.corner_shapes),
+            );
         }
 
         window.paint_inset_shadows(bounds, corner_radii, &self.box_shadow);
@@ -745,14 +752,17 @@ impl Style {
             let border_widths = self.border_widths.to_pixels(rem_size);
             let mut background = self.border_color.unwrap_or_default();
             background.a = 0.;
-            window.paint_quad(quad(
-                bounds,
-                corner_radii,
-                background,
-                border_widths,
-                self.border_color.unwrap_or_default(),
-                self.border_style,
-            ));
+            window.paint_quad(
+                quad(
+                    bounds,
+                    corner_radii,
+                    background,
+                    border_widths,
+                    self.border_color.unwrap_or_default(),
+                    self.border_style,
+                )
+                .corner_shapes(self.corner_shapes),
+            );
         }
 
         #[cfg(debug_assertions)]
@@ -805,6 +815,7 @@ impl Default for Style {
             border_color: None,
             border_style: BorderStyle::default(),
             corner_radii: Corners::default(),
+            corner_shapes: Corners::default(),
             box_shadow: Default::default(),
             text: TextStyleRefinement::default(),
             mouse_cursor: None,

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,8 +1,8 @@
 use crate::{
-    self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
-    DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
-    FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent, Length,
-    SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
+    self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CornerShape,
+    CursorStyle, DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures,
+    FontStyle, FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent,
+    Length, SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
     TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
 pub use gpui_macros::{
@@ -493,6 +493,40 @@ pub trait Styled: Sized {
         Self: Sized,
     {
         self.style().background = Some(fill.into());
+        self
+    }
+
+    /// Sets the shape of every corner. See [`CornerShape`].
+    fn corner_shape(mut self, shape: CornerShape) -> Self {
+        let corners = &mut self.style().corner_shapes;
+        corners.top_left = Some(shape);
+        corners.top_right = Some(shape);
+        corners.bottom_right = Some(shape);
+        corners.bottom_left = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the top left corner.
+    fn corner_shape_tl(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.top_left = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the top right corner.
+    fn corner_shape_tr(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.top_right = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the bottom right corner.
+    fn corner_shape_br(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.bottom_right = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the bottom left corner.
+    fn corner_shape_bl(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.bottom_left = Some(shape);
         self
     }
 

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -71,16 +71,29 @@ impl IsolatedLayout {
 
     /// Run `f` with this tree in front of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, so calls that
-    /// straddle the two stay separate.
+    /// The window gets its own tree back when `f` returns, and also when `f`
+    /// panics, so a caught panic cannot leave the window on the wrong tree. A
+    /// reentered `enter` on the same value holds no tree any more and gives
+    /// the window a fresh one, so the window never sees `None`.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let outer = mem::replace(&mut window.layout_engine, self.0.take());
-        let result = f(window);
+        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
+        let outer = mem::replace(&mut window.layout_engine, Some(inner));
+        // The engines go back where they came from before the panic resumes,
+        // which is what makes the state safe to observe after a catch.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
         self.0 = mem::replace(&mut window.layout_engine, outer);
-        result
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
+    ///
+    /// Call it when a new layout of the content starts, before the first
+    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
+    /// nothing removes them, so a tree that is never cleared grows with each
+    /// pass for as long as the element lives.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();
@@ -959,5 +972,28 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
+    }
+
+    #[crate::test]
+    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
+            let mut layout = IsolatedLayout::new();
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                layout.enter(window, |_| panic!("a panic during an isolated layout"))
+            }));
+            assert!(caught.is_err());
+            // The window holds its own tree again and this value holds the
+            // isolated one, so the caller that caught the panic can go on.
+            assert!(window.layout_engine.is_some());
+            assert!(layout.0.is_some());
+            assert_eq!(layout.enter(window, |_| 7), 7);
+        })
+        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use collections::{FxHashMap, FxHashSet};
-use std::{fmt::Debug, ops::Range};
+use std::{fmt::Debug, mem, ops::Range};
 use taffy::{
     TaffyTree, TraversePartialTree as _,
     geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
@@ -35,6 +35,57 @@ pub struct TaffyLayoutEngine {
     absolute_outer_origins: FxHashMap<LayoutId, Point<f32>>,
     computed_layouts: FxHashSet<LayoutId>,
     layout_bounds_scratch_space: Vec<LayoutId>,
+}
+
+/// A layout tree of its own, for laying an element out while another tree computes.
+///
+/// Taffy computes one tree at a time. The measure closure of
+/// [`Window::request_measured_layout`] runs inside that computation, so an
+/// element that wants to measure a child there cannot use the window's tree.
+/// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
+/// in front of the window's tree for the duration of a closure.
+///
+/// With that, an element can size itself from content that the window's tree
+/// has not laid out yet. A panel that animates its height to the height of its
+/// content is the case this exists for.
+///
+/// The layout ids made inside `enter` belong to this tree and address a
+/// different node in any other tree. Every call that reads one has to run inside
+/// `enter`, which means the child's `prepaint` as well as its layout, because
+/// `prepaint` reads bounds. Two things break that rule: a child that calls
+/// `Window::defer_draw`, which prepaints after `enter` returns, and a child that
+/// keeps a layout id for a later frame.
+pub struct IsolatedLayout(Option<TaffyLayoutEngine>);
+
+impl Default for IsolatedLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsolatedLayout {
+    /// An empty tree.
+    pub fn new() -> Self {
+        Self(Some(TaffyLayoutEngine::new()))
+    }
+
+    /// Run `f` with this tree in front of the window's tree.
+    ///
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
+    pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
+        let outer = mem::replace(&mut window.layout_engine, self.0.take());
+        let result = f(window);
+        self.0 = mem::replace(&mut window.layout_engine, outer);
+        result
+    }
+
+    /// Drop everything this tree holds, keeping it usable for another frame.
+    pub fn clear(&mut self) {
+        if let Some(engine) = self.0.as_mut() {
+            engine.clear();
+        }
+    }
 }
 
 const EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by construction if possible";
@@ -772,5 +823,141 @@ mod tests {
             taffy_border.left,
             taffy::style::LengthPercentage::length(2.0)
         );
+    }
+}
+
+#[cfg(test)]
+mod isolated_layout_tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use crate::{
+        AnyElement, AnyWindowHandle, App, AppContext as _, AvailableSpace, Bounds, Context,
+        Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, IsolatedLayout,
+        LayoutId, ParentElement, Pixels, Render, Size, Style, Styled, TestAppContext, Window, div,
+        px, size,
+    };
+
+    /// An element that takes its size from content it measures during layout.
+    ///
+    /// The content is laid out in a tree of its own, because the measure closure
+    /// runs while the window's tree computes.
+    struct MeasureDuringLayout {
+        state: Rc<RefCell<(AnyElement, IsolatedLayout)>>,
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Element for MeasureDuringLayout {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            None
+        }
+
+        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            window: &mut Window,
+            _cx: &mut App,
+        ) -> (LayoutId, ()) {
+            let state = self.state.clone();
+            let layout_id = window.request_measured_layout(
+                Style::default(),
+                move |known: Size<Option<Pixels>>, available: Size<AvailableSpace>, window, cx| {
+                    let (content, layout) = &mut *state.borrow_mut();
+                    let width = known
+                        .width
+                        .map_or(available.width, AvailableSpace::Definite);
+                    layout.enter(window, |window| {
+                        content.layout_as_root(size(width, AvailableSpace::MaxContent), window, cx)
+                    })
+                },
+            );
+            (layout_id, ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+            self.bounds.set(bounds);
+        }
+
+        fn paint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _prepaint: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+        }
+    }
+
+    impl IntoElement for MeasureDuringLayout {
+        type Element = Self;
+
+        fn into_element(self) -> Self {
+            self
+        }
+    }
+
+    struct MeasureTestView {
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Render for MeasureTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            // Two children of 120 wrap into two rows of 30 at a width of 200, and
+            // sit on one row of 30 at max content.
+            let content = div()
+                .flex()
+                .flex_row()
+                .flex_wrap()
+                .child(div().w(px(120.)).h(px(30.)))
+                .child(div().w(px(120.)).h(px(30.)))
+                .into_any_element();
+
+            div()
+                .w(px(200.))
+                .flex()
+                .flex_col()
+                .child(MeasureDuringLayout {
+                    state: Rc::new(RefCell::new((content, IsolatedLayout::new()))),
+                    bounds: self.bounds.clone(),
+                })
+        }
+    }
+
+    #[crate::test]
+    fn measures_content_at_the_width_layout_resolved(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, cx| {
+            window.draw(cx).clear(cx)
+        })
+        .unwrap();
+
+        // The width reaches the measure closure, so the content wraps the way it
+        // will on screen. Without it the content would measure at max content and
+        // the element would stop at 30.
+        assert_eq!(bounds.get().size.height, px(60.));
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -43,7 +43,7 @@ pub struct TaffyLayoutEngine {
 /// [`Window::request_measured_layout`] runs inside that computation, so an
 /// element that wants to measure a child there cannot use the window's tree.
 /// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
-/// in front of the window's tree for the duration of a closure.
+/// in place of the window's tree for the duration of a closure.
 ///
 /// With that, an element can size itself from content that the window's tree
 /// has not laid out yet. A panel that animates its height to the height of its
@@ -69,23 +69,15 @@ impl IsolatedLayout {
         Self(Some(TaffyLayoutEngine::new()))
     }
 
-    /// Run `f` with this tree in front of the window's tree.
+    /// Run `f` with this tree in place of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, and also when `f`
-    /// panics, so a caught panic cannot leave the window on the wrong tree. A
-    /// reentered `enter` on the same value holds no tree any more and gives
-    /// the window a fresh one, so the window never sees `None`.
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
-        let outer = mem::replace(&mut window.layout_engine, Some(inner));
-        // The engines go back where they came from before the panic resumes,
-        // which is what makes the state safe to observe after a catch.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
-        self.0 = mem::replace(&mut window.layout_engine, outer);
-        match result {
-            Ok(value) => value,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        let result = f(window);
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        result
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
@@ -973,28 +965,5 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
-    }
-
-    #[crate::test]
-    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
-        let bounds = Rc::new(Cell::new(Bounds::default()));
-        let window = cx.add_window({
-            let bounds = bounds.clone();
-            move |_, _| MeasureTestView { bounds }
-        });
-
-        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
-            let mut layout = IsolatedLayout::new();
-            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                layout.enter(window, |_| panic!("a panic during an isolated layout"))
-            }));
-            assert!(caught.is_err());
-            // The window holds its own tree again and this value holds the
-            // isolated one, so the caller that caught the panic can go on.
-            assert!(window.layout_engine.is_some());
-            assert!(layout.0.is_some());
-            assert_eq!(layout.enter(window, |_| 7), 7);
-        })
-        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -90,10 +90,11 @@ impl IsolatedLayout {
 
     /// Drop everything this tree holds, keeping it usable for another frame.
     ///
-    /// Call it when a new layout of the content starts, before the first
-    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
-    /// nothing removes them, so a tree that is never cleared grows with each
-    /// pass for as long as the element lives.
+    /// Call it only between elements: after the old content element drops,
+    /// before the first `enter` with the new one. An element requests its
+    /// nodes once and reuses those ids in every later pass, so a clear while
+    /// the element lives makes its next layout panic on the dead ids. A tree
+    /// that lives exactly as long as one element never needs a clear.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7,15 +7,15 @@ use crate::profiler;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow,
-    Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
-    DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
-    EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
-    Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
-    KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
-    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
-    Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage,
-    RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
+    Capslock, Context, CornerShape, Corners, CursorHideMode, CursorStyle, Decorations,
+    DevicePixels, DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect,
+    Entity, EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId,
+    GpuSpecs, Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent,
+    Keystroke, KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
+    MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
+    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
+    PolychromeSprite, Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams,
+    RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
     SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow, SharedString, Size,
     StrikethroughStyle, Style, SubpixelSprite, SubscriberSet, Subscription, SystemWindowTab,
     SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task, TextInputConfiguration,
@@ -4237,11 +4237,35 @@ impl Window {
     fn largest_border_interior(quad: &Quad) -> Bounds<ScaledPixels> {
         let radii = &quad.corner_radii;
         let widths = &quad.border_widths;
+        let shapes = &quad.corner_shapes;
+        let ends =
+            |radius: ScaledPixels,
+             shape: f32,
+             horizontal_width: ScaledPixels,
+             vertical_width: ScaledPixels| {
+                let (along_horizontal, along_vertical) = crate::CornerShape(shape)
+                    .inner_curve_ends(radius.0, horizontal_width.0, vertical_width.0);
+                (ScaledPixels(along_horizontal), ScaledPixels(along_vertical))
+            };
+        let top_left = ends(radii.top_left, shapes.top_left, widths.top, widths.left);
+        let top_right = ends(radii.top_right, shapes.top_right, widths.top, widths.right);
+        let bottom_left = ends(
+            radii.bottom_left,
+            shapes.bottom_left,
+            widths.bottom,
+            widths.left,
+        );
+        let bottom_right = ends(
+            radii.bottom_right,
+            shapes.bottom_right,
+            widths.bottom,
+            widths.right,
+        );
         let edge_radii = Edges {
-            top: radii.top_left.max(radii.top_right),
-            right: radii.top_right.max(radii.bottom_right),
-            bottom: radii.bottom_left.max(radii.bottom_right),
-            left: radii.top_left.max(radii.bottom_left),
+            top: top_left.1.max(top_right.1),
+            right: top_right.0.max(bottom_right.0),
+            bottom: bottom_left.1.max(bottom_right.1),
+            left: top_left.0.max(bottom_left.0),
         };
 
         let antialias_inset = point(ScaledPixels(1.0), ScaledPixels(1.0));
@@ -4297,6 +4321,7 @@ impl Window {
             corner_radii: quad.corner_radii.scale(self.scale_factor()),
             border_widths: snapped_border_widths,
             border_style: quad.border_style,
+            corner_shapes: quad.corner_shapes.map(|shape| shape.0),
         };
 
         if !quad.background.is_transparent() {
@@ -7293,9 +7318,19 @@ pub struct PaintQuad {
     pub border_color: Hsla,
     /// The style of the quad's borders.
     pub border_style: BorderStyle,
+    /// The shape of the quad's corners.
+    pub corner_shapes: Corners<CornerShape>,
 }
 
 impl PaintQuad {
+    /// Sets the shape of the quad's corners.
+    pub fn corner_shapes(self, corner_shapes: impl Into<Corners<CornerShape>>) -> Self {
+        PaintQuad {
+            corner_shapes: corner_shapes.into(),
+            ..self
+        }
+    }
+
     /// Sets the corner radii of the quad.
     pub fn corner_radii(self, corner_radii: impl Into<Corners<Pixels>>) -> Self {
         PaintQuad {
@@ -7345,6 +7380,7 @@ pub fn quad(
         border_widths: border_widths.into(),
         border_color: border_color.into(),
         border_style,
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7357,6 +7393,7 @@ pub fn fill(bounds: impl Into<Bounds<Pixels>>, background: impl Into<Background>
         border_widths: (0.).into(),
         border_color: transparent_black(),
         border_style: BorderStyle::default(),
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7373,6 +7410,7 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7390,8 +7428,9 @@ mod tests {
         ExternalDragPayload, ExternalPaths, FileDragPaths, FileDropEvent, FocusHandle,
         InputEvent as _, InteractiveElement as _, IntoElement, LongPressEvent, MouseButton,
         MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render, RequestFrameOptions,
-        StatefulInteractiveElement as _, Styled, TestAppContext, TouchDragEvent, TouchEvent,
-        TouchId, TouchPhase, Window, WindowAppearance, WindowOptions, canvas, div, point, px, size,
+        ScaledPixels, StatefulInteractiveElement as _, Styled, TestAppContext, TouchDragEvent,
+        TouchEvent, TouchId, TouchPhase, Window, WindowAppearance, WindowOptions, canvas, div,
+        point, px, size,
     };
 
     struct EmptyView;
@@ -7425,6 +7464,78 @@ mod tests {
                 // a mid-draw arena clear when painted afterwards.
                 .child(div().child("after"))
         }
+    }
+
+    fn border_only_quad(shape: crate::CornerShape) -> crate::Quad {
+        border_only_quad_with(
+            shape,
+            crate::Edges::all(ScaledPixels(8.)),
+            size(ScaledPixels(120.), ScaledPixels(120.)),
+        )
+    }
+
+    fn border_only_quad_with(
+        shape: crate::CornerShape,
+        border_widths: crate::Edges<ScaledPixels>,
+        size: crate::Size<ScaledPixels>,
+    ) -> crate::Quad {
+        crate::Quad {
+            order: 0,
+            border_style: Default::default(),
+            bounds: Bounds::new(point(ScaledPixels(0.), ScaledPixels(0.)), size),
+            content_mask: Default::default(),
+            background: Default::default(),
+            border_color: Default::default(),
+            corner_radii: crate::Corners::all(ScaledPixels(40.)),
+            border_widths,
+            corner_shapes: crate::Corners::all(shape.0),
+        }
+    }
+
+    #[test]
+    fn test_border_interior_stops_where_the_inner_edge_reaches() {
+        let round = Window::largest_border_interior(&border_only_quad(crate::CornerShape::ROUND));
+        assert_eq!(round.top(), ScaledPixels(41.));
+        assert_eq!(round.left(), ScaledPixels(9.));
+
+        let notch = Window::largest_border_interior(&border_only_quad(crate::CornerShape::NOTCH));
+        assert_eq!(notch.top(), ScaledPixels(49.));
+        assert_eq!(notch.bottom(), ScaledPixels(71.));
+        assert_eq!(notch.left(), ScaledPixels(9.));
+
+        let bevel = Window::largest_border_interior(&border_only_quad(crate::CornerShape::BEVEL));
+        assert!((bevel.top().0 - (41. + 8. / std::f32::consts::SQRT_2)).abs() < 1e-3);
+        assert_eq!(bevel.left(), ScaledPixels(9.));
+    }
+
+    #[test]
+    fn test_border_interior_with_two_border_widths_at_a_corner() {
+        let widths = crate::Edges {
+            top: ScaledPixels(4.),
+            bottom: ScaledPixels(4.),
+            left: ScaledPixels(12.),
+            right: ScaledPixels(12.),
+        };
+        // The tall quad keeps the band between the top and bottom corners, the
+        // wide one the band between the left and right corners.
+        let tall = size(ScaledPixels(120.), ScaledPixels(400.));
+        let wide = size(ScaledPixels(400.), ScaledPixels(120.));
+
+        // A bite moves each end of the curve by the width of the other edge.
+        let notch = crate::CornerShape::NOTCH;
+        let interior = Window::largest_border_interior(&border_only_quad_with(notch, widths, tall));
+        assert_eq!(interior.top(), ScaledPixels(53.));
+        let interior = Window::largest_border_interior(&border_only_quad_with(notch, widths, wide));
+        assert_eq!(interior.left(), ScaledPixels(45.));
+
+        // The bevel's inner line tilts so the border grows from 4 to 12. Its
+        // ends land at 0.8 of the top width along the top edge and 0.6 of the
+        // left width down the left edge.
+        let bevel = crate::CornerShape::BEVEL;
+        let interior = Window::largest_border_interior(&border_only_quad_with(bevel, widths, tall));
+        assert!((interior.top().0 - (41. + 12. * 0.6)).abs() < 1e-3);
+        let interior = Window::largest_border_interior(&border_only_quad_with(bevel, widths, wide));
+        assert!((interior.left().0 - (41. + 4. * 0.8)).abs() < 1e-3);
     }
 
     /// Opening a window synchronously draws it and requests an element arena

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1160,7 +1160,7 @@ pub struct Window {
     /// a given rem size.
     rem_size_override_stack: SmallVec<[Pixels; 8]>,
     pub(crate) viewport_size: Size<Pixels>,
-    layout_engine: Option<TaffyLayoutEngine>,
+    pub(crate) layout_engine: Option<TaffyLayoutEngine>,
     pub(crate) root: Option<AnyView>,
     pub(crate) element_id_stack: SmallVec<[ElementId; 32]>,
     pub(crate) text_style_stack: Vec<TextStyleRefinement>,

--- a/crates/gpui_apple/src/shaders.metal
+++ b/crates/gpui_apple/src/shaders.metal
@@ -25,6 +25,27 @@ float dash_alpha(float t, float period, float length, float dash_velocity,
                  float antialias_threshold);
 float quarter_ellipse_sdf(float2 point, float2 radii);
 float pick_corner_radius(float2 center_to_point, Corners_ScaledPixels corner_radii);
+float pick_corner_shape(float2 center_to_point, Corners_f32 corner_shapes);
+float superellipse_sdf(float2 point, float2 radii, float n);
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+  float2 start;
+  float2 end;
+  float2 start_normal;
+  float2 end_normal;
+};
+
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset);
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight);
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius,
+                         float shape, float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point);
 float quad_sdf(float2 point, Bounds_ScaledPixels bounds,
                Corners_ScaledPixels corner_radii);
 float quad_sdf_impl(float2 center_to_point, float corner_radius);
@@ -127,8 +148,9 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   // minimum distance between the center of the pixel and the edge.
   const float antialias_threshold = 0.5;
 
-  // Radius of the nearest corner
+  // Radius and shape of the nearest corner
   float corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+  float corner_shape = pick_corner_shape(center_to_point, quad.corner_shapes);
 
   // Width of the nearest borders
   float2 border = float2(
@@ -150,10 +172,16 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   // mirrored into bottom right quadrant.
   float2 corner_center_to_point = corner_to_point + corner_radius;
 
-  // Whether the nearest point on the border is rounded
+  // Whether the nearest point on the border is rounded. The inner edge of a
+  // concave or a bevelled corner reaches past the corner box.
+  float2 corner_reach = corner_center_to_point;
+  if (corner_shape != 1.0) {
+    CornerCurve inner_curve = corner_curve(corner_radius, corner_shape, border);
+    corner_reach += float2(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+  }
   bool is_near_rounded_corner =
-    corner_center_to_point.x >= 0.0 &&
-    corner_center_to_point.y >= 0.0;
+    corner_reach.x >= 0.0 &&
+    corner_reach.y >= 0.0;
 
   // Vector from straight border inner corner to point.
   //
@@ -179,7 +207,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   }
 
   // Signed distance of the point to the outside edge of the quad's border
-  float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+  float outer_sdf;
 
   // Approximate signed distance of the point to the inside edge of the quad's
   // border. It is negative outside this edge (within the border), and
@@ -190,19 +218,29 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   //   nearest-point-on-ellipse.
   // * When it is quickly known to be outside the edge, -1.0 is used.
   float inner_sdf = 0.0;
-  if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
-    // Fast paths for straight borders
-    inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                     straight_border_inner_corner_to_point.y);
-  } else if (is_beyond_inner_straight_border) {
-    // Fast path for points that must be outside the inner edge
-    inner_sdf = -1.0;
-  } else if (reduced_border.x == reduced_border.y) {
-    // Fast path for circular inner edge.
-    inner_sdf = -(outer_sdf + reduced_border.x);
+  if (corner_shape == 1.0 || corner_radius == 0.0) {
+    outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+      if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
+      // Fast paths for straight borders
+      inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                       straight_border_inner_corner_to_point.y);
+    } else if (is_beyond_inner_straight_border) {
+      // Fast path for points that must be outside the inner edge
+      inner_sdf = -1.0;
+    } else if (reduced_border.x == reduced_border.y) {
+      // Fast path for circular inner edge.
+      inner_sdf = -(outer_sdf + reduced_border.x);
+    } else {
+      float2 ellipse_radii = max(float2(0.0), float2(corner_radius) - reduced_border);
+      inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+    }
   } else {
-    float2 ellipse_radii = max(float2(0.0), float2(corner_radius) - reduced_border);
-    inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+    // Any other corner shape: a superellipse, or a bite out of the corner.
+    float2 sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+                                    reduced_border,
+                                    straight_border_inner_corner_to_point);
+    outer_sdf = sdfs.x;
+    inner_sdf = sdfs.y;
   }
 
   // Negative when inside the border
@@ -1056,6 +1094,139 @@ float pick_corner_radius(float2 center_to_point, Corners_ScaledPixels corner_rad
       return corner_radii.bottom_right;
     }
   }
+}
+
+float pick_corner_shape(float2 center_to_point, Corners_f32 corner_shapes) {
+  if (center_to_point.x < 0.) {
+    if (center_to_point.y < 0.) {
+      return corner_shapes.top_left;
+    } else {
+      return corner_shapes.bottom_left;
+    }
+  } else {
+    if (center_to_point.y < 0.) {
+      return corner_shapes.top_right;
+    } else {
+      return corner_shapes.bottom_right;
+    }
+  }
+}
+
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+float superellipse_sdf(float2 point, float2 radii, float n) {
+  if (isinf(n)) {
+    float2 to_edge = point - radii;
+    return max(to_edge.x, to_edge.y);
+  }
+  float2 unit = point / radii;
+  float largest = max(max(unit.x, unit.y), 1e-6);
+  float2 scaled = unit / largest;
+  float rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+  float2 gradient = pow(scaled * (largest / rho), n - 1.0) / radii;
+  return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset) {
+  float half_corner = pow(0.5, 1.0 / exp2(fabs(shape)));
+  if (shape < 0.0) {
+    half_corner = 1.0 - half_corner;
+  }
+  float control =
+    clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+  float start_control = control;
+  float inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+  if (inset_diff != 0.0) {
+    float s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+    float bevel_control = (s - inset_diff) / (2.0 * s);
+    start_control = shape < 0.0
+      ? bevel_control * 2.0 * control
+      : 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+  }
+  float end_control = 2.0 * control - start_control;
+  CornerCurve curve;
+  curve.start_normal = normalize(float2(1.0 - start_control, start_control));
+  curve.end_normal = normalize(float2(end_control, 1.0 - end_control));
+  curve.start = float2(corner_radius, 0.0) + inset.y * curve.start_normal;
+  curve.end = float2(0.0, corner_radius) + inset.x * curve.end_normal;
+  return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight) {
+  float n = exp2(fabs(shape));
+  if (shape >= 0.0) {
+    float2 center = float2(curve.start.x, curve.end.y);
+    float2 radii = float2(center.x - curve.end.x, center.y - curve.start.y);
+    float2 center_to_point = center - from_corner;
+    if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+        radii.x <= 0.0 || radii.y <= 0.0) {
+      return straight;
+    }
+    return max(straight, superellipse_sdf(center_to_point, radii, n));
+  }
+  if (shape <= -1.0) {
+    float2 origin = float2(curve.end.x, curve.start.y);
+    float2 radii = float2(curve.start.x - origin.x, curve.end.y - origin.y);
+    float2 origin_to_point = max(from_corner - origin, 0.0);
+    return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+  }
+  // Between a bevel and a scoop the spec draws a quarter circle mapped into
+  // the frame of the two ends and the point where their tangents meet.
+  float2 start_tangent = float2(-curve.start_normal.y, curve.start_normal.x);
+  float2 end_tangent = float2(-curve.end_normal.y, curve.end_normal.x);
+  float2 start_to_end = curve.end - curve.start;
+  float tangents_cross =
+    start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+  float2 meet = curve.start;
+  if (fabs(tangents_cross) > 1e-6) {
+    float t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+              tangents_cross;
+    meet = curve.start + t * start_tangent;
+  }
+  float2 to_end = curve.end - meet;
+  float2 to_start = curve.start - meet;
+  float det = to_end.x * to_start.y - to_end.y * to_start.x;
+  if (fabs(det) < 1e-6) {
+    return straight;
+  }
+  float2 d = from_corner - meet;
+  float x = (d.x * to_start.y - d.y * to_start.x) / det;
+  float y = (to_end.x * d.y - to_end.y * d.x) / det;
+  float2 unit = 1.0 - float2(x, y);
+  float f = dot(unit, unit) - 1.0;
+  float2 g = -2.0 * unit;
+  float2 gradient = float2(to_start.y * g.x - to_end.y * g.y,
+                           to_end.x * g.y - to_start.x * g.x) / det;
+  return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius,
+                         float shape, float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point) {
+  float2 from_corner = -corner_to_point;
+  CornerCurve outer_curve = corner_curve(corner_radius, shape, float2(0.0));
+  CornerCurve inner_curve = corner_curve(corner_radius, shape, reduced_border);
+  float straight_outer = max(corner_to_point.x, corner_to_point.y);
+  float straight_inner = max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+  return float2(
+    corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+    -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
 }
 
 // Signed distance of the point to the quad's border - positive outside the

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -354,6 +354,148 @@ fn pick_corner_radius(center_to_point: vec2<f32>, radii: Corners) -> f32 {
     }
 }
 
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+fn superellipse_sdf(point: vec2<f32>, radii: vec2<f32>, n: f32) -> f32 {
+    // WGSL has no infinity literal or isinf, so a huge exponent stands in.
+    if (n > 1.0e30) {
+        let to_edge = point - radii;
+        return max(to_edge.x, to_edge.y);
+    }
+    let unit = point / radii;
+    let largest = max(max(unit.x, unit.y), 1e-6);
+    let scaled = unit / largest;
+    let rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+    let gradient = pow(scaled * (largest / rho), vec2<f32>(n - 1.0)) / radii;
+    return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+    start: vec2<f32>,
+    end: vec2<f32>,
+    start_normal: vec2<f32>,
+    end_normal: vec2<f32>,
+}
+
+// Past 2^64 every superellipse is a box to the pixel, so cap the exponent
+// there. WGSL has no infinity literal.
+fn superellipse_exponent(shape: f32) -> f32 {
+    if (abs(shape) < 64.0) {
+        return exp2(abs(shape));
+    }
+    return 1.0e31;
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+fn corner_curve(corner_radius: f32, shape: f32, inset: vec2<f32>) -> CornerCurve {
+    var half_corner = pow(0.5, 1.0 / superellipse_exponent(shape));
+    if (shape < 0.0) {
+        half_corner = 1.0 - half_corner;
+    }
+    let control =
+        clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+    var start_control = control;
+    let inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+    if (inset_diff != 0.0) {
+        let s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+        let bevel_control = (s - inset_diff) / (2.0 * s);
+        if (shape < 0.0) {
+            start_control = bevel_control * 2.0 * control;
+        } else {
+            start_control = 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+        }
+    }
+    let end_control = 2.0 * control - start_control;
+    var curve: CornerCurve;
+    curve.start_normal = normalize(vec2<f32>(1.0 - start_control, start_control));
+    curve.end_normal = normalize(vec2<f32>(end_control, 1.0 - end_control));
+    curve.start = vec2<f32>(corner_radius, 0.0) + inset.y * curve.start_normal;
+    curve.end = vec2<f32>(0.0, corner_radius) + inset.x * curve.end_normal;
+    return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+fn corner_curve_sdf(from_corner: vec2<f32>, curve: CornerCurve, shape: f32,
+    straight: f32) -> f32 {
+    let n = superellipse_exponent(shape);
+    if (shape >= 0.0) {
+        let center = vec2<f32>(curve.start.x, curve.end.y);
+        let radii = vec2<f32>(center.x - curve.end.x, center.y - curve.start.y);
+        let center_to_point = center - from_corner;
+        if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+            radii.x <= 0.0 || radii.y <= 0.0) {
+            return straight;
+        }
+        return max(straight, superellipse_sdf(center_to_point, radii, n));
+    }
+    if (shape <= -1.0) {
+        let origin = vec2<f32>(curve.end.x, curve.start.y);
+        let radii = vec2<f32>(curve.start.x - origin.x, curve.end.y - origin.y);
+        let origin_to_point = max(from_corner - origin, vec2<f32>(0.0));
+        return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+    }
+    // Between a bevel and a scoop the spec draws a quarter circle mapped into
+    // the frame of the two ends and the point where their tangents meet.
+    let start_tangent = vec2<f32>(-curve.start_normal.y, curve.start_normal.x);
+    let end_tangent = vec2<f32>(-curve.end_normal.y, curve.end_normal.x);
+    let start_to_end = curve.end - curve.start;
+    let tangents_cross =
+        start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+    var meet = curve.start;
+    if (abs(tangents_cross) > 1e-6) {
+        let t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+            tangents_cross;
+        meet = curve.start + t * start_tangent;
+    }
+    let to_end = curve.end - meet;
+    let to_start = curve.start - meet;
+    let det = to_end.x * to_start.y - to_end.y * to_start.x;
+    if (abs(det) < 1e-6) {
+        return straight;
+    }
+    let d = from_corner - meet;
+    let x = (d.x * to_start.y - d.y * to_start.x) / det;
+    let y = (to_end.x * d.y - to_end.y * d.x) / det;
+    let unit = 1.0 - vec2<f32>(x, y);
+    let f = dot(unit, unit) - 1.0;
+    let g = -2.0 * unit;
+    let gradient = vec2<f32>(to_start.y * g.x - to_end.y * g.y,
+        to_end.x * g.y - to_start.x * g.x) / det;
+    return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+fn shaped_corner_sdf(corner_to_point: vec2<f32>, corner_radius: f32, shape: f32,
+    reduced_border: vec2<f32>,
+    straight_border_inner_corner_to_point: vec2<f32>) -> vec2<f32> {
+    let from_corner = -corner_to_point;
+    let outer_curve = corner_curve(corner_radius, shape, vec2<f32>(0.0));
+    let inner_curve = corner_curve(corner_radius, shape, reduced_border);
+    let straight_outer = max(corner_to_point.x, corner_to_point.y);
+    let straight_inner = max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+    return vec2<f32>(
+        corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+        -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
+}
+
 // Signed distance of the point to the quad's border - positive outside the
 // border, and negative inside.
 //
@@ -525,6 +667,7 @@ struct Quad {
     border_color: Hsla,
     corner_radii: Corners,
     border_widths: Edges,
+    corner_shapes: Corners,
 }
 
 struct QuadVarying {
@@ -598,6 +741,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
     // Radius of the nearest corner
     let corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+    let corner_shape = pick_corner_radius(center_to_point, quad.corner_shapes);
 
     // Width of the nearest borders
     let border = vec2<f32>(
@@ -624,10 +768,14 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     // mirrored into bottom right quadrant.
     let corner_center_to_point = corner_to_point + corner_radius;
 
-    // Whether the nearest point on the border is rounded
-    let is_near_rounded_corner =
-            corner_center_to_point.x >= 0 &&
-            corner_center_to_point.y >= 0;
+    // Whether the nearest point on the border is rounded. The inner edge of a
+    // concave or a bevelled corner reaches past the corner box.
+    var corner_reach = corner_center_to_point;
+    if (corner_shape != 1.0) {
+        let inner_curve = corner_curve(corner_radius, corner_shape, border);
+        corner_reach += vec2<f32>(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+    }
+    let is_near_rounded_corner = corner_reach.x >= 0.0 && corner_reach.y >= 0.0;
 
     // Vector from straight border inner corner to point.
     let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
@@ -655,7 +803,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
     // Signed distance of the point to the outside edge of the quad's border. It
     // is positive outside this edge, and negative inside.
-    let outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    var outer_sdf = 0.0;
 
     // Approximate signed distance of the point to the inside edge of the quad's
     // border. It is negative outside this edge (within the border), and
@@ -666,19 +814,28 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     //   nearest-point-on-ellipse.
     // * When it is quickly known to be outside the edge, -1.0 is used.
     var inner_sdf = 0.0;
-    if (corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0) {
-        // Fast paths for straight borders.
-        inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                         straight_border_inner_corner_to_point.y);
-    } else if (is_beyond_inner_straight_border) {
-        // Fast path for points that must be outside the inner edge.
-        inner_sdf = -1.0;
-    } else if (reduced_border.x == reduced_border.y) {
-        // Fast path for circular inner edge.
-        inner_sdf = -(outer_sdf + reduced_border.x);
+    if (corner_shape == 1.0 || corner_radius == 0.0) {
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+            if (corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0) {
+            // Fast paths for straight borders.
+            inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+        } else if (is_beyond_inner_straight_border) {
+            // Fast path for points that must be outside the inner edge.
+            inner_sdf = -1.0;
+        } else if (reduced_border.x == reduced_border.y) {
+            // Fast path for circular inner edge.
+            inner_sdf = -(outer_sdf + reduced_border.x);
+        } else {
+            let ellipse_radii = max(vec2<f32>(0.0), corner_radius - reduced_border);
+            inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        }
     } else {
-        let ellipse_radii = max(vec2<f32>(0.0), corner_radius - reduced_border);
-        inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        // Any other corner shape: a superellipse, or a bite out of the corner.
+        let sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+            reduced_border, straight_border_inner_corner_to_point);
+        outer_sdf = sdfs.x;
+        inner_sdf = sdfs.y;
     }
 
     // Negative when inside the border

--- a/crates/gpui_wgpu/src/shaders_webgl.wgsl
+++ b/crates/gpui_wgpu/src/shaders_webgl.wgsl
@@ -136,7 +136,7 @@ fn read_transformation(cursor: ptr<function, InstanceCursor>) -> TransformationM
 }
 
 fn load_quad(instance_id: u32) -> Quad {
-    var cursor = instance_cursor(instance_id * 40u);
+    var cursor = instance_cursor(instance_id * 44u);
     return Quad(
         read_word(&cursor),
         read_word(&cursor),
@@ -146,6 +146,7 @@ fn load_quad(instance_id: u32) -> Quad {
         read_hsla(&cursor),
         read_corners(&cursor),
         read_edges(&cursor),
+        read_corners(&cursor),
     );
 }
 

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2231,7 +2231,7 @@ mod tests {
 
     #[test]
     fn webgl_record_sizes_match_shader_word_strides() {
-        assert_eq!(std::mem::size_of::<Quad>(), 40 * 4);
+        assert_eq!(std::mem::size_of::<Quad>(), 44 * 4);
         assert_eq!(std::mem::size_of::<Shadow>(), 28 * 4);
         assert_eq!(std::mem::size_of::<PathRasterizationVertex>(), 26 * 4);
         assert_eq!(std::mem::size_of::<PathSprite>(), 4 * 4);

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -286,7 +286,142 @@ float4 to_device_position_transformed(float2 unit_vertex, Bounds bounds,
     return float4(device_position, 0.0, 1.0);
 }
 
-// Implementation of quad signed distance field
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+float superellipse_sdf(float2 pt, float2 radii, float n) {
+    if (n > 1e30) {
+        float2 to_edge = pt - radii;
+        return max(to_edge.x, to_edge.y);
+    }
+    float2 unit = pt / radii;
+    float largest = max(max(unit.x, unit.y), 1e-6);
+    float2 scaled = unit / largest;
+    float rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+    float2 gradient = pow(scaled * (largest / rho), n - 1.0) / radii;
+    return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+    float2 start;
+    float2 end;
+    float2 start_normal;
+    float2 end_normal;
+};
+
+// Past 2^64 every superellipse is a box to the pixel, so cap the exponent
+// there.
+float superellipse_exponent(float shape) {
+    return abs(shape) < 64.0 ? exp2(abs(shape)) : 1e31;
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset) {
+    float half_corner = pow(0.5, 1.0 / superellipse_exponent(shape));
+    if (shape < 0.0) {
+        half_corner = 1.0 - half_corner;
+    }
+    float control =
+        clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+    float start_control = control;
+    float inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+    if (inset_diff != 0.0) {
+        float s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+        float bevel_control = (s - inset_diff) / (2.0 * s);
+        start_control = shape < 0.0
+            ? bevel_control * 2.0 * control
+            : 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+    }
+    float end_control = 2.0 * control - start_control;
+    CornerCurve curve;
+    curve.start_normal = normalize(float2(1.0 - start_control, start_control));
+    curve.end_normal = normalize(float2(end_control, 1.0 - end_control));
+    curve.start = float2(corner_radius, 0.0) + inset.y * curve.start_normal;
+    curve.end = float2(0.0, corner_radius) + inset.x * curve.end_normal;
+    return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight) {
+    float n = superellipse_exponent(shape);
+    if (shape >= 0.0) {
+        float2 center = float2(curve.start.x, curve.end.y);
+        float2 radii = float2(center.x - curve.end.x, center.y - curve.start.y);
+        float2 center_to_point = center - from_corner;
+        if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+            radii.x <= 0.0 || radii.y <= 0.0) {
+            return straight;
+        }
+        return max(straight, superellipse_sdf(center_to_point, radii, n));
+    }
+    if (shape <= -1.0) {
+        float2 origin = float2(curve.end.x, curve.start.y);
+        float2 radii = float2(curve.start.x - origin.x, curve.end.y - origin.y);
+        float2 origin_to_point = max(from_corner - origin, float2(0.0, 0.0));
+        return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+    }
+    // Between a bevel and a scoop the spec draws a quarter circle mapped into
+    // the frame of the two ends and the point where their tangents meet.
+    float2 start_tangent = float2(-curve.start_normal.y, curve.start_normal.x);
+    float2 end_tangent = float2(-curve.end_normal.y, curve.end_normal.x);
+    float2 start_to_end = curve.end - curve.start;
+    float tangents_cross =
+        start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+    float2 meet = curve.start;
+    if (abs(tangents_cross) > 1e-6) {
+        float t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+                  tangents_cross;
+        meet = curve.start + t * start_tangent;
+    }
+    float2 to_end = curve.end - meet;
+    float2 to_start = curve.start - meet;
+    float det = to_end.x * to_start.y - to_end.y * to_start.x;
+    if (abs(det) < 1e-6) {
+        return straight;
+    }
+    float2 d = from_corner - meet;
+    float x = (d.x * to_start.y - d.y * to_start.x) / det;
+    float y = (to_end.x * d.y - to_end.y * d.x) / det;
+    float2 unit = 1.0 - float2(x, y);
+    float f = dot(unit, unit) - 1.0;
+    float2 g = -2.0 * unit;
+    float2 gradient = float2(to_start.y * g.x - to_end.y * g.y,
+                             to_end.x * g.y - to_start.x * g.x) / det;
+    return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius, float shape,
+                         float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point) {
+    float2 from_corner = -corner_to_point;
+    CornerCurve outer_curve = corner_curve(corner_radius, shape, float2(0.0, 0.0));
+    CornerCurve inner_curve = corner_curve(corner_radius, shape, reduced_border);
+    float straight_outer = max(corner_to_point.x, corner_to_point.y);
+    float straight_inner = max(straight_border_inner_corner_to_point.x,
+                               straight_border_inner_corner_to_point.y);
+    return float2(
+        corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+        -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
+}
+
 float quad_sdf_impl(float2 corner_center_to_point, float corner_radius) {
     if (corner_radius == 0.0) {
         // Fast path for unrounded corners
@@ -507,6 +642,7 @@ struct Quad {
     Hsla border_color;
     Corners corner_radii;
     Edges border_widths;
+    Corners corner_shapes;
 };
 
 struct QuadVertexOutput {
@@ -584,8 +720,9 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     // minimum distance between the center of the pixel and the edge.
     const float antialias_threshold = 0.5;
 
-    // Radius of the nearest corner
+    // Radius and shape of the nearest corner
     float corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+    float corner_shape = pick_corner_radius(center_to_point, quad.corner_shapes);
 
     float2 border = float2(
         center_to_point.x < 0.0 ? quad.border_widths.left : quad.border_widths.right,
@@ -607,10 +744,16 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     // mirrored into bottom right quadrant.
     float2 corner_center_to_point = corner_to_point + corner_radius;
 
-    // Whether the nearest point on the border is rounded
+    // Whether the nearest point on the border is rounded. The inner edge of a
+    // concave or a bevelled corner reaches past the corner box.
+    float2 corner_reach = corner_center_to_point;
+    if (corner_shape != 1.0) {
+        CornerCurve inner_curve = corner_curve(corner_radius, corner_shape, border);
+        corner_reach += float2(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+    }
     bool is_near_rounded_corner =
-        corner_center_to_point.x >= 0.0 &&
-        corner_center_to_point.y >= 0.0;
+        corner_reach.x >= 0.0 &&
+        corner_reach.y >= 0.0;
 
     // Vector from straight border inner corner to point.
     //
@@ -634,31 +777,42 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
         return background_color;
     }
 
-    // Signed distance of the point to the outside edge of the quad's border
-    float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    float outer_sdf;
+    float inner_sdf;
+    if (corner_shape == 1.0 || corner_radius == 0.0) {
+        // Signed distance of the point to the outside edge of the quad's border
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
 
-    // Approximate signed distance of the point to the inside edge of the quad's
-    // border. It is negative outside this edge (within the border), and
-    // positive inside.
-    //
-    // This is not always an accurate signed distance:
-    // * The rounded portions with varying border width use an approximation of
-    //   nearest-point-on-ellipse.
-    // * When it is quickly known to be outside the edge, -1.0 is used.
-    float inner_sdf = 0.0;
-    if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
-        // Fast paths for straight borders
-        inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                        straight_border_inner_corner_to_point.y);
-    } else if (is_beyond_inner_straight_border) {
-        // Fast path for points that must be outside the inner edge
-        inner_sdf = -1.0;
-    } else if (reduced_border.x == reduced_border.y) {
-        // Fast path for circular inner edge.
-        inner_sdf = -(outer_sdf + reduced_border.x);
+        // Approximate signed distance of the point to the inside edge of the quad's
+        // border. It is negative outside this edge (within the border), and
+        // positive inside.
+        //
+        // This is not always an accurate signed distance:
+        // * The rounded portions with varying border width use an approximation of
+        //   nearest-point-on-ellipse.
+        // * When it is quickly known to be outside the edge, -1.0 is used.
+        inner_sdf = 0.0;
+        if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
+            // Fast paths for straight borders
+            inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                            straight_border_inner_corner_to_point.y);
+        } else if (is_beyond_inner_straight_border) {
+            // Fast path for points that must be outside the inner edge
+            inner_sdf = -1.0;
+        } else if (reduced_border.x == reduced_border.y) {
+            // Fast path for circular inner edge.
+            inner_sdf = -(outer_sdf + reduced_border.x);
+        } else {
+            float2 ellipse_radii = max(float2(0.0, 0.0), float2(corner_radius, corner_radius) - reduced_border);
+            inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        }
     } else {
-        float2 ellipse_radii = max(float2(0.0, 0.0), float2(corner_radius, corner_radius) - reduced_border);
-        inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        // Any other corner shape: a superellipse, or a bite out of the corner.
+        float2 sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+                                        reduced_border,
+                                        straight_border_inner_corner_to_point);
+        outer_sdf = sdfs.x;
+        inner_sdf = sdfs.y;
     }
 
     // Negative when inside the border


### PR DESCRIPTION
# Objective

CSS `corner-shape` lets a corner be a squircle, a bevel, a scoop or a notch, not only a quarter circle. GPUI quads draw only the quarter circle today.

I need it for `corner-shape` in GPUIX, a React renderer for GPUI by @remorses. Same change as remorses/zed#6.

Stacked on #63771, so the diff GitHub shows includes that PR. This PR alone: https://github.com/mateo-m/zed/compare/zed/gpui-isolated-layout...zed/gpui-corner-shapes. #63793 builds on this branch. The stack started as one PR, #63773, and I split it so each part gets its own review. This PR and #63793 were one PR, #63772. The two features share no code, so I split it.

## Solution

- `CornerShape(pub f32)` with the CSS values as constants: `ROUND` 1.0, `SQUIRCLE` 2.0, `SQUARE` infinity, `BEVEL` 0.0, `SCOOP` -1.0, `NOTCH` negative infinity. `Default` is `ROUND`. `Quad` carries one shape per corner. `Styled` gets `corner_shape` and one setter per corner.
- The shaders use a superellipse signed distance for a shaped corner. A round corner, or a corner with radius 0, takes the same path as before.
- The inner edge of the border follows css-borders-4, "Rendering corner-shape". Chrome does not shrink the outer curve by the border width. It moves each end of the curve inward along a normal, by the width of the edge that end sits on. When the two widths differ, it tilts both normals so the border grows evenly from one end to the other. For a round or squircle corner the normals are the axes, so the result is the shrunk curve as before. For a bevel the normal is the diagonal, so the border keeps its width along the cut. A concave bite moves each end by the width of the other edge. `corner_curve` in the three shaders builds that curve, and `CornerShape::inner_curve_ends` gives the same two end points to the Rust side.
- A shape between bevel and scoop, `superellipse(K)` with -1 < K < 0, is not a superellipse in the spec. It is a quarter circle mapped into the frame of the curve's two ends and the point where their tangents meet. The shaders draw that curve.
- The inner edge of a concave or a bevelled corner reaches past the corner box. Two places had to learn that. The shader fast path for "inside the straight border, not near a corner" now counts that band as near the corner. `largest_border_interior`, which splits a border-only quad into four strips and skips the middle, now keeps the band out of the skipped middle. Without both, a notch with a border draws the sides of its bite without a border.
- Metal, wgpu and DirectX shaders updated. The WebGL shader reads the four shapes and gets the new quad stride.
- `Quad` grows from 160 to 176 bytes.

## Testing

- Two new tests in `crates/gpui/src/window.rs`: the skipped interior of a border-only quad starts where the inner curve meets the straight inner edges. One checks a notch and a bevel with an 8 px border, the other a notch and a bevel with a 4 px top and a 12 px left border. Every assertion fails without its fix.
- Pixel comparison against Chrome, at the head of #63793, which adds the 5-stop gradient the boxes use. Fourteen 120 px boxes with `border-radius: 40px`: the five keywords with an 8 px white border, the same five with a 4 px top and bottom and a 12 px left and right border, and `superellipse(0.5)`, `(-0.5)`, `(1.5)` and `(-2)` with an 8 px border. Rendered on Metal and on gpui_web, and by Chrome from CSS `corner-shape` with `background-origin: border-box`, because gpui paints the gradient over the whole bounds. Metal and gpui_web differ from each other by at most 15 of 255 in any pixel. Against Chrome, over each box the mean difference is under 2.5 of 255 on Metal and under 4.5 on gpui_web. At most 0.35% of the pixels of a box differ by more than 64, with two exceptions below. Those pixels sit on the outer antialiased edge of the corners: gpui paints the background and the border as two quads and blends both edges, Chrome paints one shape. That is the same for a round corner on `main`.
- The two exceptions. The round corner with two border widths has 0.6% of its pixels over 64. Its inner edge is the quarter-ellipse approximation from `main`, which this PR does not touch. `superellipse(-0.5)` has 0.9%. I sampled the inner edge of its border per row: gpui puts it on the curve the spec describes to within 0.05 px, Chrome puts it about 0.5 px further out. The outer edge agrees to within 0.2 px in both.
- The HLSL compiles with `dxc -T lib_6_3` from the DirectX Shader Compiler Linux release, run in Docker on macOS. Zed builds it with `fxc` on Windows, which I could not run.
- `cargo test -p gpui` at this head: 313 passed, 1 doc test passed. `cargo test -p gpui_wgpu`: 30 passed. `cargo build -p gpui_apple` compiles the Metal. `cargo clippy -p gpui -p gpui_wgpu -p gpui_apple --all-targets` is clean. `cargo fmt --check` is clean.
- `cargo check -p gpui_windows --target x86_64-pc-windows-msvc` passes from macOS. I have not run this on Windows.
- Performance: a round corner takes the old shader path. `Quad` grows by 16 bytes, so every quad instance is larger.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Screenshots

The GPUIX test renderer on Metal, at the head of #63793. The six `corner-shape` keywords, two `superellipse()` values and some per-corner shorthands, each one quad.

![corner shapes](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-corners.png)

A notch and a bevel with an 8 px border, four times enlarged. Left to right: Chrome, Metal, gpui_web.

![notch border against Chrome](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-notch-border.png)

![bevel border against Chrome](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-bevel-border.png)

A scoop, a bevel and a notch with a 4 px top and bottom border and a 12 px left and right border, twice enlarged. Top to bottom: Chrome, Metal, gpui_web.

![two border widths against Chrome](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-uneven-border.png)

`superellipse(0.5)`, `(-0.5)`, `(1.5)` and `(-2)` with an 8 px border, twice enlarged, in the same order.

![shapes between the keywords against Chrome](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-between-shapes.png)

---

Release Notes:

- N/A
