### PR TITLE
recent_projects: Show remote picker scrollbar

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1500,7 +1500,10 @@ impl RemoteServerProjects {
                 true,
                 cx,
             );
-            Picker::list(delegate, window, cx).embedded()
+            Picker::list(delegate, window, cx)
+                .list_measure_all()
+                .show_scrollbar(true)
+                .embedded()
         });
         let mut read_ssh_config = RemoteSettings::get_global(cx).read_ssh_config;
         let ssh_config_updates = if read_ssh_config {


### PR DESCRIPTION
Make overflowing remote lists discoverable and size the scrollbar accurately from the first layout, matching the Recent Projects picker.

Closes #63856.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable (the impact on [large remote lists](https://github.com/zed-industries/zed/blob/84d9a73c1957a8181c8ae017e703d1d56a18426a/crates/gpui/src/elements/list.rs#L196-L201) was not tested)

---

Release Notes:

- Fixed a missing scrollbar in the Open Remote picker, making additional remote servers easier to discover
