### PR TITLE
lsp_locations: add docked references panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10455,6 +10455,7 @@ dependencies = [
  "language",
  "log",
  "lsp",
+ "menu",
  "picker",
  "picker_preview",
  "project",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -463,6 +463,7 @@
   //
   // 1. Open the results in a multibuffer: `multi_buffer` (default)
   // 2. Open the results in a filterable picker: `picker`
+  // 3. Open the results in a docked panel with a navigable list: `panel`
   "lsp_results_location": "multi_buffer",
   // Which level to use to filter out diagnostics displayed in the editor.
   //

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -41920,6 +41920,12 @@ fn test_open_results_in_action_argument_parsing() {
             .open_results_in,
         Some(OpenResultsIn::MultiBuffer),
     );
+    assert_eq!(
+        serde_json::from_value::<FindAllReferences>(json!({ "open_results_in": "panel" }))
+            .unwrap()
+            .open_results_in,
+        Some(OpenResultsIn::Panel),
+    );
 
     // The argument coexists with `FindAllReferences`'s existing field, which
     // keeps its own default when only `open_results_in` is provided.

--- a/crates/lsp_locations/Cargo.toml
+++ b/crates/lsp_locations/Cargo.toml
@@ -21,6 +21,7 @@ fuzzy.workspace = true
 gpui.workspace = true
 language.workspace = true
 log.workspace = true
+menu.workspace = true
 picker.workspace = true
 picker_preview.workspace = true
 project.workspace = true

--- a/crates/lsp_locations/src/lsp_locations.rs
+++ b/crates/lsp_locations/src/lsp_locations.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
-use std::sync::Arc;
 
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use editor::actions::{
     FindAllReferences, GoToDeclaration, GoToDefinition, GoToImplementation, GoToTypeDefinition,
 };
@@ -9,25 +8,38 @@ use editor::{Editor, EditorSettings, GotoDefinitionKind, OpenResultsIn};
 use file_icons::FileIcons;
 use fuzzy::StringMatchCandidate;
 use gpui::{
-    AnyElement, App, AppContext, AsyncWindowContext, Context, DismissEvent, Entity, EventEmitter,
-    FocusHandle, Focusable, HighlightStyle, StyledText, Subscription, Task, TextStyle, WeakEntity,
-    prelude::*,
+    Action, AnyElement, App, AppContext, AsyncWindowContext, ClickEvent, Context, DismissEvent,
+    Entity, EventEmitter, FocusHandle, Focusable, HighlightStyle, ListSizingBehavior, Pixels,
+    ScrollStrategy, StyledText, Subscription, Task, TextStyle, UniformListScrollHandle, WeakEntity,
+    actions, div, prelude::*, uniform_list,
 };
 use language::{Buffer, HighlightId, LanguageAwareStyling};
+use menu::{Confirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use picker::{Picker, PickerDelegate};
 use project::{Location, Project, ProjectPath};
 use settings::{GoToDefinitionFallback, Settings as _};
 use text::{Anchor, Point};
 use theme_settings::ThemeSettings;
 use ui::{Divider, FluentBuilder};
-use ui::{ListItem, ListItemSpacing, prelude::*};
+use ui::{ListItem, ListItemSpacing, ScrollAxes, Scrollbars, WithScrollbar, prelude::*};
 use util::ResultExt as _;
+use workspace::dock::{DockPosition, Panel, PanelEvent};
 use workspace::item::ItemSettings;
 use workspace::notifications::NotificationId;
 use workspace::{ModalView, Toast, Workspace};
 
+actions!(lsp_locations, [ToggleReferencesPanel]);
+
+const REFERENCES_PANEL_KEY: &str = "ReferencesPanel";
+
 pub fn init(cx: &mut App) {
     cx.observe_new(register).detach();
+    cx.observe_new(|workspace: &mut Workspace, _, _| {
+        workspace.register_action(|workspace, _: &ToggleReferencesPanel, window, cx| {
+            workspace.toggle_panel_focus::<LspLocationsPanel>(window, cx);
+        });
+    })
+    .detach();
 }
 
 /// Registers handlers for the navigation actions on each full editor. When the
@@ -108,9 +120,10 @@ fn register(editor: &mut Editor, _window: Option<&mut Window>, cx: &mut Context<
         .detach();
 }
 
-/// Either opens the picker for the editor, or propagates the action so the
-/// editor's built-in (multibuffer) handler runs. A `None` argument falls back to
-/// the `lsp_results_location` setting.
+/// Either opens the picker or panel for the editor, or propagates the action so
+/// the editor's built-in (multibuffer) handler runs. A `None` argument falls
+/// back to the `lsp_results_location` setting. Only "find all references"
+/// currently has a docked panel, the other kinds fall back to the picker.
 fn handle_nav_action(
     open_results_in: Option<OpenResultsIn>,
     kind: LspPickerKind,
@@ -120,11 +133,20 @@ fn handle_nav_action(
 ) {
     let open_results_in =
         open_results_in.unwrap_or_else(|| EditorSettings::get_global(cx).lsp_results_location);
-    if open_results_in != OpenResultsIn::Picker {
-        cx.propagate();
-        return;
+    match open_results_in {
+        OpenResultsIn::Picker => {
+            LspLocationsPicker::open_for_editor(kind, editor.clone(), window, cx);
+        }
+        OpenResultsIn::Panel if kind == LspPickerKind::References => {
+            LspLocationsPanel::open_for_editor(kind, editor.clone(), window, cx);
+        }
+        OpenResultsIn::Panel => {
+            LspLocationsPicker::open_for_editor(kind, editor.clone(), window, cx);
+        }
+        OpenResultsIn::MultiBuffer => {
+            cx.propagate();
+        }
     }
-    LspLocationsPicker::open_for_editor(kind, editor.clone(), window, cx);
 }
 
 /// Runs the LSP query for `kind` and returns the raw locations. Returns `None`
@@ -380,6 +402,489 @@ impl Render for LspLocationsPicker {
     }
 }
 
+/// A docked panel showing LSP results (currently "find all references") as a
+/// filterable, navigable list
+pub struct LspLocationsPanel {
+    delegate: LspLocationsDelegate,
+    scroll_handle: UniformListScrollHandle,
+    focus_handle: FocusHandle,
+}
+
+impl LspLocationsPanel {
+    fn open_for_editor(
+        kind: LspPickerKind,
+        editor: WeakEntity<Editor>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let Some(editor) = editor.upgrade() else {
+            return;
+        };
+        let Some(workspace) = editor.read(cx).workspace() else {
+            return;
+        };
+        workspace.update(cx, |workspace, cx| {
+            Self::open(kind, editor, workspace, window, cx);
+        });
+    }
+
+    /// Opens the panel for `kind`: reveals it, runs the LSP query, then fills
+    /// it with the results.
+    fn open(
+        kind: LspPickerKind,
+        editor: Entity<Editor>,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let project = workspace.project().clone();
+        let editor = editor.downgrade();
+        cx.spawn_in(window, async move |workspace, cx| {
+            //  Reveal the panel so the user sees it while the query runs.
+            let Some(panel) = workspace
+                .update_in(cx, |workspace, window, cx| {
+                    let panel = match workspace.panel::<LspLocationsPanel>(cx) {
+                        Some(panel) => {
+                            panel.update(cx, |panel, cx| {
+                                panel.reset(kind, project.clone(), editor.clone(), cx);
+                            });
+                            panel
+                        }
+                        None => {
+                            let panel = LspLocationsPanel::new(
+                                kind,
+                                project.clone(),
+                                editor.clone(),
+                                window,
+                                cx,
+                            );
+                            workspace.add_panel(panel.clone(), window, cx);
+                            panel
+                        }
+                    };
+                    workspace.reveal_panel::<LspLocationsPanel>(window, cx);
+                    panel.update(cx, |panel, cx| {
+                        panel.focus_handle.focus(window, cx);
+                    });
+                    panel
+                })
+                .log_err()
+            else {
+                return;
+            };
+
+            // Run the LSP query.
+            let Some(locations) = run_picker_query(kind, &editor, &workspace, &project, cx).await
+            else {
+                return;
+            };
+
+            if locations.is_empty() {
+                return;
+            }
+
+            // Add all matches.
+            panel
+                .update_in(cx, |panel, _window, cx| {
+                    let matches = build_location_matches(&locations, cx);
+                    panel.delegate.append_matches(matches);
+                    panel.scroll_to_selected();
+                    cx.notify();
+                })
+                .log_err();
+
+            let total = panel.update(cx, |panel, _cx| panel.delegate.all_matches.len());
+            if total == 1 {
+                let location = panel.update(cx, |panel, _cx| {
+                    let location_match = &panel.delegate.all_matches[0];
+                    Location {
+                        buffer: location_match.buffer.clone(),
+                        range: location_match.anchor_range.clone(),
+                    }
+                });
+                if let Ok(task) = editor.update_in(cx, |editor, window, cx| {
+                    editor.open_location(location, false, window, cx)
+                }) {
+                    task.await.log_err();
+                }
+            }
+        })
+        .detach();
+    }
+
+    /// Creates the panel empty, ready for the LSP results to be added.
+    fn new(
+        kind: LspPickerKind,
+        project: Entity<Project>,
+        editor: WeakEntity<Editor>,
+        _window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Entity<Self> {
+        cx.new(|cx| Self {
+            delegate: LspLocationsDelegate::empty_tree(kind, project, editor),
+            scroll_handle: UniformListScrollHandle::new(),
+            focus_handle: cx.focus_handle(),
+        })
+    }
+
+    /// Resets the panel to an empty state for a fresh query.
+    fn reset(
+        &mut self,
+        kind: LspPickerKind,
+        project: Entity<Project>,
+        editor: WeakEntity<Editor>,
+        cx: &mut Context<Self>,
+    ) {
+        self.delegate = LspLocationsDelegate::empty_tree(kind, project, editor);
+        self.scroll_to_selected();
+        cx.notify();
+    }
+
+    fn selectable(&self, ix: usize) -> bool {
+        self.delegate
+            .entries
+            .get(ix)
+            .is_some_and(|entry| self.delegate.entry_is_selectable(entry))
+    }
+
+    fn select_next(&mut self) {
+        let count = self.delegate.entries.len();
+        let mut ix = self.delegate.selected_index + 1;
+        while ix < count && !self.selectable(ix) {
+            ix += 1;
+        }
+        if ix < count {
+            self.delegate.selected_index = ix;
+        }
+    }
+
+    fn select_previous(&mut self) {
+        let mut ix = self.delegate.selected_index;
+        while ix > 0 {
+            ix -= 1;
+            if self.selectable(ix) {
+                self.delegate.selected_index = ix;
+                break;
+            }
+        }
+    }
+
+    fn select_first(&mut self) {
+        if let Some(ix) = self.delegate.first_selectable_index() {
+            self.delegate.selected_index = ix;
+        }
+    }
+
+    fn select_last(&mut self) {
+        for ix in (0..self.delegate.entries.len()).rev() {
+            if self.selectable(ix) {
+                self.delegate.selected_index = ix;
+                return;
+            }
+        }
+    }
+
+    fn confirm(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.delegate.entries.get(self.delegate.selected_index) {
+            Some(Entry::Header(path)) => {
+                self.delegate.toggle_collapsed(path.clone());
+                self.scroll_to_selected();
+                cx.notify();
+            }
+            Some(Entry::Match(_)) => self.open_selected(false, window, cx),
+            _ => {}
+        }
+    }
+
+    fn click_row(&mut self, ix: usize, window: &mut Window, cx: &mut Context<Self>) {
+        self.delegate.selected_index = ix;
+        self.confirm(window, cx);
+    }
+
+    fn open_selected(&mut self, split: bool, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(location_match) = self.delegate.selected_location_match() else {
+            return;
+        };
+        let location = Location {
+            buffer: location_match.buffer.clone(),
+            range: location_match.anchor_range.clone(),
+        };
+        let Some(editor) = self.delegate.editor.upgrade() else {
+            return;
+        };
+        editor
+            .update(cx, |editor, cx| {
+                editor.open_location(location, split, window, cx)
+            })
+            .detach_and_log_err(cx);
+    }
+
+    fn scroll_to_selected(&self) {
+        self.scroll_handle
+            .scroll_to_item(self.delegate.selected_index, ScrollStrategy::Nearest);
+    }
+
+    fn confirm_action(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        self.confirm(window, cx);
+    }
+
+    fn select_next_action(&mut self, _: &SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+        self.select_next();
+        self.scroll_to_selected();
+        cx.notify();
+    }
+
+    fn select_previous_action(
+        &mut self,
+        _: &SelectPrevious,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_previous();
+        self.scroll_to_selected();
+        cx.notify();
+    }
+
+    fn select_first_action(
+        &mut self,
+        _: &SelectFirst,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_first();
+        self.scroll_to_selected();
+        cx.notify();
+    }
+
+    fn select_last_action(&mut self, _: &SelectLast, _window: &mut Window, cx: &mut Context<Self>) {
+        self.select_last();
+        self.scroll_to_selected();
+        cx.notify();
+    }
+
+    fn render_entry(&self, ix: usize, _window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+        match self.delegate.entries.get(ix) {
+            Some(Entry::Header(path)) => {
+                let selected = ix == self.delegate.selected_index;
+                let collapsed = self.delegate.is_collapsed(path);
+                let path_style = self.delegate.project.read(cx).path_style(cx);
+                let file_name = path
+                    .path
+                    .file_name()
+                    .map(|name| name.to_string())
+                    .unwrap_or_default();
+                let directory = path
+                    .path
+                    .parent()
+                    .map(|parent| parent.display(path_style))
+                    .map(SharedString::new)
+                    .unwrap_or_default();
+                let file_icon = ItemSettings::get_global(cx)
+                    .file_icons
+                    .then(|| FileIcons::get_icon(path.path.as_std_path(), cx))
+                    .flatten()
+                    .map(|icon| {
+                        Icon::from_path(icon)
+                            .color(Color::Muted)
+                            .size(IconSize::Small)
+                    });
+                ListItem::new(ix)
+                    .spacing(ListItemSpacing::Sparse)
+                    .inset(true)
+                    .toggle_state(selected)
+                    .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                        this.click_row(ix, window, cx);
+                    }))
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .min_w_0()
+                            .gap_1p5()
+                            .child(
+                                Icon::new(if collapsed {
+                                    IconName::ChevronRight
+                                } else {
+                                    IconName::ChevronDown
+                                })
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                            )
+                            .children(file_icon)
+                            .child(
+                                h_flex()
+                                    .w_full()
+                                    .min_w_0()
+                                    .gap_1()
+                                    .child(Label::new(file_name).size(LabelSize::Small))
+                                    .when(!directory.is_empty(), |this| {
+                                        this.child(
+                                            Label::new(directory)
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted)
+                                                .truncate_start(),
+                                        )
+                                    }),
+                            ),
+                    )
+                    .into_any_element()
+            }
+            Some(Entry::Match(match_index)) => {
+                let selected = ix == self.delegate.selected_index;
+                let location_match = &self.delegate.all_matches[*match_index];
+                ListItem::new(ix)
+                    .spacing(ListItemSpacing::Sparse)
+                    .inset(true)
+                    .toggle_state(selected)
+                    .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                        this.click_row(ix, window, cx);
+                    }))
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .min_w_0()
+                            .gap_2p5()
+                            .text_sm()
+                            .child(
+                                h_flex()
+                                    .w(rems(
+                                        (self.delegate.max_line_number.max(1).ilog10() + 1) as f32
+                                            * 0.5,
+                                    ))
+                                    .justify_end()
+                                    .child(
+                                        Label::new(location_match.line_number.to_string()).color(
+                                            Color::Custom(
+                                                cx.theme().colors().text_muted.opacity(0.5),
+                                            ),
+                                        ),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .child(render_matched_line(location_match, cx)),
+                            ),
+                    )
+                    .into_any_element()
+            }
+            _ => div().into_any_element(),
+        }
+    }
+
+    fn render_header(&self, cx: &Context<Self>) -> Div {
+        let (results, files) = self.delegate.summary();
+        let text = if results == 0 {
+            self.delegate.kind.empty_message().to_string()
+        } else {
+            let results_word = if results == 1 { "result" } else { "results" };
+            let files_word = if files == 1 { "file" } else { "files" };
+            format!("{results} {results_word} in {files} {files_word}")
+        };
+        h_flex()
+            .w_full()
+            .px(DynamicSpacing::Base06.rems(cx))
+            .py_1()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(Label::new(text).size(LabelSize::Small).color(Color::Muted))
+    }
+}
+
+impl Focusable for LspLocationsPanel {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl EventEmitter<PanelEvent> for LspLocationsPanel {}
+
+impl Panel for LspLocationsPanel {
+    fn persistent_name() -> &'static str {
+        "References Panel"
+    }
+
+    fn panel_key() -> &'static str {
+        REFERENCES_PANEL_KEY
+    }
+
+    fn activation_focus_handle(&self, cx: &App) -> FocusHandle {
+        self.focus_handle(cx)
+    }
+
+    fn position(&self, _window: &Window, _cx: &App) -> DockPosition {
+        DockPosition::Left
+    }
+
+    fn position_is_valid(&self, position: DockPosition) -> bool {
+        matches!(position, DockPosition::Left | DockPosition::Right)
+    }
+
+    fn set_position(
+        &mut self,
+        _position: DockPosition,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn default_size(&self, _window: &Window, _cx: &App) -> Pixels {
+        px(320.)
+    }
+
+    fn icon(&self, _window: &Window, _cx: &App) -> Option<IconName> {
+        Some(IconName::ArrowRightLeft)
+    }
+
+    fn icon_tooltip(&self, _window: &Window, _cx: &App) -> Option<&'static str> {
+        Some("References Panel")
+    }
+
+    fn toggle_action(&self) -> Box<dyn Action> {
+        Box::new(ToggleReferencesPanel)
+    }
+
+    fn activation_priority(&self) -> u32 {
+        8
+    }
+}
+
+impl Render for LspLocationsPanel {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let header = self.render_header(cx);
+        let list = uniform_list(
+            "references",
+            self.delegate.entries.len(),
+            cx.processor(move |panel: &mut Self, range: Range<usize>, window, cx| {
+                range.map(|ix| panel.render_entry(ix, window, cx)).collect()
+            }),
+        )
+        .with_sizing_behavior(ListSizingBehavior::Auto)
+        .flex_grow_1()
+        .min_h_0()
+        .track_scroll(&self.scroll_handle)
+        .into_any_element();
+
+        v_flex()
+            .size_full()
+            .key_context("ReferencesPanel")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::confirm_action))
+            .on_action(cx.listener(Self::select_next_action))
+            .on_action(cx.listener(Self::select_previous_action))
+            .on_action(cx.listener(Self::select_first_action))
+            .on_action(cx.listener(Self::select_last_action))
+            .child(header)
+            .child(list)
+            .custom_scrollbars(
+                Scrollbars::new(ScrollAxes::Vertical).tracked_scroll_handle(&self.scroll_handle),
+                window,
+                cx,
+            )
+    }
+}
+
 struct LocationMatch {
     path: ProjectPath,
     buffer: Entity<Buffer>,
@@ -404,11 +909,14 @@ struct LspLocationsDelegate {
     project: Entity<Project>,
     editor: WeakEntity<Editor>,
     all_matches: Vec<LocationMatch>,
-    candidates: Arc<[StringMatchCandidate]>,
+    candidates: Vec<StringMatchCandidate>,
     matches: Vec<usize>,
     entries: Vec<Entry>,
     selected_index: usize,
     max_line_number: u32,
+    /// When true, files collapse/expand.
+    collapse_enabled: bool,
+    collapsed_paths: HashSet<ProjectPath>,
 }
 
 impl LspLocationsDelegate {
@@ -417,6 +925,24 @@ impl LspLocationsDelegate {
         all_matches: Vec<LocationMatch>,
         project: Entity<Project>,
         editor: WeakEntity<Editor>,
+    ) -> Self {
+        Self::with_collapse(kind, all_matches, project, editor, false)
+    }
+
+    fn empty_tree(
+        kind: LspPickerKind,
+        project: Entity<Project>,
+        editor: WeakEntity<Editor>,
+    ) -> Self {
+        Self::with_collapse(kind, Vec::new(), project, editor, true)
+    }
+
+    fn with_collapse(
+        kind: LspPickerKind,
+        all_matches: Vec<LocationMatch>,
+        project: Entity<Project>,
+        editor: WeakEntity<Editor>,
+        collapse_enabled: bool,
     ) -> Self {
         // Match against the line text and the file path, mirroring the fuzzy
         // matching every other Zed picker uses.
@@ -445,14 +971,57 @@ impl LspLocationsDelegate {
             entries: Vec::new(),
             selected_index: 0,
             max_line_number: 0,
+            collapse_enabled,
+            collapsed_paths: HashSet::default(),
         };
+        if collapse_enabled {
+            // Start collapsed so the panel reads as a list of files until the
+            // user expands one.
+            this.collapsed_paths = this.all_matches.iter().map(|m| m.path.clone()).collect();
+        }
         this.rebuild_entries();
         this
     }
 
+    /// Appends a batch of freshly-built matches, used for progressive loading.
+    fn append_matches(&mut self, new_matches: Vec<LocationMatch>) {
+        if new_matches.is_empty() {
+            return;
+        }
+        let new_count = new_matches.len();
+        let base = self.all_matches.len();
+        for (index, location_match) in new_matches.iter().enumerate() {
+            self.candidates.push(StringMatchCandidate::new(
+                base + index,
+                &format!(
+                    "{} {}",
+                    location_match.display_text,
+                    location_match.path.path.as_unix_str()
+                ),
+            ));
+            if self.collapse_enabled {
+                self.collapsed_paths.insert(location_match.path.clone());
+            }
+        }
+        self.all_matches.extend(new_matches);
+        self.matches.extend(base..base + new_count);
+        self.rebuild_entries();
+    }
+
+    /// The number of (filtered) results and the number of distinct files among
+    /// them, used for the "N results in M files" panel header.
+    fn summary(&self) -> (usize, usize) {
+        let mut files = HashSet::default();
+        for &match_index in &self.matches {
+            files.insert(&self.all_matches[match_index].path);
+        }
+        (self.matches.len(), files.len())
+    }
+
     /// Rebuilds the grouped [`Self::entries`] from the filtered [`Self::matches`]:
-    /// one header per file, its matches, and a separator before every group
-    /// after the first. Selection snaps to the first selectable row.
+    /// one header per file, its (expanded) matches, and a separator before every
+    /// group after the first (only for the flat modal picker). The collapsible
+    /// panel omits separators so its uniform list rows share a height.
     fn rebuild_entries(&mut self) {
         let mut entries = Vec::with_capacity(self.matches.len());
         let mut last_path: Option<&ProjectPath> = None;
@@ -460,24 +1029,50 @@ impl LspLocationsDelegate {
         for &match_index in &self.matches {
             let location_match = &self.all_matches[match_index];
             if last_path != Some(&location_match.path) {
-                if last_path.is_some() {
+                if last_path.is_some() && !self.collapse_enabled {
                     entries.push(Entry::Separator);
                 }
                 entries.push(Entry::Header(location_match.path.clone()));
                 last_path = Some(&location_match.path);
             }
             max_line_number = max_line_number.max(location_match.line_number);
-            entries.push(Entry::Match(match_index));
+            if !(self.collapse_enabled && self.is_collapsed(&location_match.path)) {
+                entries.push(Entry::Match(match_index));
+            }
         }
         self.entries = entries;
         self.max_line_number = max_line_number;
         self.selected_index = self.first_selectable_index().unwrap_or(0);
     }
 
+    fn is_collapsed(&self, path: &ProjectPath) -> bool {
+        self.collapse_enabled && self.collapsed_paths.contains(path)
+    }
+
+    fn toggle_collapsed(&mut self, path: ProjectPath) {
+        if !self.collapsed_paths.remove(&path) {
+            self.collapsed_paths.insert(path.clone());
+        }
+        self.rebuild_entries();
+        self.selected_index = self
+            .entries
+            .iter()
+            .position(|entry| matches!(entry, Entry::Header(p) if *p == path))
+            .unwrap_or_else(|| self.first_selectable_index().unwrap_or(0));
+    }
+
     fn first_selectable_index(&self) -> Option<usize> {
         self.entries
             .iter()
-            .position(|entry| matches!(entry, Entry::Match(_)))
+            .position(|entry| self.entry_is_selectable(entry))
+    }
+
+    fn entry_is_selectable(&self, entry: &Entry) -> bool {
+        match entry {
+            Entry::Match(_) => true,
+            Entry::Header(_) => self.collapse_enabled,
+            Entry::Separator => false,
+        }
     }
 
     fn selected_location_match(&self) -> Option<&LocationMatch> {
@@ -714,6 +1309,7 @@ impl PickerDelegate for LspLocationsDelegate {
                             .color(Color::Muted)
                             .size(IconSize::Small)
                     });
+
                 Some(
                     h_flex()
                         .w_full()
@@ -840,9 +1436,25 @@ mod tests {
         cx.run_until_parked();
     }
 
+    fn open_panel(cx: &mut EditorLspTestContext, kind: LspPickerKind) {
+        let editor = cx.editor.clone();
+        let workspace = cx.workspace.clone();
+        cx.update(|window, cx| {
+            workspace.update(cx, |workspace, cx| {
+                LspLocationsPanel::open(kind, editor, workspace, window, cx);
+            });
+        });
+        cx.run_until_parked();
+    }
+
     fn active_picker(cx: &mut EditorLspTestContext) -> Option<Entity<LspLocationsPicker>> {
         let workspace = cx.workspace.clone();
         cx.update(|_window, cx| workspace.read(cx).active_modal::<LspLocationsPicker>(cx))
+    }
+
+    fn active_panel(cx: &mut EditorLspTestContext) -> Option<Entity<LspLocationsPanel>> {
+        let workspace = cx.workspace.clone();
+        cx.update(|_window, cx| workspace.read(cx).panel::<LspLocationsPanel>(cx))
     }
 
     fn references(uri: lsp::Uri, ranges: &[(u32, u32, u32)]) -> Vec<lsp::Location> {
@@ -945,6 +1557,134 @@ mod tests {
             active_picker(&mut cx).is_none(),
             "an empty result should not open the picker"
         );
+    }
+
+    #[gpui::test]
+    async fn test_multiple_references_open_panel(cx: &mut TestAppContext) {
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.set_state(SOURCE);
+        cx.lsp
+            .set_request_handler::<lsp::request::References, _, _>(async move |params, _| {
+                let uri = params.text_document_position.text_document.uri;
+                Ok(Some(references(uri, &[(1, 8, 11), (2, 14, 17)])))
+            });
+
+        open_panel(&mut cx, LspPickerKind::References);
+
+        assert!(
+            active_panel(&mut cx).is_some(),
+            "multiple references should open the docked panel"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_find_all_references_honors_lsp_results_location_panel(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.update(|_window, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.editor.lsp_results_location = Some(OpenResultsIn::Panel);
+                });
+            });
+        });
+        cx.set_state(SOURCE);
+        cx.lsp
+            .set_request_handler::<lsp::request::References, _, _>(async move |params, _| {
+                let uri = params.text_document_position.text_document.uri;
+                Ok(Some(references(uri, &[(1, 8, 11), (2, 14, 17)])))
+            });
+
+        cx.dispatch_action(FindAllReferences::default());
+        cx.run_until_parked();
+
+        assert!(
+            active_panel(&mut cx).is_some(),
+            "FindAllReferences should open the panel when lsp_results_location is panel"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_panel_starts_with_files_collapsed(cx: &mut TestAppContext) {
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.set_state(SOURCE);
+        cx.lsp
+            .set_request_handler::<lsp::request::References, _, _>(async move |params, _| {
+                let uri = params.text_document_position.text_document.uri;
+                Ok(Some(references(uri, &[(1, 8, 11), (2, 14, 17)])))
+            });
+
+        open_panel(&mut cx, LspPickerKind::References);
+        let panel = active_panel(&mut cx).expect("multiple references should open the panel");
+
+        cx.update(|_window, cx| {
+            let delegate = &panel.read(cx).delegate;
+            // Files start collapsed, so the only entry is the file header; the
+            // match rows are hidden until the file is expanded.
+            assert_eq!(
+                delegate.entries.len(),
+                1,
+                "the panel should start collapsed, showing only file headers"
+            );
+            assert!(matches!(delegate.entries[0], Entry::Header(_)));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_panel_expand_reveals_matches(cx: &mut TestAppContext) {
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                references_provider: Some(lsp::OneOf::Left(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.set_state(SOURCE);
+        cx.lsp
+            .set_request_handler::<lsp::request::References, _, _>(async move |params, _| {
+                let uri = params.text_document_position.text_document.uri;
+                Ok(Some(references(uri, &[(1, 8, 11), (2, 14, 17)])))
+            });
+
+        open_panel(&mut cx, LspPickerKind::References);
+        let panel = active_panel(&mut cx).expect("multiple references should open the panel");
+
+        cx.update(|_window, cx| {
+            panel.update(cx, |panel, _cx| {
+                let path = panel.delegate.all_matches[0].path.clone();
+                panel.delegate.toggle_collapsed(path);
+                assert_eq!(
+                    panel.delegate.entries.len(),
+                    3,
+                    "expanding the file should reveal its reference rows"
+                );
+                assert!(matches!(panel.delegate.entries[0], Entry::Header(_)));
+                assert!(matches!(panel.delegate.entries[1], Entry::Match(_)));
+                assert!(matches!(panel.delegate.entries[2], Entry::Match(_)));
+            });
+        });
     }
 
     #[gpui::test]

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -911,6 +911,8 @@ pub enum OpenResultsIn {
     MultiBuffer,
     /// Open the results in a filterable picker.
     Picker,
+    /// Open the results in a docked panel with a navigable list.
+    Panel,
 }
 
 /// How to scroll the target into view when navigating to a definition or reference.


### PR DESCRIPTION
# Objective

- Add a docked, "Find All References" panel (similar to the many requests in #5117) . Currently "Find All References" only opens a multibuffer (default) or a filterable modal picker (`lsp_results_location: picker`). This adds a third option: a persistent, collapsible file-tree panel that lists references grouped by file, docked alongside the editor.

Happy to do any UX changes if needed . 

## Solution

- Added a new value `Panel` to the existing `OpenResultsIn` enum (`crates/settings_content`). Users opt in via `"lsp_results_location": "panel"` in settings, or the existing per-action `open_results_in: "panel"` argument.

## Testing
- Ran `cargo test -p lsp_locations` all tests pass

To test manually: set `"lsp_results_location": "panel"` in settings, then run "Find All References" 

## Showcase



https://github.com/user-attachments/assets/c87d5d7e-87e7-4c37-a21e-cbe2b70299db


---

Release Notes:

- Added a docked "Find All References" panel, configured via `lsp_results_location: "panel"`.
