### PR TITLE
fs: Speed up worktree scanning on Windows by not opening every file

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -141,11 +141,26 @@ pub trait Fs: Send + Sync {
     async fn is_file(&self, path: &Path) -> bool;
     async fn is_dir(&self, path: &Path) -> bool;
     async fn metadata(&self, path: &Path) -> Result<Option<Metadata>>;
+    async fn is_executable(&self, path: &Path) -> bool;
     async fn read_link(&self, path: &Path) -> Result<PathBuf>;
     async fn read_dir(
         &self,
         path: &Path,
     ) -> Result<Pin<Box<dyn Send + Stream<Item = Result<PathBuf>>>>>;
+
+    async fn read_dir_with_metadata(
+        &self,
+        path: &Path,
+    ) -> Result<Vec<(PathBuf, Option<Metadata>)>> {
+        let mut children = self.read_dir(path).await?;
+        let mut result = Vec::new();
+        while let Some(child) = children.next().await {
+            let child = child?;
+            let metadata = self.metadata(&child).await.ok().flatten();
+            result.push((child, metadata));
+        }
+        Ok(result)
+    }
 
     async fn watch(
         &self,
@@ -301,7 +316,6 @@ pub struct Metadata {
     pub is_dir: bool,
     pub len: u64,
     pub is_fifo: bool,
-    pub is_executable: bool,
     pub is_writable: bool,
 }
 
@@ -1101,12 +1115,6 @@ impl Fs for RealFs {
         #[cfg(unix)]
         let is_fifo = metadata.file_type().is_fifo();
 
-        let path_buf = path.to_path_buf();
-        let is_executable = self
-            .executor
-            .spawn(async move { path_buf.is_executable() })
-            .await;
-
         Ok(Some(Metadata {
             inode,
             mtime: MTime(metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)),
@@ -1114,9 +1122,37 @@ impl Fs for RealFs {
             is_symlink,
             is_dir: metadata.file_type().is_dir(),
             is_fifo,
-            is_executable,
             is_writable: !metadata.permissions().readonly(),
         }))
+    }
+
+    async fn is_executable(&self, path: &Path) -> bool {
+        let path = path.to_path_buf();
+        self.executor
+            .spawn(async move { path.is_executable() })
+            .await
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn read_dir_with_metadata(
+        &self,
+        path: &Path,
+    ) -> Result<Vec<(PathBuf, Option<Metadata>)>> {
+        let dir = path.to_path_buf();
+        let entries = self
+            .executor
+            .spawn(async move { read_dir_with_metadata_windows(&dir) })
+            .await?;
+
+        let mut result = Vec::with_capacity(entries.len());
+        for (path, metadata) in entries {
+            let metadata = match metadata {
+                Some(metadata) => Some(metadata),
+                None => self.metadata(&path).await.ok().flatten(),
+            };
+            result.push((path, metadata));
+        }
+        Ok(result)
     }
 
     async fn read_link(&self, path: &Path) -> Result<PathBuf> {
@@ -3265,7 +3301,6 @@ impl Fs for FakeFs {
                     is_dir: false,
                     is_symlink,
                     is_fifo: false,
-                    is_executable: false,
                     is_writable: true,
                 },
                 FakeFsEntry::Dir {
@@ -3277,7 +3312,6 @@ impl Fs for FakeFs {
                     is_dir: true,
                     is_symlink,
                     is_fifo: false,
-                    is_executable: false,
                     is_writable: true,
                 },
                 FakeFsEntry::Symlink { .. } => unreachable!(),
@@ -3285,6 +3319,10 @@ impl Fs for FakeFs {
         } else {
             Ok(None)
         }
+    }
+
+    async fn is_executable(&self, _path: &Path) -> bool {
+        false
     }
 
     async fn read_link(&self, path: &Path) -> Result<PathBuf> {
@@ -3537,6 +3575,114 @@ fn read_recursive<'a>(
         Ok(())
     }
     .boxed()
+}
+
+/// Enumerates `dir`, returning each child's name together with everything [`Metadata`] needs.
+#[cfg(target_os = "windows")]
+fn read_dir_with_metadata_windows(dir: &Path) -> Result<Vec<(PathBuf, Option<Metadata>)>> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Foundation::{ERROR_NO_MORE_FILES, HANDLE};
+    use windows::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_READONLY, FILE_ATTRIBUTE_REPARSE_POINT,
+        FILE_FLAG_BACKUP_SEMANTICS, FileIdBothDirectoryInfo, GetFileInformationByHandleEx,
+    };
+
+    // Field offsets of `FILE_ID_BOTH_DIR_INFO`.
+    const OFF_NEXT_ENTRY: usize = 0;
+    const OFF_LAST_WRITE_TIME: usize = 24;
+    const OFF_END_OF_FILE: usize = 40;
+    const OFF_FILE_ATTRIBUTES: usize = 56;
+    const OFF_FILE_NAME_LENGTH: usize = 60;
+    const OFF_FILE_ID: usize = 96;
+    const OFF_FILE_NAME: usize = 104;
+    /// 100ns intervals between 1601-01-01 and the Unix epoch.
+    const FILETIME_TO_UNIX: i64 = 116_444_736_000_000_000;
+
+    let directory = {
+        use std::os::windows::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
+            .open(dir)
+            .with_context(|| format!("failed to open directory {dir:?}"))?
+    };
+    let handle = HANDLE(directory.as_raw_handle() as _);
+
+    fn as_bytes(buffer: &[u64]) -> &[u8] {
+        // SAFETY: `u8` has weaker alignment than `u64` and every bit pattern is valid for it.
+        unsafe { std::slice::from_raw_parts(buffer.as_ptr().cast(), size_of_val(buffer)) }
+    }
+
+    // contain `LARGE_INTEGER` fields
+    let mut buffer = vec![0u64; 32 * 1024 / size_of::<u64>()];
+    let byte_len = (buffer.len() * size_of::<u64>()) as u32;
+    let mut entries = Vec::new();
+
+    loop {
+        // SAFETY: `buffer` is owned here, correctly aligned, and its length in bytes is passed
+        // alongside it; `handle` is open for the duration of the call.
+        let more = unsafe {
+            GetFileInformationByHandleEx(
+                handle,
+                FileIdBothDirectoryInfo,
+                buffer.as_mut_ptr().cast(),
+                byte_len,
+            )
+        };
+        if let Err(error) = more {
+            if error.code() == ERROR_NO_MORE_FILES.to_hresult() {
+                break;
+            }
+            return Err(anyhow::Error::new(error))
+                .with_context(|| format!("failed to enumerate directory {dir:?}"));
+        }
+
+        let bytes: &[u8] = as_bytes(&buffer);
+        let mut offset = 0usize;
+        loop {
+            let entry = &bytes[offset..];
+            let read_u32 = |at: usize| u32::from_le_bytes(entry[at..at + 4].try_into().unwrap());
+            let read_i64 = |at: usize| i64::from_le_bytes(entry[at..at + 8].try_into().unwrap());
+
+            let name_len = read_u32(OFF_FILE_NAME_LENGTH) as usize / size_of::<u16>();
+            let name: Vec<u16> = entry[OFF_FILE_NAME..OFF_FILE_NAME + name_len * 2]
+                .chunks_exact(2)
+                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .collect();
+            let name = String::from_utf16_lossy(&name);
+
+            if name != "." && name != ".." {
+                let attributes = read_u32(OFF_FILE_ATTRIBUTES);
+                let is_symlink = attributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0;
+                let is_dir = attributes & FILE_ATTRIBUTE_DIRECTORY.0 != 0;
+                let metadata = (!is_symlink && !is_dir).then(|| {
+                    let filetime = read_i64(OFF_LAST_WRITE_TIME) - FILETIME_TO_UNIX;
+                    let (secs, nanos) = (
+                        (filetime / 10_000_000).max(0) as u64,
+                        ((filetime % 10_000_000).max(0) * 100) as u32,
+                    );
+                    Metadata {
+                        inode: read_i64(OFF_FILE_ID) as u64,
+                        mtime: MTime::from_seconds_and_nanos(secs, nanos),
+                        len: read_i64(OFF_END_OF_FILE) as u64,
+                        is_dir: false,
+                        is_symlink: false,
+                        is_fifo: false,
+                        is_writable: attributes & FILE_ATTRIBUTE_READONLY.0 == 0,
+                    }
+                });
+                entries.push((dir.join(&name), metadata));
+            }
+
+            let next = read_u32(OFF_NEXT_ENTRY) as usize;
+            if next == 0 {
+                break;
+            }
+            offset += next;
+        }
+    }
+
+    Ok(entries)
 }
 
 // todo(windows)

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -682,7 +682,7 @@ async fn test_realfs_broken_symlink_metadata(executor: BackgroundExecutor) {
     assert!(metadata.is_symlink);
     assert!(!metadata.is_dir);
     assert!(!metadata.is_fifo);
-    assert!(!metadata.is_executable);
+    assert!(!fs.is_executable(&symlink_path).await);
     // don't care about len or mtime on symlinks?
 }
 
@@ -702,7 +702,7 @@ async fn test_realfs_symlink_loop_metadata(executor: BackgroundExecutor) {
     assert!(metadata.is_symlink);
     assert!(!metadata.is_dir);
     assert!(!metadata.is_fifo);
-    assert!(!metadata.is_executable);
+    assert!(!fs.is_executable(&symlink_path).await);
     // don't care about len or mtime on symlinks?
 }
 
@@ -1228,4 +1228,79 @@ async fn restore_can_be_retried_after_collision(cx: &mut TestAppContext) {
         fs.restore(trash_id).await.unwrap_err(),
         TrashRestoreError::AlreadyRestored
     ));
