### PR TITLE
agent_ui: Skip task-notification entries when scrolling to user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -308,29 +308,22 @@ pub struct Checkpoint {
 }
 
 impl UserMessage {
-    /// Claude Code injects background subagent completions as user-side
-    /// `<task-notification>` blocks over ACP. They are stored as `UserMessage`
-    /// entries (including after session restore) but are not real user prompts.
+    // Claude Code injects these as UserMessageChunks over ACP (also after restore).
     pub fn is_task_notification(&self) -> bool {
-        let mut saw_text = false;
-        for chunk in &self.chunks {
-            match chunk {
+        self.chunks
+            .iter()
+            .find_map(|chunk| match chunk {
                 acp::ContentBlock::Text(text) => {
                     let trimmed = text.text.trim_start();
                     if trimmed.is_empty() {
-                        continue;
-                    }
-                    if !saw_text {
-                        if !trimmed.starts_with("<task-notification") {
-                            return false;
-                        }
-                        saw_text = true;
+                        None
+                    } else {
+                        Some(trimmed.starts_with("<task-notification"))
                     }
                 }
-                _ => return false,
-            }
-        }
-        saw_text
+                _ => Some(false),
+            })
+            .unwrap_or(false)
     }
 
     fn to_markdown(&self, cx: &App) -> String {

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -317,7 +317,7 @@ impl UserMessage {
                     let trimmed = text.text.trim_start();
                     (!trimmed.is_empty()).then_some(trimmed.starts_with("<task-notification"))
                 }
-                _ => Some(false),
+                _ => None,
             })
             .unwrap_or(false)
     }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -315,11 +315,7 @@ impl UserMessage {
             .find_map(|chunk| match chunk {
                 acp::ContentBlock::Text(text) => {
                     let trimmed = text.text.trim_start();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.starts_with("<task-notification"))
-                    }
+                    (!trimmed.is_empty()).then_some(trimmed.starts_with("<task-notification"))
                 }
                 _ => Some(false),
             })

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -308,6 +308,31 @@ pub struct Checkpoint {
 }
 
 impl UserMessage {
+    /// Claude Code injects background subagent completions as user-side
+    /// `<task-notification>` blocks over ACP. They are stored as `UserMessage`
+    /// entries (including after session restore) but are not real user prompts.
+    pub fn is_task_notification(&self) -> bool {
+        let mut saw_text = false;
+        for chunk in &self.chunks {
+            match chunk {
+                acp::ContentBlock::Text(text) => {
+                    let trimmed = text.text.trim_start();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if !saw_text {
+                        if !trimmed.starts_with("<task-notification") {
+                            return false;
+                        }
+                        saw_text = true;
+                    }
+                }
+                _ => return false,
+            }
+        }
+        saw_text
+    }
+
     fn to_markdown(&self, cx: &App) -> String {
         let mut markdown = String::new();
         if self

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7101,6 +7101,144 @@ pub(crate) mod tests {
         });
     }
 
