### PR TITLE
language: Treat sparse NUL bytes as binary instead of text

### DIFF
--- a/crates/language/src/file_content.rs
+++ b/crates/language/src/file_content.rs
@@ -100,9 +100,9 @@ pub enum ByteContent {
     Unknown,
 }
 
-// Heuristic check using null byte distribution plus a generic text-likeness
-// heuristic. This prefers UTF-16 when many bytes are NUL and otherwise
-// distinguishes between text-like and binary-like content.
+// Heuristic check based on NUL bytes: content without any is treated as text,
+// content with them is UTF-16 when its NUL distribution and code units look
+// like UTF-16 text, and binary otherwise.
 pub fn analyze_byte_content(bytes: &[u8]) -> ByteContent {
     if bytes.len() < 2 {
         return ByteContent::Unknown;
@@ -115,7 +115,6 @@ pub fn analyze_byte_content(bytes: &[u8]) -> ByteContent {
     let limit = bytes.len().min(FILE_ANALYSIS_BYTES);
     let mut even_null_count = 0usize;
     let mut odd_null_count = 0usize;
-    let mut non_text_like_count = 0usize;
 
     for (i, &byte) in bytes[..limit].iter().enumerate() {
         if byte == 0 {
@@ -124,20 +123,6 @@ pub fn analyze_byte_content(bytes: &[u8]) -> ByteContent {
             } else {
                 odd_null_count += 1;
             }
-            non_text_like_count += 1;
-            continue;
-        }
-
-        let is_text_like = match byte {
-            b'\t' | b'\n' | b'\r' | 0x0C => true,
-            0x20..=0x7E => true,
-            // Treat bytes that are likely part of UTF-8 or single-byte encodings as text-like.
-            0x80..=0xBF | 0xC2..=0xF4 => true,
-            _ => false,
-        };
-
-        if !is_text_like {
-            non_text_like_count += 1;
         }
     }
 
@@ -148,6 +133,11 @@ pub fn analyze_byte_content(bytes: &[u8]) -> ByteContent {
         return ByteContent::Unknown;
     }
 
+    // UTF-16 text spends roughly half its bytes on NUL, so this density check
+    // is what rules the encoding out below rather than merely failing to
+    // confirm it: with a single NUL byte the skew comparisons pass trivially,
+    // and ASCII read as UTF-16 lands on code units that
+    // `is_plausible_utf16_text` counts as word-like.
     let has_significant_nulls = total_null_count >= limit / 16;
     let nulls_skew_to_even = even_null_count > odd_null_count * 4;
     let nulls_skew_to_odd = odd_null_count > even_null_count * 4;
@@ -165,15 +155,14 @@ pub fn analyze_byte_content(bytes: &[u8]) -> ByteContent {
         if nulls_skew_to_odd && is_plausible_utf16_text(sample, true) {
             return ByteContent::Utf16Le;
         }
-
-        return ByteContent::Binary;
     }
 
-    if non_text_like_count * 100 < limit * 8 {
-        ByteContent::Unknown
-    } else {
-        ByteContent::Binary
-    }
+    // Not UTF-16, and NUL bytes are present. Weighing how many of them there
+    // are against how text-like the rest of the prefix looks would let through
+    // container formats that put a short binary header in front of an ASCII
+    // payload: a `.safetensors` file spends eight bytes on a little-endian
+    // header length and the whole rest of the sniffed prefix on JSON.
+    ByteContent::Binary
 }
 
 fn is_known_binary_header(bytes: &[u8]) -> bool {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -7633,6 +7633,54 @@ mod tests {
         );
     }
 
+    // A `.safetensors` file starts with an 8-byte little-endian length for its
+    // JSON header, followed by that JSON, so the sniffed prefix is a handful of
+    // NUL bytes in front of a kilobyte of ASCII.
+    fn build_safetensors_bytes(header_len: u64) -> Vec<u8> {
+        let mut bytes = header_len.to_le_bytes().to_vec();
+        let json = br#"{"__metadata__":{"format":"pt"},"encoder.conv_in.weight":{"dtype":"BF16","shape":[128,3,3,3],"data_offsets":[0,6912]},"#;
+        while bytes.len() < FILE_ANALYSIS_BYTES {
+            let take = (FILE_ANALYSIS_BYTES - bytes.len()).min(json.len());
+            bytes.extend_from_slice(&json[..take]);
+        }
+        bytes
+    }
+
+    #[test]
+    fn test_safetensors_detected_as_binary() {
+        // Header lengths spanning what real models carry, from a single small
+        // tensor up to the tens of kilobytes of a full diffusion model.
+        for header_len in [120, 4660, 28 * 1024, 1 << 24] {
+            let bytes = build_safetensors_bytes(header_len);
+            assert_eq!(bytes.len(), FILE_ANALYSIS_BYTES);
+
+            assert_eq!(
+                analyze_byte_content(&bytes),
+                ByteContent::Binary,
+                "safetensors with a {header_len} byte JSON header should be detected as Binary"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sparse_nulls_not_misdetected_as_utf16() {
+        // One NUL byte satisfies the even/odd skew comparison trivially, and
+        // ASCII read as UTF-16 lands on code units above U+00FF, which the
+        // plausibility check counts as word-like. Nothing but the NUL density
+        // requirement keeps this out of the UTF-16 branch.
+        let mut bytes = b"# config\nkey = value\n\0".to_vec();
+        while bytes.len() < FILE_ANALYSIS_BYTES {
+            bytes.extend_from_slice(b"another = line\n");
+        }
+        bytes.truncate(FILE_ANALYSIS_BYTES);
+
+        assert_eq!(
+            analyze_byte_content(&bytes),
+            ByteContent::Binary,
+            "text with a single stray NUL byte should not be read as UTF-16"
+        );
+    }
+
     #[test]
     fn test_utf16le_text_detected_as_utf16le() {
         let text = "Hello, world! This is a UTF-16 test string. ";


### PR DESCRIPTION
# Objective

- Fixes #63341
- Clicking a `.safetensors` model file, or dragging one into the project panel, makes Zed read the whole file into memory and try to open it as an editable buffer. The reporter saw resident memory grow by 4.7 GB.
- The size guard is not what is failing here. `analyze_byte_content` classifies the file as text in the first place, so the 6 GiB `FILE_SIZE_MAX` in `Worktree::load_file` is the only thing standing between a click and the whole model in RAM.

## Solution

A `.safetensors` file begins with an 8-byte little-endian header length, followed by that many bytes of JSON. The header runs to tens of kilobytes on a real model, so the 1024-byte prefix Zed sniffs is six or seven NUL bytes followed by pure ASCII.

`analyze_byte_content` only concluded "binary" from NUL bytes once they made up a sixteenth of the prefix — 64 of 1024. Below that it fell through to a text-likeness ratio, which a JSON payload passes comfortably. So the file was classified `Unknown`, i.e. text.

This PR drops the text-likeness fallback: NUL bytes that do not look like UTF-16 now mean binary. That is the rule git, ripgrep and VS Code use, and it fixes the shape rather than the format — any container that puts a short binary header in front of an ASCII payload contributes too few NUL bytes for a density test to catch.

The density requirement stays where it is actually needed, guarding the UTF-16 hypothesis. That is load-bearing and I nearly removed it by mistake: with a single NUL byte the even/odd skew comparisons pass trivially, and ASCII read as UTF-16 lands on code units above U+00FF, which `is_plausible_utf16_text` counts as word-like. Without the gate, a text file with one stray NUL is misdetected as UTF-16BE and decoded into garbage — strictly worse than the bug being fixed. `test_sparse_nulls_not_misdetected_as_utf16` pins that down.

## Testing

- `cargo test -p worktree --lib tests::` — 16 pass, including the six pre-existing UTF-16 and binary-header tests, so legitimate UTF-16 detection is untouched.
- Two new tests in `crates/worktree/src/worktree.rs`, alongside the existing detection tests:
  - `test_safetensors_detected_as_binary`, over JSON header lengths from 120 bytes to 16 MiB.
  - `test_sparse_nulls_not_misdetected_as_utf16`, which fails if the density gate on the UTF-16 branch is removed.
- Verified against real files rather than only synthetic ones: fetched the first 1 KiB of `sentence-transformers/all-MiniLM-L6-v2` and `stabilityai/sdxl-vae` with HTTP range requests (header lengths 11408 and 27808, six NUL bytes each). Both classify `Unknown` before the patch and `Binary` after.
- Ran the old and new versions of `analyze_byte_content` side by side over a matrix of encodings. Only two inputs change classification, both intended: a `.safetensors` prefix, and ASCII text carrying a stray NUL byte. BOM-less UTF-16 in ASCII, Cyrillic and Greek, UTF-8 CJK, and Latin-1 are all unchanged. BOM-less UTF-16 CJK was already `Binary` before this change.
- `cargo clippy -p language -p worktree --all-targets` and `cargo fmt --check` are clean.
- Not tested: opening a real multi-GB model in a running Zed. I do not have the disk headroom for a full app build, so the verification above is at the classifier level.

## Notes for review

- I asked in the issue which of the two shapes below you would prefer before opening a PR, and have put this up anyway rather than sit on it — CONTRIBUTING suggests opening early so the discussion can happen with code in hand. Swapping to the narrow version is a small change.
- **This changes behaviour beyond the reported bug.** Any non-UTF-16 file with even one NUL byte in its first kilobyte is now binary where it used to open. Three call sites see it: file open (`worktree.rs:7248`, `:7276`) now reports "Binary files are not supported", project search silently skips the file (`project_search.rs:843`), and reloading an already-open buffer hard-errors (`buffer.rs:1680`). The realistic casualty is something like a saved `find -print0` listing. I think that trade is right — those files are binary by every other tool's definition — but it is a product call, so say the word if you would rather have the narrow version.
- **The narrow alternative**, if you prefer zero collateral: a structural `.safetensors` signature in `is_known_binary_header` — first eight bytes parse as a plausible header length and byte 8 is `{`. It fixes only this format. I can swap to it in a few minutes.
- **An adjacent defect I deliberately left alone.** Even with correct detection, `decode_file_text` re-reads the whole file into a `Vec<u8>` and runs chardetng over all of it whenever the streaming UTF-8 path bails, bounded only by `FILE_SIZE_MAX`. A large Windows-1252 log has the same memory profile as the model file in this issue. Out of scope here; happy to open a separate issue.
- The reporter also mentions that appending readable text to an ELF binary defeats the check. I could not reproduce that — ELF's magic sits at offset 0, so `is_known_binary_header` still catches it — and did not chase it in this PR.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A, no unsafe code
- [x] The content adheres to Zed's UI standards — N/A, no UI change
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — the loop now does strictly less work per byte, and still only over the first kilobyte

---

Release Notes:

- Fixed: Zed no longer reads large model files such as `.safetensors` into memory as though they were text.
