### PR TITLE
gpui_web: Disable native canvas selection

### DIFF
--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -122,6 +122,8 @@ impl WebWindow {
             ("outline", "none"),
             ("touch-action", "none"),
             ("-webkit-touch-callout", "none"),
+            ("user-select", "none"),
+            ("-webkit-user-select", "none"),
         ] {
             style.set_property(property, value).map_err(|error| {
                 anyhow::anyhow!("Failed to set canvas {property} style: {error:?}")


### PR DESCRIPTION
Follow up on #63775: disabling WebKit touch callouts did not fully prevent iOS Safari from selecting the entire GPUI canvas alongside the app's text selection.

Remote Web Inspector captured a viewport-sized DOM range containing the canvas while its computed `-webkit-touch-callout` was `none` but `-webkit-user-select` was `text`. Set both standard and WebKit-prefixed `user-select` to `none` directly when GPUI creates the canvas, without relying on the embedding application's stylesheet. This leaves touch-event handling and the hidden IME textarea unchanged.

Closes DEL-2016

## Validation

- On an iPhone, injecting ordinary inline `-webkit-user-select: none` prevented the issue; switching it back to `text` reproduced it. No `!important` was necessary. This tested the equivalent runtime style, not a rebuilt app containing this commit.
- `cargo fmt -p gpui_web -- --check` passed.
- `RUSTC_BOOTSTRAP=1 cargo check -p gpui_web --target wasm32-unknown-unknown` passed. The bootstrap flag is required by the existing `wasm_thread` dependency.

Release Notes:

- Fixed unintended whole-canvas selection when long-pressing in GPUI web applications on iOS.
