### PR TITLE
Adjust Git Panel default settings and make git_commit_buffer_font_size configurable in settings_ui

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -77,8 +77,9 @@
   "agent_buffer_font_family": null,
   // The default font size for user messages in the agent panel.
   "agent_buffer_font_size": 12,
-  // The default font size for the commit editor in the git panel and commit modal.
-  "git_commit_buffer_font_size": 12,
+  // The font size for the commit editor in the git panel and commit modal.
+  // Falls back to the buffer font size if unset.
+  "git_commit_buffer_font_size": null,
   // How much to fade out unused code.
   "unnecessary_code_fade": 0.3,
   // Active pane styling settings.
@@ -1061,9 +1062,9 @@
     // Whether to show the git panel button in the status bar.
     "button": true,
     // Where to dock the git panel. Can be 'left' or 'right'.
-    "dock": "right",
+    "dock": "left",
     // Default width of the git panel.
-    "default_width": 360,
+    "default_width": 640,
     // Style of the git status indicator in the panel.
     //
     // Choices: label_color, icon

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6364,7 +6364,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 18] {
+    fn git_panel_section() -> [SettingsPageItem; 19] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6428,6 +6428,26 @@ fn panels_page() -> SettingsPage {
                             .git_panel
                             .get_or_insert_default()
                             .default_width = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Commit Editor Font Size",
+                description: "Font size for the commit editor in the Git panel and commit modal. Falls back to the editor font size.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git_commit_buffer_font_size"),
+                    pick: |settings_content| {
+                        settings_content
+                            .theme
+                            .git_commit_buffer_font_size
+                            .as_ref()
+                            .or(settings_content.theme.buffer_font_size.as_ref())
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.theme.git_commit_buffer_font_size = value;
                     },
                 }),
                 metadata: None,

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5858,7 +5858,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
   "git_panel": {
     "button": true,
     "dock": "left",
-    "default_width": 360,
+    "default_width": 640,
     "status_style": "icon",
     "fallback_branch_name": "main",
     "sort_by": "path",
@@ -5884,6 +5884,16 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `collapse_untracked_diff`: Whether to collapse untracked files in the diff panel
 - `scrollbar`: When to show the scrollbar in the git panel
 - `starts_open`: Whether the git panel should open on startup
+
+## Git Commit Buffer Font Size
+
+- Description: The font size for the commit editor in the Git panel and commit modal. Falls back to `buffer_font_size` when unset.
+- Setting: `git_commit_buffer_font_size`
+- Default: `null`
+
+**Options**
+
+An integer font size from `6` to `100` pixels (inclusive)
 
 ## Git Worktree Directory
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -584,7 +584,7 @@ See [Terminal settings](./reference/all-settings.md#terminal) for additional non
   "git_panel": {
     "button": true,               // Show/hide status bar icon
     "dock": "left",               // Where to dock: left, right
-    "default_width": 360,         // Default width of the git panel.
+    "default_width": 640,         // Default width of the git panel.
     "status_style": "icon",       // label_color, icon
     "sort_by": "path",            // path, name
     "group_by": "status",         // none, status, staging


### PR DESCRIPTION
# Objective

Fixes #63907

## Solution

- change Git Panel default settings
  - "git_panel.dock": "left"
  - "git_panel.default_width": 640
  - "git_commit_buffer_font_size" now falls back to "buffer_font_size" (12 -> 15)
- make "git_commit_buffer_font_size" configurable in settings_ui

## Testing

It's a minimal change. Won't require much testing.

Use `zed --user-data-dir ~/Desktop/somewhere` to see the new defaults.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)

The new default behavior should be more adhering to Zed's UI standards and improve accessibility.

## Showcase

<img width="3839" height="2074" alt="new defaults" src="https://github.com/user-attachments/assets/dbaea50e-7ff5-409d-81f1-2a11f551be68" />

---

Release Notes:

- Improved default Git Panel UX and make "git_commit_buffer_font_size" configurable in settings UI