### PR TITLE
google_ai: Propagate thought signatures across parallel tool calls and turns

### DIFF
--- a/crates/google_ai/src/completion.rs
+++ b/crates/google_ai/src/completion.rs
@@ -24,6 +24,17 @@ pub fn into_google(
 ) -> Result<crate::GenerateContentRequest> {
     fn map_content(content: Vec<MessageContent>) -> Result<Vec<Part>> {
         let mut mapped_parts = Vec::new();
+        let turn_signature = content.iter().find_map(|c| match c {
+            MessageContent::Thinking {
+                signature: Some(sig),
+                ..
+            } if !sig.is_empty() => Some(sig.clone()),
+            MessageContent::ToolUse(tu) => {
+                tu.thought_signature.as_ref().filter(|s| !s.is_empty()).cloned()
+            }
+            _ => None,
+        });
+
         for content in content {
             match content {
                 MessageContent::Text(text) => {
@@ -58,7 +69,10 @@ pub fn into_google(
                     }));
                 }
                 MessageContent::ToolUse(tool_use) => {
-                    let thought_signature = tool_use.thought_signature.filter(|s| !s.is_empty());
+                    let thought_signature = tool_use
+                        .thought_signature
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| turn_signature.clone());
                     let LanguageModelToolUseInput::Json(input) = tool_use.input else {
                         anyhow::bail!("Google AI does not support custom tool calls");
                     };
@@ -279,6 +293,7 @@ fn supports_thinking_budget_disable(model_id: &str) -> bool {
 pub struct GoogleEventMapper {
     usage: UsageMetadata,
     stop_reason: StopReason,
+    last_thought_signature: Option<String>,
 }
 
 impl GoogleEventMapper {
@@ -286,6 +301,7 @@ impl GoogleEventMapper {
         Self {
             usage: UsageMetadata::default(),
             stop_reason: StopReason::EndTurn,
+            last_thought_signature: None,
         }
     }
 
@@ -377,6 +393,9 @@ impl GoogleEventMapper {
                         Part::TextPart(text_part) => {
                             let thought_signature =
                                 text_part.thought_signature.filter(|s| !s.is_empty());
+                            if let Some(ref sig) = thought_signature {
+                                self.last_thought_signature = Some(sig.clone());
+                            }
                             if text_part.thought {
                                 if !text_part.text.is_empty() || thought_signature.is_some() {
                                     events.push(Ok(LanguageModelCompletionEvent::Thinking {
@@ -411,10 +430,13 @@ impl GoogleEventMapper {
                                     format!("{}-{}", name, next_tool_id).into()
                                 };
 
-                            // Normalize empty string signatures to None
-                            let thought_signature = function_call_part
+                            if let Some(sig) = function_call_part
                                 .thought_signature
-                                .filter(|s| !s.is_empty());
+                                .filter(|s| !s.is_empty())
+                            {
+                                self.last_thought_signature = Some(sig);
+                            }
+                            let thought_signature = self.last_thought_signature.clone();
 
                             events.push(Ok(LanguageModelCompletionEvent::ToolUse(
                                 LanguageModelToolUse {
@@ -880,5 +902,98 @@ mod tests {
         } else {
             panic!("Expected ToolUse event");
         }
+    }
+
+    #[test]
+    fn test_parallel_function_calls_inherit_thought_signature() {
+        let mut mapper = GoogleEventMapper::new();
+
+        let response = GenerateContentResponse {
+            candidates: Some(vec![GenerateContentCandidate {
+                index: Some(0),
+                content: Content {
+                    parts: vec![
+                        Part::FunctionCallPart(FunctionCallPart {
+                            function_call: FunctionCall {
+                                name: "first_tool".to_string(),
+                                args: json!({}),
+                                id: None,
+                            },
+                            thought_signature: Some("batch_signature_123".to_string()),
+                        }),
+                        Part::FunctionCallPart(FunctionCallPart {
+                            function_call: FunctionCall {
+                                name: "second_tool".to_string(),
+                                args: json!({}),
+                                id: None,
+                            },
+                            thought_signature: None,
+                        }),
+                    ],
+                    role: GoogleRole::Model,
+                },
+                finish_reason: None,
+                finish_message: None,
+                safety_ratings: None,
+                citation_metadata: None,
+            }]),
+            prompt_feedback: None,
+            usage_metadata: None,
+        };
+
+        let events = mapper.map_event(response);
+        assert_eq!(events.len(), 3);
+
+        if let Ok(LanguageModelCompletionEvent::ToolUse(tu1)) = &events[0] {
+            assert_eq!(tu1.name.as_ref(), "first_tool");
+            assert_eq!(tu1.thought_signature.as_deref(), Some("batch_signature_123"));
+        } else {
+            panic!("Expected ToolUse 1");
+        }
+
+        if let Ok(LanguageModelCompletionEvent::ToolUse(tu2)) = &events[1] {
+            assert_eq!(tu2.name.as_ref(), "second_tool");
+            assert_eq!(tu2.thought_signature.as_deref(), Some("batch_signature_123"));
+        } else {
+            panic!("Expected ToolUse 2 to inherit batch signature");
+        }
+    }
+
+    #[test]
+    fn test_into_google_tool_use_without_signature_inherits_turn_thinking_signature() {
+        let request = LanguageModelRequest {
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::Thinking {
+                        text: "planning".to_string(),
+                        signature: Some("thinking_sig_456".to_string()),
+                    },
+                    MessageContent::ToolUse(LanguageModelToolUse {
+                        id: "call_1".into(),
+                        name: "test_tool".into(),
+                        input: LanguageModelToolUseInput::Json(json!({})),
+                        raw_input: "{}".to_string(),
+                        is_input_complete: true,
+                        thought_signature: None,
+                    }),
+                ],
+                cache: false,
+                reasoning_details: None,
+            }],
+            ..Default::default()
+        };
+
+        let google_req = into_google(
+            request,
+            "gemini-3.8-flash".to_string(),
+            GoogleModelMode::Thinking { budget_tokens: None },
+        )
+        .unwrap();
+
+        let Part::FunctionCallPart(fc) = &google_req.contents[0].parts[1] else {
+            panic!("expected FunctionCallPart");
+        };
+        assert_eq!(fc.thought_signature.as_deref(), Some("thinking_sig_456"));
     }
 }


### PR DESCRIPTION
# Objective

Fixes #64035

Fix an HTTP 400 error (`Function call is missing a thought_signature in functionCall parts`) when using Google Gemini thinking models (such as Gemini 3.8 Flash, Gemini 3.5 Flash) with tool calling, particularly on Google Vertex AI.

## Problem

1. **Parallel tool calls**: When Gemini responds with multiple tool calls in parallel, the API emits `thought_signature` on only the first `FunctionCallPart` (or preceding `TextPart`). In `GoogleEventMapper::map_event`, parts were mapped independently, causing subsequent parallel tool calls to receive `thought_signature: None`.
2. **Outbound history replay**: When re-sending history to the model, `into_google` omits `thoughtSignature` on any `FunctionCallPart` whose `tool_use.thought_signature` is `None`. While Google AI Studio is more lenient, Google Vertex AI strictly validates the entire `contents` payload and rejects any function call missing `thoughtSignature`, bricking subsequent turns in the thread.

## Solution

1. In `GoogleEventMapper`, track `last_thought_signature` across the candidate parts so parallel `FunctionCallPart`s inherit the turn's thought signature.
2. In `into_google`, fall back to the turn's `MessageContent::Thinking` or prior tool call signature if an individual `ToolUse` lacks one.
3. Added unit tests for both parallel tool signature inheritance and `into_google` turn signature fallback.

## Testing

Ran `cargo test -p google_ai`: all 25 tests pass.

- `test_parallel_function_calls_inherit_thought_signature`
- `test_into_google_tool_use_without_signature_inherits_turn_thinking_signature`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed missing thought signatures on parallel tool calls when using Gemini thinking models