### PR TITLE
Disable unused Chrome apt repository in CI

### DIFF
--- a/.github/workflows/autofix_pr.yml
+++ b/.github/workflows/autofix_pr.yml
@@ -44,7 +44,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_pnpm

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -33,7 +33,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::cargo_fmt
@@ -64,7 +66,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::cargo_install_nextest

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -101,7 +101,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/generate-action-metadata

--- a/.github/workflows/publish_extension_cli.yml
+++ b/.github/workflows/publish_extension_cli.yml
@@ -28,7 +28,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: publish_extension_cli::publish_job::build_extension_cli
       run: cargo build --release --package extension_cli
     - name: publish_extension_cli::publish_job::upload_binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -210,7 +212,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
@@ -399,7 +403,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux
@@ -444,7 +450,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -56,7 +56,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -126,7 +128,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux
@@ -175,7 +179,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -38,7 +38,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux
@@ -82,7 +84,9 @@ jobs:
       with:
         token: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/bundle-linux

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -243,7 +243,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
@@ -393,7 +395,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::setup_node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
@@ -536,7 +540,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_cargo_config
@@ -588,7 +594,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_sccache
@@ -745,7 +753,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_linux
-      run: ./script/linux
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: ./script/generate-action-metadata

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -319,7 +319,12 @@ pub fn cache_nix_store_macos() -> Step<Use> {
 }
 
 pub fn setup_linux() -> Step<Run> {
-    named::bash("./script/linux")
+    // The runners include Chrome, but CI does not use it. Do not let its external repository
+    // prevent installing Zed's Linux dependencies when the repository is unavailable.
+    named::bash(indoc::indoc! {r#"
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+        ./script/linux
+    "#})
 }
 
 pub(crate) fn download_wasi_sdk() -> Step<Run> {


### PR DESCRIPTION
## Summary

- Remove the preconfigured Google Chrome APT sources before installing Linux dependencies
- Keep unrelated Chrome repository failures from blocking Zed CI jobs
- Regenerate all affected workflows from the xtask workflow definitions

Google issue: https://issuetracker.google.com/issues/559075205

## Testing

- `corgi run -p xtask -- workflows`
- `corgi fmt -- --check`
- `git diff --check`
- Confirmed all 19 generated `steps::setup_linux` invocations remove the Chrome repository

Release Notes:

- N/A