+    /// Issue #63789: restored ACP history replays Claude Code
+    /// `<task-notification>` blocks as `UserMessage` entries. "Scroll to User
+    /// Message" must skip those and land only on real user prompts.
+    #[gpui::test]
+    async fn test_scroll_to_user_message_skips_task_notifications(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+        connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new("Working on it.".into()),
+        )]);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection.clone()), cx).await;
+
+        let thread = conversation_view
+            .read_with(cx, |view, cx| {
+                view.active_thread().map(|r| r.read(cx).thread.clone())
+            })
+            .unwrap();
+
+        thread
+            .update(cx, |thread, cx| {
+                thread.send_raw(
+                    "Run two sub-agents in parallel in background, one to sleep for 3 seconds, the other for 7.",
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Simulate session/load (or live) replay of background-task completion
+        // notifications, which arrive as agent-injected UserMessageChunks.
+        // Distinct message_ids keep them from merging into one entry.
+        let task_notification = "\
+<task-notification>
+  <task-id>agent-sleep-3s</task-id>
+  <status>completed</status>
+  <summary>Agent \"sleep 3s\" completed</summary>
+</task-notification>";
+        thread
+            .update(cx, |thread, cx| {
+                thread.handle_session_update(
+                    acp::SessionUpdate::UserMessageChunk(
+                        acp::ContentChunk::new(task_notification.into())
+                            .message_id("task-notif-sleep-3s"),
+                    ),
+                    cx,
+                )
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        let second_notification = "\
+<task-notification>
+  <task-id>agent-sleep-7s</task-id>
+  <status>completed</status>
+  <summary>Agent \"sleep 7s\" completed</summary>
+</task-notification>";
+        thread
+            .update(cx, |thread, cx| {
+                thread.handle_session_update(
+                    acp::SessionUpdate::UserMessageChunk(
+                        acp::ContentChunk::new(second_notification.into())
+                            .message_id("task-notif-sleep-7s"),
+                    ),
+                    cx,
+                )
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        let (prompt_ix, first_notification_ix, second_notification_ix) =
+            thread.read_with(cx, |thread, _| {
+                let entries = thread.entries();
+                assert!(
+                    entries.len() >= 4,
+                    "expected user + assistant + 2 notifications, got {}",
+                    entries.len()
+                );
+                let prompt_ix = entries
+                    .iter()
+                    .position(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
+                    .expect("user prompt");
+                let notification_indices: Vec<_> = entries
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(ix, entry)| match entry {
+                        AgentThreadEntry::UserMessage(message)
+                            if message.is_task_notification() =>
+                        {
+                            Some(ix)
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(
+                    notification_indices.len(),
+                    2,
+                    "both task notifications should be recognized as UserMessage entries"
+                );
+                (
+                    prompt_ix,
+                    notification_indices[0],
+                    notification_indices[1],
+                )
+            });
+
+        active_thread(&conversation_view, cx).update(cx, |view, cx| {
+            view.scroll_to_top(cx);
+            view.scroll_to_user_message_index(None, cx);
+            assert_eq!(
+                view.list_state.logical_scroll_top().item_ix,
+                prompt_ix,
+                "fallback scroll must skip task-notification UserMessages"
+            );
+
+            view.scroll_to_top(cx);
+            // Turn-end controls currently bind to the nearest prior UserMessage,
+            // which after restore is often a task-notification.
+            view.scroll_to_user_message_index(Some(second_notification_ix), cx);
+            assert_eq!(
+                view.list_state.logical_scroll_top().item_ix,
+                prompt_ix,
+                "scroll target must walk past task-notification indices to a real prompt"
+            );
+
+            view.scroll_to_top(cx);
+            view.scroll_to_user_message_index(Some(first_notification_ix), cx);
+            assert_eq!(
+                view.list_state.logical_scroll_top().item_ix,
+                prompt_ix,
+                "scroll target must walk past earlier task-notification indices too"
+            );
+        });
+    }
+
     #[gpui::test]
     async fn test_thread_search_finds_matches_across_entries(cx: &mut TestAppContext) {
         init_test(cx);

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7101,9 +7101,6 @@ pub(crate) mod tests {
         });
     }
 
-    /// Issue #63789: restored ACP history replays Claude Code
-    /// `<task-notification>` blocks as `UserMessage` entries. "Scroll to User
-    /// Message" must skip those and land only on real user prompts.
     #[gpui::test]
     async fn test_scroll_to_user_message_skips_task_notifications(cx: &mut TestAppContext) {
         init_test(cx);
@@ -7124,18 +7121,12 @@ pub(crate) mod tests {
 
         thread
             .update(cx, |thread, cx| {
-                thread.send_raw(
-                    "Run two sub-agents in parallel in background, one to sleep for 3 seconds, the other for 7.",
-                    cx,
-                )
+                thread.send_raw("Run two background sub-agents that sleep.", cx)
             })
             .await
             .unwrap();
         cx.run_until_parked();
 
-        // Simulate session/load (or live) replay of background-task completion
-        // notifications, which arrive as agent-injected UserMessageChunks.
-        // Distinct message_ids keep them from merging into one entry.
         let task_notification = "\
 <task-notification>
   <task-id>agent-sleep-3s</task-id>
@@ -7177,14 +7168,16 @@ pub(crate) mod tests {
         let (prompt_ix, first_notification_ix, second_notification_ix) =
             thread.read_with(cx, |thread, _| {
                 let entries = thread.entries();
-                assert!(
-                    entries.len() >= 4,
-                    "expected user + assistant + 2 notifications, got {}",
-                    entries.len()
-                );
+                assert!(entries.len() >= 4);
                 let prompt_ix = entries
                     .iter()
-                    .position(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
+                    .position(|entry| {
+                        matches!(
+                            entry,
+                            AgentThreadEntry::UserMessage(message)
+                                if !message.is_task_notification()
+                        )
+                    })
                     .expect("user prompt");
                 let notification_indices: Vec<_> = entries
                     .iter()
@@ -7198,11 +7191,7 @@ pub(crate) mod tests {
                         _ => None,
                     })
                     .collect();
-                assert_eq!(
-                    notification_indices.len(),
-                    2,
-                    "both task notifications should be recognized as UserMessage entries"
-                );
+                assert_eq!(notification_indices.len(), 2);
                 (
                     prompt_ix,
                     notification_indices[0],
@@ -7213,29 +7202,15 @@ pub(crate) mod tests {
         active_thread(&conversation_view, cx).update(cx, |view, cx| {
             view.scroll_to_top(cx);
             view.scroll_to_user_message_index(None, cx);
-            assert_eq!(
-                view.list_state.logical_scroll_top().item_ix,
-                prompt_ix,
-                "fallback scroll must skip task-notification UserMessages"
-            );
+            assert_eq!(view.list_state.logical_scroll_top().item_ix, prompt_ix);
 
             view.scroll_to_top(cx);
-            // Turn-end controls currently bind to the nearest prior UserMessage,
-            // which after restore is often a task-notification.
             view.scroll_to_user_message_index(Some(second_notification_ix), cx);
-            assert_eq!(
-                view.list_state.logical_scroll_top().item_ix,
-                prompt_ix,
-                "scroll target must walk past task-notification indices to a real prompt"
-            );
+            assert_eq!(view.list_state.logical_scroll_top().item_ix, prompt_ix);
 
             view.scroll_to_top(cx);
             view.scroll_to_user_message_index(Some(first_notification_ix), cx);
-            assert_eq!(
-                view.list_state.logical_scroll_top().item_ix,
-                prompt_ix,
-                "scroll target must walk past earlier task-notification indices too"
-            );
+            assert_eq!(view.list_state.logical_scroll_top().item_ix, prompt_ix);
         });
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7005,16 +7005,12 @@ impl ThreadView {
             return;
         }
 
-        // Walk earlier when the bound index (or most-recent UserMessage) is a
-        // Claude Code <task-notification>, which is stored as a UserMessage.
         let search_end = user_message_index.unwrap_or(entries.len() - 1);
         if let Some(ix) = (0..=search_end).rev().find(|&ix| {
-            entries.get(ix).is_some_and(|entry| {
-                matches!(
-                    entry,
-                    AgentThreadEntry::UserMessage(message) if !message.is_task_notification()
-                )
-            })
+            matches!(
+                entries.get(ix),
+                Some(AgentThreadEntry::UserMessage(message)) if !message.is_task_notification()
+            )
         }) {
             self.list_state.scroll_to(ListOffset {
                 item_ix: ix,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6530,7 +6530,12 @@ impl ThreadView {
                 .entries()
                 .iter()
                 .take(entry_ix)
-                .rposition(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)));
+                .rposition(|entry| {
+                    matches!(
+                        entry,
+                        AgentThreadEntry::UserMessage(message) if !message.is_task_notification()
+                    )
+                });
 
             v_flex()
                 .w_full()
@@ -7000,12 +7005,16 @@ impl ThreadView {
             return;
         }
 
-        // Scroll to the provided user message, or fall back to the most recent one.
-        // (Fallback: if no user message exists, scroll to the bottom.)
-        if let Some(ix) = user_message_index.or_else(|| {
-            entries
-                .iter()
-                .rposition(|entry| matches!(entry, AgentThreadEntry::UserMessage(_)))
+        // Walk earlier when the bound index (or most-recent UserMessage) is a
+        // Claude Code <task-notification>, which is stored as a UserMessage.
+        let search_end = user_message_index.unwrap_or(entries.len() - 1);
+        if let Some(ix) = (0..=search_end).rev().find(|&ix| {
+            entries.get(ix).is_some_and(|entry| {
+                matches!(
+                    entry,
+                    AgentThreadEntry::UserMessage(message) if !message.is_task_notification()
+                )
+            })
         }) {
             self.list_state.scroll_to(ListOffset {
                 item_ix: ix,
@@ -7112,10 +7121,12 @@ impl ThreadView {
     ) {
         let entries = self.thread.read(cx).entries();
         let current_ix = self.list_state.logical_scroll_top().item_ix;
-        if let Some(target_ix) = (0..current_ix)
-            .rev()
-            .find(|&i| matches!(entries.get(i), Some(AgentThreadEntry::UserMessage(_))))
-        {
+        if let Some(target_ix) = (0..current_ix).rev().find(|&i| {
+            matches!(
+                entries.get(i),
+                Some(AgentThreadEntry::UserMessage(message)) if !message.is_task_notification()
+            )
+        }) {
             self.list_state.scroll_to(ListOffset {
                 item_ix: target_ix,
                 offset_in_item: px(0.),
@@ -7132,9 +7143,12 @@ impl ThreadView {
     ) {
         let entries = self.thread.read(cx).entries();
         let current_ix = self.list_state.logical_scroll_top().item_ix;
-        if let Some(target_ix) = (current_ix + 1..entries.len())
-            .find(|&i| matches!(entries.get(i), Some(AgentThreadEntry::UserMessage(_))))
-        {
+        if let Some(target_ix) = (current_ix + 1..entries.len()).find(|&i| {
+            matches!(
+                entries.get(i),
+                Some(AgentThreadEntry::UserMessage(message)) if !message.is_task_notification()
+            )
+        }) {
             self.list_state.scroll_to(ListOffset {
                 item_ix: target_ix,
                 offset_in_item: px(0.),


### PR DESCRIPTION
Hi there! Jumping in to support this one. Let me know if there's any feedback here. Happy to amend.

## Why

After restoring an ACP thread, Claude Code task completions are stored as `UserMessage` entries (they arrive as `UserMessageChunk`s, including after `session/load`). Clicking "Scroll to user message" treated every `UserMessage` as a real prompt, so expanded `<task-notification>` blocks became scroll stops. Fixes https://github.com/zed-industries/zed/issues/63789.

## Scope

- Add `UserMessage::is_task_notification()` in `crates/acp_thread/src/acp_thread.rs` (detects leading `<task-notification` in text chunks).
- Filter those entries out of scroll-to-user-message, turn-end button targeting, and prev/next user-message scroll in `crates/agent_ui/src/conversation_view/thread_view.rs`.
- Add `test_scroll_to_user_message_skips_task_notifications` in `crates/agent_ui/src/conversation_view.rs`.

Out of scope: raw XML rendering of task notifications (#63662).

## Verification

```
cargo test -p agent_ui --features test-support test_scroll_to -- --nocapture
```

Result: 3 passed (including the new skip-task-notifications test). Bugbot review on the branch found no bugs.

Release Notes:

- Fixed scrolling to the latest user message in ACP threads so Claude Code task notifications are skipped