### PR TITLE
Pin to specific miri version

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -505,9 +505,9 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: run_tests::miri_scheduler::install_miri
-      run: rustup toolchain install nightly --profile minimal --component miri --component rust-src
+      run: rustup toolchain install nightly-2026-09-09 --profile minimal --component miri --component rust-src
     - name: run_tests::miri_scheduler::run_scheduler_tests_under_miri
-      run: cargo +nightly -q miri test -p scheduler
+      run: cargo +nightly-2026-09-09 -q miri test -p scheduler
     - name: steps::cleanup_cargo_config
       if: always()
       run: |

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -731,12 +731,12 @@ pub(crate) fn check_postgres_and_protobuf_migrations() -> NamedJob {
 fn miri_scheduler() -> NamedJob {
     fn install_miri() -> Step<Run> {
         named::bash(
-            "rustup toolchain install nightly --profile minimal --component miri --component rust-src",
+            "rustup toolchain install nightly-2026-09-09 --profile minimal --component miri --component rust-src",
         )
     }
 
     fn run_scheduler_tests_under_miri() -> Step<Run> {
-        named::bash("cargo +nightly -q miri test -p scheduler")
+        named::bash("cargo +nightly-2026-09-09 -q miri test -p scheduler")
     }
 
     named::job(


### PR DESCRIPTION
Seems that a few PRs' CI start to fail with unrelated errors, e.g. https://github.com/zed-industries/zed/actions/runs/34428484649/job/102747668773?pr=63933

```
warning: integer-to-pointer cast
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.12/src/word_lock.rs:320:9
    |
320 |         (self & QUEUE_MASK) as *const ThreadData
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer cast
    |
    = help: this program is using integer-to-pointer casts or (equivalently) `ptr::with_exposed_provenance`, which means that Miri might miss pointer bugs in this program
    = help: see https://doc.rust-lang.org/nightly/std/ptr/fn.with_exposed_provenance.html for more details on that operation
    = help: to ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
    = help: you can then set `MIRIFLAGS=-Zmiri-strict-provenance` to ensure you are not relying on `with_exposed_provenance` semantics
    = help: alternatively, `MIRIFLAGS=-Zmiri-permissive-provenance` disables this warning
    = note: this is on thread `tests::test_non`
    = note: stack backtrace:
```

No new parking lot releases yet: https://github.com/Amanieu/parking_lot/pull/502 hence pin Miri to version that does not fail for now.

Release Notes:

- N/A
