### PR TITLE
Add pinned agent threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -963,6 +963,7 @@ fn thread_metadata_to_debug_json(
         "interacted_at": metadata.interacted_at.as_ref().map(format_timestamp_human),
         "worktree_paths": format!("{:?}", metadata.worktree_paths),
         "archived": metadata.archived,
+        "pinned": metadata.pinned,
     })
 }
 
@@ -8078,6 +8079,7 @@ mod tests {
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
                         archived: false,
+                        pinned: false,
                     },
                     cx,
                 );

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -4714,6 +4714,7 @@ pub(crate) mod tests {
                         worktree_paths: WorktreePaths::from_folder_paths(&PathList::default()),
                         remote_connection: None,
                         archived: false,
+                        pinned: false,
                     },
                     cx,
                 );

--- a/crates/agent_ui/src/thread_import.rs
+++ b/crates/agent_ui/src/thread_import.rs
@@ -882,6 +882,7 @@ fn collect_importable_threads(
                 worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                 remote_connection: remote_connection.clone(),
                 archived: true,
+                pinned: false,
             });
         }
     }
@@ -1280,6 +1281,23 @@ mod tests {
             .find(|t| t.display_title().as_ref() == "Archived Thread")
             .unwrap();
         assert!(archived.archived);
+    }
+
+    #[test]
+    fn test_imports_threads_from_channel_without_pinned_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let connection = create_channel_db(dir.path(), ReleaseChannel::Nightly);
+        insert_thread(&connection, "Legacy Thread", "2025-01-15T10:00:00Z", false);
+        connection
+            .exec("ALTER TABLE sidebar_threads DROP COLUMN pinned")
+            .unwrap()()
+        .unwrap();
+        drop(connection);
+
+        let threads = read_threads_from_channel(dir.path(), ReleaseChannel::Nightly).unwrap();
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].display_title().as_ref(), "Legacy Thread");
+        assert!(!threads[0].pinned);
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -67,7 +67,13 @@ const THREAD_ID_MIGRATION_KEY: &str = "thread-metadata-thread-id-backfill";
 pub(crate) fn list_thread_metadata_from_connection(
     connection: &db::sqlez::connection::Connection,
 ) -> anyhow::Result<Vec<ThreadMetadata>> {
-    connection.select::<ThreadMetadata>(ThreadMetadataDb::LIST_QUERY)?()
+    if let Ok(mut query) = connection.select::<ThreadMetadata>(ThreadMetadataDb::LIST_QUERY) {
+        return query();
+    }
+
+    // Other release channels may not have run the pinned migration yet.
+    // Treat those threads as unpinned while importing their metadata.
+    connection.select::<ThreadMetadata>(ThreadMetadataDb::LEGACY_LIST_QUERY)?()
 }
 
 /// Run the `ThreadMetadataDb` migrations on a raw connection.
