### PR TITLE
opencode: Sync bundled Go models with registry (8 new models, fix grok-4.6 availability)

### DIFF
--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use collections::BTreeMap;
 use credentials_provider::CredentialsProvider;
 use fs::Fs;
-use futures::{FutureExt, StreamExt, future::BoxFuture};
+use futures::{AsyncReadExt, FutureExt, StreamExt, future::BoxFuture};
 use gpui::{App, AsyncApp, Context, Entity, SharedString, Task, TaskExt, Window};
-use http_client::{AsyncBody, CustomHeaders, HttpClient, http};
+use http_client::{AsyncBody, CustomHeaders, HttpClient, RequestBuilderExt, http};
 use language_model::{
     ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, InlineDescription, LanguageModel,
     LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelEffortLevel,
@@ -67,6 +67,215 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 const OPENCODE_SESSION_HEADER_NAME: &str = "x-opencode-session";
 pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &[OPENCODE_SESSION_HEADER_NAME];
 
+/// The models.dev registry, which OpenCode keeps up to date with newly
+/// released models for its Zen and Go subscriptions.
+const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryProvider {
+    #[serde(default)]
+    npm: Option<String>,
+    #[serde(default)]
+    models: BTreeMap<String, RegistryModel>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryModel {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    family: Option<String>,
+    #[serde(default)]
+    reasoning_options: Vec<RegistryReasoningOption>,
+    #[serde(default)]
+    interleaved: Option<RegistryInterleaved>,
+    #[serde(default)]
+    modalities: Option<RegistryModalities>,
+    #[serde(default)]
+    limit: Option<RegistryLimit>,
+    #[serde(default)]
+    provider: Option<RegistryModelProvider>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize)]
+struct RegistryReasoningOption {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    values: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryInterleaved {
+    #[serde(default)]
+    field: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryModalities {
+    #[serde(default)]
+    input: Option<Vec<String>>,
+    #[serde(default)]
+    output: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryLimit {
+    #[serde(default)]
+    context: Option<u64>,
+    #[serde(default)]
+    output: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+struct RegistryModelProvider {
+    #[serde(default)]
+    npm: Option<String>,
+}
+
+impl RegistryModel {
+    /// Converts a registry model into a custom OpenCode model, resolving the
+    /// API protocol from the registry's per-model SDK, the model family, and
+    /// finally the provider-level SDK default.
+    fn into_custom(self, id: String, provider_npm: Option<&str>) -> Option<opencode::Model> {
+        let protocol = self
+            .provider
+            .as_ref()
+            .and_then(|provider| provider.npm.as_deref())
+            .and_then(protocol_from_npm)
+            .or_else(|| self.family.as_deref().and_then(protocol_from_family))
+            .or_else(|| provider_npm.and_then(protocol_from_npm))
+            .unwrap_or(ApiProtocol::OpenAiChat);
+        Some(opencode::Model::Custom {
+            name: id,
+            display_name: self.name,
+            max_tokens: self
+                .limit
+                .as_ref()
+                .and_then(|limit| limit.context)
+                .unwrap_or(128_000),
+            max_output_tokens: self.limit.as_ref().and_then(|limit| limit.output),
+            protocol,
+            reasoning_effort_levels: registry_reasoning_effort_levels(&self.reasoning_options),
+            custom_model_api_url: None,
+            interleaved_reasoning: self.interleaved.is_some_and(|interleaved| {
+                interleaved.field.as_deref() == Some("reasoning_content")
+            }),
+        })
+    }
+}
+
+fn protocol_from_npm(npm: &str) -> Option<ApiProtocol> {
+    match npm {
+        "@ai-sdk/anthropic" => Some(ApiProtocol::Anthropic),
+        "@ai-sdk/openai" => Some(ApiProtocol::OpenAiResponses),
+        "@ai-sdk/google" => Some(ApiProtocol::Google),
+        "@ai-sdk/openai-compatible" => Some(ApiProtocol::OpenAiChat),
+        _ => None,
+    }
+}
+
+fn protocol_from_family(family: &str) -> Option<ApiProtocol> {
+    let family = family.to_ascii_lowercase();
+    if family.starts_with("claude") {
+        Some(ApiProtocol::Anthropic)
+    } else if family.starts_with("gpt") || family.starts_with("grok") || family.starts_with("muse")
+    {
+        Some(ApiProtocol::OpenAiResponses)
+    } else if family.starts_with("gemini") {
+        Some(ApiProtocol::Google)
+    } else if family.starts_with("qwen") {
+        Some(ApiProtocol::Anthropic)
+    } else if family.starts_with("deepseek")
+        || family.starts_with("glm")
+        || family.starts_with("kimi")
+        || family.starts_with("minimax")
+        || family.starts_with("mimo")
+        || family.starts_with("hy")
+        || family.starts_with("longcat")
+    {
+        Some(ApiProtocol::OpenAiChat)
+    } else {
+        None
+    }
+}
+
+fn registry_reasoning_effort_levels(
+    options: &[RegistryReasoningOption],
+) -> Option<Vec<ReasoningEffort>> {
+    let effort_levels: Vec<ReasoningEffort> = options
+        .iter()
+        .filter(|option| option.kind.as_deref() == Some("effort"))
+        .flat_map(|option| option.values.iter().flatten())
+        .filter_map(|value| normalize_reasoning_effort(value))
+        .collect();
+    if !effort_levels.is_empty() {
+        Some(effort_levels)
+    } else if options
+        .iter()
+        .any(|option| option.kind.as_deref() == Some("toggle"))
+    {
+        // Toggle-only reasoning models can't express effort levels; enabling
+        // reasoning means requesting the highest effort (see Kimi K3).
+        Some(vec![ReasoningEffort::Max])
+    } else {
+        None
+    }
+}
+
+fn parse_registry_models(body: &str) -> Result<Vec<(OpenCodeSubscription, opencode::Model)>> {
+    let registry: serde_json::Value = serde_json::from_str(body)?;
+    let mut models = Vec::new();
+    for (provider_id, subscription) in [
+        ("opencode", OpenCodeSubscription::Zen),
+        ("opencode-go", OpenCodeSubscription::Go),
+    ] {
+        let Some(provider_value) = registry.get(provider_id) else {
+            log::warn!("OpenCode model registry is missing the {provider_id} provider");
+            continue;
+        };
+        let provider: RegistryProvider = match serde_json::from_value(provider_value.clone()) {
+            Ok(provider) => provider,
+            Err(error) => {
+                log::warn!(
+                    "failed to parse the {provider_id} provider in the OpenCode model registry: {error:?}"
+                );
+                continue;
+            }
+        };
+        let provider_npm = provider.npm.clone();
+        for (id, model) in provider.models {
+            if let Some(model) = model.into_custom(id, provider_npm.as_deref()) {
+                models.push((subscription, model));
+            }
+        }
+    }
+    Ok(models)
+}
+
+async fn fetch_registry_models(
+    http_client: &dyn HttpClient,
+    extra_headers: &CustomHeaders,
+) -> Result<Vec<(OpenCodeSubscription, opencode::Model)>> {
+    let request = http::Request::builder()
+        .method(http::Method::GET)
+        .uri(MODELS_DEV_API_URL)
+        .header("Content-Type", "application/json")
+        .extra_headers(extra_headers)
+        .body(AsyncBody::empty())?;
+    let mut response = http_client.send(request).await?;
+    let mut body = String::new();
+    response.body_mut().read_to_string(&mut body).await?;
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "failed to fetch the OpenCode model registry, status code: {:?}, body: {}",
+            response.status(),
+            body
+        ));
+    }
+    parse_registry_models(&body)
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct OpenCodeSettings {
     pub api_url: String,
@@ -74,6 +283,7 @@ pub struct OpenCodeSettings {
     pub custom_headers: CustomHeaders,
     pub show_zen_models: bool,
     pub show_go_models: bool,
+    pub fetch_registry_models: bool,
 }
 
 pub struct OpenCodeLanguageModelProvider {
@@ -84,6 +294,10 @@ pub struct OpenCodeLanguageModelProvider {
 pub struct State {
     api_key_state: ApiKeyState,
     credentials_provider: Arc<dyn CredentialsProvider>,
+    http_client: Arc<dyn HttpClient>,
+    registry_models: Option<Vec<(OpenCodeSubscription, opencode::Model)>>,
+    registry_fetch_task: Option<Task<()>>,
+    registry_fetch_attempted: bool,
 }
 
 impl State {
@@ -113,6 +327,39 @@ impl State {
             cx,
         )
     }
+
+    /// Fetches the models.dev registry so that newly released OpenCode models
+    /// show up without a Zed release. Built-in models take precedence; this
+    /// only fills in models that Zed doesn't bundle yet.
+    fn maybe_fetch_registry_models(&mut self, cx: &mut Context<Self>) {
+        if self.registry_fetch_attempted
+            || !OpenCodeLanguageModelProvider::settings(cx).fetch_registry_models
+        {
+            return;
+        }
+        self.registry_fetch_attempted = true;
+        let http_client = self.http_client.clone();
+        let extra_headers = OpenCodeLanguageModelProvider::settings(cx)
+            .custom_headers
+            .clone();
+        let task = cx.spawn(async move |this, cx| {
+            let registry_models = fetch_registry_models(http_client.as_ref(), &extra_headers).await;
+            this.update(cx, |state, cx| {
+                state.registry_fetch_task.take();
+                match registry_models {
+                    Ok(registry_models) => {
+                        state.registry_models = Some(registry_models);
+                        cx.notify();
+                    }
+                    Err(error) => {
+                        log::warn!("failed to fetch the OpenCode model registry: {error:?}");
+                    }
+                }
+            })
+            .ok();
+        });
+        self.registry_fetch_task = Some(task);
+    }
 }
 
 impl OpenCodeLanguageModelProvider {
@@ -137,8 +384,13 @@ impl OpenCodeLanguageModelProvider {
             State {
                 api_key_state: ApiKeyState::new(Self::api_url(cx), (*API_KEY_ENV_VAR).clone()),
                 credentials_provider,
+                http_client: http_client.clone(),
+                registry_models: None,
+                registry_fetch_task: None,
+                registry_fetch_attempted: false,
             }
         });
+        state.update(cx, |state, cx| state.maybe_fetch_registry_models(cx));
 
         Self { http_client, state }
     }
@@ -247,6 +499,17 @@ impl LanguageModelProvider for OpenCodeLanguageModelProvider {
                 if Self::subscription_enabled(subscription, cx) {
                     let key = format!("{}/{}", subscription.id_prefix(), model.id());
                     models.insert(key, (model.clone(), subscription));
+                }
+            }
+        }
+
+        if settings.fetch_registry_models {
+            if let Some(registry_models) = self.state.read(cx).registry_models.clone() {
+                for (subscription, model) in registry_models {
+                    if Self::subscription_enabled(subscription, cx) {
+                        let key = format!("{}/{}", subscription.id_prefix(), model.id());
+                        models.entry(key).or_insert((model, subscription));
+                    }
                 }
             }
         }
@@ -994,6 +1257,7 @@ impl Render for ConfigurationView {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use collections::HashMap;
     use http_client::{FakeHttpClient, Response};
     use language_model::{LanguageModelRequestMessage, MessageContent, Role};
     use parking_lot::Mutex;
@@ -1024,6 +1288,109 @@ mod tests {
         let value = opencode_session_header_value(Some("thread\n123"));
 
         assert_generated_session_id(&value);
+    }
+
+    #[test]
+    fn test_parse_registry_models_resolves_protocols_and_metadata() {
+        let body = r#"
+        {
+          "opencode": {
+            "npm": "@ai-sdk/openai-compatible",
+            "models": {
+              "claude-opus-5": {
+                "provider": { "npm": "@ai-sdk/anthropic" },
+                "limit": { "context": 1000000, "output": 128000 }
+              },
+              "glm-5.3": {
+                "family": "glm",
+                "interleaved": { "field": "reasoning_content" },
+                "limit": { "context": 1000000, "output": 131072 }
+              }
+            }
+          },
+          "opencode-go": {
+            "npm": "@ai-sdk/openai-compatible",
+            "models": {
+              "kimi-k3": {
+                "reasoning_options": [{ "type": "toggle" }],
+                "limit": { "context": 1048576, "output": 131072 }
+              },
+              "qwen3.8-flash": {
+                "provider": { "npm": "@ai-sdk/anthropic" },
+                "limit": { "context": 1000000 }
+              }
+            }
+          },
+          "other-provider": {
+            "models": { "should-be-ignored": {} }
+          }
+        }"#;
+
+        let models = parse_registry_models(body).unwrap();
+        assert_eq!(models.len(), 4);
+        let by_id: HashMap<_, _> = models
+            .iter()
+            .map(|(subscription, model)| {
+                (
+                    format!("{}/{}", subscription.id_prefix(), model.id()),
+                    model,
+                )
+            })
+            .collect();
+
+        let claude = by_id["zen/claude-opus-5"].clone();
+        let opencode::Model::Custom {
+            name,
+            max_tokens,
+            max_output_tokens,
+            protocol,
+            interleaved_reasoning,
+            ..
+        } = claude
+        else {
+            panic!("registry models should be custom models");
+        };
+        assert_eq!(name, "claude-opus-5");
+        assert_eq!(max_tokens, 1_000_000);
+        assert_eq!(max_output_tokens, Some(128_000));
+        assert_eq!(protocol, ApiProtocol::Anthropic);
+        assert!(!interleaved_reasoning);
+
+        let opencode::Model::Custom {
+            protocol,
+            interleaved_reasoning,
+            ..
+        } = &by_id["zen/glm-5.3"]
+        else {
+            panic!("registry models should be custom models");
+        };
+        assert_eq!(*protocol, ApiProtocol::OpenAiChat);
+        assert!(*interleaved_reasoning);
+
+        let opencode::Model::Custom {
+            protocol,
+            reasoning_effort_levels,
+            ..
+        } = &by_id["go/kimi-k3"]
+        else {
+            panic!("registry models should be custom models");
+        };
+        assert_eq!(*protocol, ApiProtocol::OpenAiChat);
+        assert_eq!(
+            reasoning_effort_levels.as_ref().unwrap(),
+            &vec![ReasoningEffort::Max]
+        );
+
+        let opencode::Model::Custom {
+            protocol,
+            max_output_tokens,
+            ..
+        } = &by_id["go/qwen3.8-flash"]
+        else {
+            panic!("registry models should be custom models");
+        };
+        assert_eq!(*protocol, ApiProtocol::Anthropic);
+        assert_eq!(*max_output_tokens, None);
     }
 
     #[gpui::test]

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -158,6 +158,7 @@ impl settings::Settings for AllLanguageModelSettings {
                 ),
                 show_zen_models: opencode.show_zen_models.unwrap_or(true),
                 show_go_models: opencode.show_go_models.unwrap_or(true),
+                fetch_registry_models: opencode.fetch_registry_models.unwrap_or(true),
             },
             open_router: OpenRouterSettings {
                 api_url: open_router.api_url.unwrap(),

--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -140,6 +140,10 @@ pub enum Model {
     DeepSeekV4Pro,
     #[serde(rename = "deepseek-v4-flash")]
     DeepSeekV4Flash,
+    #[serde(rename = "deepseek-v4-flash-vision-exp")]
+    DeepSeekV4FlashVisionExp,
+    #[serde(rename = "deepseek-v4.1-flash")]
+    DeepSeekV4_1Flash,
     #[serde(rename = "minimax-m2.5")]
     MiniMaxM2_5,
     #[serde(rename = "glm-5")]
@@ -150,6 +154,8 @@ pub enum Model {
     Glm5_2,
     #[serde(rename = "glm-5.3")]
     Glm5_3,
+    #[serde(rename = "glm-5.3-flash")]
+    Glm5_3Flash,
     #[serde(rename = "grok-build-0.1")]
     GrokBuild0_1,
     #[serde(rename = "grok-4.5")]
@@ -158,6 +164,10 @@ pub enum Model {
     Grok4_6,
     #[serde(rename = "muse-spark-1.2")]
     MuseSpark1_2,
+    #[serde(rename = "muse-spark-1.2-contributor")]
+    MuseSpark1_2Contributor,
+    #[serde(rename = "muse-spark-1.3-contributor")]
+    MuseSpark1_3Contributor,
     #[serde(rename = "kimi-k2.5")]
     KimiK2_5,
     #[serde(rename = "kimi-k2.6")]
@@ -174,6 +184,8 @@ pub enum Model {
     MimoV2_5Pro,
     #[serde(rename = "mimo-v2.5")]
     MimoV2_5,
+    #[serde(rename = "longcat-2.0")]
+    Longcat2_0,
     #[serde(rename = "qwen3.5-plus")]
     Qwen3_5Plus,
     #[serde(rename = "qwen3.6-plus")]
@@ -184,8 +196,12 @@ pub enum Model {
     Qwen3_7Max,
     #[serde(rename = "qwen3.8-max")]
     Qwen3_8Max,
+    #[serde(rename = "qwen3.8-flash")]
+    Qwen3_8Flash,
     #[serde(rename = "hy3")]
     Hy3,
+    #[serde(rename = "hy4-preview")]
+    Hy4Preview,
 
     // -- Custom model --
     #[serde(rename = "custom")]
@@ -219,6 +235,8 @@ impl Model {
             // Models available in both Zen and Go
             Self::Glm5_1
             | Self::Glm5_2
+            | Self::Glm5_3Flash
+            | Self::Grok4_6
             | Self::Grok4_5
             | Self::KimiK2_6
             | Self::KimiK2_7Code
@@ -227,6 +245,7 @@ impl Model {
             | Self::MiniMaxM3
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
+            | Self::DeepSeekV4FlashVisionExp
             | Self::Gpt5_6Luna
             | Self::Qwen3_6Plus => &[OpenCodeSubscription::Zen, OpenCodeSubscription::Go],
 
@@ -234,10 +253,16 @@ impl Model {
             Self::MimoV2_5Pro
             | Self::MimoV2_5
             | Self::Glm5_3
+            | Self::DeepSeekV4_1Flash
+            | Self::Longcat2_0
+            | Self::MuseSpark1_2Contributor
+            | Self::MuseSpark1_3Contributor
             | Self::Qwen3_7Plus
             | Self::Qwen3_7Max
             | Self::Qwen3_8Max
-            | Self::Hy3 => &[OpenCodeSubscription::Go],
+            | Self::Qwen3_8Flash
+            | Self::Hy3
+            | Self::Hy4Preview => &[OpenCodeSubscription::Go],
 
             // Deprecated on Go (per models.dev); still offered on Zen
             Self::Glm5 | Self::KimiK2_5 | Self::MiniMaxM2_5 | Self::Qwen3_5Plus => {
@@ -296,15 +321,20 @@ impl Model {
 
             Self::DeepSeekV4Pro => "deepseek-v4-pro",
             Self::DeepSeekV4Flash => "deepseek-v4-flash",
+            Self::DeepSeekV4FlashVisionExp => "deepseek-v4-flash-vision-exp",
+            Self::DeepSeekV4_1Flash => "deepseek-v4.1-flash",
             Self::MiniMaxM2_5 => "minimax-m2.5",
             Self::Glm5 => "glm-5",
             Self::Glm5_1 => "glm-5.1",
             Self::Glm5_2 => "glm-5.2",
             Self::Glm5_3 => "glm-5.3",
+            Self::Glm5_3Flash => "glm-5.3-flash",
             Self::GrokBuild0_1 => "grok-build-0.1",
             Self::Grok4_5 => "grok-4.5",
             Self::Grok4_6 => "grok-4.6",
             Self::MuseSpark1_2 => "muse-spark-1.2",
+            Self::MuseSpark1_2Contributor => "muse-spark-1.2-contributor",
+            Self::MuseSpark1_3Contributor => "muse-spark-1.3-contributor",
             Self::KimiK2_5 => "kimi-k2.5",
             Self::KimiK2_6 => "kimi-k2.6",
             Self::KimiK2_7Code => "kimi-k2.7-code",
@@ -313,12 +343,15 @@ impl Model {
             Self::MiniMaxM3 => "minimax-m3",
             Self::MimoV2_5Pro => "mimo-v2.5-pro",
             Self::MimoV2_5 => "mimo-v2.5",
+            Self::Longcat2_0 => "longcat-2.0",
             Self::Qwen3_5Plus => "qwen3.5-plus",
             Self::Qwen3_6Plus => "qwen3.6-plus",
             Self::Qwen3_7Plus => "qwen3.7-plus",
             Self::Qwen3_7Max => "qwen3.7-max",
             Self::Qwen3_8Max => "qwen3.8-max",
+            Self::Qwen3_8Flash => "qwen3.8-flash",
             Self::Hy3 => "hy3",
+            Self::Hy4Preview => "hy4-preview",
 
             Self::Custom { name, .. } => name,
         }
@@ -368,15 +401,20 @@ impl Model {
 
             Self::DeepSeekV4Pro => "DeepSeek V4 Pro",
             Self::DeepSeekV4Flash => "DeepSeek V4 Flash",
+            Self::DeepSeekV4FlashVisionExp => "DeepSeek V4 Flash Vision Exp",
+            Self::DeepSeekV4_1Flash => "DeepSeek V4.1 Flash",
             Self::MiniMaxM2_5 => "MiniMax M2.5",
             Self::Glm5 => "GLM 5",
             Self::Glm5_1 => "GLM 5.1",
             Self::Glm5_2 => "GLM 5.2",
             Self::Glm5_3 => "GLM 5.3",
+            Self::Glm5_3Flash => "GLM 5.3 Flash",
             Self::GrokBuild0_1 => "Grok Build 0.1",
             Self::Grok4_5 => "Grok 4.5",
             Self::Grok4_6 => "Grok 4.6",
             Self::MuseSpark1_2 => "Muse Spark 1.2",
+            Self::MuseSpark1_2Contributor => "Muse Spark 1.2 Contributor",
+            Self::MuseSpark1_3Contributor => "Muse Spark 1.3 Contributor",
             Self::KimiK2_5 => "Kimi K2.5",
             Self::KimiK2_6 => "Kimi K2.6",
             Self::KimiK2_7Code => "Kimi K2.7 Code",
@@ -385,12 +423,15 @@ impl Model {
             Self::MiniMaxM3 => "MiniMax M3",
             Self::MimoV2_5Pro => "MiMo V2.5 Pro",
             Self::MimoV2_5 => "MiMo V2.5",
+            Self::Longcat2_0 => "LongCat 2.0",
             Self::Qwen3_5Plus => "Qwen3.5 Plus",
             Self::Qwen3_6Plus => "Qwen3.6 Plus",
             Self::Qwen3_7Plus => "Qwen3.7 Plus",
             Self::Qwen3_7Max => "Qwen3.7 Max",
             Self::Qwen3_8Max => "Qwen3.8 Max",
+            Self::Qwen3_8Flash => "Qwen3.8 Flash",
             Self::Hy3 => "Hy3",
+            Self::Hy4Preview => "Hy4 Preview",
 
             Self::Custom {
                 name, display_name, ..
@@ -451,6 +492,7 @@ impl Model {
             | Self::Gemini3_7Flash => ApiProtocol::Google,
 
             Self::Qwen3_8Max
+            | Self::Qwen3_8Flash
             | Self::Qwen3_7Max
             | Self::Qwen3_7Plus
             | Self::Qwen3_6Plus
@@ -460,6 +502,7 @@ impl Model {
             | Self::Glm5_1
             | Self::Glm5_2
             | Self::Glm5_3
+            | Self::Glm5_3Flash
             | Self::GrokBuild0_1
             | Self::KimiK2_5
             | Self::KimiK2_6
@@ -467,11 +510,19 @@ impl Model {
             | Self::KimiK3
             | Self::MimoV2_5Pro
             | Self::MimoV2_5
+            | Self::Longcat2_0
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
-            | Self::Hy3 => ApiProtocol::OpenAiChat,
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash
+            | Self::Hy3
+            | Self::Hy4Preview => ApiProtocol::OpenAiChat,
 
-            Self::Grok4_6 | Self::Grok4_5 | Self::MuseSpark1_2 => ApiProtocol::OpenAiResponses,
+            Self::Grok4_6
+            | Self::Grok4_5
+            | Self::MuseSpark1_2
+            | Self::MuseSpark1_2Contributor
+            | Self::MuseSpark1_3Contributor => ApiProtocol::OpenAiResponses,
 
             Self::Custom { protocol, .. } => *protocol,
         }
@@ -481,16 +532,20 @@ impl Model {
         match self {
             Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash
             | Self::KimiK2_5
             | Self::KimiK2_6
             | Self::KimiK2_7Code
             | Self::KimiK3
             | Self::MimoV2_5
             | Self::MimoV2_5Pro
+            | Self::Longcat2_0
             | Self::Glm5
             | Self::Glm5_1
             | Self::Glm5_2
             | Self::Glm5_3
+            | Self::Glm5_3Flash
             | Self::MiniMaxM2_5
             | Self::MiniMaxM2_7
             | Self::MiniMaxM3 => true,
@@ -553,14 +608,16 @@ impl Model {
                     204_800
                 }
             }
-            Self::Glm5_3 | Self::Glm5_2 => 1_000_000,
+            Self::Glm5_3 | Self::Glm5_3Flash | Self::Glm5_2 => 1_000_000,
             Self::KimiK2_6 | Self::KimiK2_5 | Self::KimiK2_7Code => 262_144,
             Self::KimiK3 => 1_048_576,
             Self::GrokBuild0_1 => 256_000,
             Self::Grok4_6 | Self::Grok4_5 => 500_000,
             Self::MuseSpark1_2 => 1_048_576,
+            Self::MuseSpark1_2Contributor | Self::MuseSpark1_3Contributor => 1_048_576,
             Self::MimoV2_5Pro => 1_048_576,
             Self::MimoV2_5 => 1_000_000,
+            Self::Longcat2_0 => 1_000_000,
             Self::Qwen3_5Plus => 262_144,
             Self::Qwen3_6Plus => {
                 if subscription == OpenCodeSubscription::Go {
@@ -569,9 +626,15 @@ impl Model {
                     262_144
                 }
             }
-            Self::Qwen3_8Max | Self::Qwen3_7Max | Self::Qwen3_7Plus => 1_000_000,
+            Self::Qwen3_8Max | Self::Qwen3_8Flash | Self::Qwen3_7Max | Self::Qwen3_7Plus => {
+                1_000_000
+            }
             Self::Hy3 => 256_000,
-            Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => 1_000_000,
+            Self::Hy4Preview => 1_024_000,
+            Self::DeepSeekV4Pro
+            | Self::DeepSeekV4Flash
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash => 1_000_000,
 
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -644,20 +707,25 @@ impl Model {
                     Some(131_072)
                 }
             }
-            Self::Glm5_3 | Self::Glm5_2 => Some(131_072),
+            Self::Glm5_3 | Self::Glm5_3Flash | Self::Glm5_2 => Some(131_072),
             Self::KimiK2_6 | Self::KimiK2_5 => Some(65_536),
             Self::KimiK2_7Code => Some(262_144),
             Self::KimiK3 => Some(131_072),
             Self::GrokBuild0_1 => Some(256_000),
             Self::Grok4_6 | Self::Grok4_5 => Some(500_000),
             Self::MuseSpark1_2 => Some(131_072),
+            Self::MuseSpark1_2Contributor | Self::MuseSpark1_3Contributor => Some(131_072),
             Self::Qwen3_7Max | Self::Qwen3_7Plus | Self::Qwen3_6Plus | Self::Qwen3_5Plus => {
                 Some(65_536)
             }
-            Self::Qwen3_8Max => Some(131_072),
-            Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => Some(384_000),
+            Self::Qwen3_8Max | Self::Qwen3_8Flash => Some(131_072),
+            Self::DeepSeekV4Pro
+            | Self::DeepSeekV4Flash
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash => Some(384_000),
             Self::MimoV2_5Pro | Self::MimoV2_5 => Some(128_000),
-            Self::Hy3 => Some(64_000),
+            Self::Longcat2_0 => Some(131_072),
+            Self::Hy3 | Self::Hy4Preview => Some(64_000),
 
             Self::Custom {
                 max_output_tokens, ..
@@ -725,11 +793,17 @@ impl Model {
             | Self::Grok4_5
             | Self::Grok4_6
             | Self::MuseSpark1_2
+            | Self::MuseSpark1_2Contributor
+            | Self::MuseSpark1_3Contributor
             | Self::MimoV2_5
             | Self::Qwen3_5Plus
             | Self::Qwen3_6Plus
             | Self::Qwen3_7Plus
             | Self::Qwen3_8Max
+            | Self::Qwen3_8Flash
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash
+            | Self::Glm5_3Flash
             | Self::MiniMaxM3 => true,
 
             // OpenAI-compatible models without image support
@@ -743,7 +817,9 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::Qwen3_7Max
-            | Self::Hy3 => false,
+            | Self::Longcat2_0
+            | Self::Hy3
+            | Self::Hy4Preview => false,
 
             Self::Custom { protocol, .. } => matches!(
                 protocol,
@@ -857,7 +933,10 @@ impl Model {
             ]),
 
             // DeepSeek models
-            Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => Some(vec![
+            Self::DeepSeekV4Pro
+            | Self::DeepSeekV4Flash
+            | Self::DeepSeekV4FlashVisionExp
+            | Self::DeepSeekV4_1Flash => Some(vec![
                 // OpenCode also supports Low&Medium but as per DeepSeek those are mapped to High
                 ReasoningEffort::High,
                 ReasoningEffort::Max,
@@ -876,10 +955,20 @@ impl Model {
                 ReasoningEffort::High,
             ]),
 
+            // Meituan LongCat models
+            Self::Longcat2_0 => Some(vec![ReasoningEffort::Max]),
+
+            // Alibaba Qwen models
+            Self::Qwen3_8Flash => Some(vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::XHigh,
+            ]),
+
             // Z AI models
             Self::Glm5_2 => Some(vec![ReasoningEffort::High, ReasoningEffort::Max]),
 
-            Self::Glm5_3 => Some(vec![
+            Self::Glm5_3 | Self::Glm5_3Flash => Some(vec![
                 ReasoningEffort::Low,
                 ReasoningEffort::High,
                 ReasoningEffort::Max,
@@ -891,6 +980,8 @@ impl Model {
                 ReasoningEffort::Low,
                 ReasoningEffort::High,
             ]),
+
+            Self::Hy4Preview => Some(vec![ReasoningEffort::None, ReasoningEffort::High]),
 
             // SpaceXAI models
             Self::Grok4_6 => Some(vec![
@@ -907,13 +998,15 @@ impl Model {
             ]),
 
             // Meta AI models
-            Self::MuseSpark1_2 => Some(vec![
-                ReasoningEffort::Minimal,
-                ReasoningEffort::Low,
-                ReasoningEffort::Medium,
-                ReasoningEffort::High,
-                ReasoningEffort::XHigh,
-            ]),
+            Self::MuseSpark1_2 | Self::MuseSpark1_2Contributor | Self::MuseSpark1_3Contributor => {
+                Some(vec![
+                    ReasoningEffort::Minimal,
+                    ReasoningEffort::Low,
+                    ReasoningEffort::Medium,
+                    ReasoningEffort::High,
+                    ReasoningEffort::XHigh,
+                ])
+            }
 
             Self::Custom {
                 reasoning_effort_levels,

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -245,6 +245,10 @@ pub struct OpenCodeSettingsContent {
     pub show_zen_models: Option<bool>,
     /// Whether to show OpenCode Go models. Defaults to true.
     pub show_go_models: Option<bool>,
+    /// Whether to fetch newly released OpenCode models from the models.dev registry,
+    /// so they show up without a Zed release. Bundled models take precedence over
+    /// registry models, and user-defined models over both. Defaults to true.
+    pub fetch_registry_models: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]


### PR DESCRIPTION
## Problem

The OpenCode provider ships a compiled-in model list, so models added to OpenCode don't appear in the Agent Panel until a Zed release refreshes the list — even though models.dev (the registry OpenCode's own CLI consumes) already knows about them.

Comparing `opencode models opencode-go` (27 models on the live Go subscription) against `main`'s bundled list, 8 models are missing:

| Model | Subscriptions | Protocol | Ctx / Out | Images | Efforts |
|---|---|---|---|---|---|
| `deepseek-v4-flash-vision-exp` | Zen + Go | openai_chat | 1M / 384K | yes | High, Max |
| `deepseek-v4.1-flash` | Go | openai_chat | 1M / 384K | yes | High, Max |
| `glm-5.3-flash` | Zen + Go | openai_chat | 1M / 131K | yes | Low, High, Max |
| `hy4-preview` | Go | openai_chat | 1,024K / 64K | no | None, High |
| `longcat-2.0` | Go | openai_chat | 1M / 131K | no | Max (toggle-only) |
| `muse-spark-1.2-contributor` | Go | openai_responses | 1,048K / 131K | yes | Minimal, Low, Medium, High, XHigh |
| `muse-spark-1.3-contributor` | Go | openai_responses | 1,048K / 131K | yes | Minimal, Low, Medium, High, XHigh |
| `qwen3.8-flash` | Go | anthropic | 1M / 131K | yes | Low, Medium, XHigh |

## Changes

### 1. Bundled list refresh (commit 1)

Adds the 8 models above with entries in all companion match arms: `id`, `display_name`, `available_subscriptions`, `protocol`, `interleaved_reasoning`, `max_token_count`, `max_output_tokens`, `supports_images`, `supported_reasoning_effort_levels`. Also fixes `grok-4.6` availability: it fell through to the Zen-only bucket, but models.dev and the `opencode` CLI list it under the Go subscription as well — moved to the Zen+Go bucket.

### 2. Dynamic registry fetch (commit 2)

Fetches `https://models.dev/api.json` once per session when the provider is constructed and merges registry-only models into the model list, so newly released OpenCode models show up without a Zed release:

- Emits registry models through the existing `Model::Custom` variant, so no provider rewiring is needed.
- **Precedence:** user-defined `available_models` > registry > bundled (registry uses `entry().or_insert()`, user models overwrite).
- **Subscriptions** come from the registry provider sections (`opencode` → Zen, `opencode-go` → Go), respecting the existing `show_zen_models` / `show_go_models` toggles.
- **API protocol** resolves from the per-model SDK (`provider.npm`), then the model family, then the provider-level SDK default — mirroring how the OpenCode CLI resolves it.
- **Limits, interleaved reasoning, and effort levels** map from the registry schema; toggle-only reasoning maps to max effort (mirroring Kimi K3).
- **Settings:** `fetch_registry_models` (default `true`) to opt out.
- **Failure handling:** offline / malformed registry / schema drift leaves the bundled list untouched (registry parse is per-provider, so one bad provider can't kill the rest).
- New unit test covers protocol resolution (per-model SDK → family → provider default), limits, interleaved reasoning, and toggle-only efforts.

### Cross-project companion

One registry gap remains: the OpenCode Go Qwen entries lack the per-model `provider.npm` that would make the registry alone authoritative about the Anthropic protocol (the entries already use `budget_tokens` reasoning and `qwen3.8-max`'s comments cite the Anthropic Messages API, while its sibling `qwen3.8-flash` declares the override). Filed upstream: anomalyco/models.dev#6856. Until it merges, this PR's family fallback (`qwen` → Anthropic) keeps behavior identical to the bundled list.

Release Notes:

- Added OpenCode Go models: DeepSeek V4 Flash Vision Exp, DeepSeek V4.1 Flash, GLM 5.3 Flash, Hy4 Preview, LongCat 2.0, Muse Spark 1.2/1.3 Contributor, Qwen3.8 Flash.
- Fixed Grok 4.6 availability on the OpenCode Go subscription.
- Newly released OpenCode models now appear automatically via the models.dev registry (configurable via `fetch_registry_models`).
