### PR TITLE
remote: Use --exec for WSL command execution

### DIFF
--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -568,6 +568,13 @@ impl RemoteConnection for WslRemoteConnection {
         let (command, args) =
             ShellBuilder::new(&Shell::Program(self.shell.clone()), false).build(Some(exec), &[]);
 
+        // `--exec` runs the command without a WSL default shell wrapping the
+        // argv. Passing `--` instead would make wsl.exe join the argv back into
+        // a single command line using Windows quoting rules and hand it to the
+        // distro's default shell for re-interpretation. That extra shell layer
+        // strips single quotes of their literal meaning, so any `$VAR` inside
+        // single quotes (including quotes the layers above already added) gets
+        // expanded despite POSIX quoting.
         let mut wsl_args = if let Some(user) = &self.connection_options.user {
             vec![
                 "--distribution".to_string(),
@@ -576,7 +583,7 @@ impl RemoteConnection for WslRemoteConnection {
                 user.clone(),
                 "--cd".to_string(),
                 working_dir,
-                "--".to_string(),
+                "--exec".to_string(),
                 command,
             ]
         } else {
@@ -585,7 +592,7 @@ impl RemoteConnection for WslRemoteConnection {
                 self.connection_options.distro_name.clone(),
                 "--cd".to_string(),
                 working_dir,
-                "--".to_string(),
+                "--exec".to_string(),
                 command,
             ]
         };

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -762,3 +762,112 @@ fn wsl_command_impl(
     log::debug!("wsl {:?}", command);
     command
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_connection(user: Option<String>) -> WslRemoteConnection {
+        WslRemoteConnection {
+            remote_binary_path: None,
+            platform: RemotePlatform {
+                os: RemoteOs::Linux,
+                arch: RemoteArch::X86_64,
+            },
+            os_version: None,
+            shell: "/bin/bash".to_string(),
+            shell_kind: ShellKind::Posix,
+            default_system_shell: "/bin/bash".to_string(),
+            has_wsl_interop: false,
+            connection_options: WslConnectionOptions {
+                distro_name: "Ubuntu".to_string(),
+                user,
+            },
+        }
+    }
+
+    #[test]
+    fn test_build_command_uses_exec_without_user() {
+        let connection = test_connection(None);
+        let command = connection
+            .build_command(
+                Some("remote_program".to_string()),
+                &["arg with space".to_string()],
+                &HashMap::default(),
+                Some("/home/user".to_string()),
+                None,
+                Interactive::No,
+            )
+            .unwrap();
+
+        assert_eq!(command.program, "wsl.exe");
+        // `--exec` must be used so wsl.exe does not wrap the command in the
+        // distro's default shell, which would re-interpret quoting.
+        assert_eq!(command.args.first().unwrap(), "--distribution");
+        let exec_index = command
+            .args
+            .iter()
+            .position(|arg| arg == "--exec")
+            .expect("--exec must be present");
+        assert!(!command.args.iter().any(|arg| arg == "--"));
+        // The program and its arguments follow `--exec`.
+        assert_eq!(command.args[exec_index + 1], "/bin/bash");
+        assert!(command.args[exec_index + 2..].contains(&"-c".to_string()));
+    }
+
+    #[test]
+    fn test_build_command_uses_exec_with_user() {
+        let connection = test_connection(Some("user".to_string()));
+        let command = connection
+            .build_command(
+                Some("remote_program".to_string()),
+                &[],
+                &HashMap::default(),
+                Some("/home/user".to_string()),
+                None,
+                Interactive::No,
+            )
+            .unwrap();
+
+        assert!(
+            command
+                .args
+                .windows(2)
+                .any(|window| window[0] == "--user" && window[1] == "user")
+        );
+        let exec_index = command
+            .args
+            .iter()
+            .position(|arg| arg == "--exec")
+            .expect("--exec must be present");
+        assert!(!command.args.iter().any(|arg| arg == "--"));
+        assert_eq!(command.args[exec_index + 1], "/bin/bash");
+    }
+
+    #[test]
+    fn test_build_command_without_program_starts_login_shell() {
+        let connection = test_connection(None);
+        let command = connection
+            .build_command(None, &[], &HashMap::default(), None, None, Interactive::No)
+            .unwrap();
+
+        // A bare `--exec` still applies: the login shell must be exec'd
+        // directly as well, not passed through the distro's default shell.
+        let exec_index = command
+            .args
+            .iter()
+            .position(|arg| arg == "--exec")
+            .expect("--exec must be present");
+        assert!(!command.args.iter().any(|arg| arg == "--"));
+        assert_eq!(command.args[exec_index + 1], "/bin/bash");
+        // ShellBuilder turns the `exec "<shell> -l`" script into
+        // `<shell> -i -c "<shell> -l"` (interactive is hard-coded to true in
+        // `build_command`), so the login flag lives inside the -c script.
+        let script_index = command
+            .args
+            .iter()
+            .position(|arg| arg == "-c")
+            .expect("-c must be present");
+        assert!(command.args[script_index + 1].contains("-l"));
+    }
+}


### PR DESCRIPTION
Updated WSL command execution to use '--exec' instead of '--'. This change ensures commands are run without a WSL default shell wrapping.

# Objective

Commands spawned for WSL remote projects (terminals, remote processes) were
passed to `wsl.exe` after `--`, which makes `wsl.exe` join the argv back into
a single command line using Windows quoting rules and hand it to the distro's
default shell for re-interpretation. That extra shell layer breaks POSIX
quoting: single quotes lose their literal meaning, so `$VAR` inside single
quotes gets expanded, and heredocs with quoted delimiters (`<<'EOF'`) have
their contents interpolated before the intended shell ever sees them.

Reproduction (Windows + WSL remote project, e.g. the agent's terminal tool):

- `echo '$HOME'` printed `/home/<user>` instead of the literal `$HOME`
- a heredoc with a quoted delimiter wrote files with variables already
  substituted

No existing issue tracks this exact symptom. Related history:
#38380 removed quoting from this path and was reverted in #38647 because the
joined command line was then word-split by the default shell. #50805 tracks
the same re-interpretation problem on a sibling path (`run_wsl_command`).


# Solution

Use `wsl.exe --exec` in `WslRemoteConnection::build_command` instead of `--`,
so `wsl.exe` execs the command directly instead of wrapping it in the distro's
default shell. The script is then interpreted exactly once, by the shell it
was built for, restoring POSIX quoting semantics.

`--exec` removes the re-interpretation layer entirely rather than trying to
quote around it, which is the same strategy this file already uses in
`run_wsl_command_with_output_impl` and the interop probes. The invoked shell
comes from `$SHELL` as an absolute path, so `--exec` runs it directly without
relying on PATH.


# Testing

- Manually verified on Windows 11 + WSL2 (Ubuntu) by running the exact
  `wsl.exe` command line this code produces, once with `--` and once with
  `--exec` (the only difference this PR makes):
  - `--`: `echo '$HOME'` printed `/home/<user>`; heredoc `<<'EOF'` contents
    were interpolated
  - `--exec`: literal `$HOME`; heredoc contents preserved verbatim
  - with `--exec`, shell spawn and remote processes still work
- `cargo check -p remote`, `cargo clippy -p remote` (clean)
- `cargo test -p remote` (36 passing)
- `cargo test -p agent terminal_tool`, `cargo test -p acp_thread terminal`
- Added unit tests for `WslRemoteConnection::build_command` asserting the
  generated `wsl.exe` invocation uses `--exec` (and never `--`) in both the
  user and no-user branches, mirroring `ssh.rs`'s `test_build_command`. These
  are pure string assertions, so they run on any platform.

For reviewers: this only affects commands Zed spawns as scripts (the agent's
terminal tool, tasks, remote processes) — commands typed into an
already-running interactive terminal never pass through this path, on either
version. A quick check on Windows: in a WSL remote project, ask the agent to
run `echo '$HOME'` with its terminal tool and verify the literal output.


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed quoted variables being expanded and heredocs being interpolated in
  WSL remote terminal commands.
