### PR TITLE
agent_ui: surface elicitation as "awaiting confirmation" thread status

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -424,6 +424,15 @@ impl Conversation {
             .unwrap_or(0)
     }
 
+    /// Returns true if `session_id` has an outstanding elicitation request
+    /// (a question the agent asked the user, distinct from a tool
+    /// authorization request).
+    pub fn has_pending_elicitation(&self, session_id: &acp::SessionId) -> bool {
+        self.elicitation_requests
+            .get(session_id)
+            .is_some_and(|ids| !ids.is_empty())
+    }
+
     pub fn respond_to_elicitation(
         &mut self,
         session_id: acp::SessionId,
@@ -659,17 +668,23 @@ impl ConversationView {
             .pending_tool_call(&session_id, cx)
     }
 
-    pub fn root_thread_has_pending_tool_call(&self, cx: &App) -> bool {
+    /// Returns true if the root thread is blocked on the user: either a
+    /// pending tool authorization request, or a pending elicitation (a
+    /// question the agent asked, e.g. via `AskUserQuestion`). Both cases
+    /// should surface the same "awaiting confirmation" status regardless
+    /// of which agent (Claude, Codex, Gemini, or any other ACP agent) is
+    /// driving the thread, since both go through the same `AcpThread`.
+    pub fn root_thread_is_awaiting_user(&self, cx: &App) -> bool {
         let Some(root_thread) = self.root_thread_view() else {
             return false;
         };
         let root_session_id = root_thread.read(cx).thread.read(cx).session_id().clone();
         self.as_connected().is_some_and(|connected| {
-            connected
-                .conversation
-                .read(cx)
+            let conversation = connected.conversation.read(cx);
+            conversation
                 .pending_tool_call(&root_session_id, cx)
                 .is_some()
+                || conversation.has_pending_elicitation(&root_session_id)
         })
     }
 
@@ -4948,6 +4963,76 @@ pub(crate) mod tests {
             cx.windows()
                 .iter()
                 .any(|window| window.downcast::<AgentNotification>().is_some())
+        );
+    }
+
+    #[gpui::test]
+    async fn test_root_thread_is_awaiting_user_for_elicitation(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+
+        message_editor(&conversation_view, cx).update_in(cx, |editor, window, cx| {
+            editor.set_text("Hello", window, cx);
+        });
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |view, window, cx| view.send(window, cx));
+        cx.run_until_parked();
+
+        assert!(
+            !conversation_view.read_with(cx, |view, cx| view.root_thread_is_awaiting_user(cx)),
+            "a freshly started thread should not be reported as awaiting user input"
+        );
+
+        let session_id = active_thread(&conversation_view, cx)
+            .read_with(cx, |view, cx| view.thread.read(cx).session_id().clone());
+        let thread = conversation_view
+            .read_with(cx, |view, cx| view.root_thread(cx))
+            .expect("root thread should exist once a session is active");
+
+        let elicitation_id = thread.update(cx, |thread, cx| {
+            let (id, task) = thread
+                .request_elicitation_with_id(
+                    acp::CreateElicitationRequest::new(
+                        acp::ElicitationFormMode::new(
+                            acp::ElicitationSessionScope::new(session_id),
+                            acp::ElicitationSchema::new().string("choice", true),
+                        ),
+                        "Which option do you want?",
+                    ),
+                    cx,
+                )
+                .expect("elicitation request should be accepted");
+            task.detach();
+            id
+        });
+        cx.run_until_parked();
+
+        // This is the AskUserQuestion / "agent is waiting for an answer" case
+        // reported by users, as opposed to a tool authorization request —
+        // both must surface the same "awaiting confirmation" thread status,
+        // regardless of which ACP agent (Claude, Codex, Gemini, ...) sent it.
+        assert!(
+            conversation_view.read_with(cx, |view, cx| view.root_thread_is_awaiting_user(cx)),
+            "thread should be reported as awaiting user input while an elicitation \
+             (a question the agent asked) is still pending"
+        );
+
+        thread.update(cx, |thread, cx| {
+            thread.respond_to_elicitation(
+                &elicitation_id,
+                acp::CreateElicitationResponse::new(acp::ElicitationAction::Decline),
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        assert!(
+            !conversation_view.read_with(cx, |view, cx| view.root_thread_is_awaiting_user(cx)),
+            "thread should stop being reported as awaiting user input once the \
+             elicitation has been answered"
         );
     }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -8027,9 +8027,9 @@ fn all_thread_infos_for_workspace(
         .conversation_views()
         .into_iter()
         .filter_map(|conversation_view| {
-            let has_pending_tool_call = conversation_view
+            let is_awaiting_user = conversation_view
                 .read(cx)
-                .root_thread_has_pending_tool_call(cx);
+                .root_thread_is_awaiting_user(cx);
             let conversation_thread_id = conversation_view.read(cx).parent_id();
             let thread_view = conversation_view.read(cx).root_thread_view()?;
             let thread_view_ref = thread_view.read(cx);
@@ -8046,7 +8046,7 @@ fn all_thread_infos_for_workspace(
             let session_id = thread.session_id().clone();
             let is_background = agent_panel.is_retained_thread(&conversation_thread_id);
 
-            let status = if has_pending_tool_call {
+            let status = if is_awaiting_user {
                 AgentThreadStatus::WaitingForConfirmation
             } else if thread.had_error() {
                 AgentThreadStatus::Error
@@ -8271,7 +8271,7 @@ fn dump_single_workspace(workspace: &Workspace, output: &mut String, cx: &gpui::
                 .is_some_and(|conversation_view| {
                     conversation_view
                         .read(cx)
-                        .root_thread_has_pending_tool_call(cx)
+                        .root_thread_is_awaiting_user(cx)
                 })
             {
                 write!(output, ", awaiting confirmation").ok();
@@ -8302,7 +8302,7 @@ fn dump_single_workspace(workspace: &Workspace, output: &mut String, cx: &gpui::
                     write!(output, " [{status}, {entry_count} entries").ok();
                     if conversation_view
                         .read(cx)
-                        .root_thread_has_pending_tool_call(cx)
+                        .root_thread_is_awaiting_user(cx)
                     {
                         write!(output, ", awaiting confirmation").ok();
                     }


### PR DESCRIPTION
This fixes a small but annoying gap in Zed's sidebar. When an agent asks a question via `AskUserQuestion` and just sits there waiting for me to click something, the thread in the sidebar looks exactly the same as one that's still generating or already finished. I first ran into this with Grok, though it affects Claude and Codex too. I kept missing pending questions because there was no visual cue.

I found the actual reason in Zed's code. The sidebar's "waiting" status only checks for a pending *tool authorization* request (`Conversation::pending_tool_call`) and completely ignores pending *elicitations* (`Conversation::elicitation_requests`), which is the path `AskUserQuestion` actually goes through. So I added a `has_pending_elicitation()` check and folded it into the same function the sidebar already uses. I renamed that function so it's clear it now covers both cases.

How I tested it:
- Added a unit test (`test_root_thread_is_awaiting_user_for_elicitation`) that drives a real elicitation through `AcpThread::request_elicitation_with_id`/`respond_to_elicitation` and checks the status flips correctly. I confirmed it actually catches the bug by temporarily reverting my fix: the test failed exactly where expected.
- Ran it directly with `cargo test -p agent_ui test_root_thread_is_awaiting_user_for_elicitation`. It passes.
- `cargo check -p sidebar -p agent_ui` came back clean, no new warnings.
- Beyond the automated test, I use this daily with a custom Grok integration that goes through the same ACP elicitation path. I confirmed live in Zed that a pending question now shows the "awaiting confirmation" icon in the sidebar instead of looking identical to a running thread.
