### PR TITLE
ui: Fix modifier key hints on macOS

### DIFF
--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -822,7 +822,12 @@ impl EditPredictionButton {
                     ContextMenuEntry::new("Subtle")
                         .toggleable(IconPosition::Start, subtle_mode)
                         .documentation_aside(DocumentationSide::Left, move |_| {
-                            Label::new("Display predictions inline only when holding a modifier key (alt by default).").into_any_element()
+                            Label::new(if cfg!(target_os = "macos") {
+                                "Display predictions inline only when holding a modifier key (option by default)."
+                            } else {
+                                "Display predictions inline only when holding a modifier key (alt by default)."
+                            })
+                            .into_any_element()
                         })
                         .handler({
                             let fs = fs.clone();

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -822,11 +822,11 @@ impl EditPredictionButton {
                     ContextMenuEntry::new("Subtle")
                         .toggleable(IconPosition::Start, subtle_mode)
                         .documentation_aside(DocumentationSide::Left, move |_| {
-                            Label::new(if cfg!(target_os = "macos") {
-                                "Display predictions inline only when holding a modifier key (option by default)."
-                            } else {
-                                "Display predictions inline only when holding a modifier key (alt by default)."
-                            })
+                            Label::new(concat!(
+                                "Display predictions inline only when holding a modifier key (",
+                                ui::alt_key_name!(),
+                                " by default)."
+                            ))
                             .into_any_element()
                         })
                         .handler({

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -883,7 +883,11 @@ impl Render for DeleteBranchTooltip {
             Tooltip::with_meta_in(
                 "Delete Branch",
                 Some(&branch_picker::DeleteBranch),
-                "Hold alt to force delete",
+                if cfg!(target_os = "macos") {
+                    "Hold option to force delete"
+                } else {
+                    "Hold alt to force delete"
+                },
                 &self.focus_handle,
                 cx,
             )

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -883,11 +883,7 @@ impl Render for DeleteBranchTooltip {
             Tooltip::with_meta_in(
                 "Delete Branch",
                 Some(&branch_picker::DeleteBranch),
-                if cfg!(target_os = "macos") {
-                    "Hold option to force delete"
-                } else {
-                    "Hold alt to force delete"
-                },
+                concat!("Hold ", ui::alt_key_name!(), " to force delete"),
                 &self.focus_handle,
                 cx,
             )

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -413,7 +413,11 @@ impl Render for DeleteWorktreeTooltip {
             Tooltip::with_meta_in(
                 "Delete Worktree",
                 Some(&DeleteWorktree),
-                "Hold alt to force delete",
+                if cfg!(target_os = "macos") {
+                    "Hold option to force delete"
+                } else {
+                    "Hold alt to force delete"
+                },
                 &self.focus_handle,
                 cx,
             )

--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -413,11 +413,7 @@ impl Render for DeleteWorktreeTooltip {
             Tooltip::with_meta_in(
                 "Delete Worktree",
                 Some(&DeleteWorktree),
-                if cfg!(target_os = "macos") {
-                    "Hold option to force delete"
-                } else {
-                    "Hold alt to force delete"
-                },
+                concat!("Hold ", ui::alt_key_name!(), " to force delete"),
                 &self.focus_handle,
                 cx,
             )

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1163,7 +1163,11 @@ impl KeymapEditor {
                         Tooltip::with_meta(
                             "View conflicts",
                             Some(&ToggleConflictFilter),
-                            "Use alt+click to show all conflicts",
+                            if cfg!(target_os = "macos") {
+                                "Use option+click to show all conflicts"
+                            } else {
+                                "Use alt+click to show all conflicts"
+                            },
                             cx,
                         )
                     })
@@ -1197,7 +1201,11 @@ impl KeymapEditor {
                         Tooltip::with_meta(
                             "Show matching keybinds",
                             Some(&ShowMatchingKeybinds),
-                            "This binding is overridden by other bindings.\nUse alt+click to edit this binding",
+                            if cfg!(target_os = "macos") {
+                                "This binding is overridden by other bindings.\nUse option+click to edit this binding"
+                            } else {
+                                "This binding is overridden by other bindings.\nUse alt+click to edit this binding"
+                            },
                             cx,
                         )
                     })

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1163,11 +1163,7 @@ impl KeymapEditor {
                         Tooltip::with_meta(
                             "View conflicts",
                             Some(&ToggleConflictFilter),
-                            if cfg!(target_os = "macos") {
-                                "Use option+click to show all conflicts"
-                            } else {
-                                "Use alt+click to show all conflicts"
-                            },
+                            concat!("Use ", ui::alt_key_name!(), "+click to show all conflicts"),
                             cx,
                         )
                     })
@@ -1197,15 +1193,15 @@ impl KeymapEditor {
                     }))
             } else {
                 base_button_style(index, IconName::Info)
-                    .tooltip(|_window, cx|  {
+                    .tooltip(|_window, cx| {
                         Tooltip::with_meta(
                             "Show matching keybinds",
                             Some(&ShowMatchingKeybinds),
-                            if cfg!(target_os = "macos") {
-                                "This binding is overridden by other bindings.\nUse option+click to edit this binding"
-                            } else {
-                                "This binding is overridden by other bindings.\nUse alt+click to edit this binding"
-                            },
+                            concat!(
+                                "This binding is overridden by other bindings.\nUse ",
+                                ui::alt_key_name!(),
+                                "+click to edit this binding"
+                            ),
                             cx,
                         )
                     })

--- a/crates/ui/src/styles/platform.rs
+++ b/crates/ui/src/styles/platform.rs
@@ -1,3 +1,21 @@
+/// Expands to a literal so platform-specific hints can use `concat!` without allocating.
+#[cfg(target_os = "macos")]
+#[macro_export]
+macro_rules! alt_key_name {
+    () => {
+        "option"
+    };
+}
+
+/// Expands to a literal so platform-specific hints can use `concat!` without allocating.
+#[cfg(not(target_os = "macos"))]
+#[macro_export]
+macro_rules! alt_key_name {
+    () => {
+        "alt"
+    };
+}
+
 /// The platform style to use when rendering UI.
 ///
 /// This can be used to abstract over platform differences.


### PR DESCRIPTION
# Objective

Fixes #63805 

## Solution

change alt -> option!

## Testing

I built it and saw.

## Self-Review Checklist:

- [y] I've reviewed my own diff for quality, security, and reliability
- [y] Unsafe blocks (if any) have justifying comments
- [y] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [n] Tests cover the new/changed behavior (no behavior change)
- [y] Performance impact has been considered and is acceptable

## Showcase

<img width="258" height="52" alt="image" src="https://github.com/user-attachments/assets/73c215d2-dbf6-4eb7-9a96-7ef082d2be8d" />

---

Release Notes:

- Fixed hints for branch and worktree deletion, keybinding conflicts, and edit predictions referring to Alt instead of Option on macOS.
