### PR TITLE
docs: Clarify anonymous remote MCP setup

### DIFF
--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -72,7 +72,29 @@ You can connect both local and remote MCP servers from **Settings → AI → MCP
 }
 ```
 
-> Note: When a remote MCP server has no configured `"Authorization"` header, Zed will prompt you to authenticate yourself against the MCP server using the standard MCP OAuth flow.
+> **Note:** Remote MCP servers can allow anonymous connections. Without a configured `"Authorization"` header, Zed uses the standard MCP OAuth flow when the server requires authentication.
+
+#### Anonymous Remote Servers {#anonymous-remote-servers}
+
+For example, [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides `web_search` and `web_fetch` without a Parallel account or API key. Free access is rate limited.
+
+In **Settings → AI → MCP Servers**, choose **Add Server → Add Remote Server**, enter `parallel-search` as the name and `https://search.parallel.ai/mcp` as the URL, and leave the headers empty.
+
+Or merge this entry into `context_servers` in your settings file:
+
+```json [settings]
+{
+  "context_servers": {
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+Once connected, the agent can use these tools subject to your [tool permissions](./tool-permissions.md). Tool calls send queries, requested URLs, and any supplied objectives or context to Parallel. Zed's existing `User-Agent` identifies the application and its version, allowing Parallel to measure aggregate usage from Zed.
+
+To disconnect, remove the `parallel-search` entry from your settings file. Adding this server does not change your built-in tools or other configured servers.
 
 ## Using MCP Servers
 


### PR DESCRIPTION
# Objective

Zed connects to MCP servers to give its agent extra tools, such as web search or fetching a page. For a remote server, you add its URL under `context_servers`; authentication headers are optional.

The guide said that leaving out the Authorization header would trigger OAuth. That makes anonymous servers look like they need a login. Zed already supports them: a fresh connection can proceed without credentials, and a server response of HTTP 401 tells Zed authentication is needed. Existing transport and server-store tests check that a 401 moves the connection into an authentication-required state.

## Solution

Updates the guide to explain when authentication is needed and adds Parallel Search as a concrete anonymous example. Readers can add `https://search.parallel.ai/mcp` through Settings or copy the URL-only JSON to get `web_search` and `web_fetch`, without a Parallel account or API key.

The example also explains rate limits, how to disconnect, and what tool calls send to Parallel: queries, URLs, and supplied context. It documents Zed's existing versioned User-Agent, which lets Parallel measure aggregate usage from Zed. This changes the setup instructions only; the client, built-in tools, other servers, and tool permissions keep their existing behavior.

I work at Parallel, which operates this service.

## Testing

Verified the exact configuration in Zed 1.19.2 on macOS, including tool discovery, live search and fetch results, approval prompts, and removal of the server. A local deterministic chat fixture drove the tool calls. Separate request capture confirmed the existing Zed User-Agent and no Authorization header.

`script/prettier`, diff checks, and documentation link checks passed. Full source and mdBook builds were not run; runtime validation used the released app. Downstream analytics were not checked.

Release Notes:

- N/A
