### PR TITLE
theme: Allow customizing CodeLens text color

### DIFF
--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -204,6 +204,8 @@ pub struct ThemeColors {
     // Editor
     // ===
     pub editor_foreground: Hsla,
+    /// Text color used for CodeLens items in the editor.
+    pub editor_code_lens_foreground: Hsla,
     pub editor_background: Hsla,
     pub editor_gutter_background: Hsla,
     pub editor_subheader_background: Hsla,


### PR DESCRIPTION
CodeLens text currently uses `text.muted`, which means changing its color also changes unrelated muted UI text such as the sidebar.

This exposes a dedicated `editor.code_lens.foreground` theme color and keeps the current `text.muted` value as the default, so existing themes remain visually unchanged.

Release Notes:

- Added a theme color for customizing CodeLens text independently.