### PR TITLE
agent: persist user-message times for temporal context

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -4121,14 +4121,12 @@ mod internal_tests {
             request.intent,
             Some(CompletionIntent::ThreadContextSummarization)
         );
-        assert_eq!(
-            request_texts_after_system(&request.messages),
-            vec![
-                "old user".to_string(),
-                "old assistant".to_string(),
-                COMPACTION_PROMPT.to_string(),
-            ]
-        );
+        let request_texts = request_texts_after_system(&request.messages);
+        assert_eq!(request_texts.len(), 3);
+        assert!(request_texts[0].starts_with("<time>"));
+        assert!(request_texts[0].ends_with("old user"));
+        assert_eq!(request_texts[1], "old assistant");
+        assert_eq!(request_texts[2], COMPACTION_PROMPT);
 
         model.send_completion_stream_text_chunk(&request, "summary");
         model.end_completion_stream(&request);

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -250,6 +250,7 @@ impl DbThread {
                         // MessageId from old format can't be meaningfully converted, so generate a new one
                         id,
                         content: Arc::from(content),
+                        created_at: None,
                     })
                 }
                 language_model::Role::Assistant => {

--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -42,7 +42,6 @@ pub struct SystemPromptTemplate<'a> {
     pub project: &'a prompt_store::ProjectContext,
     pub available_tools: Vec<SharedString>,
     pub model_name: Option<String>,
-    pub date: String,
     /// Contents of the user-global `~/.config/zed/AGENTS.md` file (or the
     /// platform equivalent), if present and non-empty.
     pub user_agents_md: Option<SharedString>,
@@ -103,7 +102,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: false,
             is_linux: false,
@@ -112,7 +110,6 @@ mod tests {
         let templates = Templates::new();
         let rendered = template.render(&templates).unwrap();
         assert!(rendered.contains("You are the Zed coding agent"));
-        assert!(rendered.contains("Today's Date: 2026-01-01"));
         assert!(rendered.contains("## Fixing Diagnostics"));
         assert!(rendered.contains("test-model"));
     }
@@ -136,7 +133,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: Some("always be concise".into()),
             sandboxing: false,
             is_linux: false,
@@ -165,7 +161,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: false,
             is_linux: false,
@@ -198,7 +193,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into(), "terminal".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: true,
             is_linux: false,
@@ -241,7 +235,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into(), "terminal".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: true,
             is_linux: true,
@@ -274,7 +267,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into(), "terminal".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: true,
             is_linux: false,
@@ -304,7 +296,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into(), "terminal".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: true,
             is_linux: false,
@@ -326,7 +317,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: true,
             is_linux: false,
@@ -346,7 +336,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: false,
             is_linux: false,
@@ -364,7 +353,6 @@ mod tests {
             project: &project,
             available_tools: vec!["echo".into()],
             model_name: Some("test-model".to_string()),
-            date: "2026-01-01".to_string(),
             user_agents_md: None,
             sandboxing: false,
             is_linux: false,

--- a/crates/agent/src/templates/experimental_system_prompt.hbs
+++ b/crates/agent/src/templates/experimental_system_prompt.hbs
@@ -125,7 +125,6 @@ If the user references a file, function, type, command, or other project-specifi
 
 Operating System: {{os}}
 Default Shell: {{shell}}
-Today's Date: {{date}}
 
 The current project contains the following root directories:
 

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -145,7 +145,6 @@ If the user references a file, function, type, command, or other project-specifi
 
 Operating System: {{os}}
 Default Shell: {{shell}}
-Today's Date: {{date}}
 
 The current project contains the following root directories:
 

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -69,6 +69,21 @@ pub(crate) fn release_dropped_entities(cx: &mut TestAppContext) {
     cx.run_until_parked();
 }
 
+fn without_user_message_timestamps(
+    messages: &[LanguageModelRequestMessage],
+) -> Vec<LanguageModelRequestMessage> {
+    messages
+        .iter()
+        .cloned()
+        .map(|mut message| {
+            message.content.retain(
+                |content| !matches!(content, MessageContent::Text(text) if text.starts_with("<time>")),
+            );
+            message
+        })
+        .collect()
+}
+
 pub(crate) struct FakeTerminalHandle {
     killed: Arc<AtomicBool>,
     stopped_by_user: Arc<AtomicBool>,
@@ -629,7 +644,7 @@ async fn test_prompt_caching(cx: &mut TestAppContext) {
 
     let completion = fake_model.pending_completions().pop().unwrap();
     assert_eq!(
-        completion.messages[1..],
+        without_user_message_timestamps(&completion.messages[1..]),
         vec![LanguageModelRequestMessage {
             role: Role::User,
             content: vec!["Message 1".into()],
@@ -653,7 +668,7 @@ async fn test_prompt_caching(cx: &mut TestAppContext) {
 
     let completion = fake_model.pending_completions().pop().unwrap();
     assert_eq!(
-        completion.messages[1..],
+        without_user_message_timestamps(&completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -712,7 +727,7 @@ async fn test_prompt_caching(cx: &mut TestAppContext) {
         output: Some("test".into()),
     };
     assert_eq!(
-        completion.messages[1..],
+        without_user_message_timestamps(&completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -4137,7 +4152,7 @@ async fn test_building_request_with_pending_tools(cx: &mut TestAppContext) {
         })
         .unwrap();
     assert_eq!(
-        request.messages[1..],
+        without_user_message_timestamps(&request.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -4525,7 +4540,7 @@ async fn test_send_retry_finishes_tool_calls_on_error(cx: &mut TestAppContext) {
         )));
     let completion = fake_model.pending_completions().pop().unwrap();
     assert_eq!(
-        completion.messages[1..],
+        without_user_message_timestamps(&completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -4699,7 +4714,7 @@ async fn test_streaming_tool_completes_when_llm_stream_ends_without_final_input(
         .pop()
         .expect("No running turn");
     assert_eq!(
-        completion.messages[1..],
+        without_user_message_timestamps(&completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -8487,7 +8502,7 @@ async fn test_streaming_tool_error_breaks_stream_loop_immediately(cx: &mut TestA
     let last_completion = completions.last().unwrap();
 
     assert_eq!(
-        last_completion.messages[1..],
+        without_user_message_timestamps(&last_completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,
@@ -8593,7 +8608,7 @@ async fn test_streaming_tool_error_waits_for_prior_tools_to_complete(cx: &mut Te
     let last_completion = completions.last().unwrap();
 
     assert_eq!(
-        last_completion.messages[1..],
+        without_user_message_timestamps(&last_completion.messages[1..]),
         vec![
             LanguageModelRequestMessage {
                 role: Role::User,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -22,7 +22,7 @@ use agent_settings::{
     SUMMARIZE_THREAD_DETAILED_PROMPT, SUMMARIZE_THREAD_PROMPT, builtin_profiles,
 };
 use anyhow::{Context as _, Result, anyhow};
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, FixedOffset, Local, Utc};
 use client::UserStore;
 use cloud_api_types::Plan;
 use collections::{HashMap, HashSet, IndexMap};
@@ -283,6 +283,9 @@ impl Message {
 pub struct UserMessage {
     pub id: ClientUserMessageId,
     pub content: Arc<[UserMessageContent]>,
+    /// The creation time and original local UTC offset for temporal model context.
+    #[serde(default)]
+    pub created_at: Option<DateTime<FixedOffset>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -486,6 +489,16 @@ impl UserMessage {
             };
 
             message.content.push(chunk);
+        }
+
+        if let Some(ref timestamp) = self.created_at {
+            let time_tag = format!(
+                "<time>{}</time>\n",
+                timestamp.format("%a %Y-%m-%dT%H:%M:%S%:z")
+            );
+            message
+                .content
+                .insert(0, language_model::MessageContent::Text(time_tag));
         }
 
         let len_before_context = message.content.len();
@@ -2533,8 +2546,11 @@ impl Thread {
         let content = content.into_iter().map(Into::into).collect::<Arc<_>>();
         log::debug!("Thread::send content: {:?}", content);
 
-        self.messages
-            .push(Arc::new(Message::User(UserMessage { id, content })));
+        self.messages.push(Arc::new(Message::User(UserMessage {
+            id,
+            content,
+            created_at: Some(Local::now().fixed_offset()),
+        })));
         cx.notify();
 
         self.send_existing(cx)
@@ -2660,8 +2676,11 @@ impl Thread {
             .into_iter()
             .map(|block| UserMessageContent::from_content_block(block, path_style))
             .collect::<Arc<_>>();
-        self.messages
-            .push(Arc::new(Message::User(UserMessage { id, content })));
+        self.messages.push(Arc::new(Message::User(UserMessage {
+            id,
+            content,
+            created_at: Some(Local::now().fixed_offset()),
+        })));
         cx.notify();
     }
 
@@ -3264,6 +3283,7 @@ impl Thread {
                     this.messages.push(Arc::new(Message::User(UserMessage {
                         id: marker_id,
                         content: Arc::from([]),
+                        created_at: None,
                     })));
                     this.messages.push(compaction);
                 }
@@ -4325,7 +4345,6 @@ impl Thread {
             project: self.project_context.read(cx),
             available_tools,
             model_name: self.model().map(|m| m.name().0.to_string()),
-            date: Local::now().format("%Y-%m-%d").to_string(),
             user_agents_md,
             sandboxing: crate::sandboxing::sandboxing_enabled_for_project(
                 self.project.read(cx),
@@ -6879,6 +6898,72 @@ mod tests {
     }
 
     #[test]
+    fn test_user_message_timestamp_renders_in_context() {
+        let timestamp = DateTime::parse_from_rfc3339("2026-05-26T16:53:58+02:00").unwrap();
+        let message = UserMessage {
+            id: ClientUserMessageId::new(),
+            content: vec![UserMessageContent::Text("hello".to_string())].into(),
+            created_at: Some(timestamp),
+        };
+
+        let request = message.to_request();
+        let texts = request
+            .content
+            .iter()
+            .map(|content| {
+                let language_model::MessageContent::Text(text) = content else {
+                    panic!("expected text content");
+                };
+                text.as_str()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            texts[0],
+            format!(
+                "<time>{}</time>\n",
+                timestamp.format("%a %Y-%m-%dT%H:%M:%S%:z")
+            )
+        );
+        assert_eq!(texts[1], "hello");
+    }
+
+    #[test]
+    fn test_user_message_without_timestamp_has_no_context() {
+        let message = UserMessage {
+            id: ClientUserMessageId::new(),
+            content: vec![UserMessageContent::Text("hello".to_string())].into(),
+            created_at: None,
+        };
+
+        let request = message.to_request();
+        assert_eq!(request.content.len(), 1);
+        let language_model::MessageContent::Text(text) = &request.content[0] else {
+            panic!("expected text content");
+        };
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn test_user_message_timestamp_serialization() {
+        let timestamp =
+            DateTime::parse_from_rfc3339("2026-05-26T16:53:58.123456789+05:30").unwrap();
+        let message = UserMessage {
+            id: ClientUserMessageId::new(),
+            content: vec![UserMessageContent::Text("hello".to_string())].into(),
+            created_at: Some(timestamp),
+        };
+
+        let mut serialized = serde_json::to_value(&message).unwrap();
+        let deserialized: UserMessage = serde_json::from_value(serialized.clone()).unwrap();
+        assert_eq!(deserialized.created_at, Some(timestamp));
+
+        serialized.as_object_mut().unwrap().remove("created_at");
+        let deserialized: UserMessage = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized.created_at, None);
+    }
+
+    #[test]
     fn test_summary_compaction_renders_for_request_and_markdown() {
         let message = Message::Compaction(CompactionInfo::Summary("Older context".into()));
 
@@ -6904,6 +6989,7 @@ mod tests {
         Arc::new(Message::User(UserMessage {
             id,
             content: vec![UserMessageContent::Text(text.to_string())].into(),
+            created_at: None,
         }))
     }
 
@@ -7309,14 +7395,15 @@ mod tests {
 
         let final_request = model.pending_completions().pop().unwrap();
         assert_eq!(final_request.intent, Some(CompletionIntent::UserPrompt));
+        let request_texts = request_texts_after_system(&final_request.messages);
+        assert_eq!(request_texts.len(), 3);
+        assert_eq!(request_texts[0], "old user");
         assert_eq!(
-            request_texts_after_system(&final_request.messages),
-            vec![
-                "old user".to_string(),
-                summary_request_text("compacted old context"),
-                "new prompt".to_string(),
-            ]
+            request_texts[1],
+            summary_request_text("compacted old context")
         );
+        assert!(request_texts[2].ends_with("new prompt"));
+        assert!(request_texts[2].starts_with("<time>"));
 
         model.send_completion_stream_text_chunk(&final_request, "answer");
         model.end_completion_stream(&final_request);
@@ -7391,7 +7478,7 @@ mod tests {
                 assert!(matches!(&*thread.messages[1], Message::Agent(_)));
                 assert!(matches!(
                     &*thread.messages[2],
-                    Message::User(UserMessage { id, content }) if id == &compact_message_id && content.is_empty()
+                    Message::User(UserMessage { id, content, .. }) if id == &compact_message_id && content.is_empty()
                 ));
                 assert!(matches!(
                     &*thread.messages[3],
@@ -7541,6 +7628,7 @@ mod tests {
                 thread.messages.push(Arc::new(Message::User(UserMessage {
                     id: marker_id.clone(),
                     content: Arc::from([]),
+                    created_at: None,
                 })));
                 thread.messages.push(summary_compaction("summary"));
                 thread.replay(cx)

--- a/crates/agent/src/tools/evals/edit_file.rs
+++ b/crates/agent/src/tools/evals/edit_file.rs
@@ -366,7 +366,6 @@ impl EditToolTest {
                 project: &project_context,
                 available_tools: tool_names,
                 model_name: None,
-                date: chrono::Local::now().format("%Y-%m-%d").to_string(),
                 user_agents_md: None,
                 sandboxing: false,
                 is_linux: cfg!(target_os = "linux"),

--- a/crates/agent/src/tools/evals/terminal_tool.rs
+++ b/crates/agent/src/tools/evals/terminal_tool.rs
@@ -225,7 +225,6 @@ impl TerminalToolTest {
                 project: &project_context,
                 available_tools: tool_names,
                 model_name: None,
-                date: chrono::Local::now().format("%Y-%m-%d").to_string(),
                 user_agents_md: None,
                 sandboxing: false,
                 is_linux: cfg!(target_os = "linux"),

--- a/crates/agent/src/tools/evals/write_file.rs
+++ b/crates/agent/src/tools/evals/write_file.rs
@@ -196,7 +196,6 @@ impl WriteToolTest {
                 project: &project_context,
                 available_tools: tool_names,
                 model_name: None,
-                date: chrono::Local::now().format("%Y-%m-%d").to_string(),
                 user_agents_md: None,
                 sandboxing: false,
                 is_linux: cfg!(target_os = "linux"),


### PR DESCRIPTION
## TL;DR

Zed does not persist when each user message was created, and its current date lives in
the cache-sensitive system prompt. Persist each user message's creation time and original
UTC offset, expose it to the model as one compact `<time>` block, and remove the
conditional midnight cache invalidation.

## Objective

Persist the wall-clock creation time of user messages and use it to give the agent
accurate temporal context throughout long-running threads.

Zed stores thread-level creation/update times but no wall-clock time for each message.
Once a message has been saved, the time when Zed accepted it cannot be reconstructed for
model context, transcript forensics, or another consumer.

Zed currently renders only the current date in the system prompt. That cannot distinguish
user messages sent seconds apart from messages sent hours or days apart, so the model
cannot reliably interpret relative phrases such as “this morning” or “tomorrow,” or
reason about pauses and scheduling boundaries in long-running threads.

Putting changing temporal data in the system prompt is also cache-unfriendly. When an
active long thread crosses the local date boundary, the system message changes before the
conversation history, so the downstream cached prefix can no longer match. The resulting
one-request “day tax” can recache several hundred thousand tokens. At current
[Anthropic Opus list prices](https://platform.claude.com/docs/en/about-claude/pricing),
rewriting a 500k-token one-hour cache rather than reading it is a $4.75 difference;
actual provider and Zed billing varies. Storing time on each message keeps historical
bytes stable and removes date rollover from the system prefix.

Zed previously exposed a `now` tool, removed in #56164. Passive temporal context avoids
requiring the model to decide that it needs a clock tool before it can reason correctly.

We believe per-turn time is a useful capability, and one mainstream agent already ships
it. [GitHub Copilot CLI](https://github.com/github/copilot-cli/blob/main/changelog.md) is
the only prior per-turn date/time/offset implementation we found. It has supplied this
context since version 1.0.32 on 2026-04-17. Local model-request logs from current version
1.0.83 show this as the first block of the captured user message:

```xml
<current_datetime>2026-09-09T22:02:57.364+02:00</current_datetime>
```

This PR promotes that established cache-friendly placement into Zed and adds persistence,
so each historical user turn keeps its actual creation time rather than being rerendered
with the current clock. It deliberately adapts three details:

- `<time>` describes a persisted historical message more accurately than
  `<current_datetime>`.
- The abbreviated weekday is supplied explicitly because models can derive it incorrectly
  from a known date; [anthropics/claude-code#76170](https://github.com/anthropics/claude-code/issues/76170)
  records a current reproduced example.
- The database retains full timestamp precision for ordering and correlation, but the
  model-facing context omits milliseconds because human user-message chronology does not
  need subsecond resolution.

The timestamp also should not be recomputed when an old thread is rendered: historical
messages need their original creation time and UTC offset, not the current time or the
timezone of the machine reopening the thread.

Related prior work:

- [Zed discussion #37788](https://github.com/zed-industries/zed/discussions/37788)
  reports agents producing incorrect dates when they do not check the clock.
- [Zed discussion #50700](https://github.com/zed-industries/zed/discussions/50700)
  requests persisted/displayed message timestamps. This PR does not add UI timestamps or
  agent-response duration tracking; it only supplies persisted user-message times to the
  model context.
- VS Code already injects its date context through the per-turn user-message context
  rather than mutating the system prompt, which is cache-friendly.
  [microsoft/vscode#314377](https://github.com/microsoft/vscode/issues/314377) proposed
  extending that context with configurable time, weekday, and timezone; it was closed as
  `not planned` after receiving 7 of the 20 votes required by that backlog process. We
  still think the capability is useful, and that per-message implementation provided the
  working precedent for this Zed change.
- The gap is not editor-specific: *The Verge* documented ChatGPT's inconsistent clock
  answers in
  [“Why Can't ChatGPT Tell Time?”](https://www.theverge.com/report/829137/openai-chatgpt-time-date),
  while [anthropics/claude-code#1164](https://github.com/anthropics/claude-code/issues/1164)
  reports that instructions to call the system clock are often ignored.

## Solution

- Store an optional fixed-offset `created_at` timestamp on each new `UserMessage`.
- Persist it with the thread; legacy messages deserialize with `None`.
- Render the stored value as one compact metadata block alongside the user message,
  without repeating the larger attachment-context preamble:

  ```xml
  <time>Wed 2026-09-09T01:22:58+02:00</time>
  ```

Remove the date from the normal and experimental system-prompt templates. Past message
timestamps are stable across subsequent requests, while each newest user message was
already new context, so temporal grounding no longer invalidates the reusable earlier
message prefix at midnight.

The format includes the weekday because deriving it reliably from a date is surprisingly
error-prone for language models. The UTC offset makes relative expressions such as “this
morning,” “EOD,” and “tomorrow” functional across intercontinental communication.

The UTC offset is stored with the timestamp rather than recomputed from `chrono::Local`
after deserialization, preserving the recording machine's original local time when a
thread is moved to another machine or timezone.

The model-context cost is only the compact `<time>…</time>` line (about 42 ASCII
characters) per user message. Its position in the persisted user message defines it as
that message's creation time, not a continuously refreshed clock. No timestamp is added
to agent messages, tool results, internal compaction markers, or legacy messages without
recorded creation time. This preserves user-turn chronology; it does not provide a
continuously refreshed clock during autonomous tool-only rounds or measure assistant
response duration.

## Testing

- `cargo test -p agent` — 738 passed, 11 ignored, 0 failed.
  - timestamped messages render weekday, date, time, and UTC offset in context;
  - timestamps preserve their original UTC offset through serialization;
  - legacy/untimestamped messages deserialize with `None` and do not create an
    otherwise-empty context block;
  - existing request-shape, caching, tool, retry, and compaction tests pass with
    timestamp metadata.
- `cargo check -p agent --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Tested on Linux. The implementation uses `chrono::Local` and is not platform-specific.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (none added)
- [x] The content adheres to Zed's UI standards (no UI change)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved agent time awareness by preserving the creation time, weekday, and UTC
  offset of user messages.