### PR TITLE
Fix connecting to devcontainers, ssh, or wsl, with a locally built Zed

### DIFF
--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -18,7 +18,7 @@ name = "remote_server"
 
 [features]
 default = []
-debug-embed = ["dep:rust-embed"]
+debug-embed = ["dep:rust-embed", "util/debug-embed"]
 test-support = ["fs/test-support"]
 
 [dependencies]


### PR DESCRIPTION
# Objective

Video overview of this PR, maybe it helps with the review: https://youtu.be/-JhKcZttXp8

Fixes: #63828

Building Zed from source and opening a project in a dev container fails with `Remote server exited with status 1`.

Zed compiles `remote_server` and uploads it into the container. The binary loads Zed's default settings from the Zed source directory, which doesn't exist there, and panics in `settings::init`:

```
thread 'main' panicked at crates/util/src/util.rs:729:10:
dev asset loading requires running from within the checkout
```

The build passes `--features debug-embed` to embed those assets instead, but `remote_server/debug-embed` only enabled its own (unused) `rust-embed` dependency. It never reached `util/debug-embed`, which is what `fs_embed!` gates on. Regression from #63396.

SSH and WSL remotes are affected the same way. Release builds are not: assets are embedded whenever `debug_assertions` is off.

## Solution

Forward the feature.

```diff
-debug-embed = ["dep:rust-embed"]
+debug-embed = ["dep:rust-embed", "util/debug-embed"]
```

The same one-line change is already included as a secondary fix in #63613, whose subject is unrelated; its author offered to split it out.

## Testing

- `cargo tree --package remote_server --features debug-embed` now resolves `util` with `debug-embed`. Before: `rand,test-support,util_macros`.
- `cargo check -p remote_server --features debug-embed --target x86_64-unknown-linux-musl` passes clean.
- Manually: built Zed from source on Linux x86_64, opened a project in a dev container (`mcr.microsoft.com/devcontainers/base:ubuntu`). Before: panic at startup. After: connects.

Not tested on macOS or Windows hosts.

No test added: this is feature wiring, and #63577 notes that nothing in Zed's graph enables `util/debug-embed`, so CI can't exercise it.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
