### PR TITLE
Upgrade ACP to 2.1 and futures to 0.3.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
+checksum = "6395d81d91fd2ee93f48ea31cfc511356e75b9061ca0389cefd0308507cc11ba"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
+checksum = "7e8d5f32208cdc11238004bec4e4229d68fb937598f900e153468ca084865fa5"
 dependencies = [
  "quote",
  "syn 3.0.3",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
+checksum = "ca98360c7bb8cc97d7acd49e2a8a851c3f7bee6b2f0535036d8ab86b5fcd223d"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "env_logger 0.11.8",
  "feature_flags",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_proxy",
  "image",
@@ -161,7 +161,7 @@ dependencies = [
  "collections",
  "ctor",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "gpui",
  "indoc",
@@ -188,7 +188,7 @@ dependencies = [
  "editor",
  "extension_host",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "language",
  "project",
@@ -262,7 +262,7 @@ dependencies = [
  "eval_utils",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "gpui",
  "gpui_tokio",
@@ -329,7 +329,7 @@ dependencies = [
  "async-io",
  "async-process",
  "blocking",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-concurrency",
  "rustc-hash 2.1.1",
  "rustix",
@@ -383,7 +383,7 @@ dependencies = [
  "env_logger 0.11.8",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "google_ai",
  "gpui",
  "gpui_tokio",
@@ -417,7 +417,7 @@ dependencies = [
  "collections",
  "convert_case 0.11.0",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "language_model",
  "log",
@@ -440,7 +440,7 @@ dependencies = [
  "base64 0.22.1",
  "const_format",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "paths",
  "serde",
@@ -482,7 +482,7 @@ dependencies = [
  "feature_flags",
  "file_icons",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "git",
  "git_ui_core",
@@ -780,7 +780,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "log",
@@ -918,7 +918,7 @@ name = "askpass"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "log",
  "net",
@@ -1105,7 +1105,7 @@ name = "async-pipe"
 version = "0.1.3"
 source = "git+https://github.com/zed-industries/async-pipe-rs?rev=82d00a04211cf4e1236029aa03e6b6ce2a74c553#82d00a04211cf4e1236029aa03e6b6ce2a74c553"
 dependencies = [
- "futures 0.3.32",
+ "futures 0.3.34",
  "log",
 ]
 
@@ -1376,7 +1376,7 @@ dependencies = [
  "clock",
  "ctor",
  "db",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "gpui",
  "http_client",
@@ -2097,7 +2097,7 @@ dependencies = [
  "anyhow",
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "schemars 1.0.4",
  "serde",
@@ -2122,7 +2122,7 @@ dependencies = [
  "assets",
  "criterion",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_platform",
  "indoc",
@@ -2635,7 +2635,7 @@ dependencies = [
  "collections",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_tokio",
  "language",
@@ -2656,7 +2656,7 @@ name = "call_hierarchy"
 version = "0.1.0"
 dependencies = [
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "language",
@@ -2925,7 +2925,7 @@ dependencies = [
  "client",
  "clock",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "language",
@@ -3133,7 +3133,7 @@ dependencies = [
  "derive_more",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_tokio",
  "http_client",
@@ -3188,7 +3188,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "cloud_api_types",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "gpui",
  "gpui_tokio",
@@ -3323,7 +3323,7 @@ dependencies = [
  "anyhow",
  "edit_prediction",
  "edit_prediction_types",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "icons",
@@ -3370,7 +3370,7 @@ dependencies = [
  "extension",
  "file_finder",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "git_hosting_providers",
  "git_ui",
@@ -3445,7 +3445,7 @@ dependencies = [
  "collections",
  "db",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "livekit_client",
@@ -3558,7 +3558,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "derive_more",
- "futures 0.3.32",
+ "futures 0.3.34",
  "indoc",
  "itertools 0.14.0",
  "jsonwebtoken",
@@ -3726,7 +3726,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "gpui",
  "http_client",
@@ -3776,7 +3776,7 @@ dependencies = [
  "edit_prediction_types",
  "editor",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "icons",
  "indoc",
@@ -3808,7 +3808,7 @@ dependencies = [
  "anyhow",
  "collections",
  "credentials_provider",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "language_model",
@@ -4605,7 +4605,7 @@ dependencies = [
  "collections",
  "dap-types",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "language",
@@ -4646,7 +4646,7 @@ dependencies = [
  "dap",
  "dotenvy",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "json_dotpath",
@@ -4849,7 +4849,7 @@ dependencies = [
  "anyhow",
  "dap",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "project",
  "serde_json",
@@ -4874,7 +4874,7 @@ dependencies = [
  "editor",
  "feature_flags",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "hex",
@@ -4928,7 +4928,7 @@ name = "deepseek"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "schemars 1.0.4",
  "serde",
@@ -5025,7 +5025,7 @@ dependencies = [
  "async-trait",
  "env_logger 0.11.8",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http 1.3.1",
  "http_client",
@@ -5358,7 +5358,7 @@ dependencies = [
  "edit_prediction_types",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "gpui",
  "heapless",
@@ -5423,7 +5423,7 @@ dependencies = [
  "extension",
  "flate2",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gaoya",
  "gpui",
  "gpui_platform",
@@ -5474,7 +5474,7 @@ dependencies = [
  "clock",
  "collections",
  "env_logger 0.11.8",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "indoc",
  "language",
@@ -5535,7 +5535,7 @@ dependencies = [
  "editor",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "indoc",
  "language",
@@ -5578,7 +5578,7 @@ dependencies = [
  "feature_flags",
  "file_icons",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "fuzzy",
  "git",
@@ -6009,7 +6009,7 @@ dependencies = [
  "extension",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_platform",
  "gpui_tokio",
@@ -6120,7 +6120,7 @@ dependencies = [
  "collections",
  "dap",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "heck 0.5.0",
  "http_client",
@@ -6157,7 +6157,7 @@ dependencies = [
  "env_logger 0.11.8",
  "extension",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui_platform",
  "http_client",
  "language",
@@ -6192,7 +6192,7 @@ dependencies = [
  "dap",
  "extension",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_tokio",
  "http_client",
@@ -6405,7 +6405,7 @@ dependencies = [
  "ctor",
  "editor",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "fuzzy_nucleo",
  "gpui",
@@ -6684,7 +6684,7 @@ dependencies = [
  "collections",
  "dunce",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "gpui",
  "ignore",
@@ -6777,9 +6777,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -6792,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6815,15 +6815,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -6843,9 +6843,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -6877,32 +6877,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -7119,7 +7119,7 @@ dependencies = [
  "async-trait",
  "collections",
  "derive_more",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "itertools 0.14.0",
@@ -7152,7 +7152,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "gpui",
  "http_client",
@@ -7186,7 +7186,7 @@ dependencies = [
  "editor",
  "file_icons",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "fuzzy",
  "fuzzy_nucleo",
@@ -7247,7 +7247,7 @@ dependencies = [
  "db",
  "editor",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "git",
  "gpui",
@@ -7434,7 +7434,7 @@ name = "google_ai"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "log",
@@ -7498,7 +7498,7 @@ dependencies = [
  "embed-resource",
  "env_logger 0.11.8",
  "etagere",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-concurrency",
  "getrandom 0.3.4",
  "gpui_macros",
@@ -7596,7 +7596,7 @@ dependencies = [
  "calloop-wayland-source",
  "collections",
  "filedescriptor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_util",
  "gpui_wgpu",
@@ -7645,7 +7645,7 @@ dependencies = [
  "ctor",
  "dispatch2",
  "foreign-types 0.5.0",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_apple",
  "gpui_util",
@@ -7729,7 +7729,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_wgpu",
  "http_client",
@@ -7783,7 +7783,7 @@ dependencies = [
  "collections",
  "dunce",
  "etagere",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_util",
  "image",
@@ -8278,7 +8278,7 @@ dependencies = [
  "async-tar",
  "bytes 1.11.1",
  "derive_more",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http 1.3.1",
  "http-body 1.0.1",
  "log",
@@ -8308,7 +8308,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "httparse",
  "idna",
  "log",
@@ -9351,7 +9351,7 @@ dependencies = [
  "async-trait",
  "bytes 1.11.1",
  "chrono",
- "futures 0.3.32",
+ "futures 0.3.34",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -9368,7 +9368,7 @@ dependencies = [
  "async-trait",
  "async-tungstenite",
  "bytes 1.11.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "jupyter-protocol",
  "serde",
  "serde_json",
@@ -9492,7 +9492,7 @@ dependencies = [
  "ec4rs",
  "encoding_rs",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "fuzzy_nucleo",
  "globset",
@@ -9586,7 +9586,7 @@ dependencies = [
  "async-trait",
  "collections",
  "extension",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "language",
  "log",
@@ -9608,7 +9608,7 @@ dependencies = [
  "collections",
  "credentials_provider",
  "env_var",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_util",
  "http_client",
@@ -9629,7 +9629,7 @@ dependencies = [
  "async-lock",
  "cloud_llm_client",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui_shared_string",
  "http_client",
  "log",
@@ -9673,7 +9673,7 @@ dependencies = [
  "extension_host",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "google_ai",
  "gpui",
  "gpui_tokio",
@@ -9714,7 +9714,7 @@ dependencies = [
  "anthropic",
  "anyhow",
  "cloud_llm_client",
- "futures 0.3.32",
+ "futures 0.3.34",
  "google_ai",
  "gpui",
  "http_client",
@@ -9770,7 +9770,7 @@ dependencies = [
  "command_palette_hooks",
  "edit_prediction",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "itertools 0.14.0",
  "language",
@@ -9807,7 +9807,7 @@ dependencies = [
  "chrono",
  "collections",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "globset",
  "gpui",
  "grammars",
@@ -10176,7 +10176,7 @@ dependencies = [
  "core-video",
  "coreaudio-rs 0.12.1",
  "cpal",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_platform",
  "gpui_tokio",
@@ -10208,7 +10208,7 @@ name = "llama_cpp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "schemars 1.0.4",
@@ -10233,7 +10233,7 @@ name = "lmstudio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "schemars 1.0.4",
@@ -10391,7 +10391,7 @@ dependencies = [
  "async-pipe",
  "collections",
  "ctor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "gpui",
  "gpui_util",
@@ -10425,7 +10425,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "language",
@@ -11117,7 +11117,7 @@ name = "mistral"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "schemars 1.0.4",
  "serde",
@@ -11350,7 +11350,7 @@ dependencies = [
  "async-tar",
  "async-trait",
  "chrono",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "log",
  "paths",
@@ -11713,7 +11713,7 @@ version = "0.9.2"
 source = "git+https://github.com/KillTheMule/nvim-rs?rev=764dd270c642f77f10f3e19d05cc178a6cbe69f3#764dd270c642f77f10f3e19d05cc178a6cbe69f3"
 dependencies = [
  "async-trait",
- "futures 0.3.32",
+ "futures 0.3.34",
  "log",
  "rmp",
  "rmpv",
@@ -11726,7 +11726,7 @@ name = "oauth_callback_server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "log",
  "tiny_http",
  "url",
@@ -12118,7 +12118,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "either",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-core",
  "futures-util",
  "getrandom 0.2.16",
@@ -12151,7 +12151,7 @@ name = "ollama"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "schemars 1.0.4",
  "serde",
@@ -12261,7 +12261,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "log",
@@ -12280,7 +12280,7 @@ version = "0.1.0"
 dependencies = [
  "editor",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "picker",
@@ -12300,7 +12300,7 @@ name = "open_router"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "http_client",
  "language_model_core",
  "open_ai",
@@ -12318,7 +12318,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "credentials_provider",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "language_model",
@@ -12340,7 +12340,7 @@ name = "opencode"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "google_ai",
  "http_client",
  "language_model_core",
@@ -12479,7 +12479,7 @@ name = "outline"
 version = "0.1.0"
 dependencies = [
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy_nucleo",
  "gpui",
  "indoc",
@@ -12509,7 +12509,7 @@ dependencies = [
  "db",
  "editor",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "itertools 0.14.0",
@@ -13711,7 +13711,7 @@ checksum = "af3fb618632874fb76937c2361a7f22afd393c982a2165595407edc75b06d3c1"
 dependencies = [
  "atomic",
  "crossbeam-queue",
- "futures 0.3.32",
+ "futures 0.3.34",
  "log",
  "parking_lot",
  "pin-project",
@@ -13938,7 +13938,7 @@ dependencies = [
  "extension",
  "fancy-regex",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "fuzzy_nucleo",
  "git",
@@ -14006,7 +14006,7 @@ dependencies = [
  "askpass",
  "clap",
  "client",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "gpui_platform",
  "http_client",
@@ -14032,7 +14032,7 @@ dependencies = [
  "editor",
  "file_icons",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "git_ui",
  "git_ui_core",
@@ -14069,7 +14069,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "language",
@@ -14114,7 +14114,7 @@ dependencies = [
  "collections",
  "db",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "handlebars 4.5.0",
  "heed",
@@ -14298,7 +14298,7 @@ name = "proxy_handshake"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "httparse",
  "percent-encoding",
  "piper",
@@ -14856,7 +14856,7 @@ dependencies = [
  "extension",
  "extension_host",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy_nucleo",
  "gpui",
  "http_client",
@@ -15027,7 +15027,7 @@ dependencies = [
  "base64 0.22.1",
  "collections",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "log",
  "parking_lot",
@@ -15056,7 +15056,7 @@ dependencies = [
  "askpass",
  "auto_update",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "log",
  "markdown",
@@ -15096,7 +15096,7 @@ dependencies = [
  "extension",
  "extension_host",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "git_hosting_providers",
  "gpui",
@@ -15177,7 +15177,7 @@ dependencies = [
  "editor",
  "feature_flags",
  "file_icons",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "html_to_markdown",
  "http_client",
@@ -15303,7 +15303,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes 1.11.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui_util",
  "http_client",
  "http_client_tls",
@@ -15495,7 +15495,7 @@ dependencies = [
  "async-tungstenite",
  "base64 0.22.1",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "parking_lot",
  "proto",
@@ -15561,7 +15561,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "dirs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "glob",
  "jupyter-protocol",
  "serde",
@@ -15870,7 +15870,7 @@ name = "sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_proxy",
  "libc",
@@ -15911,7 +15911,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "flume 0.12.0",
- "futures 0.3.32",
+ "futures 0.3.34",
  "parking_lot",
  "rand 0.9.4",
  "wasm_thread",
@@ -16150,7 +16150,7 @@ dependencies = [
  "editor",
  "file_icons",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "itertools 0.14.0",
  "language",
@@ -16507,7 +16507,7 @@ dependencies = [
  "collections",
  "ec4rs",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "indoc",
  "inventory",
@@ -16619,7 +16619,7 @@ dependencies = [
  "extension_host",
  "feature_flags",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "heck 0.5.0",
@@ -17050,7 +17050,7 @@ dependencies = [
  "collections",
  "extension",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "indoc",
  "parking_lot",
@@ -17162,7 +17162,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "indoc",
  "libsqlite3-sys",
  "log",
@@ -18122,7 +18122,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "hex",
  "log",
@@ -18181,7 +18181,7 @@ dependencies = [
 name = "telemetry"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.32",
+ "futures 0.3.34",
  "serde_json",
  "telemetry_events",
 ]
@@ -18234,7 +18234,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "collections",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "gpui",
  "itertools 0.14.0",
@@ -18282,7 +18282,7 @@ dependencies = [
  "db",
  "dirs",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "itertools 0.14.0",
  "language",
@@ -18911,7 +18911,7 @@ dependencies = [
  "anyhow",
  "convert_case 0.11.0",
  "editor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "gpui",
  "language",
@@ -19765,7 +19765,7 @@ dependencies = [
  "command-fds",
  "dirs",
  "dunce",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "globset",
  "gpui_util",
@@ -19912,7 +19912,7 @@ dependencies = [
  "db",
  "editor",
  "env_logger 0.11.8",
- "futures 0.3.32",
+ "futures 0.3.34",
  "fuzzy",
  "git_ui",
  "gpui",
@@ -20273,7 +20273,7 @@ name = "wasm_thread"
 version = "0.3.3"
 source = "git+https://github.com/zed-industries/wasm_thread?rev=0cf96c7708dfb97ccf3da50347e25edcf75d6937#0cf96c7708dfb97ccf3da50347e25edcf75d6937"
 dependencies = [
- "futures 0.3.32",
+ "futures 0.3.34",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -20350,7 +20350,7 @@ dependencies = [
  "bumpalo",
  "cc",
  "encoding_rs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "libc",
  "log",
  "mach2 0.6.0",
@@ -20575,7 +20575,7 @@ dependencies = [
  "bytes 1.11.1",
  "cap-fs-ext",
  "cap-primitives",
- "futures 0.3.32",
+ "futures 0.3.34",
  "rand 0.10.2",
  "rustix",
  "thiserror 2.0.17",
@@ -20596,7 +20596,7 @@ checksum = "6a557bc8a7232cd079f6b423a9bb385f3ff9148824f3c26c07a028b499fab2bf"
 dependencies = [
  "async-trait",
  "bytes 1.11.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "tracing",
  "wasmtime",
 ]
@@ -20616,7 +20616,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "ctor",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "parking_lot",
  "zlog",
@@ -20788,7 +20788,7 @@ dependencies = [
  "cloud_api_client",
  "cloud_api_types",
  "cloud_llm_client",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "http_client",
  "language_model",
@@ -22028,7 +22028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"
 dependencies = [
  "bitflags 2.13.1",
- "futures 0.3.32",
+ "futures 0.3.34",
  "once_cell",
 ]
 
@@ -22299,7 +22299,7 @@ dependencies = [
  "db",
  "dirs",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "git",
  "gpui",
@@ -22351,7 +22351,7 @@ dependencies = [
  "collections",
  "encoding_rs",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "futures-lite 2.6.1",
  "fuzzy",
  "git",
@@ -22621,7 +22621,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes 1.11.1",
  "flate2",
- "futures 0.3.32",
+ "futures 0.3.34",
  "getrandom 0.2.16",
  "http-body-util",
  "hyper 1.7.0",
@@ -22839,7 +22839,7 @@ dependencies = [
  "feedback",
  "file_finder",
  "fs",
- "futures 0.3.32",
+ "futures 0.3.34",
  "git",
  "git_hosting_providers",
  "git_ui",
@@ -23081,7 +23081,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "credentials_provider",
- "futures 0.3.32",
+ "futures 0.3.34",
  "gpui",
  "paths",
  "release_channel",
@@ -23233,7 +23233,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
  "crossbeam-queue",
- "futures 0.3.32",
+ "futures 0.3.34",
  "log",
  "num-traits",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -624,7 +624,7 @@ fancy-regex = "0.19"
 flume = "0.12"
 foreign-types = "0.5"
 fork = "0.4.0"
-futures = "0.3.32"
+futures = "0.3.34"
 futures-concurrency = "7.7.1"
 futures-lite = "2"
 gh-workflow = { git = "https://github.com/zed-industries/gh-workflow", rev = "37f3c0575d379c218a9c455ee67585184e40d43f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,7 +518,7 @@ accesskit = { version = "0.24.0", features = ["enumn"] }
 accesskit_macos = "0.26.0"
 accesskit_unix = "0.22"
 accesskit_windows = "0.34"
-agent-client-protocol = { version = "=2.0.0", features = ["unstable"] }
+agent-client-protocol = { version = "=2.1.0", features = ["unstable"] }
 aho-corasick = "1.1"
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "4c129667ce56611becdc82de6e28218c80e2e88f" }
 any_vec = "0.14"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -11,7 +11,6 @@ use agent_client_protocol::{Agent, Client, ConnectionTo, JsonRpcResponse, Lines,
 use anyhow::anyhow;
 use async_channel;
 use collections::{HashMap, HashSet};
-use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _};
 use futures::channel::mpsc;
 use futures::future::Shared;
 use futures::io::BufReader;
@@ -661,19 +660,6 @@ pub async fn connect(
 
 const MINIMUM_SUPPORTED_VERSION: ProtocolVersion = ProtocolVersion::V1;
 
-/// Build a `Client` connection over `transport` with Zed's full
-/// agent→client handler set wired up.
-///
-/// All incoming requests and notifications are forwarded to the foreground
-/// dispatch queue via `dispatch_tx`, where they are handled by the
-/// `handle_*` functions on a GPUI context. The returned future drives the
-/// connection and completes when the transport closes; callers are expected
-/// to poll it in the background and hold the task for the lifetime of the
-/// connection. In unoptimized builds each inbound dispatch needs ~0.5 MiB
-/// of stack, so poll it on a thread with room to spare (macOS GCD workers'
-/// 512 KiB is not enough — see `AcpConnection::stdio`). The `connection_tx`
-/// oneshot receives the `ConnectionTo<Agent>` handle as soon as the builder
-/// runs its `main_fn`.
 fn connect_client_future(
     name: &'static str,
     transport: impl agent_client_protocol::ConnectTo<Client> + 'static,
@@ -926,26 +912,14 @@ impl AcpConnection {
             }
         });
 
-        // `connect_client_future` installs the production handler set and
-        // hands us back both the connection-future and a oneshot receiver
-        // that produces the `ConnectionTo<Agent>` once the transport
-        // handshake is ready. The future must be polled on a dedicated
-        // thread rather than via `background_spawn`: in unoptimized builds
-        // its dispatch chain needs ~0.5 MiB of stack per inbound message,
-        // which overflows the fixed 512 KiB stacks of the GCD workers that
-        // poll background tasks on macOS, crashing dev builds as soon as an
-        // agent sends its first message. See `spawn_dedicated` for the
-        // stack guarantee that makes the dedicated thread sufficient.
         let (connection_tx, connection_rx) = futures::channel::oneshot::channel();
         let connection_future =
             connect_client_future("zed", transport, dispatch_tx.clone(), connection_tx);
-        let io_task = cx
-            .background_executor()
-            .spawn_dedicated(move |_executor| async move {
-                if let Err(err) = connection_future.await {
-                    log::error!("ACP connection error: {err}");
-                }
-            });
+        let io_task = cx.background_spawn(async move {
+            if let Err(err) = connection_future.await {
+                log::error!("ACP connection error: {err}");
+            }
+        });
 
         let connection_rx = async move {
             connection_rx
@@ -1603,12 +1577,7 @@ fn meta_terminal_auth_task(
         env: HashMap<String, String>,
     }
 
-    let meta = match method {
-        acp::AuthMethod::EnvVar(env_var) => env_var.meta.as_ref(),
-        acp::AuthMethod::Terminal(terminal) => terminal.meta.as_ref(),
-        acp::AuthMethod::Agent(agent) => agent.meta.as_ref(),
-        _ => None,
-    }?;
+    let meta = method.meta()?;
     let terminal_auth =
         serde_json::from_value::<MetaTerminalAuth>(meta.get("terminal-auth")?.clone()).ok()?;
 
@@ -1860,7 +1829,7 @@ impl AgentConnection for AcpConnection {
             .find(|method| method.id() == method_id)?;
 
         match method {
-            acp::AuthMethod::Terminal(terminal) if cx.has_flag::<AcpBetaFeatureFlag>() => {
+            acp::AuthMethod::Terminal(terminal) => {
                 let agent_id = self.id.clone();
                 let terminal = terminal.clone();
                 let store = self.agent_server_store.clone();
@@ -2190,6 +2159,7 @@ pub mod test_support {
         pub connection: Rc<AcpConnection>,
         pub load_session_count: Arc<AtomicUsize>,
         pub close_session_count: Arc<AtomicUsize>,
+        pub authenticate_count: Arc<AtomicUsize>,
         pub logout_count: Arc<AtomicUsize>,
         pub keep_agent_alive: Task<anyhow::Result<()>>,
     }
@@ -2374,6 +2344,7 @@ pub mod test_support {
     ) -> Result<FakeAcpConnectionHarness> {
         let (client_transport, agent_transport) = agent_client_protocol::Channel::duplex();
 
+        let authenticate_count = Arc::new(AtomicUsize::new(0));
         let logout_count = Arc::new(AtomicUsize::new(0));
         let sessions: Rc<RefCell<HashMap<acp::SessionId, AcpSession>>> =
             Rc::new(RefCell::new(HashMap::default()));
@@ -2400,10 +2371,12 @@ pub mod test_support {
             )
             .on_receive_request(
                 {
+                    let authenticate_count = authenticate_count.clone();
                     let auth_elicitation_request = auth_elicitation_request.clone();
                     let auth_elicitation_response = auth_elicitation_response.clone();
                     let auth_elicitation_completion = auth_elicitation_completion.clone();
                     async move |_req: acp::AuthenticateRequest, responder, cx| {
+                        authenticate_count.fetch_add(1, Ordering::SeqCst);
                         let request = auth_elicitation_request
                             .lock()
                             .expect("auth elicitation request lock should not be poisoned")
@@ -2561,6 +2534,7 @@ pub mod test_support {
             connection: Rc::new(connection),
             load_session_count,
             close_session_count,
+            authenticate_count,
             logout_count,
             keep_agent_alive,
         })
@@ -2658,7 +2632,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
-    use feature_flags::FeatureFlag as _;
+    use feature_flags::{AcpBetaFeatureFlag, FeatureFlag as _, FeatureFlagAppExt as _};
     use settings::Settings as _;
 
     fn init_feature_flags_test(cx: &mut gpui::TestAppContext) {
@@ -3002,6 +2976,55 @@ mod tests {
                 .and_then(|config_options| config_options.boolean)
                 .is_some()
         );
+    }
+
+    #[gpui::test]
+    async fn connection_routes_terminal_auth_without_acp_beta(cx: &mut gpui::TestAppContext) {
+        init_feature_flags_test(cx);
+
+        let fs = fs::FakeFs::new(cx.executor());
+        fs.insert_tree("/", serde_json::json!({ "project": {} }))
+            .await;
+        let project = project::Project::test(fs, [std::path::Path::new("/project")], cx).await;
+        let mut harness = test_support::connect_fake_acp_connection(project, cx).await;
+        let method_id = acp::AuthMethodId::new("login");
+        let method = acp::AuthMethod::Terminal(
+            acp::AuthMethodTerminal::new(method_id.clone(), "First-class login")
+                .args(vec!["first-class-auth".into()])
+                .meta(acp::Meta::from_iter([(
+                    "terminal-auth".to_string(),
+                    serde_json::json!({
+                        "label": "Legacy login",
+                        "command": "legacy-agent",
+                        "args": ["legacy-auth"],
+                    }),
+                )])),
+        );
+        Rc::get_mut(&mut harness.connection)
+            .expect("test harness should have the only connection handle")
+            .auth_methods = vec![method];
+
+        let terminal_task = cx
+            .update(|cx| {
+                cx.update_flags(true, Vec::new());
+                feature_flags::FeatureFlagsSettings::override_global(
+                    feature_flags::FeatureFlagsSettings {
+                        overrides: HashMap::from_iter([(
+                            AcpBetaFeatureFlag::NAME.into(),
+                            "off".into(),
+                        )]),
+                    },
+                    cx,
+                );
+                assert!(!cx.has_flag::<AcpBetaFeatureFlag>());
+                harness.connection.terminal_auth_task(&method_id, cx)
+            })
+            .expect("first-class terminal auth should be routed without ACP beta");
+        terminal_task
+            .await
+            .expect_err("first-class routing should resolve the test agent's external command");
+
+        assert_eq!(harness.authenticate_count.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -98,27 +98,6 @@ impl BackgroundExecutor {
         self.dispatcher.prevent_app_nap(reason)
     }
 
-    /// Spawn a closure on a fresh session pinned to its own [`SchedulerLocalExecutor`].
-    /// The closure runs on a new OS thread under the platform scheduler, or on
-    /// the test scheduler's loop in tests.
-    ///
-    /// Prefer this over [`Self::spawn`] for futures whose polls need more stack
-    /// than shared background threads guarantee. Dedicated threads get the
-    /// standard library's default 2 MiB, while `spawn` polls futures on
-    /// whatever threads the platform dispatcher provides — on macOS those are
-    /// GCD workers whose stacks are fixed at 512 KiB by the kernel (see `PTH_DEFAULT_STACKSIZE` in
-    /// <https://github.com/apple-oss-distributions/libpthread/blob/42d026df5b07825070f60134b980a1ec2552dfee/kern/kern_internal.h#L154>),
-    /// the tightest background-stack budget of any platform.
-    #[track_caller]
-    pub fn spawn_dedicated<F, Fut>(&self, f: F) -> Task<Fut::Output>
-    where
-        F: FnOnce(SchedulerLocalExecutor) -> Fut + Send + 'static,
-        Fut: Future + 'static,
-        Fut::Output: Send + Sync + 'static,
-    {
-        self.inner.spawn_dedicated(f)
-    }
-
     /// Enqueues the given future to be run to completion on a background thread.
     #[track_caller]
     pub fn spawn<R>(&self, future: impl Future<Output = R> + Send + 'static) -> Task<R>


### PR DESCRIPTION
Upgrade to ACP SDK 2.1 and futures 0.3.34. Remove the dedicated-thread polling workaround introduced in #62259 now that the SDK bounds dispatch-chain stack usage.

This is the first PR from the ACP integration work. First-class tool-call names, context compaction support, and the independent native elicitation ID fix are intentionally deferred to separate PRs.

- Upgrade the ACP SDK and derive crate to 2.1.0, with schema 1.7.0.
- Upgrade the nine futures-rs 0.3 components to 0.3.34, including the [cloned-waker identity fix](https://github.com/rust-lang/futures-rs/pull/3032) identified through [ACP rust-sdk#254](https://github.com/agentclientprotocol/rust-sdk/issues/254).
- Poll ACP connections on the normal GPUI background executor and remove the now-unused ACP-specific dedicated-spawn wrapper. Keep the general scheduler dedicated-executor APIs intact.
- Use the stable authentication metadata accessor and route first-class terminal authentication without requiring ACP beta. Keep legacy terminal-auth metadata as a fallback for other authentication methods.

Also upgrades a big fix release of the futures crates because there was some polling issues with FuturesUnordered reported with the old versions.

Release Notes:

- Improved ACP compatibility and async task wakeup handling.