@@ -142,6 +148,7 @@ fn migrate_thread_metadata(cx: &mut App) -> Task<anyhow::Result<()>> {
                         worktree_paths: WorktreePaths::from_folder_paths(&entry.folder_paths),
                         remote_connection: None,
                         archived: true,
+                        pinned: false,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -323,6 +330,9 @@ pub struct ThreadMetadata {
     pub worktree_paths: WorktreePaths,
     pub remote_connection: Option<RemoteConnectionOptions>,
     pub archived: bool,
+    /// User-managed pin. Pinned threads are sorted before other threads and
+    /// cannot be archived until they are unpinned.
+    pub pinned: bool,
 }
 
 impl ThreadMetadata {
@@ -612,6 +622,11 @@ impl ThreadMetadataStore {
         self.entries().filter(|t| t.archived)
     }
 
+    /// Returns all user-pinned threads.
+    pub fn pinned_entries(&self) -> impl Iterator<Item = &ThreadMetadata> + '_ {
+        self.entries().filter(|t| t.pinned)
+    }
+
     /// Returns all threads for the given path list and remote connection,
     /// excluding archived threads.
     ///
@@ -861,6 +876,10 @@ impl ThreadMetadataStore {
         archive_job: Option<(Task<()>, async_channel::Sender<()>)>,
         cx: &mut Context<Self>,
     ) {
+        if self.entry(thread_id).is_some_and(|thread| thread.pinned) {
+            return;
+        }
+
         self.update_archived(thread_id, true, cx);
 
         if let Some(job) = archive_job {
@@ -874,6 +893,21 @@ impl ThreadMetadataStore {
         self.update_archived(thread_id, false, cx);
         // Dropping the Sender triggers cancellation in the background task.
         self.in_flight_archives.remove(&thread_id);
+    }
+
+    pub fn set_pinned(&mut self, thread_id: ThreadId, pinned: bool, cx: &mut Context<Self>) {
+        if let Some(thread) = self.threads.get(&thread_id) {
+            if pinned && thread.archived {
+                return;
+            }
+            if thread.pinned != pinned {
+                self.save_internal(ThreadMetadata {
+                    pinned,
+                    ..thread.clone()
+                });
+                cx.notify();
+            }
+        }
     }
 
     pub fn cleanup_completed_archive(&mut self, thread_id: ThreadId) {
@@ -1329,6 +1363,7 @@ impl ThreadMetadataStore {
         let archived = existing_thread
             .map(|t| t.archived)
             .unwrap_or(worktree_paths.is_empty());
+        let pinned = existing_thread.is_some_and(|t| t.pinned);
 
         let was_draft = existing_thread.map_or(true, |t| t.is_draft());
         if was_draft && !is_draft {
@@ -1350,6 +1385,7 @@ impl ThreadMetadataStore {
             worktree_paths,
             remote_connection,
             archived,
+            pinned,
         };
 
         self.save(metadata, cx);
@@ -1462,6 +1498,9 @@ impl Domain for ThreadMetadataDb {
         sql!(
             ALTER TABLE sidebar_threads ADD COLUMN title_override TEXT;
         ),
+        sql!(
+            ALTER TABLE sidebar_threads ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
+        ),
     ];
 }
 
@@ -1477,7 +1516,13 @@ impl ThreadMetadataDb {
     }
 
     const LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
-        created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, \
+        created_at, interacted_at, folder_paths, folder_paths_order, archived, pinned, main_worktree_paths, \
+        main_worktree_paths_order, remote_connection, title_override \
+        FROM sidebar_threads \
+        ORDER BY updated_at DESC";
+
+    const LEGACY_LIST_QUERY: &str = "SELECT thread_id, session_id, agent_id, title, updated_at, \
+        created_at, interacted_at, folder_paths, folder_paths_order, archived, 0 AS pinned, main_worktree_paths, \
         main_worktree_paths_order, remote_connection, title_override \
         FROM sidebar_threads \
         ORDER BY updated_at DESC";
@@ -1531,10 +1576,11 @@ impl ThreadMetadataDb {
         let title_override = row.title_override.as_ref().map(|t| t.to_string());
         let thread_id = row.thread_id;
         let archived = row.archived;
+        let pinned = row.pinned;
 
         self.write(move |conn| {
-            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, main_worktree_paths, main_worktree_paths_order, remote_connection, title_override) \
-                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+            let sql = "INSERT INTO sidebar_threads(thread_id, session_id, agent_id, title, updated_at, created_at, interacted_at, folder_paths, folder_paths_order, archived, pinned, main_worktree_paths, main_worktree_paths_order, remote_connection, title_override) \
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
                        ON CONFLICT(thread_id) DO UPDATE SET \
                            session_id = excluded.session_id, \
                            agent_id = excluded.agent_id, \
@@ -1545,6 +1591,7 @@ impl ThreadMetadataDb {
                            folder_paths = excluded.folder_paths, \
                            folder_paths_order = excluded.folder_paths_order, \
                            archived = excluded.archived, \
+                           pinned = excluded.pinned, \
                            main_worktree_paths = excluded.main_worktree_paths, \
                            main_worktree_paths_order = excluded.main_worktree_paths_order, \
                            remote_connection = excluded.remote_connection, \
@@ -1560,6 +1607,7 @@ impl ThreadMetadataDb {
             i = stmt.bind(&folder_paths, i)?;
             i = stmt.bind(&folder_paths_order, i)?;
             i = stmt.bind(&archived, i)?;
+            i = stmt.bind(&pinned, i)?;
             i = stmt.bind(&main_worktree_paths, i)?;
             i = stmt.bind(&main_worktree_paths_order, i)?;
             i = stmt.bind(&remote_connection, i)?;
@@ -1714,6 +1762,7 @@ impl Column for ThreadMetadata {
         let (folder_paths_order_str, next): (Option<String>, i32) =
             Column::column(statement, next)?;
         let (archived, next): (bool, i32) = Column::column(statement, next)?;
+        let (pinned, next): (bool, i32) = Column::column(statement, next)?;
         let (main_worktree_paths_str, next): (Option<String>, i32) =
             Column::column(statement, next)?;
         let (main_worktree_paths_order_str, next): (Option<String>, i32) =
@@ -1787,6 +1836,7 @@ impl Column for ThreadMetadata {
                 worktree_paths,
                 remote_connection,
                 archived,
+                pinned,
             },
             next,
         ))
@@ -1864,6 +1914,7 @@ mod tests {
         ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            pinned: false,
             session_id: Some(acp::SessionId::new(session_id)),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: if title.is_empty() {
@@ -2171,6 +2222,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&second_paths),
             remote_connection: None,
             archived: false,
+            pinned: false,
         };
 
         cx.update(|cx| {
@@ -2256,6 +2308,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&project_a_paths),
             remote_connection: None,
             archived: false,
+            pinned: false,
         };
 
         cx.update(|cx| {
@@ -2382,6 +2435,7 @@ mod tests {
             worktree_paths: WorktreePaths::from_folder_paths(&project_paths),
             remote_connection: None,
             archived: false,
+            pinned: false,
         };
 
         cx.update(|cx| {
@@ -3117,6 +3171,7 @@ mod tests {
         let local_linked_thread = ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            pinned: false,
             session_id: Some(acp::SessionId::new("local-linked")),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Local Linked".into()),
@@ -3131,6 +3186,7 @@ mod tests {
         let remote_linked_thread = ThreadMetadata {
             thread_id: ThreadId::new(),
             archived: false,
+            pinned: false,
             session_id: Some(acp::SessionId::new("remote-linked")),
             agent_id: agent::ZED_AGENT_ID.clone(),
             title: Some("Remote Linked".into()),
@@ -3310,6 +3366,76 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_pinned_flag_persists_across_reload(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let metadata = make_metadata(
+            "session-1",
+            "Thread 1",
+            Utc::now(),
+            PathList::new(&[Path::new("/project-a")]),
+        );
+        let thread_id = metadata.thread_id;
+
+        cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(metadata, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.set_pinned(thread_id, true, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                let _ = store.reload(cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx).read(cx);
+            assert!(store.entry(thread_id).unwrap().pinned);
+            assert_eq!(store.pinned_entries().count(), 1);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_pinned_thread_cannot_be_archived(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let metadata = make_metadata(
+            "session-1",
+            "Pinned Thread",
+            Utc::now(),
+            PathList::new(&[Path::new("/project-a")]),
+        );
+        let thread_id = metadata.thread_id;
+
+        cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(metadata, cx);
+                store.set_pinned(thread_id, true, cx);
+                store.archive(thread_id, None, cx);
+            });
+        });
+
+        cx.update(|cx| {
+            let thread = ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entry(thread_id)
+                .unwrap();
+            assert!(thread.pinned);
+            assert!(!thread.archived);
+        });
+    }
+
+    #[gpui::test]
     async fn test_archive_nonexistent_thread_is_noop(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -3362,6 +3488,7 @@ mod tests {
                 entries,
                 vec![ThreadMetadata {
                     archived: true,
+                    pinned: false,
                     ..metadata
                 }]
             );

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -51,6 +51,7 @@ enum ThreadFilter {
     #[default]
     All,
     ArchivedOnly,
+    PinnedOnly,
 }
 
 #[derive(Clone)]
@@ -270,11 +271,12 @@ impl ThreadsArchiveView {
     fn update_items(&mut self, cx: &mut Context<Self>) {
         let store = ThreadMetadataStore::global(cx).read(cx);
 
-        // If we're filtering to archived threads but none remain (e.g. the
-        // user just deleted the last one), fall back to showing all threads
-        // so they aren't stranded with an empty list and a disabled toggle.
-        if self.thread_filter == ThreadFilter::ArchivedOnly
-            && store.archived_entries().next().is_none()
+        // Fall back to all threads when the current special filter no longer
+        // has entries, so the archive view never becomes a dead end.
+        if (self.thread_filter == ThreadFilter::ArchivedOnly
+            && store.archived_entries().next().is_none())
+            || (self.thread_filter == ThreadFilter::PinnedOnly
+                && store.pinned_entries().next().is_none())
         {
             self.thread_filter = ThreadFilter::All;
         }
@@ -285,8 +287,9 @@ impl ThreadsArchiveView {
             .filter(|t| match thread_filter {
                 ThreadFilter::All => true,
                 ThreadFilter::ArchivedOnly => t.archived,
+                ThreadFilter::PinnedOnly => t.pinned,
             })
-            .sorted_by_cached_key(|t| t.created_at.unwrap_or(t.updated_at))
+            .sorted_by_cached_key(|t| (t.pinned, t.created_at.unwrap_or(t.updated_at)))
             .rev()
             .cloned()
             .collect::<Vec<_>>();
@@ -422,6 +425,13 @@ impl ThreadsArchiveView {
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.archive(thread_id, None, cx));
     }
 
+    fn toggle_pinned_thread(&mut self, thread_id: ThreadId, cx: &mut Context<Self>) {
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            let pinned = store.entry(thread_id).is_some_and(|thread| !thread.pinned);
+            store.set_pinned(thread_id, pinned, cx);
+        });
+    }
+
     fn archive_selected_thread(
         &mut self,
         _: &ArchiveSelectedThread,
@@ -433,7 +443,7 @@ impl ThreadsArchiveView {
             return;
         };
 
-        if thread.archived {
+        if thread.archived || thread.pinned {
             return;
         }
 
@@ -641,6 +651,7 @@ impl ThreadsArchiveView {
                 let is_restoring = self.restoring.contains(&thread.thread_id);
 
                 let is_archived = thread.archived;
+                let is_pinned = thread.pinned;
 
                 let branch_names_for_thread: HashMap<PathBuf, SharedString> = self
                     .archived_branch_names
@@ -746,25 +757,52 @@ impl ThreadsArchiveView {
                     .into_any_element()
                 } else {
                     base.action_slot(
-                        IconButton::new("archive-thread", IconName::Archive)
-                            .icon_size(IconSize::Small)
-                            .icon_color(Color::Muted)
-                            .tooltip({
-                                move |_window, cx| {
-                                    Tooltip::for_action_in(
-                                        "Archive Thread",
-                                        &ArchiveSelectedThread,
-                                        &focus_handle,
-                                        cx,
-                                    )
-                                }
-                            })
-                            .on_click({
-                                let thread_id = thread.thread_id;
-                                cx.listener(move |this, _, _, cx| {
-                                    this.archive_thread(thread_id, cx);
-                                    cx.stop_propagation();
-                                })
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                IconButton::new("toggle-pinned-thread", IconName::Pin)
+                                    .icon_size(IconSize::Small)
+                                    .icon_color(if is_pinned {
+                                        Color::Accent
+                                    } else {
+                                        Color::Muted
+                                    })
+                                    .tooltip(Tooltip::text(if is_pinned {
+                                        "Unpin Thread"
+                                    } else {
+                                        "Pin Thread"
+                                    }))
+                                    .on_click({
+                                        let thread_id = thread.thread_id;
+                                        cx.listener(move |this, _, _, cx| {
+                                            this.toggle_pinned_thread(thread_id, cx);
+                                            cx.stop_propagation();
+                                        })
+                                    }),
+                            )
+                            .when(!is_pinned, |this| {
+                                this.child(
+                                    IconButton::new("archive-thread", IconName::Archive)
+                                        .icon_size(IconSize::Small)
+                                        .icon_color(Color::Muted)
+                                        .tooltip({
+                                            move |_window, cx| {
+                                                Tooltip::for_action_in(
+                                                    "Archive Thread",
+                                                    &ArchiveSelectedThread,
+                                                    &focus_handle,
+                                                    cx,
+                                                )
+                                            }
+                                        })
+                                        .on_click({
+                                            let thread_id = thread.thread_id;
+                                            cx.listener(move |this, _, _, cx| {
+                                                this.archive_thread(thread_id, cx);
+                                                cx.stop_propagation();
+                                            })
+                                        }),
+                                )
                             }),
                     )
                     .on_click({
@@ -951,6 +989,10 @@ impl ThreadsArchiveView {
             let store = ThreadMetadataStore::global(cx).read(cx);
             store.archived_entries().next().is_some()
         };
+        let has_pinned_threads = {
+            let store = ThreadMetadataStore::global(cx).read(cx);
+            store.pinned_entries().next().is_some()
+        };
 
         let count_label = if entry_count == 1 {
             "1 thread".to_string()
@@ -988,6 +1030,28 @@ impl ThreadsArchiveView {
                             .tooltip(Tooltip::text("Import Threads"))
                             .on_click(cx.listener(|_this, _, _, cx| {
                                 cx.emit(ThreadsArchiveViewEvent::Import);
+                            })),
+                    )
+                    .child(
+                        IconButton::new("filter-pinned-only", IconName::Pin)
+                            .icon_size(IconSize::Small)
+                            .disabled(!has_pinned_threads)
+                            .toggle_state(self.thread_filter == ThreadFilter::PinnedOnly)
+                            .tooltip(Tooltip::text(
+                                if self.thread_filter == ThreadFilter::PinnedOnly {
+                                    "Show All Threads"
+                                } else {
+                                    "Show Only Pinned Threads"
+                                },
+                            ))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.thread_filter =
+                                    if this.thread_filter == ThreadFilter::PinnedOnly {
+                                        ThreadFilter::All
+                                    } else {
+                                        ThreadFilter::PinnedOnly
+                                    };
+                                this.update_items(cx);
                             })),
                     )
                     .child(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -127,6 +127,8 @@ struct SerializedSidebar {
     width: Option<f32>,
     #[serde(default)]
     active_view: SerializedSidebarView,
+    #[serde(default)]
+    show_pinned_threads_only: bool,
 }
 
 #[derive(Debug, Default)]
@@ -800,6 +802,7 @@ pub struct Sidebar {
     /// its interaction time.
     draft_kinds: HashMap<ThreadId, DraftKind>,
     view: SidebarView,
+    show_pinned_threads_only: bool,
     restoring_tasks: HashMap<agent_ui::ThreadId, Task<()>>,
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
@@ -938,6 +941,7 @@ impl Sidebar {
             live_thread_statuses: HashMap::new(),
             draft_kinds: HashMap::new(),
             view: SidebarView::default(),
+            show_pinned_threads_only: false,
             restoring_tasks: HashMap::new(),
             recent_projects_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
@@ -957,6 +961,9 @@ impl Sidebar {
     }
 
     fn is_group_collapsed(&self, key: &ProjectGroupKey, cx: &App) -> bool {
+        if self.show_pinned_threads_only {
+            return false;
+        }
         self.multi_workspace
             .upgrade()
             .and_then(|mw| {
@@ -1570,7 +1577,8 @@ impl Sidebar {
             let label = group_key.display_name(&path_detail_map);
 
             let is_collapsed = self.is_group_collapsed(group_key, cx);
-            let should_load_threads = !is_collapsed || !query.is_empty();
+            let should_load_threads =
+                self.show_pinned_threads_only || !is_collapsed || !query.is_empty();
 
             let is_active = active_workspace
                 .as_ref()
@@ -1820,6 +1828,16 @@ impl Sidebar {
                     && let Some(ActiveEntry::Thread { thread_id, .. }) = self.active_entry.as_ref()
                 {
                     notified_threads.remove(thread_id);
+                }
+            }
+
+            if self.show_pinned_threads_only {
+                current_thread_ids.extend(threads.iter().map(|thread| thread.metadata.thread_id));
+                threads.retain(|thread| thread.metadata.pinned);
+                terminals.clear();
+
+                if threads.is_empty() {
+                    continue;
                 }
             }
 
@@ -3261,6 +3279,9 @@ impl Sidebar {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.show_pinned_threads_only {
+            return;
+        }
         let is_collapsed = self.is_group_collapsed(project_group_key, cx);
         self.set_group_expanded(project_group_key, is_collapsed, cx);
         self.update_entries(cx);
@@ -5321,6 +5342,9 @@ impl Sidebar {
     ) {
         let store = ThreadMetadataStore::global(cx);
         let metadata = store.read(cx).entry_by_session(session_id).cloned();
+        if metadata.as_ref().is_some_and(|metadata| metadata.pinned) {
+            return;
+        }
         let metadata_thread_id = metadata.as_ref().map(|metadata| metadata.thread_id);
         let thread_entry = self.contents.entries.iter().find_map(|entry| match entry {
             ListEntry::Thread(thread) => metadata_thread_id
@@ -5713,6 +5737,9 @@ impl Sidebar {
         };
         match self.contents.entries.get(ix) {
             Some(ListEntry::Thread(thread)) => {
+                if thread.metadata.pinned {
+                    return;
+                }
                 match thread.status {
                     AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation => {
                         return;
@@ -5771,6 +5798,13 @@ impl Sidebar {
         })
     }
 
+    fn toggle_thread_pinned(&mut self, thread_id: ThreadId, cx: &mut Context<Self>) {
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            let pinned = store.entry(thread_id).is_some_and(|thread| !thread.pinned);
+            store.set_pinned(thread_id, pinned, cx);
+        });
+    }
+
     fn thread_display_time(metadata: &ThreadMetadata) -> DateTime<Utc> {
         metadata.interacted_at.unwrap_or(metadata.updated_at)
     }
@@ -5793,11 +5827,15 @@ impl Sidebar {
             }
         }
 
+        fn is_pinned(entry: &ListEntry) -> bool {
+            matches!(entry, ListEntry::Thread(thread) if thread.metadata.pinned)
+        }
+
         let row_entries = terminals
             .into_iter()
             .map(ListEntry::Terminal)
             .chain(threads.into_iter().map(ListEntry::Thread))
-            .sorted_by_key(|right| std::cmp::Reverse(display_time(right)));
+            .sorted_by_key(|right| std::cmp::Reverse((is_pinned(right), display_time(right))));
 
         for entry in row_entries {
             if let ListEntry::Thread(thread) = &entry {
@@ -6253,6 +6291,7 @@ impl Sidebar {
             || self
                 .regenerating_titles
                 .contains(&thread.metadata.thread_id);
+        let is_pinned = thread.metadata.pinned;
 
         let thread_item = ThreadItem::new(id, title.clone())
             .base_bg(sidebar_bg)
@@ -6290,7 +6329,24 @@ impl Sidebar {
             .when_some(rename_title_editor, |this, title_editor| {
                 this.is_truncated(false).title_slot(title_editor)
             })
-            .when(is_hovered && !is_renaming, |this| {
+            .when((is_hovered || is_pinned) && !is_renaming, |this| {
+                let pin_button = IconButton::new(("pin-thread", ix), IconName::Pin)
+                    .icon_size(IconSize::Small)
+                    .icon_color(if is_pinned {
+                        Color::Accent
+                    } else {
+                        Color::Muted
+                    })
+                    .tooltip(Tooltip::text(if is_pinned {
+                        "Unpin Thread"
+                    } else {
+                        "Pin Thread"
+                    }))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.toggle_thread_pinned(thread_id_for_actions, cx);
+                        cx.stop_propagation();
+                    }));
+
                 let rename_button = IconButton::new(("rename-thread", ix), IconName::Pencil)
                     .icon_size(IconSize::Small)
                     .tooltip({
@@ -6349,7 +6405,7 @@ impl Sidebar {
                                 })
                                 .into_any_element(),
                         ),
-                        None => Some(
+                        None if !is_pinned => Some(
                             IconButton::new("archive-thread", IconName::Archive)
                                 .icon_size(IconSize::Small)
                                 .tooltip({
@@ -6373,14 +6429,18 @@ impl Sidebar {
                                 })
                                 .into_any_element(),
                         ),
+                        None => None,
                     }
                 };
 
                 this.action_slot(
                     h_flex()
                         .gap_0p5()
-                        .child(rename_button)
-                        .when_some(contextual_action, |this, action| this.child(action)),
+                        .child(pin_button)
+                        .when(is_hovered, |this| this.child(rename_button))
+                        .when(is_hovered, |this| {
+                            this.when_some(contextual_action, |this, action| this.child(action))
+                        }),
                 )
             })
             .on_click({
@@ -6521,16 +6581,20 @@ impl Sidebar {
                             });
                         }
 
-                        menu.separator().entry("Archive Thread", None, {
-                            let session_id = session_id.clone();
-                            move |window, cx| {
-                                sidebar
-                                    .update(cx, |sidebar, cx| {
-                                        sidebar.archive_thread(&session_id, window, cx);
-                                    })
-                                    .ok();
-                            }
-                        })
+                        if is_pinned {
+                            menu
+                        } else {
+                            menu.separator().entry("Archive Thread", None, {
+                                let session_id = session_id.clone();
+                                move |window, cx| {
+                                    sidebar
+                                        .update(cx, |sidebar, cx| {
+                                            sidebar.archive_thread(&session_id, window, cx);
+                                        })
+                                        .ok();
+                                }
+                            })
+                        }
                     })
                 }
             })
@@ -7260,6 +7324,8 @@ impl Sidebar {
         let has_query = self.has_filter_query(cx);
         let message = if has_query {
             "No threads match your search."
+        } else if self.show_pinned_threads_only {
+            "No pinned threads"
         } else {
             "No threads yet"
         };
@@ -7370,7 +7436,28 @@ impl Sidebar {
                                             this.update_entries(cx);
                                         })),
                                 )
-                            }),
+                            })
+                            .child(
+                                IconButton::new("toggle-pinned-threads", IconName::Pin)
+                                    .icon_size(IconSize::Small)
+                                    .icon_color(if self.show_pinned_threads_only {
+                                        Color::Accent
+                                    } else {
+                                        Color::Muted
+                                    })
+                                    .tooltip(Tooltip::text(if self.show_pinned_threads_only {
+                                        "Show All Threads"
+                                    } else {
+                                        "Show Pinned Threads"
+                                    }))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.show_pinned_threads_only =
+                                            !this.show_pinned_threads_only;
+                                        this.selection = None;
+                                        this.serialize(cx);
+                                        this.update_entries(cx);
+                                    })),
+                            ),
                     )
             })
             .when(right_window_controls, |this| {
@@ -7833,6 +7920,7 @@ impl WorkspaceSidebar for Sidebar {
                 SidebarView::ThreadList => SerializedSidebarView::ThreadList,
                 SidebarView::Archive(_) => SerializedSidebarView::History,
             },
+            show_pinned_threads_only: self.show_pinned_threads_only,
         };
         serde_json::to_string(&serialized).ok()
     }
@@ -7847,6 +7935,7 @@ impl WorkspaceSidebar for Sidebar {
             if let Some(width) = serialized.width {
                 self.width = px(width).clamp(MIN_WIDTH, MAX_WIDTH);
             }
+            self.show_pinned_threads_only = serialized.show_pinned_threads_only;
             if serialized.active_view == SerializedSidebarView::History {
                 cx.defer_in(window, |this, window, cx| {
                     this.show_archive(window, cx);

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -473,6 +473,7 @@ fn save_thread_metadata(
             interacted_at,
             worktree_paths,
             archived: false,
+            pinned: false,
             remote_connection,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -509,6 +510,7 @@ fn save_thread_metadata_with_main_paths(
         interacted_at: None,
         worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, folder_paths).unwrap(),
         archived: false,
+        pinned: false,
         remote_connection: None,
     };
     cx.update(|cx| {
@@ -536,6 +538,7 @@ fn save_draft_metadata_with_main_paths(
         interacted_at: None,
         worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, folder_paths).unwrap(),
         archived: false,
+        pinned: false,
         remote_connection: None,
     };
     cx.update(|cx| {
@@ -1162,6 +1165,7 @@ async fn test_neighboring_activatable_entry_stays_within_project(cx: &mut TestAp
                 created_at: Some(Utc::now()),
                 interacted_at: None,
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             icon: IconName::ZedAgent,
@@ -1254,6 +1258,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     created_at: Some(Utc::now()),
                     interacted_at: None,
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 icon: IconName::ZedAgent,
@@ -1281,6 +1286,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     created_at: Some(Utc::now()),
                     interacted_at: None,
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 icon: IconName::ZedAgent,
@@ -1308,6 +1314,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     created_at: Some(Utc::now()),
                     interacted_at: None,
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 icon: IconName::ZedAgent,
@@ -1336,6 +1343,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     created_at: Some(Utc::now()),
                     interacted_at: None,
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 icon: IconName::ZedAgent,
@@ -1364,6 +1372,7 @@ async fn test_visible_entries_as_strings(cx: &mut TestAppContext) {
                     created_at: Some(Utc::now()),
                     interacted_at: None,
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 icon: IconName::ZedAgent,
@@ -7664,6 +7673,7 @@ async fn test_sidebar_keeps_multi_root_thread_with_stale_main_paths(cx: &mut Tes
                     interacted_at: None,
                     worktree_paths: WorktreePaths::from_folder_paths(&folder_paths),
                     archived: false,
+                    pinned: false,
                     remote_connection: None,
                 },
                 cx,
@@ -7747,6 +7757,7 @@ async fn test_activate_archived_thread_with_saved_paths_activates_matching_works
                     "/project-b",
                 )])),
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             window,
@@ -7817,6 +7828,7 @@ async fn test_activate_archived_thread_cwd_fallback_with_matching_workspace(
                     std::path::PathBuf::from("/project-b"),
                 ])),
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             window,
@@ -7883,6 +7895,7 @@ async fn test_activate_archived_thread_no_paths_no_cwd_uses_active_workspace(
                 interacted_at: None,
                 worktree_paths: WorktreePaths::default(),
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             window,
@@ -7941,6 +7954,7 @@ async fn test_activate_archived_thread_saved_paths_opens_new_workspace(cx: &mut 
                 interacted_at: None,
                 worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             window,
@@ -8000,6 +8014,7 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window(cx: &m
                     "/project-b",
                 )])),
                 archived: false,
+                pinned: false,
                 remote_connection: None,
             },
             window,
@@ -8079,6 +8094,7 @@ async fn test_activate_archived_thread_reuses_workspace_in_another_window_with_t
             "/project-b",
         )])),
         archived: false,
+        pinned: false,
         remote_connection: None,
     };
     seed_thread_metadata(metadata.clone(), cx_a);
@@ -8162,6 +8178,7 @@ async fn test_activate_archived_thread_prefers_current_window_for_matching_paths
             "/project-a",
         )])),
         archived: false,
+        pinned: false,
         remote_connection: None,
     };
     seed_thread_metadata(metadata.clone(), cx_a);
@@ -8492,6 +8509,7 @@ async fn test_archive_last_worktree_thread_removes_workspace(cx: &mut TestAppCon
                 "/remote/project",
             )])),
             archived: false,
+            pinned: false,
             remote_connection: Some(remote_host),
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -9146,6 +9164,7 @@ async fn test_archive_last_worktree_thread_not_blocked_by_remote_thread_at_same_
                 "/wt-feature-a",
             )])),
             archived: false,
