### PR TITLE
project: Stop sharing private files through project search

### DIFF
--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -7690,3 +7690,84 @@ async fn test_guest_can_rejoin_shared_project_after_leaving_call(
         );
     })
 }
+
+/// Tests that a guest's project search does not return the contents of files the host has marked
+/// private.
+#[gpui::test]
+async fn test_project_search_excludes_private_files(
+    executor: BackgroundExecutor,
+    cx_a: &mut TestAppContext,
+    cx_b: &mut TestAppContext,
+) {
+    let mut server = TestServer::start(executor.clone()).await;
+    let client_a = server.create_client(cx_a, "user_a").await;
+    let client_b = server.create_client(cx_b, "user_b").await;
+    server
+        .create_room(&mut [(&client_a, cx_a), (&client_b, cx_b)])
+        .await;
+    let active_call_a = cx_a.read(ActiveCall::global);
+
+    cx_a.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |file| {
+                file.project.worktree.private_files = Some(vec!["**/.env".to_string()].into());
+            });
+        });
+    });
+
+    client_a
+        .fs()
+        .insert_tree(
+            "/root",
+            json!({
+                "dir-1": {
+                    "a.txt": "the secret is out",
+                    ".env": "API_KEY=secret",
+                }
+            }),
+        )
+        .await;
+    let (project_a, _) = client_a.build_local_project("/root/dir-1", cx_a).await;
+    let project_id = active_call_a
+        .update(cx_a, |call, cx| call.share_project(project_a.clone(), cx))
+        .await
+        .unwrap();
+    let project_b = client_b.join_remote_project(project_id, cx_b).await;
+
+    let mut results = HashMap::default();
+    let search_rx = project_b.update(cx_b, |project, cx| {
+        project.search(
+            SearchQuery::text(
+                "secret",
+                false,
+                false,
+                false,
+                Default::default(),
+                Default::default(),
+                false,
+                None,
+            )
+            .unwrap(),
+            cx,
+        )
+    });
+    while let Ok(result) = search_rx.rx.recv().await {
+        if let SearchResult::Buffer { buffer, ranges } = result {
+            results.entry(buffer).or_insert(ranges);
+        }
+    }
+
+    let mut paths = results
+        .into_iter()
+        .map(|(buffer, _)| {
+            buffer.read_with(cx_b, |buffer, cx| buffer.file().unwrap().full_path(cx))
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    assert_eq!(
+        paths,
+        &[PathBuf::from("dir-1/a.txt")],
+        "the guest's search returned a file the host marked private"
+    );
+}

--- a/crates/collab/tests/integration/integration_tests.rs
+++ b/crates/collab/tests/integration/integration_tests.rs
@@ -7758,10 +7758,8 @@ async fn test_project_search_excludes_private_files(
     }
 
     let mut paths = results
-        .into_iter()
-        .map(|(buffer, _)| {
-            buffer.read_with(cx_b, |buffer, cx| buffer.file().unwrap().full_path(cx))
-        })
+        .into_keys()
+        .map(|buffer| buffer.read_with(cx_b, |buffer, cx| buffer.file().unwrap().full_path(cx)))
         .collect::<Vec<_>>();
     paths.sort();
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5885,6 +5885,13 @@ impl Project {
             });
 
             while let Some((buffer, _)) = new_matches.next().await {
+                let is_private = buffer.read_with(cx, |buffer, _| {
+                    buffer.file().is_some_and(|file| file.is_private())
+                });
+                if is_private {
+                    continue;
+                }
+
                 let buffer_id = this.update(cx, |this, cx| {
                     this.create_buffer_for_peer(&buffer, peer_id, cx).to_proto()
                 });


### PR DESCRIPTION
# Objective

Files matching the `private_files` setting are meant not to be shared with collaborators. That is true when a guest asks to open one directly, `respond_to_open_buffer_request` refuses with `ErrorCode::UnsharedItem`.

Project search reaches the same `create_buffer_for_peer` without passing through that check. In `handle_search_candidate_buffers`, every matching buffer was shared with the requesting peer unconditionally, so a guest searching for a string that happens to appear in a private file received the buffer containing it.

## Solution

Check `is_private` before sharing a matched buffer with a peer

## Testing

added new test `test_project_search_excludes_private_files` in the collab integration suite:"
 The host configures `private_files: ["**/.env"]` and has two files `.env` containing `API_KEY=secret` and `a.txt` containing `the secret is out`. The guest joins the shared project and searches for `secret`.



---

Release Notes:
- Fixed private files being shared with collaborators through project search.
