### PR TITLE
gpui_windows: Restore the top window border on Windows 10

### DIFF
--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use gpui_util::ResultExt;
 use windows::{
     Win32::{
-        Foundation::HWND,
+        Foundation::{HWND, RECT},
         Graphics::{
             Direct3D::*,
             Direct3D11::*,
@@ -118,7 +118,57 @@ impl Drop for Annotation<'_> {
 struct DirectComposition {
     comp_device: IDCompositionDevice,
     comp_target: IDCompositionTarget,
+    root_visual: IDCompositionVisual,
     comp_visual: IDCompositionVisual,
+    /// Carries the window's top border while the window is inactive. `None`
+    /// anywhere DWM draws that border itself, which is everywhere but Windows
+    /// 10.
+    border: Option<TopBorderVisual>,
+}
+
+/// The window's inactive top border, as a composition visual of its own rather
+/// than a row of the rendered scene, so that showing and hiding it costs a
+/// composition commit instead of a whole frame. See
+/// [`WindowsWindowInner::update_top_border`].
+struct TopBorderVisual {
+    visual: IDCompositionVisual,
+    /// A single premultiplied pixel of border colour, stretched to the width of
+    /// the window by `scale`. One pixel rather than a wide buffer so there is
+    /// no maximum texture size to bump into on lower feature levels.
+    swap_chain: IDXGISwapChain1,
+    scale: IDCompositionScaleTransform,
+}
+
+impl TopBorderVisual {
+    fn new(comp_device: &IDCompositionDevice, devices: &DirectXRendererDevices) -> Result<Self> {
+        let swap_chain =
+            create_swap_chain_for_composition(&devices.dxgi_factory, &devices.device, 1, 1)
+                .context("Creating the top border swap chain")?;
+        unsafe {
+            let buffer: ID3D11Texture2D = swap_chain.GetBuffer(0)?;
+            let mut view = None;
+            devices
+                .device
+                .CreateRenderTargetView(&buffer, None, Some(&mut view))?;
+            let view = view.context("missing border render target view")?;
+            devices
+                .device_context
+                .ClearRenderTargetView(&view, &top_border_color());
+            swap_chain.Present(0, DXGI_PRESENT(0)).ok()?;
+        }
+
+        let visual = unsafe { comp_device.CreateVisual() }?;
+        let scale = unsafe { comp_device.CreateScaleTransform() }?;
+        unsafe {
+            scale.SetScaleY2(1.0)?;
+            visual.SetTransform(&scale)?;
+        }
+        Ok(Self {
+            visual,
+            swap_chain,
+            scale,
+        })
+    }
 }
 
 impl DirectXRendererDevices {
@@ -174,10 +224,11 @@ impl DirectXRenderer {
         let direct_composition = if disable_direct_composition {
             None
         } else {
-            let composition = DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), hwnd)
-                .context("Creating DirectComposition")?;
+            let composition =
+                DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), hwnd, &devices)
+                    .context("Creating DirectComposition")?;
             composition
-                .set_swap_chain(&resources.swap_chain)
+                .set_swap_chain(&resources.swap_chain, 1)
                 .context("Setting swap chain for DirectComposition")?;
             Some(composition)
         };
@@ -305,8 +356,8 @@ impl DirectXRenderer {
             None
         } else {
             let composition =
-                DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), self.hwnd)?;
-            composition.set_swap_chain(&resources.swap_chain)?;
+                DirectComposition::new(devices.dxgi_device.as_ref().unwrap(), self.hwnd, &devices)?;
+            composition.set_swap_chain(&resources.swap_chain, self.width)?;
             Some(composition)
         };
 
