### PR TITLE
Pin miri to the version that does not fail

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -505,9 +505,11 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: run_tests::miri_scheduler::install_miri
-      run: rustup toolchain install nightly --profile minimal --component miri --component rust-src
+      run: rustup toolchain install nightly-2026-09-09 --profile minimal --component miri --component rust-src
+    - name: run_tests::miri_scheduler::clean_miri
+      run: cargo +nightly-2026-09-09 miri clean
     - name: run_tests::miri_scheduler::run_scheduler_tests_under_miri
-      run: cargo +nightly -q miri test -p scheduler
+      run: cargo +nightly-2026-09-09 -q miri test -p scheduler
     - name: steps::cleanup_cargo_config
       if: always()
       run: |

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -730,13 +730,19 @@ pub(crate) fn check_postgres_and_protobuf_migrations() -> NamedJob {
 
 fn miri_scheduler() -> NamedJob {
     fn install_miri() -> Step<Run> {
+        // TODO: Unpin Miri after updating parking_lot_core to fix its futex argument types.
+        // Nightly 2026-09-10 added stricter checks in rust-lang/rust#161734.
         named::bash(
-            "rustup toolchain install nightly --profile minimal --component miri --component rust-src",
+            "rustup toolchain install nightly-2026-09-09 --profile minimal --component miri --component rust-src",
         )
     }
 
+    fn clean_miri() -> Step<Run> {
+        named::bash("cargo +nightly-2026-09-09 miri clean")
+    }
+
     fn run_scheduler_tests_under_miri() -> Step<Run> {
-        named::bash("cargo +nightly -q miri test -p scheduler")
+        named::bash("cargo +nightly-2026-09-09 -q miri test -p scheduler")
     }
 
     named::job(
@@ -747,6 +753,7 @@ fn miri_scheduler() -> NamedJob {
             .add_step(steps::setup_cargo_config(Platform::Linux))
             .add_step(steps::cache_rust_dependencies_namespace())
             .add_step(install_miri())
+            .add_step(clean_miri())
             .add_step(run_scheduler_tests_under_miri())
             .add_step(steps::cleanup_cargo_config(Platform::Linux)),
     )


### PR DESCRIPTION
Seems that a few PRs' CI start to fail with unrelated errors, e.g. https://github.com/zed-industries/zed/actions/runs/34428484649/job/102747668773?pr=63933

```
warning: integer-to-pointer cast
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parking_lot_core-0.9.12/src/word_lock.rs:320:9
    |
320 |         (self & QUEUE_MASK) as *const ThreadData
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer cast
    |
    = help: this program is using integer-to-pointer casts or (equivalently) `ptr::with_exposed_provenance`, which means that Miri might miss pointer bugs in this program
    = help: see https://doc.rust-lang.org/nightly/std/ptr/fn.with_exposed_provenance.html for more details on that operation
    = help: to ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
    = help: you can then set `MIRIFLAGS=-Zmiri-strict-provenance` to ensure you are not relying on `with_exposed_provenance` semantics
    = help: alternatively, `MIRIFLAGS=-Zmiri-permissive-provenance` disables this warning
    = note: this is on thread `tests::test_non`
    = note: stack backtrace:
```

That used to be the case before too: https://github.com/zed-industries/zed/actions/runs/34360850759/job/102497345024#step:9:402 but with the recent version bump it became a hard error ergo this for now.

No new parking lot releases yet: https://github.com/Amanieu/parking_lot/pull/502 hence pin Miri to version that does not fail for now.

Release Notes:

- N/A
