### PR TITLE
markdown: Respect preview theme for bold text

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -172,6 +172,13 @@ pub enum MarkdownFont {
     Preview,
 }
 
+fn strong_text_style() -> TextStyleRefinement {
+    TextStyleRefinement {
+        font_weight: Some(FontWeight::BOLD),
+        ..Default::default()
+    }
+}
+
 impl MarkdownStyle {
     pub fn themed(font: MarkdownFont, window: &Window, cx: &App) -> Self {
         let colors = cx.theme().colors();
@@ -2811,11 +2818,7 @@ impl Element for MarkdownElement {
                             font_style: Some(FontStyle::Italic),
                             ..Default::default()
                         }),
-                        MarkdownTag::Strong => builder.push_text_style(TextStyleRefinement {
-                            font_weight: Some(FontWeight::BOLD),
-                            color: Some(cx.theme().colors().text),
-                            ..Default::default()
-                        }),
+                        MarkdownTag::Strong => builder.push_text_style(strong_text_style()),
                         MarkdownTag::Strikethrough => {
                             builder.push_text_style(TextStyleRefinement {
                                 strikethrough: Some(StrikethroughStyle {
@@ -6603,6 +6606,20 @@ mod tests {
             assert!(markdown.context_menu_selected_markdown().is_none());
             assert!(markdown.context_menu_selected_text().is_none());
         });
+    }
+
+    #[test]
+    fn test_strong_text_style_inherits_color() {
+        let inherited_color: Hsla = gpui::rgba(0x123456ff).into();
+        let mut text_style = TextStyle {
+            color: inherited_color,
+            ..Default::default()
+        };
+
+        text_style.refine(&strong_text_style());
+
+        assert_eq!(text_style.color, inherited_color);
+        assert_eq!(text_style.font_weight, FontWeight::BOLD);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Fixes #62814.

Zed displays Markdown files in two ways:

- The editor shows the Markdown source that you type, such as `**bold text**`.
- The Markdown preview shows the same file as a formatted document, with the `**` markers hidden.

The editor and the formatted preview can use different color themes. Currently, normal words in the formatted preview use the preview colors, but bold words incorrectly use the editor colors. For example, with a dark editor and a light preview, bold words can appear very light against a light background and become difficult to read.

## Solution

Make bold formatting change only the font weight. Bold words now inherit the color of the surrounding formatted document, including the color selected by the Markdown preview theme.

Related work: #62837 identified the same root cause and attempted a fix but was closed.

## Testing

- `cargo test -p markdown`
- `cargo test -p markdown_preview`
- `cargo fmt --all -- --check`
- `./script/clippy -p markdown`

## Self-Review Checklist:

- [x] I reviewed the diff for quality, security, and reliability
- [x] Unsafe blocks, if any, have justifying comments
- [x] The content follows Zed UI standards
- [x] Tests cover the changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed bold words using the wrong color theme in Markdown previews.