### PR TITLE
editor: Skip punctuation when selecting next/previous syntax node

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -39562,6 +39562,63 @@ async fn test_select_next_prev_syntax_node(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_next_prev_syntax_node_skips_punctuation(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "JavaScript".into(),
+            ..Default::default()
+        },
+        Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
+    ));
+
+    let text = "let a = { alice: 1, bob: [2, 3] };";
+
+    let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(language, cx));
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
+
+    // Stepping between the properties of an object should not stop on the comma
+    // that separates them.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 10)..DisplayPoint::new(DisplayRow(0), 18)
+            ]);
+        });
+        editor.select_next_syntax_node(&SelectNextSyntaxNode, window, cx);
+    });
+    editor.update(cx, |editor, cx| {
+        assert_text_with_selections(editor, "let a = { alice: 1, «bob: [2, 3]ˇ» };", cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.select_prev_syntax_node(&SelectPreviousSyntaxNode, window, cx);
+    });
+    editor.update(cx, |editor, cx| {
+        assert_text_with_selections(editor, "let a = { «alice: 1ˇ», bob: [2, 3] };", cx);
+    });
+
+    // The same holds for the elements of an array.
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 26)..DisplayPoint::new(DisplayRow(0), 27)
+            ]);
+        });
+        editor.select_next_syntax_node(&SelectNextSyntaxNode, window, cx);
+    });
+    editor.update(cx, |editor, cx| {
+        assert_text_with_selections(editor, "let a = { alice: 1, bob: [2, «3ˇ»] };", cx);
+    });
+}
+
+#[gpui::test]
 async fn test_next_prev_document_highlight(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4586,15 +4586,20 @@ impl BufferSnapshot {
         result
     }
 
-    /// Find the previous sibling syntax node at the given range.
+    /// Find the previous named sibling syntax node at the given range.
     ///
     /// This function locates the syntax node that precedes the node containing
     /// the given range. It searches hierarchically by:
     /// 1. Finding the node that contains the given range
-    /// 2. Looking for the previous sibling at the same tree level
+    /// 2. Looking for the previous named sibling at the same tree level
     /// 3. If no sibling is found, moving up to parent levels and searching for siblings
     ///
-    /// Returns `None` if there is no previous sibling at any ancestor level.
+    /// Anonymous nodes such as punctuation, delimiters and keywords are
+    /// skipped, so that stepping between siblings settles on the same nodes
+    /// that `SelectLargerSyntaxNode` settles on. If every remaining sibling at
+    /// a level is anonymous, the search continues at the parent level.
+    ///
+    /// Returns `None` if there is no previous named sibling at any ancestor level.
     pub fn syntax_prev_sibling<'a, T: ToOffset>(
         &'a self,
         range: Range<T>,
@@ -4618,6 +4623,12 @@ impl BufferSnapshot {
                 if cursor.goto_previous_sibling() {
                     let layer_result = cursor.node();
 
+                    // Punctuation and other anonymous tokens aren't nodes a
+                    // reader thinks in terms of, so keep scanning past them.
+                    if !layer_result.is_named() {
+                        continue;
+                    }
+
                     if let Some(previous_result) = &result {
                         if previous_result.byte_range().end < layer_result.byte_range().end {
                             continue;
@@ -4637,15 +4648,20 @@ impl BufferSnapshot {
         result
     }
 
-    /// Find the next sibling syntax node at the given range.
+    /// Find the next named sibling syntax node at the given range.
     ///
     /// This function locates the syntax node that follows the node containing
     /// the given range. It searches hierarchically by:
     /// 1. Finding the node that contains the given range
-    /// 2. Looking for the next sibling at the same tree level
+    /// 2. Looking for the next named sibling at the same tree level
     /// 3. If no sibling is found, moving up to parent levels and searching for siblings
     ///
-    /// Returns `None` if there is no next sibling at any ancestor level.
+    /// Anonymous nodes such as punctuation, delimiters and keywords are
+    /// skipped, so that stepping between siblings settles on the same nodes
+    /// that `SelectLargerSyntaxNode` settles on. If every remaining sibling at
+    /// a level is anonymous, the search continues at the parent level.
+    ///
+    /// Returns `None` if there is no next named sibling at any ancestor level.
     pub fn syntax_next_sibling<'a, T: ToOffset>(
         &'a self,
         range: Range<T>,
@@ -4668,6 +4684,12 @@ impl BufferSnapshot {
             loop {
                 if cursor.goto_next_sibling() {
                     let layer_result = cursor.node();
+
+                    // Punctuation and other anonymous tokens aren't nodes a
+                    // reader thinks in terms of, so keep scanning past them.
+                    if !layer_result.is_named() {
+                        continue;
+                    }
 
                     if let Some(previous_result) = &result {
                         if previous_result.byte_range().start > layer_result.byte_range().start {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2034,6 +2034,115 @@ fn test_range_for_syntax_ancestor(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_range_for_syntax_siblings(cx: &mut App) {
+    cx.new(|cx| {
+        let text = r#"{"alice": 1, "bob": [2, 3], "carol": {"x": 4}}"#;
+        let buffer = Buffer::local(text, cx).with_language(json_lang(), cx);
+        let snapshot = buffer.snapshot();
+
+        // Stepping between the members of an object skips the separating commas.
+        assert_eq!(
+            snapshot
+                .syntax_next_sibling(range_of(text, r#""alice": 1"#))
+                .unwrap()
+                .byte_range(),
+            range_of(text, r#""bob": [2, 3]"#)
+        );
+        assert_eq!(
+            snapshot
+                .syntax_prev_sibling(range_of(text, r#""carol": {"x": 4}"#))
+                .unwrap()
+                .byte_range(),
+            range_of(text, r#""bob": [2, 3]"#)
+        );
+
+        // The same holds for the elements of an array.
+        assert_eq!(
+            snapshot
+                .syntax_next_sibling(range_of(text, "2"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "3")
+        );
+        assert_eq!(
+            snapshot
+                .syntax_prev_sibling(range_of(text, "3"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "2")
+        );
+
+        // Starting from a comma still lands on the members around it.
+        assert_eq!(
+            snapshot
+                .syntax_next_sibling(range_of(text, ","))
+                .unwrap()
+                .byte_range(),
+            range_of(text, r#""bob": [2, 3]"#)
+        );
+
+        // The last member has no named sibling left, at any ancestor level.
+        assert_eq!(
+            snapshot.syntax_next_sibling(range_of(text, r#""carol": {"x": 4}"#)),
+            None
+        );
+
+        buffer
+    });
+
+    cx.new(|cx| {
+        let text = "// a comment\nfn f(a: u32, b: u32) {\n    let x = 1;\n}\nfn g() {}";
+        let buffer = Buffer::local(text, cx).with_language(rust_lang(), cx);
+        let snapshot = buffer.snapshot();
+
+        // Function parameters are separated by commas too.
+        assert_eq!(
+            snapshot
+                .syntax_next_sibling(range_of(text, "a: u32"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "b: u32")
+        );
+
+        // Comments are named nodes, so they stay reachable.
+        assert_eq!(
+            snapshot
+                .syntax_prev_sibling(range_of(text, "fn f"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "// a comment")
+        );
+
+        // A level whose remaining siblings are all anonymous is not a stopping
+        // point: the search continues at the parent level, the same way it
+        // already did for a level with no siblings at all. So the only
+        // statement of a body steps out to the next item rather than to `}`,
+        // and symmetrically backwards to the parameter list rather than `{`.
+        assert_eq!(
+            snapshot
+                .syntax_next_sibling(range_of(text, "let x = 1;"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "fn g() {}")
+        );
+        assert_eq!(
+            snapshot
+                .syntax_prev_sibling(range_of(text, "let x = 1;"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "(a: u32, b: u32)")
+        );
+
+        buffer
+    });
+
+    fn range_of(text: &str, part: &str) -> Range<usize> {
+        let start = text.find(part).unwrap();
+        start..start + part.len()
+    }
+}
+
+#[gpui::test]
 fn test_autoindent_with_soft_tabs(cx: &mut App) {
     init_settings(cx, |_| {});
 


### PR DESCRIPTION
# Objective

Fixes #63810.

`editor::SelectLargerSyntaxNode` skips anonymous syntax nodes, but
`editor::SelectNextSyntaxNode` and `editor::SelectPreviousSyntaxNode` do not.
Stepping between the members of a JSON object, the elements of an array, or the
parameters of a function therefore stops on every separating comma, so each move
to the "next node" takes two presses and leaves an intermediate selection on
punctuation.

As @andrepd puts it in the issue: if the selection is an argument to a function,
pressing next/previous syntax node should move along *the arguments to that
function*.

## Solution

`syntax_next_sibling` and `syntax_prev_sibling` walk siblings with
`goto_next_sibling`/`goto_previous_sibling`, which visit anonymous tokens
(commas, colons, braces, keywords) along with named nodes. Skip the anonymous
ones, so the two actions settle on the same nodes the expand/shrink pair already
settles on.

The filter lives in `crates/language/src/buffer.rs` rather than in the editor
because those two functions are reached only from `select_next_syntax_node` and
`select_prev_syntax_node`, and both want the same notion of a node. Doing it
there is also a single cursor walk; filtering at the call site would mean
re-entering the function once per skipped token, each time re-walking the layer
from its root and re-crossing the multibuffer excerpt mapping.

### Behavior change worth reviewing

The existing "if no sibling is found, move up to parent levels" rule now fires in
cases where the walk previously stopped on a delimiter. Concretely, for

```rust
fn f(a: u32, b: u32) {
    let x = 1;
}
fn g() {}
```

`next` from `let x = 1;` used to return `}` and now returns `fn g() {}`;
symmetrically `prev` used to return `{` and now returns `(a: u32, b: u32)`.

I believe this is the intended direction rather than a side effect: the existing
`test_select_next_prev_syntax_node` already carries the comment *"Since `let a =
1;` has no siblings in the if block, it should move up to find `let b = 2;`"* —
and before this PR it did not, it selected `}`. The test passed only because its
assertion is `assert_ne!`. Both tests pass either way, so I've pinned the ascent
explicitly in `test_range_for_syntax_siblings`.

The trade-off: because ascending changes level, `next` and `prev` are not
inverses across a boundary. Starting from `c` in `b(|c| {})`, `next` gives the
`{}` block and `prev` from there gives `|c|`, not `c`. That asymmetry existed
before at levels with no siblings at all; this PR makes those levels more
common. `crates/vim/src/visual.rs` repeats these actions `count` times, so N
forward then N back can land somewhere else. If you'd rather a level whose
remaining siblings are all anonymous be a dead end (return `None`, leaving the
selection put) instead of ascending, that is a one-line change — but it would
contradict the existing test's stated intent, so I did not make that call.

## Testing

`test_range_for_syntax_siblings` in `crates/language/src/buffer_tests.rs` covers
object members, array elements, function parameters, starting from a comma, the
last-member case that has no named sibling anywhere, that comments stay reachable
(they are named nodes), and the ascent described above.
`test_select_next_prev_syntax_node_skips_punctuation` in
`crates/editor/src/editor_tests.rs` covers the same thing through the actions.

I checked the tests discriminate rather than just pass: removing only the
`next`-side skip fails the first next assertion with the comma's range in place
of the member's; removing only the `prev`-side skip fails the first prev
assertion the same way; reverting both fails the editor test with `«,ˇ»`
selected.

Suites run on macOS (aarch64): `-p language --lib` 181 passed, `-p editor --lib`
1021 passed, `-p vim --lib` 569 passed, `cargo clippy -p language -p editor
--all-targets` clean.

Tested in a real build on **macOS 15.6.1 (aarch64)**, `cargo build -p zed`, opening
a JSON file and using the default `cmd-ctrl-down` binding. I have not tested on
Linux or Windows; nothing in the change is platform-specific.

Reviewers can reproduce with the file in the showcase below: put the cursor
inside `alice`, press `cmd-ctrl-right` three times to select the pair, then
`cmd-ctrl-down` once.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Performance: the walk visits the anonymous siblings it skips instead of stopping
at the first one, which is bounded by the number of children of the current node
and costs no extra allocation or tree re-entry.

## Showcase

```json
{
    "alice": 1,
    "bob": [2, 3],
    "carol": {"x": 4}
}
```

Starting with `"alice": 1` selected, one press of `cmd-ctrl-down`
(`editor::SelectNextSyntaxNode`):

**Before** — the selection lands on the comma, and the breadcrumb loses `alice`:

<img width="900" alt="before: the comma is selected" src="https://raw.githubusercontent.com/kakiuwang-ui/zed/img-63810/63810-before.png">

**After** — the selection lands on the next member:

<img width="900" alt="after: the next object member is selected" src="https://raw.githubusercontent.com/kakiuwang-ui/zed/img-63810/63810-after.png">

### Notes for review

- **Adjacent, not fixed:** when several syntax layers overlap the range (an
  injection, e.g. JS inside `<script>`), the multi-layer tie-break in both
  functions picks the wrong layer — `next` from `let x = 1;` inside a
  `<script>` block returns the host layer's `</script>` rather than the
  following statement. I confirmed this is unchanged by this PR (identical
  output before and after), so I left it alone rather than widening the diff.
  Happy to open a separate issue.
- The `continue` in the existing tie-break sits inside the sibling loop rather
  than the `for layer` loop, so it advances to a farther sibling instead of
  moving on to the next layer. That looks like the cause of the above, but I
  did not want to change layer-selection semantics in a punctuation fix.

---

Release Notes:

- Fixed `editor: select next/previous syntax node` stopping on punctuation such as the commas between object members or function arguments.
