### PR TITLE
Serialize Concurrent External Agent npm Installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11357,6 +11357,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
+ "tempfile",
  "util",
  "watch",
  "which",

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -36,5 +36,8 @@ which.workspace = true
 [target.'cfg(windows)'.dependencies]
 async-std.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [package.metadata.cargo-shear]
 ignored = ["async-std"]

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -46,6 +46,8 @@ pub enum VersionStrategy<'a> {
     Pin(&'a Version),
     /// Install if current version is older than latest version
     Latest(&'a Version),
+    /// Install if current version exceeds the maximum allowed version
+    Maximum(&'a Version),
 }
 
 #[derive(Clone)]
@@ -232,10 +234,14 @@ impl NodeRuntime {
         &self,
         directory: &Path,
         args: &[&str],
-    ) -> Result<Output> {
+        should_install: impl std::future::Future<Output = bool>,
+    ) -> Result<()> {
         let _install_lock = acquire_npm_install_lock(directory).await?;
-        self.run_npm_subcommand(Some(directory), "install", args)
-            .await
+        if should_install.await {
+            self.run_npm_subcommand(Some(directory), "install", args)
+                .await?;
+        }
+        Ok(())
     }
 
     pub async fn npm_package_installed_version(
@@ -403,6 +409,7 @@ impl NodeRuntime {
         let version_strategy_label = match &version_strategy {
             VersionStrategy::Pin(version) => format!("pin:{version}"),
             VersionStrategy::Latest(version) => format!("latest:{version}"),
+            VersionStrategy::Maximum(version) => format!("maximum:{version}"),
         };
         let should_install =
             should_install_npm_package_version(&installed_version, version_strategy);
@@ -438,6 +445,7 @@ fn should_install_npm_package_version(
     match version_strategy {
         VersionStrategy::Pin(pinned_version) => installed_version != pinned_version,
         VersionStrategy::Latest(latest_version) => installed_version < latest_version,
+        VersionStrategy::Maximum(maximum_version) => installed_version > maximum_version,
     }
 }
 
@@ -1250,6 +1258,7 @@ mod tests {
     struct ConcurrentNpmRuntime {
         active_installs: Arc<AtomicUsize>,
         maximum_concurrent_installs: Arc<AtomicUsize>,
+        completed_installs: Arc<AtomicUsize>,
     }
 
     #[async_trait]
@@ -1274,6 +1283,7 @@ mod tests {
                 .fetch_max(active_installs, Ordering::SeqCst);
             smol::future::yield_now().await;
             self.active_installs.fetch_sub(1, Ordering::SeqCst);
+            self.completed_installs.fetch_add(1, Ordering::SeqCst);
 
             Ok(Output {
                 status: ExitStatus::from_raw(0),
@@ -1304,6 +1314,7 @@ mod tests {
     fn concurrent_npm_runtime(
         active_installs: Arc<AtomicUsize>,
         maximum_concurrent_installs: Arc<AtomicUsize>,
+        completed_installs: Arc<AtomicUsize>,
     ) -> NodeRuntime {
         let options = NodeBinaryOptions::default();
         NodeRuntime(Arc::new(Mutex::new(NodeRuntimeState {
@@ -1311,6 +1322,7 @@ mod tests {
             instance: Some(Box::new(ConcurrentNpmRuntime {
                 active_installs,
                 maximum_concurrent_installs,
+                completed_installs,
             })),
             last_options: Some(options.clone()),
             options: watch::channel(Some(options)).1,
@@ -1319,27 +1331,50 @@ mod tests {
     }
 
     #[test]
-    fn test_npm_installs_are_serialized_per_directory() {
+    fn test_npm_installs_are_serialized_and_rechecked_per_directory() {
         smol::block_on(async {
             let temp_dir = tempfile::tempdir().unwrap();
             let active_installs = Arc::new(AtomicUsize::new(0));
             let maximum_concurrent_installs = Arc::new(AtomicUsize::new(0));
+            let completed_installs = Arc::new(AtomicUsize::new(0));
             let first_runtime = concurrent_npm_runtime(
                 active_installs.clone(),
                 maximum_concurrent_installs.clone(),
+                completed_installs.clone(),
             );
-            let second_runtime =
-                concurrent_npm_runtime(active_installs, maximum_concurrent_installs.clone());
+            let second_runtime = concurrent_npm_runtime(
+                active_installs,
+                maximum_concurrent_installs.clone(),
+                completed_installs.clone(),
+            );
+
+            let first_should_install = {
+                let completed_installs = completed_installs.clone();
+                async move { completed_installs.load(Ordering::SeqCst) == 0 }
+            };
+            let second_should_install = {
+                let completed_installs = completed_installs.clone();
+                async move { completed_installs.load(Ordering::SeqCst) == 0 }
+            };
 
             let (first_result, second_result) = future::join(
-                first_runtime.run_npm_install_with_lock(temp_dir.path(), &["test-package"]),
-                second_runtime.run_npm_install_with_lock(temp_dir.path(), &["test-package"]),
+                first_runtime.run_npm_install_with_lock(
+                    temp_dir.path(),
+                    &["test-package"],
+                    first_should_install,
+                ),
+                second_runtime.run_npm_install_with_lock(
+                    temp_dir.path(),
+                    &["test-package"],
+                    second_should_install,
+                ),
             )
             .await;
 
             first_result.unwrap();
             second_result.unwrap();
             assert_eq!(maximum_concurrent_installs.load(Ordering::SeqCst), 1);
+            assert_eq!(completed_installs.load(Ordering::SeqCst), 1);
         });
     }
 
@@ -1440,6 +1475,26 @@ mod tests {
         assert!(!should_install_npm_package_version(
             &Version::parse("3.0.0")?,
             VersionStrategy::Latest(&target_version)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_maximum_version_strategy_accepts_older_installed_versions() -> Result<()> {
+        let maximum_version = Version::parse("2.0.0")?;
+
+        assert!(!should_install_npm_package_version(
+            &Version::parse("2.0.0")?,
+            VersionStrategy::Maximum(&maximum_version)
+        ));
+        assert!(!should_install_npm_package_version(
+            &Version::parse("1.0.0")?,
+            VersionStrategy::Maximum(&maximum_version)
+        ));
+        assert!(should_install_npm_package_version(
+            &Version::parse("3.0.0")?,
+            VersionStrategy::Maximum(&maximum_version)
         ));
 
         Ok(())

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -228,6 +228,16 @@ impl NodeRuntime {
             .await
     }
 
+    pub async fn run_npm_install_with_lock(
+        &self,
+        directory: &Path,
+        args: &[&str],
+    ) -> Result<Output> {
+        let _install_lock = acquire_npm_install_lock(directory).await?;
+        self.run_npm_subcommand(Some(directory), "install", args)
+            .await
+    }
+
     pub async fn npm_package_installed_version(
         &self,
         local_package_directory: &Path,
@@ -401,6 +411,24 @@ impl NodeRuntime {
         );
         should_install
     }
+}
+
+async fn acquire_npm_install_lock(directory: &Path) -> Result<std::fs::File> {
+    let lock_path = directory.join(".zed-npm-install.lock");
+    smol::unblock(move || {
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("opening npm install lock {}", lock_path.display()))?;
+        lock_file
+            .lock()
+            .with_context(|| format!("acquiring npm install lock {}", lock_path.display()))?;
+        Ok(lock_file)
+    })
+    .await
 }
 
 fn should_install_npm_package_version(
@@ -1190,16 +1218,130 @@ pub fn npm_command_env(node_binary: &Path) -> HashMap<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{
+        path::{Path, PathBuf},
+        process::{ExitStatus, Output},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt as _;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt as _;
 
     use anyhow::{Result, bail};
+    use async_trait::async_trait;
+    use futures::{FutureExt as _, channel::oneshot, future};
+    use http_client::BlockedHttpClient;
     use http_client::Url;
     use semver::{Version, VersionReq};
+    use smol::lock::Mutex;
 
     use super::{
-        NpmInfo, VersionStrategy, build_npm_command_args, deserialize_npm_info_from_response,
+        NodeBinaryOptions, NodeRuntime, NodeRuntimeState, NodeRuntimeTrait, NpmCommand, NpmInfo,
+        VersionStrategy, build_npm_command_args, deserialize_npm_info_from_response,
         proxy_argument, select_npm_package_version, should_install_npm_package_version,
     };
+
+    #[derive(Clone)]
+    struct ConcurrentNpmRuntime {
+        active_installs: Arc<AtomicUsize>,
+        maximum_concurrent_installs: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl NodeRuntimeTrait for ConcurrentNpmRuntime {
+        fn boxed_clone(&self) -> Box<dyn NodeRuntimeTrait> {
+            Box::new(self.clone())
+        }
+
+        fn binary_path(&self) -> Result<PathBuf> {
+            Ok(PathBuf::from("node"))
+        }
+
+        async fn run_npm_subcommand(
+            &self,
+            _directory: Option<&Path>,
+            _proxy: Option<&Url>,
+            _subcommand: &str,
+            _args: &[&str],
+        ) -> Result<Output> {
+            let active_installs = self.active_installs.fetch_add(1, Ordering::SeqCst) + 1;
+            self.maximum_concurrent_installs
+                .fetch_max(active_installs, Ordering::SeqCst);
+            smol::future::yield_now().await;
+            self.active_installs.fetch_sub(1, Ordering::SeqCst);
+
+            Ok(Output {
+                status: ExitStatus::from_raw(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        }
+
+        async fn npm_command(
+            &self,
+            _prefix_dir: Option<&Path>,
+            _proxy: Option<&Url>,
+            _subcommand: &str,
+            _args: &[&str],
+        ) -> Result<NpmCommand> {
+            bail!("not used by this test")
+        }
+
+        async fn npm_package_installed_version(
+            &self,
+            _local_package_directory: &Path,
+            _name: &str,
+        ) -> Result<Option<Version>> {
+            bail!("not used by this test")
+        }
+    }
+
+    fn concurrent_npm_runtime(
+        active_installs: Arc<AtomicUsize>,
+        maximum_concurrent_installs: Arc<AtomicUsize>,
+    ) -> NodeRuntime {
+        let options = NodeBinaryOptions::default();
+        NodeRuntime(Arc::new(Mutex::new(NodeRuntimeState {
+            http: Arc::new(BlockedHttpClient),
+            instance: Some(Box::new(ConcurrentNpmRuntime {
+                active_installs,
+                maximum_concurrent_installs,
+            })),
+            last_options: Some(options.clone()),
+            options: watch::channel(Some(options)).1,
+            shell_env_loaded: oneshot::channel().1.shared(),
+        })))
+    }
+
+    #[test]
+    fn test_npm_installs_are_serialized_per_directory() {
+        smol::block_on(async {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let active_installs = Arc::new(AtomicUsize::new(0));
+            let maximum_concurrent_installs = Arc::new(AtomicUsize::new(0));
+            let first_runtime = concurrent_npm_runtime(
+                active_installs.clone(),
+                maximum_concurrent_installs.clone(),
+            );
+            let second_runtime =
+                concurrent_npm_runtime(active_installs, maximum_concurrent_installs.clone());
+
+            let (first_result, second_result) = future::join(
+                first_runtime.run_npm_install_with_lock(temp_dir.path(), &["test-package"]),
+                second_runtime.run_npm_install_with_lock(temp_dir.path(), &["test-package"]),
+            )
+            .await;
+
+            first_result.unwrap();
+            second_result.unwrap();
+            assert_eq!(maximum_concurrent_installs.load(Ordering::SeqCst), 1);
+        });
+    }
 
     // Map localhost to 127.0.0.1
     // NodeRuntime without environment information can not parse `localhost` correctly.

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1392,11 +1392,7 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
 
             let (package_name, package_spec) = bounded_npm_package_spec(&package);
             node_runtime
-                .run_npm_subcommand(
-                    Some(&install_dir),
-                    "install",
-                    &[package_spec.as_str(), "--save-exact"],
-                )
+                .run_npm_install_with_lock(&install_dir, &[package_spec.as_str(), "--save-exact"])
                 .await?;
             let executable = node_runtime::read_package_executable(
                 install_dir.join("node_modules"),

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1390,9 +1390,34 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
                 .join(sanitize_path_component(&registry_id));
             fs.create_dir(&install_dir).await?;
 
-            let (package_name, package_spec) = bounded_npm_package_spec(&package);
+            let (package_name, package_spec, maximum_version) = bounded_npm_package_spec(&package);
+            let should_install = async {
+                let Some(maximum_version) = maximum_version.as_ref() else {
+                    return true;
+                };
+                let Ok(executable) = node_runtime::read_package_executable(
+                    install_dir.join("node_modules"),
+                    package_name,
+                )
+                .await
+                else {
+                    return true;
+                };
+                node_runtime
+                    .should_install_npm_package(
+                        package_name,
+                        &executable,
+                        &install_dir,
+                        node_runtime::VersionStrategy::Maximum(maximum_version),
+                    )
+                    .await
+            };
             node_runtime
-                .run_npm_install_with_lock(&install_dir, &[package_spec.as_str(), "--save-exact"])
+                .run_npm_install_with_lock(
+                    &install_dir,
+                    &[package_spec.as_str(), "--save-exact"],
+                    should_install,
+                )
                 .await?;
             let executable = node_runtime::read_package_executable(
                 install_dir.join("node_modules"),
@@ -1449,18 +1474,22 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
 /// strips during parsing. PS only re-adds CRT-style transport quotes around native command args
 /// containing whitespace, so `package@<=0.25.3` reaches cmd.exe bare and the unquoted `<` is
 /// interpreted as input redirection. See zed-industries/zed#55921.
-fn bounded_npm_package_spec(package_spec: &str) -> (&str, String) {
+fn bounded_npm_package_spec(package_spec: &str) -> (&str, String, Option<Version>) {
     let Some((package_name, version)) = package_spec.rsplit_once('@') else {
-        return (package_spec, package_spec.to_string());
+        return (package_spec, package_spec.to_string(), None);
     };
     if package_name.is_empty() {
-        return (package_spec, package_spec.to_string());
+        return (package_spec, package_spec.to_string(), None);
     }
-    if Version::parse(version).is_err() {
-        return (package_name, package_spec.to_string());
-    }
+    let Ok(version) = Version::parse(version) else {
+        return (package_name, package_spec.to_string(), None);
+    };
 
-    (package_name, format!("{package_name}@0.0.0 - {version}"))
+    (
+        package_name,
+        format!("{package_name}@0.0.0 - {version}"),
+        Some(version),
+    )
 }
 
 struct LocalCustomAgent {
@@ -1834,22 +1863,31 @@ mod tests {
     fn builds_bounded_npm_package_specs() {
         assert_eq!(
             bounded_npm_package_spec("agent-package@1.2.3"),
-            ("agent-package", "agent-package@0.0.0 - 1.2.3".to_string())
+            (
+                "agent-package",
+                "agent-package@0.0.0 - 1.2.3".to_string(),
+                Some(Version::parse("1.2.3").unwrap())
+            )
         );
         assert_eq!(
             bounded_npm_package_spec("@scope/agent-package@1.2.3-beta.1"),
             (
                 "@scope/agent-package",
-                "@scope/agent-package@0.0.0 - 1.2.3-beta.1".to_string()
+                "@scope/agent-package@0.0.0 - 1.2.3-beta.1".to_string(),
+                Some(Version::parse("1.2.3-beta.1").unwrap())
             )
         );
         assert_eq!(
             bounded_npm_package_spec("@scope/agent-package"),
-            ("@scope/agent-package", "@scope/agent-package".to_string())
+            (
+                "@scope/agent-package",
+                "@scope/agent-package".to_string(),
+                None
+            )
         );
         assert_eq!(
             bounded_npm_package_spec("agent-package@latest"),
-            ("agent-package", "agent-package@latest".to_string())
+            ("agent-package", "agent-package@latest".to_string(), None)
         );
     }
 


### PR DESCRIPTION
# Objective

Fixes #63743.

Concurrent external-agent panel launches can start npm installs in the same target directory. On Windows, those installs can collide while renaming or deleting shared files and leave agents stuck loading.

## Solution

- Serialize npm installs per target directory with a separate OS-locked file. The lock handle is released automatically if its owning process exits.
- Recheck the installed executable and package version after acquiring the lock, so waiting panels reuse a compatible completed install instead of running npm again.
- Preserve the existing error path for lock and npm failures.

## Testing

- `cargo test -p node_runtime`
- `cargo test -p project agent_server_store --lib`
- `cargo check -p project`
- `cargo clippy -p node_runtime -p project --release --all-targets --all-features -- --deny warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The concurrency regression test launches two independent `NodeRuntime` instances against the same directory. With the lock temporarily removed, it fails after observing two concurrent installs. With this change, maximum concurrency is one and only one install completes because the second caller's post-lock recheck skips redundant work.

Tested on Windows. Manual concurrent Claude Agent launches both eventually completed, so the nondeterministic full UI hang was not observed locally. The deterministic regression test directly exercises the reported install race.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed external agents hanging during concurrent package installation.