### PR TITLE
Fix threads sidebar visibility when zooming workspace

### DIFF
--- a/crates/platform_title_bar/src/platform_title_bar.rs
+++ b/crates/platform_title_bar/src/platform_title_bar.rs
@@ -243,7 +243,7 @@ impl Render for PlatformTitleBar {
                     )
             })
             .map(|this| {
-                let show_left_controls = !(sidebar.open && sidebar.side == SidebarSide::Left);
+                let show_left_controls = !(sidebar.visible && sidebar.side == SidebarSide::Left);
 
                 if window.is_fullscreen() || window.is_simple_fullscreen() {
                     this.pl_2()
@@ -269,12 +269,12 @@ impl Render for PlatformTitleBar {
                 Decorations::Client { tiling, .. } => el
                     .when(
                         !(tiling.top || tiling.right)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Right),
+                            && !(sidebar.visible && sidebar.side == SidebarSide::Right),
                         |el| el.rounded_tr(theme::CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     .when(
                         !(tiling.top || tiling.left)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Left),
+                            && !(sidebar.visible && sidebar.side == SidebarSide::Left),
                         |el| el.rounded_tl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     // this border is to avoid a transparent gap in the rounded corners
@@ -299,7 +299,8 @@ impl Render for PlatformTitleBar {
             .when(
                 !window.is_fullscreen() && !window.is_simple_fullscreen(),
                 |title_bar| {
-                    let show_right_controls = !(sidebar.open && sidebar.side == SidebarSide::Right);
+                    let show_right_controls =
+                        !(sidebar.visible && sidebar.side == SidebarSide::Right);
 
                     let title_bar = title_bar.children(
                         show_right_controls

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -63,6 +63,7 @@ actions!(
 #[derive(Default)]
 pub struct SidebarRenderState {
     pub open: bool,
+    pub visible: bool,
     pub side: SidebarSide,
 }
 
@@ -334,6 +335,7 @@ impl MultiWorkspace {
     pub fn sidebar_render_state(&self, cx: &App) -> SidebarRenderState {
         SidebarRenderState {
             open: self.sidebar_open() && self.multi_workspace_enabled(cx),
+            visible: self.sidebar_visible(cx),
             side: self.sidebar_side(cx),
         }
     }
@@ -409,6 +411,12 @@ impl MultiWorkspace {
 
     pub fn sidebar_open(&self) -> bool {
         self.sidebar_open
+    }
+
+    fn sidebar_visible(&self, cx: &App) -> bool {
+        self.multi_workspace_enabled(cx)
+            && self.sidebar_open()
+            && self.workspace().read(cx).zoomed_item().is_none()
     }
 
     pub fn sidebar_has_notifications(&self, cx: &App) -> bool {
@@ -604,11 +612,17 @@ impl MultiWorkspace {
         })
         .detach();
 
-        cx.subscribe_in(workspace, window, |this, workspace, event, window, cx| {
-            if let WorkspaceEvent::Activate = event {
-                this.activate(workspace.clone(), None, window, cx);
-            }
-        })
+        cx.subscribe_in(
+            workspace,
+            window,
+            |this, workspace, event, window, cx| match event {
+                WorkspaceEvent::Activate => {
+                    this.activate(workspace.clone(), None, window, cx);
+                }
+                WorkspaceEvent::ZoomChanged => cx.notify(),
+                _ => {}
+            },
+        )
         .detach();
     }
 
@@ -1994,11 +2008,10 @@ impl MultiWorkspace {
 
 impl Render for MultiWorkspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let multi_workspace_enabled = self.multi_workspace_enabled(cx);
         let sidebar_side = self.sidebar_side(cx);
         let sidebar_on_right = sidebar_side == SidebarSide::Right;
 
-        let sidebar: Option<AnyElement> = if multi_workspace_enabled && self.sidebar_open() {
+        let sidebar: Option<AnyElement> = if self.sidebar_visible(cx) {
             self.sidebar.as_ref().map(|sidebar_handle| {
                 let weak = cx.weak_entity();
 
@@ -2148,26 +2161,20 @@ impl Render for MultiWorkspace {
                         ))
                     })
                 })
-                .when(
-                    self.sidebar_open() && self.multi_workspace_enabled(cx),
-                    |this| {
-                        this.on_drag_move(cx.listener(
-                            move |this: &mut Self,
-                                  e: &DragMoveEvent<DraggedSidebar>,
-                                  window,
-                                  cx| {
-                                if let Some(sidebar) = &this.sidebar {
-                                    let new_width = if sidebar_on_right {
-                                        window.bounds().size.width - e.event.position.x
-                                    } else {
-                                        e.event.position.x
-                                    };
-                                    sidebar.set_width(Some(new_width), cx);
-                                }
-                            },
-                        ))
-                    },
-                )
+                .when(self.sidebar_visible(cx), |this| {
+                    this.on_drag_move(cx.listener(
+                        move |this: &mut Self, e: &DragMoveEvent<DraggedSidebar>, window, cx| {
+                            if let Some(sidebar) = &this.sidebar {
+                                let new_width = if sidebar_on_right {
+                                    window.bounds().size.width - e.event.position.x
+                                } else {
+                                    e.event.position.x
+                                };
+                                sidebar.set_width(Some(new_width), cx);
+                            }
+                        },
+                    ))
+                })
                 .children(left_sidebar)
                 .child(
                     div()

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -118,6 +118,46 @@ async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_sidebar_is_hidden_while_workspace_is_zoomed(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let (multi_workspace, cx) = setup_multi_workspace(&[project], cx);
+
+    let workspace = multi_workspace.read_with(cx, |multi_workspace, cx| {
+        let sidebar = multi_workspace.sidebar_render_state(cx);
+        assert!(sidebar.open);
+        assert!(sidebar.visible);
+        multi_workspace.workspace().clone()
+    });
+    let pane = workspace.read_with(cx, |workspace, _cx| workspace.active_pane().clone());
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        let item = cx.new(TestItem::new);
+        workspace.add_item(pane.clone(), Box::new(item), None, true, true, window, cx);
+    });
+    pane.update_in(cx, |pane, window, cx| {
+        pane.zoom_in(&crate::ZoomIn, window, cx);
+    });
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        let sidebar = multi_workspace.sidebar_render_state(cx);
+        assert!(sidebar.open);
+        assert!(!sidebar.visible);
+    });
+
+    pane.update_in(cx, |pane, window, cx| {
+        pane.zoom_out(&crate::ZoomOut, window, cx);
+    });
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        let sidebar = multi_workspace.sidebar_render_state(cx);
+        assert!(sidebar.open);
+        assert!(sidebar.visible);
+    });
+}
+
+#[gpui::test]
 async fn test_multi_workspace_collapses_when_agent_is_disabled(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -73,6 +73,7 @@ trait StatusItemViewHandle: Send {
 #[derive(Default)]
 struct SidebarStatus {
     open: bool,
+    visible: bool,
     side: SidebarSide,
     has_notifications: bool,
     show_toggle: bool,
@@ -86,9 +87,11 @@ impl SidebarStatus {
             .map(|mw| {
                 let mw = mw.read(cx);
                 let enabled = mw.multi_workspace_enabled(cx);
+                let sidebar = mw.sidebar_render_state(cx);
                 Self {
-                    open: mw.sidebar_open() && enabled,
-                    side: mw.sidebar_side(cx),
+                    open: sidebar.open,
+                    visible: sidebar.visible,
+                    side: sidebar.side,
                     has_notifications: mw.sidebar_has_notifications(cx),
                     show_toggle: enabled,
                 }
@@ -157,12 +160,12 @@ impl Render for StatusBar {
                 Decorations::Client { tiling, .. } => el
                     .when(
                         !(tiling.bottom || tiling.right)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Right),
+                            && !(sidebar.visible && sidebar.side == SidebarSide::Right),
                         |el| el.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     .when(
                         !(tiling.bottom || tiling.left)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Left),
+                            && !(sidebar.visible && sidebar.side == SidebarSide::Left),
                         |el| el.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     // This border is to avoid a transparent gap in the rounded corners


### PR DESCRIPTION
# Objective

Fixes #63873

When a workspace pane is zoomed, the threads sidebar remained visible. The
title bar and status bar also treated the hidden sidebar as occupying space,
which conflicted with macOS window controls.

## Solution

- Hide the rendered threads sidebar while the active workspace is zoomed and
  restore it when zoom ends.
- Keep the sidebar logically open while hidden, so sidebar actions and toggle
  state remain intact.
- Track sidebar visibility separately from its open state, and use visibility
  when positioning title-bar and status-bar chrome.

## Testing

- Ran `cargo test -p workspace test_sidebar_is_hidden_while_workspace_is_zoomed`.
- The regression test verifies that zooming hides the sidebar without closing
  it and restores it after zooming out.
- Manual macOS visual verification remains useful to confirm the traffic-light
  controls are positioned correctly while zoomed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

[My super cool demos here
](https://github.com/user-attachments/assets/84914f77-be6b-40bf-a371-8eb5d73a6f34)
</details>

---

Release Notes:

- Fixed the threads sidebar remaining visible when a workspace pane is zoomed.