+            pinned: false,
             remote_connection: Some(remote_host),
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| {
@@ -9959,6 +9978,7 @@ async fn test_unarchive_first_thread_in_group_does_not_create_spurious_draft(
                     interacted_at: None,
                     worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
+                    pinned: false,
                     remote_connection: None,
                 },
                 cx,
@@ -10053,6 +10073,7 @@ async fn test_unarchive_into_new_workspace_does_not_create_duplicate_real_thread
                     interacted_at: None,
                     worktree_paths: WorktreePaths::from_folder_paths(&path_list_b),
                     archived: true,
+                    pinned: false,
                     remote_connection: None,
                 },
                 cx,
@@ -10282,6 +10303,7 @@ async fn test_unarchive_into_inactive_existing_workspace_does_not_leave_active_d
                         PathBuf::from("/project-b"),
                     ])),
                     archived: true,
+                    pinned: false,
                     remote_connection: None,
                 },
                 cx,
@@ -11135,6 +11157,7 @@ async fn test_unarchive_linked_worktree_thread_into_project_group_shows_only_res
                     )
                     .expect("main and folder paths should be well-formed"),
                     archived: true,
+                    pinned: false,
                     remote_connection: None,
                 },
                 cx,
@@ -11684,6 +11707,7 @@ async fn test_legacy_thread_with_canonical_path_opens_main_repo_workspace(cx: &m
                 "/project",
             )])),
             archived: false,
