### PR TITLE
gpui: Add touch input support for Wayland

### DIFF
--- a/crates/gpui/src/gestures.rs
+++ b/crates/gpui/src/gestures.rs
@@ -25,6 +25,14 @@ use crate::{
 
 const SCROLL_EVENT_SEPARATION: Duration = Duration::from_millis(28);
 
+/// How long after a touch resolves (or a finger lifts) a subsequent second
+/// touch still counts as part of the same two-finger gesture. A second finger
+/// landing within this window promotes an in-progress single-finger drag to
+/// scroll, so "two fingers down" always reads as scroll and never as two taps.
+/// Kept short enough that deliberate separate taps aren't merged; tune here if
+/// the feel is off.
+pub const PENDING_TOUCH_WINDOW: Duration = Duration::from_millis(100);
+
 fn dominant_axis(delta: Point<Pixels>) -> Axis {
     if delta.x.abs() <= delta.y.abs() {
         Axis::Vertical
@@ -492,6 +500,10 @@ pub(crate) struct TouchGestureRecognizer {
     state: TouchGestureState,
     momentum: Option<Momentum>,
     last_tap: Option<CompletedTap>,
+    /// When the most recent touch resolved (ended/cancelled), or `None` if no
+    /// touch has happened yet. A second touch arriving within
+    /// [`PENDING_TOUCH_WINDOW`] of this is treated as a two-finger gesture.
+    last_resolved_at: Option<Instant>,
 }
 
 /// A semantic event recognized from raw touches, ready to dispatch through
@@ -578,6 +590,7 @@ impl TouchGestureRecognizer {
             state: TouchGestureState::Idle,
             momentum: None,
             last_tap: None,
+            last_resolved_at: None,
         }
     }
 
@@ -606,6 +619,28 @@ impl TouchGestureRecognizer {
                 } else {
                     None
                 };
+                // A second finger landing while a pan is already underway means this
+                // is a two-finger gesture: take over the touch so its movement scrolls.
+                let promote_to_pan = matches!(self.state, TouchGestureState::Panning { .. });
+                if promote_to_pan {
+                    let mut velocity_tracker = VelocityTracker::default();
+                    velocity_tracker.push(now, event.position);
+                    let touch = ActiveTouch {
+                        id: event.id,
+                        start_position: event.position,
+                        last_position: event.position,
+                        emitted_position: event.position,
+                        last_movement: Point::default(),
+                        velocity_tracker,
+                    };
+                    // No prior pan to inherit an axis from; start vertical (the
+                    // common case) and let the first movement pick it.
+                    self.state = TouchGestureState::Panning {
+                        touch,
+                        axis: Axis::Vertical,
+                    };
+                    return recognized;
+                }
                 if matches!(self.state, TouchGestureState::Idle) {
                     let mut velocity_tracker = VelocityTracker::default();
                     velocity_tracker.push(now, event.position);
@@ -763,6 +798,7 @@ impl TouchGestureRecognizer {
                             click_count: tap_count,
                         },
                     });
+                    self.last_resolved_at = Some(now);
                 }
                 TouchGestureState::Panning { touch, axis } if touch.id == event.id => {
                     // The release deliberately contributes no velocity
@@ -829,6 +865,7 @@ impl TouchGestureRecognizer {
                         release_delta,
                         TouchPhase::Ended,
                     )));