+}
+
+/// Tests that `read_dir_with_metadata` reports the same metadata as `metadata` does, for every
+/// field and every kind of entry.
+#[gpui::test]
+async fn test_read_dir_with_metadata_matches_metadata(executor: BackgroundExecutor) {
+    executor.allow_parking();
+
+    let tempdir = TempDir::new().unwrap();
+    let root = tempdir.path();
+    let fs = RealFs::new(None, executor);
+
+    std::fs::create_dir(root.join("subdir")).unwrap();
+    std::fs::write(root.join("empty.txt"), b"").unwrap();
+    std::fs::write(root.join("small.txt"), b"hello").unwrap();
+    std::fs::write(root.join("larger.bin"), vec![7u8; 100_000]).unwrap();
+    std::fs::write(root.join("subdir").join("nested.txt"), b"nested").unwrap();
+    std::fs::write(root.join("naïve_λ.txt"), b"unicode name").unwrap();
+
+    let read_only = root.join("readonly.txt");
+    std::fs::write(&read_only, b"locked down").unwrap();
+    let mut permissions = std::fs::metadata(&read_only).unwrap().permissions();
+    permissions.set_readonly(true);
+    std::fs::set_permissions(&read_only, permissions).unwrap();
+
+    let listed = fs.read_dir_with_metadata(root).await.unwrap();
+    assert!(
+        listed.len() == 6,
+        "expected every entry to be listed, got {:?}",
+        listed.iter().map(|(p, _)| p).collect::<Vec<_>>()
+    );
+
+    for (path, listed_metadata) in listed {
+        let expected = fs
+            .metadata(&path)
+            .await
+            .unwrap_or_else(|error| panic!("metadata for {path:?} failed: {error}"))
+            .unwrap_or_else(|| panic!("no metadata for {path:?}"));
+        let listed_metadata =
+            listed_metadata.unwrap_or_else(|| panic!("no listed metadata for {path:?}"));
+
+        assert_eq!(listed_metadata.is_dir, expected.is_dir, "is_dir {path:?}");
+        assert_eq!(
+            listed_metadata.is_symlink, expected.is_symlink,
+            "is_symlink {path:?}"
+        );
+        assert_eq!(listed_metadata.inode, expected.inode, "inode {path:?}");
+        assert_eq!(
+            listed_metadata.is_fifo, expected.is_fifo,
+            "is_fifo {path:?}"
+        );
+        assert_eq!(
+            listed_metadata.is_writable, expected.is_writable,
+            "is_writable {path:?}"
+        );
+        assert_eq!(listed_metadata.mtime, expected.mtime, "mtime {path:?}");
+        if !expected.is_dir {
+            assert_eq!(listed_metadata.len, expected.len, "len {path:?}");
+        }
+    }
+
+    let listed = fs.read_dir_with_metadata(root).await.unwrap();
+    let mut inodes = listed
+        .iter()
+        .filter(|(path, _)| path.is_file())
+        .filter_map(|(_, metadata)| metadata.as_ref().map(|metadata| metadata.inode))
+        .collect::<Vec<_>>();
+    let total = inodes.len();
+    inodes.sort_unstable();
+    inodes.dedup();
+    assert_eq!(
+        inodes.len(),
+        total,
+        "file ids must be unique across entries"
+    );
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8909,7 +8909,7 @@ impl Repository {
                         ..
                     }) => {
                         let executable = match fs.metadata(&abs_path).await {
-                            Ok(Some(meta)) => meta.is_executable,
+                            Ok(Some(_)) => fs.is_executable(&abs_path).await,
                             Ok(None) => false,
                             Err(_err) => false,
                         };

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5362,34 +5362,20 @@ impl BackgroundScanner {
         let mut root_canonical_path = None;
         let mut new_entries: Vec<Entry> = Vec::new();
         let mut new_jobs: Vec<Option<ScanJob>> = Vec::new();
-        let mut child_paths = self
-            .fs
-            .read_dir(&job.abs_path)
-            .await?
-            .filter_map(|entry| async {
-                match entry {
-                    Ok(entry) => Some(entry),
-                    Err(error) => {
-                        log::error!("error processing entry {:?}", error);
-                        None
-                    }
-                }
-            })
-            .collect::<Vec<_>>()
-            .await;
+        let mut child_paths = self.fs.read_dir_with_metadata(&job.abs_path).await?;
 
         // Ensure that .git and .gitignore are processed first.
         swap_to_front(&mut child_paths, GITIGNORE);
         swap_to_front(&mut child_paths, DOT_GIT);
 
-        if let Some(path) = child_paths.first()
+        if let Some((path, _)) = child_paths.first()
             && path.ends_with(DOT_GIT)
         {
             ignore_stack.repo_root = Some(job.abs_path.clone());
             ignore_stack.global_ignore_root = Some(job.abs_path.clone());
         }
 
-        for child_abs_path in child_paths {
+        for (child_abs_path, child_listed_metadata) in child_paths {
             let child_abs_path: Arc<Path> = child_abs_path.into();
             let child_name = child_abs_path.file_name().unwrap();
             let Some(child_path) = child_name
@@ -5445,13 +5431,16 @@ impl BackgroundScanner {
                 continue;
             }
 
-            let child_metadata = match self.fs.metadata(&child_abs_path).await {
-                Ok(Some(metadata)) => metadata,
-                Ok(None) => continue,
-                Err(err) => {
-                    log::error!("error processing {:?}: {err:#}", child_abs_path.display());
-                    continue;
-                }
+            let child_metadata = match child_listed_metadata {
+                Some(metadata) => metadata,
+                None => match self.fs.metadata(&child_abs_path).await {
+                    Ok(Some(metadata)) => metadata,
+                    Ok(None) => continue,
+                    Err(err) => {
+                        log::error!("error processing {:?}: {err:#}", child_abs_path.display());
+                        continue;
+                    }
+                },
             };
 
             let mut child_entry = Entry::new(
@@ -6473,10 +6462,10 @@ fn is_beyond_scan_depth(file_scan_depth: Option<u32>, path: &RelPath) -> bool {
     file_scan_depth.is_some_and(|depth| path.components().count() >= depth as usize)
 }
 
-fn swap_to_front(child_paths: &mut Vec<PathBuf>, file: &str) {
+fn swap_to_front(child_paths: &mut Vec<(PathBuf, Option<fs::Metadata>)>, file: &str) {
     let position = child_paths
         .iter()
-        .position(|path| path.file_name().unwrap() == file);
+        .position(|(path, _)| path.file_name().unwrap() == file);
     if let Some(position) = position {
         let temp = child_paths.remove(position);
         child_paths.insert(0, temp);


### PR DESCRIPTION
# Objective


Opening a folder in Zed on Windows is far slower than it needs to be, because scanning a worktree opens every file in the repository twice.

`Fs::metadata` is called for every entry a scan touches, and on Windows two of its fields are obtained by opening the file:

- `is_executable` -> `GetBinaryTypeW`, which **reads the file's PE header** to classify the binary
- `inode` -> `file_id`, which opens the file to read its 64-bit index

Neither is needed per entry. `is_executable`'s only caller needs it when staging a file to git, and the worktree `Entry` has no field for it at all,  so the value was computed for every file and immediately discarded

.

## Solution

**1. `is_executable` moves off `Metadata` onto its own `Fs` method**, so it is computed when a caller asks for it rather than for every entry a scan touches.

**2. `Fs::read_dir_with_metadata` pairs each child with its metadata.** The default implementation reads the directory and stats each child, so Unix behaviour is unchanged. Windows overrides it with a single `GetFileInformationByHandleEx(FileIdBothDirectoryInfo)` call per directory, which returns names, attributes, sizes, mtimes **and file ids** together. The scanner carries that metadata through instead of re-statting each child.

Directories and reparse points still fall back to a stat: NTFS updates a subdirectory's timestamps in its parent's index lazily, so the listing can report a stale mtime for one, and a listing describes a symlink rather than its target.

Linux kernel tree, Windows on 5950x by running  ``release\worktree_benchmarks.exe``:

| | cold | warm |
|---|---|---|
| before | 34.8s | 2.89s |
| after | **0.96s** | **0.91s** |

## Testing

New test `test_read_dir_with_metadata_matches_metadata` asserts the listing agrees with `metadata` on every field (`inode`, `len`, `mtime`, `is_dir`, `is_symlink`, `is_fifo`, `is_writable`) across files, directories, a read-only file etc 



Release Notes:

- Improved the speed of opening a project on Windows.