+            pinned: false,
             remote_connection: None,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -12672,6 +12696,7 @@ mod property_test {
             interacted_at: None,
             worktree_paths: WorktreePaths::from_path_lists(main_worktree_paths, path_list).unwrap(),
             archived: false,
+            pinned: false,
             remote_connection: None,
         };
         cx.update(|_, cx| {
@@ -12745,6 +12770,7 @@ mod property_test {
                         interacted_at: None,
                         worktree_paths: project.read(cx).worktree_paths(cx),
                         archived: false,
+                        pinned: false,
                         remote_connection: project.read(cx).remote_connection_options(cx),
                     });
                     cx.update(|_, cx| {
@@ -13613,6 +13639,7 @@ async fn test_remote_project_integration_does_not_briefly_render_as_separate_pro
             )
             .unwrap(),
             archived: false,
+            pinned: false,
             remote_connection,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -14578,6 +14605,7 @@ async fn test_remote_archive_thread_with_active_connection(
             )
             .unwrap(),
             archived: false,
+            pinned: false,
             remote_connection,
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));
@@ -14719,6 +14747,7 @@ async fn test_remote_linked_worktree_workspace_to_remove_uses_remote_connection(
             )
             .unwrap(),
             archived: false,
+            pinned: false,
             remote_connection: Some(remote_connection.clone()),
         };
         ThreadMetadataStore::global(cx).update(cx, |store, cx| store.save(metadata, cx));


### PR DESCRIPTION
## Summary

- retain pinned agent threads in thread metadata
- surface pinned threads in the sidebar and add a persisted pinned-only filter

## Testing

- `cargo fmt --check`
- `cargo test -p sidebar` (stopped when the local disk filled)

## Suggested .rules additions

- None.

Release Notes:

- Added pinned agent threads and a sidebar filter to show them