### PR TITLE
Fix thread switcher registration after enabling AI

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -355,6 +355,8 @@ impl MultiWorkspace {
                 let multi_workspace_enabled = this.multi_workspace_enabled(cx);
                 if previous_multi_workspace_enabled && !multi_workspace_enabled {
                     this.collapse_to_single_workspace(window, cx);
+                } else if !previous_multi_workspace_enabled && multi_workspace_enabled {
+                    cx.notify();
                 }
                 previous_multi_workspace_enabled = multi_workspace_enabled;
             }

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -118,6 +118,42 @@ async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_multi_workspace_notifies_when_agent_is_enabled(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.update(|cx| {
+        let mut settings = AgentSettings::get_global(cx).clone();
+        settings.enabled = false;
+        AgentSettings::override_global(settings, cx);
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+    let notification_count = Rc::new(Cell::new(0));
+    let _subscription = cx.update(|_, cx| {
+        cx.observe(&multi_workspace, {
+            let notification_count = notification_count.clone();
+            move |_, _| notification_count.set(notification_count.get() + 1)
+        })
+    });
+
+    cx.update(|_, cx| {
+        let mut settings = AgentSettings::get_global(cx).clone();
+        settings.enabled = true;
+        AgentSettings::override_global(settings, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        notification_count.get(),
+        1,
+        "enabling the agent should rerender MultiWorkspace so its actions are registered"
+    );
+}
+
+#[gpui::test]
 async fn test_multi_workspace_collapses_when_agent_is_disabled(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());


### PR DESCRIPTION
# Objective

Fixes #62838.

When Zed is launched from the terminal, the window can render before AI and multi-workspace functionality becomes enabled. The related action handlers are registered conditionally during rendering, but the transition from disabled to enabled did not request another render.

As a result, `agents_sidebar::ToggleThreadSwitcher` could remain unavailable until opening the Threads Sidebar triggered an unrelated render.

## Solution

Notify `MultiWorkspace` when AI functionality transitions from disabled to enabled. This causes the view to render again and register its workspace and thread action handlers.

The existing behavior for the opposite transition is unchanged: disabling AI still collapses the window to a single workspace.

A regression test verifies that enabling the agent after `MultiWorkspace` is created notifies the view.

## Testing

Tested on Windows:

```text
cargo test -p workspace test_multi_workspace_notifies_when_agent_is_enabled -- --nocapture
```

Result: **1 passed, 0 failed, 269 filtered out.**

Additional checks:

```text
cargo fmt -p workspace -- --check
git diff --check
```

Both checks passed.

I did not manually verify the complete `zed .` launch flow on macOS. The regression test covers the disabled-to-enabled state transition responsible for registering the conditional actions.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability.
- [x] Unsafe blocks, if any, have justifying comments.
- [x] The content adheres to Zed's [UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines.
- [x] Tests cover the new or changed behavior.
- [x] Performance impact has been considered and is acceptable.

---

Release Notes:

- Fixed thread-switcher shortcuts sometimes not working until the Threads Sidebar was opened.