@@ -331,6 +382,7 @@ impl DirectXRenderer {
         &mut self,
         scene: &Scene,
         background_appearance: WindowBackgroundAppearance,
+        top_border_height: u32,
     ) -> Result<()> {
         if self.skip_draws {
             // skip drawing this frame, we just recovered from a device lost event
@@ -338,7 +390,59 @@ impl DirectXRenderer {
             return Ok(());
         }
         self.render(scene, background_appearance)?;
+        self.draw_top_border(top_border_height).log_err();
         self.present()
+    }
+
+    /// Paint the window's top border over the top `height` physical pixels of
+    /// the frame, in premultiplied `color`.
+    ///
+    /// See [`WindowsWindowInner::top_border_height`]: this only runs on Windows
+    /// 10. While the window is active `color` is fully transparent, uncovering
+    /// the pixel of DWM frame extended underneath so the system draws its own
+    /// border; when it is inactive DWM leaves that pixel alone and `color` is
+    /// the border itself, translucent like the ones DWM draws down the other
+    /// three edges.
+    ///
+    /// Either way this needs the premultiplied-alpha DirectComposition swap
+    /// chain, since the row is written with its alpha intact; the fallback swap
+    /// chain is created with [`DXGI_ALPHA_MODE_IGNORE`], which would turn the
+    /// transparent row into an opaque black line.
+    /// Show or hide the inactive top border. See
+    /// [`WindowsWindowInner::top_border_height`].
+    pub(crate) fn set_top_border_visible(&self, visible: bool) -> Result<()> {
+        let Some(composition) = self.direct_composition.as_ref() else {
+            return Ok(());
+        };
+        composition.set_border_visible(visible)
+    }
+
+    fn draw_top_border(&self, height: u32) -> Result<()> {
+        if height == 0 || self.direct_composition.is_none() {
+            return Ok(());
+        }
+        let resources = self.resources.as_ref().context("resources missing")?;
+        let render_target_view = resources
+            .render_target_view
+            .as_ref()
+            .context("missing render target view")?;
+        let device_context: ID3D11DeviceContext1 = self
+            .devices
+            .as_ref()
+            .context("devices missing")?
+            .device_context
+            .cast()?;
+        let rect = RECT {
+            left: 0,
+            top: 0,
+            right: self.width as i32,
+            bottom: height as i32,
+        };
+        // Cleared, never coloured: whatever occupies the row is composited
+        // underneath by DWM (the active border) or over it by the border visual
+        // (the inactive one), and both are independent of this frame.
+        unsafe { device_context.ClearView(render_target_view, &[0.0; 4], Some(&[rect])) };
+        Ok(())
     }
 
     /// Clear the render target for `background_appearance` and encode every
@@ -521,6 +625,10 @@ impl DirectXRenderer {
             devices
                 .device_context
                 .OMSetRenderTargets(Some(slice::from_ref(&resources.render_target_view)), None);
+        }
+
+        if let Some(composition) = self.direct_composition.as_ref() {
+            composition.set_border_width(width).log_err();
         }
 
         Ok(())
@@ -1006,22 +1114,69 @@ impl DirectXRenderPipelines {
 }
 
 impl DirectComposition {
-    pub fn new(dxgi_device: &IDXGIDevice, hwnd: HWND) -> Result<Self> {
+    pub fn new(
+        dxgi_device: &IDXGIDevice,
+        hwnd: HWND,
+        devices: &DirectXRendererDevices,
+    ) -> Result<Self> {
         let comp_device = get_comp_device(dxgi_device)?;
         let comp_target = unsafe { comp_device.CreateTargetForHwnd(hwnd, true) }?;
+        let root_visual = unsafe { comp_device.CreateVisual() }?;
         let comp_visual = unsafe { comp_device.CreateVisual() }?;
+        unsafe { root_visual.AddVisual(&comp_visual, false, None) }?;
+
+        let border = is_windows_10()
+            .then(|| TopBorderVisual::new(&comp_device, devices))
+            .transpose()?;
+        if let Some(border) = border.as_ref() {
+            // Above the scene, covering the row the renderer keeps clear.
+            unsafe { root_visual.AddVisual(&border.visual, true, &comp_visual) }?;
+        }
 
         Ok(Self {
             comp_device,
             comp_target,
+            root_visual,
             comp_visual,
+            border,
         })
     }
 
-    pub fn set_swap_chain(&self, swap_chain: &IDXGISwapChain1) -> Result<()> {
+    pub fn set_swap_chain(&self, swap_chain: &IDXGISwapChain1, width: u32) -> Result<()> {
         unsafe {
             self.comp_visual.SetContent(swap_chain)?;
-            self.comp_target.SetRoot(&self.comp_visual)?;
+            self.comp_target.SetRoot(&self.root_visual)?;
+        }
+        self.set_border_width(width)?;
+        unsafe { self.comp_device.Commit() }?;
+        Ok(())
+    }
+
+    /// Show or hide the inactive top border. Cheap enough to call from a window
+    /// message: it is a content swap and a commit, with no rendering.
+    fn set_border_visible(&self, visible: bool) -> Result<()> {
+        let Some(border) = self.border.as_ref() else {
+            return Ok(());
+        };
+        unsafe {
+            if visible {
+                border.visual.SetContent(&border.swap_chain)?;
+            } else {
+                border.visual.SetContent(None)?;
+            }
+            self.comp_device.Commit()?;
+        }
+        Ok(())
+    }
+
+    /// Stretch the border across the window. The single pixel of colour is
+    /// scaled rather than redrawn, so this is just a transform update.
+    fn set_border_width(&self, width: u32) -> Result<()> {
+        let Some(border) = self.border.as_ref() else {
+            return Ok(());
+        };
+        unsafe {
+            border.scale.SetScaleX2(width as f32)?;
             self.comp_device.Commit()?;
         }
         Ok(())

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -5,7 +5,7 @@ use gpui_util::ResultExt;
 use windows::{
     Win32::{
         Foundation::*,
-        Graphics::Gdi::*,
+        Graphics::{Dwm::DwmExtendFrameIntoClientArea, Gdi::*},
         System::SystemServices::*,
         UI::{
             Controls::*,
@@ -31,6 +31,10 @@ pub(crate) const WM_GPUI_KEYDOWN: u32 = WM_USER + 8;
 pub(crate) const WM_GPUI_END_SESSION: u32 = WM_USER + 9;
 
 const SIZE_MOVE_LOOP_TIMER_ID: usize = 1;
+
+/// Height of the border DWM draws along the top edge of a window. It is one
+/// physical pixel at every DPI, which is why this is not scaled.
+const TOP_BORDER_HEIGHT: u32 = 1;
 
 /// Coordinates window draws on the UI thread. Owned by the platform and
 /// shared with every window (like `WindowsPlatformState::cursor_visible`),
@@ -97,7 +101,7 @@ impl WindowsWindowInner {
             WM_ACTIVATE => self.handle_activate_msg(wparam),
             WM_CREATE => self.handle_create_msg(handle),
             WM_MOVE => self.handle_move_msg(handle, lparam),
-            WM_SIZE => self.handle_size_msg(wparam, lparam),
+            WM_SIZE => self.handle_size_msg(handle, wparam, lparam),
             WM_GETMINMAXINFO => self.handle_get_min_max_info_msg(lparam),
             WM_ENTERSIZEMOVE | WM_ENTERMENULOOP => self.handle_size_move_loop(handle),
             WM_EXITSIZEMOVE | WM_EXITMENULOOP => self.handle_size_move_loop_exit(handle),
@@ -236,7 +240,7 @@ impl WindowsWindowInner {
         Some(0)
     }
 
-    fn handle_size_msg(&self, wparam: WPARAM, lparam: LPARAM) -> Option<isize> {
+    fn handle_size_msg(&self, handle: HWND, wparam: WPARAM, lparam: LPARAM) -> Option<isize> {
         // Don't resize the renderer when the window is minimized, but record that it was minimized so
         // that on restore the swap chain can be recreated via `update_drawable_size_even_if_unchanged`.
         if wparam.0 == SIZE_MINIMIZED as usize {
@@ -245,6 +249,10 @@ impl WindowsWindowInner {
                 .set(self.state.callbacks.request_frame.take());
             return Some(0);
         }
+
+        // Maximizing or restoring changes whether there is a border at all.
+        self.update_frame_margins(handle);
+        self.update_top_border();
 
         let width = lparam.loword().max(1) as i32;
         let height = lparam.hiword().max(1) as i32;
@@ -796,8 +804,100 @@ impl WindowsWindowInner {
         }
     }
 
+    /// Height, in physical pixels, of the system border along the top edge of
+    /// the client area. Zero when the window does not need one.
+    ///
+    /// [`Self::handle_calc_client_size`] gives the whole top edge of the window
+    /// rect to the client area so that the system title bar disappears. The
+    /// left, right and bottom borders survive that, because `DefWindowProc`
+    /// still insets the client rect by the resize frame on those sides, leaving
+    /// room for DWM to draw them in. The top edge has no such room left.
+    ///
+    /// On Windows 11 that costs nothing: DWM paints the border in its own frame
+    /// layer, composited over the top edge of the window (the same layer that
+    /// gives every window rounded corners without the application taking part),
+    /// so it does not care what the client rect says. On Windows 10 DWM only
+    /// paints a top border where the window has frame area of its own, so the
+    /// border disappears entirely.
+    ///
+    /// Windows 10 needs the border put back by hand. [`Self::update_frame_margins`]
+    /// extends the DWM frame exactly this far into the client area and the
+    /// renderer leaves that row alone ([`Self::top_border_color`]), so DWM
+    /// draws the real border into it.
+    ///
+    /// The one alternative, leaving a pixel of *non-client* area for it
+    /// (`rgrc[0].top + 1`), was measured and rejected: DWM does draw a correct
+    /// border, and a full native caption above the window along with it, which
+    /// is the thing the pixel is there to get rid of. DWM draws either the
+    /// whole top frame or none of it.
+    pub(crate) fn top_border_height(&self) -> u32 {
+        if !self.needs_win10_top_border() {
+            return 0;
+        }
+        // A maximized or fullscreen window has no visible border: its resize
+        // frame hangs off the edges of the monitor and is clipped away.
+        if self.state.is_maximized() || self.state.is_fullscreen() {
+            return 0;
+        }
+        TOP_BORDER_HEIGHT
+    }
+
+    /// Whether this window has to put its top border back by hand, which only
+    /// windows that hide the system title bar need, and only on Windows 10.
+    pub(crate) fn needs_win10_top_border(&self) -> bool {
+        self.hide_title_bar && is_windows_10()
+    }
+
+    /// Show the inactive top border, or hide it and let DWM draw the active one.
+    ///
+    /// Deliberately not part of the rendered frame: the border changes on every
+    /// focus change, GPUI does not redraw a window whose scene has not changed,
+    /// and forcing a redraw costs a whole frame - measured at 45-60ms - during
+    /// which the row still shows the previous state while DWM has already
+    /// switched, which reads as a flash. Swapping a composition visual instead
+    /// takes a commit and lands with DWM's own change.
+    pub(crate) fn update_top_border(&self) {
+        if !self.needs_win10_top_border() {
+            return;
+        }
+        let visible = !self.state.active.get() && self.top_border_height() > 0;
+        // A draw may be in flight when activation changes; the next one applies
+        // the same state anyway, so there is nothing to retry.
+        if let Ok(renderer) = self.state.renderer.try_borrow() {
+            renderer.set_top_border_visible(visible).log_err();
+        }
+    }
+
+    /// Extend the DWM frame exactly [`TOP_BORDER_HEIGHT`] pixels into the client
+    /// area, so that DWM draws its own border there and the renderer can leave
+    /// that row transparent for it to show through.
+    ///
+    /// The margin has to be exactly the border height. Extending by the whole
+    /// top frame instead (as an app that keeps `WS_CAPTION` would) makes DWM
+    /// fill it with caption rather than border. Extending at all also makes DWM
+    /// render the border of a light-themed window pure white, which is why
+    /// these windows ask for a dark frame regardless of theme; see
+    /// [`configure_dwm_dark_mode`].
+    pub(crate) fn update_frame_margins(&self, handle: HWND) {
+        if !self.needs_win10_top_border() {
+            return;
+        }
+        // Retracts to nothing while maximized or fullscreen, where
+        // `top_border_height` is zero because there is no visible border.
+        let margins = MARGINS {
+            cxLeftWidth: 0,
+            cxRightWidth: 0,
+            cyTopHeight: self.top_border_height() as i32,
+            cyBottomHeight: 0,
+        };
+        unsafe { DwmExtendFrameIntoClientArea(handle, &margins).log_err() };
+    }
+
     fn handle_activate_msg(self: &Rc<Self>, wparam: WPARAM) -> Option<isize> {
         let activated = wparam.loword() > 0;
+
+        self.state.active.set(activated);
+        self.update_top_border();
 
         let events = self
             .state
@@ -864,6 +964,7 @@ impl WindowsWindowInner {
 
     fn handle_create_msg(&self, handle: HWND) -> Option<isize> {
         if self.hide_title_bar {
+            self.update_frame_margins(handle);
             notify_frame_changed(handle);
             Some(0)
         } else {
@@ -1241,7 +1342,7 @@ impl WindowsWindowInner {
 
                     callback();
                     self.state.callbacks.appearance_changed.set(Some(callback));
-                    configure_dwm_dark_mode(handle, new_appearance);
+                    configure_dwm_dark_mode(handle, new_appearance, self.needs_win10_top_border());
                 }
             }
         }

--- a/crates/gpui_windows/src/util.rs
+++ b/crates/gpui_windows/src/util.rs
@@ -7,6 +7,7 @@ use windows::{
         Color,
         ViewManagement::{UIColorType, UISettings},
     },
+    Wdk::System::SystemServices::RtlGetVersion,
     Win32::{
         Foundation::*, Graphics::Dwm::*, System::LibraryLoader::LoadLibraryA,
         UI::WindowsAndMessaging::*,
@@ -16,6 +17,46 @@ use windows::{
 
 use crate::*;
 use gpui::*;
+
+/// The first Windows 11 build. Windows 11 reports itself as major version 10,
+/// so the build number is the only way to tell the two apart.
+const WINDOWS_11_BUILD_NUMBER: u32 = 22000;
+
+/// Whether we are running on Windows 10 rather than Windows 11 or newer.
+///
+/// The two draw the window border differently, which matters for windows that
+/// hide the system title bar: see [`WindowsWindowInner::top_border_height`].
+pub(crate) fn is_windows_10() -> bool {
+    static IS_WINDOWS_10: OnceLock<bool> = OnceLock::new();
+    *IS_WINDOWS_10.get_or_init(|| {
+        let mut version = unsafe { std::mem::zeroed() };
+        let status = unsafe { RtlGetVersion(&mut version) };
+        status.is_ok() && version.dwBuildNumber < WINDOWS_11_BUILD_NUMBER
+    })
+}
+
+/// Colour of the border Windows 10 draws around an *inactive* window, in
+/// premultiplied RGBA components.
+///
+/// Only the inactive border has to be reproduced. DWM fills the pixel of frame
+/// extended into the client area (see
+/// `WindowsWindowInner::update_frame_margins`) while the window is active, so
+/// the active border - accent colour included - comes from the system itself.
+/// It leaves that pixel alone once the window goes inactive, and this goes
+/// there instead.
+///
+/// Measured off the frame DWM draws for a stock window on Windows 10 build
+/// 19045, by sampling the border over five backdrop greys and solving
+/// `observed = premultiplied + (1 - alpha) * backdrop`: 43 over black through
+/// 170 over white, giving RGB(86, 86, 86) at 50% alpha with residuals under
+/// 0.3. It agrees with the value derived independently in the Handmade Network
+/// write-up of this same problem.
+const INACTIVE_BORDER_PREMULTIPLIED: [u8; 4] = [43, 43, 43, 128];
+
+/// [`INACTIVE_BORDER_PREMULTIPLIED`] in the form the renderer wants.
+pub(crate) fn top_border_color() -> [f32; 4] {
+    INACTIVE_BORDER_PREMULTIPLIED.map(|component| component as f32 / 255.0)
+}
 
 pub(crate) trait HiLoWord {
     fn hiword(&self) -> u16;
@@ -130,11 +171,25 @@ pub(crate) fn load_cursor(style: CursorStyle) -> Option<HCURSOR> {
     )
 }
 
-/// This function is used to configure the dark mode for the window built-in title bar.
-pub(crate) fn configure_dwm_dark_mode(hwnd: HWND, appearance: WindowAppearance) {
-    let dark_mode_enabled: BOOL = match appearance {
-        WindowAppearance::Dark | WindowAppearance::VibrantDark => true.into(),
-        WindowAppearance::Light | WindowAppearance::VibrantLight => false.into(),
+/// Configure dark mode for the window's built-in title bar.
+///
+/// `force_dark_frame` overrides `appearance` and is set for windows that hide
+/// their title bar on Windows 10: nothing of the frame is visible there except
+/// the border, and DWM renders the border of a frame-extended window pure white
+/// under the light theme. Asking for a dark frame is what makes that border
+/// visible again; see `WindowsWindowInner::update_frame_margins`.
+pub(crate) fn configure_dwm_dark_mode(
+    hwnd: HWND,
+    appearance: WindowAppearance,
+    force_dark_frame: bool,
+) {
+    let dark_mode_enabled: BOOL = if force_dark_frame {
+        true.into()
+    } else {
+        match appearance {
+            WindowAppearance::Dark | WindowAppearance::VibrantDark => true.into(),
+            WindowAppearance::Light | WindowAppearance::VibrantLight => false.into(),
+        }
     };
     unsafe {
         DwmSetWindowAttribute(

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -50,6 +50,10 @@ pub struct WindowsWindowState {
     pub border_offset: WindowBorderOffset,
     pub appearance: Cell<WindowAppearance>,
     pub background_appearance: Cell<WindowBackgroundAppearance>,
+    /// Whether the window is active, tracked from `WM_ACTIVATE`. Decides
+    /// whether the inactive top border is shown; see
+    /// [`WindowsWindowInner::update_top_border`].
+    pub active: Cell<bool>,
     pub scale_factor: Cell<f32>,
     pub restore_from_minimized: Cell<Option<Box<dyn FnMut(RequestFrameOptions)>>>,
 
@@ -162,6 +166,7 @@ impl WindowsWindowState {
             border_offset,
             appearance: Cell::new(appearance),
             background_appearance: Cell::new(WindowBackgroundAppearance::Opaque),
+            active: Cell::new(false),
             scale_factor: Cell::new(scale_factor),
             restore_from_minimized: Cell::new(restore_from_minimized),
             min_size,
@@ -550,7 +555,7 @@ impl WindowsWindow {
 
         register_drag_drop(&this)?;
         set_non_rude_hwnd(hwnd, true);
-        configure_dwm_dark_mode(hwnd, appearance);
+        configure_dwm_dark_mode(hwnd, appearance, this.needs_win10_top_border());
         this.state.border_offset.update(hwnd)?;
         let placement =
             retrieve_window_placement(hwnd, display, params.bounds, &this.state.border_offset)?;
@@ -984,10 +989,15 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn draw(&self, scene: &Scene) {
+        let top_border_height = self.top_border_height();
         self.state
             .renderer
             .borrow_mut()
-            .draw(scene, self.state.background_appearance.get())
+            .draw(
+                scene,
+                self.state.background_appearance.get(),
+                top_border_height,
+            )
             .log_err();
     }
 


### PR DESCRIPTION
# Objective

Fixes missing top window border on Windows 10 when using a custom frameless/hidden title bar, and resolves visual flickering on focus changes by aligning border updates with DWM composition commits.
Fixes #63812

## Solution

- Extended the DWM frame by extending its top margin by exactly 1 pixel into the client area via DwmExtendFrameIntoClientArea.
- Kept the top 1-pixel row clear of application rendering within GPUI to allow DWM to render its native active border (honoring user accent colors) directly into that space.
- Handled the inactive window state by leveraging composition visuals to update the 1-pixel top border asynchronously with focus changes. This avoids forcing a full engine redraw cycle (saving a ~45–60ms frame delay) and prevents active/inactive transition flashes.

## Testing

- Verified color blending mathematically by sampling pixel values at top and bottom window edges across five different backdrop grays.
- Solved the alpha blending equation $observed = premultiplied + (1 - \alpha) \cdot backdrop$ for both states:
   - Active State: Premultiplied 38.1 at $\alpha = 0.659$
   - Inactive State: Premultiplied 43.1 at $\alpha = 0.502$
   - Residuals remained under 0.3, confirming consistent rendering between top and bottom borders.
- Tested on Windows 10 and Windows 11 to confirm visual consistency across OS frame layer behaviors.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Fixed:
<img width="851" height="572" alt="image" src="https://github.com/user-attachments/assets/ccb792f6-a709-4e60-9945-ae5f76dc0c2c" />
Broken:
<img width="405" height="240" alt="image" src="https://github.com/user-attachments/assets/ae81d293-983c-4d55-9ad2-d5f25cc0bc15" />

---

Release Notes:

- Fixed missing top window border on Windows 10 when the title bar is hidden, and eliminated visual flashing during window focus changes.
