### PR TITLE
Fix git blame on shallow commit boundary

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -1,6 +1,6 @@
 use crate::Oid;
 use crate::commit::{get_messages, get_tag_names};
-use crate::repository::{GitBinary, RepoPath};
+use crate::repository::{GitBinary, RepoPath, is_shallow_boundary_commit};
 use anyhow::{Context as _, Result};
 use collections::{HashMap, HashSet};
 use futures::{AsyncWriteExt, TryFutureExt, try_join};
@@ -41,8 +41,22 @@ impl Blame {
     }
 
     async fn with_commit_details(git: &GitBinary, mut entries: Vec<BlameEntry>) -> Result<Self> {
-        let mut unique_shas = HashSet::default();
+        let shallow_file_path = git
+            .run(&[
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "shallow",
+            ])
+            .await
+            .context("resolving shallow file path")?;
+        let shallow_file_path = std::path::Path::new(shallow_file_path.trim());
+        for entry in entries.iter_mut().filter(|entry| entry.boundary) {
+            entry.boundary =
+                is_shallow_boundary_commit(git, shallow_file_path, &entry.sha.to_string()).await?;
+        }
 
+        let mut unique_shas = HashSet::default();
         for entry in entries.iter_mut() {
             unique_shas.insert(entry.sha);
         }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -631,7 +631,7 @@ async fn read_shallow_file(shallow_file_path: &Path) -> Result<Option<String>> {
     }
 }
 
-async fn is_shallow_boundary_commit(
+pub(crate) async fn is_shallow_boundary_commit(
     git: &GitBinary,
     shallow_file_path: &Path,
     commit: &str,
@@ -5993,6 +5993,70 @@ mod tests {
                 .map(|entry| (entry.sha.to_string(), entry.range.clone()))
                 .collect::<Vec<_>>(),
             vec![(first_sha.clone(), 0..1)]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_blame_boundary_only_for_shallow_repository(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let source_dir = tempfile::tempdir().unwrap();
+        git_init_repo(source_dir.path());
+        fs::write(source_dir.path().join("a.txt"), "one\n").unwrap();
+        git_command(source_dir.path(), ["add", "a.txt"]);
+        git_command(source_dir.path(), ["commit", "-m", "first"]);
+        let head_sha = git_command_output(source_dir.path(), ["rev-parse", "HEAD"]);
+        let source_repo = RealGitRepository::new(
+            &source_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let source_blame = source_repo
+            .blame(repo_path("a.txt"), Rope::from("one\n"), LineEnding::Unix)
+            .await
+            .unwrap();
+        assert_eq!(
+            source_blame
+                .entries
+                .iter()
+                .map(|entry| (entry.sha.to_string(), entry.range.clone(), entry.boundary))
+                .collect::<Vec<_>>(),
+            vec![(head_sha.clone(), 0..1, false)]
+        );
+
+        let clone_dir = tempfile::tempdir().unwrap();
+        git_command(
+            clone_dir.path(),
+            [
+                "clone".to_string(),
+                "--depth=1".to_string(),
+                format!("file://{}", source_dir.path().display()),
+                "shallow".to_string(),
+            ],
+        );
+        let shallow_repo = RealGitRepository::new(
+            &clone_dir.path().join("shallow/.git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let shallow_blame = shallow_repo
+            .blame(repo_path("a.txt"), Rope::from("one\n"), LineEnding::Unix)
+            .await
+            .unwrap();
+        assert_eq!(
+            shallow_blame
+                .entries
+                .iter()
+                .map(|entry| (entry.sha.to_string(), entry.range.clone(), entry.boundary))
+                .collect::<Vec<_>>(),
+            vec![(head_sha, 0..1, true)]
         );
     }
 


### PR DESCRIPTION
# Objective

Fixes #63838

## Solution

with_commit_details() now checks if commit falls into shallow boundary or not

## Testing

- Did you test these changes? If so, how? I first made test which fails on this, patched, then passed.
- Are there any parts that need more testing? No.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? git clone with --depth 1 would make false alarm when it had only one branch at total for the commit boundary.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? macos!

## Self-Review Checklist:

- [y] I've reviewed my own diff for quality, security, and reliability
- [y] Unsafe blocks (if any) have justifying comments
- [y] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [y] Tests cover the new/changed behavior
- [y] Performance impact has been considered and is acceptable: I worried if hovering could call git commands, but the boundary was clear.

## Showcase

<img width="523" height="99" alt="image" src="https://github.com/user-attachments/assets/064961b4-7a9a-4bdd-9ebc-0df693cc5078" />

---

Release Notes:

- Fix false alarm on shallow boundary commit
