### PR TITLE
Fix Linux mailto URI handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0848bedd08067dca1c02c31cbb371a94ad4f2f8a61a82f2c43d96ec36a395244"
+checksum = "0b09507a218cf6eb4ab0659883e54880cea3984e3dbaa4989b6cda3f8f8a97a5"
 dependencies = [
  "enumflags2",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,7 +524,7 @@ alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev 
 any_vec = "0.14"
 anyhow = "1.0.86"
 arc-swap = "1.9.0"
-ashpd = { version = "0.13.5", default-features = false, features = [
+ashpd = { version = "0.13", default-features = false, features = [
     "async-io",
     "inhibit",
     "notification",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,7 +524,7 @@ alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev 
 any_vec = "0.14"
 anyhow = "1.0.86"
 arc-swap = "1.9.0"
-ashpd = { version = "0.13", default-features = false, features = [
+ashpd = { version = "0.13.5", default-features = false, features = [
     "async-io",
     "inhibit",
     "notification",


### PR DESCRIPTION
Fixes #64071

# Objective

Fix `Help → Email Us...` on Linux when using an affected version of `ashpd`.

The `mailto:` URI generated by Zed is valid, but older `ashpd` versions incorrectly reject URIs that contain a scheme without `://`, causing the URI to fail before it can be opened.

## Solution

Update the `ashpd` dependency to `0.13.5`, which contains the upstream fix for URI parsing ([ashpd#385](https://github.com/bilelmoussaoui/ashpd/issues/385), [ashpd#386](https://github.com/bilelmoussaoui/ashpd/pull/386)).

Also update `Cargo.lock` to ensure the fixed version is used.

## Testing

Verified that `cargo tree -p ashpd` resolves to `ashpd v0.13.5` and that the project builds successfully.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Not applicable. This PR does not introduce a visual change or new user-facing UI.

---

Release Notes:

- Fixed Linux `mailto:` URI handling when using `Help → Email Us...`.