### PR TITLE
grammars: Highlight C23 `constexpr` keyword

### DIFF
--- a/crates/grammars/src/c/highlights.scm
+++ b/crates/grammars/src/c/highlights.scm
@@ -1,5 +1,6 @@
 [
   "const"
+  "constexpr"
   "enum"
   "extern"
   "inline"


### PR DESCRIPTION
# Objective

- the keyword `constexpr` was added in c23, see [here](https://en.wikipedia.org/wiki/C23_(C_standard_revision)#Constants)

## Solution

- added `constexpr` to keyword list in c

## Testing

- compiled and tested it to see `constexpr` is now highlighted

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- added `constexpr` keyword to c language 
