### PR TITLE
anthropic: Classify exhausted credits as payment required

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -1317,6 +1317,13 @@ fn completion_error_from_anthropic_api_with_status(
                 ProviderErrorCategory::PromptTooLarge {
                     tokens: Some(tokens),
                 }
+            } else if error
+                .message
+                .starts_with("Your credit balance is too low to access the Anthropic API.")
+            {
+                // Anthropic sends credit exhaustion as invalid_request_error rather than
+                // the billing_error documented at https://platform.claude.com/docs/en/api/errors.
+                ProviderErrorCategory::PaymentRequired
             } else {
                 ProviderErrorCategory::InvalidRequest
             }


### PR DESCRIPTION
Anthropic reports exhausted credits as `invalid_request_error` rather than the documented `billing_error`. Recognize the specific credit-balance message when converting Anthropic API errors to `PaymentRequired`.

This preserves the original status, code, and message, handles errors with or without an HTTP status, and leaves other invalid requests unchanged. The comment links to Anthropic's error documentation.

Closes DELTA-77

Validation: the existing Anthropic billing-error test and package formatting check pass. A temporary classification test also passed for exhausted credits and malformed requests, with and without HTTP status; it is not included in this PR.

Release Notes:

- Fixed Anthropic credit exhaustion being classified as a malformed request instead of a payment issue.
