### PR TITLE
Clamp compaction request output budget to the context window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4128,6 +4128,7 @@ impl Thread {
             thinking_effort: self.thinking_effort.clone(),
             speed: self.speed(),
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         log::debug!("Completion request built successfully");
@@ -4494,6 +4495,8 @@ impl Thread {
             ..Default::default()
         };
 
+        request.max_output_tokens = self.compaction_max_output_tokens(model);
+
         request.messages.push(LanguageModelRequestMessage {
             role: Role::User,
             content: vec![COMPACTION_PROMPT.into()],
@@ -4502,6 +4505,30 @@ impl Thread {
         });
 
         request
+    }
+
+    /// The output-token budget for a compaction request.
+    ///
+    /// Compaction replays the whole conversation as its prompt, so the prompt
+    /// can already be at (or past) the model's reserved input budget by the time
+    /// it runs. Reserving the model's full `max_output_tokens` on top of that
+    /// overflows the context window (`input + max_output > max_token_count`) and
+    /// the server rejects the request with `context_length_exceeded`, so the
+    /// auto-compaction loop repeats the same overflow four times and gives up.
+    /// Budget the summary against the measured input and leave at least half of
+    /// the remaining window free as headroom for prompt growth, capped at the
+    /// model's default output budget.
+    fn compaction_max_output_tokens(&self, model: &Arc<dyn LanguageModel>) -> Option<u64> {
+        let max_token_count = model.max_token_count();
+        let default_output = model.max_output_tokens();
+        let Some(input_tokens) = self.latest_request_token_usage().map(total_input_tokens) else {
+            return default_output;
+        };
+        let budget = max_token_count.saturating_sub(input_tokens) / 2;
+        Some(match default_output {
+            Some(default) => budget.min(default),
+            None => budget,
+        })
     }
 
     pub fn to_markdown(&self) -> String {
@@ -4523,13 +4550,28 @@ impl Thread {
         use LanguageModelCompletionError::*;
 
         match error {
+            // A `PromptTooLarge` rejection can never succeed on its own:
+            // the same oversized prompt would be rejected again. But a
+            // zero-delay retry is the hook that lets the agentic loop reach
+            // `perform_compaction_if_needed` at the top of the next iteration
+            // so auto-compaction can shrink the context before the request is
+            // re-sent. Some providers (e.g. vLLM) return a plain HTTP 400 with
+            // no `Retry-After`, so this must be keyed on the category rather
+            // than on transience.
+            ProviderRejection {
+                category: ProviderErrorCategory::PromptTooLarge { .. },
+                ..
+            } => Some(RetryStrategy::FixedDelay {
+                delay: Duration::ZERO,
+                max_attempts: MAX_RETRY_ATTEMPTS,
+            }),
             // A rejection with no status (e.g. a content-policy rejection
             // like `cyber_policy`) is permanent: retrying sends the same
             // request and gets the same answer. A rejection with a
-            // non-retryable status (auth, payload too large, ...) is
-            // permanent for the same reason. Otherwise, honor the
-            // provider's requested delay when it gave one, and fall back to
-            // exponential backoff when it didn't.
+            // non-retryable status (auth, ...) is permanent for the same
+            // reason. Otherwise, honor the provider's requested delay when
+            // it gave one, and fall back to exponential backoff when it
+            // didn't.
             ProviderRejection { retry_after, .. } => {
                 if !error.is_transient() {
                     return None;
@@ -7129,6 +7171,75 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_compaction_max_output_tokens_clamps_to_context_window(cx: &mut TestAppContext) {
+        let (thread, _event_stream) = setup_thread_for_test(cx).await;
+        let fake_model = Arc::new(FakeLanguageModel::default());
+        // A small default caps the budget, but the clamp must never let
+        // input + budget exceed the model's context window.
+        fake_model.set_max_output_tokens(Some(32_000));
+        let model: Arc<dyn LanguageModel> = fake_model;
+        let user_message_id = ClientUserMessageId::new();
+
+        cx.update(|cx| {
+            thread.update(cx, |thread, cx| {
+                thread.set_model(model.clone(), cx);
+                thread.messages.push(user_text_message(
+                    user_message_id.clone(),
+                    "near input limit",
+                ));
+                thread.request_token_usage.insert(
+                    user_message_id.clone(),
+                    language_model::TokenUsage {
+                        input_tokens: 800_000,
+                        ..Default::default()
+                    },
+                );
+
+                // With input at 80% of the window, the default cap applies but
+                // input + budget must still fit.
+                let budget = thread
+                    .compaction_max_output_tokens(&model)
+                    .expect("model reports a max output budget");
+                let input = thread
+                    .latest_request_token_usage()
+                    .map(total_input_tokens)
+                    .unwrap();
+                assert!(budget <= 32_000);
+                assert!(input + budget <= model.max_token_count());
+
+                // Near the very limit the budget shrinks so that input + output
+                // never exceeds the window (this is where the previous bug
+                // overflowed and the server rejected the compaction request).
+                thread.request_token_usage.insert(
+                    user_message_id.clone(),
+                    language_model::TokenUsage {
+                        input_tokens: 999_000,
+                        ..Default::default()
+                    },
+                );
+                let budget = thread
+                    .compaction_max_output_tokens(&model)
+                    .expect("model reports a max output budget");
+                let input = thread
+                    .latest_request_token_usage()
+                    .map(total_input_tokens)
+                    .unwrap();
+                assert!(input + budget <= model.max_token_count());
+
+                // Even without a model-provided default, the budget stays within
+                // the window.
+                let fake_model_without_default = Arc::new(FakeLanguageModel::default());
+                let model_without_default: Arc<dyn LanguageModel> = fake_model_without_default;
+                thread.set_model(model_without_default.clone(), cx);
+                let budget = thread
+                    .compaction_max_output_tokens(&model_without_default)
+                    .expect("clamped budget is still returned");
+                assert!(input + budget <= model_without_default.max_token_count());
+            });
+        });
+    }
+
+    #[gpui::test]
     async fn test_compaction_threshold_respects_enabled_setting(cx: &mut TestAppContext) {
         let (thread, _event_stream) = setup_thread_for_test(cx).await;
         let model = Arc::new(FakeLanguageModel::default());
@@ -8522,6 +8633,38 @@ mod tests {
             strategy.delay_after(&error, MAX_RETRY_ATTEMPTS),
             Some(retry_after)
         );
+        assert_eq!(strategy.delay_after(&error, MAX_RETRY_ATTEMPTS + 1), None);
+    }
+
+    #[test]
+    fn test_retry_strategy_retries_prompt_too_large_with_zero_delay() {
+        // vLLM-style providers (like the Albert proxy) return a plain HTTP
+        // 400 `context_length_exceeded` with no `Retry-After`. The retry
+        // gives the agentic loop a chance to auto-compact before re-sending.
+        let error = LanguageModelCompletionError::from_provider_response(
+            language_model::LanguageModelProviderName::new("DeepSeek"),
+            Some(http_client::StatusCode::BAD_REQUEST),
+            Some("context_length_exceeded".to_string()),
+            "This model's maximum context length is 131072 tokens. \
+            However, you requested 24576 output tokens and your prompt \
+            contains at least 106497 input tokens, for a total of at least \
+            131073 tokens. Please reduce the length of the input prompt or \
+            the number of requested output tokens. (parameter=input_tokens, \
+            value=106497)"
+                .to_string(),
+            None,
+            language_model::ProviderErrorCategory::PromptTooLarge { tokens: None },
+        );
+        let strategy = Thread::retry_strategy_for(&error)
+            .expect("a prompt-too-large rejection should be retried");
+        assert_eq!(
+            strategy,
+            RetryStrategy::FixedDelay {
+                delay: Duration::ZERO,
+                max_attempts: MAX_RETRY_ATTEMPTS,
+            }
+        );
+        assert_eq!(strategy.delay_after(&error, 1), Some(Duration::ZERO));
         assert_eq!(strategy.delay_after(&error, MAX_RETRY_ATTEMPTS + 1), None);
     }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4521,9 +4521,19 @@ impl Thread {
     fn compaction_max_output_tokens(&self, model: &Arc<dyn LanguageModel>) -> Option<u64> {
         let max_token_count = model.max_token_count();
         let default_output = model.max_output_tokens();
-        let Some(input_tokens) = self.latest_request_token_usage().map(total_input_tokens) else {
+        let Some(mut input_tokens) = self.latest_request_token_usage().map(total_input_tokens) else {
             return default_output;
         };
+
+        // `mark_token_limit_exceeded` stores `input_tokens >= max_token_count` to drive the UI.
+        // That synthetic value isn't suitable for output budgeting, so fall back to the
+        // provider's reserved input budget when we have one.
+        if input_tokens >= max_token_count {
+            if let Some(default) = default_output {
+                input_tokens = max_token_count.saturating_sub(default);
+            }
+        }
+
         let budget = max_token_count.saturating_sub(input_tokens) / 2;
         Some(match default_output {
             Some(default) => budget.min(default),

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -557,6 +557,7 @@ impl CodegenAlternative {
                 thinking_effort: None,
                 speed: None,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             }
         }))
     }
@@ -639,6 +640,7 @@ impl CodegenAlternative {
                 thinking_effort: None,
                 speed: None,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             }
         }))
     }

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -276,6 +276,7 @@ impl TerminalInlineAssistant {
                 thinking_effort: None,
                 speed: None,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             }
         }))
     }

