### PR TITLE
editor: Fix vertical scroll margin calculation

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -237,7 +237,8 @@ impl Editor {
             AutoscrollStrategy::Fit | AutoscrollStrategy::Newest => {
                 let margin_top = margin.min(self.scroll_manager.vertical_scroll_margin);
                 let total_free_space = visible_lines - (target_bottom - target_top);
-                let margin_bottom = (total_free_space - margin).min(self.scroll_manager.vertical_scroll_margin);
+                let margin_bottom =
+                    (total_free_space - margin).min(self.scroll_manager.vertical_scroll_margin);
                 let target_top = (target_top - margin_top - visible_sticky_headers as f64).max(0.0);
                 let target_bottom = target_bottom + margin_bottom;
 

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -235,9 +235,12 @@ impl Editor {
 
         let was_autoscrolled = match strategy {
             AutoscrollStrategy::Fit | AutoscrollStrategy::Newest => {
-                let margin = margin.min(self.scroll_manager.vertical_scroll_margin);
-                let target_top = (target_top - margin - visible_sticky_headers as f64).max(0.0);
-                let target_bottom = target_bottom + margin;
+                let margin_top = margin.min(self.scroll_manager.vertical_scroll_margin);
+                let total_free_space = visible_lines - (target_bottom - target_top);
+                let margin_bottom = (total_free_space - margin).min(self.scroll_manager.vertical_scroll_margin);
+                let target_top = (target_top - margin_top - visible_sticky_headers as f64).max(0.0);
+                let target_bottom = target_bottom + margin_bottom;
+
                 let start_row = scroll_position.y;
                 let end_row = start_row + visible_lines;
 


### PR DESCRIPTION
# Objective

- Fixes an issue where setting an arbitrarily high `Vertical Scroll Margin` fails to perfectly lock the cursor in the center of the viewport (Typewriter Mode?). In certain cases one could go up/down a line before auto-scroll gets triggered, deviating from user intent.
- Fixes #63862

## Solution

- **The Issue:** When `Vertical Scroll Margin` is very high, the effective margin applied above and below the cursor is derived from the viewport's free space:
  ```rust
  ((visible_lines - (target_bottom - target_top)) / 2.0).floor()
  ```
- **The Fix:** Instead of using the same rounded number for both the top and bottom margins, calculate them separately:
  1. The top margin stays the same as before.
  2. The bottom margin is calculated by subtracting the top margin from the total free screen space.
- This ensures the bottom margin automatically catches whatever fraction the floor operation on the top margin drops, so the two margins always sum to the full available space.

## Testing

- Did you test these changes? If so, how?
  Ran `cargo test -p editor`, all passed. I've also attached the results of manual testing in the Showcase section below.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([[UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [[icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md)](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before and after screen recording

<details>
<summary>Click to view showcase</summary>

**Before:**

https://private-user-images.githubusercontent.com/63847494/646999418-4dd388b8-4aba-4004-ac4f-6f1e0dad0f70.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODg5MTE3MTUsIm5iZiI6MTc4ODkxMTQxNSwicGF0aCI6Ii82Mzg0NzQ5NC82NDY5OTk0MTgtNGRkMzg4YjgtNGFiYS00MDA0LWFjNGYtNmYxZTBkYWQwZjcwLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA5MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwOTA4VDIzNTAxNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWRhZGM5MWExMDkyMDIzZjVlYjcxYmQ4YTRmOTM3MDliNDcyOTUzZjFhYmY1ZTgwMDY0YzhlYmQ1NzllYWYyN2EmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRm1wNCJ9.DG6RpiEM-781ZctlvtQeWhw3kAYJ4KS6rNsAmMU38fg

**After:**

https://github.com/user-attachments/assets/4bf870e0-84ba-449a-bf2a-925c4a90d5ed

</details>

Release Notes:

- Fixed the cursor not staying perfectly centered when using a high Vertical Scroll Margin (Typewriter Mode).