### PR TITLE
agent_ui: Sync generated thread titles to ThreadMetadataStore on TitleUpdated

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1802,14 +1802,24 @@ impl ConversationView {
                         .entry(self.thread_id)
                         .and_then(|m| m.title_override.clone())
                 });
-                let title = override_title.or_else(|| thread.read(cx).title());
-                if let Some(title) = title
+                let generated_title = thread.read(cx).title();
+                let display_title = override_title.clone().or_else(|| generated_title.clone());
+                if let Some(display_title) = display_title
                     && let Some(active_thread) = self.thread_view(&session_id)
                 {
                     let title_editor = active_thread.read(cx).title_editor.clone();
                     title_editor.update(cx, |editor, cx| {
-                        if editor.text(cx) != title {
-                            editor.set_text(title, window, cx);
+                        if editor.text(cx) != display_title {
+                            editor.set_text(display_title, window, cx);
+                        }
+                    });
+                }
+                if let Some(generated_title) = generated_title
+                    && let Some(store) = ThreadMetadataStore::try_global(cx)
+                {
+                    store.update(cx, |store, cx| {
+                        if override_title.is_none() {
+                            store.set_generated_title(self.thread_id, generated_title, cx);
                         }
                     });
                 }


### PR DESCRIPTION
### Summary
When an assistant thread generates a title in the background, `ConversationView` updates the tab's `title_editor` upon receiving `AcpThreadEvent::TitleUpdated`, but previously did not notify `ThreadMetadataStore`. 

As a result, auto-generated titles were not persisted to the metadata database or reflected in the sidebar thread history until a user manually triggered "Regenerate Thread Title" from the context menu.

### Changes
* In `ConversationView::handle_event` (`AcpThreadEvent::TitleUpdated`), call `ThreadMetadataStore::set_generated_title` when a new generated title is received (preserving any existing user `title_override`).
* Automatically syncs the thread history sidebar in real-time when the background LLM title generation completes.

### Testing
* Verified that auto-generated thread titles immediately update both the editor tab header and the sidebar thread history list without requiring a manual regenerate action.

Release Notes:

- Fixed auto-generated agent thread titles not syncing to the thread history sidebar until manually regenerated.