### PR TITLE
refactor: remove unessecary path prefix check git

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1658,9 +1658,7 @@ impl GitRepository for RealGitRepository {
                 }
 
                 let path = PathBuf::from(&raw_path);
-                let path = if let Some(path) = raw_path.strip_prefix("~/") {
-                    paths::home_dir().join(path)
-                } else if path.is_relative() {
+                let path = if path.is_relative() {
                     working_directory.join(path)
                 } else {
                     path


### PR DESCRIPTION
# Objective

Just refactors a condition which will never happen in crates/git/repoistory.ts. There is a check to see if git config commit.template outputs ~/ as prefix instead of /Users/user/home. This check is unnecessary and confused me because git config commit.template will never output ~/ in the path. I checked the git codebase and they output the full path without the prefix.

## Solution

Removed the condition. Easier to read the code now.

## Testing

Ran test cases which passed. Also checked on macos, windows and linux and seems to work in each.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---
