### PR TITLE
Add an option to keep title bar menus inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -616,6 +616,8 @@
     "show_sign_in": true,
     // Whether to show the menus in the titlebar.
     "show_menus": false,
+    // Whether to keep visible menus on the same row as other titlebar items.
+    "inline_menus": false,
     // The layout of window control buttons in the title bar (Linux only).
     "button_layout": "platform_default",
   },

--- a/crates/settings_content/src/title_bar.rs
+++ b/crates/settings_content/src/title_bar.rs
@@ -119,6 +119,11 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_menus: Option<bool>,
+    /// Whether to keep menus on the same row as other title bar items when
+    /// `show_menus` is enabled (Windows and Linux only).
+    ///
+    /// Default: false
+    pub inline_menus: Option<bool>,
     /// The layout of window control buttons in the title bar (Linux only).
     ///
     /// This can be set to "platform_default" to follow the system configuration, or

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4252,7 +4252,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn title_bar_section() -> [SettingsPageItem; 11] {
+    fn title_bar_section() -> [SettingsPageItem; 12] {
         [
             SettingsPageItem::SectionHeader("Title Bar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4445,6 +4445,25 @@ fn window_and_layout_page() -> SettingsPage {
                             .title_bar
                             .get_or_insert_default()
                             .show_menus = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Inline Menus",
+                description: "Keep menus on the same row as other title bar items when Show Menus is enabled (Windows and Linux only).",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("title_bar.inline_menus"),
+                    pick: |settings_content| {
+                        settings_content.title_bar.as_ref()?.inline_menus.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .title_bar
+                            .get_or_insert_default()
+                            .inline_menus = value;
                     },
                 }),
                 metadata: None,

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -242,6 +242,8 @@ impl Render for TitleBar {
         let is_git_enabled = ProjectSettings::get_global(cx).git.enabled.status;
 
         let show_menus = show_menus(cx);
+        let inline_menus = show_menus && title_bar_settings.inline_menus;
+        let separate_menu_row = show_menus && !inline_menus;
 
         let mut children = <ArrayVec<_, 5>>::new();
 
@@ -315,15 +317,15 @@ impl Render for TitleBar {
                         || title_bar_settings.show_project_items;
                     title_bar
                         .when_some(
-                            self.application_menu.clone().filter(|_| !show_menus),
+                            self.application_menu.clone().filter(|_| !separate_menu_row),
                             |title_bar, menu| {
                                 // Hide the project/branch items to make room when the
-                                // menu bar is expanded -- except in accessible mode,
-                                // where the menu bar is always expanded but those
-                                // controls must still remain reachable.
+                                // menu bar is temporarily expanded. Permanently inline
+                                // menus must leave those controls reachable.
                                 render_project_items &= !menu
                                     .update(cx, |menu, cx| menu.all_menus_shown(cx))
-                                    || cx.accessible_mode();
+                                    || cx.accessible_mode()
+                                    || inline_menus;
                                 title_bar.child(menu)
                             },
                         )
@@ -409,7 +411,7 @@ impl Render for TitleBar {
                 .into_any_element(),
         );
 
-        if show_menus {
+        if separate_menu_row {
             self.platform_titlebar.update(cx, |this, _| {
                 this.set_button_layout(button_layout);
                 this.set_children(

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -12,6 +12,7 @@ pub struct TitleBarSettings {
     pub show_sign_in: bool,
     pub show_user_menu: bool,
     pub show_menus: bool,
+    pub inline_menus: bool,
     pub button_layout: Option<WindowButtonLayout>,
 }
 
@@ -28,6 +29,7 @@ impl Settings for TitleBarSettings {
             show_sign_in: content.show_sign_in.unwrap(),
             show_user_menu: content.show_user_menu.unwrap(),
             show_menus: content.show_menus.unwrap(),
+            inline_menus: content.inline_menus.unwrap_or(false),
             button_layout: content.button_layout.unwrap_or_default().into_layout(),
         }
     }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5257,6 +5257,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "show_user_menu": true,
     "show_sign_in": true,
     "show_menus": false,
+    "inline_menus": false,
     "button_layout": "platform_default"
   }
 }
@@ -5273,6 +5274,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 - `show_user_menu`: Whether to show the user menu button in the titlebar (the one that displays your avatar by default and contains options like Settings, Keymap, Themes, etc.)
 - `show_sign_in`: Whether to show the sign in button in the titlebar
 - `show_menus`: Whether to show the menus in the titlebar
+- `inline_menus`: Whether to keep menus on the same row as other titlebar items when `show_menus` is enabled (Windows and Linux only). This does not enable accessible mode or change menu interactions.
 - `button_layout`: The layout of window control buttons in the title bar (Linux only). Can be set to `"platform_default"` to follow the system setting, `"standard"` to use Zed's built-in layout, or a custom format like `"close:minimize,maximize"`
 
 ## Window Title Format


### PR DESCRIPTION
# Objective

- Currently when enabling "Show Menus" the Title Bar has two rows. I personally wanted an option to have this in only one row.
- So this PR adds the setting for that and basically gets that behavior from the accessible mode.
- And to be honest: This code was written by AI, because i don't really know Rust - i took a look at it and imo it looks good, but let me know if there are changes needed.

## Solution

When `title_bar.show_menus` is enabled, Zed currently renders the application
menu in a separate title bar row. This adds the opt-in
`title_bar.inline_menus` setting so menus stay on the same row as the other
title bar items. Project and branch controls remain reachable, matching the
existing Accessible Mode layout.

The setting is available in the Settings Editor under Window and Layout and is
documented in the settings reference. The default remains `false`.

## Testing

- Did you test these changes? If so, how?
    - AI used these commands to check code-wise:
        - `cargo check -p title_bar -p settings_ui --locked --offline`
        - `cargo test -p title_bar -p settings_ui --lib --locked --offline` (65 passed)
        - `cargo build -p zed --bin zed --locked --offline`
        - `cargo fmt -p title_bar -p settings_ui -- --check`
    - I did some visual testing, there also is a screen recording below. 
- Are there any parts that need more testing?
    - Maybe testing on small screens, but i think the behavior would be the same as in my resizing done in the screen-recording
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>View Screen-Recording</summary>

<img width="720" height="480" alt="ZED_Showcase" src="https://github.com/user-attachments/assets/5c3ae684-31af-4b6d-a14a-5b68e2db36b5" />

</details>

---

Release Notes:

- Added `title_bar.inline_menus` to keep always-visible menus on the same row as other title bar items on Windows and Linux.
