### PR TITLE
gpui: add multi-stop linear gradients

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -773,6 +773,28 @@ impl Display for ColorSpace {
     }
 }
 
+/// The most color stops one gradient carries. Extra stops are dropped.
+pub const MAX_GRADIENT_STOPS: usize = 8;
+
+/// Where the line of a linear gradient points.
+///
+/// A corner keyword is not a fixed angle. The line for `to top right` is
+/// perpendicular to the diagonal between the two other corners, so it
+/// depends on the size of the box, which only the shader knows.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GradientLine {
+    /// Degrees clockwise from `to top`, as in CSS.
+    Angle(f32),
+    /// `to top left`.
+    ToTopLeft,
+    /// `to top right`.
+    ToTopRight,
+    /// `to bottom right`.
+    ToBottomRight,
+    /// `to bottom left`.
+    ToBottomLeft,
+}
+
 /// A background color, which can be either a solid color or a linear gradient.
 #[derive(Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[repr(C)]
@@ -781,8 +803,17 @@ pub struct Background {
     pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
     pub(crate) gradient_angle_or_pattern_height: f32,
-    pub(crate) colors: [LinearColorStop; 2],
-    /// Padding for alignment for repr(C) layout.
+    /// The color stops, in order. Only the first `stop_count` are live.
+    pub(crate) colors: [LinearColorStop; MAX_GRADIENT_STOPS],
+    /// How many entries of `colors` are live. The shaders clamp it to 1 to 8.
+    pub(crate) stop_count: u32,
+    /// 0 when `gradient_angle_or_pattern_height` is the angle, else the
+    /// corner the line points at: 1 top left, 2 top right, 3 bottom right,
+    /// 4 bottom left.
+    pub(crate) corner: u32,
+    /// WGSL rounds the stride of an `array<Quad>` up to 8 bytes because
+    /// `Bounds` holds a `vec2<f32>`. Rust packs at 4. This pad keeps every
+    /// record that holds a `Background` at a size that is a multiple of 8.
     pad: u32,
 }
 
@@ -792,8 +823,10 @@ impl std::fmt::Debug for Background {
             BackgroundTag::Solid => write!(f, "Solid({:?})", self.solid),
             BackgroundTag::LinearGradient => write!(
                 f,
-                "LinearGradient({}, {:?}, {:?})",
-                self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
+                "LinearGradient({}, corner {}, {:?})",
+                self.gradient_angle_or_pattern_height,
+                self.corner,
+                self.live_stops()
             ),
             BackgroundTag::PatternSlash => write!(
                 f,
@@ -817,7 +850,9 @@ impl Default for Background {
             solid: Hsla::default(),
             color_space: ColorSpace::default(),
             gradient_angle_or_pattern_height: 0.0,
-            colors: [LinearColorStop::default(), LinearColorStop::default()],
+            colors: [LinearColorStop::default(); MAX_GRADIENT_STOPS],
+            stop_count: 0,
+            corner: 0,
             pad: 0,
         }
     }
@@ -867,10 +902,42 @@ pub fn linear_gradient(
     from: impl Into<LinearColorStop>,
     to: impl Into<LinearColorStop>,
 ) -> Background {
+    linear_gradient_stops(GradientLine::Angle(angle), &[from.into(), to.into()])
+}
+
+/// Creates a LinearGradient background with any number of color stops.
+///
+/// Stop positions run from 0.0 to 1.0 along the gradient line and must not
+/// decrease. Fix them up before calling, as CSS Images 3 §3.4.3 describes.
+/// A gradient keeps at most [`MAX_GRADIENT_STOPS`] stops and drops the rest.
+/// One stop paints that color. No stops paint nothing.
+pub fn linear_gradient_stops(line: GradientLine, stops: &[LinearColorStop]) -> Background {
+    if stops.is_empty() {
+        return Background::default();
+    }
+    let (angle, corner) = match line {
+        GradientLine::Angle(angle) => (angle, 0),
+        GradientLine::ToTopLeft => (0.0, 1),
+        GradientLine::ToTopRight => (0.0, 2),
+        GradientLine::ToBottomRight => (0.0, 3),
+        GradientLine::ToBottomLeft => (0.0, 4),
+    };
+    if stops.len() > MAX_GRADIENT_STOPS {
+        log::warn!(
+            "a gradient has {} color stops; only the first {} paint",
+            stops.len(),
+            MAX_GRADIENT_STOPS
+        );
+    }
+    let mut colors = [LinearColorStop::default(); MAX_GRADIENT_STOPS];
+    let kept = stops.len().min(MAX_GRADIENT_STOPS);
+    colors[..kept].copy_from_slice(&stops[..kept]);
     Background {
         tag: BackgroundTag::LinearGradient,
         gradient_angle_or_pattern_height: angle,
-        colors: [from.into(), to.into()],
+        colors,
+        stop_count: kept as u32,
+        corner,
         ..Default::default()
     }
 }
@@ -885,6 +952,11 @@ pub struct LinearColorStop {
     pub color: Hsla,
     /// The percentage of the gradient, in the range 0.0 to 1.0.
     pub percentage: f32,
+    /// Where between this stop and the next the color is half way, as a
+    /// fraction of that span. 0.0 means no hint, which is the same as 0.5.
+    ///
+    /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#color-hint>
+    pub hint: f32,
 }
 
 /// Creates a new linear color stop.
@@ -894,6 +966,7 @@ pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> LinearColor
     LinearColorStop {
         color: color.into(),
         percentage,
+        hint: 0.0,
     }
 }
 
