### PR TITLE
Inherit file scan exclusions in project settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -56,17 +56,6 @@
   "formatter": "auto",
   "remove_trailing_whitespace_on_save": true,
   "ensure_final_newline_on_save": true,
-  "file_scan_exclusions": [
-    "crates/agent/src/tools/evals/fixtures",
-    "**/.git",
-    "**/.svn",
-    "**/.hg",
-    "**/.jj",
-    "**/CVS",
-    "**/.DS_Store",
-    "**/Thumbs.db",
-    "**/.classpath",
-    "**/.settings",
-  ],
+  "file_scan_exclusions": ["...", "crates/agent/src/tools/evals/fixtures"],
   "read_only_files": ["**/.rustup/**", "**/.cargo/registry/**", "**/.cargo/git/**", "target/**/*.rs", "**/*.lock"],
 }


### PR DESCRIPTION
## Objective

Follow-up to #62769.

## Solution

Now that Zed Stable supports `"..."`, we can make the project settings update [deferred from the original PR](https://github.com/zed-industries/zed/pull/62769#discussion_r3799304949).

## Testing

Rust tests and in-app validation were not run for this configuration-only change.

## Self-Review Checklist:

- [x] I’ve reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed’s UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A