### PR TITLE
Indicate incomplete project search results for deferred directories

### DIFF
--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -199,7 +199,11 @@ impl AgentTool for GrepTool {
                         has_more_matches = true;
                         break;
                     }
-                    Some(SearchResult::WaitingForScan | SearchResult::Searching) => continue,
+                    Some(
+                        SearchResult::WaitingForScan
+                        | SearchResult::Searching
+                        | SearchResult::PartialIndex { .. },
+                    ) => continue,
                     None => break,
                 };
                 if ranges.is_empty() {

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -5565,7 +5565,9 @@ async fn test_project_search(
                     "Unexpectedly reached search limit in tests. If you do want to assert limit-reached, change this panic call."
                 )
             }
-            SearchResult::WaitingForScan | SearchResult::Searching => {}
+            SearchResult::WaitingForScan
+            | SearchResult::Searching
+            | SearchResult::PartialIndex { .. } => {}
         };
     }
 

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -452,6 +452,7 @@ impl Search {
             _ = maybe!(async move {
                 let gitignored_tracker = PathInclusionMatcher::new(query.clone());
                 let include_ignored = query.include_ignored();
+                let mut total_deferred_dirs: u32 = 0;
                 for worktree in worktrees {
                     let scan_complete = worktree.read_with(cx, |worktree, _| {
                         worktree.as_local().map(|local| local.scan_complete())
@@ -470,6 +471,7 @@ impl Search {
                             Some((this.snapshot(), this.as_local()?.settings()))
                         })
                         .context("The worktree is not local")?;
+
                     if query.include_ignored() {
                         // Pre-fetch all of the ignored directories as they're going to be searched.
                         let mut entries_to_refresh = vec![];
@@ -496,6 +498,10 @@ impl Search {
                         }
                         snapshot = worktree.read_with(cx, |this, _| this.snapshot());
                     }
+
+                    total_deferred_dirs = total_deferred_dirs
+                        .saturating_add(snapshot.deferred_scan_dir_count() as u32);
+
                     let tx = tx.clone();
                     let results = results.clone();
                     let snapshot = Arc::new(snapshot);
@@ -519,6 +525,14 @@ impl Search {
                                     return;
                                 };
                             }
+                        })
+                        .await;
+                }
+
+                if total_deferred_dirs > 0 {
+                    _ = results_tx
+                        .send(SearchResult::PartialIndex {
+                            deferred_dirs: total_deferred_dirs,
                         })
                         .await;
                 }

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -28,6 +28,9 @@ pub enum SearchResult {
     LimitReached,
     WaitingForScan,
     Searching,
+    PartialIndex {
+        deferred_dirs: u32,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12662,6 +12662,255 @@ async fn test_search_in_unopened_non_utf8_files(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_project_search_reports_deferred_dirs_in_non_git_workspace(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_depth = Some(5);
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "shallow.txt": "alpha 637390123 bravo\n",
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {
+                            "e": {
+                                "f": {
+                                    "deep.txt": "637390123\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let query = SearchQuery::text(
+        "637390123",
+        false,
+        true,
+        false,
+        PathMatcher::default(),
+        PathMatcher::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (results, deferred_dirs) = search_with_diagnostics(&project, query, cx).await.unwrap();
+
+    // The shallow file is reachable; the deep one is not.
+    assert!(
+        results.contains_key(&path!("root/shallow.txt").to_string()),
+        "shallow file should be searched; got {results:?}"
+    );
+    assert!(
+        !results.contains_key(&path!("root/a/b/c/d/e/f/deep.txt").to_string()),
+        "deep unopened file should be silently omitted; got {results:?}"
+    );
+
+    // The deferred dir (e.g. `a`) is reported via PartialIndex so the UI can
+    // warn the user that the search result is incomplete.
+    assert!(
+        deferred_dirs >= 1,
+        "expected at least one deferred dir reported via PartialIndex, got {deferred_dirs}"
+    );
+}
+
+// #63739 — when `file_scan_inclusions` covers a path past the depth cap, the
+// scanner pierces the depth for those paths at scan time and project search
+// finds the deep file on the first search (without requiring the user to
+// open it). This is integration coverage for the worktree scanner pierce + the
+// project-search enumerator pipeline.
+#[gpui::test]
+async fn test_project_search_finds_deep_files_when_inclusions_pierce_depth(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_depth = Some(5);
+                settings.project.worktree.file_scan_inclusions = Some(vec!["src/**".to_string()]);
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "src": {
+                "a": { "b": { "c": { "d": { "e": { "f": {
+                    "deep.txt": "alpha 637390123 bravo\n"
+                } } } } } }
+            },
+            "other": {
+                "x": { "y": { "z": { "u": { "v": { "w": {
+                    "other.txt": "637390123\n"
+                } } } } } }
+            },
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let query = SearchQuery::text(
+        "637390123",
+        false,
+        true,
+        false,
+        PathMatcher::default(),
+        PathMatcher::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (results, deferred_dirs) = search_with_diagnostics(&project, query, cx).await.unwrap();
+
+    assert!(
+        results.contains_key(&path!("root/src/a/b/c/d/e/f/deep.txt").to_string()),
+        "deep file under `src/**` should be discovered via inclusions; got {results:?}"
+    );
+    assert!(
+        !results.contains_key(&path!("root/other/x/y/z/u/v/w/other.txt").to_string()),
+        "deep file NOT covered by inclusions should remain unsearched; got {results:?}"
+    );
+
+    // `src/**` was pierced by the scanner so it should not appear in the
+    // deferred count, but `other` is still deferred (and reported).
+    assert!(
+        deferred_dirs >= 1,
+        "uncovered deep dirs should still be reported as deferred"
+    );
+}
+
+// #63739 — when no `file_scan_inclusions` is set and the workspace only has
+// files within the depth cap, no `PartialIndex` warning is emitted.
+#[gpui::test]
+async fn test_project_search_no_partial_when_workspace_shallow(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_depth = Some(5);
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "shallow.txt": "alpha 637390123 bravo\n",
+            "sub": { "deeper.txt": "637390123\n" },
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let query = SearchQuery::text(
+        "637390123",
+        false,
+        true,
+        false,
+        PathMatcher::default(),
+        PathMatcher::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (results, deferred_dirs) = search_with_diagnostics(&project, query, cx).await.unwrap();
+
+    assert_eq!(deferred_dirs, 0, "no PartialIndex expected");
+    assert_eq!(results.len(), 2, "both shallow files should match");
+}
+
+// #63739 — non-included deferred directories are NOT force-expanded. The
+// scanner pierces only paths covered by `file_scan_inclusions`; unrelated
+// deep dirs remain deferred and are reported via PartialIndex so the user
+// knows the result is partial.
+#[gpui::test]
+async fn test_project_search_does_not_force_expand_unrelated_deferred_dirs(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_depth = Some(5);
+                settings.project.worktree.file_scan_inclusions = Some(vec!["src/**".to_string()]);
+            });
+        });
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "src": {
+                "a": { "b": { "c": { "d": { "e": { "f": {
+                    "in_inclusions.txt": "alpha 637390123 bravo\n"
+                } } } } } }
+            },
+            "node_modules": {
+                "x": { "y": { "z": { "u": { "v": { "w": {
+                    "not_in_inclusions.txt": "637390123\n"
+                } } } } } }
+            },
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let query = SearchQuery::text(
+        "637390123",
+        false,
+        true,
+        false,
+        PathMatcher::default(),
+        PathMatcher::default(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    let (results, deferred_dirs) = search_with_diagnostics(&project, query, cx).await.unwrap();
+
+    assert!(
+        results.contains_key(&path!("root/src/a/b/c/d/e/f/in_inclusions.txt").to_string()),
+        "included deep file should be searched; got {results:?}"
+    );
+    assert!(
+        !results.contains_key(
+            &path!("root/node_modules/x/y/z/u/v/w/not_in_inclusions.txt").to_string()
+        ),
+        "non-included deep file must NOT be force-expanded; got {results:?}"
+    );
+
+    // `node_modules` is past depth and NOT covered by `src/**`, so it must
+    // remain deferred and be reported via PartialIndex.
+    assert!(
+        deferred_dirs >= 1,
+        "non-included deferred dirs should still be reported as deferred"
+    );
+}
+
+#[gpui::test]
 async fn test_create_entry(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
@@ -19574,8 +19823,10 @@ async fn search(
             SearchResult::Buffer { buffer, ranges } => {
                 results.entry(buffer).or_insert(ranges);
             }
-            SearchResult::LimitReached | SearchResult::WaitingForScan | SearchResult::Searching => {
-            }
+            SearchResult::LimitReached
+            | SearchResult::WaitingForScan
+            | SearchResult::Searching
+            | SearchResult::PartialIndex { .. } => {}
         }
     }
     Ok(results
@@ -19596,6 +19847,51 @@ async fn search(
             })
         })
         .collect())
+}
+
+/// Run a project search and return the matched files plus any deferred-dir
+/// diagnostics emitted by the search pipeline.
+async fn search_with_diagnostics(
+    project: &Entity<Project>,
+    query: SearchQuery,
+    cx: &mut gpui::TestAppContext,
+) -> Result<(HashMap<String, Vec<Range<usize>>>, u32)> {
+    let search_rx = project.update(cx, |project, cx| project.search(query, cx));
+    let mut results = HashMap::default();
+    let mut deferred_dirs: u32 = 0;
+    while let Ok(search_result) = search_rx.rx.recv().await {
+        match search_result {
+            SearchResult::Buffer { buffer, ranges } => {
+                results.entry(buffer).or_insert(ranges);
+            }
+            SearchResult::LimitReached | SearchResult::WaitingForScan | SearchResult::Searching => {
+            }
+            SearchResult::PartialIndex {
+                deferred_dirs: count,
+            } => {
+                deferred_dirs = deferred_dirs.saturating_add(count);
+            }
+        }
+    }
+    let results = results
+        .into_iter()
+        .map(|(buffer, ranges)| {
+            buffer.update(cx, |buffer, cx| {
+                let path = buffer
+                    .file()
+                    .unwrap()
+                    .full_path(cx)
+                    .to_string_lossy()
+                    .to_string();
+                let ranges = ranges
+                    .into_iter()
+                    .map(|range| range.to_offset(buffer))
+                    .collect::<Vec<_>>();
+                (path, ranges)
+            })
+        })
+        .collect();
+    Ok((results, deferred_dirs))
 }
 
 #[gpui::test]

--- a/crates/project_benchmarks/src/main.rs
+++ b/crates/project_benchmarks/src/main.rs
@@ -218,7 +218,9 @@ fn main() -> Result<(), anyhow::Error> {
                             matched_chunks += ranges.len();
                         }
                         SearchResult::LimitReached => break,
-                        SearchResult::WaitingForScan | SearchResult::Searching => continue,
+                        SearchResult::WaitingForScan
+                        | SearchResult::Searching
+                        | SearchResult::PartialIndex { .. } => continue,
                     }
                 }
                 let elapsed = timer.elapsed();

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -332,7 +332,9 @@ async fn do_search_and_assert(
             match response {
                 SearchResult::Buffer { buffer, .. } => break buffer,
                 SearchResult::LimitReached => panic!("incorrect result"),
-                SearchResult::WaitingForScan | SearchResult::Searching => continue,
+                SearchResult::WaitingForScan
+                | SearchResult::Searching
+                | SearchResult::PartialIndex { .. } => continue,
             }
         };
         buffer.update(&mut cx, |buffer, cx| {
@@ -739,7 +741,9 @@ async fn test_remote_project_search_reports_untitled_buffer_once(
         match result {
             SearchResult::Buffer { buffer, .. } => result_buffers.push(buffer),
             SearchResult::LimitReached => panic!("unexpected limit"),
-            SearchResult::WaitingForScan | SearchResult::Searching => {}
+            SearchResult::WaitingForScan
+            | SearchResult::Searching
+            | SearchResult::PartialIndex { .. } => {}
         }
     }
     assert_eq!(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -321,8 +321,48 @@ enum SearchActivity {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SearchCompletion {
-    NoResults,
-    Results { limit_reached: bool },
+    NoResults {
+        deferred_dirs: u32,
+    },
+    Results {
+        limit_reached: bool,
+        deferred_dirs: u32,
+    },
+}
+
+impl Default for SearchCompletion {
+    fn default() -> Self {
+        SearchCompletion::NoResults { deferred_dirs: 0 }
+    }
+}
+
+fn partial_index_message(deferred_dirs: u32) -> String {
+    format!(
+        "Results may be incomplete — {deferred_dirs} director{} {} not indexed due to `file_scan_depth`. Add paths to `file_scan_inclusions` or raise `file_scan_depth` to search them.",
+        if deferred_dirs == 1 { "y" } else { "ies" },
+        if deferred_dirs == 1 { "was" } else { "were" },
+    )
+}
+
+#[cfg(test)]
+mod partial_index_message_tests {
+    use super::partial_index_message;
+
+    #[test]
+    fn singular() {
+        assert_eq!(
+            partial_index_message(1),
+            "Results may be incomplete — 1 directory was not indexed due to `file_scan_depth`. Add paths to `file_scan_inclusions` or raise `file_scan_depth` to search them."
+        );
+    }
+
+    #[test]
+    fn plural() {
+        assert_eq!(
+            partial_index_message(42),
+            "Results may be incomplete — 42 directories were not indexed due to `file_scan_depth`. Add paths to `file_scan_inclusions` or raise `file_scan_depth` to search them."
+        );
+    }
 }
 
 impl SearchState {
@@ -338,16 +378,25 @@ impl SearchState {
     }
 
     fn no_results_so_far(self) -> bool {
-        self.completion() == Some(SearchCompletion::NoResults)
+        matches!(self.completion(), Some(SearchCompletion::NoResults { .. }))
     }
 
     fn limit_reached(self) -> bool {
         matches!(
             self.completion(),
             Some(SearchCompletion::Results {
-                limit_reached: true
+                limit_reached: true,
+                ..
             })
         )
+    }
+
+    fn deferred_dirs(self) -> u32 {
+        match self.completion() {
+            Some(SearchCompletion::NoResults { deferred_dirs })
+            | Some(SearchCompletion::Results { deferred_dirs, .. }) => deferred_dirs,
+            None => 0,
+        }
     }
 }
 
@@ -670,17 +719,19 @@ async fn consume_search_stream(
     let mut matches = pin!(search_results.rx.clone().ready_chunks(1024));
 
     let mut limit_reached = false;
+    let mut partial_deferred_dirs: u32 = 0;
     let mut reused_results = if reuse_excerpts {
         Some(project_search.read_with(cx, ReusedResults::new).ok()?)
     } else {
         None
     };
     while let Some(results) = matches.next().await {
-        let (buffers_with_ranges, has_reached_limit, search_activity) = cx
+        let (buffers_with_ranges, has_reached_limit, search_activity, partial_index) = cx
             .background_executor()
             .spawn(async move {
                 let mut limit_reached = false;
                 let mut search_activity = None;
+                let mut partial_index: u32 = 0;
                 let mut buffers_with_ranges = Vec::with_capacity(results.len());
                 for result in results {
                     match result {
@@ -696,12 +747,21 @@ async fn consume_search_stream(
                         project::search::SearchResult::Searching => {
                             search_activity = Some(SearchActivity::Searching);
                         }
+                        project::search::SearchResult::PartialIndex { deferred_dirs } => {
+                            partial_index = partial_index.saturating_add(deferred_dirs);
+                        }
                     }
                 }
-                (buffers_with_ranges, limit_reached, search_activity)
+                (
+                    buffers_with_ranges,
+                    limit_reached,
+                    search_activity,
+                    partial_index,
+                )
             })
             .await;
         limit_reached |= has_reached_limit;
+        partial_deferred_dirs = partial_deferred_dirs.saturating_add(partial_index);
         if let Some(search_activity) = search_activity {
             project_search
                 .update(cx, |project_search, cx| {
@@ -788,9 +848,14 @@ async fn consume_search_stream(
                 reused_results.finish(project_search, cx);
             }
             project_search.search_state = if project_search.match_ranges.is_empty() {
-                SearchState::Completed(SearchCompletion::NoResults)
+                SearchState::Completed(SearchCompletion::NoResults {
+                    deferred_dirs: partial_deferred_dirs,
+                })
             } else {
-                SearchState::Completed(SearchCompletion::Results { limit_reached })
+                SearchState::Completed(SearchCompletion::Results {
+                    limit_reached,
+                    deferred_dirs: partial_deferred_dirs,
+                })
             };
             project_search.pending_search.take();
             cx.notify();
@@ -1057,7 +1122,7 @@ impl Render for ProjectSearchView {
                     activity: SearchActivity::Searching,
                     ..
                 } => "Searching…",
-                SearchState::Completed(SearchCompletion::NoResults) => "No Results",
+                SearchState::Completed(SearchCompletion::NoResults { .. }) => "No Results",
                 _ => "Search All Files",
             };
 
@@ -1067,11 +1132,24 @@ impl Render for ProjectSearchView {
 
             let page_content: Option<AnyElement> = match model.search_state {
                 SearchState::Idle => Some(self.landing_text_minor(cx).into_any_element()),
-                _ if model.search_state.no_results_so_far() => Some(
-                    Label::new("No results found in this project for the provided query")
-                        .size(LabelSize::Small)
-                        .into_any_element(),
-                ),
+                _ if model.search_state.no_results_so_far() => {
+                    let deferred_dirs = model.search_state.deferred_dirs();
+                    let mut elements: Vec<AnyElement> = Vec::new();
+                    elements.push(
+                        Label::new("No results found in this project for the provided query")
+                            .size(LabelSize::Small)
+                            .into_any_element(),
+                    );
+                    if deferred_dirs > 0 {
+                        elements.push(
+                            Label::new(partial_index_message(deferred_dirs))
+                                .size(LabelSize::Small)
+                                .color(Color::Warning)
+                                .into_any_element(),
+                        );
+                    }
+                    Some(v_flex().gap_1().children(elements).into_any_element())
+                }
                 _ => None,
             };
 
@@ -3005,6 +3083,7 @@ impl Render for ProjectSearchBar {
         let theme_colors = cx.theme().colors();
         let project_search = search.entity.read(cx);
         let limit_reached = project_search.search_state.limit_reached();
+        let deferred_dirs = project_search.search_state.deferred_dirs();
         let is_search_underway = project_search.pending_search.is_some();
 
         let color_override = match (
@@ -3131,7 +3210,21 @@ impl Render for ProjectSearchBar {
                             "Search Limits Reached\nTry narrowing your search",
                         ))
                     }),
-            );
+            )
+            .when(deferred_dirs > 0, |this| {
+                this.child(
+                    div()
+                        .id("partial-index-warning")
+                        .ml_1()
+                        .child(
+                            Icon::new(IconName::Warning)
+                                .color(Color::Warning)
+                                .size(IconSize::Small)
+                                .into_any_element(),
+                        )
+                        .tooltip(Tooltip::text(partial_index_message(deferred_dirs))),
+                )
+            });
 
         let mode_column = h_flex()
             .gap_1()

--- a/crates/search/src/text_finder/delegate.rs
+++ b/crates/search/src/text_finder/delegate.rs
@@ -1268,7 +1268,9 @@ async fn stream_results_to_picker(
                 SearchResult::LimitReached => {
                     limit_reached = true;
                 }
-                SearchResult::WaitingForScan | SearchResult::Searching => {}
+                SearchResult::WaitingForScan
+                | SearchResult::Searching
+                | SearchResult::PartialIndex { .. } => {}
             }
         }
 


### PR DESCRIPTION
## Objective

Fixes #63739

Project search can silently return incomplete results in non-Git workspaces when directories remain unindexed beyond `file_scan_depth`.

Files inside deferred directories are not included in the worktree snapshot used to provide project search paths. As a result, searching for content in an unopened file beyond the scan depth can return no results. Opening or otherwise scanning the path makes the file searchable, which makes the missing result appear inconsistent.

The `file_scan_depth` behavior itself is intentional and exists to avoid recursively indexing very large workspaces. The issue is that project search did not communicate when its results were incomplete because of deferred directories.

## Solution

Add partial-index reporting to project search.

When project search completes, it checks the existing deferred scan directory count from the worktree snapshot. If directories remain deferred, project search emits a `PartialIndex` status containing the number of deferred directories.

The search UI then indicates that results may be incomplete:

* The no-results landing page explains that some directories were not indexed because of `file_scan_depth`.
* A warning icon is shown next to the search result count when deferred directories remain.
* The warning provides guidance about `file_scan_depth` and `file_scan_inclusions`.
* The partial-index warning is separate from the existing search limit warning so both states can be communicated at the same time.

This does not change `file_scan_depth` behavior or force project search to scan deferred directories. Existing `file_scan_inclusions` behavior continues to pierce the scan depth through the normal scanner.

## Showcase

The recording below reproduces the original behavior in a fresh non-Git workspace.

The workspace contains:

```text
zed-search-depth-test/
├── shallow.txt
└── a/b/c/d/e/f/deep.txt
```

`deep.txt` is located beyond the default `file_scan_depth` and contains a unique search string.

The recording demonstrates:

1. Searching for content in the unopened deep file.
2. The file not being returned because its directory remains deferred.
3. The new warning indicating that project search results may be incomplete due to `file_scan_depth`.
4. Searching for a shallow file to confirm that normally indexed files are still returned correctly.
5. Opening the deep file and searching again to demonstrate why the original behavior appeared inconsistent once the path was scanned.

https://github.com/user-attachments/assets/51c394b9-103c-4df1-b5a8-95611c097ee2


## Testing

Added and updated coverage for:

* Project search reporting deferred directories in a non-Git workspace with files beyond the scan depth.
* Project search behavior when `file_scan_inclusions` pierces the scan depth.
* Unrelated deferred directories remaining unexpanded.
* Fully indexed shallow workspaces not reporting partial results.
* Singular and plural partial-index warning messages.

### Manual verification

I also verified the change manually using a fresh non-Git workspace with a shallow file and a file nested beyond the default `file_scan_depth`.

The reproduction was run with a fresh Zed user data directory to ensure the deep path had not previously been scanned.

The following behavior was confirmed:

* Searching for content in the unopened deep file returns no match.
* The new partial-index warning is displayed and explains that results may be incomplete because directories remain unindexed due to `file_scan_depth`.
* Searching for content in the shallow file returns the expected match.
* After opening the deep file and causing its path to be scanned, searching for its content returns the expected match.

This confirms both the original reproduction and that the new UI surfaces the reason search results can be incomplete.

Verified with:

* `cargo fmt --check`
* `cargo check --workspace`
* `cargo clippy -p worktree -p project -p search -- -D warnings`
* Project search integration tests
* Project search UI tests
* Worktree `file_scan_depth` tests
* Full worktree integration test suite
* `grep_tool` tests
* Downstream compilation checks for consumers of `SearchResult`

All automated checks and manual verification passed.

## Self-Review Checklist

* [x] I've reviewed my own diff for quality, security, and reliability
* [x] Unsafe blocks are not introduced by this change
* [x] The content adheres to Zed's UI standards
* [x] Tests cover the new and changed behavior
* [x] Performance impact has been considered and is acceptable

## Release Notes

* Fixed project search silently returning incomplete results when directories are deferred by `file_scan_depth`.
