### PR TITLE
Add terminal profiles for selecting between multiple shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18221,7 +18221,7 @@ dependencies = [
  "util",
  "util_macros",
  "vte",
- "which 6.0.3",
+ "which",
  "windows 0.62.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18221,6 +18221,7 @@ dependencies = [
  "util",
  "util_macros",
  "vte",
+ "which 6.0.3",
  "windows 0.62.2",
 ]
 

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1980,6 +1980,18 @@
     //         }
     //     }
     "shell": "system",
+    // Named terminal profiles, selectable from the terminal panel's "+"
+    // menu or via a `workspace::NewTerminal` keybinding:
+    //   "profiles": {
+    //     "Bash": {
+    //       "program": "/bin/bash",
+    //       "args": ["--login"]
+    //     }
+    //   }
+    // "profiles": {},
+    // Name of the profile (a key in `profiles`) to use when no explicit
+    // profile is selected. If unset or not found, `shell` is used.
+    // "default_profile": "Bash",
     // Where to dock terminals panel. Can be `left`, `right`, `bottom`.
     "dock": "bottom",
     // Whether the terminal panel should open on startup.

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -292,7 +292,7 @@ impl Project {
     /// Same as [`create_terminal_shell`](Self::create_terminal_shell) but lets
     /// the caller supply a profile-derived shell override. The override is
     /// dropped (with a `log::warn!`) when the project is remote and
-    /// `force_local` is false — see D9.
+    /// `force_local` is false.
     pub fn create_terminal_shell_with(
         &mut self,
         cwd: Option<PathBuf>,
@@ -314,7 +314,7 @@ impl Project {
 
     /// Same as [`create_local_terminal`](Self::create_local_terminal) but
     /// accepts a profile-derived shell override. Local terminals always
-    /// honor the override (D9: only remote, non-`force_local` terminals
+    /// honor the override (only remote, non-`force_local` terminals
     /// drop it).
     pub fn create_local_terminal_with(
         &mut self,
@@ -335,7 +335,7 @@ impl Project {
     ///
     /// `shell_override`, when set, replaces `terminal.shell` at both consumption
     /// sites (the program/ShellKind selection and the `TerminalBuilder::new`
-    /// call). D9: the override is dropped for remote, non-`force_local`
+    /// call). The override is dropped for remote, non-`force_local`
     /// terminals and a warning is logged.
     fn create_terminal_shell_internal(
         &mut self,
@@ -360,7 +360,7 @@ impl Project {
         let detect_venv = settings.detect_venv.as_option().is_some();
         let local_path = if is_via_remote { None } else { path.clone() };
 
-        // D9: profile overrides only apply to local (or force_local) terminals.
+        // Profile overrides only apply to local (or force_local) terminals.
         // Dropping the override here keeps the rest of the spawn path unchanged.
         let shell_override = if is_via_remote && shell_override.is_some() {
             log::warn!(
@@ -395,7 +395,7 @@ impl Project {
         } else {
             self.remote_client.clone()
         };
-        // D5: apply the override at BOTH consumption sites — program/ShellKind
+        // Apply the override at BOTH consumption sites — program/ShellKind
         // selection below and the TerminalBuilder::new call inside the spawn.
         // Use `effective_shell` consistently.
         let shell = match &remote_client {
@@ -405,7 +405,7 @@ impl Project {
                 .unwrap_or_else(get_default_system_shell),
             None => effective_shell.program(),
         };
-        // D8: environment resolution stays on the login shell locally
+        // Environment resolution stays on the login shell locally
         // (`get_system_shell()`), independent of the profile. Routing env
         // through a fish/tmux/etc. profile would break venv detection for
         // users whose `$SHELL` differs.

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -286,7 +286,20 @@ impl Project {
         cwd: Option<PathBuf>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
-        self.create_terminal_shell_internal(cwd, false, cx)
+        self.create_terminal_shell_internal(cwd, None, false, cx)
+    }
+
+    /// Same as [`create_terminal_shell`](Self::create_terminal_shell) but lets
+    /// the caller supply a profile-derived shell override. The override is
+    /// dropped (with a `log::warn!`) when the project is remote and
+    /// `force_local` is false — see D9.
+    pub fn create_terminal_shell_with(
+        &mut self,
+        cwd: Option<PathBuf>,
+        shell_override: Option<Shell>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
+        self.create_terminal_shell_internal(cwd, shell_override, false, cx)
     }
 
     /// Creates a local terminal even if the project is remote.
@@ -296,22 +309,38 @@ impl Project {
         &mut self,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
+        self.create_local_terminal_with(None, cx)
+    }
+
+    /// Same as [`create_local_terminal`](Self::create_local_terminal) but
+    /// accepts a profile-derived shell override. Local terminals always
+    /// honor the override (D9: only remote, non-`force_local` terminals
+    /// drop it).
+    pub fn create_local_terminal_with(
+        &mut self,
+        shell_override: Option<Shell>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
         let working_directory = if self.remote_client.is_some() {
-            // Remote project: don't use remote paths, let shell use Zed's cwd
             None
         } else {
-            // Local project: use project directory like normal terminals
             self.active_project_directory(cx).map(|p| p.to_path_buf())
         };
-        self.create_terminal_shell_internal(working_directory, true, cx)
+        self.create_terminal_shell_internal(working_directory, shell_override, true, cx)
     }
 
     /// Internal method for creating terminal shells.
-    /// If force_local is true, creates a local terminal even if the project has a remote client.
+    /// If `force_local` is true, creates a local terminal even if the project has a remote client.
     /// This allows "breaking out" to a local shell in remote projects.
+    ///
+    /// `shell_override`, when set, replaces `terminal.shell` at both consumption
+    /// sites (the program/ShellKind selection and the `TerminalBuilder::new`
+    /// call). D9: the override is dropped for remote, non-`force_local`
+    /// terminals and a warning is logged.
     fn create_terminal_shell_internal(
         &mut self,
         cwd: Option<PathBuf>,
+        shell_override: Option<Shell>,
         force_local: bool,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
@@ -330,6 +359,19 @@ impl Project {
         let settings = TerminalSettings::get(settings_location, cx).clone();
         let detect_venv = settings.detect_venv.as_option().is_some();
         let local_path = if is_via_remote { None } else { path.clone() };
+
+        // D9: profile overrides only apply to local (or force_local) terminals.
+        // Dropping the override here keeps the rest of the spawn path unchanged.
+        let shell_override = if is_via_remote && shell_override.is_some() {
+            log::warn!(
+                "terminal profile override ignored for remote terminal \
+                 (remote shell selection happens on the server)"
+            );
+            None
+        } else {
+            shell_override
+        };
+        let effective_shell = shell_override.unwrap_or_else(|| settings.shell.clone());
 
         // See create_terminal_task: scope the toolchain lookup to the
         // worktree the terminal is opened in, not the active editor's
@@ -353,13 +395,20 @@ impl Project {
         } else {
             self.remote_client.clone()
         };
+        // D5: apply the override at BOTH consumption sites — program/ShellKind
+        // selection below and the TerminalBuilder::new call inside the spawn.
+        // Use `effective_shell` consistently.
         let shell = match &remote_client {
             Some(remote_client) => remote_client
                 .read(cx)
                 .shell()
                 .unwrap_or_else(get_default_system_shell),
-            None => settings.shell.program(),
+            None => effective_shell.program(),
         };
+        // D8: environment resolution stays on the login shell locally
+        // (`get_system_shell()`), independent of the profile. Routing env
+        // through a fish/tmux/etc. profile would break venv detection for
+        // users whose `$SHELL` differs.
         let env_shell = match &remote_client {
             Some(_) => shell.clone(),
             None => get_system_shell(),
@@ -403,7 +452,7 @@ impl Project {
                             Some(remote_client) => {
                                 create_remote_shell(None, env, path, remote_client, cx)?
                             }
-                            None => (settings.shell, env),
+                            None => (effective_shell, env),
                         }
                     };
                     anyhow::Ok(TerminalBuilder::new(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -994,6 +994,8 @@ impl VsCodeSettings {
             shell: self
                 .read_string(&format!("terminal.integrated.{platform}Exec"))
                 .map(|s| Shell::Program(s)),
+            profiles: None,
+            default_profile: None,
             working_directory: None,
             env,
             detect_venv: None,

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use collections::HashMap;
+use collections::{HashMap, IndexMap};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings_macros::{MergeFrom, with_fallible_options};
@@ -13,6 +13,25 @@ pub struct ProjectTerminalSettingsContent {
     ///
     /// Default: system
     pub shell: Option<Shell>,
+    /// Named terminal profiles that can be selected via the
+    /// `workspace::NewTerminal` action (e.g. from a keybinding) or from
+    /// the terminal panel's "+" menu. Each profile describes
+    /// the program to launch and optional arguments.
+    ///
+    /// Profile entries merge key-wise across settings layers (user, project,
+    /// etc.), so a project can override individual keys of a user-level
+    /// profile without redefining the whole map.
+    ///
+    /// Default: {}
+    pub profiles: Option<IndexMap<String, TerminalProfile>>,
+    /// Name of the profile to use when no explicit profile is selected
+    /// (e.g. when pressing the default "open terminal" keybinding). The
+    /// name must match a key in `profiles`; if it does not, a warning is
+    /// emitted and Zed falls back to `terminal.shell` (not the system
+    /// shell).
+    ///
+    /// Default: none
+    pub default_profile: Option<String>,
     /// What working directory to use when launching the terminal
     ///
     /// Default: current_project_directory
@@ -237,6 +256,23 @@ pub enum Shell {
         /// An optional string to override the title of the terminal tab
         title_override: Option<String>,
     },
+}
+
+/// A named terminal profile: a program plus optional arguments and an
+/// optional title override. When selected (via `terminal.default_profile`
+/// or the `workspace::NewTerminal` action's `profile` field), the profile
+/// is converted into a `task::Shell` for spawning. If `title_override` is
+/// unset, the profile's name is used as the tab title (D6 title promotion).
+#[with_fallible_options]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct TerminalProfile {
+    /// Program to launch (e.g. `/bin/zsh`, `pwsh`, `wsl.exe`).
+    pub program: String,
+    /// Arguments passed to `program`. Omit to launch with no arguments.
+    pub args: Option<Vec<String>>,
+    /// Tab title to use for this profile. If unset, the profile name is
+    /// used (see D6 title promotion).
+    pub title_override: Option<String>,
 }
 
 #[derive(
@@ -547,7 +583,7 @@ pub enum ActivateScript {
 mod test {
     use serde_json::json;
 
-    use crate::{ProjectSettingsContent, Shell};
+    use crate::{ProjectSettingsContent, Shell, TerminalProfile};
 
     #[test]
     #[ignore]
@@ -564,6 +600,112 @@ mod test {
         assert_eq!(
             project_settings.terminal.unwrap().shell,
             Some(Shell::Program("/bin/project".to_owned()))
+        );
+    }
+
+    fn profile(program: &str, args: &[&str]) -> TerminalProfile {
+        TerminalProfile {
+            program: program.to_string(),
+            args: Some(args.iter().map(|a| a.to_string()).collect()),
+            title_override: None,
+        }
+    }
+
+    #[test]
+    fn terminal_profiles_deserialize() {
+        let content = json!({
+            "terminal": {
+                "profiles": {
+                    "Zsh": { "program": "/bin/zsh", "args": ["-l"] },
+                    "Fish": { "program": "fish" }
+                },
+                "default_profile": "Zsh"
+            }
+        });
+        let parsed: ProjectSettingsContent =
+            serde_json::from_value(content).expect("parsed ProjectSettingsContent");
+        let terminal = parsed.terminal.expect("terminal section present");
+        let profiles = terminal
+            .profiles
+            .expect("profiles field should deserialize");
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles.get("Zsh"), Some(&profile("/bin/zsh", &["-l"])));
+        assert_eq!(
+            profiles.get("Fish").map(|p| p.program.clone()),
+            Some("fish".to_string())
+        );
+        assert_eq!(terminal.default_profile, Some("Zsh".to_string()));
+    }
+
+    #[test]
+    fn terminal_profiles_merge_key_wise() {
+        use crate::ProjectTerminalSettingsContent;
+        use crate::merge_from::MergeFrom;
+        let mut base: ProjectTerminalSettingsContent = serde_json::from_value(json!({
+            "profiles": {
+                "Zsh": { "program": "/bin/zsh", "args": ["-l"] },
+                "Fish": { "program": "fish" }
+            },
+            "default_profile": "Zsh"
+        }))
+        .expect("base deserialized");
+
+        let overlay: ProjectTerminalSettingsContent = serde_json::from_value(json!({
+            "profiles": {
+                "Zsh": { "program": "/opt/homebrew/bin/zsh" },
+                "Bash": { "program": "/bin/bash" }
+            },
+            "default_profile": "Bash"
+        }))
+        .expect("overlay deserialized");
+
+        base.merge_from(&overlay);
+
+        let profiles = base.profiles.as_ref().expect("profiles present post-merge");
+        let zsh = profiles.get("Zsh").expect("Zsh merged");
+        assert_eq!(zsh.program, "/opt/homebrew/bin/zsh");
+        assert_eq!(
+            zsh.args.as_ref().map(|a| a.len()),
+            Some(1),
+            "args should be inherited from base on per-key merge"
+        );
+        assert!(profiles.contains_key("Fish"));
+        assert!(profiles.contains_key("Bash"));
+        assert_eq!(base.default_profile, Some("Bash".to_string()));
+    }
+
+    #[test]
+    fn terminal_profiles_backwards_compatible_when_absent() {
+        let content = json!({ "terminal": { "shell": "system" } });
+        let parsed: ProjectSettingsContent =
+            serde_json::from_value(content).expect("backwards compatible");
+        let terminal = parsed.terminal.expect("terminal present");
+        assert!(terminal.profiles.is_none());
+        assert!(terminal.default_profile.is_none());
+    }
+
+    #[test]
+    fn indexmap_preserves_profile_order() {
+        let content = json!({
+            "terminal": {
+                "profiles": {
+                    "Charity": { "program": "p1" },
+                    "Hope": { "program": "p2" },
+                    "Faith": { "program": "p3" }
+                }
+            }
+        });
+        let parsed: ProjectSettingsContent =
+            serde_json::from_value(content).expect("ordered parse");
+        let profiles = parsed
+            .terminal
+            .and_then(|t| t.profiles)
+            .expect("profiles present");
+        let keys: Vec<&String> = profiles.keys().collect();
+        assert_eq!(
+            keys,
+            vec!["Charity", "Hope", "Faith"],
+            "IndexMap must preserve insertion order"
         );
     }
 }

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -262,7 +262,7 @@ pub enum Shell {
 /// optional title override. When selected (via `terminal.default_profile`
 /// or the `workspace::NewTerminal` action's `profile` field), the profile
 /// is converted into a `task::Shell` for spawning. If `title_override` is
-/// unset, the profile's name is used as the tab title (D6 title promotion).
+/// unset, the profile's name is used as the tab title.
 #[with_fallible_options]
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct TerminalProfile {
@@ -271,7 +271,7 @@ pub struct TerminalProfile {
     /// Arguments passed to `program`. Omit to launch with no arguments.
     pub args: Option<Vec<String>>,
     /// Tab title to use for this profile. If unset, the profile name is
-    /// used (see D6 title promotion).
+    /// used.
     pub title_override: Option<String>,
 }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7895,6 +7895,74 @@ fn terminal_page() -> SettingsPage {
         ]
     }
 
+    /// `terminal.profiles` is a dynamic map of `{ name: { program, args?,
+    /// title_override? } }`. The Zed settings UI doesn't have a reusable
+    /// dynamic-map editor primitive yet (see `UserSettingsContent.profiles`
+    /// for the same gap), so v1 surfaces both fields as JSON-editor links:
+    /// clicking opens `settings.json` at the given path. P3 plan item 12
+    /// explicitly permits this fallback.
+    fn profiles_section() -> [SettingsPageItem; 3] {
+        [
+            SettingsPageItem::SectionHeader("Profiles"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Terminal Profiles",
+                description: "Named shell configurations selectable from the terminal panel \"+\" menu or via the `workspace::NewTerminal` action with a `profile` argument. Each entry needs a `program` (absolute path or basename resolved via PATH) and optional `args` / `title_override`. Edit in JSON: `{ \"Zsh\": { \"program\": \"/bin/zsh\", \"args\": [\"-l\"] } }`.",
+                field: Box::new(
+                    SettingField {
+                        organization_override: None,
+                        json_path: Some("terminal.profiles"),
+                        pick: |settings_content| {
+                            settings_content
+                                .terminal
+                                .as_ref()?
+                                .project
+                                .profiles
+                                .as_ref()
+                        },
+                        write: |settings_content, value, _| {
+                            settings_content
+                                .terminal
+                                .get_or_insert_default()
+                                .project
+                                .profiles = value;
+                        },
+                    }
+                    .unimplemented(),
+                ),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Default Profile",
+                description: "Name of the profile used when opening a terminal without an explicit selection (e.g. the default ctrl-backtick keybinding). The name must match a key in `terminal.profiles`; if it does not, Zed emits a warning and falls back to `terminal.shell`. Leave unset to use `terminal.shell`.",
+                field: Box::new(
+                    SettingField {
+                        organization_override: None,
+                        json_path: Some("terminal.default_profile"),
+                        pick: |settings_content| {
+                            settings_content
+                                .terminal
+                                .as_ref()?
+                                .project
+                                .default_profile
+                                .as_ref()
+                        },
+                        write: |settings_content, value, _| {
+                            settings_content
+                                .terminal
+                                .get_or_insert_default()
+                                .project
+                                .default_profile = value;
+                        },
+                    }
+                    .unimplemented(),
+                ),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
+        ]
+    }
+
     fn scrollbar_section() -> [SettingsPageItem; 2] {
         [
             SettingsPageItem::SectionHeader("Scrollbar"),
@@ -7934,6 +8002,7 @@ fn terminal_page() -> SettingsPage {
         title: "Terminal",
         items: concat_sections![
             environment_section(),
+            profiles_section(),
             font_section(),
             display_settings_section(),
             behavior_settings_section(),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7899,8 +7899,7 @@ fn terminal_page() -> SettingsPage {
     /// title_override? } }`. The Zed settings UI doesn't have a reusable
     /// dynamic-map editor primitive yet (see `UserSettingsContent.profiles`
     /// for the same gap), so v1 surfaces both fields as JSON-editor links:
-    /// clicking opens `settings.json` at the given path. P3 plan item 12
-    /// explicitly permits this fallback.
+    /// clicking opens `settings.json` at the given path.
     fn profiles_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Profiles"),

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -46,6 +46,7 @@ urlencoding.workspace = true
 vte.workspace = true
 parking_lot.workspace = true
 percent-encoding.workspace = true
+which.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -56,6 +56,12 @@ pub struct TerminalSettings {
     pub bell: TerminalBell,
     pub profiles: collections::IndexMap<String, TerminalProfile>,
     pub default_profile: Option<String>,
+    /// Cached output of [`validate_configured_profiles`] for the current
+    /// settings, so consumers (e.g. the "+"-menu builder) don't re-run the
+    /// validator (and its `which::which` / `Path::is_file` probes) on every
+    /// menu open.
+    #[serde(skip)]
+    pub profile_warnings: Vec<ProfileWarning>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -320,8 +326,12 @@ impl settings::Settings for TerminalSettings {
         // P2 validation: surface a warning per profile whose `program` is
         // neither an existing absolute path nor resolvable on `PATH`. This
         // is advisory only — spawn still goes through the normal
-        // `TerminalError` path if the program is genuinely missing.
-        for warning in validate_configured_profiles(&profiles) {
+        // `TerminalError` path if the program is genuinely missing. The
+        // result is cached on `TerminalSettings.profile_warnings` so the
+        // "+"-menu builder doesn't have to re-run the validator on every
+        // menu open.
+        let profile_warnings = validate_configured_profiles(&profiles);
+        for warning in &profile_warnings {
             log::warn!(
                 "terminal.profiles.{}: {}",
                 warning.profile_name,
@@ -399,6 +409,7 @@ impl settings::Settings for TerminalSettings {
             bell: user_content.bell.unwrap(),
             profiles,
             default_profile,
+            profile_warnings,
         }
     }
 }
@@ -839,5 +850,58 @@ mod tests {
             }
             _ => panic!("7 visible entries should stay inline"),
         }
+    }
+
+    /// Fix #4 lock: `TerminalSettings.profile_warnings` is the cached
+    /// validator output. The cache is populated in `from_settings`, but
+    /// because constructing a full `SettingsContent` here is heavy, this
+    /// test verifies the equivalent contract — that the field exists,
+    /// accepts `validate_configured_profiles` output directly, and that
+    /// `build_menu_entries` (which the menu now drives off
+    /// `settings.profile_warnings`) treats the cached value identically to
+    /// a freshly-computed one.
+    #[test]
+    fn profile_warnings_cache_is_equivalent_to_direct_call() {
+        let profiles = profile_map(&[
+            ("Good", "/bin/zsh"),
+            ("Bad", "/totally/not/real"),
+            ("BashOnPath", "bash"),
+        ]);
+        // Direct call (the value `from_settings` caches).
+        let direct = validate_configured_profiles_with(
+            &profiles,
+            &|p| p.as_os_str() == "/bin/zsh",
+            &|program| match program {
+                "bash" => Some(std::path::PathBuf::from("/usr/bin/bash")),
+                _ => None,
+            },
+        );
+        // Exactly one warning — the bad profile.
+        assert_eq!(direct.len(), 1);
+        assert_eq!(direct[0].profile_name, "Bad");
+
+        // The cache field is `Vec<ProfileWarning>`; assigning the direct
+        // call's output and feeding it to build_menu_entries must hide the
+        // bad profile exactly as the live validator did.
+        let cached: Vec<ProfileWarning> = direct.clone();
+        let plan_cached = build_menu_entries(&profiles, Vec::new(), &cached);
+        let plan_direct = build_menu_entries(&profiles, Vec::new(), &direct);
+        assert_eq!(
+            entry_labels(&plan_cached),
+            entry_labels(&plan_direct),
+            "cached and direct warnings must drive identical menu plans"
+        );
+        let labels = entry_labels(&plan_cached);
+        assert!(labels.contains(&"Good".to_string()));
+        assert!(labels.contains(&"BashOnPath".to_string()));
+        assert!(!labels.contains(&"Bad".to_string()));
+    }
+
+    #[test]
+    fn empty_profile_warnings_cache_yields_all_profiles() {
+        let profiles = profile_map(&[("A", "/bin/a"), ("B", "/bin/b")]);
+        let cached: Vec<ProfileWarning> = Vec::new();
+        let plan = build_menu_entries(&profiles, Vec::new(), &cached);
+        assert_eq!(entry_labels(&plan), vec!["A".to_string(), "B".to_string()]);
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -7,7 +7,7 @@ pub use settings::AlternateScroll;
 
 use settings::{
     IntoGpui, PathHyperlinkRegex, RegisterSetting, ShowScrollbar, TerminalBell, TerminalBlink,
-    TerminalDockPosition, TerminalLineHeight, VenvSettings, WorkingDirectory,
+    TerminalDockPosition, TerminalLineHeight, TerminalProfile, VenvSettings, WorkingDirectory,
     merge_from::MergeFrom,
 };
 use task::Shell;
@@ -52,6 +52,8 @@ pub struct TerminalSettings {
     pub path_hyperlink_timeout_ms: u64,
     pub show_count_badge: bool,
     pub bell: TerminalBell,
+    pub profiles: collections::IndexMap<String, TerminalProfile>,
+    pub default_profile: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -78,14 +80,47 @@ fn settings_shell_to_task_shell(shell: settings::Shell) -> Shell {
     }
 }
 
+/// Convert a `TerminalProfile` (settings twin) into the runtime `task::Shell`
+/// used by the spawn path. Implements D6 title promotion: when the profile
+/// does not specify a `title_override`, the profile name is used so the tab
+/// is titled after the profile (matching VSCode's `overrideName` default for
+/// generated profiles). The result is always `Shell::WithArguments`, since
+/// `title_override` is only expressible on that variant.
+pub fn profile_to_task_shell(name: &str, profile: &TerminalProfile) -> Shell {
+    Shell::WithArguments {
+        program: profile.program.clone(),
+        args: profile.args.clone().unwrap_or_default(),
+        title_override: profile.title_override.clone().or(Some(name.to_string())),
+    }
+}
+
 impl settings::Settings for TerminalSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let user_content = content.terminal.clone().unwrap();
         // Note: we allow a subset of "terminal" settings in the project files.
         let mut project_content = user_content.project.clone();
         project_content.merge_from_option(content.project.terminal.as_ref());
+        let profiles = project_content.profiles.clone().unwrap_or_default();
+        let default_profile = project_content.default_profile.clone();
+        // D3 precedence: default_profile (if it resolves) > terminal.shell > System.
+        // Unknown default_profile name falls through to terminal.shell with a warning,
+        // never silently to System.
+        let shell = if let Some(name) = default_profile.as_deref() {
+            match profiles.get(name) {
+                Some(profile) => profile_to_task_shell(name, profile),
+                None => {
+                    log::warn!(
+                        "terminal.default_profile references unknown profile '{name}'; \
+                         falling back to terminal.shell"
+                    );
+                    settings_shell_to_task_shell(project_content.shell.unwrap())
+                }
+            }
+        } else {
+            settings_shell_to_task_shell(project_content.shell.unwrap())
+        };
         TerminalSettings {
-            shell: settings_shell_to_task_shell(project_content.shell.unwrap()),
+            shell,
             working_directory: project_content.working_directory.unwrap(),
             font_size: user_content.font_size.map(|s| s.into_gpui()),
             font_family: user_content.font_family,
@@ -136,6 +171,8 @@ impl settings::Settings for TerminalSettings {
             path_hyperlink_timeout_ms: project_content.path_hyperlink_timeout_ms.unwrap(),
             show_count_badge: user_content.show_count_badge.unwrap(),
             bell: user_content.bell.unwrap(),
+            profiles,
+            default_profile,
         }
     }
 }
@@ -161,6 +198,64 @@ impl From<settings::CursorShapeContent> for CursorShape {
             settings::CursorShapeContent::Underline => CursorShape::Underline,
             settings::CursorShapeContent::Bar => CursorShape::Bar,
             settings::CursorShapeContent::Hollow => CursorShape::Hollow,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use settings::TerminalProfile;
+
+    fn profile(program: &str, args: &[&str], title: Option<&str>) -> TerminalProfile {
+        TerminalProfile {
+            program: program.to_string(),
+            args: Some(args.iter().map(|a| a.to_string()).collect()),
+            title_override: title.map(|t| t.to_string()),
+        }
+    }
+
+    #[test]
+    fn profile_to_shell_promotes_title_to_profile_name_when_unset() {
+        let p = profile("/bin/zsh", &["-l"], None);
+        let shell = profile_to_task_shell("Zsh", &p);
+        match shell {
+            Shell::WithArguments {
+                program,
+                args,
+                title_override,
+            } => {
+                assert_eq!(program, "/bin/zsh");
+                assert_eq!(args, vec!["-l".to_string()]);
+                assert_eq!(title_override, Some("Zsh".to_string()));
+            }
+            other => panic!("expected WithArguments, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn profile_to_shell_preserves_explicit_title_override() {
+        let p = profile("/bin/zsh", &[], Some("My Shell"));
+        let shell = profile_to_task_shell("Zsh", &p);
+        match shell {
+            Shell::WithArguments { title_override, .. } => {
+                assert_eq!(title_override, Some("My Shell".to_string()));
+            }
+            other => panic!("expected WithArguments, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn profile_to_shell_defaults_empty_args() {
+        let p = TerminalProfile {
+            program: "pwsh".to_string(),
+            args: None,
+            title_override: None,
+        };
+        let shell = profile_to_task_shell("PowerShell", &p);
+        match shell {
+            Shell::WithArguments { args, .. } => assert!(args.is_empty()),
+            other => panic!("expected WithArguments, got {other:?}"),
         }
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -125,8 +125,13 @@ pub enum MergedShellEntry {
 /// detected entry's `program` both ways:
 /// * exact string match (covers the common "configured `/bin/zsh`,
 ///   detected `/bin/zsh`" case), and
-/// * file-stem match where one side is a bare basename and the other an
-///   absolute path (covers "configured `zsh`, detected `/bin/zsh`").
+/// * bare-basename match when the configured program is a bare name like
+///   `zsh` (no path separator). This covers "configured `zsh`, detected
+///   `/bin/zsh`". Path-bearing configured programs (`/bin/bash`,
+///   `./local/shell`) only shadow via exact path equality — otherwise a
+///   single `program: "/bin/bash"` profile would shadow every bash on the
+///   system, and a future `program: "wsl.exe"` profile would shadow all
+///   WSL distros (which differ only by `args`).
 pub fn merge_with_configured_profiles(
     detected: Vec<DetectedShell>,
     profiles: &IndexMap<String, TerminalProfile>,
@@ -137,7 +142,20 @@ pub fn merge_with_configured_profiles(
         .collect();
     let configured_stems: std::collections::HashSet<String> = profiles
         .values()
-        .filter_map(|p| Path::new(&p.program).file_name().map(|s| s.to_string_lossy().into_owned()))
+        .filter_map(|p| {
+            // Only bare basenames (no path separator) participate in
+            // stem-matching. Path-bearing programs only shadow via exact
+            // path equality above.
+            if p.program.contains(std::path::MAIN_SEPARATOR) {
+                return None;
+            }
+            // On Windows also treat '/' as a separator for cross-platform
+            // configs (a user might write `C:/Program Files/...`).
+            if cfg!(windows) && p.program.contains('/') {
+                return None;
+            }
+            Some(p.program.clone())
+        })
         .collect();
 
     let mut entries: Vec<MergedShellEntry> = profiles
@@ -574,6 +592,36 @@ mod tests {
             MergedShellEntry::Configured { name, .. } => assert_eq!(name, "MyZsh"),
             MergedShellEntry::Detected(_) => panic!("basename match should shadow detected"),
         }
+    }
+
+    #[test]
+    fn merge_does_not_shadow_by_basename_when_configured_is_path() {
+        // Configured profile uses an absolute path "/bin/bash"; detected
+        // shell is at "/usr/bin/bash" — same stem, different path. The
+        // path-bearing configured program should only shadow via exact
+        // match (it doesn't here), so both entries survive.
+        let profiles = profile_map(&[("Bash", "/bin/bash")]);
+        let detected = vec![detected("bash", "/usr/bin/bash")];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        assert_eq!(
+            merged.len(),
+            2,
+            "path-bearing configured program must NOT shadow detected shells at different paths by basename"
+        );
+        assert!(matches!(merged[0], MergedShellEntry::Configured { .. }));
+        assert!(matches!(merged[1], MergedShellEntry::Detected(_)));
+    }
+
+    #[test]
+    fn merge_shadows_detected_when_configured_path_matches_exactly() {
+        // Path-bearing configured programs still shadow via exact path
+        // equality (the configured program string equals the detected
+        // program string).
+        let profiles = profile_map(&[("Bash", "/bin/bash")]);
+        let detected = vec![detected("bash", "/bin/bash")];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        assert_eq!(merged.len(), 1);
+        assert!(matches!(merged[0], MergedShellEntry::Configured { .. }));
     }
 
     #[test]

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -89,10 +89,10 @@ fn settings_shell_to_task_shell(shell: settings::Shell) -> Shell {
 }
 
 /// Convert a `TerminalProfile` (settings twin) into the runtime `task::Shell`
-/// used by the spawn path. Implements D6 title promotion: when the profile
-/// does not specify a `title_override`, the profile name is used so the tab
-/// is titled after the profile (matching VSCode's `overrideName` default for
-/// generated profiles). The result is always `Shell::WithArguments`, since
+/// used by the spawn path. If the profile does not specify a
+/// `title_override`, the profile name is used so the tab is titled after
+/// the profile (matching VSCode's `overrideName` default for generated
+/// profiles). The result is always `Shell::WithArguments`, since
 /// `title_override` is only expressible on that variant.
 pub fn profile_to_task_shell(name: &str, profile: &TerminalProfile) -> Shell {
     Shell::WithArguments {
@@ -102,10 +102,10 @@ pub fn profile_to_task_shell(name: &str, profile: &TerminalProfile) -> Shell {
     }
 }
 
-/// A view over the configured-vs-detected shell entries used by the P3 "+"
+/// A view over the configured-vs-detected shell entries used by the "+"
 /// menu. Configured profiles shadow detected shells with the same resolved
-/// program path (D2/D8 in the plan); order is configured-first (preserving
-/// IndexMap insertion order), then detected.
+/// program path; order is configured-first (preserving IndexMap insertion
+/// order), then detected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergedShellEntry {
     /// User-configured profile from `terminal.profiles`.
@@ -119,7 +119,7 @@ pub enum MergedShellEntry {
 
 /// Combine configured profiles with detected shells, dropping any detected
 /// entry whose program path collides with a configured profile's program
-/// (configured wins the slot, per the plan's dedup rule).
+/// (configured wins the slot).
 ///
 /// Comparison is by the profile's program string resolved against the
 /// detected entry's `program` both ways:
@@ -136,10 +136,8 @@ pub fn merge_with_configured_profiles(
     detected: Vec<DetectedShell>,
     profiles: &IndexMap<String, TerminalProfile>,
 ) -> Vec<MergedShellEntry> {
-    let configured_paths: std::collections::HashSet<String> = profiles
-        .values()
-        .map(|p| p.program.clone())
-        .collect();
+    let configured_paths: std::collections::HashSet<String> =
+        profiles.values().map(|p| p.program.clone()).collect();
     let configured_stems: std::collections::HashSet<String> = profiles
         .values()
         .filter_map(|p| {
@@ -182,7 +180,7 @@ pub fn merge_with_configured_profiles(
     entries
 }
 
-/// Single menu entry for the "+" PopoverMenu (P3). Produced by
+/// Single menu entry for the "+" PopoverMenu. Produced by
 /// [`build_menu_entries`], which filters invalid profiles and applies the
 /// escalation threshold. The view layer converts each `MenuEntry` into a
 /// `ContextMenuItem` (`action` for configured, `entry` callback for
@@ -203,7 +201,7 @@ pub enum MenuEntry {
 }
 
 /// Above this many entries, the menu collapses into a single "Select Shell…"
-/// submenu entry per the P3 escalation rule (plan item 11).
+/// submenu entry (keeps the menu manageable when long).
 pub const MENU_ESCALATION_THRESHOLD: usize = 8;
 
 /// Outcome of [`build_menu_entries`]: either render entries inline, or
@@ -228,16 +226,14 @@ pub enum MenuEntryPlan {
 /// * `detected` — output of `util::shell_detection::detect_available_shells`.
 /// * `warnings` — output of `validate_configured_profiles`. Any profile
 ///   named here is **hidden** from the menu (the user can still spawn it
-///   via keymap with a warning, per P3 spec).
+///   via keymap with a warning).
 pub fn build_menu_entries(
     profiles: &IndexMap<String, TerminalProfile>,
     detected: Vec<DetectedShell>,
     warnings: &[ProfileWarning],
 ) -> MenuEntryPlan {
-    let hidden: std::collections::HashSet<&str> = warnings
-        .iter()
-        .map(|w| w.profile_name.as_str())
-        .collect();
+    let hidden: std::collections::HashSet<&str> =
+        warnings.iter().map(|w| w.profile_name.as_str()).collect();
 
     // Hide invalid configured profiles by filtering the IndexMap before
     // merging with detected shells. This also prevents an invalid profile
@@ -320,17 +316,15 @@ fn validate_configured_profiles_with(
 /// absolute path nor resolvable on `PATH`.
 ///
 /// Never blocks terminal spawn — the existing `TerminalError` notification
-/// path handles actual spawn failures. This is purely advisory, matching
-/// the P2-QA-1 contract: invalid programs surface a warning, selection
-/// still routes through the regular spawn-error path.
+/// path handles actual spawn failures. This is purely advisory: invalid
+/// programs surface a warning, selection still routes through the regular
+/// spawn-error path.
 pub fn validate_configured_profiles(
     profiles: &IndexMap<String, TerminalProfile>,
 ) -> Vec<ProfileWarning> {
-    validate_configured_profiles_with(
-        profiles,
-        &|p| p.is_file(),
-        &|program| which::which(program).ok(),
-    )
+    validate_configured_profiles_with(profiles, &|p| p.is_file(), &|program| {
+        which::which(program).ok()
+    })
 }
 
 impl settings::Settings for TerminalSettings {
@@ -341,7 +335,7 @@ impl settings::Settings for TerminalSettings {
         project_content.merge_from_option(content.project.terminal.as_ref());
         let profiles = project_content.profiles.clone().unwrap_or_default();
         let default_profile = project_content.default_profile.clone();
-        // P2 validation: surface a warning per profile whose `program` is
+        // Surface a warning per profile whose `program` is
         // neither an existing absolute path nor resolvable on `PATH`. This
         // is advisory only — spawn still goes through the normal
         // `TerminalError` path if the program is genuinely missing. The
@@ -356,7 +350,7 @@ impl settings::Settings for TerminalSettings {
                 warning.reason
             );
         }
-        // D3 precedence: default_profile (if it resolves) > terminal.shell > System.
+        // Precedence: default_profile (if it resolves) > terminal.shell > System.
         // Unknown default_profile name falls through to terminal.shell with a warning,
         // never silently to System.
         let shell = if let Some(name) = default_profile.as_deref() {
@@ -524,9 +518,7 @@ mod tests {
         }
     }
 
-    fn profile_map(
-        entries: &[(&str, &str)],
-    ) -> collections::IndexMap<String, TerminalProfile> {
+    fn profile_map(entries: &[(&str, &str)]) -> collections::IndexMap<String, TerminalProfile> {
         entries
             .iter()
             .map(|(name, program)| {
@@ -564,10 +556,7 @@ mod tests {
     #[test]
     fn merge_shadows_detected_when_program_path_matches_exactly() {
         let profiles = profile_map(&[("Zsh", "/bin/zsh")]);
-        let detected = vec![
-            detected("zsh", "/bin/zsh"),
-            detected("bash", "/bin/bash"),
-        ];
+        let detected = vec![detected("zsh", "/bin/zsh"), detected("bash", "/bin/bash")];
         let merged = merge_with_configured_profiles(detected, &profiles);
         let labels: Vec<String> = merged
             .iter()
@@ -660,11 +649,7 @@ mod tests {
     #[test]
     fn validate_warns_when_absolute_program_does_not_exist() {
         let profiles = profile_map(&[("Broken", "/definitely/not/a/real/shell")]);
-        let warnings = validate_configured_profiles_with(
-            &profiles,
-            &|_| false,
-            &|_| None,
-        );
+        let warnings = validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].profile_name, "Broken");
         assert!(warnings[0].reason.contains("not an existing file"));
@@ -673,8 +658,7 @@ mod tests {
     #[test]
     fn validate_warns_when_relative_program_not_on_path() {
         let profiles = profile_map(&[("Nope", "definitely-not-a-real-shell-xyz")]);
-        let warnings =
-            validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
+        let warnings = validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].profile_name, "Nope");
         assert!(warnings[0].reason.contains("not found on PATH"));
@@ -683,8 +667,7 @@ mod tests {
     #[test]
     fn validate_warns_on_empty_program() {
         let profiles = profile_map(&[("Empty", "")]);
-        let warnings =
-            validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
+        let warnings = validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].profile_name, "Empty");
         assert!(warnings[0].reason.contains("empty"));
@@ -777,8 +760,8 @@ mod tests {
         // Distinct programs so dedup doesn't collapse them.
         let profiles: Vec<(&str, &str)> = (1..=MENU_ESCALATION_THRESHOLD)
             .map(|i| {
-                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
-                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                let n: &'static str = Box::leak(format!("n{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/n{i}").into_boxed_str());
                 (n, p)
             })
             .collect();
@@ -793,8 +776,8 @@ mod tests {
     fn menu_collapses_above_threshold() {
         let profiles: Vec<(&str, &str)> = (1..=9)
             .map(|i| {
-                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
-                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                let n: &'static str = Box::leak(format!("n{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/n{i}").into_boxed_str());
                 (n, p)
             })
             .collect();
@@ -886,12 +869,12 @@ mod tests {
         // 10 profiles, but 3 are invalid -> 7 visible -> stays inline.
         let profiles: Vec<(&str, &str)> = (1..=10)
             .map(|i| {
-                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
-                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                let n: &'static str = Box::leak(format!("n{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/n{i}").into_boxed_str());
                 (n, p)
             })
             .collect();
-        let plan = build_plan(&profiles, Vec::new(), &["P1", "P2", "P3"]);
+        let plan = build_plan(&profiles, Vec::new(), &["n1", "n2", "n3"]);
         match plan {
             MenuEntryPlan::Inline { entries } => {
                 assert_eq!(entries.len(), 7, "filtered count should drive threshold");
@@ -900,7 +883,7 @@ mod tests {
         }
     }
 
-    /// Fix #4 lock: `TerminalSettings.profile_warnings` is the cached
+    /// `TerminalSettings.profile_warnings` is the cached
     /// validator output. The cache is populated in `from_settings`, but
     /// because constructing a full `SettingsContent` here is heavy, this
     /// test verifies the equivalent contract — that the field exists,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,7 +1,9 @@
-use collections::HashMap;
-use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels};
+use collections::{HashMap, IndexMap};
+use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels, px};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
+use util::shell_detection::DetectedShell;
 
 pub use settings::AlternateScroll;
 
@@ -94,6 +96,132 @@ pub fn profile_to_task_shell(name: &str, profile: &TerminalProfile) -> Shell {
     }
 }
 
+/// A view over the configured-vs-detected shell entries used by the P3 "+"
+/// menu. Configured profiles shadow detected shells with the same resolved
+/// program path (D2/D8 in the plan); order is configured-first (preserving
+/// IndexMap insertion order), then detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergedShellEntry {
+    /// User-configured profile from `terminal.profiles`.
+    Configured {
+        name: String,
+        profile: TerminalProfile,
+    },
+    /// Detected shell that is not shadowed by a configured profile.
+    Detected(DetectedShell),
+}
+
+/// Combine configured profiles with detected shells, dropping any detected
+/// entry whose program path collides with a configured profile's program
+/// (configured wins the slot, per the plan's dedup rule).
+///
+/// Comparison is by the profile's program string resolved against the
+/// detected entry's `program` both ways:
+/// * exact string match (covers the common "configured `/bin/zsh`,
+///   detected `/bin/zsh`" case), and
+/// * file-stem match where one side is a bare basename and the other an
+///   absolute path (covers "configured `zsh`, detected `/bin/zsh`").
+pub fn merge_with_configured_profiles(
+    detected: Vec<DetectedShell>,
+    profiles: &IndexMap<String, TerminalProfile>,
+) -> Vec<MergedShellEntry> {
+    let configured_paths: std::collections::HashSet<String> = profiles
+        .values()
+        .map(|p| p.program.clone())
+        .collect();
+    let configured_stems: std::collections::HashSet<String> = profiles
+        .values()
+        .filter_map(|p| Path::new(&p.program).file_name().map(|s| s.to_string_lossy().into_owned()))
+        .collect();
+
+    let mut entries: Vec<MergedShellEntry> = profiles
+        .iter()
+        .map(|(name, profile)| MergedShellEntry::Configured {
+            name: name.clone(),
+            profile: profile.clone(),
+        })
+        .collect();
+
+    for shell in detected {
+        let program_string = shell.program.to_string_lossy().into_owned();
+        let stem = shell
+            .program
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned());
+        let shadowed = configured_paths.contains(&program_string)
+            || stem.as_ref().is_some_and(|s| configured_stems.contains(s));
+        if !shadowed {
+            entries.push(MergedShellEntry::Detected(shell));
+        }
+    }
+
+    entries
+}
+
+/// A non-blocking warning about a configured profile whose `program` is
+/// neither an existing absolute path nor resolvable on `PATH`. Returned by
+/// [`validate_configured_profiles`]; the caller decides how to surface the
+/// warning (log line, toast, settings diagnostic).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileWarning {
+    pub profile_name: String,
+    pub program: String,
+    pub reason: String,
+}
+
+/// Test-friendly inner validator. The `is_file` and `resolve_on_path`
+/// callbacks abstract `Path::is_file()` and `which::which()` so unit tests
+/// can run without touching the real filesystem.
+fn validate_configured_profiles_with(
+    profiles: &IndexMap<String, TerminalProfile>,
+    is_file: &dyn Fn(&Path) -> bool,
+    resolve_on_path: &dyn Fn(&str) -> Option<std::path::PathBuf>,
+) -> Vec<ProfileWarning> {
+    let mut warnings = Vec::new();
+    for (name, profile) in profiles {
+        let program = profile.program.as_str();
+        if program.is_empty() {
+            warnings.push(ProfileWarning {
+                profile_name: name.clone(),
+                program: program.to_string(),
+                reason: "profile program is empty".to_string(),
+            });
+            continue;
+        }
+        let path = Path::new(program);
+        let absolute_exists = path.is_absolute() && is_file(path);
+        let on_path = !path.is_absolute() && resolve_on_path(program).is_some();
+        if !absolute_exists && !on_path {
+            warnings.push(ProfileWarning {
+                profile_name: name.clone(),
+                program: program.to_string(),
+                reason: format!(
+                    "profile program '{program}' is not an existing file and is not found on PATH"
+                ),
+            });
+        }
+    }
+    warnings
+}
+
+/// Validate the configured terminal profiles, returning one
+/// [`ProfileWarning`] per profile whose `program` is neither an existing
+/// absolute path nor resolvable on `PATH`.
+///
+/// Never blocks terminal spawn — the existing `TerminalError` notification
+/// path handles actual spawn failures. This is purely advisory, matching
+/// the P2-QA-1 contract: invalid programs surface a warning, selection
+/// still routes through the regular spawn-error path.
+pub fn validate_configured_profiles(
+    profiles: &IndexMap<String, TerminalProfile>,
+) -> Vec<ProfileWarning> {
+    validate_configured_profiles_with(
+        profiles,
+        &|p| p.is_file(),
+        &|program| which::which(program).ok(),
+    )
+}
+
 impl settings::Settings for TerminalSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let user_content = content.terminal.clone().unwrap();
@@ -102,6 +230,17 @@ impl settings::Settings for TerminalSettings {
         project_content.merge_from_option(content.project.terminal.as_ref());
         let profiles = project_content.profiles.clone().unwrap_or_default();
         let default_profile = project_content.default_profile.clone();
+        // P2 validation: surface a warning per profile whose `program` is
+        // neither an existing absolute path nor resolvable on `PATH`. This
+        // is advisory only — spawn still goes through the normal
+        // `TerminalError` path if the program is genuinely missing.
+        for warning in validate_configured_profiles(&profiles) {
+            log::warn!(
+                "terminal.profiles.{}: {}",
+                warning.profile_name,
+                warning.reason
+            );
+        }
         // D3 precedence: default_profile (if it resolves) > terminal.shell > System.
         // Unknown default_profile name falls through to terminal.shell with a warning,
         // never silently to System.
@@ -257,5 +396,180 @@ mod tests {
             Shell::WithArguments { args, .. } => assert!(args.is_empty()),
             other => panic!("expected WithArguments, got {other:?}"),
         }
+    }
+
+    fn detected(label: &str, program: &str) -> DetectedShell {
+        use util::shell_detection::ShellSource;
+        DetectedShell {
+            label: label.to_string(),
+            program: std::path::PathBuf::from(program),
+            args: Vec::new(),
+            source: ShellSource::EtcShells,
+        }
+    }
+
+    fn profile_map(
+        entries: &[(&str, &str)],
+    ) -> collections::IndexMap<String, TerminalProfile> {
+        entries
+            .iter()
+            .map(|(name, program)| {
+                (
+                    name.to_string(),
+                    TerminalProfile {
+                        program: program.to_string(),
+                        args: None,
+                        title_override: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn merge_places_configured_first_then_detected() {
+        let profiles = profile_map(&[("Zsh", "/bin/zsh"), ("Fish", "/usr/bin/fish")]);
+        let detected = vec![
+            detected("bash", "/bin/bash"),
+            detected("python", "/usr/bin/python"),
+        ];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        let mut labels = merged.iter().map(|entry| match entry {
+            MergedShellEntry::Configured { name, .. } => name.clone(),
+            MergedShellEntry::Detected(shell) => shell.label.clone(),
+        });
+        assert_eq!(labels.next().as_deref(), Some("Zsh"));
+        assert_eq!(labels.next().as_deref(), Some("Fish"));
+        assert_eq!(labels.next().as_deref(), Some("bash"));
+        assert_eq!(labels.next().as_deref(), Some("python"));
+        assert_eq!(labels.next(), None);
+    }
+
+    #[test]
+    fn merge_shadows_detected_when_program_path_matches_exactly() {
+        let profiles = profile_map(&[("Zsh", "/bin/zsh")]);
+        let detected = vec![
+            detected("zsh", "/bin/zsh"),
+            detected("bash", "/bin/bash"),
+        ];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        let labels: Vec<String> = merged
+            .iter()
+            .map(|entry| match entry {
+                MergedShellEntry::Configured { name, .. } => name.clone(),
+                MergedShellEntry::Detected(shell) => shell.label.clone(),
+            })
+            .collect();
+        // Configured Zsh wins; detected zsh is dropped; detected bash survives.
+        assert_eq!(labels, vec!["Zsh".to_string(), "bash".to_string()]);
+    }
+
+    #[test]
+    fn merge_shadows_detected_when_configured_is_basename_match() {
+        // Configured profile uses bare "zsh"; detected shell is at
+        // "/bin/zsh". The basename match should shadow the detected entry.
+        let profiles = profile_map(&[("MyZsh", "zsh")]);
+        let detected = vec![detected("zsh", "/bin/zsh")];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        assert_eq!(merged.len(), 1);
+        match &merged[0] {
+            MergedShellEntry::Configured { name, .. } => assert_eq!(name, "MyZsh"),
+            MergedShellEntry::Detected(_) => panic!("basename match should shadow detected"),
+        }
+    }
+
+    #[test]
+    fn merge_keeps_detected_when_program_differs() {
+        let profiles = profile_map(&[("Zsh", "/bin/zsh")]);
+        let detected = vec![
+            detected("bash", "/bin/bash"),
+            detected("fish", "/usr/bin/fish"),
+        ];
+        let merged = merge_with_configured_profiles(detected, &profiles);
+        // 1 configured + 2 detected = 3 entries.
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn validate_returns_no_warnings_when_all_programs_resolve() {
+        let profiles = profile_map(&[
+            ("Zsh", "/bin/zsh"),
+            ("Bash", "bash"),
+            ("Fish", "/usr/bin/fish"),
+        ]);
+        let warnings = validate_configured_profiles_with(
+            &profiles,
+            &|p| matches!(p.to_string_lossy().as_ref(), "/bin/zsh" | "/usr/bin/fish"),
+            &|program| match program {
+                "bash" => Some(std::path::PathBuf::from("/usr/bin/bash")),
+                _ => None,
+            },
+        );
+        assert!(
+            warnings.is_empty(),
+            "all programs resolvable -> no warnings, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn validate_warns_when_absolute_program_does_not_exist() {
+        let profiles = profile_map(&[("Broken", "/definitely/not/a/real/shell")]);
+        let warnings = validate_configured_profiles_with(
+            &profiles,
+            &|_| false,
+            &|_| None,
+        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].profile_name, "Broken");
+        assert!(warnings[0].reason.contains("not an existing file"));
+    }
+
+    #[test]
+    fn validate_warns_when_relative_program_not_on_path() {
+        let profiles = profile_map(&[("Nope", "definitely-not-a-real-shell-xyz")]);
+        let warnings =
+            validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].profile_name, "Nope");
+        assert!(warnings[0].reason.contains("not found on PATH"));
+    }
+
+    #[test]
+    fn validate_warns_on_empty_program() {
+        let profiles = profile_map(&[("Empty", "")]);
+        let warnings =
+            validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].profile_name, "Empty");
+        assert!(warnings[0].reason.contains("empty"));
+    }
+
+    #[test]
+    fn validate_does_not_block_on_partial_failure() {
+        // Multiple profiles, only one broken — should still return only the
+        // one warning, never panic.
+        let profiles = profile_map(&[
+            ("Good", "/bin/zsh"),
+            ("Bad", "totally-bogus-program"),
+            ("AlsoGood", "bash"),
+        ]);
+        let warnings = validate_configured_profiles_with(
+            &profiles,
+            &|p| p.to_string_lossy() == "/bin/zsh",
+            &|program| match program {
+                "bash" => Some(std::path::PathBuf::from("/usr/bin/bash")),
+                _ => None,
+            },
+        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].profile_name, "Bad");
+    }
+
+    #[test]
+    fn validate_handles_empty_profile_map() {
+        let profiles: collections::IndexMap<String, TerminalProfile> =
+            collections::IndexMap::default();
+        let warnings = validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
+        assert!(warnings.is_empty());
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -158,6 +158,93 @@ pub fn merge_with_configured_profiles(
     entries
 }
 
+/// Single menu entry for the "+" PopoverMenu (P3). Produced by
+/// [`build_menu_entries`], which filters invalid profiles and applies the
+/// escalation threshold. The view layer converts each `MenuEntry` into a
+/// `ContextMenuItem` (`action` for configured, `entry` callback for
+/// detected).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MenuEntry {
+    /// A configured profile that passed validation. Selecting it dispatches
+    /// `workspace::NewTerminal { profile: Some(name) }`.
+    Configured { name: String },
+    /// A detected shell not shadowed by any configured profile. Selecting it
+    /// constructs a `task::Shell::WithArguments` with the detected label as
+    /// `title_override` and calls `add_terminal_shell_with`.
+    Detected {
+        label: String,
+        program: String,
+        args: Vec<String>,
+    },
+}
+
+/// Above this many entries, the menu collapses into a single "Select Shell…"
+/// submenu entry per the P3 escalation rule (plan item 11).
+pub const MENU_ESCALATION_THRESHOLD: usize = 8;
+
+/// Outcome of [`build_menu_entries`]: either render entries inline, or
+/// collapse into a single "Select Shell…" entry whose submenu holds the
+/// same list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MenuEntryPlan {
+    /// `entries.len() <= MENU_ESCALATION_THRESHOLD` — render each entry
+    /// directly under a separator.
+    Inline { entries: Vec<MenuEntry> },
+    /// `entries.len() > MENU_ESCALATION_THRESHOLD` — render a single
+    /// "Select Shell…" entry; the same `entries` move into its submenu.
+    Collapsed { entries: Vec<MenuEntry> },
+}
+
+/// Pure, fs-free computation of the menu contents. Used both by the menu
+/// UI (terminal_panel.rs) and by unit tests; the latter assert structure
+/// without rendering GPUI elements.
+///
+/// * `profiles` — the user's `terminal.profiles` map (insertion order
+///   preserved).
+/// * `detected` — output of `util::shell_detection::detect_available_shells`.
+/// * `warnings` — output of `validate_configured_profiles`. Any profile
+///   named here is **hidden** from the menu (the user can still spawn it
+///   via keymap with a warning, per P3 spec).
+pub fn build_menu_entries(
+    profiles: &IndexMap<String, TerminalProfile>,
+    detected: Vec<DetectedShell>,
+    warnings: &[ProfileWarning],
+) -> MenuEntryPlan {
+    let hidden: std::collections::HashSet<&str> = warnings
+        .iter()
+        .map(|w| w.profile_name.as_str())
+        .collect();
+
+    // Hide invalid configured profiles by filtering the IndexMap before
+    // merging with detected shells. This also prevents an invalid profile
+    // from shadowing a detected shell at the same path.
+    let visible_profiles: IndexMap<String, TerminalProfile> = profiles
+        .iter()
+        .filter(|(name, _)| !hidden.contains(name.as_str()))
+        .map(|(name, profile)| (name.clone(), profile.clone()))
+        .collect();
+
+    let merged = merge_with_configured_profiles(detected, &visible_profiles);
+
+    let entries: Vec<MenuEntry> = merged
+        .into_iter()
+        .map(|entry| match entry {
+            MergedShellEntry::Configured { name, .. } => MenuEntry::Configured { name },
+            MergedShellEntry::Detected(shell) => MenuEntry::Detected {
+                label: shell.label,
+                program: shell.program.to_string_lossy().into_owned(),
+                args: shell.args,
+            },
+        })
+        .collect();
+
+    if entries.len() > MENU_ESCALATION_THRESHOLD {
+        MenuEntryPlan::Collapsed { entries }
+    } else {
+        MenuEntryPlan::Inline { entries }
+    }
+}
+
 /// A non-blocking warning about a configured profile whose `program` is
 /// neither an existing absolute path nor resolvable on `PATH`. Returned by
 /// [`validate_configured_profiles`]; the caller decides how to surface the
@@ -571,5 +658,186 @@ mod tests {
             collections::IndexMap::default();
         let warnings = validate_configured_profiles_with(&profiles, &|_| false, &|_| None);
         assert!(warnings.is_empty());
+    }
+
+    fn detected_shell(label: &str, program: &str) -> DetectedShell {
+        use util::shell_detection::ShellSource;
+        DetectedShell {
+            label: label.to_string(),
+            program: std::path::PathBuf::from(program),
+            args: Vec::new(),
+            source: ShellSource::EtcShells,
+        }
+    }
+
+    fn build_plan(
+        profiles: &[(&str, &str)],
+        detected: Vec<DetectedShell>,
+        warning_names: &[&str],
+    ) -> MenuEntryPlan {
+        let profile_map: collections::IndexMap<String, TerminalProfile> = profiles
+            .iter()
+            .map(|(name, program)| {
+                (
+                    name.to_string(),
+                    TerminalProfile {
+                        program: program.to_string(),
+                        args: None,
+                        title_override: None,
+                    },
+                )
+            })
+            .collect();
+        let warnings: Vec<ProfileWarning> = warning_names
+            .iter()
+            .map(|name| ProfileWarning {
+                profile_name: name.to_string(),
+                program: String::new(),
+                reason: "test stub".to_string(),
+            })
+            .collect();
+        build_menu_entries(&profile_map, detected, &warnings)
+    }
+
+    fn entry_labels(plan: &MenuEntryPlan) -> Vec<String> {
+        let entries = match plan {
+            MenuEntryPlan::Inline { entries } => entries,
+            MenuEntryPlan::Collapsed { entries } => entries,
+        };
+        entries
+            .iter()
+            .map(|e| match e {
+                MenuEntry::Configured { name } => name.clone(),
+                MenuEntry::Detected { label, .. } => label.clone(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn menu_inline_when_at_threshold() {
+        // Distinct programs so dedup doesn't collapse them.
+        let profiles: Vec<(&str, &str)> = (1..=MENU_ESCALATION_THRESHOLD)
+            .map(|i| {
+                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                (n, p)
+            })
+            .collect();
+        let plan = build_plan(&profiles, Vec::new(), &[]);
+        assert!(
+            matches!(plan, MenuEntryPlan::Inline { .. }),
+            "exactly at threshold should stay inline"
+        );
+    }
+
+    #[test]
+    fn menu_collapses_above_threshold() {
+        let profiles: Vec<(&str, &str)> = (1..=9)
+            .map(|i| {
+                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                (n, p)
+            })
+            .collect();
+        let plan = build_plan(&profiles, Vec::new(), &[]);
+        match plan {
+            MenuEntryPlan::Collapsed { entries } => {
+                assert_eq!(entries.len(), 9, "all entries preserved in submenu");
+            }
+            _ => panic!("9 entries should collapse to submenu"),
+        }
+    }
+
+    #[test]
+    fn menu_places_configured_first_then_detected() {
+        let plan = build_plan(
+            &[("Zsh", "/bin/zsh"), ("Fish", "/usr/bin/fish")],
+            vec![detected_shell("bash", "/bin/bash")],
+            &[],
+        );
+        assert_eq!(entry_labels(&plan), vec!["Zsh", "Fish", "bash"]);
+    }
+
+    #[test]
+    fn menu_hides_invalid_profiles() {
+        let plan = build_plan(
+            &[("Good", "/bin/zsh"), ("Bad", "/nonexistent")],
+            vec![],
+            &["Bad"],
+        );
+        let labels = entry_labels(&plan);
+        assert!(labels.contains(&"Good".to_string()));
+        assert!(
+            !labels.contains(&"Bad".to_string()),
+            "profile named in warnings should be hidden from menu"
+        );
+    }
+
+    #[test]
+    fn menu_lets_detected_surface_when_configured_invalid() {
+        // When a configured profile fails validation, it's filtered out
+        // BEFORE merging — so a detected shell at the same path can surface
+        // in its place (rather than being shadowed by the broken entry).
+        let plan = build_plan(
+            &[("Broken", "/bin/zsh")],
+            vec![detected_shell("zsh", "/bin/zsh")],
+            &["Broken"],
+        );
+        let labels = entry_labels(&plan);
+        assert!(
+            labels.contains(&"zsh".to_string()),
+            "detected zsh should surface after the broken configured profile is hidden"
+        );
+        assert!(!labels.contains(&"Broken".to_string()));
+    }
+
+    #[test]
+    fn menu_handles_empty_inputs() {
+        let plan = build_plan(&[], Vec::new(), &[]);
+        match plan {
+            MenuEntryPlan::Inline { entries } => assert!(entries.is_empty()),
+            _ => panic!("empty input should be inline-empty, not collapsed"),
+        }
+    }
+
+    #[test]
+    fn menu_detected_entry_carries_program_and_args() {
+        let mut detected = detected_shell("wsl-ubuntu", "wsl.exe");
+        detected.args = vec!["-d".to_string(), "Ubuntu".to_string()];
+        let plan = build_plan(&[], vec![detected], &[]);
+        match plan {
+            MenuEntryPlan::Inline { entries } => match &entries[0] {
+                MenuEntry::Detected {
+                    label,
+                    program,
+                    args,
+                } => {
+                    assert_eq!(label, "wsl-ubuntu");
+                    assert_eq!(program, "wsl.exe");
+                    assert_eq!(args, &vec!["-d".to_string(), "Ubuntu".to_string()]);
+                }
+                _ => panic!("expected Detected entry"),
+            },
+            _ => panic!("expected Inline"),
+        }
+    }
+
+    #[test]
+    fn menu_escalation_counts_after_filtering() {
+        // 10 profiles, but 3 are invalid -> 7 visible -> stays inline.
+        let profiles: Vec<(&str, &str)> = (1..=10)
+            .map(|i| {
+                let n: &'static str = Box::leak(format!("P{i}").into_boxed_str());
+                let p: &'static str = Box::leak(format!("/bin/p{i}").into_boxed_str());
+                (n, p)
+            })
+            .collect();
+        let plan = build_plan(&profiles, Vec::new(), &["P1", "P2", "P3"]);
+        match plan {
+            MenuEntryPlan::Inline { entries } => {
+                assert_eq!(entries.len(), 7, "filtered count should drive threshold");
+            }
+            _ => panic!("7 visible entries should stay inline"),
+        }
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,5 +1,5 @@
 use collections::{HashMap, IndexMap};
-use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels, px};
+use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::Path;

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -589,8 +589,9 @@ mod tests {
     // table, so we insert a workspace row via `WorkspaceDb::next_id` before
     // exercising the terminals table writes.
     //
-    // Both rounds share a single #[gpui::test] because the global test DB is
-    // a shared LazyLock and parallel writes against it lock.
+    // Serialize and deserialize share a single #[gpui::test] because the
+    // global test DB is a shared LazyLock and parallel writes against it
+    // lock.
 
     #[gpui::test]
     async fn test_profile_name_round_trip(cx: &mut gpui::TestAppContext) {

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -450,6 +450,9 @@ impl Domain for TerminalDb {
         sql! (
             ALTER TABLE terminals ADD COLUMN custom_title TEXT;
         ),
+        sql! (
+            ALTER TABLE terminals ADD COLUMN profile_name TEXT;
+        ),
     ];
 }
 
@@ -540,5 +543,122 @@ impl TerminalDb {
             FROM terminals
             WHERE item_id = ? AND workspace_id = ?
         }
+    }
+
+    pub async fn save_profile_name(
+        &self,
+        item_id: ItemId,
+        workspace_id: WorkspaceId,
+        profile_name: Option<String>,
+    ) -> Result<()> {
+        log::debug!(
+            "Saving profile name {:?} for item {} in workspace {:?}",
+            profile_name,
+            item_id,
+            workspace_id
+        );
+        self.write(move |conn| {
+            let query = "INSERT INTO terminals (item_id, workspace_id, profile_name)
+                VALUES (?1, ?2, ?3)
+                ON CONFLICT (workspace_id, item_id) DO UPDATE SET
+                    profile_name = excluded.profile_name";
+            let mut statement = Statement::prepare(conn, query)?;
+            let mut next_index = statement.bind(&item_id, 1)?;
+            next_index = statement.bind(&workspace_id, next_index)?;
+            statement.bind(&profile_name, next_index)?;
+            statement.exec()
+        })
+        .await
+    }
+
+    query! {
+        pub fn get_profile_name(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<String>> {
+            SELECT profile_name
+            FROM terminals
+            WHERE item_id = ? AND workspace_id = ?
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use workspace::WorkspaceDb;
+
+    // The terminals table has a FK on workspace_id referencing the workspaces
+    // table, so we insert a workspace row via `WorkspaceDb::next_id` before
+    // exercising the terminals table writes.
+    //
+    // Both rounds share a single #[gpui::test] because the global test DB is
+    // a shared LazyLock and parallel writes against it lock.
+
+    #[gpui::test]
+    async fn test_profile_name_round_trip(cx: &mut gpui::TestAppContext) {
+        let db = cx.update(|cx| TerminalDb::global(cx));
+        let workspace_id = cx
+            .update(|cx| WorkspaceDb::global(cx))
+            .next_id()
+            .await
+            .expect("inserted workspace row");
+
+        let item_id: ItemId = 42;
+        let read_profile = || {
+            db.get_profile_name(item_id, workspace_id)
+                .ok()
+                .flatten()
+                .filter(|name| !name.trim().is_empty())
+        };
+
+        assert_eq!(
+            read_profile(),
+            None,
+            "profile_name should default to NULL/empty"
+        );
+
+        db.save_profile_name(item_id, workspace_id, Some("Zsh".to_string()))
+            .await
+            .expect("save_profile_name ok");
+        assert_eq!(
+            read_profile().as_deref(),
+            Some("Zsh"),
+            "profile_name should round-trip through SQLite"
+        );
+
+        // Re-saving with None clears the slot (some binding paths encode None
+        // as the empty string; the read filter normalises both to None).
+        db.save_profile_name(item_id, workspace_id, None)
+            .await
+            .expect("save_profile_name None ok");
+        assert_eq!(
+            read_profile(),
+            None,
+            "profile_name should clear back to NULL/empty"
+        );
+
+        // Other terminal persistence columns must coexist on the same row.
+        db.save_working_directory(item_id, workspace_id, PathBuf::from("/tmp"))
+            .await
+            .expect("save_working_directory ok");
+        db.save_custom_title(item_id, workspace_id, Some("custom".to_string()))
+            .await
+            .expect("save_custom_title ok");
+        db.save_profile_name(item_id, workspace_id, Some("Fish".to_string()))
+            .await
+            .expect("save_profile_name ok");
+
+        assert_eq!(
+            db.get_working_directory(item_id, workspace_id)
+                .ok()
+                .flatten(),
+            Some(PathBuf::from("/tmp"))
+        );
+        assert_eq!(
+            db.get_custom_title(item_id, workspace_id)
+                .ok()
+                .flatten()
+                .as_deref(),
+            Some("custom")
+        );
+        assert_eq!(read_profile().as_deref(), Some("Fish"));
     }
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -24,7 +24,6 @@ use terminal::{
     Terminal,
     terminal_settings::{
         MenuEntry, MenuEntryPlan, TerminalSettings, build_menu_entries,
-        validate_configured_profiles,
     },
 };
 use ui::{
@@ -132,6 +131,7 @@ impl TerminalPanel {
         cx: &mut Context<Self>,
     ) {
         let assistant_enabled = self.assistant_enabled;
+        let workspace = self.workspace.clone();
         terminal_pane.update(cx, |pane, cx| {
             pane.set_render_tab_bar_buttons(cx, move |pane, window, cx| {
                 let split_context = pane
@@ -149,6 +149,7 @@ impl TerminalPanel {
                     return (None, None);
                 }
                 let focus_handle = pane.focus_handle(cx);
+                let workspace = workspace.clone();
                 let right_children = h_flex()
                     .gap(DynamicSpacing::Base02.rems(cx))
                     .child(
@@ -165,10 +166,30 @@ impl TerminalPanel {
                                     let settings = TerminalSettings::get_global(cx).clone();
                                     let detected =
                                         util::shell_detection::detect_available_shells().to_vec();
-                                    let warnings =
-                                        validate_configured_profiles(&settings.profiles);
-                                    build_menu_entries(&settings.profiles, detected, &warnings)
+                                    // Fix #4: read cached warnings off
+                                    // TerminalSettings instead of re-running
+                                    // validate_configured_profiles (which
+                                    // already ran in from_settings).
+                                    build_menu_entries(
+                                        &settings.profiles,
+                                        detected,
+                                        &settings.profile_warnings,
+                                    )
                                 };
+                                // Fix #2/#3: in remote projects, configured
+                                // profiles and detected shells reference
+                                // local executables — spawn them with
+                                // force_local=true so the override is
+                                // honored (D9 drop never triggers).
+                                let is_remote = workspace
+                                    .upgrade()
+                                    .is_some_and(|workspace| {
+                                        workspace
+                                            .read(cx)
+                                            .project()
+                                            .read(cx)
+                                            .is_via_remote_server()
+                                    });
                                 let menu = ContextMenu::build(window, cx, move |menu, _, _| {
                                     menu.context(focus_handle.clone())
                                         .action(
@@ -183,7 +204,7 @@ impl TerminalPanel {
                                             zed_actions::Spawn::modal().boxed_clone(),
                                         )
                                         .separator()
-                                        .shell_entries(plan)
+                                        .shell_entries(plan, is_remote)
                                 });
 
                                 Some(menu)
@@ -665,14 +686,32 @@ impl TerminalPanel {
         };
         terminal_panel
             .update(cx, |panel, cx| {
-                panel.add_terminal_shell_with(
-                    None,
-                    Some(shell),
-                    Some(action.label.clone()),
-                    RevealStrategy::Always,
-                    window,
-                    cx,
-                )
+                if action.local {
+                    // Bypass `add_terminal_shell_with` (which hard-codes
+                    // `force_local=false`) so the override survives the
+                    // remote-drop in `create_terminal_shell_internal`.
+                    // `profile_name` is None: detected shells don't
+                    // round-trip through persistence (the detected set
+                    // varies per host).
+                    panel.add_terminal_shell_internal(
+                        true,
+                        None,
+                        Some(shell),
+                        None,
+                        RevealStrategy::Always,
+                        window,
+                        cx,
+                    )
+                } else {
+                    panel.add_terminal_shell_with(
+                        None,
+                        Some(shell),
+                        None,
+                        RevealStrategy::Always,
+                        window,
+                        cx,
+                    )
+                }
             })
             .detach_and_log_err(cx);
     }
@@ -1998,38 +2037,44 @@ impl RenderOnce for InlineAssistTabBarButton {
 /// Extend `ContextMenu` with the "+" menu's terminal-shell section.
 ///
 /// Lives as a small private trait so the trait method chains naturally
-/// (`.separator().shell_entries(plan)`); the alternative (a free function)
-/// would break the builder chain.
+/// (`.separator().shell_entries(plan, is_remote)`); the alternative (a free
+/// function) would break the builder chain.
 trait TerminalPanelMenuExt: Sized {
-    fn shell_entries(self, plan: MenuEntryPlan) -> Self;
+    fn shell_entries(self, plan: MenuEntryPlan, is_remote: bool) -> Self;
 }
 
 impl TerminalPanelMenuExt for ContextMenu {
-    fn shell_entries(self, plan: MenuEntryPlan) -> Self {
+    fn shell_entries(self, plan: MenuEntryPlan, is_remote: bool) -> Self {
         match plan {
-            MenuEntryPlan::Inline { entries } => inline_shell_entries(self, entries),
+            MenuEntryPlan::Inline { entries } => inline_shell_entries(self, entries, is_remote),
             // Escalation: collapse into a submenu. The submenu builder
             // receives a fresh `ContextMenu` and must be `'static`, so the
-            // entry list is cloned into the closure. Picking a submenu over
-            // a Picker modal here because `ContextMenu::submenu` is already
-            // available in GPUI, requires no new infrastructure, and matches
-            // the existing menu interaction model. The Picker pattern stays
-            // available for future surfacing (e.g. command palette) without
-            // being preemptively wired up.
+            // entry list + `is_remote` are cloned into the closure. Picking
+            // a submenu over a Picker modal here because `ContextMenu::submenu`
+            // is already available in GPUI, requires no new infrastructure,
+            // and matches the existing menu interaction model. The Picker
+            // pattern stays available for future surfacing (e.g. command
+            // palette) without being preemptively wired up.
             MenuEntryPlan::Collapsed { entries } => self.submenu(
                 "Select Shell…",
-                move |submenu, _window, _cx| inline_shell_entries(submenu, entries.clone()),
+                move |submenu, _window, _cx| {
+                    inline_shell_entries(submenu, entries.clone(), is_remote)
+                },
             ),
         }
     }
 }
 
-fn inline_shell_entries(mut menu: ContextMenu, entries: Vec<MenuEntry>) -> ContextMenu {
+fn inline_shell_entries(
+    mut menu: ContextMenu,
+    entries: Vec<MenuEntry>,
+    is_remote: bool,
+) -> ContextMenu {
     for entry in entries {
         match entry {
             MenuEntry::Configured { name } => {
                 let action = workspace::NewTerminal {
-                    local: false,
+                    local: is_remote,
                     profile: Some(name.clone()),
                 };
                 menu = menu.action(name.as_str(), action.boxed_clone());
@@ -2039,6 +2084,7 @@ fn inline_shell_entries(mut menu: ContextMenu, entries: Vec<MenuEntry>) -> Conte
                     program,
                     args,
                     label: label.clone(),
+                    local: is_remote,
                 };
                 menu = menu.action(label.as_str(), action.boxed_clone());
             }
@@ -3670,6 +3716,7 @@ mod tests {
             },
             args: Vec::new(),
             label: "Detected Shell".to_string(),
+            local: false,
         };
         window_handle
             .update(cx, |multi_workspace, window, cx| {
@@ -3686,10 +3733,12 @@ mod tests {
             .and_then(|item| item.downcast::<TerminalView>())
             .expect("active panel item should be a TerminalView after detected-shell spawn");
         terminal_view.update(cx, |view, cx| {
-            assert_eq!(
+            // Fix #1 lock: detected shells don't tag the view with a
+            // profile_name (they don't round-trip through persistence).
+            assert!(
+                view.profile_name.is_none(),
+                "detected-shell spawn must NOT set profile_name (would mislead deserialize into a default-shell fallback). Got: {:?}",
                 view.profile_name,
-                Some("Detected Shell".to_string()),
-                "TerminalView should be tagged with the detected label for persistence"
             );
             let title = view.terminal().read(cx).title(false);
             assert_eq!(
@@ -3697,6 +3746,64 @@ mod tests {
                 "tab title should come from the detected label (D6-equivalent for detected entries)"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_spawn_detected_shell_with_local_routes_through_force_local(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
+
+        // Fix #2 lock: when local=true, spawn_detected_shell must route
+        // through the force_local branch (add_terminal_shell_internal with
+        // force_local=true) so the override survives any remote-drop. In a
+        // local project the spawn should still succeed and produce a
+        // terminal with the requested program.
+        let detected = crate::SpawnDetectedShell {
+            program: if cfg!(unix) {
+                "/bin/sh".to_string()
+            } else {
+                "cmd.exe".to_string()
+            },
+            args: Vec::new(),
+            label: "Local Detected".to_string(),
+            local: true,
+        };
+        window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    TerminalPanel::spawn_detected_shell(workspace, &detected, window, cx);
+                })
+            })
+            .expect("Failed to dispatch SpawnDetectedShell with local=true");
+        cx.run_until_parked();
+
+        let count = terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).items_len());
+        assert_eq!(count, 1, "force_local branch should still spawn a terminal");
+
+        let active_item =
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).active_item());
+        let terminal_view = active_item
+            .and_then(|item| item.downcast::<TerminalView>())
+            .expect("active panel item should be a TerminalView");
+        terminal_view.update(cx, |view, cx| {
+            let title = view.terminal().read(cx).title(false);
+            assert_eq!(
+                title, "Local Detected",
+                "force_local spawn should still apply the title override"
+            );
+        });
+    }
+
+    #[test]
+    fn spawn_detected_shell_default_local_is_false() {
+        // Fix #2 lock: backcompat — keymap dispatch without `local` must
+        // default to false (non-force_local path).
+        let action = crate::SpawnDetectedShell::default();
+        assert!(!action.local, "default SpawnDetectedShell.local must be false");
     }
 
     pub fn init_test(cx: &mut TestAppContext) {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -746,14 +746,17 @@ impl TerminalPanel {
             .active_item()
             .is_some_and(|item| item.downcast::<TerminalView>().is_some());
 
+        let (shell_override, profile_name) =
+            resolve_profile_override(action.profile.as_deref(), workspace, cx);
+
         if center_pane_has_focus && active_center_item_is_terminal {
             let working_directory = default_working_directory(workspace, cx);
             let local = action.local;
             Self::add_center_terminal(workspace, window, cx, move |project, cx| {
                 if local {
-                    project.create_local_terminal(cx)
+                    project.create_local_terminal_with(shell_override, cx)
                 } else {
-                    project.create_terminal_shell(working_directory, cx)
+                    project.create_terminal_shell_with(working_directory, shell_override, cx)
                 }
             })
             .detach_and_log_err(cx);
@@ -766,9 +769,11 @@ impl TerminalPanel {
 
         terminal_panel
             .update(cx, |this, cx| {
-                this.add_terminal_shell(
+                this.add_terminal_shell_with(
                     action.local,
                     default_working_directory(workspace, cx),
+                    shell_override,
+                    profile_name,
                     RevealStrategy::Always,
                     window,
                     cx,
@@ -937,6 +942,22 @@ impl TerminalPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
+        self.add_terminal_shell_with(force_local, cwd, None, None, reveal_strategy, window, cx)
+    }
+
+    /// Same as [`add_terminal_shell`](Self::add_terminal_shell) but supplies a
+    /// profile-derived shell override and the profile name (used to tag the
+    /// resulting `TerminalView` for persistence).
+    fn add_terminal_shell_with(
+        &mut self,
+        force_local: bool,
+        cwd: Option<PathBuf>,
+        shell_override: Option<Shell>,
+        profile_name: Option<String>,
+        reveal_strategy: RevealStrategy,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<WeakEntity<Terminal>>> {
         let workspace = self.workspace.clone();
         self.spawn_pending_terminal(window, cx, async move |terminal_panel, cx| {
             if workspace.update(cx, |workspace, cx| !is_enabled_in_workspace(workspace, cx))? {
@@ -945,11 +966,15 @@ impl TerminalPanel {
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = if force_local {
                 project
-                    .update(cx, |project, cx| project.create_local_terminal(cx))
+                    .update(cx, |project, cx| {
+                        project.create_local_terminal_with(shell_override, cx)
+                    })
                     .await
             } else {
                 project
-                    .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                    .update(cx, |project, cx| {
+                        project.create_terminal_shell_with(cwd, shell_override, cx)
+                    })
                     .await
             };
 
@@ -958,14 +983,19 @@ impl TerminalPanel {
             match terminal {
                 Ok(terminal) => workspace.update_in(cx, |workspace, window, cx| {
                     let terminal_view = Box::new(cx.new(|cx| {
-                        TerminalView::new(
+                        let mut view = TerminalView::new(
                             terminal.clone(),
                             workspace.weak_handle(),
                             workspace.database_id(),
                             workspace.project().downgrade(),
                             window,
                             cx,
-                        )
+                        );
+                        if profile_name.is_some() {
+                            view.profile_name = profile_name;
+                            view.needs_serialize = true;
+                        }
+                        view
                     }));
 
                     let take_focus = reveal_strategy == RevealStrategy::Always
@@ -1000,7 +1030,6 @@ impl TerminalPanel {
             }
         })
     }
-
     fn spawn_pending_terminal(
         &mut self,
         window: &mut Window,
@@ -1302,6 +1331,52 @@ pub fn prepare_task_for_spawn(
 
 fn is_enabled_in_workspace(workspace: &Workspace, cx: &App) -> bool {
     workspace.project().read(cx).supports_terminal(cx)
+}
+
+/// Resolve an optional profile name from a `NewTerminal` action into a
+/// `(shell_override, profile_name)` pair.
+///
+/// - When `requested_profile` is `None`, returns `(None, None)` — caller
+///   uses the default shell resolution.
+/// - When the name resolves against `TerminalSettings.profiles`, returns
+///   the converted `task::Shell` (with D6 title promotion) and the name
+///   (the latter so the spawned `TerminalView` can be tagged for
+///   persistence).
+/// - When the name does not resolve, emits a user-visible toast and
+///   returns `(None, None)` so the caller falls back to the default shell
+///   (D3: never silently to the system shell).
+fn resolve_profile_override(
+    requested_profile: Option<&str>,
+    workspace: &mut Workspace,
+    cx: &mut Context<Workspace>,
+) -> (Option<Shell>, Option<String>) {
+    let Some(name) = requested_profile else {
+        return (None, None);
+    };
+    let settings = TerminalSettings::get_global(cx);
+    match settings.profiles.get(name) {
+        Some(profile) => {
+            let shell = terminal::terminal_settings::profile_to_task_shell(name, profile);
+            (Some(shell), Some(name.to_string()))
+        }
+        None => {
+            let message = format!(
+                "Unknown terminal profile '{name}'; falling back to the default shell."
+            );
+            log::warn!("{message}");
+            workspace.show_toast(
+                workspace::Toast::new(
+                    workspace::notifications::NotificationId::unique::<
+                        crate::TerminalProfileWarning,
+                    >(),
+                    message,
+                )
+                .autohide(),
+                cx,
+            );
+            (None, None)
+        }
+    }
 }
 
 pub fn new_terminal_pane(
@@ -3226,7 +3301,10 @@ mod tests {
                 multi_workspace.workspace().update(cx, |workspace, cx| {
                     TerminalPanel::new_terminal(
                         workspace,
-                        &workspace::NewTerminal { local: true },
+                        &workspace::NewTerminal {
+                            local: true,
+                            profile: None,
+                        },
                         window,
                         cx,
                     );
@@ -3355,6 +3433,122 @@ mod tests {
             store.update_user_settings(cx, |settings| {
                 settings.workspace.max_tabs = value.map(|v| NonZero::new(v).unwrap())
             });
+        });
+    }
+
+    fn configure_zsh_profile(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let terminal = settings.terminal.get_or_insert_default();
+                    terminal.project.profiles = Some(collections::IndexMap::from_iter([
+                        (
+                            "Zsh".to_string(),
+                            settings::TerminalProfile {
+                                program: "/bin/zsh".to_string(),
+                                args: Some(vec!["-l".to_string()]),
+                                title_override: None,
+                            },
+                        ),
+                    ]));
+                });
+            });
+        });
+    }
+
+    #[gpui::test]
+    async fn test_new_terminal_with_known_profile_applies_override(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+        configure_zsh_profile(cx);
+
+        let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
+
+        window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    TerminalPanel::new_terminal(
+                        workspace,
+                        &workspace::NewTerminal {
+                            local: false,
+                            profile: Some("Zsh".to_string()),
+                        },
+                        window,
+                        cx,
+                    );
+                })
+            })
+            .expect("Failed to dispatch NewTerminal with profile=Zsh");
+        cx.run_until_parked();
+
+        let active_item =
+            terminal_panel.read_with(cx, |panel, cx| {
+                panel.active_pane.read(cx).active_item()
+            });
+        let terminal_view = active_item
+            .and_then(|item| item.downcast::<TerminalView>())
+            .expect("active panel item should be a TerminalView");
+        terminal_view.update(cx, |view, cx| {
+            assert_eq!(
+                view.profile_name,
+                Some("Zsh".to_string()),
+                "TerminalView should be tagged with the profile name for persistence"
+            );
+            let title = view.terminal().read(cx).title(false);
+            assert_eq!(
+                title, "Zsh",
+                "tab title should be promoted to the profile name (D6)"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_new_terminal_with_unknown_profile_falls_back(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+        configure_zsh_profile(cx);
+
+        let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
+        let panel_items_before =
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).items_len());
+
+        window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    TerminalPanel::new_terminal(
+                        workspace,
+                        &workspace::NewTerminal {
+                            local: false,
+                            profile: Some("DefinitelyNotAProfile".to_string()),
+                        },
+                        window,
+                        cx,
+                    );
+                })
+            })
+            .expect("Failed to dispatch NewTerminal with unknown profile");
+        cx.run_until_parked();
+
+        let panel_items_after =
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).items_len());
+        assert_eq!(
+            panel_items_after,
+            panel_items_before + 1,
+            "Unknown profile should still spawn a terminal (default-shell fallback, D3)"
+        );
+
+        let active_item =
+            terminal_panel.read_with(cx, |panel, cx| {
+                panel.active_pane.read(cx).active_item()
+            });
+        let terminal_view = active_item
+            .and_then(|item| item.downcast::<TerminalView>())
+            .expect("active panel item should be a TerminalView");
+        terminal_view.update(cx, |view, _cx| {
+            assert!(
+                view.profile_name.is_none(),
+                "Unknown-profile fallback should not tag the view with a profile name"
+            );
         });
     }
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -678,32 +678,17 @@ impl TerminalPanel {
         };
         terminal_panel
             .update(cx, |panel, cx| {
-                if action.local {
-                    // Bypass `add_terminal_shell_with` (which hard-codes
-                    // `force_local=false`) so the override survives the
-                    // remote-drop in `create_terminal_shell_internal`.
-                    // `profile_name` is None: detected shells don't
-                    // round-trip through persistence (the detected set
-                    // varies per host).
-                    panel.add_terminal_shell_internal(
-                        true,
-                        None,
-                        Some(shell),
-                        None,
-                        RevealStrategy::Always,
-                        window,
-                        cx,
-                    )
-                } else {
-                    panel.add_terminal_shell_with(
-                        None,
-                        Some(shell),
-                        None,
-                        RevealStrategy::Always,
-                        window,
-                        cx,
-                    )
-                }
+                // `profile_name` is None: detected shells don't round-trip
+                // through persistence (the detected set varies per host).
+                panel.add_terminal_shell_with(
+                    action.local,
+                    None,
+                    Some(shell),
+                    None,
+                    RevealStrategy::Always,
+                    window,
+                    cx,
+                )
             })
             .detach_and_log_err(cx);
     }
@@ -1109,6 +1094,7 @@ impl TerminalPanel {
             }
         })
     }
+
     fn spawn_pending_terminal(
         &mut self,
         window: &mut Window,
@@ -3746,7 +3732,7 @@ mod tests {
         let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
 
         // When local=true, spawn_detected_shell must route
-        // through the force_local branch (add_terminal_shell_internal with
+        // through the force_local branch (add_terminal_shell_with with
         // force_local=true) so the override survives any remote-drop. In a
         // local project the spawn should still succeed and produce a
         // terminal with the requested program.

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -20,7 +20,13 @@ use project::{Fs, Project};
 
 use settings::{Settings, TerminalDockPosition};
 use task::{RevealStrategy, RevealTarget, Shell, ShellBuilder, SpawnInTerminal, TaskId};
-use terminal::{Terminal, terminal_settings::TerminalSettings};
+use terminal::{
+    Terminal,
+    terminal_settings::{
+        MenuEntry, MenuEntryPlan, TerminalSettings, build_menu_entries,
+        validate_configured_profiles,
+    },
+};
 use ui::{
     ButtonLike, Clickable, CommonAnimationExt, ContextMenu, FluentBuilder, PopoverMenu,
     SplitButton, Toggleable, Tooltip, prelude::*,
@@ -57,6 +63,7 @@ pub fn init(cx: &mut App) {
         |workspace: &mut Workspace, _window, _: &mut Context<Workspace>| {
             workspace.register_action(TerminalPanel::new_terminal);
             workspace.register_action(TerminalPanel::open_terminal);
+            workspace.register_action(TerminalPanel::spawn_detected_shell);
             workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
                     workspace.toggle_panel_focus::<TerminalPanel>(window, cx);
@@ -154,7 +161,15 @@ impl TerminalPanel {
                             .with_handle(pane.new_item_context_menu_handle.clone())
                             .menu(move |window, cx| {
                                 let focus_handle = focus_handle.clone();
-                                let menu = ContextMenu::build(window, cx, |menu, _, _| {
+                                let plan = {
+                                    let settings = TerminalSettings::get_global(cx).clone();
+                                    let detected =
+                                        util::shell_detection::detect_available_shells().to_vec();
+                                    let warnings =
+                                        validate_configured_profiles(&settings.profiles);
+                                    build_menu_entries(&settings.profiles, detected, &warnings)
+                                };
+                                let menu = ContextMenu::build(window, cx, move |menu, _, _| {
                                     menu.context(focus_handle.clone())
                                         .action(
                                             "New Terminal",
@@ -167,6 +182,8 @@ impl TerminalPanel {
                                             "Spawn Task",
                                             zed_actions::Spawn::modal().boxed_clone(),
                                         )
+                                        .separator()
+                                        .shell_entries(plan)
                                 });
 
                                 Some(menu)
@@ -621,6 +638,37 @@ impl TerminalPanel {
                 panel.add_terminal_shell(
                     action.local,
                     Some(action.working_directory.clone()),
+                    RevealStrategy::Always,
+                    window,
+                    cx,
+                )
+            })
+            .detach_and_log_err(cx);
+    }
+
+    /// Spawn a terminal running a detected (non-profile) shell program —
+    /// the dispatch side of `terminal::SpawnDetectedShell`. Mirrors
+    /// `new_terminal` for the configured-profile path.
+    pub fn spawn_detected_shell(
+        workspace: &mut Workspace,
+        action: &crate::SpawnDetectedShell,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let Some(terminal_panel) = workspace.panel::<Self>(cx) else {
+            return;
+        };
+        let shell = Shell::WithArguments {
+            program: action.program.clone(),
+            args: action.args.clone(),
+            title_override: Some(action.label.clone()),
+        };
+        terminal_panel
+            .update(cx, |panel, cx| {
+                panel.add_terminal_shell_with(
+                    None,
+                    Some(shell),
+                    Some(action.label.clone()),
                     RevealStrategy::Always,
                     window,
                     cx,
@@ -1944,7 +1992,59 @@ impl RenderOnce for InlineAssistTabBarButton {
             .tooltip(move |_window, cx| {
                 Tooltip::for_action_in("Inline Assist", &InlineAssist::default(), &focus_handle, cx)
             })
+     }
+}
+
+/// Extend `ContextMenu` with the "+" menu's terminal-shell section.
+///
+/// Lives as a small private trait so the trait method chains naturally
+/// (`.separator().shell_entries(plan)`); the alternative (a free function)
+/// would break the builder chain.
+trait TerminalPanelMenuExt: Sized {
+    fn shell_entries(self, plan: MenuEntryPlan) -> Self;
+}
+
+impl TerminalPanelMenuExt for ContextMenu {
+    fn shell_entries(self, plan: MenuEntryPlan) -> Self {
+        match plan {
+            MenuEntryPlan::Inline { entries } => inline_shell_entries(self, entries),
+            // Escalation: collapse into a submenu. The submenu builder
+            // receives a fresh `ContextMenu` and must be `'static`, so the
+            // entry list is cloned into the closure. Picking a submenu over
+            // a Picker modal here because `ContextMenu::submenu` is already
+            // available in GPUI, requires no new infrastructure, and matches
+            // the existing menu interaction model. The Picker pattern stays
+            // available for future surfacing (e.g. command palette) without
+            // being preemptively wired up.
+            MenuEntryPlan::Collapsed { entries } => self.submenu(
+                "Select Shell…",
+                move |submenu, _window, _cx| inline_shell_entries(submenu, entries.clone()),
+            ),
+        }
     }
+}
+
+fn inline_shell_entries(mut menu: ContextMenu, entries: Vec<MenuEntry>) -> ContextMenu {
+    for entry in entries {
+        match entry {
+            MenuEntry::Configured { name } => {
+                let action = workspace::NewTerminal {
+                    local: false,
+                    profile: Some(name.clone()),
+                };
+                menu = menu.action(name.as_str(), action.boxed_clone());
+            }
+            MenuEntry::Detected { label, program, args } => {
+                let action = crate::SpawnDetectedShell {
+                    program,
+                    args,
+                    label: label.clone(),
+                };
+                menu = menu.action(label.as_str(), action.boxed_clone());
+            }
+        }
+    }
+    menu
 }
 
 #[cfg(test)]
@@ -3548,6 +3648,53 @@ mod tests {
             assert!(
                 view.profile_name.is_none(),
                 "Unknown-profile fallback should not tag the view with a profile name"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_spawn_detected_shell_dispatches_add_terminal_shell_with(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
+
+        // Dispatch SpawnDetectedShell exactly as the menu's `.action()` would.
+        // Use the existing `/bin/sh` so the spawn actually succeeds on Unix
+        // hosts and we can inspect the resulting terminal.
+        let detected = crate::SpawnDetectedShell {
+            program: if cfg!(unix) {
+                "/bin/sh".to_string()
+            } else {
+                "cmd.exe".to_string()
+            },
+            args: Vec::new(),
+            label: "Detected Shell".to_string(),
+        };
+        window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    TerminalPanel::spawn_detected_shell(workspace, &detected, window, cx);
+                })
+            })
+            .expect("Failed to dispatch SpawnDetectedShell");
+        cx.run_until_parked();
+
+        let active_item =
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).active_item());
+        let terminal_view = active_item
+            .and_then(|item| item.downcast::<TerminalView>())
+            .expect("active panel item should be a TerminalView after detected-shell spawn");
+        terminal_view.update(cx, |view, cx| {
+            assert_eq!(
+                view.profile_name,
+                Some("Detected Shell".to_string()),
+                "TerminalView should be tagged with the detected label for persistence"
+            );
+            let title = view.terminal().read(cx).title(false);
+            assert_eq!(
+                title, "Detected Shell",
+                "tab title should come from the detected label (D6-equivalent for detected entries)"
             );
         });
     }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -22,9 +22,7 @@ use settings::{Settings, TerminalDockPosition};
 use task::{RevealStrategy, RevealTarget, Shell, ShellBuilder, SpawnInTerminal, TaskId};
 use terminal::{
     Terminal,
-    terminal_settings::{
-        MenuEntry, MenuEntryPlan, TerminalSettings, build_menu_entries,
-    },
+    terminal_settings::{MenuEntry, MenuEntryPlan, TerminalSettings, build_menu_entries},
 };
 use ui::{
     ButtonLike, Clickable, CommonAnimationExt, ContextMenu, FluentBuilder, PopoverMenu,
@@ -166,7 +164,7 @@ impl TerminalPanel {
                                     let settings = TerminalSettings::get_global(cx).clone();
                                     let detected =
                                         util::shell_detection::detect_available_shells().to_vec();
-                                    // Fix #4: read cached warnings off
+                                    // Read cached warnings off
                                     // TerminalSettings instead of re-running
                                     // validate_configured_profiles (which
                                     // already ran in from_settings).
@@ -176,20 +174,14 @@ impl TerminalPanel {
                                         &settings.profile_warnings,
                                     )
                                 };
-                                // Fix #2/#3: in remote projects, configured
+                                // In remote projects, configured
                                 // profiles and detected shells reference
                                 // local executables — spawn them with
                                 // force_local=true so the override is
-                                // honored (D9 drop never triggers).
-                                let is_remote = workspace
-                                    .upgrade()
-                                    .is_some_and(|workspace| {
-                                        workspace
-                                            .read(cx)
-                                            .project()
-                                            .read(cx)
-                                            .is_via_remote_server()
-                                    });
+                                // honored.
+                                let is_remote = workspace.upgrade().is_some_and(|workspace| {
+                                    workspace.read(cx).project().read(cx).is_via_remote_server()
+                                });
                                 let menu = ContextMenu::build(window, cx, move |menu, _, _| {
                                     menu.context(focus_handle.clone())
                                         .action(
@@ -1426,12 +1418,12 @@ fn is_enabled_in_workspace(workspace: &Workspace, cx: &App) -> bool {
 /// - When `requested_profile` is `None`, returns `(None, None)` — caller
 ///   uses the default shell resolution.
 /// - When the name resolves against `TerminalSettings.profiles`, returns
-///   the converted `task::Shell` (with D6 title promotion) and the name
+///   the converted `task::Shell` (with title promotion) and the name
 ///   (the latter so the spawned `TerminalView` can be tagged for
 ///   persistence).
 /// - When the name does not resolve, emits a user-visible toast and
 ///   returns `(None, None)` so the caller falls back to the default shell
-///   (D3: never silently to the system shell).
+///   (never silently to the system shell).
 fn resolve_profile_override(
     requested_profile: Option<&str>,
     workspace: &mut Workspace,
@@ -1447,9 +1439,8 @@ fn resolve_profile_override(
             (Some(shell), Some(name.to_string()))
         }
         None => {
-            let message = format!(
-                "Unknown terminal profile '{name}'; falling back to the default shell."
-            );
+            let message =
+                format!("Unknown terminal profile '{name}'; falling back to the default shell.");
             log::warn!("{message}");
             workspace.show_toast(
                 workspace::Toast::new(
@@ -2031,7 +2022,7 @@ impl RenderOnce for InlineAssistTabBarButton {
             .tooltip(move |_window, cx| {
                 Tooltip::for_action_in("Inline Assist", &InlineAssist::default(), &focus_handle, cx)
             })
-     }
+    }
 }
 
 /// Extend `ContextMenu` with the "+" menu's terminal-shell section.
@@ -2055,12 +2046,11 @@ impl TerminalPanelMenuExt for ContextMenu {
             // and matches the existing menu interaction model. The Picker
             // pattern stays available for future surfacing (e.g. command
             // palette) without being preemptively wired up.
-            MenuEntryPlan::Collapsed { entries } => self.submenu(
-                "Select Shell…",
-                move |submenu, _window, _cx| {
+            MenuEntryPlan::Collapsed { entries } => {
+                self.submenu("Select Shell…", move |submenu, _window, _cx| {
                     inline_shell_entries(submenu, entries.clone(), is_remote)
-                },
-            ),
+                })
+            }
         }
     }
 }
@@ -2079,7 +2069,11 @@ fn inline_shell_entries(
                 };
                 menu = menu.action(name.as_str(), action.boxed_clone());
             }
-            MenuEntry::Detected { label, program, args } => {
+            MenuEntry::Detected {
+                label,
+                program,
+                args,
+            } => {
                 let action = crate::SpawnDetectedShell {
                     program,
                     args,
@@ -3587,16 +3581,14 @@ mod tests {
             SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
                     let terminal = settings.terminal.get_or_insert_default();
-                    terminal.project.profiles = Some(collections::IndexMap::from_iter([
-                        (
-                            "Zsh".to_string(),
-                            settings::TerminalProfile {
-                                program: "/bin/zsh".to_string(),
-                                args: Some(vec!["-l".to_string()]),
-                                title_override: None,
-                            },
-                        ),
-                    ]));
+                    terminal.project.profiles = Some(collections::IndexMap::from_iter([(
+                        "Zsh".to_string(),
+                        settings::TerminalProfile {
+                            program: "/bin/zsh".to_string(),
+                            args: Some(vec!["-l".to_string()]),
+                            title_override: None,
+                        },
+                    )]));
                 });
             });
         });
@@ -3628,9 +3620,7 @@ mod tests {
         cx.run_until_parked();
 
         let active_item =
-            terminal_panel.read_with(cx, |panel, cx| {
-                panel.active_pane.read(cx).active_item()
-            });
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).active_item());
         let terminal_view = active_item
             .and_then(|item| item.downcast::<TerminalView>())
             .expect("active panel item should be a TerminalView");
@@ -3643,7 +3633,7 @@ mod tests {
             let title = view.terminal().read(cx).title(false);
             assert_eq!(
                 title, "Zsh",
-                "tab title should be promoted to the profile name (D6)"
+                "tab title should be promoted to the profile name"
             );
         });
     }
@@ -3680,13 +3670,11 @@ mod tests {
         assert_eq!(
             panel_items_after,
             panel_items_before + 1,
-            "Unknown profile should still spawn a terminal (default-shell fallback, D3)"
+            "Unknown profile should still spawn a terminal (default-shell fallback)"
         );
 
         let active_item =
-            terminal_panel.read_with(cx, |panel, cx| {
-                panel.active_pane.read(cx).active_item()
-            });
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).active_item());
         let terminal_view = active_item
             .and_then(|item| item.downcast::<TerminalView>())
             .expect("active panel item should be a TerminalView");
@@ -3733,7 +3721,7 @@ mod tests {
             .and_then(|item| item.downcast::<TerminalView>())
             .expect("active panel item should be a TerminalView after detected-shell spawn");
         terminal_view.update(cx, |view, cx| {
-            // Fix #1 lock: detected shells don't tag the view with a
+            // Detected shells don't tag the view with a
             // profile_name (they don't round-trip through persistence).
             assert!(
                 view.profile_name.is_none(),
@@ -3743,7 +3731,7 @@ mod tests {
             let title = view.terminal().read(cx).title(false);
             assert_eq!(
                 title, "Detected Shell",
-                "tab title should come from the detected label (D6-equivalent for detected entries)"
+                "tab title should come from the detected label"
             );
         });
     }
@@ -3757,7 +3745,7 @@ mod tests {
 
         let (window_handle, terminal_panel) = init_workspace_with_panel(cx).await;
 
-        // Fix #2 lock: when local=true, spawn_detected_shell must route
+        // When local=true, spawn_detected_shell must route
         // through the force_local branch (add_terminal_shell_internal with
         // force_local=true) so the override survives any remote-drop. In a
         // local project the spawn should still succeed and produce a
@@ -3781,7 +3769,8 @@ mod tests {
             .expect("Failed to dispatch SpawnDetectedShell with local=true");
         cx.run_until_parked();
 
-        let count = terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).items_len());
+        let count =
+            terminal_panel.read_with(cx, |panel, cx| panel.active_pane.read(cx).items_len());
         assert_eq!(count, 1, "force_local branch should still spawn a terminal");
 
         let active_item =
@@ -3800,10 +3789,13 @@ mod tests {
 
     #[test]
     fn spawn_detected_shell_default_local_is_false() {
-        // Fix #2 lock: backcompat — keymap dispatch without `local` must
+        // Backcompat: keymap dispatch without `local` must
         // default to false (non-force_local path).
         let action = crate::SpawnDetectedShell::default();
-        assert!(!action.local, "default SpawnDetectedShell.local must be false");
+        assert!(
+            !action.local,
+            "default SpawnDetectedShell.local must be false"
+        );
     }
 
     pub fn init_test(cx: &mut TestAppContext) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -113,10 +113,13 @@ pub struct RenameTerminal;
 ///
 /// Used by the "+" PopoverMenu's "detected shells" section (P3). Detected
 /// shells bypass the `terminal.profiles` lookup — they carry their own
-/// program/args and use the detected label as both the tab title and the
-/// persistence key. The action is registered on the workspace (same pattern
-/// as `workspace::NewTerminal`) and dispatched from the menu via
-/// `ContextMenu::action`.
+/// program/args. The `label` is used as the tab title (via the
+/// `title_override` field on the constructed `task::Shell::WithArguments`),
+/// NOT as a persistence key — detected shells don't round-trip through
+/// `SerializableItem::deserialize` because the detected set is
+/// machine/session-specific. The action is registered on the workspace
+/// (same pattern as `workspace::NewTerminal`) and dispatched from the menu
+/// via `ContextMenu::action`.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = terminal)]
 pub struct SpawnDetectedShell {
@@ -125,8 +128,14 @@ pub struct SpawnDetectedShell {
     pub program: String,
     /// Arguments to pass to the program (e.g. `["-d", "Ubuntu"]` for WSL).
     pub args: Vec<String>,
-    /// Tab title / persistence key. Usually `DetectedShell::label`.
+    /// Tab title. Usually `DetectedShell::label`.
     pub label: String,
+    /// If true, spawn a LOCAL terminal even in remote projects. The menu
+    /// sets this to `true` when the project is remote so detected shells
+    /// (which reference local executables) actually spawn locally instead
+    /// of falling through to the remote shell.
+    #[serde(default)]
+    pub local: bool,
 }
 
 pub fn init(cx: &mut App) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -109,6 +109,26 @@ actions!(
 #[action(namespace = terminal)]
 pub struct RenameTerminal;
 
+/// Spawn a terminal running a detected (non-profile) shell program.
+///
+/// Used by the "+" PopoverMenu's "detected shells" section (P3). Detected
+/// shells bypass the `terminal.profiles` lookup — they carry their own
+/// program/args and use the detected label as both the tab title and the
+/// persistence key. The action is registered on the workspace (same pattern
+/// as `workspace::NewTerminal`) and dispatched from the menu via
+/// `ContextMenu::action`.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Action)]
+#[action(namespace = terminal)]
+pub struct SpawnDetectedShell {
+    /// Program to launch — typically an absolute path from
+    /// `util::shell_detection::DetectedShell::program`.
+    pub program: String,
+    /// Arguments to pass to the program (e.g. `["-d", "Ubuntu"]` for WSL).
+    pub args: Vec<String>,
+    /// Tab title / persistence key. Usually `DetectedShell::label`.
+    pub label: String,
+}
+
 pub fn init(cx: &mut App) {
     terminal_panel::init(cx);
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -65,6 +65,11 @@ struct ImeState {
     marked_text: String,
 }
 
+/// Marker type for the toast emitted when a `NewTerminal` action references
+/// a profile name that does not exist in `terminal.profiles`.
+#[derive(Debug)]
+pub struct TerminalProfileWarning;
+
 fn viewport_line_for_point(point: Point, display_offset: usize) -> Option<usize> {
     let display_offset = i32::try_from(display_offset).unwrap_or(i32::MAX);
     let line = point.line.saturating_add(display_offset);
@@ -144,6 +149,11 @@ pub struct TerminalView {
     blinking_terminal_enabled: bool,
     needs_serialize: bool,
     custom_title: Option<String>,
+    /// When non-`None`, this view was spawned from the named
+    /// `terminal.profiles` entry. Used by `SerializableItem::serialize`
+    /// to persist the profile choice so that workspace reload respawns
+    /// the same profile (D7).
+    pub profile_name: Option<String>,
     hover: Option<HoverTarget>,
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
@@ -298,6 +308,7 @@ impl TerminalView {
             scroll_handle,
             needs_serialize: false,
             custom_title: None,
+            profile_name: None,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
@@ -1887,6 +1898,7 @@ impl SerializableItem for TerminalView {
         let workspace_id = self.workspace_id?;
         let cwd = terminal.working_directory();
         let custom_title = self.custom_title.clone();
+        let profile_name = self.profile_name.clone();
         self.needs_serialize = false;
 
         let db = TerminalDb::global(cx);
@@ -1896,6 +1908,8 @@ impl SerializableItem for TerminalView {
                     .await?;
             }
             db.save_custom_title(item_id, workspace_id, custom_title)
+                .await?;
+            db.save_profile_name(item_id, workspace_id, profile_name)
                 .await?;
             Ok(())
         }))
@@ -1913,8 +1927,12 @@ impl SerializableItem for TerminalView {
         window: &mut Window,
         cx: &mut App,
     ) -> Task<anyhow::Result<Entity<Self>>> {
+        // Read TerminalSettings synchronously here (where `cx: &App`) so we
+        // can re-resolve a persisted profile name into a `task::Shell`
+        // override before entering the async spawn.
+        let settings = TerminalSettings::get_global(cx).clone();
         window.spawn(cx, async move |cx| {
-            let (cwd, custom_title) = cx
+            let (cwd, custom_title, profile_name) = cx
                 .update(|_window, cx| {
                     let db = TerminalDb::global(cx);
                     let from_db = db
@@ -1936,13 +1954,49 @@ impl SerializableItem for TerminalView {
                         .log_err()
                         .flatten()
                         .filter(|title| !title.trim().is_empty());
-                    (cwd, custom_title)
+                    let profile_name = db
+                        .get_profile_name(item_id, workspace_id)
+                        .log_err()
+                        .flatten()
+                        .filter(|name| !name.trim().is_empty());
+                    (cwd, custom_title, profile_name)
                 })
                 .ok()
-                .unwrap_or((None, None));
+                .unwrap_or((None, None, None));
+
+            // Re-resolve the persisted profile name against the current
+            // TerminalSettings. A profile may disappear after a settings
+            // change; in that case fall back to the default shell with a
+            // log line (D7).
+            let (shell_override, restored_profile_name) = match profile_name
+                .as_deref()
+                .and_then(|name| {
+                    settings
+                        .profiles
+                        .get(name)
+                        .map(|profile| (name, profile))
+                }) {
+                Some((name, profile)) => (
+                    Some(terminal::terminal_settings::profile_to_task_shell(
+                        name, profile,
+                    )),
+                    Some(name.to_string()),
+                ),
+                None => {
+                    if let Some(name) = &profile_name {
+                        log::warn!(
+                            "Persisted terminal profile '{name}' is no longer defined; \
+                             falling back to the default shell"
+                        );
+                    }
+                    (None, None)
+                }
+            };
 
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                .update(cx, |project, cx| {
+                    project.create_terminal_shell_with(cwd, shell_override, cx)
+                })
                 .await?;
             cx.update(|window, cx| {
                 cx.new(|cx| {
@@ -1957,6 +2011,7 @@ impl SerializableItem for TerminalView {
                     if custom_title.is_some() {
                         view.custom_title = custom_title;
                     }
+                    view.profile_name = restored_profile_name;
                     view
                 })
             })

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -111,7 +111,7 @@ pub struct RenameTerminal;
 
 /// Spawn a terminal running a detected (non-profile) shell program.
 ///
-/// Used by the "+" PopoverMenu's "detected shells" section (P3). Detected
+/// Used by the "+" PopoverMenu's "detected shells" section. Detected
 /// shells bypass the `terminal.profiles` lookup — they carry their own
 /// program/args. The `label` is used as the tab title (via the
 /// `title_override` field on the constructed `task::Shell::WithArguments`),
@@ -181,7 +181,7 @@ pub struct TerminalView {
     /// When non-`None`, this view was spawned from the named
     /// `terminal.profiles` entry. Used by `SerializableItem::serialize`
     /// to persist the profile choice so that workspace reload respawns
-    /// the same profile (D7).
+    /// the same profile.
     pub profile_name: Option<String>,
     hover: Option<HoverTarget>,
     hover_tooltip_update: Task<()>,
@@ -1996,15 +1996,11 @@ impl SerializableItem for TerminalView {
             // Re-resolve the persisted profile name against the current
             // TerminalSettings. A profile may disappear after a settings
             // change; in that case fall back to the default shell with a
-            // log line (D7).
+            // log line.
             let (shell_override, restored_profile_name) = match profile_name
                 .as_deref()
-                .and_then(|name| {
-                    settings
-                        .profiles
-                        .get(name)
-                        .map(|profile| (name, profile))
-                }) {
+                .and_then(|name| settings.profiles.get(name).map(|profile| (name, profile)))
+            {
                 Some((name, profile)) => (
                     Some(terminal::terminal_settings::profile_to_task_shell(
                         name, profile,
@@ -2024,11 +2020,11 @@ impl SerializableItem for TerminalView {
 
             let terminal = project
                 .update(cx, |project, cx| {
-                    // Round-1 fixup made the menu spawn profile-tagged
-                    // terminals with `local: is_remote` so the override
-                    // survives D9's remote-drop. Persisted terminals must
-                    // restore the same way: when the project is remote AND
-                    // we have an override to restore, route through
+                    // The menu spawns profile-tagged terminals with
+                    // `local: is_remote` so the override survives the
+                    // remote-drop. Persisted terminals restore the same
+                    // way: when the project is remote AND we have an
+                    // override to restore, route through
                     // `create_local_terminal_with` (force_local=true) so the
                     // override is honored. Otherwise (local project, or no
                     // override) the normal spawn path applies.

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2024,7 +2024,20 @@ impl SerializableItem for TerminalView {
 
             let terminal = project
                 .update(cx, |project, cx| {
-                    project.create_terminal_shell_with(cwd, shell_override, cx)
+                    // Round-1 fixup made the menu spawn profile-tagged
+                    // terminals with `local: is_remote` so the override
+                    // survives D9's remote-drop. Persisted terminals must
+                    // restore the same way: when the project is remote AND
+                    // we have an override to restore, route through
+                    // `create_local_terminal_with` (force_local=true) so the
+                    // override is honored. Otherwise (local project, or no
+                    // override) the normal spawn path applies.
+                    let is_remote = project.is_via_remote_server();
+                    if is_remote && shell_override.is_some() {
+                        project.create_local_terminal_with(shell_override, cx)
+                    } else {
+                        project.create_terminal_shell_with(cwd, shell_override, cx)
+                    }
                 })
                 .await?;
             cx.update(|window, cx| {

--- a/crates/util/src/shell_detection.rs
+++ b/crates/util/src/shell_detection.rs
@@ -1,0 +1,674 @@
+//! Discovery of installed shells for the terminal profile picker (P2).
+//!
+//! The public entry point is [`detect_available_shells`], a cached list of
+//! shells found on the local machine. It backs the P3 "+"-menu "Detected
+//! shells" section and the P2 profile validator.
+//!
+//! The heavy lifting is done by [`detect_available_shells_inner`], a pure
+//! function that takes injectable inputs (file contents, env, and a
+//! `path_exists` predicate). That makes the Unix and Windows code paths
+//! unit-testable from any host platform without touching the real
+//! filesystem.
+
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use collections::HashSet;
+
+use crate::shell::{get_windows_bash, get_windows_system_shell};
+use crate::get_system_shell;
+
+/// Where a [`DetectedShell`] came from. P3 uses this to group menu entries
+/// (e.g. configured vs `/etc/shells` vs PATH-resolved).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellSource {
+    /// Discovered by parsing `/etc/shells`.
+    EtcShells,
+    /// The login shell (`$SHELL` on Unix, system shell on Windows).
+    LoginShell,
+    /// One of the always-probed well-known locations (fallback when
+    /// `/etc/shells` is unreadable or empty).
+    KnownLocation,
+    /// Resolved via the `PATH` environment variable (relative name in
+    /// `/etc/shells`, or a basename that matched a `PATH` entry).
+    Path,
+    /// A Windows Subsystem for Linux distribution.
+    Wsl,
+}
+
+/// A shell discovered on the local machine. P3 renders one menu entry per
+/// `DetectedShell` that isn't shadowed by a configured profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedShell {
+    /// Human-readable label, e.g. `bash`, `zsh`, or `Ubuntu` (for WSL).
+    /// Duplicate basenames get `" (2)"`, `" (3)"` suffixes following the
+    /// VSCode convention.
+    pub label: String,
+    /// Absolute path to the executable (or `wsl.exe` for WSL distros).
+    pub program: PathBuf,
+    /// Extra args needed to launch this shell into a useful interactive
+    /// state. Currently only populated for WSL (`["-d", "<distro>"]`).
+    pub args: Vec<String>,
+    /// Provenance of the entry — see [`ShellSource`].
+    pub source: ShellSource,
+}
+
+/// Host OS the detection should run against. The inner detection function
+/// is platform-agnostic so that Unix tests can exercise the Windows code
+/// path (and vice versa) without requiring a real platform match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    Unix,
+    Windows,
+}
+
+impl Platform {
+    fn host() -> Self {
+        if cfg!(target_os = "windows") {
+            Platform::Windows
+        } else {
+            Platform::Unix
+        }
+    }
+}
+
+static DETECTED_SHELLS: LazyLock<Vec<DetectedShell>> = LazyLock::new(detect_available_shells_blocking);
+
+/// Cached enumeration of installed shells on the local machine.
+///
+/// Backed by a `LazyLock` so the filesystem is walked at most once per
+/// process. Tests should call [`detect_available_shells_inner`] directly
+/// with injected inputs rather than this function.
+pub fn detect_available_shells() -> &'static [DetectedShell] {
+    &DETECTED_SHELLS
+}
+
+#[cfg(not(target_os = "windows"))]
+fn read_etc_shells() -> Option<String> {
+    std::fs::read_to_string("/etc/shells").ok()
+}
+
+#[cfg(target_os = "windows")]
+fn read_etc_shells() -> Option<String> {
+    None
+}
+
+fn detect_available_shells_blocking() -> Vec<DetectedShell> {
+    let platform = Platform::host();
+    let login_shell = if platform == Platform::Unix {
+        get_system_shell()
+    } else {
+        get_windows_system_shell()
+    };
+    let path_env = std::env::var_os("PATH").map(|os| os.to_string_lossy().into_owned());
+    let etc_shells = if platform == Platform::Unix {
+        read_etc_shells()
+    } else {
+        None
+    };
+    let path_exists = |p: &Path| p.exists();
+
+    let mut shells =
+        detect_available_shells_inner(platform, etc_shells.as_deref(), &login_shell, path_env.as_deref(), &path_exists);
+
+    if platform == Platform::Windows {
+        let wsl = enumerate_wsl_distros();
+        shells.extend(wsl);
+    }
+
+    dedup_by_program(shells)
+}
+
+/// Pure, testable detector. Walks the supplied inputs without touching the
+/// real filesystem — every existence check goes through `path_exists`.
+///
+/// * `etc_shells_content` — contents of `/etc/shells` (Unix only); `None`
+///   triggers the well-known-paths fallback.
+/// * `login_shell` — `$SHELL` (Unix) or the resolved Windows system shell.
+/// * `path_env` — `PATH`/`Path` value used to resolve relative names; on
+///   Unix the separator is `':'`, on Windows `';'`.
+/// * `path_exists` — injection point for `Path::exists()` so tests can
+///   simulate any filesystem layout.
+pub fn detect_available_shells_inner(
+    platform: Platform,
+    etc_shells_content: Option<&str>,
+    login_shell: &str,
+    path_env: Option<&str>,
+    path_exists: &dyn Fn(&Path) -> bool,
+) -> Vec<DetectedShell> {
+    match platform {
+        Platform::Unix => detect_unix_inner(
+            etc_shells_content,
+            login_shell,
+            path_env,
+            path_exists,
+        ),
+        Platform::Windows => detect_windows_inner(login_shell, path_env, path_exists),
+    }
+}
+
+fn detect_unix_inner(
+    etc_shells_content: Option<&str>,
+    login_shell: &str,
+    path_env: Option<&str>,
+    path_exists: &dyn Fn(&Path) -> bool,
+) -> Vec<DetectedShell> {
+    let mut shells: Vec<DetectedShell> = Vec::new();
+    let mut seen_paths: HashSet<PathBuf> = HashSet::default();
+
+    if let Some(content) = etc_shells_content {
+        for raw in content.lines() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some(shell) = resolve_etc_shells_entry(line, path_env, path_exists) {
+                if seen_paths.insert(shell.program.clone()) {
+                    shells.push(shell);
+                }
+            }
+        }
+    }
+
+    // Always include the login shell ($SHELL) even if absent from /etc/shells.
+    if !login_shell.is_empty() {
+        let login_path = PathBuf::from(login_shell);
+        if path_exists(&login_path) && seen_paths.insert(login_path.clone()) {
+            shells.push(DetectedShell {
+                label: basename_label(&login_path),
+                program: login_path,
+                args: Vec::new(),
+                source: ShellSource::LoginShell,
+            });
+        }
+    }
+
+    // If /etc/shells is missing or empty, fall back to probing a small set
+    // of well-known absolute locations. This matches VSCode's behavior on
+    // systems without /etc/shells (some containers, macOS variants).
+    let probed_fallback = etc_shells_content
+        .map(|c| c.lines().any(|l| !l.trim().is_empty() && !l.trim().starts_with('#')))
+        .unwrap_or(false);
+    if !probed_fallback {
+        for known in ["/bin/bash", "/usr/bin/bash", "/bin/zsh", "/usr/bin/zsh", "/bin/sh", "/usr/bin/fish"] {
+            let path = PathBuf::from(known);
+            if path_exists(&path) && seen_paths.insert(path.clone()) {
+                shells.push(DetectedShell {
+                    label: basename_label(&path),
+                    program: path,
+                    args: Vec::new(),
+                    source: ShellSource::KnownLocation,
+                });
+            }
+        }
+    }
+
+    dedup_by_program(shells)
+}
+
+/// Resolve a single non-comment line from `/etc/shells` into a
+/// [`DetectedShell`]. Returns `None` if the entry doesn't exist as a file
+/// (or, for relative basenames, cannot be found on `PATH`).
+fn resolve_etc_shells_entry(
+    line: &str,
+    path_env: Option<&str>,
+    path_exists: &dyn Fn(&Path) -> bool,
+) -> Option<DetectedShell> {
+    let path = Path::new(line);
+    if path.is_absolute() {
+        if path_exists(path) {
+            return Some(DetectedShell {
+                label: basename_label(path),
+                program: path.to_path_buf(),
+                args: Vec::new(),
+                source: ShellSource::EtcShells,
+            });
+        }
+        return None;
+    }
+
+    // Relative entry (basename only by /etc/shells convention): try each
+    // PATH directory in order. This mirrors VSCode's `findExecutable`.
+    let name = path.file_name()?;
+    let path_env = path_env?;
+    for dir in path_env.split(':') {
+        if dir.is_empty() {
+            continue;
+        }
+        let candidate = Path::new(dir).join(name);
+        if path_exists(&candidate) {
+            return Some(DetectedShell {
+                label: basename_label(&candidate),
+                program: candidate,
+                args: Vec::new(),
+                source: ShellSource::Path,
+            });
+        }
+    }
+    None
+}
+
+fn detect_windows_inner(
+    login_shell: &str,
+    _path_env: Option<&str>,
+    path_exists: &dyn Fn(&Path) -> bool,
+) -> Vec<DetectedShell> {
+    let mut shells: Vec<DetectedShell> = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::default();
+
+    // The login shell value on Windows is whichever of pwsh/powershell/cmd
+    // the existing LazyLock-based picker found first.
+    if !login_shell.is_empty() {
+        let program = PathBuf::from(login_shell);
+        if path_exists(&program) && seen.insert(program.clone()) {
+            shells.push(DetectedShell {
+                label: basename_label(&program),
+                program,
+                args: Vec::new(),
+                source: ShellSource::LoginShell,
+            });
+        }
+    }
+
+    // Always probe Windows PowerShell + cmd directly — they ship with the OS
+    // and the user may want them even if `get_windows_system_shell` picked
+    // pwsh.
+    let windir = std::env::var_os("WINDIR").map(PathBuf::from);
+    if let Some(windir) = windir {
+        let powershell = windir
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0")
+            .join("powershell.exe");
+        if path_exists(&powershell) && seen.insert(powershell.clone()) {
+            shells.push(DetectedShell {
+                label: "PowerShell".to_string(),
+                program: powershell,
+                args: Vec::new(),
+                source: ShellSource::KnownLocation,
+            });
+        }
+
+        let cmd = windir.join("System32").join("cmd.exe");
+        if path_exists(&cmd) && seen.insert(cmd.clone()) {
+            shells.push(DetectedShell {
+                label: "Command Prompt".to_string(),
+                program: cmd,
+                args: Vec::new(),
+                source: ShellSource::KnownLocation,
+            });
+        }
+    }
+
+    // Git Bash (Scoop shim, or alongside a git-for-windows install).
+    if let Some(bash) = get_windows_bash() {
+        let bash_path = PathBuf::from(bash);
+        if path_exists(&bash_path) && seen.insert(bash_path.clone()) {
+            shells.push(DetectedShell {
+                label: "Git Bash".to_string(),
+                program: bash_path,
+                args: Vec::new(),
+                source: ShellSource::Path,
+            });
+        }
+    }
+
+    dedup_by_program(shells)
+}
+
+/// Enumerate WSL distros via `wsl.exe -l -q`, returning one entry per
+/// non-`docker-desktop*` distro on Windows builds >= 19041.
+///
+/// **Currently a stub.** Implementation deferred within P2 because:
+/// 1. WSL probing requires spawning `wsl.exe`, which can't be exercised
+///    from unit tests on non-Windows hosts.
+/// 2. The output is UTF-16LE with a BOM and embedded NULs, requiring
+///    careful decoding.
+/// 3. The plan explicitly marks WSL optional within P2.
+///
+/// The [`ShellSource::Wsl`] variant is in place so P3 can render WSL
+/// entries without further schema changes once this is filled in.
+#[cfg(target_os = "windows")]
+fn enumerate_wsl_distros() -> Vec<DetectedShell> {
+    // TODO(p2-terminal-profiles): implement WSL distro enumeration.
+    //                       Use `windows::Wdk::System::SystemServices::RtlGetVersion`
+    //                       for the build-number >= 19041 gate (see
+    //                       `crates/platform_title_bar/src/platforms/platform_windows.rs`
+    //                       for the precedent). Decode the `wsl.exe -l -q`
+    //                       output as UTF-16LE, strip the BOM, filter out
+    //                       distros whose name starts with `docker-desktop`.
+    //                       Emit:
+    //                       DetectedShell {
+    //                           label: <distro>,
+    //                           program: PathBuf::from("wsl.exe"),
+    //                           args: vec!["-d".to_string(), <distro>],
+    //                           source: ShellSource::Wsl,
+    //                       }
+    Vec::new()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn enumerate_wsl_distros() -> Vec<DetectedShell> {
+    Vec::new()
+}
+
+/// Strip duplicate programs (by raw path equality) and apply VSCode-style
+/// `" (n)"` suffixes to entries sharing a label.
+///
+/// We intentionally dedup on the raw `program` string rather than
+/// canonicalizing: canonicalization requires touching the real filesystem
+/// (which would break the fs-free testable inner fn) and yields
+/// platform-dependent results. `/etc/shells` rarely lists the same path
+/// twice, so raw-path dedup is sufficient in practice. VSCode itself
+/// falls back to raw-path comparison when `realpath` fails.
+fn dedup_by_program(mut shells: Vec<DetectedShell>) -> Vec<DetectedShell> {
+    let mut seen: HashSet<PathBuf> = HashSet::default();
+    shells.retain(|shell| seen.insert(shell.program.clone()));
+    apply_duplicate_label_suffixes(shells)
+}
+
+fn apply_duplicate_label_suffixes(mut shells: Vec<DetectedShell>) -> Vec<DetectedShell> {
+    let mut label_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for shell in &mut shells {
+        let base = shell.label.clone();
+        let count = label_counts.entry(base.clone()).or_insert(0);
+        *count += 1;
+        if *count > 1 {
+            shell.label = format!("{base} ({count})");
+        }
+    }
+    shells
+}
+
+fn basename_label(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn detected(label: &str, program: &str, source: ShellSource) -> DetectedShell {
+        DetectedShell {
+            label: label.to_string(),
+            program: PathBuf::from(program),
+            args: Vec::new(),
+            source,
+        }
+    }
+
+    fn always_exists(_: &Path) -> bool {
+        true
+    }
+
+    fn never_exists(_: &Path) -> bool {
+        false
+    }
+
+    fn exists_set(set: &[&str]) -> impl Fn(&Path) -> bool {
+        let set: HashSet<PathBuf> = set.iter().map(PathBuf::from).collect();
+        move |p| set.contains(p)
+    }
+
+    /// `/etc/shells` parser: strips comments and blanks, drops nonexistent
+    /// absolute entries, keeps duplicates separate (dedup happens later).
+    #[test]
+    fn etc_shells_strips_comments_and_blanks() {        let content = "# This is a comment\n\n/bin/bash\n  /bin/zsh  \n# trailing comment\n";
+        let shells = detect_unix_inner(Some(content), "", Some("/bin"), &always_exists);
+        let labels: Vec<&str> = shells.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["bash", "zsh"]);
+        assert!(shells.iter().all(|s| s.source == ShellSource::EtcShells));
+    }
+
+    #[test]
+    fn etc_shells_drops_nonexistent_absolute_entries() {
+        let content = "/bin/bash\n/definitely/not/real/zsh\n/bin/fish\n";
+        let exists = exists_set(&["/bin/bash", "/bin/fish"]);
+        let shells = detect_unix_inner(Some(content), "", Some("/bin"), &exists);
+        let labels: Vec<&str> = shells.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["bash", "fish"]);
+    }
+
+    #[test]
+    fn etc_shells_dedupes_repeated_programs() {
+        // /bin/sh is frequently a symlink to /bin/bash on Linux; both
+        // /etc/shells entries should survive (different program strings)
+        // unless canonicalized to the same path. The never_exists probe
+        // means neither survives — but the parser itself doesn't dedup.
+        let content = "/bin/bash\n/bin/bash\n";
+        // Use always_exists so both entries would pass the file check; the
+        // canonical-dedup pass collapses identical absolute paths.
+        let shells = detect_unix_inner(Some(content), "", Some("/bin"), &always_exists);
+        let bash_count = shells
+            .iter()
+            .filter(|s| s.program.as_os_str() == "/bin/bash")
+            .count();
+        assert_eq!(
+            bash_count, 1,
+            "duplicate /bin/bash entries should collapse to one after dedup"
+        );
+    }
+
+    #[test]
+    fn etc_shells_resolves_relative_entries_via_path() {
+        let content = "bash\nzsh\n";
+        let exists = exists_set(&["/usr/bin/bash", "/usr/local/bin/zsh"]);
+        let shells = detect_unix_inner(Some(content), "", Some("/usr/bin:/usr/local/bin"), &exists);
+        assert_eq!(shells.len(), 2);
+        let bash = shells
+            .iter()
+            .find(|s| s.label == "bash")
+            .expect("bash should be resolved via PATH");
+        assert_eq!(bash.program, PathBuf::from("/usr/bin/bash"));
+        assert_eq!(bash.source, ShellSource::Path);
+    }
+
+    #[test]
+    fn etc_shells_drops_unresolvable_relative_entries() {
+        let content = "nosuchshell\n";
+        let shells = detect_unix_inner(Some(content), "", Some("/usr/bin"), &never_exists);
+        assert!(
+            shells.is_empty(),
+            "unresolvable relative entries should produce no shells"
+        );
+    }
+
+    #[test]
+    fn login_shell_always_included_even_if_absent_from_etc_shells() {
+        let content = "/bin/bash\n";
+        let exists = exists_set(&["/bin/bash", "/bin/zsh"]);
+        let shells = detect_unix_inner(Some(content), "/bin/zsh", Some("/bin"), &exists);
+        let has_zsh = shells
+            .iter()
+            .any(|s| s.program.as_os_str() == "/bin/zsh" && s.source == ShellSource::LoginShell);
+        assert!(
+            has_zsh,
+            "login shell should be included even when absent from /etc/shells"
+        );
+    }
+
+    #[test]
+    fn missing_etc_shells_falls_back_to_known_locations() {
+        let exists = exists_set(&["/bin/bash", "/bin/zsh", "/bin/sh"]);
+        let shells = detect_unix_inner(None, "", Some("/usr/bin"), &exists);
+        // Should include whichever of /bin/bash, /bin/zsh, /bin/sh exist.
+        let labels: Vec<&str> = shells.iter().map(|s| s.label.as_str()).collect();
+        assert!(labels.contains(&"bash"));
+        assert!(labels.contains(&"zsh"));
+        assert!(labels.contains(&"sh"));
+        assert!(shells
+            .iter()
+            .all(|s| s.source == ShellSource::KnownLocation));
+    }
+
+    #[test]
+    fn empty_etc_shells_falls_back_to_known_locations() {
+        let content = "# only comments\n\n";
+        let exists = exists_set(&["/bin/bash"]);
+        let shells = detect_unix_inner(Some(content), "", Some("/usr/bin"), &exists);
+        let labels: Vec<&str> = shells.iter().map(|s| s.label.as_str()).collect();
+        assert!(
+            labels.contains(&"bash"),
+            "empty /etc/shells should still produce known-location fallback"
+        );
+    }
+
+    #[test]
+    fn duplicate_labels_get_vscode_style_suffixes() {
+        let shells = vec![
+            detected("bash", "/bin/bash", ShellSource::EtcShells),
+            detected("bash", "/usr/local/bin/bash", ShellSource::Path),
+            detected("bash", "/opt/bash", ShellSource::KnownLocation),
+            detected("zsh", "/bin/zsh", ShellSource::EtcShells),
+        ];
+        let merged = apply_duplicate_label_suffixes(shells);
+        let labels: Vec<&str> = merged.iter().map(|s| s.label.as_str()).collect();
+        assert_eq!(labels, vec!["bash", "bash (2)", "bash (3)", "zsh"]);
+    }
+
+    #[test]
+    fn dedup_by_program_uses_raw_path_equality() {
+        // Distinct raw program strings survive even if they would
+        // canonicalize to the same inode on a real filesystem. This
+        // keeps the inner fn fs-free (canonicalize touches the real fs).
+        let shells = vec![
+            detected("bash", "/bin/bash", ShellSource::EtcShells),
+            detected("bash (2)", "/usr/bin/bash", ShellSource::Path),
+        ];
+        let merged = dedup_by_program(shells);
+        assert_eq!(
+            merged.len(),
+            2,
+            "distinct raw paths should both survive dedup"
+        );
+    }
+
+    #[test]
+    fn dedup_by_program_drops_exact_duplicates() {
+        let shells = vec![
+            detected("bash", "/bin/bash", ShellSource::EtcShells),
+            detected("bash", "/bin/bash", ShellSource::Path),
+        ];
+        let merged = dedup_by_program(shells);
+        assert_eq!(merged.len(), 1, "exact raw-path duplicates collapse");
+    }
+
+    /// Windows: well-known entries (PowerShell + cmd) are emitted via the
+    /// injectable `path_exists`, in a stable order.
+    #[test]
+    fn windows_probes_emit_powershell_and_cmd_in_order() {
+        // Simulate a Windows environment by setting WINDIR; we can't
+        // actually mutate std::env::var_os safely in a parallel test
+        // suite, so instead we check the behavior when WINDIR is unset:
+        // no PowerShell/cmd entries, but the login shell still appears.
+        let exists = always_exists;
+        let shells = detect_windows_inner("C:\\Program Files\\PowerShell\\7\\pwsh.exe", None, &exists);
+        // Login shell always wins when WINDIR is unset.
+        assert_eq!(shells.len(), 1);
+        assert_eq!(shells[0].source, ShellSource::LoginShell);
+    }
+
+    #[test]
+    fn windows_emits_powershell_and_cmd_when_windir_set() {
+        // We can't safely mutate env vars in parallel tests; verify the
+        // behavior by exercising the inner fn directly with WINDIR unset
+        // (already covered above) and trust the env-reading code by
+        // inspection. The dedup logic is exercised by other tests.
+        let exists = exists_set(&["C:\\Program Files\\PowerShell\\7\\pwsh.exe"]);
+        let shells = detect_windows_inner(
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            None,
+            &exists,
+        );
+        assert_eq!(shells.len(), 1);
+    }
+
+    #[test]
+    fn windows_dedupes_when_login_shell_equals_known_location() {
+        // If pwsh is both the system shell AND in a well-known location,
+        // only one entry should survive.
+        let exists = exists_set(&[
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+            "C:\\Windows\\System32\\cmd.exe",
+        ]);
+        let shells = detect_windows_inner(
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            None,
+            &exists,
+        );
+        // No WINDIR set here; only the login shell survives.
+        assert_eq!(shells.len(), 1);
+    }
+
+    #[test]
+    fn platform_host_matches_cfg() {
+        let host = Platform::host();
+        if cfg!(target_os = "windows") {
+            assert_eq!(host, Platform::Windows);
+        } else {
+            assert_eq!(host, Platform::Unix);
+        }
+    }
+
+    #[test]
+    fn inner_fn_unix_dispatch() {
+        // Make sure the public testable entrypoint routes Unix correctly.
+        let shells = detect_available_shells_inner(
+            Platform::Unix,
+            Some("/bin/bash\n"),
+            "/bin/zsh",
+            Some("/bin"),
+            &exists_set(&["/bin/bash", "/bin/zsh"]),
+        );
+        assert!(shells.iter().any(|s| s.label == "bash"));
+        assert!(shells.iter().any(|s| s.label == "zsh"));
+    }
+
+    #[test]
+    fn inner_fn_windows_dispatch() {
+        let shells = detect_available_shells_inner(
+            Platform::Windows,
+            None,
+            "C:\\pwsh.exe",
+            Some("C:\\Windows\\System32"),
+            &exists_set(&["C:\\pwsh.exe"]),
+        );
+        assert_eq!(shells.len(), 1);
+        assert_eq!(shells[0].source, ShellSource::LoginShell);
+    }
+
+    /// The public `detect_available_shells()` cache returns a non-empty
+    /// list on Unix dev hosts (where /bin/sh almost always exists).
+    #[test]
+    fn public_detect_returns_nonempty_on_unix_host() {
+        if !cfg!(unix) {
+            return;
+        }
+        let shells = detect_available_shells();
+        assert!(
+            !shells.is_empty(),
+            "detect_available_shells() should find at least the login shell on Unix"
+        );
+    }
+
+    #[test]
+    fn basename_label_uses_file_stem() {
+        assert_eq!(basename_label(Path::new("/bin/bash")), "bash");
+        assert_eq!(basename_label(Path::new("/usr/bin/zsh")), "zsh");
+        // Windows-style paths use `\` as separator only on Windows; on Unix
+        // hosts `file_stem` returns the last `/`-separated component, which
+        // for a literal `"C:\\..."` string is the whole thing. Gate the
+        // expectation so the test stays meaningful on both platforms.
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                basename_label(Path::new("C:\\Program Files\\PowerShell\\7\\pwsh.exe")),
+                "pwsh"
+            );
+        }
+    }
+}

--- a/crates/util/src/shell_detection.rs
+++ b/crates/util/src/shell_detection.rs
@@ -106,10 +106,21 @@ fn detect_available_shells_blocking() -> Vec<DetectedShell> {
     } else {
         None
     };
+    let windir = if platform == Platform::Windows {
+        std::env::var_os("WINDIR").map(PathBuf::from)
+    } else {
+        None
+    };
     let path_exists = |p: &Path| p.exists();
 
-    let mut shells =
-        detect_available_shells_inner(platform, etc_shells.as_deref(), &login_shell, path_env.as_deref(), &path_exists);
+    let mut shells = detect_available_shells_inner(
+        platform,
+        etc_shells.as_deref(),
+        &login_shell,
+        path_env.as_deref(),
+        windir.as_deref(),
+        &path_exists,
+    );
 
     if platform == Platform::Windows {
         let wsl = enumerate_wsl_distros();
@@ -127,6 +138,10 @@ fn detect_available_shells_blocking() -> Vec<DetectedShell> {
 /// * `login_shell` — `$SHELL` (Unix) or the resolved Windows system shell.
 /// * `path_env` — `PATH`/`Path` value used to resolve relative names; on
 ///   Unix the separator is `':'`, on Windows `';'`.
+/// * `windir` — value of `%WINDIR%` (Windows only); `None` skips the
+///   PowerShell/cmd probes. Injected rather than read from `std::env`
+///   so tests can exercise those branches in parallel without mutating
+///   global process state.
 /// * `path_exists` — injection point for `Path::exists()` so tests can
 ///   simulate any filesystem layout.
 pub fn detect_available_shells_inner(
@@ -134,6 +149,7 @@ pub fn detect_available_shells_inner(
     etc_shells_content: Option<&str>,
     login_shell: &str,
     path_env: Option<&str>,
+    windir: Option<&Path>,
     path_exists: &dyn Fn(&Path) -> bool,
 ) -> Vec<DetectedShell> {
     match platform {
@@ -143,7 +159,9 @@ pub fn detect_available_shells_inner(
             path_env,
             path_exists,
         ),
-        Platform::Windows => detect_windows_inner(login_shell, path_env, path_exists),
+        Platform::Windows => {
+            detect_windows_inner(login_shell, path_env, windir, path_exists)
+        }
     }
 }
 
@@ -251,6 +269,7 @@ fn resolve_etc_shells_entry(
 fn detect_windows_inner(
     login_shell: &str,
     _path_env: Option<&str>,
+    windir: Option<&Path>,
     path_exists: &dyn Fn(&Path) -> bool,
 ) -> Vec<DetectedShell> {
     let mut shells: Vec<DetectedShell> = Vec::new();
@@ -273,7 +292,6 @@ fn detect_windows_inner(
     // Always probe Windows PowerShell + cmd directly — they ship with the OS
     // and the user may want them even if `get_windows_system_shell` picked
     // pwsh.
-    let windir = std::env::var_os("WINDIR").map(PathBuf::from);
     if let Some(windir) = windir {
         let powershell = windir
             .join("System32")
@@ -560,13 +578,16 @@ mod tests {
     /// Windows: well-known entries (PowerShell + cmd) are emitted via the
     /// injectable `path_exists`, in a stable order.
     #[test]
-    fn windows_probes_emit_powershell_and_cmd_in_order() {
-        // Simulate a Windows environment by setting WINDIR; we can't
-        // actually mutate std::env::var_os safely in a parallel test
-        // suite, so instead we check the behavior when WINDIR is unset:
-        // no PowerShell/cmd entries, but the login shell still appears.
+    fn windows_probes_emit_login_shell_when_windir_unset() {
+        // Pre-fix #3 contract still holds: when windir is None, no
+        // PowerShell/cmd entries, but the login shell still appears.
         let exists = always_exists;
-        let shells = detect_windows_inner("C:\\Program Files\\PowerShell\\7\\pwsh.exe", None, &exists);
+        let shells = detect_windows_inner(
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            None,
+            None,
+            &exists,
+        );
         // Login shell always wins when WINDIR is unset.
         assert_eq!(shells.len(), 1);
         assert_eq!(shells[0].source, ShellSource::LoginShell);
@@ -574,35 +595,124 @@ mod tests {
 
     #[test]
     fn windows_emits_powershell_and_cmd_when_windir_set() {
-        // We can't safely mutate env vars in parallel tests; verify the
-        // behavior by exercising the inner fn directly with WINDIR unset
-        // (already covered above) and trust the env-reading code by
-        // inspection. The dedup logic is exercised by other tests.
-        let exists = exists_set(&["C:\\Program Files\\PowerShell\\7\\pwsh.exe"]);
+        // Fix #3 lock: with an injected windir, both Windows PowerShell and
+        // cmd.exe should be emitted in stable order (login shell, then
+        // PowerShell, then cmd), each with its well-known label.
+        // Build expected paths via the same join semantics the production
+        // code uses, so the test is portable across Unix/Windows hosts
+        // (Path::join uses the host separator).
+        let windir = Path::new("C:\\Windows");
+        let pwsh = Path::new("C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+        let powershell = windir
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0")
+            .join("powershell.exe");
+        let cmd = windir.join("System32").join("cmd.exe");
+        let paths = [
+            pwsh.to_str().expect("utf8"),
+            powershell.to_str().expect("utf8"),
+            cmd.to_str().expect("utf8"),
+        ];
+        let exists = exists_set(&paths);
         let shells = detect_windows_inner(
-            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            pwsh.to_str().expect("utf8"),
             None,
+            Some(windir),
             &exists,
         );
-        assert_eq!(shells.len(), 1);
+        assert_eq!(
+            shells.len(),
+            3,
+            "login shell + PowerShell + cmd should all surface"
+        );
+        assert_eq!(shells[0].source, ShellSource::LoginShell);
+        assert_eq!(shells[0].program.as_os_str(), pwsh.as_os_str());
+
+        assert_eq!(shells[1].label, "PowerShell");
+        assert_eq!(shells[1].source, ShellSource::KnownLocation);
+        assert_eq!(shells[1].program.as_os_str(), powershell.as_os_str());
+
+        assert_eq!(shells[2].label, "Command Prompt");
+        assert_eq!(shells[2].source, ShellSource::KnownLocation);
+        assert_eq!(shells[2].program.as_os_str(), cmd.as_os_str());
+    }
+
+    #[test]
+    fn windows_skips_missing_windir_entries() {
+        // windir is set but the PowerShell file doesn't exist on the
+        // simulated fs — only cmd should surface alongside the login shell.
+        let windir = Path::new("C:\\Windows");
+        let pwsh = Path::new("C:\\pwsh.exe");
+        let cmd = windir.join("System32").join("cmd.exe");
+        let paths = [
+            pwsh.to_str().expect("utf8"),
+            cmd.to_str().expect("utf8"),
+        ];
+        let exists = exists_set(&paths);
+        let shells = detect_windows_inner(
+            pwsh.to_str().expect("utf8"),
+            None,
+            Some(windir),
+            &exists,
+        );
+        assert_eq!(shells.len(), 2);
+        assert_eq!(shells[0].program.as_os_str(), pwsh.as_os_str());
+        assert_eq!(shells[1].label, "Command Prompt");
+        assert!(
+            !shells
+                .iter()
+                .any(|s| s.label == "PowerShell"),
+            "PowerShell should be skipped when its file is missing"
+        );
     }
 
     #[test]
     fn windows_dedupes_when_login_shell_equals_known_location() {
         // If pwsh is both the system shell AND in a well-known location,
-        // only one entry should survive.
-        let exists = exists_set(&[
-            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
-            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-            "C:\\Windows\\System32\\cmd.exe",
-        ]);
+        // only one entry should survive. Here both point at the SAME path
+        // under the injected windir, so the known-location entry dedups
+        // against the login-shell entry.
+        let windir = Path::new("C:\\Windows");
+        let powershell = windir
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0")
+            .join("powershell.exe");
+        let cmd = windir.join("System32").join("cmd.exe");
+        let paths = [
+            powershell.to_str().expect("utf8"),
+            cmd.to_str().expect("utf8"),
+        ];
+        let exists = exists_set(&paths);
         let shells = detect_windows_inner(
-            "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+            powershell.to_str().expect("utf8"),
             None,
+            Some(windir),
             &exists,
         );
-        // No WINDIR set here; only the login shell survives.
+        // Login shell (powershell) + cmd; powershell known-location entry
+        // dedups against the login shell.
+        assert_eq!(shells.len(), 2);
+        assert_eq!(shells[0].program.as_os_str(), powershell.as_os_str());
+        assert_eq!(shells[1].label, "Command Prompt");
+    }
+
+    #[test]
+    fn windows_windir_ignored_on_unix_platform_via_inner_fn() {
+        // The public testable entrypoint passes windir through to the
+        // Windows branch but ignores it on Unix. Sanity check: passing a
+        // windir to the Unix branch doesn't change behavior.
+        let shells = detect_available_shells_inner(
+            Platform::Unix,
+            Some("/bin/bash\n"),
+            "",
+            Some("/bin"),
+            Some(Path::new("C:\\should\\be\\ignored")),
+            &exists_set(&["/bin/bash"]),
+        );
         assert_eq!(shells.len(), 1);
+        assert_eq!(shells[0].label, "bash");
     }
 
     #[test]
@@ -623,6 +733,7 @@ mod tests {
             Some("/bin/bash\n"),
             "/bin/zsh",
             Some("/bin"),
+            None,
             &exists_set(&["/bin/bash", "/bin/zsh"]),
         );
         assert!(shells.iter().any(|s| s.label == "bash"));
@@ -636,6 +747,7 @@ mod tests {
             None,
             "C:\\pwsh.exe",
             Some("C:\\Windows\\System32"),
+            None,
             &exists_set(&["C:\\pwsh.exe"]),
         );
         assert_eq!(shells.len(), 1);

--- a/crates/util/src/shell_detection.rs
+++ b/crates/util/src/shell_detection.rs
@@ -16,7 +16,9 @@ use std::sync::LazyLock;
 use collections::HashSet;
 
 use crate::get_system_shell;
-use crate::shell::{get_windows_bash, get_windows_system_shell};
+#[cfg(target_os = "windows")]
+use crate::shell::get_windows_bash;
+use crate::shell::get_windows_system_shell;
 
 /// Where a [`DetectedShell`] came from. The menu uses this to group entries
 /// (e.g. configured vs `/etc/shells` vs PATH-resolved).
@@ -323,6 +325,7 @@ fn detect_windows_inner(
     }
 
     // Git Bash (Scoop shim, or alongside a git-for-windows install).
+    #[cfg(target_os = "windows")]
     if let Some(bash) = get_windows_bash() {
         let bash_path = PathBuf::from(bash);
         if path_exists(&bash_path) && seen.insert(bash_path.clone()) {
@@ -339,7 +342,7 @@ fn detect_windows_inner(
 }
 
 /// Enumerate WSL distros via `wsl.exe -l -q`, returning one entry per
-/// non-`docker-desktop*` distro on Windows builds >= 19041.
+/// non-`docker-desktop*` distro.
 ///
 /// **Currently a stub.** Deferred because:
 /// 1. WSL probing requires spawning `wsl.exe`, which can't be exercised

--- a/crates/util/src/shell_detection.rs
+++ b/crates/util/src/shell_detection.rs
@@ -1,8 +1,8 @@
-//! Discovery of installed shells for the terminal profile picker (P2).
+//! Discovery of installed shells for the terminal profile picker.
 //!
 //! The public entry point is [`detect_available_shells`], a cached list of
-//! shells found on the local machine. It backs the P3 "+"-menu "Detected
-//! shells" section and the P2 profile validator.
+//! shells found on the local machine. It backs the "+"-menu "Detected
+//! shells" section and the profile validator.
 //!
 //! The heavy lifting is done by [`detect_available_shells_inner`], a pure
 //! function that takes injectable inputs (file contents, env, and a
@@ -15,10 +15,10 @@ use std::sync::LazyLock;
 
 use collections::HashSet;
 
-use crate::shell::{get_windows_bash, get_windows_system_shell};
 use crate::get_system_shell;
+use crate::shell::{get_windows_bash, get_windows_system_shell};
 
-/// Where a [`DetectedShell`] came from. P3 uses this to group menu entries
+/// Where a [`DetectedShell`] came from. The menu uses this to group entries
 /// (e.g. configured vs `/etc/shells` vs PATH-resolved).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShellSource {
@@ -36,7 +36,7 @@ pub enum ShellSource {
     Wsl,
 }
 
-/// A shell discovered on the local machine. P3 renders one menu entry per
+/// A shell discovered on the local machine. The menu renders one entry per
 /// `DetectedShell` that isn't shadowed by a configured profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DetectedShell {
@@ -72,7 +72,8 @@ impl Platform {
     }
 }
 
-static DETECTED_SHELLS: LazyLock<Vec<DetectedShell>> = LazyLock::new(detect_available_shells_blocking);
+static DETECTED_SHELLS: LazyLock<Vec<DetectedShell>> =
+    LazyLock::new(detect_available_shells_blocking);
 
 /// Cached enumeration of installed shells on the local machine.
 ///
@@ -153,15 +154,8 @@ pub fn detect_available_shells_inner(
     path_exists: &dyn Fn(&Path) -> bool,
 ) -> Vec<DetectedShell> {
     match platform {
-        Platform::Unix => detect_unix_inner(
-            etc_shells_content,
-            login_shell,
-            path_env,
-            path_exists,
-        ),
-        Platform::Windows => {
-            detect_windows_inner(login_shell, path_env, windir, path_exists)
-        }
+        Platform::Unix => detect_unix_inner(etc_shells_content, login_shell, path_env, path_exists),
+        Platform::Windows => detect_windows_inner(login_shell, path_env, windir, path_exists),
     }
 }
 
@@ -205,10 +199,20 @@ fn detect_unix_inner(
     // of well-known absolute locations. This matches VSCode's behavior on
     // systems without /etc/shells (some containers, macOS variants).
     let probed_fallback = etc_shells_content
-        .map(|c| c.lines().any(|l| !l.trim().is_empty() && !l.trim().starts_with('#')))
+        .map(|c| {
+            c.lines()
+                .any(|l| !l.trim().is_empty() && !l.trim().starts_with('#'))
+        })
         .unwrap_or(false);
     if !probed_fallback {
-        for known in ["/bin/bash", "/usr/bin/bash", "/bin/zsh", "/usr/bin/zsh", "/bin/sh", "/usr/bin/fish"] {
+        for known in [
+            "/bin/bash",
+            "/usr/bin/bash",
+            "/bin/zsh",
+            "/usr/bin/zsh",
+            "/bin/sh",
+            "/usr/bin/fish",
+        ] {
             let path = PathBuf::from(known);
             if path_exists(&path) && seen_paths.insert(path.clone()) {
                 shells.push(DetectedShell {
@@ -337,24 +341,24 @@ fn detect_windows_inner(
 /// Enumerate WSL distros via `wsl.exe -l -q`, returning one entry per
 /// non-`docker-desktop*` distro on Windows builds >= 19041.
 ///
-/// **Currently a stub.** Implementation deferred within P2 because:
+/// **Currently a stub.** Deferred because:
 /// 1. WSL probing requires spawning `wsl.exe`, which can't be exercised
 ///    from unit tests on non-Windows hosts.
 /// 2. The output is UTF-16LE with a BOM and embedded NULs, requiring
 ///    careful decoding.
-/// 3. The plan explicitly marks WSL optional within P2.
 ///
-/// The [`ShellSource::Wsl`] variant is in place so P3 can render WSL
+/// The [`ShellSource::Wsl`] variant is in place so the menu can render WSL
 /// entries without further schema changes once this is filled in.
 #[cfg(target_os = "windows")]
 fn enumerate_wsl_distros() -> Vec<DetectedShell> {
-    // TODO(p2-terminal-profiles): implement WSL distro enumeration.
-    //                       Use `windows::Wdk::System::SystemServices::RtlGetVersion`
-    //                       for the build-number >= 19041 gate (see
-    //                       `crates/platform_title_bar/src/platforms/platform_windows.rs`
-    //                       for the precedent). Decode the `wsl.exe -l -q`
-    //                       output as UTF-16LE, strip the BOM, filter out
-    //                       distros whose name starts with `docker-desktop`.
+    // TODO: implement WSL distro enumeration.
+    //                       Decode the `wsl.exe -l -q` output as UTF-8 when
+    //                       `WSL_UTF8=1` is set, otherwise UTF-16LE with a
+    //                       BOM; filter out distros whose name starts with
+    //                       `docker-desktop`; treat an error or empty
+    //                       output as "no distros" (WSL2 and `wsl --list`
+    //                       work from 1903 build 18362.1049, so don't gate
+    //                       on the Windows build number).
     //                       Emit:
     //                       DetectedShell {
     //                           label: <distro>,
@@ -435,7 +439,8 @@ mod tests {
     /// `/etc/shells` parser: strips comments and blanks, drops nonexistent
     /// absolute entries, keeps duplicates separate (dedup happens later).
     #[test]
-    fn etc_shells_strips_comments_and_blanks() {        let content = "# This is a comment\n\n/bin/bash\n  /bin/zsh  \n# trailing comment\n";
+    fn etc_shells_strips_comments_and_blanks() {
+        let content = "# This is a comment\n\n/bin/bash\n  /bin/zsh  \n# trailing comment\n";
         let shells = detect_unix_inner(Some(content), "", Some("/bin"), &always_exists);
         let labels: Vec<&str> = shells.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["bash", "zsh"]);
@@ -518,9 +523,11 @@ mod tests {
         assert!(labels.contains(&"bash"));
         assert!(labels.contains(&"zsh"));
         assert!(labels.contains(&"sh"));
-        assert!(shells
-            .iter()
-            .all(|s| s.source == ShellSource::KnownLocation));
+        assert!(
+            shells
+                .iter()
+                .all(|s| s.source == ShellSource::KnownLocation)
+        );
     }
 
     #[test]
@@ -579,8 +586,8 @@ mod tests {
     /// injectable `path_exists`, in a stable order.
     #[test]
     fn windows_probes_emit_login_shell_when_windir_unset() {
-        // Pre-fix #3 contract still holds: when windir is None, no
-        // PowerShell/cmd entries, but the login shell still appears.
+        // When windir is None, no PowerShell/cmd entries are emitted, but
+        // the login shell still appears.
         let exists = always_exists;
         let shells = detect_windows_inner(
             "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
@@ -595,7 +602,7 @@ mod tests {
 
     #[test]
     fn windows_emits_powershell_and_cmd_when_windir_set() {
-        // Fix #3 lock: with an injected windir, both Windows PowerShell and
+        // With an injected windir, both Windows PowerShell and
         // cmd.exe should be emitted in stable order (login shell, then
         // PowerShell, then cmd), each with its well-known label.
         // Build expected paths via the same join semantics the production
@@ -615,12 +622,8 @@ mod tests {
             cmd.to_str().expect("utf8"),
         ];
         let exists = exists_set(&paths);
-        let shells = detect_windows_inner(
-            pwsh.to_str().expect("utf8"),
-            None,
-            Some(windir),
-            &exists,
-        );
+        let shells =
+            detect_windows_inner(pwsh.to_str().expect("utf8"), None, Some(windir), &exists);
         assert_eq!(
             shells.len(),
             3,
@@ -645,24 +648,15 @@ mod tests {
         let windir = Path::new("C:\\Windows");
         let pwsh = Path::new("C:\\pwsh.exe");
         let cmd = windir.join("System32").join("cmd.exe");
-        let paths = [
-            pwsh.to_str().expect("utf8"),
-            cmd.to_str().expect("utf8"),
-        ];
+        let paths = [pwsh.to_str().expect("utf8"), cmd.to_str().expect("utf8")];
         let exists = exists_set(&paths);
-        let shells = detect_windows_inner(
-            pwsh.to_str().expect("utf8"),
-            None,
-            Some(windir),
-            &exists,
-        );
+        let shells =
+            detect_windows_inner(pwsh.to_str().expect("utf8"), None, Some(windir), &exists);
         assert_eq!(shells.len(), 2);
         assert_eq!(shells[0].program.as_os_str(), pwsh.as_os_str());
         assert_eq!(shells[1].label, "Command Prompt");
         assert!(
-            !shells
-                .iter()
-                .any(|s| s.label == "PowerShell"),
+            !shells.iter().any(|s| s.label == "PowerShell"),
             "PowerShell should be skipped when its file is missing"
         );
     }

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -14,6 +14,8 @@ pub mod shell;
 #[cfg(not(target_family = "wasm"))]
 pub mod shell_builder;
 #[cfg(not(target_family = "wasm"))]
+pub mod shell_detection;
+#[cfg(not(target_family = "wasm"))]
 pub mod shell_env;
 
 pub mod disambiguate;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -641,6 +641,11 @@ pub struct NewTerminal {
     /// If true, creates a local terminal even in remote projects.
     #[serde(default)]
     pub local: bool,
+    /// Optional name of a `terminal.profiles` entry to spawn. If the name
+    /// does not match a configured profile, Zed emits a warning and falls
+    /// back to the default shell.
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 /// Increases size of a currently focused dock by a given amount of pixels.

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -124,6 +124,20 @@ Use the {#action workspace::NewTerminal} action with a `profile` argument to spa
 
 If the named profile does not exist, Zed emits a warning and opens a terminal with the default shell instead.
 
+### Picking a Shell from the Menu {#picking-from-menu}
+
+Click the terminal panel's **"+"** button to see all available shells:
+
+- **New Terminal** and **Spawn Task** entries (always present).
+- One entry per configured profile (in `terminal.profiles` order).
+- One entry per detected shell not already covered by a configured profile. Detected shells come from `/etc/shells` (Unix) or a small set of well-known Windows locations (PowerShell, Command Prompt, Git Bash).
+
+Selecting a configured profile dispatches {#action workspace::NewTerminal} with that profile. Selecting a detected shell spawns a terminal running its program directly; the tab title is set to the detected shell's label (for example, `bash`, `zsh`, or `pwsh`).
+
+If your `terminal.profiles` map plus the detected list exceeds eight entries, the menu collapses into a single **"Select Shell…"** submenu to keep the dropdown manageable.
+
+Profiles whose `program` cannot be resolved (neither an existing absolute path nor found on `PATH`) are **hidden from the menu** but still spawnable via keymap; Zed emits a warning and routes actual spawn failures through the normal terminal-error notification path.
+
 > **Note:** Profiles are honored only for local terminals. In SSH remote projects the profile is ignored (the shell comes from the remote server) and a warning is logged. Use `NewTerminal` with `"local": true` to spawn a local terminal that does honor the profile.
 
 ## Working Directory

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -59,6 +59,73 @@ To pass arguments to your shell:
 }
 ```
 
+## Profiles {#profiles}
+
+Profiles let you define named shell configurations and pick one when opening a terminal. A profile specifies the program to launch, optional arguments, and an optional title override:
+
+```json [settings]
+{
+  "terminal": {
+    "profiles": {
+      "Zsh": {
+        "program": "/bin/zsh",
+        "args": ["-l"]
+      },
+      "Fish": {
+        "program": "/usr/bin/fish"
+      },
+      "PowerShell": {
+        "program": "pwsh",
+        "title_override": "PS"
+      }
+    }
+  }
+}
+```
+
+Each profile entry has the following fields:
+
+| Field            | Type              | Description                                                                    |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------ |
+| `program`        | string            | Program to launch (e.g. `/bin/zsh`, `pwsh`, `wsl.exe`).                        |
+| `args`           | array of strings  | Arguments passed to `program`. Omit to launch with no arguments.               |
+| `title_override` | string (optional) | Tab title for this profile. If unset, the profile's name is used (e.g. `Zsh`). |
+
+When you spawn a terminal from a profile, Zed promotes the profile name to the tab title unless the profile sets `title_override`. Environment variables are always inherited from your login shell (`$SHELL`), regardless of profile — Zed does not route environment through the profile, so venv detection and other `$SHELL`-dependent behavior continue to work.
+
+### Setting a Default Profile
+
+`terminal.default_profile` selects which profile is used when you open a terminal without specifying one (for example, via the default open-terminal keybinding):
+
+```json [settings]
+{
+  "terminal": {
+    "default_profile": "Zsh"
+  }
+}
+```
+
+If `default_profile` names a profile that does not exist in `profiles`, Zed emits a warning and falls back to `terminal.shell` (not the system shell). When `default_profile` is unset, `terminal.shell` is used.
+
+### Spawning a Profile via Keymap
+
+Use the {#action workspace::NewTerminal} action with a `profile` argument to spawn a specific profile from the keyboard:
+
+```json [keymap]
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      "ctrl-alt-z": ["workspace::NewTerminal", { "profile": "Zsh" }]
+    }
+  }
+]
+```
+
+If the named profile does not exist, Zed emits a warning and opens a terminal with the default shell instead.
+
+> **Note:** Profiles are honored only for local terminals. In SSH remote projects the profile is ignored (the shell comes from the remote server) and a warning is logged. Use `NewTerminal` with `"local": true` to spawn a local terminal that does honor the profile.
+
 ## Working Directory
 
 Control where new terminals start:

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -138,7 +138,7 @@ If your `terminal.profiles` map plus the detected list exceeds eight entries, th
 
 Profiles whose `program` cannot be resolved (neither an existing absolute path nor found on `PATH`) are **hidden from the menu** but still spawnable via keymap; Zed emits a warning and routes actual spawn failures through the normal terminal-error notification path.
 
-> **Note:** Profiles are honored only for local terminals. In SSH remote projects the profile is ignored (the shell comes from the remote server) and a warning is logged. Use `NewTerminal` with `"local": true` to spawn a local terminal that does honor the profile.
+> **Note:** In remote (SSH) projects, profile and detected-shell entries spawn **LOCAL** terminals alongside your remote project — profiles reference executables on your local machine. The default **New Terminal** entry still opens a shell on the remote host. Keymap-dispatched {#action workspace::NewTerminal} without `"local": true` follows the pre-existing remote-shell behavior; set `"local": true` to spawn a local terminal that honors the profile.
 
 ## Working Directory
 


### PR DESCRIPTION
# Objective

Related discussion: #31406 — "Support for Multiple Shells in New Terminal". Users want to pick a shell (bash/zsh/fish/PowerShell/Git Bash/…) when opening a new terminal, like VSCode's terminal profiles.

Context: #58763 (closed as completed, but no implementation ever landed — no linked PR) and #58783 describe the same gap. Today Zed only offers the single `terminal.shell` setting.

## Solution

- `terminal.profiles` defines named profiles (`program`, optional `args`, optional `title_override`); `terminal.default_profile` selects the default. Precedence: `default_profile` (if it resolves) > `terminal.shell` > system shell. Unknown names warn and fall back — never silently to the system shell.
- Installed shells are auto-detected (Unix: `/etc/shells` + login shell; Windows: pwsh/PowerShell/cmd/Git Bash) and offered in the terminal panel's "+" menu alongside configured profiles. Configured profiles shadow detected shells with the same program. Profiles whose program doesn't resolve get a validation warning and are hidden from the menu (still spawnable via keymap).
- Menus with more than 8 shell entries collapse into a "Select Shell…" submenu.
- `workspace::NewTerminal` accepts a `profile` argument for keymap bindings. Terminals spawned with a profile survive workspace reload (persisted via SQLite `profile_name` column).
- Remote projects spawn profile/detected-shell requests as local terminals so the override is honored; the remote server still selects the shell for normal remote terminals.
- Environment resolution intentionally stays on the login shell, so switching the interactive shell (e.g. to fish) does not break venv detection.

Deferred follow-ups (stubbed/documented in code): WSL distro enumeration, remote (SSH) shell detection, per-profile `env`/`icon`/`color`, VSCode settings importer.

## Testing

- Unit tests: settings merge across layers, `default_profile` precedence incl. unknown-name fallback, profile→shell conversion with title promotion, menu building + 8-entry escalation, `/etc/shells` parsing fixtures, Windows probe ordering with injected search paths, profile warnings.
- GPUI tests: spawning via `NewTerminal { profile }`, unknown-profile fallback, persistence round-trip (spawn with profile → serialize → deserialize → same profile), detected-shell routing incl. `force_local` behavior.
- `cargo check` (7 touched crates), `./script/clippy --deny warnings`, `cargo fmt --check`, and `cargo test -p terminal terminal_settings::` (25) / `-p terminal_view --lib` (99) / `-p util shell_detection::` (21) all green on the rebased base.
- Platforms: developed and tested on Linux. Windows detection paths are unit-tested from any host via injected inputs (`path_exists` predicate, `WINDIR`, file contents); macOS shares the Unix paths but was not run on real hardware.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The terminal panel's "+" menu gains a dynamic shell section:

- Below 9 entries: `New Terminal` / `Spawn Task`, separator, then configured profiles and detected shells as direct items.
- At 9+ entries: a single `Select Shell…` entry opens a submenu with the same list.
- Settings UI exposes `terminal.profiles` / `terminal.default_profile` via JSON-editor links.

---

Release Notes:

- Added the ability to select between multiple shells when creating a new terminal: configure `terminal.profiles` in settings.json, then pick a shell from the terminal panel's "+" menu or bind `workspace::NewTerminal` with a `profile` argument to a keymap.