+                    self.last_resolved_at = Some(now);
                 }
                 TouchGestureState::LongPressing(touch) if touch.id == event.id => {
                     recognized.push(RecognizedTouchGesture::LongPress(LongPressEvent {
@@ -847,13 +884,16 @@ impl TouchGestureRecognizer {
                 other => self.state = other,
             },
             TouchPhase::Cancelled => match mem::replace(&mut self.state, TouchGestureState::Idle) {
-                TouchGestureState::Pending { touch, .. } if touch.id == event.id => {}
+                TouchGestureState::Pending { touch, .. } if touch.id == event.id => {
+                    self.last_resolved_at = Some(now);
+                }
                 TouchGestureState::Panning { touch, .. } if touch.id == event.id => {
                     recognized.push(RecognizedTouchGesture::Scroll(scroll_event(
                         touch.start_position,
                         Point::default(),
                         TouchPhase::Cancelled,
                     )));
+                    self.last_resolved_at = Some(now);
                 }
                 TouchGestureState::LongPressing(touch) if touch.id == event.id => {
                     recognized.push(RecognizedTouchGesture::LongPress(LongPressEvent {
@@ -2197,6 +2237,136 @@ mod tests {
 
         assert!(recognizer.offer_long_press(completed_touch).is_none());
         assert!(recognizer.offer_long_press(replacement_touch).is_some());
+    }
+
+    #[test]
+    fn fast_flick_still_scrolls() {
+        // A single-finger drag past the slop is a scroll — no synthesized
+        // mouse events.
+        let mut recognizer = TouchGestureRecognizer::new(GestureTuning::default());
+        let now = Instant::now();
+        let touch = TouchId(1);
+
+        recognizer.handle_event_at(&touch_event(touch, TouchPhase::Started, 100., 100.), now);
+
+        // A fast flick past the slop: it stays a scroll.
+        let recognized = recognizer.handle_event_at(
+            &touch_event(touch, TouchPhase::Moved, 100., 140.),
+            now + Duration::from_millis(20),
+        );
+        let [RecognizedTouchGesture::Scroll(scroll)] = recognized.as_slice() else {
+            panic!("expected scroll, got {recognized:?}");
+        };
+        assert_eq!(scroll.touch_phase, TouchPhase::Started);
+
+        // Subsequent movement is still scrolling.
+        let recognized = recognizer.handle_event_at(
+            &touch_event(touch, TouchPhase::Moved, 100., 180.),
+            now + Duration::from_millis(40),
+        );
+        let [RecognizedTouchGesture::Scroll(scroll)] = recognized.as_slice() else {
+            panic!("expected scroll, got {recognized:?}");
+        };
+        assert_eq!(scroll.touch_phase, TouchPhase::Moved);
+    }
+
+    #[test]
+    fn second_finger_during_slow_drag_promotes_to_scroll() {
+        let mut recognizer = TouchGestureRecognizer::new(GestureTuning::default());
+        let now = Instant::now();
+
+        // Start a single-finger drag past the slop: it becomes a scroll.
+        recognizer.handle_event_at(
+            &touch_event(TouchId(1), TouchPhase::Started, 100., 100.),
+            now,
+        );
+
+        recognizer.handle_event_at(
+            &touch_event(TouchId(1), TouchPhase::Moved, 100., 112.),
+            now + Duration::from_millis(80),
+        );
+
+        // A second finger lands while the pan is in progress: it promotes to a two-finger scroll and emits nothing for the new finger itself.
+        let recognized = recognizer.handle_event_at(
+            &touch_event(TouchId(2), TouchPhase::Started, 130., 105.),
+            now + Duration::from_millis(100),
+        );
+        assert!(
+            recognized.is_empty(),
+            "expected no events, got {recognized:?}"
+        );
+
+        // Moving the second finger scrolls (axis-locked vertical).
+        let recognized = recognizer.handle_event_at(
+            &touch_event(TouchId(2), TouchPhase::Moved, 130., 90.),
+            now + Duration::from_millis(120),
+        );
+        let [RecognizedTouchGesture::Scroll(scroll)] = recognized.as_slice() else {
+            panic!("expected scroll, got {recognized:?}");
+        };
+        assert_eq!(scroll.touch_phase, TouchPhase::Moved);
+
+        // Lifting the second finger ends the scroll.
+        let recognized = recognizer.handle_event_at(
+            &touch_event(TouchId(2), TouchPhase::Ended, 130., 90.),
+            now + Duration::from_millis(140),
+        );
+        let [RecognizedTouchGesture::Scroll(scroll)] = recognized.as_slice() else {
+            panic!("expected scroll, got {recognized:?}");
+        };
+        assert_eq!(scroll.touch_phase, TouchPhase::Ended);
+    }
+
+    #[test]
+    fn separate_taps_are_not_merged_by_two_finger_window() {
+        let mut recognizer = TouchGestureRecognizer::new(GestureTuning::default());
+        let now = Instant::now();
+
+        // A tap well after PENDING_TOUCH_WINDOW of the last resolved touch is
+        // still a tap — the two-finger merge window doesn't swallow separate
+        // taps made at a normal pace.
+        recognizer.handle_event_at(
+            &touch_event(TouchId(1), TouchPhase::Started, 100., 100.),
+            now,
+        );
+        let recognized = recognizer.handle_event_at(
+            &touch_event(TouchId(1), TouchPhase::Ended, 100., 100.),
+            now + Duration::from_millis(40),
+        );
+        let [RecognizedTouchGesture::Tap { .. }] = recognized.as_slice() else {
+            panic!("expected tap, got {recognized:?}");
+        };
+
+        let later = now + Duration::from_millis(500);
+        recognizer.handle_event_at(
+            &touch_event(TouchId(2), TouchPhase::Started, 200., 200.),
+            later,
+        );
+        let recognized = recognizer.handle_event_at(
+            &touch_event(TouchId(2), TouchPhase::Ended, 200., 200.),
+            later + Duration::from_millis(40),
+        );
+        let [RecognizedTouchGesture::Tap { .. }] = recognized.as_slice() else {
+            panic!("expected tap, got {recognized:?}");
+        };
+    }
+
+    #[test]
+    fn single_finger_always_scrolls() {
+        // A slow single-finger drag is a scroll — no synthesized mouse events.
+        let mut recognizer = TouchGestureRecognizer::new(GestureTuning::default());
+        let now = Instant::now();
+        let touch = TouchId(1);
+
+        recognizer.handle_event_at(&touch_event(touch, TouchPhase::Started, 100., 100.), now);
+        let recognized = recognizer.handle_event_at(
+            &touch_event(touch, TouchPhase::Moved, 100., 112.),
+            now + Duration::from_millis(80),
+        );
+        let [RecognizedTouchGesture::Scroll(scroll)] = recognized.as_slice() else {
+            panic!("expected scroll, got {recognized:?}");
+        };
+        assert_eq!(scroll.touch_phase, TouchPhase::Started);
     }
 
     fn touch_event(id: TouchId, phase: TouchPhase, x: f32, y: f32) -> TouchEvent {

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -34,7 +34,7 @@ use wayland_client::{
     Connection, Dispatch, Proxy, QueueHandle, delegate_noop,
     protocol::{
         wl_buffer, wl_compositor, wl_keyboard, wl_pointer, wl_registry, wl_seat, wl_shm,
-        wl_shm_pool, wl_surface,
+        wl_shm_pool, wl_surface, wl_touch,
     },
 };
 use wayland_protocols::wp::pointer_gestures::zv1::client::{
@@ -101,7 +101,8 @@ use gpui::{
     Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent,
     MouseUpEvent, NavigationDirection, Pixels, PlatformDisplay, PlatformInput,
     PlatformKeyboardLayout, PlatformWindow, Point, ScrollDelta, ScrollWheelEvent, SharedString,
-    Size, TouchPhase, WindowButtonLayout, WindowKind, WindowParams, point, profiler, px, size,
+    Size, TouchEvent, TouchId, TouchPhase, WindowButtonLayout, WindowKind, WindowParams, point,
+    profiler, px, size,
 };
 use gpui_wgpu::{CompositorGpuHint, GpuContext};
 use wayland_protocols::wp::linux_dmabuf::zv1::client::{
@@ -320,6 +321,16 @@ pub(crate) struct WaylandClientState {
     pinch_gesture: Option<zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1>,
     pinch_scale: f32,
     wl_keyboard: Option<wl_keyboard::WlKeyboard>,
+    wl_touch: Option<wl_touch::WlTouch>,
+    // Surface for each in-flight touch, keyed by touch id. Only `Down` carries
+    // the surface, so we remember it to route later Motion/Up events to the
+    // window under that finger.
+    touch_surfaces: HashMap<u64, ObjectId>,
+    // Last known position for each in-flight touch, keyed by touch id. The
+    // recognizer resolves a tap from the *release* event's position, and
+    // wl_touch `Up` carries no coordinates, so we replay the finger's last
+    // reported position on release.
+    touch_positions: HashMap<u64, Point<Pixels>>,
     cursor_shape_device: Option<wp_cursor_shape_device_v1::WpCursorShapeDeviceV1>,
     data_device: Option<wl_data_device::WlDataDevice>,
     primary_selection: Option<zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1>,
@@ -901,6 +912,9 @@ impl WaylandClient {
             wl_seat: seat,
             wl_pointer: None,
             wl_keyboard: None,
+            wl_touch: None,
+            touch_surfaces: HashMap::default(),
+            touch_positions: HashMap::default(),
             pinch_gesture: None,
             pinch_scale: 1.0,
             cursor_shape_device: None,
@@ -1735,6 +1749,113 @@ impl Dispatch<wl_seat::WlSeat, ()> for WaylandClientStatePtr {
 
                 state.wl_pointer = Some(pointer);
             }
+            if capabilities.contains(wl_seat::Capability::Touch) {
+                let touch = seat.get_touch(qh, ());
+
+                if let Some(old_touch) = state.wl_touch.take() {
+                    old_touch.release();
+                }
+
+                state.wl_touch = Some(touch);
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_touch::WlTouch, ()> for WaylandClientStatePtr {
+    fn event(
+        this: &mut Self,
+        _wl_touch: &wl_touch::WlTouch,
+        event: wl_touch::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+
+        match event {
+            wl_touch::Event::Down {
+                serial,
+                surface,
+                id,
+                x,
+                y,
+                ..
+            } => {
+                state.serial_tracker.update(SerialKind::Touch, serial);
+                let touch_id = TouchId(id as u64);
+                // Only `Down` carries the touched surface; remember it so the
+                // follow-up Motion/Up events for this id can be routed to the
+                // window under that finger.
+                state.touch_surfaces.insert(touch_id.0, surface.id());
+
+                let position = point(px(x as f32), px(y as f32));
+                state.touch_positions.insert(touch_id.0, position);
+                if let Some(window) = get_window(&mut state, &surface.id()) {
+                    let input = PlatformInput::Touch(TouchEvent {
+                        id: touch_id,
+                        phase: TouchPhase::Started,
+                        position,
+                        predicted_position: None,
+                        force: None,
+                    });
+                    drop(state);
+                    window.handle_input(input);
+                }
+            }
+            wl_touch::Event::Motion { id, x, y, .. } => {
+                let touch_id = TouchId(id as u64);
+                let position = point(px(x as f32), px(y as f32));
+                state.touch_positions.insert(touch_id.0, position);
+
+                if let Some(surface_id) = state.touch_surfaces.get(&touch_id.0).cloned() {
+                    if let Some(window) = get_window(&mut state, &surface_id) {
+                        let input = PlatformInput::Touch(TouchEvent {
+                            id: touch_id,
+                            phase: TouchPhase::Moved,
+                            position,
+                            predicted_position: None,
+                            force: None,
+                        });
+                        drop(state);
+                        window.handle_input(input);
+                    }
+                }
+            }
+            wl_touch::Event::Up { id, .. } => {
+                let touch_id = TouchId(id as u64);
+
+                if let Some(surface_id) = state.touch_surfaces.remove(&touch_id.0) {
+                    // Replay the finger's last reported position: wl_touch `Up`
+                    // carries no coordinates, and the recognizer resolves the
+                    // tap from this release position.
+                    let position = state
+                        .touch_positions
+                        .remove(&touch_id.0)
+                        .unwrap_or_default();
+                    if let Some(window) = get_window(&mut state, &surface_id) {
+                        let input = PlatformInput::Touch(TouchEvent {
+                            id: touch_id,
+                            phase: TouchPhase::Ended,
+                            position,
+                            predicted_position: None,
+                            force: None,
+                        });
+                        drop(state);
+                        window.handle_input(input);
+                    }
+                }
+            }
+            wl_touch::Event::Cancel => {
+                // wl_touch v1 carries no per-touch id on Cancel, so we can't
+                // target a specific touch. Most compositors send an Up per
+                // touch before Cancel, and the recognizer recovers on the
+                // next Started, so this is intentionally left as a no-op.
+                state.touch_surfaces.clear();
+                state.touch_positions.clear();
+            }
+            _ => {}
         }
     }
 }

--- a/crates/gpui_linux/src/linux/wayland/serial.rs
+++ b/crates/gpui_linux/src/linux/wayland/serial.rs
@@ -7,6 +7,7 @@ pub(crate) enum SerialKind {
     MouseEnter,
     MousePress,
     KeyPress,
+    Touch,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
# Objective

Zed previously ignored all touch input on Linux/Wayland: there was no wl_touch binding in the Wayland client, so tap-to-click, menu and caret activation, and scrolling were impossible on a touchscreen. A related earlier attempt (PR #40139) delivered touch events to the wrong window; this fixes that targeting issue as well. This PR fixes #54473 (Zed ignores touch input on Linux/Wayland) and works towards #13698 (Support touch input).

N.B.: I met some of the Zed team at Rust Week and discussed this feature with them (thanks for the pointers, guys) and I finally got around to working on it this week!

## Solution

Translate wl_touch Down/Motion/Up/Cancel into GPUI's portable TouchEvent stream so the existing TouchGestureRecognizer can drive tap, scroll (with axis locking and momentum), and long-press on Wayland. Each event is delivered to the window under its own surface, so events reach the correct window even when several are open.

The recognizer resolves a tap from the *release* event's position, but wl_touch Up carries no coordinates. Previously we emitted Point::default() (0,0), so synthesized mouse-down/up landed at the window's top-left corner instead of where the user touched, breaking tap-to-click, menu activation, and caret placement. Track each in-flight touch's last reported position (updated on Down and Motion) and replay it on Up; clear both the surface and position maps on Cancel to avoid leaks.

A second finger that lands while a pan is already underway takes over as the active touch, so its movement drives scroll instead of being ignored — two fingers scroll even if one was already panning (e.g., after catching a fling). A single finger continues to resolve into tap or flick-scroll exactly as before.

## Testing

I have tested this on a Framework 13 Pro running Ubuntu 26.04.1. The touch behavior works intuitively and is consistent with other applications. I have not tested on other platforms.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact: I did not notice any and do not expect these changes to introduce any significant overhead

## Showcase

I don't intend to post a video of this online, but would be happy to show it off at any conferences :) 

## Release Notes:

- Implements single-finger touch support in Wayland
- Implements two-finger scrolling support in Wayland