--- a/crates/anthropic/src/completion.rs
+++ b/crates/anthropic/src/completion.rs
@@ -907,6 +907,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let anthropic_request = into_anthropic(
@@ -1015,6 +1016,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let anthropic_request = into_anthropic(
@@ -1075,6 +1077,7 @@ mod tests {
             thinking_effort: Some("xhigh".into()),
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let anthropic_request = into_anthropic(
@@ -1126,6 +1129,7 @@ mod tests {
                 thinking_effort: None,
                 speed: None,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             };
 
             let anthropic_request = into_anthropic(
@@ -1195,6 +1199,7 @@ mod tests {
                 thinking_effort: None,
                 speed: None,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             };
 
             let anthropic_request = into_anthropic(
@@ -1261,6 +1266,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let anthropic_request = into_anthropic(
@@ -1301,6 +1307,7 @@ mod tests {
             thinking_allowed: true,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
         request.messages.push(LanguageModelRequestMessage {
             role: Role::Assistant,

--- a/crates/copilot_chat/src/model.rs
+++ b/crates/copilot_chat/src/model.rs
@@ -1077,6 +1077,7 @@ fn into_copilot_responses(
         thinking_effort,
         speed: _,
         compact_at_tokens: _,
+        max_output_tokens: _,
     } = request;
 
     let mut input_items: Vec<responses::ResponseInputItem> = Vec::new();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4155,6 +4155,7 @@ impl GitPanel {
                     thinking_effort: None,
                     speed: None,
                     compact_at_tokens: None,
+                    max_output_tokens: None,
                 };
 
                 let stream = model.stream_completion_text(request, cx);

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -473,6 +473,11 @@ pub struct LanguageModelRequest {
     pub speed: Option<Speed>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_at_tokens: Option<u64>,
+    /// Overrides the provider's default output-token budget for this request.
+    /// Used by compaction, which replays a near-full conversation and therefore
+    /// can't afford to reserve the model's full `max_output_tokens` on top of it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u64>,
 }
 
 impl LanguageModelRequest {

--- a/crates/language_models/src/provider/anthropic_compatible.rs
+++ b/crates/language_models/src/provider/anthropic_compatible.rs
@@ -439,11 +439,14 @@ impl LanguageModel for AnthropicCompatibleLanguageModel {
     > {
         let has_tools = !request.tools.is_empty();
         let request_id = self.model.request_id(has_tools).to_string();
+        let max_output_tokens = request
+            .max_output_tokens
+            .unwrap_or(self.model.max_output_tokens);
         let mut request = match into_anthropic(
             request,
             request_id,
             self.model.default_temperature,
-            self.model.max_output_tokens,
+            max_output_tokens,
             self.model.mode.clone(),
             self.cache_mode,
             &self.provider_id,

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -343,7 +343,10 @@ impl LanguageModel for DeepSeekLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        let request = match into_deepseek(request, &self.model, self.max_output_tokens()) {
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
+        let request = match into_deepseek(request, &self.model, max_output_tokens) {
             Ok(request) => request,
             Err(error) => return async move { Err(error.into()) }.boxed(),
         };

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -342,11 +342,14 @@ impl LanguageModel for MistralLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        let (request, affinity) =
-            match into_mistral(request, self.model.clone(), self.max_output_tokens()) {
-                Ok(request) => request,
-                Err(error) => return async move { Err(error.into()) }.boxed(),
-            };
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
+        let (request, affinity) = match into_mistral(request, self.model.clone(), max_output_tokens)
+        {
+            Ok(request) => request,
+            Err(error) => return async move { Err(error.into()) }.boxed(),
+        };
         let stream = self.stream_completion(request, affinity, cx);
         let executor = cx.background_executor().clone();
 
@@ -883,6 +886,7 @@ mod tests {
             thinking_effort: None,
             speed: Default::default(),
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let (mistral_request, affinity) =
@@ -915,6 +919,7 @@ mod tests {
             thinking_effort: None,
             speed: Default::default(),
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let (mistral_request, _) =
@@ -958,6 +963,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let (mistral_request, _) =

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -561,12 +561,15 @@ impl LanguageModel for OpenAiLanguageModel {
         }
 
         normalize_open_ai_response_thinking_effort(&mut request, &self.model);
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
         let request = match into_open_ai_response(
             request,
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
-            self.max_output_tokens(),
+            max_output_tokens,
             default_thinking_reasoning_effort(&self.model),
             self.model
                 .supported_reasoning_efforts()
@@ -626,6 +629,9 @@ impl LanguageModel for OpenAiLanguageModel {
         if !self.model.supports_priority() {
             request.speed = None;
         }
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
         if self.model.uses_responses_api() {
             normalize_open_ai_response_thinking_effort(&mut request, &self.model);
             let request = match into_open_ai_response(
@@ -633,7 +639,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.id(),
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
-                self.max_output_tokens(),
+                max_output_tokens,
                 default_thinking_reasoning_effort(&self.model),
                 self.model
                     .supported_reasoning_efforts()
@@ -659,7 +665,7 @@ impl LanguageModel for OpenAiLanguageModel {
                 self.model.id(),
                 self.model.supports_parallel_tool_calls(),
                 self.model.supports_prompt_cache_key(),
-                self.max_output_tokens(),
+                max_output_tokens,
                 ChatCompletionMaxTokensParameter::MaxCompletionTokens,
                 None,
                 false,

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -416,6 +416,9 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
         if !self.supports_fast_mode() {
             request.speed = None;
         }
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
 
         if self.model.capabilities.chat_completions {
             let reasoning_effort = chat_completion_reasoning_effort(&request, &self.model);
@@ -424,7 +427,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 &self.model.name,
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
-                self.max_output_tokens(),
+                max_output_tokens,
                 chat_completion_max_tokens_parameter(&self.model),
                 reasoning_effort,
                 self.model.capabilities.interleaved_reasoning,
@@ -449,7 +452,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 &self.model.name,
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
-                self.max_output_tokens(),
+                max_output_tokens,
                 default_thinking_reasoning_effort(&self.model),
                 supports_none_reasoning_effort(&self.model),
                 &self.provider_id,

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -434,11 +434,13 @@ impl LanguageModel for OpenRouterLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        let openrouter_request =
-            match into_open_router(request, &self.model, self.max_output_tokens()) {
-                Ok(request) => request,
-                Err(error) => return async move { Err(error.into()) }.boxed(),
-            };
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
+        let openrouter_request = match into_open_router(request, &self.model, max_output_tokens) {
+            Ok(request) => request,
+            Err(error) => return async move { Err(error.into()) }.boxed(),
+        };
         let request = self.stream_completion(openrouter_request, cx);
         let executor = cx.background_executor().clone();
         let future = self.request_limiter.stream(async move {
@@ -867,6 +869,7 @@ mod tests {
             prompt_id: None,
             intent: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let result = into_open_router(request, &model, None).unwrap();
@@ -1009,6 +1012,7 @@ mod tests {
             prompt_id: None,
             intent: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let result = into_open_router(request, &model, None).unwrap();
@@ -1075,6 +1079,7 @@ mod tests {
             prompt_id: None,
             intent: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let result = into_open_router(request, &model, None).unwrap();

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -447,12 +447,15 @@ impl LanguageModel for VercelAiGatewayLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
         let request = match crate::provider::open_ai::into_open_ai(
             request,
             &self.model.name,
             self.model.capabilities.parallel_tool_calls,
             self.model.capabilities.prompt_cache_key,
-            self.max_output_tokens(),
+            max_output_tokens,
             crate::provider::open_ai::ChatCompletionMaxTokensParameter::MaxCompletionTokens,
             None,
             false,

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -414,12 +414,15 @@ impl LanguageModel for XAiLanguageModel {
         >,
     > {
         let reasoning_effort = reasoning_effort_for_request(&request, &self.model);
+        let max_output_tokens = request
+            .max_output_tokens
+            .or_else(|| self.max_output_tokens());
         let request = match crate::provider::open_ai::into_open_ai(
             request,
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
-            self.max_output_tokens(),
+            max_output_tokens,
             crate::provider::open_ai::ChatCompletionMaxTokensParameter::MaxCompletionTokens,
             reasoning_effort,
             false,

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -272,6 +272,7 @@ pub fn into_open_ai_response(
         thinking_effort,
         speed,
         compact_at_tokens,
+        max_output_tokens: _,
     } = request;
 
     let service_tier = service_tier_for(speed);
@@ -1834,6 +1835,7 @@ mod tests {
             thinking_effort: Some("high".into()),
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2020,6 +2022,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2121,6 +2124,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2206,6 +2210,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2272,6 +2277,7 @@ mod tests {
             thinking_effort: Some("high".into()),
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2318,6 +2324,7 @@ mod tests {
                 thinking_effort: None,
                 speed,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             };
 
             let response = into_open_ai_response(
@@ -2370,6 +2377,7 @@ mod tests {
                 thinking_effort: None,
                 speed,
                 compact_at_tokens: None,
+                max_output_tokens: None,
             };
 
             let chat = into_open_ai(
@@ -2415,6 +2423,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let chat = into_open_ai(
@@ -2454,6 +2463,7 @@ mod tests {
             thinking_effort: Some("high".into()),
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2495,6 +2505,7 @@ mod tests {
             thinking_effort: Some("none".into()),
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2548,6 +2559,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2640,6 +2652,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -2730,6 +2743,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let response = into_open_ai_response(
@@ -4034,6 +4048,7 @@ mod tests {
             thinking_effort: None,
             speed: None,
             compact_at_tokens: None,
+            max_output_tokens: None,
         };
 
         let result = into_open_ai(


### PR DESCRIPTION
## Summary

Fixes a failure mode where a `context_length_exceeded` 400 from a vLLM-style provider blocked auto-compaction entirely, leaving users stuck with repeated Context Too Large banners.

### Root cause

When the agent thread fills the context window it triggers auto-compaction by POSTing the full (near-limit) message history as a fresh completion request. That compaction request was sent with the model's full default `max_output_tokens` budget on top of the already near-limit input, so it overflowed the context window:

- `max_token_count` = 131072, `max_output_tokens` = 24576
- compaction input = 106497 tokens → 106497 + 24576 > 131072

The provider rejects this with a plain HTTP 400 `context_length_exceeded`. Because that error category was mapped to a non-retryable strategy, `perform_compaction_if_needed` never fired: auto-compaction silently failed while the user kept seeing Context Too Large banners.

### Fix

- `crates/language_model_core/src/request.rs`: add a request-scoped `max_output_tokens: Option<u64>` to `LanguageModelRequest` so compaction can carry a clamped output budget.
- `crates/agent/src/thread.rs`:
  - `build_compaction_request` sets `max_output_tokens` from the new `compaction_max_output_tokens(model)`, which clamps the budget to `(max_token_count - input_tokens) / 2`, capped at the model's default. This guarantees `input + budget ≤ max_token_count` so the compaction POST can never overflow.
  - `retry_strategy_for` now returns `PromptTooLarge` as a `FixedDelay { delay: Duration::ZERO, max_attempts: MAX_RETRY_ATTEMPTS }`, so a plain-HTTP-400 context-length rejection reaches `perform_compaction_if_needed`.
- Providers (`open_ai_compatible`, `open_ai` incl. `compact`, `anthropic_compatible`, `deepseek`, `mistral`, `open_router`, `vercel_ai_gateway`, `x_ai`) substitute `request.max_output_tokens.or_else(|| self.max_output_tokens())` so the clamped budget is honored on the wire.

### Test coverage

- `test_compaction_max_output_tokens_clamps_to_context_window` proves `input + budget ≤ max_token_count` near the limit, with and without a model-provided default.
- `test_retry_strategy_retries_prompt_too_large_with_zero_delay` covers the new retry mapping.
- `cargo test -p agent --lib thread::tests::test_compaction` (10/10), `test_retry_strategy` (6/6), and provider crates are green; `./script/clippy` and `cargo fmt --check` are clean.

## Suggested .rules additions

Compaction requests must override `max_output_tokens` on `LanguageModelRequest`, otherwise the compaction POST replays a near-full context with the full output budget and overflows; and a 400 `PromptTooLarge` only reaches compaction because `retry_strategy_for` maps that category to a zero-delay retry.

Release Notes:

- Fixed auto-compaction failing when the compaction request itself exceeds the context window