@@ -901,13 +974,20 @@ impl LinearColorStop {
     /// Returns a new color stop with the same color, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         Self {
-            percentage: self.percentage,
             color: self.color.opacity(factor),
+            ..*self
         }
     }
 }
 
 impl Background {
+    /// The live color stops. The length clamps to the array, so a
+    /// deserialized `stop_count` past [`MAX_GRADIENT_STOPS`] cannot slice
+    /// out of bounds.
+    pub(crate) fn live_stops(&self) -> &[LinearColorStop] {
+        &self.colors[..(self.stop_count as usize).min(MAX_GRADIENT_STOPS)]
+    }
+
     /// Returns the solid color if this is a solid background, None otherwise.
     pub fn as_solid(&self) -> Option<Hsla> {
         if self.tag == BackgroundTag::Solid {
@@ -929,10 +1009,9 @@ impl Background {
     pub fn opacity(&self, factor: f32) -> Self {
         let mut background = *self;
         background.solid = background.solid.opacity(factor);
-        background.colors = [
-            self.colors[0].opacity(factor),
-            self.colors[1].opacity(factor),
-        ];
+        for stop in &mut background.colors {
+            *stop = stop.opacity(factor);
+        }
         background
     }
 
@@ -940,7 +1019,9 @@ impl Background {
     pub fn is_transparent(&self) -> bool {
         match self.tag {
             BackgroundTag::Solid => self.solid.is_transparent(),
-            BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
+            BackgroundTag::LinearGradient => {
+                self.live_stops().iter().all(|c| c.color.is_transparent())
+            }
             BackgroundTag::PatternSlash => self.solid.is_transparent(),
             BackgroundTag::Checkerboard => self.solid.is_transparent(),
         }
@@ -1041,6 +1122,24 @@ mod tests {
         assert_eq!(background.opacity(0.5).colors[1], to.opacity(0.5));
         assert!(!background.is_transparent());
         assert!(background.opacity(0.0).is_transparent());
+    }
+
+    #[test]
+    fn test_empty_stops_make_a_solid_transparent_background() {
+        let background = linear_gradient_stops(GradientLine::Angle(90.0), &[]);
+        assert_eq!(background.tag, BackgroundTag::Solid);
+        assert!(background.is_transparent());
+    }
+
+    #[test]
+    fn test_a_stop_count_past_the_array_cannot_slice_out_of_bounds() {
+        let mut background = linear_gradient_stops(
+            GradientLine::Angle(90.0),
+            &[linear_color_stop(rgba(0xff0000ff), 0.0)],
+        );
+        background.stop_count = 99;
+        assert!(!format!("{background:?}").is_empty());
+        assert!(!background.is_transparent());
     }
 
     #[test]

--- a/crates/gpui/src/debug_overlay.rs
+++ b/crates/gpui/src/debug_overlay.rs
@@ -225,6 +225,7 @@ fn solid_quad(
         border_color: transparent_black(),
         corner_radii: Corners::default(),
         border_widths: Edges::default(),
+        corner_shapes: Corners::default(),
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2249,6 +2249,79 @@ impl Anchor {
     }
 }
 
+/// The shape of one corner, as the curvature of a superellipse.
+///
+/// This is the number CSS `corner-shape: superellipse()` takes. 1 is a
+/// circle, 2 a squircle, 0 a straight bevel and infinity a square corner.
+/// Negative values curve inward: -1 is a scoop and negative infinity a notch.
+/// The corner radius still sets the size; the shape only bends the curve.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[repr(transparent)]
+pub struct CornerShape(pub f32);
+
+impl CornerShape {
+    /// A quarter circle. The default.
+    pub const ROUND: Self = Self(1.0);
+    /// Between round and square.
+    pub const SQUIRCLE: Self = Self(2.0);
+    /// A plain square corner, whatever the radius.
+    pub const SQUARE: Self = Self(f32::INFINITY);
+    /// A straight cut across the corner.
+    pub const BEVEL: Self = Self(0.0);
+    /// A quarter circle bitten out of the corner.
+    pub const SCOOP: Self = Self(-1.0);
+    /// A square bitten out of the corner.
+    pub const NOTCH: Self = Self(f32::NEG_INFINITY);
+
+    /// Where the inner edge of the border meets the two straight inner edges
+    /// at this corner, as distances from the corner along the horizontal edge
+    /// and along the vertical edge.
+    ///
+    /// This follows css-borders-4 "Rendering corner-shape". Each end of the
+    /// curve moves inward along a normal by the width of its own edge, and two
+    /// different widths tilt the normals so the border grows evenly from one
+    /// end to the other. A concave bite therefore moves each end by the width
+    /// of the other edge.
+    pub(crate) fn inner_curve_ends(
+        self,
+        radius: f32,
+        horizontal_width: f32,
+        vertical_width: f32,
+    ) -> (f32, f32) {
+        let mut half_corner = 0.5f32.powf(1.0 / self.0.abs().exp2());
+        if self.0 < 0.0 {
+            half_corner = 1.0 - half_corner;
+        }
+        let control = (half_corner / (std::f32::consts::SQRT_2 - 1.0)
+            - 1.0 / std::f32::consts::SQRT_2)
+            .clamp(0.0, 1.0);
+        let mut start_control = control;
+        let inset_diff = (vertical_width - horizontal_width).clamp(-radius, radius);
+        if inset_diff != 0.0 {
+            let s = (2.0 * radius * radius - inset_diff * inset_diff).sqrt();
+            let bevel_control = (s - inset_diff) / (2.0 * s);
+            start_control = if self.0 < 0.0 {
+                bevel_control * 2.0 * control
+            } else {
+                1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control)
+            };
+        }
+        let end_control = 2.0 * control - start_control;
+        let start_normal_x = (1.0 - start_control) / (1.0 - start_control).hypot(start_control);
+        let end_normal_y = (1.0 - end_control) / end_control.hypot(1.0 - end_control);
+        (
+            radius + horizontal_width * start_normal_x,
+            radius + vertical_width * end_normal_y,
+        )
+    }
+}
+
+impl Default for CornerShape {
+    fn default() -> Self {
+        Self::ROUND
+    }
+}
+
 /// Represents the corners of a box in a 2D space, such as border radius.
 ///
 /// Each field represents the size of the corner on one side of the box: `top_left`, `top_right`, `bottom_right`, and `bottom_left`.

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -156,7 +156,7 @@ pub use subscription::*;
 pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
 use taffy::TaffyLayoutEngine;
-pub use taffy::{AvailableSpace, LayoutId};
+pub use taffy::{AvailableSpace, IsolatedLayout, LayoutId};
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
 pub use text_system::*;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -541,6 +541,8 @@ pub struct Quad {
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
+    /// The curvature of each corner. See [`crate::CornerShape`].
+    pub corner_shapes: Corners<f32>,
 }
 
 impl From<Quad> for Primitive {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use crate::{
-    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
-    CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
-    point, px, quad, rems, size,
+    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, CornerShape,
+    Corners, CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement,
+    Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels,
+    Point, PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window,
+    black, phi, point, px, quad, rems, size,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -287,6 +287,10 @@ pub struct Style {
     /// The radius of the corners of this element
     #[refineable]
     pub corner_radii: Corners<AbsoluteLength>,
+
+    /// The shape of each corner. Round unless set.
+    #[refineable]
+    pub corner_shapes: Corners<CornerShape>,
 
     /// Box shadow of the element
     pub box_shadow: Vec<BoxShadow>,
@@ -727,14 +731,17 @@ impl Style {
                 None => Hsla::default(),
             };
             border_color.a = 0.;
-            window.paint_quad(quad(
-                bounds,
-                corner_radii,
-                background_color.unwrap_or_default(),
-                Edges::default(),
-                border_color,
-                self.border_style,
-            ));
+            window.paint_quad(
+                quad(
+                    bounds,
+                    corner_radii,
+                    background_color.unwrap_or_default(),
+                    Edges::default(),
+                    border_color,
+                    self.border_style,
+                )
+                .corner_shapes(self.corner_shapes),
+            );
         }
 
         window.paint_inset_shadows(bounds, corner_radii, &self.box_shadow);
@@ -745,14 +752,17 @@ impl Style {
             let border_widths = self.border_widths.to_pixels(rem_size);
             let mut background = self.border_color.unwrap_or_default();
             background.a = 0.;
-            window.paint_quad(quad(
-                bounds,
-                corner_radii,
-                background,
-                border_widths,
-                self.border_color.unwrap_or_default(),
-                self.border_style,
-            ));
+            window.paint_quad(
+                quad(
+                    bounds,
+                    corner_radii,
+                    background,
+                    border_widths,
+                    self.border_color.unwrap_or_default(),
+                    self.border_style,
+                )
+                .corner_shapes(self.corner_shapes),
+            );
         }
 
         #[cfg(debug_assertions)]
@@ -805,6 +815,7 @@ impl Default for Style {
             border_color: None,
             border_style: BorderStyle::default(),
             corner_radii: Corners::default(),
+            corner_shapes: Corners::default(),
             box_shadow: Default::default(),
             text: TextStyleRefinement::default(),
             mouse_cursor: None,

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,8 +1,8 @@
 use crate::{
-    self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
-    DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
-    FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent, Length,
-    SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
+    self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CornerShape,
+    CursorStyle, DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures,
+    FontStyle, FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent,
+    Length, SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
     TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
 pub use gpui_macros::{
@@ -493,6 +493,40 @@ pub trait Styled: Sized {
         Self: Sized,
     {
         self.style().background = Some(fill.into());
+        self
+    }
+
+    /// Sets the shape of every corner. See [`CornerShape`].
+    fn corner_shape(mut self, shape: CornerShape) -> Self {
+        let corners = &mut self.style().corner_shapes;
+        corners.top_left = Some(shape);
+        corners.top_right = Some(shape);
+        corners.bottom_right = Some(shape);
+        corners.bottom_left = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the top left corner.
+    fn corner_shape_tl(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.top_left = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the top right corner.
+    fn corner_shape_tr(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.top_right = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the bottom right corner.
+    fn corner_shape_br(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.bottom_right = Some(shape);
+        self
+    }
+
+    /// Sets the shape of the bottom left corner.
+    fn corner_shape_bl(mut self, shape: CornerShape) -> Self {
+        self.style().corner_shapes.bottom_left = Some(shape);
         self
     }
 

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -71,16 +71,29 @@ impl IsolatedLayout {
 
     /// Run `f` with this tree in front of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, so calls that
-    /// straddle the two stay separate.
+    /// The window gets its own tree back when `f` returns, and also when `f`
+    /// panics, so a caught panic cannot leave the window on the wrong tree. A
+    /// reentered `enter` on the same value holds no tree any more and gives
+    /// the window a fresh one, so the window never sees `None`.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let outer = mem::replace(&mut window.layout_engine, self.0.take());
-        let result = f(window);
+        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
+        let outer = mem::replace(&mut window.layout_engine, Some(inner));
+        // The engines go back where they came from before the panic resumes,
+        // which is what makes the state safe to observe after a catch.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
         self.0 = mem::replace(&mut window.layout_engine, outer);
-        result
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
+    ///
+    /// Call it when a new layout of the content starts, before the first
+    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
+    /// nothing removes them, so a tree that is never cleared grows with each
+    /// pass for as long as the element lives.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();
@@ -959,5 +972,28 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
+    }
+
+    #[crate::test]
+    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
+            let mut layout = IsolatedLayout::new();
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                layout.enter(window, |_| panic!("a panic during an isolated layout"))
+            }));
+            assert!(caught.is_err());
+            // The window holds its own tree again and this value holds the
+            // isolated one, so the caller that caught the panic can go on.
+            assert!(window.layout_engine.is_some());
+            assert!(layout.0.is_some());
+            assert_eq!(layout.enter(window, |_| 7), 7);
+        })
+        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use collections::{FxHashMap, FxHashSet};
-use std::{fmt::Debug, ops::Range};
+use std::{fmt::Debug, mem, ops::Range};
 use taffy::{
     TaffyTree, TraversePartialTree as _,
     geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
@@ -35,6 +35,57 @@ pub struct TaffyLayoutEngine {
     absolute_outer_origins: FxHashMap<LayoutId, Point<f32>>,
     computed_layouts: FxHashSet<LayoutId>,
     layout_bounds_scratch_space: Vec<LayoutId>,
+}
+
+/// A layout tree of its own, for laying an element out while another tree computes.
+///
+/// Taffy computes one tree at a time. The measure closure of
+/// [`Window::request_measured_layout`] runs inside that computation, so an
+/// element that wants to measure a child there cannot use the window's tree.
+/// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
+/// in front of the window's tree for the duration of a closure.
+///
+/// With that, an element can size itself from content that the window's tree
+/// has not laid out yet. A panel that animates its height to the height of its
+/// content is the case this exists for.
+///
+/// The layout ids made inside `enter` belong to this tree and address a
+/// different node in any other tree. Every call that reads one has to run inside
+/// `enter`, which means the child's `prepaint` as well as its layout, because
+/// `prepaint` reads bounds. Two things break that rule: a child that calls
+/// `Window::defer_draw`, which prepaints after `enter` returns, and a child that
+/// keeps a layout id for a later frame.
+pub struct IsolatedLayout(Option<TaffyLayoutEngine>);
+
+impl Default for IsolatedLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IsolatedLayout {
+    /// An empty tree.
+    pub fn new() -> Self {
+        Self(Some(TaffyLayoutEngine::new()))
+    }
+
+    /// Run `f` with this tree in front of the window's tree.
+    ///
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
+    pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
+        let outer = mem::replace(&mut window.layout_engine, self.0.take());
+        let result = f(window);
+        self.0 = mem::replace(&mut window.layout_engine, outer);
+        result
+    }
+
+    /// Drop everything this tree holds, keeping it usable for another frame.
+    pub fn clear(&mut self) {
+        if let Some(engine) = self.0.as_mut() {
+            engine.clear();
+        }
+    }
 }
 
 const EXPECT_MESSAGE: &str = "we should avoid taffy layout errors by construction if possible";
@@ -772,5 +823,141 @@ mod tests {
             taffy_border.left,
             taffy::style::LengthPercentage::length(2.0)
         );
+    }
+}
+
+#[cfg(test)]
+mod isolated_layout_tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use crate::{
+        AnyElement, AnyWindowHandle, App, AppContext as _, AvailableSpace, Bounds, Context,
+        Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, IsolatedLayout,
+        LayoutId, ParentElement, Pixels, Render, Size, Style, Styled, TestAppContext, Window, div,
+        px, size,
+    };
+
+    /// An element that takes its size from content it measures during layout.
+    ///
+    /// The content is laid out in a tree of its own, because the measure closure
+    /// runs while the window's tree computes.
+    struct MeasureDuringLayout {
+        state: Rc<RefCell<(AnyElement, IsolatedLayout)>>,
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Element for MeasureDuringLayout {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+
+        fn id(&self) -> Option<ElementId> {
+            None
+        }
+
+        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+            None
+        }
+
+        fn request_layout(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            window: &mut Window,
+            _cx: &mut App,
+        ) -> (LayoutId, ()) {
+            let state = self.state.clone();
+            let layout_id = window.request_measured_layout(
+                Style::default(),
+                move |known: Size<Option<Pixels>>, available: Size<AvailableSpace>, window, cx| {
+                    let (content, layout) = &mut *state.borrow_mut();
+                    let width = known
+                        .width
+                        .map_or(available.width, AvailableSpace::Definite);
+                    layout.enter(window, |window| {
+                        content.layout_as_root(size(width, AvailableSpace::MaxContent), window, cx)
+                    })
+                },
+            );
+            (layout_id, ())
+        }
+
+        fn prepaint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+            self.bounds.set(bounds);
+        }
+
+        fn paint(
+            &mut self,
+            _id: Option<&GlobalElementId>,
+            _inspector_id: Option<&InspectorElementId>,
+            _bounds: Bounds<Pixels>,
+            _request_layout: &mut (),
+            _prepaint: &mut (),
+            _window: &mut Window,
+            _cx: &mut App,
+        ) {
+        }
+    }
+
+    impl IntoElement for MeasureDuringLayout {
+        type Element = Self;
+
+        fn into_element(self) -> Self {
+            self
+        }
+    }
+
+    struct MeasureTestView {
+        bounds: Rc<Cell<Bounds<Pixels>>>,
+    }
+
+    impl Render for MeasureTestView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            // Two children of 120 wrap into two rows of 30 at a width of 200, and
+            // sit on one row of 30 at max content.
+            let content = div()
+                .flex()
+                .flex_row()
+                .flex_wrap()
+                .child(div().w(px(120.)).h(px(30.)))
+                .child(div().w(px(120.)).h(px(30.)))
+                .into_any_element();
+
+            div()
+                .w(px(200.))
+                .flex()
+                .flex_col()
+                .child(MeasureDuringLayout {
+                    state: Rc::new(RefCell::new((content, IsolatedLayout::new()))),
+                    bounds: self.bounds.clone(),
+                })
+        }
+    }
+
+    #[crate::test]
+    fn measures_content_at_the_width_layout_resolved(cx: &mut TestAppContext) {
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let window = cx.add_window({
+            let bounds = bounds.clone();
+            move |_, _| MeasureTestView { bounds }
+        });
+
+        cx.update_window(AnyWindowHandle::from(window), |_, window, cx| {
+            window.draw(cx).clear(cx)
+        })
+        .unwrap();
+
+        // The width reaches the measure closure, so the content wraps the way it
+        // will on screen. Without it the content would measure at max content and
+        // the element would stop at 30.
+        assert_eq!(bounds.get().size.height, px(60.));
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -43,7 +43,7 @@ pub struct TaffyLayoutEngine {
 /// [`Window::request_measured_layout`] runs inside that computation, so an
 /// element that wants to measure a child there cannot use the window's tree.
 /// This holds a second tree for the child, and [`IsolatedLayout::enter`] puts it
-/// in front of the window's tree for the duration of a closure.
+/// in place of the window's tree for the duration of a closure.
 ///
 /// With that, an element can size itself from content that the window's tree
 /// has not laid out yet. A panel that animates its height to the height of its
@@ -69,23 +69,15 @@ impl IsolatedLayout {
         Self(Some(TaffyLayoutEngine::new()))
     }
 
-    /// Run `f` with this tree in front of the window's tree.
+    /// Run `f` with this tree in place of the window's tree.
     ///
-    /// The window gets its own tree back when `f` returns, and also when `f`
-    /// panics, so a caught panic cannot leave the window on the wrong tree. A
-    /// reentered `enter` on the same value holds no tree any more and gives
-    /// the window a fresh one, so the window never sees `None`.
+    /// The window gets its own tree back when `f` returns, so calls that
+    /// straddle the two stay separate.
     pub fn enter<R>(&mut self, window: &mut Window, f: impl FnOnce(&mut Window) -> R) -> R {
-        let inner = self.0.take().unwrap_or_else(TaffyLayoutEngine::new);
-        let outer = mem::replace(&mut window.layout_engine, Some(inner));
-        // The engines go back where they came from before the panic resumes,
-        // which is what makes the state safe to observe after a catch.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(window)));
-        self.0 = mem::replace(&mut window.layout_engine, outer);
-        match result {
-            Ok(value) => value,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        let result = f(window);
+        mem::swap(&mut self.0, &mut window.layout_engine);
+        result
     }
 
     /// Drop everything this tree holds, keeping it usable for another frame.
@@ -973,28 +965,5 @@ mod isolated_layout_tests {
         // will on screen. Without it the content would measure at max content and
         // the element would stop at 30.
         assert_eq!(bounds.get().size.height, px(60.));
-    }
-
-    #[crate::test]
-    fn a_panic_inside_enter_puts_both_trees_back(cx: &mut TestAppContext) {
-        let bounds = Rc::new(Cell::new(Bounds::default()));
-        let window = cx.add_window({
-            let bounds = bounds.clone();
-            move |_, _| MeasureTestView { bounds }
-        });
-
-        cx.update_window(AnyWindowHandle::from(window), |_, window, _cx| {
-            let mut layout = IsolatedLayout::new();
-            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                layout.enter(window, |_| panic!("a panic during an isolated layout"))
-            }));
-            assert!(caught.is_err());
-            // The window holds its own tree again and this value holds the
-            // isolated one, so the caller that caught the panic can go on.
-            assert!(window.layout_engine.is_some());
-            assert!(layout.0.is_some());
-            assert_eq!(layout.enter(window, |_| 7), 7);
-        })
-        .unwrap();
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -90,10 +90,11 @@ impl IsolatedLayout {
 
     /// Drop everything this tree holds, keeping it usable for another frame.
     ///
-    /// Call it when a new layout of the content starts, before the first
-    /// `enter` of that pass. Every layout inside `enter` adds nodes, and
-    /// nothing removes them, so a tree that is never cleared grows with each
-    /// pass for as long as the element lives.
+    /// Call it only between elements: after the old content element drops,
+    /// before the first `enter` with the new one. An element requests its
+    /// nodes once and reuses those ids in every later pass, so a clear while
+    /// the element lives makes its next layout panic on the dead ids. A tree
+    /// that lives exactly as long as one element never needs a clear.
     pub fn clear(&mut self) {
         if let Some(engine) = self.0.as_mut() {
             engine.clear();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -7,15 +7,15 @@ use crate::profiler;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow,
-    Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
-    DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
-    EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
-    Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
-    KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
-    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
-    Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage,
-    RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
+    Capslock, Context, CornerShape, Corners, CursorHideMode, CursorStyle, Decorations,
+    DevicePixels, DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect,
+    Entity, EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId,
+    GpuSpecs, Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent,
+    Keystroke, KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
+    MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
+    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
+    PolychromeSprite, Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams,
+    RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
     SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow, SharedString, Size,
     StrikethroughStyle, Style, SubpixelSprite, SubscriberSet, Subscription, SystemWindowTab,
     SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task, TextInputConfiguration,
@@ -4237,11 +4237,35 @@ impl Window {
     fn largest_border_interior(quad: &Quad) -> Bounds<ScaledPixels> {
         let radii = &quad.corner_radii;
         let widths = &quad.border_widths;
+        let shapes = &quad.corner_shapes;
+        let ends =
+            |radius: ScaledPixels,
+             shape: f32,
+             horizontal_width: ScaledPixels,
+             vertical_width: ScaledPixels| {
+                let (along_horizontal, along_vertical) = crate::CornerShape(shape)
+                    .inner_curve_ends(radius.0, horizontal_width.0, vertical_width.0);
+                (ScaledPixels(along_horizontal), ScaledPixels(along_vertical))
+            };
+        let top_left = ends(radii.top_left, shapes.top_left, widths.top, widths.left);
+        let top_right = ends(radii.top_right, shapes.top_right, widths.top, widths.right);
+        let bottom_left = ends(
+            radii.bottom_left,
+            shapes.bottom_left,
+            widths.bottom,
+            widths.left,
+        );
+        let bottom_right = ends(
+            radii.bottom_right,
+            shapes.bottom_right,
+            widths.bottom,
+            widths.right,
+        );
         let edge_radii = Edges {
-            top: radii.top_left.max(radii.top_right),
-            right: radii.top_right.max(radii.bottom_right),
-            bottom: radii.bottom_left.max(radii.bottom_right),
-            left: radii.top_left.max(radii.bottom_left),
+            top: top_left.1.max(top_right.1),
+            right: top_right.0.max(bottom_right.0),
+            bottom: bottom_left.1.max(bottom_right.1),
+            left: top_left.0.max(bottom_left.0),
         };
 
         let antialias_inset = point(ScaledPixels(1.0), ScaledPixels(1.0));
@@ -4297,6 +4321,7 @@ impl Window {
             corner_radii: quad.corner_radii.scale(self.scale_factor()),
             border_widths: snapped_border_widths,
             border_style: quad.border_style,
+            corner_shapes: quad.corner_shapes.map(|shape| shape.0),
         };
 
         if !quad.background.is_transparent() {
@@ -7293,9 +7318,19 @@ pub struct PaintQuad {
     pub border_color: Hsla,
     /// The style of the quad's borders.
     pub border_style: BorderStyle,
+    /// The shape of the quad's corners.
+    pub corner_shapes: Corners<CornerShape>,
 }
 
 impl PaintQuad {
+    /// Sets the shape of the quad's corners.
+    pub fn corner_shapes(self, corner_shapes: impl Into<Corners<CornerShape>>) -> Self {
+        PaintQuad {
+            corner_shapes: corner_shapes.into(),
+            ..self
+        }
+    }
+
     /// Sets the corner radii of the quad.
     pub fn corner_radii(self, corner_radii: impl Into<Corners<Pixels>>) -> Self {
         PaintQuad {
@@ -7345,6 +7380,7 @@ pub fn quad(
         border_widths: border_widths.into(),
         border_color: border_color.into(),
         border_style,
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7357,6 +7393,7 @@ pub fn fill(bounds: impl Into<Bounds<Pixels>>, background: impl Into<Background>
         border_widths: (0.).into(),
         border_color: transparent_black(),
         border_style: BorderStyle::default(),
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7373,6 +7410,7 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+        corner_shapes: Corners::default(),
     }
 }
 
@@ -7390,8 +7428,9 @@ mod tests {
         ExternalDragPayload, ExternalPaths, FileDragPaths, FileDropEvent, FocusHandle,
         InputEvent as _, InteractiveElement as _, IntoElement, LongPressEvent, MouseButton,
         MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render, RequestFrameOptions,
-        StatefulInteractiveElement as _, Styled, TestAppContext, TouchDragEvent, TouchEvent,
-        TouchId, TouchPhase, Window, WindowAppearance, WindowOptions, canvas, div, point, px, size,
+        ScaledPixels, StatefulInteractiveElement as _, Styled, TestAppContext, TouchDragEvent,
+        TouchEvent, TouchId, TouchPhase, Window, WindowAppearance, WindowOptions, canvas, div,
+        point, px, size,
     };
 
     struct EmptyView;
@@ -7425,6 +7464,78 @@ mod tests {
                 // a mid-draw arena clear when painted afterwards.
                 .child(div().child("after"))
         }
+    }
+
+    fn border_only_quad(shape: crate::CornerShape) -> crate::Quad {
+        border_only_quad_with(
+            shape,
+            crate::Edges::all(ScaledPixels(8.)),
+            size(ScaledPixels(120.), ScaledPixels(120.)),
+        )
+    }
+
+    fn border_only_quad_with(
+        shape: crate::CornerShape,
+        border_widths: crate::Edges<ScaledPixels>,
+        size: crate::Size<ScaledPixels>,
+    ) -> crate::Quad {
+        crate::Quad {
+            order: 0,
+            border_style: Default::default(),
+            bounds: Bounds::new(point(ScaledPixels(0.), ScaledPixels(0.)), size),
+            content_mask: Default::default(),
+            background: Default::default(),
+            border_color: Default::default(),
+            corner_radii: crate::Corners::all(ScaledPixels(40.)),
+            border_widths,
+            corner_shapes: crate::Corners::all(shape.0),
+        }
+    }
+
+    #[test]
+    fn test_border_interior_stops_where_the_inner_edge_reaches() {
+        let round = Window::largest_border_interior(&border_only_quad(crate::CornerShape::ROUND));
+        assert_eq!(round.top(), ScaledPixels(41.));
+        assert_eq!(round.left(), ScaledPixels(9.));
+
+        let notch = Window::largest_border_interior(&border_only_quad(crate::CornerShape::NOTCH));
+        assert_eq!(notch.top(), ScaledPixels(49.));
+        assert_eq!(notch.bottom(), ScaledPixels(71.));
+        assert_eq!(notch.left(), ScaledPixels(9.));
+
+        let bevel = Window::largest_border_interior(&border_only_quad(crate::CornerShape::BEVEL));
+        assert!((bevel.top().0 - (41. + 8. / std::f32::consts::SQRT_2)).abs() < 1e-3);
+        assert_eq!(bevel.left(), ScaledPixels(9.));
+    }
+
+    #[test]
+    fn test_border_interior_with_two_border_widths_at_a_corner() {
+        let widths = crate::Edges {
+            top: ScaledPixels(4.),
+            bottom: ScaledPixels(4.),
+            left: ScaledPixels(12.),
+            right: ScaledPixels(12.),
+        };
+        // The tall quad keeps the band between the top and bottom corners, the
+        // wide one the band between the left and right corners.
+        let tall = size(ScaledPixels(120.), ScaledPixels(400.));
+        let wide = size(ScaledPixels(400.), ScaledPixels(120.));
+
+        // A bite moves each end of the curve by the width of the other edge.
+        let notch = crate::CornerShape::NOTCH;
+        let interior = Window::largest_border_interior(&border_only_quad_with(notch, widths, tall));
+        assert_eq!(interior.top(), ScaledPixels(53.));
+        let interior = Window::largest_border_interior(&border_only_quad_with(notch, widths, wide));
+        assert_eq!(interior.left(), ScaledPixels(45.));
+
+        // The bevel's inner line tilts so the border grows from 4 to 12. Its
+        // ends land at 0.8 of the top width along the top edge and 0.6 of the
+        // left width down the left edge.
+        let bevel = crate::CornerShape::BEVEL;
+        let interior = Window::largest_border_interior(&border_only_quad_with(bevel, widths, tall));
+        assert!((interior.top().0 - (41. + 12. * 0.6)).abs() < 1e-3);
+        let interior = Window::largest_border_interior(&border_only_quad_with(bevel, widths, wide));
+        assert!((interior.left().0 - (41. + 4. * 0.8)).abs() < 1e-3);
     }
 
     /// Opening a window synchronously draws it and requests an element arena

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1160,7 +1160,7 @@ pub struct Window {
     /// a given rem size.
     rem_size_override_stack: SmallVec<[Pixels; 8]>,
     pub(crate) viewport_size: Size<Pixels>,
-    layout_engine: Option<TaffyLayoutEngine>,
+    pub(crate) layout_engine: Option<TaffyLayoutEngine>,
     pub(crate) root: Option<AnyView>,
     pub(crate) element_id_stack: SmallVec<[ElementId; 32]>,
     pub(crate) text_style_stack: Vec<TextStyleRefinement>,

--- a/crates/gpui_apple/src/shaders.metal
+++ b/crates/gpui_apple/src/shaders.metal
@@ -25,6 +25,27 @@ float dash_alpha(float t, float period, float length, float dash_velocity,
                  float antialias_threshold);
 float quarter_ellipse_sdf(float2 point, float2 radii);
 float pick_corner_radius(float2 center_to_point, Corners_ScaledPixels corner_radii);
+float pick_corner_shape(float2 center_to_point, Corners_f32 corner_shapes);
+float superellipse_sdf(float2 point, float2 radii, float n);
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+  float2 start;
+  float2 end;
+  float2 start_normal;
+  float2 end_normal;
+};
+
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset);
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight);
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius,
+                         float shape, float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point);
 float quad_sdf(float2 point, Bounds_ScaledPixels bounds,
                Corners_ScaledPixels corner_radii);
 float quad_sdf_impl(float2 center_to_point, float corner_radius);
@@ -127,8 +148,9 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   // minimum distance between the center of the pixel and the edge.
   const float antialias_threshold = 0.5;
 
-  // Radius of the nearest corner
+  // Radius and shape of the nearest corner
   float corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+  float corner_shape = pick_corner_shape(center_to_point, quad.corner_shapes);
 
   // Width of the nearest borders
   float2 border = float2(
@@ -150,10 +172,16 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   // mirrored into bottom right quadrant.
   float2 corner_center_to_point = corner_to_point + corner_radius;
 
-  // Whether the nearest point on the border is rounded
+  // Whether the nearest point on the border is rounded. The inner edge of a
+  // concave or a bevelled corner reaches past the corner box.
+  float2 corner_reach = corner_center_to_point;
+  if (corner_shape != 1.0) {
+    CornerCurve inner_curve = corner_curve(corner_radius, corner_shape, border);
+    corner_reach += float2(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+  }
   bool is_near_rounded_corner =
-    corner_center_to_point.x >= 0.0 &&
-    corner_center_to_point.y >= 0.0;
+    corner_reach.x >= 0.0 &&
+    corner_reach.y >= 0.0;
 
   // Vector from straight border inner corner to point.
   //
@@ -179,7 +207,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   }
 
   // Signed distance of the point to the outside edge of the quad's border
-  float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+  float outer_sdf;
 
   // Approximate signed distance of the point to the inside edge of the quad's
   // border. It is negative outside this edge (within the border), and
@@ -190,19 +218,29 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   //   nearest-point-on-ellipse.
   // * When it is quickly known to be outside the edge, -1.0 is used.
   float inner_sdf = 0.0;
-  if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
-    // Fast paths for straight borders
-    inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                     straight_border_inner_corner_to_point.y);
-  } else if (is_beyond_inner_straight_border) {
-    // Fast path for points that must be outside the inner edge
-    inner_sdf = -1.0;
-  } else if (reduced_border.x == reduced_border.y) {
-    // Fast path for circular inner edge.
-    inner_sdf = -(outer_sdf + reduced_border.x);
+  if (corner_shape == 1.0 || corner_radius == 0.0) {
+    outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+      if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
+      // Fast paths for straight borders
+      inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                       straight_border_inner_corner_to_point.y);
+    } else if (is_beyond_inner_straight_border) {
+      // Fast path for points that must be outside the inner edge
+      inner_sdf = -1.0;
+    } else if (reduced_border.x == reduced_border.y) {
+      // Fast path for circular inner edge.
+      inner_sdf = -(outer_sdf + reduced_border.x);
+    } else {
+      float2 ellipse_radii = max(float2(0.0), float2(corner_radius) - reduced_border);
+      inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+    }
   } else {
-    float2 ellipse_radii = max(float2(0.0), float2(corner_radius) - reduced_border);
-    inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+    // Any other corner shape: a superellipse, or a bite out of the corner.
+    float2 sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+                                    reduced_border,
+                                    straight_border_inner_corner_to_point);
+    outer_sdf = sdfs.x;
+    inner_sdf = sdfs.y;
   }
 
   // Negative when inside the border
@@ -1056,6 +1094,139 @@ float pick_corner_radius(float2 center_to_point, Corners_ScaledPixels corner_rad
       return corner_radii.bottom_right;
     }
   }
+}
+
+float pick_corner_shape(float2 center_to_point, Corners_f32 corner_shapes) {
+  if (center_to_point.x < 0.) {
+    if (center_to_point.y < 0.) {
+      return corner_shapes.top_left;
+    } else {
+      return corner_shapes.bottom_left;
+    }
+  } else {
+    if (center_to_point.y < 0.) {
+      return corner_shapes.top_right;
+    } else {
+      return corner_shapes.bottom_right;
+    }
+  }
+}
+
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+float superellipse_sdf(float2 point, float2 radii, float n) {
+  if (isinf(n)) {
+    float2 to_edge = point - radii;
+    return max(to_edge.x, to_edge.y);
+  }
+  float2 unit = point / radii;
+  float largest = max(max(unit.x, unit.y), 1e-6);
+  float2 scaled = unit / largest;
+  float rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+  float2 gradient = pow(scaled * (largest / rho), n - 1.0) / radii;
+  return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset) {
+  float half_corner = pow(0.5, 1.0 / exp2(fabs(shape)));
+  if (shape < 0.0) {
+    half_corner = 1.0 - half_corner;
+  }
+  float control =
+    clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+  float start_control = control;
+  float inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+  if (inset_diff != 0.0) {
+    float s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+    float bevel_control = (s - inset_diff) / (2.0 * s);
+    start_control = shape < 0.0
+      ? bevel_control * 2.0 * control
+      : 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+  }
+  float end_control = 2.0 * control - start_control;
+  CornerCurve curve;
+  curve.start_normal = normalize(float2(1.0 - start_control, start_control));
+  curve.end_normal = normalize(float2(end_control, 1.0 - end_control));
+  curve.start = float2(corner_radius, 0.0) + inset.y * curve.start_normal;
+  curve.end = float2(0.0, corner_radius) + inset.x * curve.end_normal;
+  return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight) {
+  float n = exp2(fabs(shape));
+  if (shape >= 0.0) {
+    float2 center = float2(curve.start.x, curve.end.y);
+    float2 radii = float2(center.x - curve.end.x, center.y - curve.start.y);
+    float2 center_to_point = center - from_corner;
+    if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+        radii.x <= 0.0 || radii.y <= 0.0) {
+      return straight;
+    }
+    return max(straight, superellipse_sdf(center_to_point, radii, n));
+  }
+  if (shape <= -1.0) {
+    float2 origin = float2(curve.end.x, curve.start.y);
+    float2 radii = float2(curve.start.x - origin.x, curve.end.y - origin.y);
+    float2 origin_to_point = max(from_corner - origin, 0.0);
+    return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+  }
+  // Between a bevel and a scoop the spec draws a quarter circle mapped into
+  // the frame of the two ends and the point where their tangents meet.
+  float2 start_tangent = float2(-curve.start_normal.y, curve.start_normal.x);
+  float2 end_tangent = float2(-curve.end_normal.y, curve.end_normal.x);
+  float2 start_to_end = curve.end - curve.start;
+  float tangents_cross =
+    start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+  float2 meet = curve.start;
+  if (fabs(tangents_cross) > 1e-6) {
+    float t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+              tangents_cross;
+    meet = curve.start + t * start_tangent;
+  }
+  float2 to_end = curve.end - meet;
+  float2 to_start = curve.start - meet;
+  float det = to_end.x * to_start.y - to_end.y * to_start.x;
+  if (fabs(det) < 1e-6) {
+    return straight;
+  }
+  float2 d = from_corner - meet;
+  float x = (d.x * to_start.y - d.y * to_start.x) / det;
+  float y = (to_end.x * d.y - to_end.y * d.x) / det;
+  float2 unit = 1.0 - float2(x, y);
+  float f = dot(unit, unit) - 1.0;
+  float2 g = -2.0 * unit;
+  float2 gradient = float2(to_start.y * g.x - to_end.y * g.y,
+                           to_end.x * g.y - to_start.x * g.x) / det;
+  return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius,
+                         float shape, float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point) {
+  float2 from_corner = -corner_to_point;
+  CornerCurve outer_curve = corner_curve(corner_radius, shape, float2(0.0));
+  CornerCurve inner_curve = corner_curve(corner_radius, shape, reduced_border);
+  float straight_outer = max(corner_to_point.x, corner_to_point.y);
+  float straight_inner = max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+  return float2(
+    corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+    -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
 }
 
 // Signed distance of the point to the quad's border - positive outside the

--- a/crates/gpui_apple/src/shaders.metal
+++ b/crates/gpui_apple/src/shaders.metal
@@ -56,22 +56,14 @@ float blur_along_x(float x, float y, float sigma, float corner,
 float4 over(float4 below, float4 above);
 float radians(float degrees);
 float4 fill_color(Background background, float2 position, Bounds_ScaledPixels bounds,
-  float4 solid_color, float4 color0, float4 color1);
-
-struct GradientColor {
-  float4 solid;
-  float4 color0;
-  float4 color1;
-};
-GradientColor prepare_fill_color(uint tag, uint color_space, Hsla solid, Hsla color0, Hsla color1);
+  float4 solid_color);
+float4 prepare_fill_color(Background background);
 
 struct QuadVertexOutput {
   uint quad_id [[flat]];
   float4 position [[position]];
   float4 border_color [[flat]];
   float4 background_solid [[flat]];
-  float4 background_color0 [[flat]];
-  float4 background_color1 [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -80,8 +72,6 @@ struct QuadFragmentInput {
   float4 position [[position]];
   float4 border_color [[flat]];
   float4 background_solid [[flat]];
-  float4 background_color0 [[flat]];
-  float4 background_color1 [[flat]];
 };
 
 vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
@@ -100,21 +90,11 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
                                                  quad.content_mask.bounds);
   float4 border_color = hsla_to_rgba(quad.border_color);
 
-  GradientColor gradient = prepare_fill_color(
-    quad.background.tag,
-    quad.background.color_space,
-    quad.background.solid,
-    quad.background.colors[0].color,
-    quad.background.colors[1].color
-  );
-
   return QuadVertexOutput{
       quad_id,
       device_position,
       border_color,
-      gradient.solid,
-      gradient.color0,
-      gradient.color1,
+      prepare_fill_color(quad.background),
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
@@ -123,7 +103,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                               [[buffer(QuadInputIndex_Quads)]]) {
   Quad quad = quads[input.quad_id];
   float4 background_color = fill_color(quad.background, input.position.xy, quad.bounds,
-    input.background_solid, input.background_color0, input.background_color1);
+    input.background_solid);
 
   bool unrounded = quad.corner_radii.top_left == 0.0 &&
     quad.corner_radii.bottom_left == 0.0 &&
@@ -830,21 +810,11 @@ fragment float4 path_rasterization_fragment(
     alpha = saturate(0.5 - distance);
   }
 
-  GradientColor gradient_color = prepare_fill_color(
-    background.tag,
-    background.color_space,
-    background.solid,
-    background.colors[0].color,
-    background.colors[1].color
-  );
-
   float4 color = fill_color(
     background,
     input.position.xy,
     path_bounds,
-    gradient_color.solid,
-    gradient_color.color0,
-    gradient_color.color1
+    prepare_fill_color(background)
   );
   return float4(color.rgb * color.a * alpha, alpha * color.a);
 }
@@ -1321,25 +1291,90 @@ float4 over(float4 below, float4 above) {
   return result;
 }
 
-GradientColor prepare_fill_color(uint tag, uint color_space, Hsla solid,
-                                     Hsla color0, Hsla color1) {
-  GradientColor out;
-  if (tag == 0 || tag == 2 || tag == 3) {
-    out.solid = hsla_to_rgba(solid);
-  } else if (tag == 1) {
-    out.color0 = hsla_to_rgba(color0);
-    out.color1 = hsla_to_rgba(color1);
+// The solid color of a fill, converted once per vertex. Gradients convert
+// their stops per fragment instead, since only two of them matter there.
+float4 prepare_fill_color(Background background) {
+  if (background.tag == 1) {
+    return float4(0.0);
+  }
+  return hsla_to_rgba(background.solid);
+}
 
-    // Prepare color space in vertex for avoid conversion
-    // in fragment shader for performance reasons
-    if (color_space == 1) {
-      // Oklab
-      out.color0 = srgb_to_oklab(out.color0);
-      out.color1 = srgb_to_oklab(out.color1);
+// One gradient stop in the space the gradient mixes in.
+float4 gradient_stop_color(Background background, uint index) {
+  float4 color = hsla_to_rgba(background.colors[index].color);
+  if (background.color_space == 1) {
+    color = srgb_to_oklab(color);
+  }
+  return color;
+}
+
+// The color of a CSS linear gradient at `position`.
+//
+// The gradient line goes through the center of the box. Its length is the
+// one CSS Images 3 defines, so 0% and 100% sit exactly on the corners the
+// line points away from and toward. A corner keyword makes the line
+// perpendicular to the diagonal between the two other corners.
+float4 linear_gradient_color(Background background, float2 position,
+                             Bounds_ScaledPixels bounds) {
+  float2 size = float2(bounds.size.width, bounds.size.height);
+  float angle;
+  if (background.corner == 0) {
+    angle = background.gradient_angle_or_pattern_height * (M_PI_F / 180.0);
+  } else {
+    float toward_top_right = atan2(size.y, size.x);
+    switch (background.corner) {
+      case 1: angle = 2.0 * M_PI_F - toward_top_right; break;
+      case 2: angle = toward_top_right; break;
+      case 3: angle = M_PI_F - toward_top_right; break;
+      default: angle = M_PI_F + toward_top_right; break;
     }
   }
+  float2 direction = float2(sin(angle), -cos(angle));
+  float line_length = abs(size.x * sin(angle)) + abs(size.y * cos(angle));
+  float2 center = float2(bounds.origin.x, bounds.origin.y) + size / 2.0;
+  float t = (dot(position - center, direction) + line_length / 2.0)
+    / max(line_length, 1e-6);
 
-  return out;
+  // A count outside 1 to 8 can only come from a hand-built struct. Clamp it
+  // so the array read stays in bounds.
+  uint last = clamp(background.stop_count, 1u, 8u) - 1;
+  float4 color;
+  if (t <= background.colors[0].percentage) {
+    color = gradient_stop_color(background, 0);
+  } else if (t >= background.colors[last].percentage) {
+    color = gradient_stop_color(background, last);
+  } else {
+    uint i = 0;
+    while (i + 1 < last && t > background.colors[i + 1].percentage) {
+      i++;
+    }
+    float start = background.colors[i].percentage;
+    float end = background.colors[i + 1].percentage;
+    float p = end > start ? (t - start) / (end - start) : 1.0;
+    // A color hint moves the half-way point of the mix between two stops.
+    float hint = background.colors[i].hint;
+    if (hint > 0.0 && hint < 1.0) {
+      p = pow(p, log(0.5) / log(hint));
+    }
+    color = mix(gradient_stop_color(background, i),
+                gradient_stop_color(background, i + 1), p);
+  }
+  if (background.color_space == 1) {
+    color = oklab_to_srgb(color);
+  }
+
+  // Dither to reduce banding in gradients (especially dark/alpha).
+  // Triangular-distributed noise breaks up 8-bit quantization steps.
+  // ±2/255 for RGB (enough for dark-on-dark compositing),
+  // ±3/255 for alpha (needs more because alpha × dark color = tiny steps).
+  float2 seed = position * 0.6180339887; // golden ratio spread
+  float r1 = fract(sin(dot(seed, float2(12.9898, 78.233))) * 43758.5453);
+  float r2 = fract(sin(dot(seed, float2(39.3460, 11.135))) * 24634.6345);
+  float tri = r1 + r2 - 1.0; // triangular PDF, range [-1, +1]
+  color.rgb += tri * 2.0 / 255.0;
+  color.a   += tri * 3.0 / 255.0;
+  return color;
 }
 
 float2x2 rotate2d(float angle) {
@@ -1351,70 +1386,16 @@ float2x2 rotate2d(float angle) {
 float4 fill_color(Background background,
                       float2 position,
                       Bounds_ScaledPixels bounds,
-                      float4 solid_color, float4 color0, float4 color1) {
+                      float4 solid_color) {
   float4 color;
 
   switch (background.tag) {
     case 0:
       color = solid_color;
       break;
-    case 1: {
-      // -90 degrees to match the CSS gradient angle.
-      float gradient_angle = background.gradient_angle_or_pattern_height;
-      float radians = (fmod(gradient_angle, 360.0) - 90.0) * (M_PI_F / 180.0);
-      float2 direction = float2(cos(radians), sin(radians));
-
-      // Expand the short side to be the same as the long side
-      if (bounds.size.width > bounds.size.height) {
-          direction.y *= bounds.size.height / bounds.size.width;
-      } else {
-          direction.x *=  bounds.size.width / bounds.size.height;
-      }
-
-      // Get the t value for the linear gradient with the color stop percentages.
-      float2 half_size = float2(bounds.size.width, bounds.size.height) / 2.;
-      float2 center = float2(bounds.origin.x, bounds.origin.y) + half_size;
-      float2 center_to_point = position - center;
-      float t = dot(center_to_point, direction) / length(direction);
-      // Check the direction to determine whether to use x or y
-      if (abs(direction.x) > abs(direction.y)) {
-          t = (t + half_size.x) / bounds.size.width;
-      } else {
-          t = (t + half_size.y) / bounds.size.height;
-      }
-
-      // Adjust t based on the stop percentages
-      t = (t - background.colors[0].percentage)
-        / (background.colors[1].percentage
-        - background.colors[0].percentage);
-      t = clamp(t, 0.0, 1.0);
-
-      switch (background.color_space) {
-        case 0:
-          color = mix(color0, color1, t);
-          break;
-        case 1: {
-          float4 oklab_color = mix(color0, color1, t);
-          color = oklab_to_srgb(oklab_color);
-          break;
-        }
-      }
-
-      // Dither to reduce banding in gradients (especially dark/alpha).
-      // Triangular-distributed noise breaks up 8-bit quantization steps.
-      // ±2/255 for RGB (enough for dark-on-dark compositing),
-      // ±3/255 for alpha (needs more because alpha × dark color = tiny steps).
-      {
-        float2 seed = position * 0.6180339887; // golden ratio spread
-        float r1 = fract(sin(dot(seed, float2(12.9898, 78.233))) * 43758.5453);
-        float r2 = fract(sin(dot(seed, float2(39.3460, 11.135))) * 24634.6345);
-        float tri = r1 + r2 - 1.0; // triangular PDF, range [-1, +1]
-        color.rgb += tri * 2.0 / 255.0;
-        color.a   += tri * 3.0 / 255.0;
-      }
-
+    case 1:
+      color = linear_gradient_color(background, position, bounds);
       break;
-    }
     case 2: {
         float gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
         float pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -354,6 +354,148 @@ fn pick_corner_radius(center_to_point: vec2<f32>, radii: Corners) -> f32 {
     }
 }
 
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+fn superellipse_sdf(point: vec2<f32>, radii: vec2<f32>, n: f32) -> f32 {
+    // WGSL has no infinity literal or isinf, so a huge exponent stands in.
+    if (n > 1.0e30) {
+        let to_edge = point - radii;
+        return max(to_edge.x, to_edge.y);
+    }
+    let unit = point / radii;
+    let largest = max(max(unit.x, unit.y), 1e-6);
+    let scaled = unit / largest;
+    let rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+    let gradient = pow(scaled * (largest / rho), vec2<f32>(n - 1.0)) / radii;
+    return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+    start: vec2<f32>,
+    end: vec2<f32>,
+    start_normal: vec2<f32>,
+    end_normal: vec2<f32>,
+}
+
+// Past 2^64 every superellipse is a box to the pixel, so cap the exponent
+// there. WGSL has no infinity literal.
+fn superellipse_exponent(shape: f32) -> f32 {
+    if (abs(shape) < 64.0) {
+        return exp2(abs(shape));
+    }
+    return 1.0e31;
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+fn corner_curve(corner_radius: f32, shape: f32, inset: vec2<f32>) -> CornerCurve {
+    var half_corner = pow(0.5, 1.0 / superellipse_exponent(shape));
+    if (shape < 0.0) {
+        half_corner = 1.0 - half_corner;
+    }
+    let control =
+        clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+    var start_control = control;
+    let inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+    if (inset_diff != 0.0) {
+        let s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+        let bevel_control = (s - inset_diff) / (2.0 * s);
+        if (shape < 0.0) {
+            start_control = bevel_control * 2.0 * control;
+        } else {
+            start_control = 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+        }
+    }
+    let end_control = 2.0 * control - start_control;
+    var curve: CornerCurve;
+    curve.start_normal = normalize(vec2<f32>(1.0 - start_control, start_control));
+    curve.end_normal = normalize(vec2<f32>(end_control, 1.0 - end_control));
+    curve.start = vec2<f32>(corner_radius, 0.0) + inset.y * curve.start_normal;
+    curve.end = vec2<f32>(0.0, corner_radius) + inset.x * curve.end_normal;
+    return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+fn corner_curve_sdf(from_corner: vec2<f32>, curve: CornerCurve, shape: f32,
+    straight: f32) -> f32 {
+    let n = superellipse_exponent(shape);
+    if (shape >= 0.0) {
+        let center = vec2<f32>(curve.start.x, curve.end.y);
+        let radii = vec2<f32>(center.x - curve.end.x, center.y - curve.start.y);
+        let center_to_point = center - from_corner;
+        if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+            radii.x <= 0.0 || radii.y <= 0.0) {
+            return straight;
+        }
+        return max(straight, superellipse_sdf(center_to_point, radii, n));
+    }
+    if (shape <= -1.0) {
+        let origin = vec2<f32>(curve.end.x, curve.start.y);
+        let radii = vec2<f32>(curve.start.x - origin.x, curve.end.y - origin.y);
+        let origin_to_point = max(from_corner - origin, vec2<f32>(0.0));
+        return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+    }
+    // Between a bevel and a scoop the spec draws a quarter circle mapped into
+    // the frame of the two ends and the point where their tangents meet.
+    let start_tangent = vec2<f32>(-curve.start_normal.y, curve.start_normal.x);
+    let end_tangent = vec2<f32>(-curve.end_normal.y, curve.end_normal.x);
+    let start_to_end = curve.end - curve.start;
+    let tangents_cross =
+        start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+    var meet = curve.start;
+    if (abs(tangents_cross) > 1e-6) {
+        let t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+            tangents_cross;
+        meet = curve.start + t * start_tangent;
+    }
+    let to_end = curve.end - meet;
+    let to_start = curve.start - meet;
+    let det = to_end.x * to_start.y - to_end.y * to_start.x;
+    if (abs(det) < 1e-6) {
+        return straight;
+    }
+    let d = from_corner - meet;
+    let x = (d.x * to_start.y - d.y * to_start.x) / det;
+    let y = (to_end.x * d.y - to_end.y * d.x) / det;
+    let unit = 1.0 - vec2<f32>(x, y);
+    let f = dot(unit, unit) - 1.0;
+    let g = -2.0 * unit;
+    let gradient = vec2<f32>(to_start.y * g.x - to_end.y * g.y,
+        to_end.x * g.y - to_start.x * g.x) / det;
+    return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+fn shaped_corner_sdf(corner_to_point: vec2<f32>, corner_radius: f32, shape: f32,
+    reduced_border: vec2<f32>,
+    straight_border_inner_corner_to_point: vec2<f32>) -> vec2<f32> {
+    let from_corner = -corner_to_point;
+    let outer_curve = corner_curve(corner_radius, shape, vec2<f32>(0.0));
+    let inner_curve = corner_curve(corner_radius, shape, reduced_border);
+    let straight_outer = max(corner_to_point.x, corner_to_point.y);
+    let straight_inner = max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+    return vec2<f32>(
+        corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+        -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
+}
+
 // Signed distance of the point to the quad's border - positive outside the
 // border, and negative inside.
 //
@@ -525,6 +667,7 @@ struct Quad {
     border_color: Hsla,
     corner_radii: Corners,
     border_widths: Edges,
+    corner_shapes: Corners,
 }
 
 struct QuadVarying {
@@ -598,6 +741,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
     // Radius of the nearest corner
     let corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+    let corner_shape = pick_corner_radius(center_to_point, quad.corner_shapes);
 
     // Width of the nearest borders
     let border = vec2<f32>(
@@ -624,10 +768,14 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     // mirrored into bottom right quadrant.
     let corner_center_to_point = corner_to_point + corner_radius;
 
-    // Whether the nearest point on the border is rounded
-    let is_near_rounded_corner =
-            corner_center_to_point.x >= 0 &&
-            corner_center_to_point.y >= 0;
+    // Whether the nearest point on the border is rounded. The inner edge of a
+    // concave or a bevelled corner reaches past the corner box.
+    var corner_reach = corner_center_to_point;
+    if (corner_shape != 1.0) {
+        let inner_curve = corner_curve(corner_radius, corner_shape, border);
+        corner_reach += vec2<f32>(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+    }
+    let is_near_rounded_corner = corner_reach.x >= 0.0 && corner_reach.y >= 0.0;
 
     // Vector from straight border inner corner to point.
     let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
@@ -655,7 +803,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
     // Signed distance of the point to the outside edge of the quad's border. It
     // is positive outside this edge, and negative inside.
-    let outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    var outer_sdf = 0.0;
 
     // Approximate signed distance of the point to the inside edge of the quad's
     // border. It is negative outside this edge (within the border), and
@@ -666,19 +814,28 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     //   nearest-point-on-ellipse.
     // * When it is quickly known to be outside the edge, -1.0 is used.
     var inner_sdf = 0.0;
-    if (corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0) {
-        // Fast paths for straight borders.
-        inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                         straight_border_inner_corner_to_point.y);
-    } else if (is_beyond_inner_straight_border) {
-        // Fast path for points that must be outside the inner edge.
-        inner_sdf = -1.0;
-    } else if (reduced_border.x == reduced_border.y) {
-        // Fast path for circular inner edge.
-        inner_sdf = -(outer_sdf + reduced_border.x);
+    if (corner_shape == 1.0 || corner_radius == 0.0) {
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+            if (corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0) {
+            // Fast paths for straight borders.
+            inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                             straight_border_inner_corner_to_point.y);
+        } else if (is_beyond_inner_straight_border) {
+            // Fast path for points that must be outside the inner edge.
+            inner_sdf = -1.0;
+        } else if (reduced_border.x == reduced_border.y) {
+            // Fast path for circular inner edge.
+            inner_sdf = -(outer_sdf + reduced_border.x);
+        } else {
+            let ellipse_radii = max(vec2<f32>(0.0), corner_radius - reduced_border);
+            inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        }
     } else {
-        let ellipse_radii = max(vec2<f32>(0.0), corner_radius - reduced_border);
-        inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        // Any other corner shape: a superellipse, or a bite out of the corner.
+        let sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+            reduced_border, straight_border_inner_corner_to_point);
+        outer_sdf = sdfs.x;
+        inner_sdf = sdfs.y;
     }
 
     // Negative when inside the border

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -128,6 +128,8 @@ struct Hsla {
 struct LinearColorStop {
     color: Hsla,
     percentage: f32,
+    // Where between this stop and the next the mix is half way. 0 = none.
+    hint: f32,
 }
 
 struct Background {
@@ -141,7 +143,11 @@ struct Background {
     color_space: u32,
     solid: Hsla,
     gradient_angle_or_pattern_height: f32,
-    colors: array<LinearColorStop, 2>,
+    colors: array<LinearColorStop, 8>,
+    // How many of `colors` are live.
+    stop_count: u32,
+    // 0 = angle, 1 top left, 2 top right, 3 bottom right, 4 bottom left.
+    corner: u32,
     pad: u32,
 }
 
@@ -537,41 +543,86 @@ fn blend_color(color: vec4<f32>, alpha_factor: f32) -> vec4<f32> {
 }
 
 
-struct GradientColor {
-    solid: vec4<f32>,
-    color0: vec4<f32>,
-    color1: vec4<f32>,
+// The solid color of a fill, converted once per vertex. Gradients convert
+// their stops per fragment instead, since only two of them matter there.
+fn prepare_fill_color(background: Background) -> vec4<f32> {
+    if (background.tag == 1u) {
+        return vec4<f32>(0.0);
+    }
+    return hsla_to_rgba(background.solid);
 }
 
-fn prepare_gradient_color(tag: u32, color_space: u32,
-    solid: Hsla, colors: array<LinearColorStop, 2>) -> GradientColor {
-    var result = GradientColor();
+// One gradient stop in the space the gradient mixes in.
+fn gradient_stop_color(background: Background, index: u32) -> vec4<f32> {
+    // hsla_to_rgba returns linear sRGB.
+    let color = hsla_to_rgba(background.colors[index].color);
+    if (background.color_space == 1u) {
+        return linear_srgb_to_oklab(color);
+    }
+    return linear_to_srgba(color);
+}
 
-    if (tag == 0u || tag == 2u || tag == 3u) {
-        result.solid = hsla_to_rgba(solid);
-    } else if (tag == 1u) {
-        // The hsla_to_rgba is returns a linear sRGB color
-        result.color0 = hsla_to_rgba(colors[0].color);
-        result.color1 = hsla_to_rgba(colors[1].color);
-
-        // Prepare color space in vertex for avoid conversion
-        // in fragment shader for performance reasons
-        if (color_space == 0u) {
-            // sRGB
-            result.color0 = linear_to_srgba(result.color0);
-            result.color1 = linear_to_srgba(result.color1);
-        } else if (color_space == 1u) {
-            // Oklab
-            result.color0 = linear_srgb_to_oklab(result.color0);
-            result.color1 = linear_srgb_to_oklab(result.color1);
+// The color of a CSS linear gradient at `position`.
+//
+// The gradient line goes through the center of the box. Its length is the
+// one CSS Images 3 defines, so 0% and 100% sit exactly on the corners the
+// line points away from and toward. A corner keyword makes the line
+// perpendicular to the diagonal between the two other corners.
+fn linear_gradient_color(background: Background, position: vec2<f32>, bounds: Bounds) -> vec4<f32> {
+    let size = bounds.size;
+    var angle: f32;
+    if (background.corner == 0u) {
+        angle = background.gradient_angle_or_pattern_height * (M_PI_F / 180.0);
+    } else {
+        let toward_top_right = atan2(size.y, size.x);
+        switch (background.corner) {
+            case 1u: { angle = 2.0 * M_PI_F - toward_top_right; }
+            case 2u: { angle = toward_top_right; }
+            case 3u: { angle = M_PI_F - toward_top_right; }
+            default: { angle = M_PI_F + toward_top_right; }
         }
     }
+    let direction = vec2<f32>(sin(angle), -cos(angle));
+    let line_length = abs(size.x * sin(angle)) + abs(size.y * cos(angle));
+    let center = bounds.origin + size / 2.0;
+    let t = (dot(position - center, direction) + line_length / 2.0)
+        / max(line_length, 1e-6);
 
-    return result;
+    // A count outside 1 to 8 can only come from a hand-built struct. Clamp it
+    // so the array read stays in bounds.
+    let last = clamp(background.stop_count, 1u, 8u) - 1u;
+    var color: vec4<f32>;
+    if (t <= background.colors[0].percentage) {
+        color = gradient_stop_color(background, 0u);
+    } else if (t >= background.colors[last].percentage) {
+        color = gradient_stop_color(background, last);
+    } else {
+        var i = 0u;
+        while (i + 1u < last && t > background.colors[i + 1u].percentage) {
+            i = i + 1u;
+        }
+        let start = background.colors[i].percentage;
+        let end = background.colors[i + 1u].percentage;
+        var p = 1.0;
+        if (end > start) {
+            p = (t - start) / (end - start);
+        }
+        // A color hint moves the half-way point of the mix between two stops.
+        let hint = background.colors[i].hint;
+        if (hint > 0.0 && hint < 1.0) {
+            p = pow(p, log(0.5) / log(hint));
+        }
+        color = mix(gradient_stop_color(background, i),
+                    gradient_stop_color(background, i + 1u), p);
+    }
+    if (background.color_space == 1u) {
+        return oklab_to_linear_srgb(color);
+    }
+    return srgba_to_linear(color);
 }
 
 fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
-    solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
+    solid_color: vec4<f32>) -> vec4<f32> {
     var background_color = vec4<f32>(0.0);
 
     switch (background.tag) {
@@ -579,46 +630,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             return solid_color;
         }
         case 1u: {
-            // Linear gradient background.
-            // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_angle_or_pattern_height;
-            let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
-            var direction = vec2<f32>(cos(radians), sin(radians));
-            let stop0_percentage = background.colors[0].percentage;
-            let stop1_percentage = background.colors[1].percentage;
-
-            // Expand the short side to be the same as the long side
-            if (bounds.size.x > bounds.size.y) {
-                direction.y *= bounds.size.y / bounds.size.x;
-            } else {
-                direction.x *= bounds.size.x / bounds.size.y;
-            }
-
-            // Get the t value for the linear gradient with the color stop percentages.
-            let half_size = bounds.size / 2.0;
-            let center = bounds.origin + half_size;
-            let center_to_point = position - center;
-            var t = dot(center_to_point, direction) / length(direction);
-            // Check the direct to determine the use x or y
-            if (abs(direction.x) > abs(direction.y)) {
-                t = (t + half_size.x) / bounds.size.x;
-            } else {
-                t = (t + half_size.y) / bounds.size.y;
-            }
-
-            // Adjust t based on the stop percentages
-            t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
-            t = clamp(t, 0.0, 1.0);
-
-            switch (background.color_space) {
-                default: {
-                    background_color = srgba_to_linear(mix(color0, color1, t));
-                }
-                case 1u: {
-                    let oklab_color = mix(color0, color1, t);
-                    background_color = oklab_to_linear_srgb(oklab_color);
-                }
-            }
+            background_color = linear_gradient_color(background, position, bounds);
         }
         case 2u: {
             // pattern slash
@@ -677,8 +689,6 @@ struct QuadVarying {
     // TODO: use `clip_distance` once Naga supports it
     @location(2) clip_distances: vec4<f32>,
     @location(3) @interpolate(flat) background_solid: vec4<f32>,
-    @location(4) @interpolate(flat) background_color0: vec4<f32>,
-    @location(5) @interpolate(flat) background_color1: vec4<f32>,
 }
 
 @vertex
@@ -689,15 +699,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     var out = QuadVarying();
     out.position = to_device_position(unit_vertex, quad.bounds);
 
-    let gradient = prepare_gradient_color(
-        quad.background.tag,
-        quad.background.color_space,
-        quad.background.solid,
-        quad.background.colors
-    );
-    out.background_solid = gradient.solid;
-    out.background_color0 = gradient.color0;
-    out.background_color1 = gradient.color1;
+    out.background_solid = prepare_fill_color(quad.background);
     out.border_color = hsla_to_rgba(quad.border_color);
     out.quad_id = instance_id;
     out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
@@ -714,7 +716,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     let quad = load_quad(input.quad_id);
 
     let background_color = gradient_color(quad.background, input.position.xy, quad.bounds,
-        input.background_solid, input.background_color0, input.background_color1);
+        input.background_solid);
 
     let unrounded = quad.corner_radii.top_left == 0.0 &&
         quad.corner_radii.bottom_left == 0.0 &&
@@ -1255,14 +1257,8 @@ fn fs_path_rasterization(input: PathRasterizationVarying) -> @location(0) vec4<f
         let distance = f / length(gradient);
         alpha = saturate(0.5 - distance);
     }
-    let prepared_gradient = prepare_gradient_color(
-        background.tag,
-        background.color_space,
-        background.solid,
-        background.colors,
-    );
     let color = gradient_color(background, input.position.xy, bounds,
-        prepared_gradient.solid, prepared_gradient.color0, prepared_gradient.color1);
+        prepare_fill_color(background));
     return vec4<f32>(color.rgb * color.a * alpha, color.a * alpha);
 }
 

--- a/crates/gpui_wgpu/src/shaders_webgl.wgsl
+++ b/crates/gpui_wgpu/src/shaders_webgl.wgsl
@@ -93,7 +93,7 @@ fn read_edges(cursor: ptr<function, InstanceCursor>) -> Edges {
 }
 
 fn read_color_stop(cursor: ptr<function, InstanceCursor>) -> LinearColorStop {
-    return LinearColorStop(read_hsla(cursor), read_f32(cursor));
+    return LinearColorStop(read_hsla(cursor), read_f32(cursor), read_f32(cursor));
 }
 
 fn read_background(cursor: ptr<function, InstanceCursor>) -> Background {
@@ -102,10 +102,18 @@ fn read_background(cursor: ptr<function, InstanceCursor>) -> Background {
         read_word(cursor),
         read_hsla(cursor),
         read_f32(cursor),
-        array<LinearColorStop, 2>(
+        array<LinearColorStop, 8>(
+            read_color_stop(cursor),
+            read_color_stop(cursor),
+            read_color_stop(cursor),
+            read_color_stop(cursor),
+            read_color_stop(cursor),
+            read_color_stop(cursor),
             read_color_stop(cursor),
             read_color_stop(cursor),
         ),
+        read_word(cursor),
+        read_word(cursor),
         read_word(cursor),
     );
 }
@@ -136,7 +144,7 @@ fn read_transformation(cursor: ptr<function, InstanceCursor>) -> TransformationM
 }
 
 fn load_quad(instance_id: u32) -> Quad {
-    var cursor = instance_cursor(instance_id * 44u);
+    var cursor = instance_cursor(instance_id * 84u);
     return Quad(
         read_word(&cursor),
         read_word(&cursor),
@@ -167,7 +175,7 @@ fn load_shadow(instance_id: u32) -> Shadow {
 }
 
 fn load_path_vertex(vertex_id: u32) -> PathRasterizationVertex {
-    var cursor = instance_cursor(vertex_id * 26u);
+    var cursor = instance_cursor(vertex_id * 66u);
     return PathRasterizationVertex(
         read_vec2_f32(&cursor),
         read_vec2_f32(&cursor),

--- a/crates/gpui_wgpu/src/shaders_webgl.wgsl
+++ b/crates/gpui_wgpu/src/shaders_webgl.wgsl
@@ -136,7 +136,7 @@ fn read_transformation(cursor: ptr<function, InstanceCursor>) -> TransformationM
 }
 
 fn load_quad(instance_id: u32) -> Quad {
-    var cursor = instance_cursor(instance_id * 40u);
+    var cursor = instance_cursor(instance_id * 44u);
     return Quad(
         read_word(&cursor),
         read_word(&cursor),
@@ -146,6 +146,7 @@ fn load_quad(instance_id: u32) -> Quad {
         read_hsla(&cursor),
         read_corners(&cursor),
         read_edges(&cursor),
+        read_corners(&cursor),
     );
 }
 

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2231,7 +2231,7 @@ mod tests {
 
     #[test]
     fn webgl_record_sizes_match_shader_word_strides() {
-        assert_eq!(std::mem::size_of::<Quad>(), 40 * 4);
+        assert_eq!(std::mem::size_of::<Quad>(), 44 * 4);
         assert_eq!(std::mem::size_of::<Shadow>(), 28 * 4);
         assert_eq!(std::mem::size_of::<PathRasterizationVertex>(), 26 * 4);
         assert_eq!(std::mem::size_of::<PathSprite>(), 4 * 4);

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2231,13 +2231,30 @@ mod tests {
 
     #[test]
     fn webgl_record_sizes_match_shader_word_strides() {
-        assert_eq!(std::mem::size_of::<Quad>(), 44 * 4);
+        assert_eq!(std::mem::size_of::<Quad>(), 84 * 4);
         assert_eq!(std::mem::size_of::<Shadow>(), 28 * 4);
-        assert_eq!(std::mem::size_of::<PathRasterizationVertex>(), 26 * 4);
+        assert_eq!(std::mem::size_of::<PathRasterizationVertex>(), 66 * 4);
         assert_eq!(std::mem::size_of::<PathSprite>(), 4 * 4);
         assert_eq!(std::mem::size_of::<Underline>(), 16 * 4);
         assert_eq!(std::mem::size_of::<MonochromeSprite>(), 28 * 4);
         assert_eq!(std::mem::size_of::<SubpixelSprite>(), 28 * 4);
         assert_eq!(std::mem::size_of::<PolychromeSprite>(), 24 * 4);
+    }
+
+    /// The storage shaders index `array<T>` with the WGSL stride, which is
+    /// the record size rounded up to the alignment of the struct. Every
+    /// record holds a `vec2<f32>`, so that alignment is 8. A Rust record
+    /// that is not a multiple of 8 bytes puts every instance after the
+    /// first at the wrong offset.
+    #[test]
+    fn storage_record_sizes_are_multiples_of_the_wgsl_alignment() {
+        assert_eq!(std::mem::size_of::<Quad>() % 8, 0);
+        assert_eq!(std::mem::size_of::<Shadow>() % 8, 0);
+        assert_eq!(std::mem::size_of::<PathRasterizationVertex>() % 8, 0);
+        assert_eq!(std::mem::size_of::<PathSprite>() % 8, 0);
+        assert_eq!(std::mem::size_of::<Underline>() % 8, 0);
+        assert_eq!(std::mem::size_of::<MonochromeSprite>() % 8, 0);
+        assert_eq!(std::mem::size_of::<SubpixelSprite>() % 8, 0);
+        assert_eq!(std::mem::size_of::<PolychromeSprite>() % 8, 0);
     }
 }

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -286,7 +286,142 @@ float4 to_device_position_transformed(float2 unit_vertex, Bounds bounds,
     return float4(device_position, 0.0, 1.0);
 }
 
-// Implementation of quad signed distance field
+// Signed distance from a point in the positive quadrant to the superellipse
+// (x/a)^n + (y/b)^n = 1. Negative inside. n is 1 for a straight line between
+// the axes, 2 for an ellipse, and infinity for the a by b box.
+//
+// The distance is the value of the implicit function over the length of its
+// gradient, which is exact for a line and a circle and close elsewhere. The
+// terms are scaled by the largest coordinate first so a big n never
+// underflows the whole sum to zero.
+float superellipse_sdf(float2 pt, float2 radii, float n) {
+    if (n > 1e30) {
+        float2 to_edge = pt - radii;
+        return max(to_edge.x, to_edge.y);
+    }
+    float2 unit = pt / radii;
+    float largest = max(max(unit.x, unit.y), 1e-6);
+    float2 scaled = unit / largest;
+    float rho = largest * pow(pow(scaled.x, n) + pow(scaled.y, n), 1.0 / n);
+    float2 gradient = pow(scaled * (largest / rho), n - 1.0) / radii;
+    return (rho - 1.0) / max(length(gradient), 1e-6);
+}
+
+// One corner curve as css-borders-4 "Rendering corner-shape" builds it. The
+// curve runs from `start` on the horizontal edge to `end` on the vertical
+// edge. Positions are distances from the corner along the horizontal edge (x)
+// and along the vertical edge (y). A border moves each end inward along its
+// normal by the width of that end's edge. Two different widths tilt both
+// normals so the border grows evenly from one end to the other.
+struct CornerCurve {
+    float2 start;
+    float2 end;
+    float2 start_normal;
+    float2 end_normal;
+};
+
+// Past 2^64 every superellipse is a box to the pixel, so cap the exponent
+// there.
+float superellipse_exponent(float shape) {
+    return abs(shape) < 64.0 ? exp2(abs(shape)) : 1e31;
+}
+
+// `inset.x` is the width of the vertical edge and moves `end`. `inset.y` is
+// the width of the horizontal edge and moves `start`.
+CornerCurve corner_curve(float corner_radius, float shape, float2 inset) {
+    float half_corner = pow(0.5, 1.0 / superellipse_exponent(shape));
+    if (shape < 0.0) {
+        half_corner = 1.0 - half_corner;
+    }
+    float control =
+        clamp(half_corner / (sqrt(2.0) - 1.0) - 1.0 / sqrt(2.0), 0.0, 1.0);
+    float start_control = control;
+    float inset_diff = clamp(inset.x - inset.y, -corner_radius, corner_radius);
+    if (inset_diff != 0.0) {
+        float s = sqrt(2.0 * corner_radius * corner_radius - inset_diff * inset_diff);
+        float bevel_control = (s - inset_diff) / (2.0 * s);
+        start_control = shape < 0.0
+            ? bevel_control * 2.0 * control
+            : 1.0 - (1.0 - bevel_control) * 2.0 * (1.0 - control);
+    }
+    float end_control = 2.0 * control - start_control;
+    CornerCurve curve;
+    curve.start_normal = normalize(float2(1.0 - start_control, start_control));
+    curve.end_normal = normalize(float2(end_control, 1.0 - end_control));
+    curve.start = float2(corner_radius, 0.0) + inset.y * curve.start_normal;
+    curve.end = float2(0.0, corner_radius) + inset.x * curve.end_normal;
+    return curve;
+}
+
+// Signed distance from a point, given as distances from the corner along the
+// two edges, to the curve. Positive on the corner side, which is outside the
+// box. `straight` is the distance to the two straight edges and wins where
+// the curve does not reach.
+float corner_curve_sdf(float2 from_corner, CornerCurve curve, float shape,
+                       float straight) {
+    float n = superellipse_exponent(shape);
+    if (shape >= 0.0) {
+        float2 center = float2(curve.start.x, curve.end.y);
+        float2 radii = float2(center.x - curve.end.x, center.y - curve.start.y);
+        float2 center_to_point = center - from_corner;
+        if (center_to_point.x < 0.0 || center_to_point.y < 0.0 ||
+            radii.x <= 0.0 || radii.y <= 0.0) {
+            return straight;
+        }
+        return max(straight, superellipse_sdf(center_to_point, radii, n));
+    }
+    if (shape <= -1.0) {
+        float2 origin = float2(curve.end.x, curve.start.y);
+        float2 radii = float2(curve.start.x - origin.x, curve.end.y - origin.y);
+        float2 origin_to_point = max(from_corner - origin, float2(0.0, 0.0));
+        return max(straight, -superellipse_sdf(origin_to_point, radii, n));
+    }
+    // Between a bevel and a scoop the spec draws a quarter circle mapped into
+    // the frame of the two ends and the point where their tangents meet.
+    float2 start_tangent = float2(-curve.start_normal.y, curve.start_normal.x);
+    float2 end_tangent = float2(-curve.end_normal.y, curve.end_normal.x);
+    float2 start_to_end = curve.end - curve.start;
+    float tangents_cross =
+        start_tangent.x * end_tangent.y - start_tangent.y * end_tangent.x;
+    float2 meet = curve.start;
+    if (abs(tangents_cross) > 1e-6) {
+        float t = (start_to_end.x * end_tangent.y - start_to_end.y * end_tangent.x) /
+                  tangents_cross;
+        meet = curve.start + t * start_tangent;
+    }
+    float2 to_end = curve.end - meet;
+    float2 to_start = curve.start - meet;
+    float det = to_end.x * to_start.y - to_end.y * to_start.x;
+    if (abs(det) < 1e-6) {
+        return straight;
+    }
+    float2 d = from_corner - meet;
+    float x = (d.x * to_start.y - d.y * to_start.x) / det;
+    float y = (to_end.x * d.y - to_end.y * d.x) / det;
+    float2 unit = 1.0 - float2(x, y);
+    float f = dot(unit, unit) - 1.0;
+    float2 g = -2.0 * unit;
+    float2 gradient = float2(to_start.y * g.x - to_end.y * g.y,
+                             to_end.x * g.y - to_start.x * g.x) / det;
+    return max(straight, -f / max(length(gradient), 1e-6));
+}
+
+// The outer and inner signed distances for one corner whose shape is not a
+// plain quarter circle. `shape` is the CSS superellipse curvature.
+float2 shaped_corner_sdf(float2 corner_to_point, float corner_radius, float shape,
+                         float2 reduced_border,
+                         float2 straight_border_inner_corner_to_point) {
+    float2 from_corner = -corner_to_point;
+    CornerCurve outer_curve = corner_curve(corner_radius, shape, float2(0.0, 0.0));
+    CornerCurve inner_curve = corner_curve(corner_radius, shape, reduced_border);
+    float straight_outer = max(corner_to_point.x, corner_to_point.y);
+    float straight_inner = max(straight_border_inner_corner_to_point.x,
+                               straight_border_inner_corner_to_point.y);
+    return float2(
+        corner_curve_sdf(from_corner, outer_curve, shape, straight_outer),
+        -corner_curve_sdf(from_corner, inner_curve, shape, straight_inner));
+}
+
 float quad_sdf_impl(float2 corner_center_to_point, float corner_radius) {
     if (corner_radius == 0.0) {
         // Fast path for unrounded corners
@@ -507,6 +642,7 @@ struct Quad {
     Hsla border_color;
     Corners corner_radii;
     Edges border_widths;
+    Corners corner_shapes;
 };
 
 struct QuadVertexOutput {
@@ -584,8 +720,9 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     // minimum distance between the center of the pixel and the edge.
     const float antialias_threshold = 0.5;
 
-    // Radius of the nearest corner
+    // Radius and shape of the nearest corner
     float corner_radius = pick_corner_radius(center_to_point, quad.corner_radii);
+    float corner_shape = pick_corner_radius(center_to_point, quad.corner_shapes);
 
     float2 border = float2(
         center_to_point.x < 0.0 ? quad.border_widths.left : quad.border_widths.right,
@@ -607,10 +744,16 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     // mirrored into bottom right quadrant.
     float2 corner_center_to_point = corner_to_point + corner_radius;
 
-    // Whether the nearest point on the border is rounded
+    // Whether the nearest point on the border is rounded. The inner edge of a
+    // concave or a bevelled corner reaches past the corner box.
+    float2 corner_reach = corner_center_to_point;
+    if (corner_shape != 1.0) {
+        CornerCurve inner_curve = corner_curve(corner_radius, corner_shape, border);
+        corner_reach += float2(inner_curve.start.x, inner_curve.end.y) - corner_radius;
+    }
     bool is_near_rounded_corner =
-        corner_center_to_point.x >= 0.0 &&
-        corner_center_to_point.y >= 0.0;
+        corner_reach.x >= 0.0 &&
+        corner_reach.y >= 0.0;
 
     // Vector from straight border inner corner to point.
     //
@@ -634,31 +777,42 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
         return background_color;
     }
 
-    // Signed distance of the point to the outside edge of the quad's border
-    float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    float outer_sdf;
+    float inner_sdf;
+    if (corner_shape == 1.0 || corner_radius == 0.0) {
+        // Signed distance of the point to the outside edge of the quad's border
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
 
-    // Approximate signed distance of the point to the inside edge of the quad's
-    // border. It is negative outside this edge (within the border), and
-    // positive inside.
-    //
-    // This is not always an accurate signed distance:
-    // * The rounded portions with varying border width use an approximation of
-    //   nearest-point-on-ellipse.
-    // * When it is quickly known to be outside the edge, -1.0 is used.
-    float inner_sdf = 0.0;
-    if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
-        // Fast paths for straight borders
-        inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                        straight_border_inner_corner_to_point.y);
-    } else if (is_beyond_inner_straight_border) {
-        // Fast path for points that must be outside the inner edge
-        inner_sdf = -1.0;
-    } else if (reduced_border.x == reduced_border.y) {
-        // Fast path for circular inner edge.
-        inner_sdf = -(outer_sdf + reduced_border.x);
+        // Approximate signed distance of the point to the inside edge of the quad's
+        // border. It is negative outside this edge (within the border), and
+        // positive inside.
+        //
+        // This is not always an accurate signed distance:
+        // * The rounded portions with varying border width use an approximation of
+        //   nearest-point-on-ellipse.
+        // * When it is quickly known to be outside the edge, -1.0 is used.
+        inner_sdf = 0.0;
+        if (corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0) {
+            // Fast paths for straight borders
+            inner_sdf = -max(straight_border_inner_corner_to_point.x,
+                            straight_border_inner_corner_to_point.y);
+        } else if (is_beyond_inner_straight_border) {
+            // Fast path for points that must be outside the inner edge
+            inner_sdf = -1.0;
+        } else if (reduced_border.x == reduced_border.y) {
+            // Fast path for circular inner edge.
+            inner_sdf = -(outer_sdf + reduced_border.x);
+        } else {
+            float2 ellipse_radii = max(float2(0.0, 0.0), float2(corner_radius, corner_radius) - reduced_border);
+            inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        }
     } else {
-        float2 ellipse_radii = max(float2(0.0, 0.0), float2(corner_radius, corner_radius) - reduced_border);
-        inner_sdf = quarter_ellipse_sdf(corner_center_to_point, ellipse_radii);
+        // Any other corner shape: a superellipse, or a bite out of the corner.
+        float2 sdfs = shaped_corner_sdf(corner_to_point, corner_radius, corner_shape,
+                                        reduced_border,
+                                        straight_border_inner_corner_to_point);
+        outer_sdf = sdfs.x;
+        inner_sdf = sdfs.y;
     }
 
     // Negative when inside the border

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -51,6 +51,8 @@ struct Hsla {
 struct LinearColorStop {
     Hsla color;
     float percentage;
+    // Where between this stop and the next the mix is half way. 0 = none.
+    float hint;
 };
 
 struct Background {
@@ -63,14 +65,13 @@ struct Background {
     uint color_space;
     Hsla solid;
     float gradient_angle_or_pattern_height;
-    LinearColorStop colors[2];
+    // Only the first `stop_count` are live.
+    LinearColorStop colors[8];
+    uint stop_count;
+    // 0 = the angle applies, 1..4 = the line points at a corner: top left,
+    // top right, bottom right, bottom left.
+    uint corner;
     uint pad;
-};
-
-struct GradientColor {
-  float4 solid;
-  float4 color0;
-  float4 color1;
 };
 
 struct AtlasTextureId {
@@ -449,24 +450,89 @@ float quad_sdf(float2 pt, Bounds bounds, Corners corner_radii) {
     return quad_sdf_impl(corner_center_to_point, corner_radius);
 }
 
-GradientColor prepare_gradient_color(uint tag, uint color_space, Hsla solid, LinearColorStop colors[2]) {
-    GradientColor output;
-    if (tag == 0 || tag == 2 || tag == 3) {
-        output.solid = hsla_to_rgba(solid);
-    } else if (tag == 1) {
-        output.color0 = hsla_to_rgba(colors[0].color);
-        output.color1 = hsla_to_rgba(colors[1].color);
+// The solid color of a fill, converted once per vertex. Gradients convert
+// their stops per fragment instead, since only two of them matter there.
+float4 prepare_fill_color(Background background) {
+    if (background.tag == 1) {
+        return float4(0.0, 0.0, 0.0, 0.0);
+    }
+    return hsla_to_rgba(background.solid);
+}
 
-        // Prepare color space in vertex for avoid conversion
-        // in fragment shader for performance reasons
-        if (color_space == 1) {
-            // Oklab
-            output.color0 = srgb_to_oklab(output.color0);
-            output.color1 = srgb_to_oklab(output.color1);
+// One gradient stop in the space the gradient mixes in.
+float4 gradient_stop_color(Background background, uint index) {
+    float4 color = hsla_to_rgba(background.colors[index].color);
+    if (background.color_space == 1) {
+        color = srgb_to_oklab(color);
+    }
+    return color;
+}
+
+// The color of a CSS linear gradient at `position`.
+//
+// The gradient line goes through the center of the box. Its length is the
+// one CSS Images 3 defines, so 0% and 100% sit exactly on the corners the
+// line points away from and toward. A corner keyword makes the line
+// perpendicular to the diagonal between the two other corners.
+float4 linear_gradient_color(Background background, float2 position, Bounds bounds) {
+    float2 size = bounds.size;
+    float angle;
+    if (background.corner == 0) {
+        angle = background.gradient_angle_or_pattern_height * (M_PI_F / 180.0);
+    } else {
+        float toward_top_right = atan2(size.y, size.x);
+        switch (background.corner) {
+            case 1: angle = 2.0 * M_PI_F - toward_top_right; break;
+            case 2: angle = toward_top_right; break;
+            case 3: angle = M_PI_F - toward_top_right; break;
+            default: angle = M_PI_F + toward_top_right; break;
         }
     }
+    float2 direction = float2(sin(angle), -cos(angle));
+    float line_length = abs(size.x * sin(angle)) + abs(size.y * cos(angle));
+    float2 center = bounds.origin + size / 2.0;
+    float t = (dot(position - center, direction) + line_length / 2.0)
+        / max(line_length, 1e-6);
 
-    return output;
+    // A count outside 1 to 8 can only come from a hand-built struct. Clamp it
+    // so the array read stays in bounds.
+    uint last = clamp(background.stop_count, 1u, 8u) - 1;
+    float4 color;
+    if (t <= background.colors[0].percentage) {
+        color = gradient_stop_color(background, 0);
+    } else if (t >= background.colors[last].percentage) {
+        color = gradient_stop_color(background, last);
+    } else {
+        uint i = 0;
+        while (i + 1 < last && t > background.colors[i + 1].percentage) {
+            i++;
+        }
+        float start = background.colors[i].percentage;
+        float end = background.colors[i + 1].percentage;
+        float p = end > start ? (t - start) / (end - start) : 1.0;
+        // A color hint moves the half-way point of the mix between two stops.
+        float hint = background.colors[i].hint;
+        if (hint > 0.0 && hint < 1.0) {
+            p = pow(p, log(0.5) / log(hint));
+        }
+        color = lerp(gradient_stop_color(background, i),
+                     gradient_stop_color(background, i + 1), p);
+    }
+    if (background.color_space == 1) {
+        color = oklab_to_srgb(color);
+    }
+
+    // Dither to reduce banding in gradients (especially dark/alpha).
+    // Triangular-distributed noise breaks up 8-bit quantization steps.
+    // ±2/255 for RGB (enough for dark-on-dark compositing),
+    // ±3/255 for alpha (needs more because alpha × dark color = tiny steps).
+    float2 seed = position * 0.6180339887; // golden ratio spread
+    float r1 = frac(sin(dot(seed, float2(12.9898, 78.233))) * 43758.5453);
+    float r2 = frac(sin(dot(seed, float2(39.3460, 11.135))) * 24634.6345);
+    float tri = r1 + r2 - 1.0; // triangular PDF, range [-1, +1]
+    color.rgb += tri * 2.0 / 255.0;
+    color.a   += tri * 3.0 / 255.0;
+    return color;
 }
 
 float2x2 rotate2d(float angle) {
@@ -478,70 +544,16 @@ float2x2 rotate2d(float angle) {
 float4 gradient_color(Background background,
                       float2 position,
                       Bounds bounds,
-                      float4 solid_color, float4 color0, float4 color1) {
+                      float4 solid_color) {
     float4 color;
 
     switch (background.tag) {
         case 0:
             color = solid_color;
             break;
-        case 1: {
-            // -90 degrees to match the CSS gradient angle.
-            float gradient_angle = background.gradient_angle_or_pattern_height;
-            float radians = (fmod(gradient_angle, 360.0) - 90.0) * (M_PI_F / 180.0);
-            float2 direction = float2(cos(radians), sin(radians));
-
-            // Expand the short side to be the same as the long side
-            if (bounds.size.x > bounds.size.y) {
-                direction.y *= bounds.size.y / bounds.size.x;
-            } else {
-                direction.x *=  bounds.size.x / bounds.size.y;
-            }
-
-            // Get the t value for the linear gradient with the color stop percentages.
-            float2 half_size = bounds.size * 0.5;
-            float2 center = bounds.origin + half_size;
-            float2 center_to_point = position - center;
-            float t = dot(center_to_point, direction) / length(direction);
-            // Check the direct to determine the use x or y
-            if (abs(direction.x) > abs(direction.y)) {
-                t = (t + half_size.x) / bounds.size.x;
-            } else {
-                t = (t + half_size.y) / bounds.size.y;
-            }
-
-            // Adjust t based on the stop percentages
-            t = (t - background.colors[0].percentage)
-                / (background.colors[1].percentage
-                - background.colors[0].percentage);
-            t = clamp(t, 0.0, 1.0);
-
-            switch (background.color_space) {
-                case 0:
-                    color = lerp(color0, color1, t);
-                    break;
-                case 1: {
-                    float4 oklab_color = lerp(color0, color1, t);
-                    color = oklab_to_srgb(oklab_color);
-                    break;
-                }
-            }
-
-            // Dither to reduce banding in gradients (especially dark/alpha).
-            // Triangular-distributed noise breaks up 8-bit quantization steps.
-            // ±2/255 for RGB (enough for dark-on-dark compositing),
-            // ±3/255 for alpha (needs more because alpha × dark color = tiny steps).
-            {
-                float2 seed = position * 0.6180339887; // golden ratio spread
-                float r1 = frac(sin(dot(seed, float2(12.9898, 78.233))) * 43758.5453);
-                float r2 = frac(sin(dot(seed, float2(39.3460, 11.135))) * 24634.6345);
-                float tri = r1 + r2 - 1.0; // triangular PDF, range [-1, +1]
-                color.rgb += tri * 2.0 / 255.0;
-                color.a   += tri * 3.0 / 255.0;
-            }
-
+        case 1:
+            color = linear_gradient_color(background, position, bounds);
             break;
-        }
         case 2: {
             float gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
             float pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;
@@ -650,8 +662,6 @@ struct QuadVertexOutput {
     float4 position: SV_Position;
     nointerpolation float4 border_color: COLOR0;
     nointerpolation float4 background_solid: COLOR1;
-    nointerpolation float4 background_color0: COLOR2;
-    nointerpolation float4 background_color1: COLOR3;
     float4 clip_distance: SV_ClipDistance;
 };
 
@@ -660,8 +670,6 @@ struct QuadFragmentInput {
     float4 position: SV_Position;
     nointerpolation float4 border_color: COLOR0;
     nointerpolation float4 background_solid: COLOR1;
-    nointerpolation float4 background_color0: COLOR2;
-    nointerpolation float4 background_color1: COLOR3;
 };
 
 StructuredBuffer<Quad> quads: register(t1);
@@ -672,12 +680,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_I
     Quad quad = quads[quad_id];
     float4 device_position = to_device_position(unit_vertex, quad.bounds);
 
-    GradientColor gradient = prepare_gradient_color(
-        quad.background.tag,
-        quad.background.color_space,
-        quad.background.solid,
-        quad.background.colors
-    );
+    float4 background_solid = prepare_fill_color(quad.background);
     float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
     float4 border_color = hsla_to_rgba(quad.border_color);
 
@@ -685,9 +688,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_I
     output.position = device_position;
     output.border_color = border_color;
     output.quad_id = quad_id;
-    output.background_solid = gradient.solid;
-    output.background_color0 = gradient.color0;
-    output.background_color1 = gradient.color1;
+    output.background_solid = background_solid;
     output.clip_distance = clip_distance;
     return output;
 }
@@ -695,7 +696,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_I
 float4 quad_fragment(QuadFragmentInput input): SV_Target {
     Quad quad = quads[input.quad_id];
     float4 background_color = gradient_color(quad.background, input.position.xy, quad.bounds,
-    input.background_solid, input.background_color0, input.background_color1);
+        input.background_solid);
 
     bool unrounded = quad.corner_radii.top_left == 0.0 &&
         quad.corner_radii.top_right == 0.0 &&
@@ -1165,11 +1166,8 @@ float4 path_rasterization_fragment(PathFragmentInput input): SV_Target {
         alpha = saturate(0.5 - distance);
     }
 
-    GradientColor gradient = prepare_gradient_color(
-        background.tag, background.color_space, background.solid, background.colors);
-
     float4 color = gradient_color(background, input.position.xy, bounds,
-        gradient.solid, gradient.color0, gradient.color1);
+        prepare_fill_color(background));
     return float4(color.rgb * color.a * alpha, alpha * color.a);
 }
 


### PR DESCRIPTION
# Objective

Linear gradients with more than two stops. `Background` holds exactly two stops today.

I need it for `background-image` in GPUIX, a React renderer for GPUI by @remorses. Same change as remorses/zed#6.

Stacked on #63792, so the diff GitHub shows includes #63771 and #63792. This PR alone: https://github.com/mateo-m/zed/compare/zed/gpui-corner-shapes...zed/gpui-linear-gradients. #63773 and #63782 build on this branch. The stack started as one PR, #63773, and I split it so each part gets its own review. This PR and #63792 were one PR, #63772. The two features share no code, so I split it.

## Solution

- `Background.colors` grows from 2 stops to `MAX_GRADIENT_STOPS` (8) plus a `stop_count`. `LinearColorStop` gets a `hint`, the CSS colour hint between two stops.
- New constructor `linear_gradient_stops(GradientLine, &[LinearColorStop])`. `linear_gradient(angle, from, to)` stays and forwards to it. `GradientLine` is an angle or one of the four corner keywords. A corner keyword is not a fixed angle, so the shader computes it from the box size.
- The gradient line length follows CSS Images 3, so 0% and 100% sit on the corners the line points away from and toward.
- Empty stops become a solid transparent background. The three shaders clamp `stop_count` to the array, so a bad count read from inspector JSON cannot index past it.
- The shaders convert the solid colour once per vertex as before. Gradient stops convert per fragment, since only two of the eight matter at one pixel.
- Metal, wgpu and DirectX shaders updated. The WebGL shader reads eight stops and gets the new strides.
- `Background` keeps its `pad` field. WGSL rounds the stride of an `array<Quad>` up to 8 bytes because `Bounds` holds a `vec2<f32>`, and Rust packs at 4. A record that is not a multiple of 8 bytes puts every quad after the first at the wrong offset on wgpu. A first version of this PR dropped the pad, and on gpui_web in Chrome only the first quad of each batch drew.
- `Quad` grows from 176 to 336 bytes. No caller in Zed uses more than two stops yet. `MAX_GRADIENT_STOPS` is one constant if the size matters more than eight stops.

## Testing

- Two new tests in `crates/gpui/src/color.rs`: empty stops make a solid transparent background, and a stop count past the array cannot slice out of bounds.
- One new test in `crates/gpui_wgpu/src/wgpu_renderer.rs` checks that every storage record size is a multiple of 8. It fails without the `pad` field.
- Pixel comparison against Chrome: the fourteen boxes in #63792 all carry a 5-stop gradient. Metal and gpui_web differ from each other by at most 15 of 255 in any pixel. Against Chrome, over each box the mean difference is under 2.5 of 255 on Metal and under 4.5 on gpui_web.
- gpui_web in headless Chrome with WebGPU, at the top of the stack: `hello_world` draws its six small squares, and an example with corner shapes and 5-stop gradients draws every tile. Without the pad both drew only the first quad.
- The HLSL compiles with `dxc -T lib_6_3` from the DirectX Shader Compiler Linux release, run in Docker on macOS. Zed builds it with `fxc` on Windows, which I could not run.
- `cargo test -p gpui` at this head: 315 passed, 1 doc test passed. `cargo test -p gpui_wgpu`: 31 passed. `cargo build -p gpui_apple` compiles the Metal. `cargo clippy -p gpui -p gpui_wgpu -p gpui_apple --all-targets` is clean. `cargo fmt --check` is clean.
- `cargo check -p gpui_windows --target x86_64-pc-windows-msvc` passes from macOS. I have not run this on Windows.
- Performance: `Quad` grows by 160 bytes, so every quad instance is larger.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Screenshots

The GPUIX test renderer on Metal, on this branch. Gradients with three, six and eight stops, a colour hint, a hard edge from two stops at the same position, and stop positions inside the box.

![multi-stop gradients](https://raw.githubusercontent.com/mateo-m/zed/pr-screenshots/pr2-gradients.png)

---

Release Notes:

- N/A
