### PR TITLE
agent: Fix elicitation tool-call IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> Remove this line to confirm you've reviewed this PR before submitting.
-
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -6364,14 +6364,14 @@ impl ToolCallEventStream {
         cx: &mut App,
     ) -> Task<Result<acp::CreateElicitationResponse>> {
         let stream = self.stream.clone();
-        let tool_use_id = self.tool_use_id.clone();
+        let tool_call_id = self.tool_call_id.clone();
         cx.spawn(async move |_cx| {
             let (response_tx, response_rx) = oneshot::channel();
             if let Err(error) =
                 stream
                     .0
                     .unbounded_send(Ok(ThreadEvent::Elicitation(ElicitationRequest {
-                        tool_call_id: acp::ToolCallId::new(tool_use_id.to_string()),
+                        tool_call_id,
                         message,
                         schema,
                         response: response_tx,

--- a/crates/agent/src/tools/ask_user_tool.rs
+++ b/crates/agent/src/tools/ask_user_tool.rs
@@ -234,6 +234,7 @@ mod tests {
     #[gpui::test]
     async fn test_ask_user_returns_selected_option(cx: &mut TestAppContext) {
         let (event_stream, mut event_rx) = ToolCallEventStream::test();
+        let tool_call_id = event_stream.tool_call_id().clone();
         let tool = Arc::new(AskUserTool);
         let task = cx.update(|cx| {
             tool.run(
@@ -248,6 +249,7 @@ mod tests {
         });
 
         let request = event_rx.expect_elicitation().await;
+        assert_eq!(request.tool_call_id, tool_call_id);
         assert_eq!(request.message, "Which approach?");
         assert!(request.schema.properties.contains_key(CHOICE_FIELD));
         assert!(!request.schema.properties.contains_key(OTHER_FIELD));


### PR DESCRIPTION
Use the native tool call's scoped ID for elicitation requests instead of constructing an ID from the raw provider-issued tool-use ID. This keeps `ask_user` forms associated with the correct conversation entry, including when providers reuse raw IDs.

Release Notes:

- N/A