### PR TITLE
Fix git restore liveness

### DIFF
--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -920,6 +920,8 @@ impl Editor {
     }
 
     fn restore_diff_hunks(&mut self, hunks: Vec<ResolvedDiffHunks>, cx: &mut Context<Self>) {
+        let save_restored_buffers = self.buffer().read(cx).all_diff_hunks_expanded();
+        let project = self.project.as_ref();
         let mut revert_changes = Vec::new();
         for hunks in hunks {
             let Some(buffer) = hunks.buffer else {
@@ -958,6 +960,11 @@ impl Editor {
                     cx,
                 );
             });
+            if save_restored_buffers && let Some(project) = project {
+                project
+                    .update(cx, |project, cx| project.save_buffer(buffer, cx))
+                    .detach_and_log_err(cx);
+            }
         }
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -9695,7 +9695,7 @@ pub(crate) fn commit_title_exceeds_limit(title: &str, max_length: usize) -> bool
 
 #[cfg(test)]
 mod tests {
-    use editor::SplittableEditor;
+    use editor::{SplittableEditor, test::editor_test_context::EditorTestContext};
     use git::{
         repository::repo_path,
         status::{StatusCode, TrackedStatus, UnmergedStatus, UnmergedStatusCode},
@@ -9886,6 +9886,171 @@ mod tests {
         await_git_panel_entries(&panel, &mut cx).await;
 
         (fs, project, workspace, panel, cx)
+    }
+
+    #[gpui::test]
+    async fn test_restoring_project_diff_hunk_updates_panel_and_only_saves_affected_buffer(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/root"),
+            json!({
+                ".git": {},
+                "file": "changed\n",
+                "other": "other on disk\n",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+            .expect("multi-workspace should have an active workspace");
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .expect("project should have a worktree")
+                .read(cx)
+                .as_local()
+                .expect("worktree should be local")
+                .scan_complete()
+        })
+        .await;
+        cx.run_until_parked();
+
+        let worktree_id = project.read_with(&cx, |project, cx| {
+            project
+                .worktrees(cx)
+                .next()
+                .expect("project should have a worktree")
+                .read(cx)
+                .id()
+        });
+        let editor = workspace
+            .update_in(&mut cx, |workspace, window, cx| {
+                workspace.open_path((worktree_id, rel_path("file")), None, true, window, cx)
+            })
+            .await
+            .expect("file should open")
+            .downcast::<Editor>()
+            .expect("opened item should be an editor");
+        cx.run_until_parked();
+
+        let mut cx = EditorTestContext::for_editor_in(editor, &mut cx).await;
+        cx.set_head_text("original\n");
+        cx.set_index_text("original\n");
+        let other_editor = workspace
+            .update_in(&mut cx.cx, |workspace, window, cx| {
+                workspace.open_path((worktree_id, rel_path("other")), None, true, window, cx)
+            })
+            .await
+            .expect("other file should open")
+            .downcast::<Editor>()
+            .expect("opened item should be an editor");
+        other_editor.update_in(&mut cx.cx, |editor, window, cx| {
+            editor.set_text("unsaved other\n", window, cx);
+        });
+        let other_buffer = other_editor.read_with(&cx.cx, |editor, cx| {
+            editor
+                .active_buffer(cx)
+                .expect("other editor should have an active buffer")
+        });
+
+        let panel = workspace.update_in(&mut cx.cx, GitPanel::new);
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        let entries = panel.read_with(&cx.cx, |panel, _| panel.entries.clone());
+        pretty_assertions::assert_eq!(
+            entries,
+            [
+                GitListEntry::Header(GitHeaderEntry {
+                    header: Section::Tracked
+                }),
+                GitListEntry::Status(GitStatusEntry {
+                    repo_path: repo_path("file"),
+                    status: StatusCode::Modified.worktree(),
+                    staging: StageStatus::Unstaged,
+                    diff_stat: Some(DiffStat {
+                        added: 1,
+                        deleted: 1,
+                    }),
+                }),
+                GitListEntry::Header(GitHeaderEntry {
+                    header: Section::New
+                }),
+                GitListEntry::Status(GitStatusEntry {
+                    repo_path: repo_path("other"),
+                    status: FileStatus::Untracked,
+                    staging: StageStatus::Unstaged,
+                    diff_stat: None,
+                }),
+            ]
+        );
+
+        cx.focus(&workspace);
+        cx.update(|window, cx| {
+            window.dispatch_action(Diff.boxed_clone(), cx);
+        });
+        cx.run_until_parked();
+        let project_diff = workspace.update(&mut cx.cx, |workspace, cx| {
+            workspace
+                .active_item_as::<ProjectDiff>(cx)
+                .expect("project diff should be open")
+        });
+        let editor = project_diff.read_with(&cx.cx, |project_diff, cx| {
+            project_diff.editor(cx).read(cx).rhs_editor().clone()
+        });
+        let mut cx = EditorTestContext::for_editor_in(editor, &mut cx.cx).await;
+
+        cx.dispatch_action(git::Restore);
+        cx.run_until_parked();
+        assert_eq!(
+            fs.read_file_sync(path!("/root/file"))
+                .expect("restored file should exist"),
+            b"original\n"
+        );
+        assert_eq!(
+            fs.read_file_sync(path!("/root/other"))
+                .expect("other file should exist"),
+            b"other on disk\n"
+        );
+        other_buffer.read_with(&cx.cx, |buffer, _| {
+            assert_eq!(buffer.text(), "unsaved other\n");
+            assert!(buffer.is_dirty());
+        });
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        let entries = panel.read_with(&cx.cx, |panel, _| panel.entries.clone());
+        pretty_assertions::assert_eq!(
+            entries,
+            [
+                GitListEntry::Header(GitHeaderEntry {
+                    header: Section::New
+                }),
+                GitListEntry::Status(GitStatusEntry {
+                    repo_path: repo_path("other"),
+                    status: FileStatus::Untracked,
+                    staging: StageStatus::Unstaged,
+                    diff_stat: None,
+                }),
+            ]
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Fixes #63855 

## Solution

save_buffer() when user restored the changes.

## Testing

- Did you test these changes? If so, how? Test is shipped in, and I saw it. Video included!

- Are there any parts that need more testing? Race on fast git restore for identical editor item, but I couldn't reproduce it with test, so probably no.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? the test references to the exact failure zed had.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? macos, I think this's platform independant

## Self-Review Checklist:

- [y] I've reviewed my own diff for quality, security, and reliability
- [y] Unsafe blocks (if any) have justifying comments
- [y] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [y] Tests cover the new/changed behavior
- [y] Performance impact has been considered and is acceptable

## Showcase

Before:

https://github.com/user-attachments/assets/37e2d920-90a5-4e8c-8b1d-251a8c92e82c

After:

https://github.com/user-attachments/assets/400ddac3-be82-431b-9401-9d6059450a8a



---

Release Notes:

- Git restore autosaves the changes
