### PR TITLE
Add option for changing whether or not to comment out empty lines

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -788,6 +788,11 @@
     // Whether to stick scopes to the top of the editor.
     "enabled": false,
   },
+  "comments": {
+    // Whether to leave empty lines untouched when toggling comments over a
+    // selection that spans multiple lines.
+    "ignore_empty_lines": true,
+  },
   "relative_line_numbers": "disabled",
   // If 'search_wrap' is disabled, search result do not wrap around the end of the file.
   "search_wrap": true,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -40,6 +40,7 @@ pub struct EditorSettings {
     pub mouse_wheel_zoom: bool,
     pub fast_scroll_sensitivity: f32,
     pub sticky_scroll: StickyScroll,
+    pub comments: Comments,
     pub relative_line_numbers: RelativeLineNumbers,
     pub seed_search_query_from_cursor: SeedQuerySetting,
     pub use_smartcase_search: bool,
@@ -97,6 +98,11 @@ pub struct Jupyter {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StickyScroll {
     pub enabled: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Comments {
+    pub ignore_empty_lines: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -224,6 +230,7 @@ impl Settings for EditorSettings {
         let search = editor.search.unwrap();
         let drag_and_drop_selection = editor.drag_and_drop_selection.unwrap();
         let sticky_scroll = editor.sticky_scroll.unwrap();
+        let comments = editor.comments.unwrap();
         let file_diff = content.git.as_ref().unwrap().file_diff.unwrap();
         Self {
             cursor_blink: editor.cursor_blink.unwrap(),
@@ -292,6 +299,9 @@ impl Settings for EditorSettings {
             fast_scroll_sensitivity: editor.fast_scroll_sensitivity.unwrap(),
             sticky_scroll: StickyScroll {
                 enabled: sticky_scroll.enabled.unwrap(),
+            },
+            comments: Comments {
+                ignore_empty_lines: comments.ignore_empty_lines.unwrap(),
             },
             relative_line_numbers: editor.relative_line_numbers.unwrap(),
             seed_search_query_from_cursor: editor.seed_search_query_from_cursor.unwrap(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -23320,6 +23320,83 @@ async fn test_toggle_comment_ignore_indent(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_toggle_comment_without_ignoring_blank_lines(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.editor.comments = Some(settings::CommentsContent {
+                    ignore_empty_lines: Some(false),
+                })
+            });
+        });
+    });
+    let mut cx = EditorTestContext::new(cx).await;
+    // A prefix without a trailing space keeps every expectation below free of
+    // trailing whitespace, which would otherwise be stripped on save and break
+    // the assertions on commented blank lines.
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            line_comments: vec!["//".into()],
+            ..Default::default()
+        },
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    ));
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+
+    cx.set_state(indoc! {"
+        «fn a() {
+            b();
+
+            c();
+        }ˇ»
+    "});
+
+    cx.update_editor(|e, window, cx| e.toggle_comments(&ToggleComments::default(), window, cx));
+
+    cx.assert_editor_state(indoc! {"
+        //«fn a() {
+        //    b();
+        //
+        //    c();
+        //}ˇ»
+    "});
+
+    // Toggling again removes the prefix from every line, blank ones included.
+    cx.update_editor(|e, window, cx| e.toggle_comments(&ToggleComments::default(), window, cx));
+
+    cx.assert_editor_state(indoc! {"
+        «fn a() {
+            b();
+
+            c();
+        }ˇ»
+    "});
+
+    // All prefixes in a block go at one shared column so they line up: the
+    // smallest indent among the rows being commented. A blank line contributes
+    // 0 and drags that to 0 - shifting every line in the block left. VS Code
+    // does the same.
+    cx.set_state(indoc! {"
+        fn a() {
+            «b();
+
+            c();ˇ»
+        }
+    "});
+
+    cx.update_editor(|e, window, cx| e.toggle_comments(&ToggleComments::default(), window, cx));
+
+    cx.assert_editor_state(indoc! {"
+        fn a() {
+        //    «b();
+        //
+        //    c();ˇ»
+        }
+    "});
+}
+
+#[gpui::test]
 async fn test_advance_downward_on_toggle_comment(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1403,6 +1403,7 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        let ignore_blank_lines = EditorSettings::get_global(cx).comments.ignore_empty_lines;
         let text_layout_details = &self.text_layout_details(window, cx);
         self.transact(window, cx, |this, window, cx| {
             let mut selections = this
@@ -1548,7 +1549,8 @@ impl Editor {
 
                     for row in start_row.0..=end_row.0 {
                         let row = MultiBufferRow(row);
-                        if start_row < end_row && snapshot.is_line_blank(row) {
+                        if start_row < end_row && snapshot.is_line_blank(row) && ignore_blank_lines
+                        {
                             continue;
                         }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -282,6 +282,7 @@ impl VsCodeSettings {
             expand_excerpt_lines: None,
             fast_scroll_sensitivity: self.read_f32("editor.fastScrollSensitivity"),
             sticky_scroll: self.sticky_scroll_content(),
+            comments: self.comments_content(),
             go_to_definition_fallback: None,
             go_to_definition_scroll_strategy: None,
             lsp_results_location: None,
@@ -343,6 +344,12 @@ impl VsCodeSettings {
     fn sticky_scroll_content(&self) -> Option<StickyScrollContent> {
         skip_default(StickyScrollContent {
             enabled: self.read_bool("editor.stickyScroll.enabled"),
+        })
+    }
+
+    fn comments_content(&self) -> Option<CommentsContent> {
+        skip_default(CommentsContent {
+            ignore_empty_lines: self.read_bool("editor.comments.ignoreEmptyLines"),
         })
     }
 
@@ -1240,6 +1247,28 @@ mod tests {
             None
         );
         assert_eq!(imported_reduce_motion("{}"), None);
+    }
+
+    #[test]
+    fn test_import_ignore_empty_lines() {
+        let imported = |content: &str| {
+            VsCodeSettings::from_str(content, VsCodeSettingsSource::VsCode)
+                .unwrap()
+                .settings_content()
+                .editor
+                .comments
+                .and_then(|comments| comments.ignore_empty_lines)
+        };
+
+        assert_eq!(
+            imported(r#"{ "editor.comments.ignoreEmptyLines": false }"#),
+            Some(false)
+        );
+        assert_eq!(
+            imported(r#"{ "editor.comments.ignoreEmptyLines": true }"#),
+            Some(true)
+        );
+        assert_eq!(imported("{}"), None);
     }
 
     #[test]

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -114,6 +114,8 @@ pub struct EditorSettingsContent {
     ///
     /// Default: sticky scroll is disabled
     pub sticky_scroll: Option<StickyScrollContent>,
+    /// Settings for toggling comments in the editor.
+    pub comments: Option<CommentsContent>,
     /// Whether the line numbers on editors gutter are relative or not.
     /// When "enabled" shows relative number of buffer lines, when "wrapped" shows
     /// relative number of display lines.
@@ -446,6 +448,17 @@ pub struct StickyScrollContent {
     ///
     /// Default: false
     pub enabled: Option<bool>,
+}
+
+/// Comment toggling related settings
+#[with_fallible_options]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct CommentsContent {
+    /// Whether to leave empty lines untouched when toggling comments over a
+    /// selection that spans multiple lines.
+    ///
+    /// Default: true
+    pub ignore_empty_lines: Option<bool>,
 }
 
 /// Minimap related settings

--- a/docs/src/migrate/vs-code.md
+++ b/docs/src/migrate/vs-code.md
@@ -52,6 +52,7 @@ The following VS Code settings are automatically imported when you use **Import 
 | `editor.minimap.showSlider`                 | `minimap.thumb`                                |
 | `editor.minimap.maxColumn`                  | `minimap.max_width_columns`                    |
 | `editor.stickyScroll.enabled`               | `sticky_scroll.enabled`                        |
+| `editor.comments.ignoreEmptyLines`          | `comments.ignore_empty_lines`                  |
 | `editor.scrollbar.horizontal`               | `scrollbar.axes.horizontal`                    |
 | `editor.scrollbar.vertical`                 | `scrollbar.axes.vertical`                      |
 | `editor.mouseWheelScrollSensitivity`        | `scroll_sensitivity`                           |


### PR DESCRIPTION


# Objective
- Fixes #60738 

## Solution

- Added an editor setting (boolean) that allows for ignoring/considering empty lines when a text block is being commented out/in.

## Testing

- Manually tested
- Added automated test `test_toggle_comment_without_ignoring_blank_lines`

- Can be tested manually as shown in the video, CI should show the result of the newly added automated test

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

Demo:

<details>
https://github.com/user-attachments/assets/d2f38d09-e352-4ce2-831b-7e655448b9a1
</details>

---

Release Notes:

- Added option to ignore or consider blank lines while commenting in/out
