### PR TITLE
agent: Bound line length and total output bytes in grep tool

### DIFF
--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -66,6 +66,28 @@ impl GrepToolInput {
 }
 
 const RESULTS_PER_PAGE: u32 = 20;
+/// Maximum line length for a match snippet before truncating (ripgrep-style max-columns).
+const MAX_LINE_LEN: usize = 500;
+/// Maximum total output bytes across all matches in a single page to prevent context window overflow.
+const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+
+fn format_snippet<'a>(chunks: impl IntoIterator<Item = &'a str>) -> String {
+    let raw: String = chunks.into_iter().collect();
+    let mut formatted = String::with_capacity(raw.len().min(MAX_LINE_LEN * 4));
+    for (i, line) in raw.split('\n').enumerate() {
+        if i > 0 {
+            formatted.push('\n');
+        }
+        if line.len() > MAX_LINE_LEN {
+            let boundary = line.floor_char_boundary(MAX_LINE_LEN);
+            formatted.push_str(&line[..boundary]);
+            let _ = write!(formatted, "... [truncated {} chars]", line.len() - boundary);
+        } else {
+            formatted.push_str(line);
+        }
+    }
+    formatted
+}
 
 pub struct GrepTool {
     project: Entity<Project>,
@@ -322,7 +344,7 @@ impl AgentTool for GrepTool {
                     };
                     writeln!(output, "{line_label}").ok();
 
-                    let snippet: String = snapshot.text_for_range(range.clone()).collect();
+                    let snippet = format_snippet(snapshot.text_for_range(range.clone()));
                     output.push_str("```\n");
                     output.push_str(&snippet);
                     output.push_str("\n```\n");
@@ -363,6 +385,12 @@ impl AgentTool for GrepTool {
                         }
 
                     matches_found += 1;
+
+                    if output.len() >= MAX_OUTPUT_BYTES {
+                        output.push_str("\n... [Output limit reached. Refine include_pattern or regex for more results]\n");
+                        has_more_matches = true;
+                        break 'outer;
+                    }
                 }
             }
 
@@ -1408,6 +1436,73 @@ mod tests {
         assert!(
             paths.iter().all(|p| !p.contains("worktree2")),
             "Should not find any matches in worktree2"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_grep_tool_truncates_long_lines(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.executor().allow_parking();
+
+        let fs = FakeFs::new(cx.executor());
+        let long_line = format!("prefix needle {}", "x".repeat(1000));
+        fs.insert_tree(
+            path!("/root"),
+            serde_json::json!({
+                "minified.js": long_line,
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+        let input = GrepToolInput {
+            regex: "needle".to_string(),
+            include_pattern: None,
+            offset: 0,
+            case_sensitive: false,
+        };
+
+        let result = run_grep_tool(input, project.clone(), cx).await;
+        assert!(result.contains("prefix needle"), "Should contain match prefix");
+        assert!(result.contains("... [truncated"), "Should contain truncation notice");
+        assert!(result.len() < 800, "Output should be bounded in length");
+    }
+
+    #[gpui::test]
+    async fn test_grep_tool_caps_output_bytes(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.executor().allow_parking();
+
+        let fs = FakeFs::new(cx.executor());
+        let lines: Vec<String> = (0..500)
+            .map(|i| format!("line {i} needle {}", "a".repeat(400)))
+            .collect();
+        fs.insert_tree(
+            path!("/root"),
+            serde_json::json!({
+                "large.txt": lines.join("\n"),
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+        let input = GrepToolInput {
+            regex: "needle".to_string(),
+            include_pattern: None,
+            offset: 0,
+            case_sensitive: false,
+        };
+
+        let result = run_grep_tool(input, project.clone(), cx).await;
+        assert!(
+            result.contains("Output limit reached"),
+            "Should contain output limit notice, got: {result}"
+        );
+        assert!(
+            result.len() <= MAX_OUTPUT_BYTES + 4096,
+            "Output size should be capped near MAX_OUTPUT_BYTES"
         );
     }
 


### PR DESCRIPTION
# Objective

Fixes #63237
Relates to #59401

Prevent the agent `grep` tool from blowing up the model's context window (e.g. triggering HTTP 400 `The input token count exceeds the maximum number of tokens allowed` or `The input is longer than the model's context length`) when matching lines in minified files, single-line data files (JSON, CSV), or large search results.

## Problem

Unlike `terminal_tool.rs` which enforces `const COMMAND_OUTPUT_LIMIT: u64 = 16 * 1024` (16 KB) with truncation indicators, `grep_tool.rs` previously had no per-line column limit and no tool output byte ceiling.

When a search pattern matches a line in a minified bundle, source map, or single-line JSON data file, `snapshot.text_for_range(range)` yields the entire line—sometimes megabytes in length. This output is injected raw into both the tool card content and the prompt history, immediately exceeding provider context window limits and permanently bricking the agent thread (#63237, #59401).

## Solution

1. **Per-line truncation (`MAX_LINE_LEN = 500`)**: Added `format_snippet` to clamp lines to 500 characters (following ripgrep's `--max-columns` pattern) on a valid UTF-8 boundary (`floor_char_boundary`), appending `... [truncated X chars]`.
2. **Output byte ceiling (`MAX_OUTPUT_BYTES = 64 * 1024`)**: If cumulative output across matches reaches 64 KB, the tool stops collecting further matches, appends an output limit notice, and marks `has_more_matches = true` so the model receives a standard paginated response.
3. **Tests**: Added unit tests in `grep_tool.rs` verifying that oversized lines are truncated and output size remains bounded.

## Testing

- Ran `cargo check -p agent --tests` to verify compilation and schema compliance.
- Added `test_grep_tool_truncates_long_lines` and `test_grep_tool_caps_output_bytes`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed agent grep tool blowing up context window when matching long lines or large search results