### PR TITLE
Use `indoc` for migrator test fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10960,7 +10960,6 @@ dependencies = [
  "streaming-iterator",
  "tree-sitter",
  "tree-sitter-json",
- "unindent",
 ]
 
 [[package]]

--- a/crates/migrator/Cargo.toml
+++ b/crates/migrator/Cargo.toml
@@ -28,4 +28,3 @@ settings_json = { workspace = true, features = ["editing"] }
 [dev-dependencies]
 indoc.workspace = true
 pretty_assertions.workspace = true
-unindent.workspace = true

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -412,7 +412,6 @@ static EDIT_PREDICTION_SETTINGS_MIGRATION_QUERY: LazyLock<Query> = LazyLock::new
 mod tests {
     use super::*;
     use indoc::indoc;
-    use unindent::Unindent as _;
 
     #[track_caller]
     fn assert_migrated_correctly(migrated: Option<String>, expected: Option<&str>) {
@@ -684,24 +683,20 @@ mod tests {
     #[test]
     fn test_nested_string_replace_for_settings() {
         assert_migrate_settings(
-            &r#"
-            {
-                "features": {
-                    "inline_completion_provider": "zed"
-                },
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            indoc! {r#"
+                {
+                    "features": {
+                        "inline_completion_provider": "zed"
+                    },
+                }
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "zed"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         )
     }
 
@@ -1251,31 +1246,29 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
-            &r#"{
-        "formatter": [
-          {
-            "code_actions": {
-              "included-1": true,
-              "included-2": true,
-              "excluded": false,
-            }
-          }
-        ]
-      }"#
-            .unindent(),
-            Some(
-                &r#"{
-        "formatter": [
-          {
-            "code_action": "included-1"
-          },
-          {
-            "code_action": "included-2"
-          }
-        ]
-      }"#
-                .unindent(),
-            ),
+            indoc! {r#"
+                {
+                  "formatter": [
+                    {
+                      "code_actions": {
+                        "included-1": true,
+                        "included-2": true,
+                        "excluded": false,
+                      }
+                    }
+                  ]
+                }"#},
+            Some(indoc! {r#"
+                {
+                  "formatter": [
+                    {
+                      "code_action": "included-1"
+                    },
+                    {
+                      "code_action": "included-2"
+                    }
+                  ]
+                }"#}),
         );
     }
 
@@ -1285,18 +1278,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
-            &r#"{
-        "formatter": {
-          "code_actions": {
-            "included-1": true,
-            "excluded": false,
-            "included-2": true
-          }
-        }
-      }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                  "formatter": {
+                    "code_actions": {
+                      "included-1": true,
+                      "excluded": false,
+                      "included-2": true
+                    }
+                  }
+                }"#},
+            Some(indoc! {r#"
+                {
                   "formatter": [
                     {
                       "code_action": "included-1"
@@ -1305,133 +1298,127 @@ mod tests {
                       "code_action": "included-2"
                     }
                   ]
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
     }
 
     #[test]
     fn test_flatten_code_action_formatters_array_with_multiple_action_blocks() {
         assert_migrate_settings(
-            &r#"{
-          "formatter": [
-            {
-               "code_actions": {
-                  "included-1": true,
-                  "included-2": true,
-                  "excluded": false,
-               }
-            },
-            {
-              "language_server": "ruff"
-            },
-            {
-               "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-               }
-            }
-            // some comment
-            ,
-            {
-               "code_actions": {
-                "excluded": false,
-                "included-3": true,
-                "included-4": true,
-               }
-            },
-          ]
-        }"#
-            .unindent(),
-            Some(
-                &r#"{
-        "formatter": [
-          {
-            "code_action": "included-1"
-          },
-          {
-            "code_action": "included-2"
-          },
-          {
-            "language_server": "ruff"
-          },
-          {
-            "code_action": "included-3"
-          },
-          {
-            "code_action": "included-4"
-          }
-        ]
-      }"#
-                .unindent(),
-            ),
+            indoc! {r#"
+                {
+                  "formatter": [
+                    {
+                       "code_actions": {
+                          "included-1": true,
+                          "included-2": true,
+                          "excluded": false,
+                       }
+                    },
+                    {
+                      "language_server": "ruff"
+                    },
+                    {
+                       "code_actions": {
+                          "excluded": false,
+                          "excluded-2": false,
+                       }
+                    }
+                    // some comment
+                    ,
+                    {
+                       "code_actions": {
+                        "excluded": false,
+                        "included-3": true,
+                        "included-4": true,
+                       }
+                    },
+                  ]
+                }"#},
+            Some(indoc! {r#"
+                {
+                  "formatter": [
+                    {
+                      "code_action": "included-1"
+                    },
+                    {
+                      "code_action": "included-2"
+                    },
+                    {
+                      "language_server": "ruff"
+                    },
+                    {
+                      "code_action": "included-3"
+                    },
+                    {
+                      "code_action": "included-4"
+                    }
+                  ]
+                }"#}),
         );
     }
 
     #[test]
     fn test_flatten_code_action_formatters_array_with_multiple_action_blocks_in_languages() {
         assert_migrate_settings(
-            &r#"{
-        "languages": {
-          "Rust": {
-            "formatter": [
-              {
-                "code_actions": {
-                  "included-1": true,
-                  "included-2": true,
-                  "excluded": false,
-                }
-              },
-              {
-                "language_server": "ruff"
-              },
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-                }
-              }
-              // some comment
-              ,
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "included-3": true,
-                  "included-4": true,
-                }
-              },
-            ]
-          }
-        }
-      }"#
-            .unindent(),
-            Some(
-                &r#"{
-          "languages": {
-            "Rust": {
-              "formatter": [
+            indoc! {r#"
                 {
-                  "code_action": "included-1"
-                },
+                  "languages": {
+                    "Rust": {
+                      "formatter": [
+                        {
+                          "code_actions": {
+                            "included-1": true,
+                            "included-2": true,
+                            "excluded": false,
+                          }
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "excluded-2": false,
+                          }
+                        }
+                        // some comment
+                        ,
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "included-3": true,
+                            "included-4": true,
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }"#},
+            Some(indoc! {r#"
                 {
-                  "code_action": "included-2"
-                },
-                {
-                  "language_server": "ruff"
-                },
-                {
-                  "code_action": "included-3"
-                },
-                {
-                  "code_action": "included-4"
-                }
-              ]
-            }
-          }
-        }"#
-                .unindent(),
-            ),
+                  "languages": {
+                    "Rust": {
+                      "formatter": [
+                        {
+                          "code_action": "included-1"
+                        },
+                        {
+                          "code_action": "included-2"
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_action": "included-3"
+                        },
+                        {
+                          "code_action": "included-4"
+                        }
+                      ]
+                    }
+                  }
+                }"#}),
         );
     }
 
@@ -1442,123 +1429,121 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
-            &r#"{
-        "formatter": {
-          "code_actions": {
-            "default-1": true,
-            "default-2": true,
-            "default-3": true,
-            "default-4": true,
-          }
-        },
-        "languages": {
-          "Rust": {
-            "formatter": [
-              {
-                "code_actions": {
-                  "included-1": true,
-                  "included-2": true,
-                  "excluded": false,
-                }
-              },
-              {
-                "language_server": "ruff"
-              },
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-                }
-              }
-              // some comment
-              ,
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "included-3": true,
-                  "included-4": true,
-                }
-              },
-            ]
-          },
-          "Python": {
-            "formatter": [
-              {
-                "language_server": "ruff"
-              },
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-                }
-              }
-              // some comment
-              ,
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "included-3": true,
-                  "included-4": true,
-                }
-              },
-            ]
-          }
-        }
-      }"#
-            .unindent(),
-            Some(
-                &r#"{
-          "formatter": [
-            {
-              "code_action": "default-1"
-            },
-            {
-              "code_action": "default-2"
-            },
-            {
-              "code_action": "default-3"
-            },
-            {
-              "code_action": "default-4"
-            }
-          ],
-          "languages": {
-            "Rust": {
-              "formatter": [
+            indoc! {r#"
                 {
-                  "code_action": "included-1"
-                },
+                  "formatter": {
+                    "code_actions": {
+                      "default-1": true,
+                      "default-2": true,
+                      "default-3": true,
+                      "default-4": true,
+                    }
+                  },
+                  "languages": {
+                    "Rust": {
+                      "formatter": [
+                        {
+                          "code_actions": {
+                            "included-1": true,
+                            "included-2": true,
+                            "excluded": false,
+                          }
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "excluded-2": false,
+                          }
+                        }
+                        // some comment
+                        ,
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "included-3": true,
+                            "included-4": true,
+                          }
+                        },
+                      ]
+                    },
+                    "Python": {
+                      "formatter": [
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "excluded-2": false,
+                          }
+                        }
+                        // some comment
+                        ,
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "included-3": true,
+                            "included-4": true,
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }"#},
+            Some(indoc! {r#"
                 {
-                  "code_action": "included-2"
-                },
-                {
-                  "language_server": "ruff"
-                },
-                {
-                  "code_action": "included-3"
-                },
-                {
-                  "code_action": "included-4"
-                }
-              ]
-            },
-            "Python": {
-              "formatter": [
-                {
-                  "language_server": "ruff"
-                },
-                {
-                  "code_action": "included-3"
-                },
-                {
-                  "code_action": "included-4"
-                }
-              ]
-            }
-          }
-        }"#
-                .unindent(),
-            ),
+                  "formatter": [
+                    {
+                      "code_action": "default-1"
+                    },
+                    {
+                      "code_action": "default-2"
+                    },
+                    {
+                      "code_action": "default-3"
+                    },
+                    {
+                      "code_action": "default-4"
+                    }
+                  ],
+                  "languages": {
+                    "Rust": {
+                      "formatter": [
+                        {
+                          "code_action": "included-1"
+                        },
+                        {
+                          "code_action": "included-2"
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_action": "included-3"
+                        },
+                        {
+                          "code_action": "included-4"
+                        }
+                      ]
+                    },
+                    "Python": {
+                      "formatter": [
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_action": "included-3"
+                        },
+                        {
+                          "code_action": "included-4"
+                        }
+                      ]
+                    }
+                  }
+                }"#}),
         );
     }
 
@@ -1568,184 +1553,181 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_01::flatten_code_actions_formatters,
             )],
-            &r#"{
-        "formatter": {
-          "code_actions": {
-            "default-1": true,
-            "default-2": true,
-            "default-3": true,
-            "default-4": true,
-          }
-        },
-        "format_on_save": [
-          {
-            "code_actions": {
-              "included-1": true,
-              "included-2": true,
-              "excluded": false,
-            }
-          },
-          {
-            "language_server": "ruff"
-          },
-          {
-            "code_actions": {
-              "excluded": false,
-              "excluded-2": false,
-            }
-          }
-          // some comment
-          ,
-          {
-            "code_actions": {
-              "excluded": false,
-              "included-3": true,
-              "included-4": true,
-            }
-          },
-        ],
-        "languages": {
-          "Rust": {
-            "format_on_save": "prettier",
-            "formatter": [
-              {
-                "code_actions": {
-                  "included-1": true,
-                  "included-2": true,
-                  "excluded": false,
-                }
-              },
-              {
-                "language_server": "ruff"
-              },
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-                }
-              }
-              // some comment
-              ,
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "included-3": true,
-                  "included-4": true,
-                }
-              },
-            ]
-          },
-          "Python": {
-            "format_on_save": {
-              "code_actions": {
-                "on-save-1": true,
-                "on-save-2": true,
-              }
-            },
-            "formatter": [
-              {
-                "language_server": "ruff"
-              },
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "excluded-2": false,
-                }
-              }
-              // some comment
-              ,
-              {
-                "code_actions": {
-                  "excluded": false,
-                  "included-3": true,
-                  "included-4": true,
-                }
-              },
-            ]
-          }
-        }
-      }"#
-            .unindent(),
-            Some(
-                &r#"
-        {
-          "formatter": [
-            {
-              "code_action": "default-1"
-            },
-            {
-              "code_action": "default-2"
-            },
-            {
-              "code_action": "default-3"
-            },
-            {
-              "code_action": "default-4"
-            }
-          ],
-          "format_on_save": [
-            {
-              "code_action": "included-1"
-            },
-            {
-              "code_action": "included-2"
-            },
-            {
-              "language_server": "ruff"
-            },
-            {
-              "code_action": "included-3"
-            },
-            {
-              "code_action": "included-4"
-            }
-          ],
-          "languages": {
-            "Rust": {
-              "format_on_save": "prettier",
-              "formatter": [
+            indoc! {r#"
                 {
-                  "code_action": "included-1"
-                },
+                  "formatter": {
+                    "code_actions": {
+                      "default-1": true,
+                      "default-2": true,
+                      "default-3": true,
+                      "default-4": true,
+                    }
+                  },
+                  "format_on_save": [
+                    {
+                      "code_actions": {
+                        "included-1": true,
+                        "included-2": true,
+                        "excluded": false,
+                      }
+                    },
+                    {
+                      "language_server": "ruff"
+                    },
+                    {
+                      "code_actions": {
+                        "excluded": false,
+                        "excluded-2": false,
+                      }
+                    }
+                    // some comment
+                    ,
+                    {
+                      "code_actions": {
+                        "excluded": false,
+                        "included-3": true,
+                        "included-4": true,
+                      }
+                    },
+                  ],
+                  "languages": {
+                    "Rust": {
+                      "format_on_save": "prettier",
+                      "formatter": [
+                        {
+                          "code_actions": {
+                            "included-1": true,
+                            "included-2": true,
+                            "excluded": false,
+                          }
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "excluded-2": false,
+                          }
+                        }
+                        // some comment
+                        ,
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "included-3": true,
+                            "included-4": true,
+                          }
+                        },
+                      ]
+                    },
+                    "Python": {
+                      "format_on_save": {
+                        "code_actions": {
+                          "on-save-1": true,
+                          "on-save-2": true,
+                        }
+                      },
+                      "formatter": [
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "excluded-2": false,
+                          }
+                        }
+                        // some comment
+                        ,
+                        {
+                          "code_actions": {
+                            "excluded": false,
+                            "included-3": true,
+                            "included-4": true,
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }"#},
+            Some(indoc! {r#"
                 {
-                  "code_action": "included-2"
-                },
-                {
-                  "language_server": "ruff"
-                },
-                {
-                  "code_action": "included-3"
-                },
-                {
-                  "code_action": "included-4"
-                }
-              ]
-            },
-            "Python": {
-              "format_on_save": [
-                {
-                  "code_action": "on-save-1"
-                },
-                {
-                  "code_action": "on-save-2"
-                }
-              ],
-              "formatter": [
-                {
-                  "language_server": "ruff"
-                },
-                {
-                  "code_action": "included-3"
-                },
-                {
-                  "code_action": "included-4"
-                }
-              ]
-            }
-          }
-        }"#
-                .unindent(),
-            ),
+                  "formatter": [
+                    {
+                      "code_action": "default-1"
+                    },
+                    {
+                      "code_action": "default-2"
+                    },
+                    {
+                      "code_action": "default-3"
+                    },
+                    {
+                      "code_action": "default-4"
+                    }
+                  ],
+                  "format_on_save": [
+                    {
+                      "code_action": "included-1"
+                    },
+                    {
+                      "code_action": "included-2"
+                    },
+                    {
+                      "language_server": "ruff"
+                    },
+                    {
+                      "code_action": "included-3"
+                    },
+                    {
+                      "code_action": "included-4"
+                    }
+                  ],
+                  "languages": {
+                    "Rust": {
+                      "format_on_save": "prettier",
+                      "formatter": [
+                        {
+                          "code_action": "included-1"
+                        },
+                        {
+                          "code_action": "included-2"
+                        },
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_action": "included-3"
+                        },
+                        {
+                          "code_action": "included-4"
+                        }
+                      ]
+                    },
+                    "Python": {
+                      "format_on_save": [
+                        {
+                          "code_action": "on-save-1"
+                        },
+                        {
+                          "code_action": "on-save-2"
+                        }
+                      ],
+                      "formatter": [
+                        {
+                          "language_server": "ruff"
+                        },
+                        {
+                          "code_action": "included-3"
+                        },
+                        {
+                          "code_action": "included-4"
+                        }
+                      ]
+                    }
+                  }
+                }"#}),
         );
     }
 
@@ -1755,17 +1737,15 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                  "format_on_save": "prettier"
-              }"#
-            .unindent(),
-            Some(
-                &r#"{
-                      "formatter": "prettier",
-                      "format_on_save": "on"
-                  }"#
-                .unindent(),
-            ),
+            indoc! {r#"
+                {
+                    "format_on_save": "prettier"
+                }"#},
+            Some(indoc! {r#"
+                {
+                    "formatter": "prettier",
+                    "format_on_save": "on"
+                }"#}),
         );
     }
 
@@ -1775,12 +1755,12 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "format_on_save": ["prettier", {"language_server": "eslint"}]
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "format_on_save": ["prettier", {"language_server": "eslint"}]
+                }"#},
+            Some(indoc! {r#"
+                {
                     "formatter": [
                         "prettier",
                         {
@@ -1788,9 +1768,7 @@ mod tests {
                         }
                     ],
                     "format_on_save": "on"
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
     }
 
@@ -1800,10 +1778,10 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "format_on_save": "on"
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "format_on_save": "on"
+                }"#},
             None,
         );
 
@@ -1811,10 +1789,10 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "format_on_save": "off"
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "format_on_save": "off"
+                }"#},
             None,
         );
     }
@@ -1825,19 +1803,19 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "languages": {
-                    "Rust": {
-                        "format_on_save": "rust-analyzer"
-                    },
-                    "Python": {
-                        "format_on_save": ["ruff", "black"]
+            indoc! {r#"
+                {
+                    "languages": {
+                        "Rust": {
+                            "format_on_save": "rust-analyzer"
+                        },
+                        "Python": {
+                            "format_on_save": ["ruff", "black"]
+                        }
                     }
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+                }"#},
+            Some(indoc! {r#"
+                {
                     "languages": {
                         "Rust": {
                             "formatter": "rust-analyzer",
@@ -1851,9 +1829,7 @@ mod tests {
                             "format_on_save": "on"
                         }
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
     }
 
@@ -1863,20 +1839,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "format_on_save": "prettier",
-                "languages": {
-                    "Rust": {
-                        "format_on_save": "rust-analyzer"
-                    },
-                    "Python": {
-                        "format_on_save": "on"
+            indoc! {r#"
+                {
+                    "format_on_save": "prettier",
+                    "languages": {
+                        "Rust": {
+                            "format_on_save": "rust-analyzer"
+                        },
+                        "Python": {
+                            "format_on_save": "on"
+                        }
                     }
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+                }"#},
+            Some(indoc! {r#"
+                {
                     "formatter": "prettier",
                     "format_on_save": "on",
                     "languages": {
@@ -1888,9 +1864,7 @@ mod tests {
                             "format_on_save": "on"
                         }
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
     }
 
@@ -1900,10 +1874,10 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_02::remove_formatters_on_save,
             )],
-            &r#"{
-                "formatter": ["prettier"]
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "formatter": ["prettier"]
+                }"#},
             None,
         );
     }
@@ -1914,34 +1888,32 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
-            &r#"{
-                "formatter": {
-                    "code_action": "foo"
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "formatter": {
+                        "code_action": "foo"
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "code_actions_on_format": {
                         "foo": true
                     },
                     "formatter": []
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
-            &r#"{
-                "formatter": [
-                    { "code_action": "foo" },
-                    "auto"
-                ]
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "formatter": [
+                        { "code_action": "foo" },
+                        "auto"
+                    ]
+                }"#},
             None,
         );
 
@@ -1949,46 +1921,44 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
-            &r#"{
-                "formatter": {
-                    "code_action": "foo"
-                },
-                "code_actions_on_format": {
-                    "bar": true,
-                    "baz": false
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "formatter": {
+                        "code_action": "foo"
+                    },
+                    "code_actions_on_format": {
+                        "bar": true,
+                        "baz": false
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "formatter": [],
                     "code_actions_on_format": {
                         "foo": true,
                         "bar": true,
                         "baz": false
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
-            &r#"{
-                "formatter": [
-                    { "code_action": "foo" },
-                    { "code_action": "qux" },
-                ],
-                "code_actions_on_format": {
-                    "bar": true,
-                    "baz": false
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "formatter": [
+                        { "code_action": "foo" },
+                        { "code_action": "qux" },
+                    ],
+                    "code_actions_on_format": {
+                        "bar": true,
+                        "baz": false
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "formatter": [],
                     "code_actions_on_format": {
                         "foo": true,
@@ -1996,23 +1966,21 @@ mod tests {
                         "bar": true,
                         "baz": false
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_16::restore_code_actions_on_format,
             )],
-            &r#"{
-                "formatter": [],
-                "code_actions_on_format": {
-                    "bar": true,
-                    "baz": false
-                }
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "formatter": [],
+                    "code_actions_on_format": {
+                        "bar": true,
+                        "baz": false
+                    }
+                }"#},
             None,
         );
     }
@@ -2023,7 +1991,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2031,60 +1999,54 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"{
-                "file_finder": {
-                    "include_ignored": true
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "file_finder": {
+                        "include_ignored": true
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "file_finder": {
                         "include_ignored": "all"
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"{
-                "file_finder": {
-                    "include_ignored": false
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "file_finder": {
+                        "include_ignored": false
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "file_finder": {
                         "include_ignored": "indexed"
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"{
-                "file_finder": {
-                    "include_ignored": null
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "file_finder": {
+                        "include_ignored": null
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "file_finder": {
                         "include_ignored": "smart"
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         // Platform key: settings nested inside "linux" should be migrated
@@ -2092,18 +2054,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"
-            {
-                "linux": {
-                    "file_finder": {
-                        "include_ignored": true
+            indoc! {r#"
+                {
+                    "linux": {
+                        "file_finder": {
+                            "include_ignored": true
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "linux": {
                         "file_finder": {
@@ -2111,9 +2071,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -2121,20 +2079,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "file_finder": {
-                            "include_ignored": false
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "file_finder": {
+                                "include_ignored": false
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -2144,9 +2100,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -2156,7 +2110,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2164,32 +2118,28 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            &r#"{
-                "relative_line_numbers": true
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "relative_line_numbers": true
+                }"#},
+            Some(indoc! {r#"
+                {
                     "relative_line_numbers": "enabled"
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            &r#"{
-                "relative_line_numbers": false
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "relative_line_numbers": false
+                }"#},
+            Some(indoc! {r#"
+                {
                     "relative_line_numbers": "disabled"
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         // Platform key: settings nested inside "macos" should be migrated
@@ -2197,24 +2147,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            &r#"
-            {
-                "macos": {
-                    "relative_line_numbers": true
+            indoc! {r#"
+                {
+                    "macos": {
+                        "relative_line_numbers": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "relative_line_numbers": "enabled"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -2222,18 +2168,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "dev": {
-                        "relative_line_numbers": false
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "dev": {
+                            "relative_line_numbers": false
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "dev": {
@@ -2241,9 +2185,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -2253,7 +2195,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2261,52 +2203,48 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"{
-                "agent": {
-                    "play_sound_when_agent_done": true
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "agent": {
+                        "play_sound_when_agent_done": true
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "agent": {
                         "play_sound_when_agent_done": "always"
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"{
-                "agent": {
-                    "play_sound_when_agent_done": false
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+            indoc! {r#"
+                {
+                    "agent": {
+                        "play_sound_when_agent_done": false
+                    }
+                }"#},
+            Some(indoc! {r#"
+                {
                     "agent": {
                         "play_sound_when_agent_done": "never"
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"{
-                "agent": {
-                    "play_sound_when_agent_done": "when_hidden"
-                }
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "agent": {
+                        "play_sound_when_agent_done": "when_hidden"
+                    }
+                }"#},
             None,
         );
 
@@ -2315,18 +2253,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"
-            {
-                "macos": {
-                    "agent": {
-                        "play_sound_when_agent_done": true
+            indoc! {r#"
+                {
+                    "macos": {
+                        "agent": {
+                            "play_sound_when_agent_done": true
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "agent": {
@@ -2334,9 +2270,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -2344,20 +2278,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "agent": {
-                            "play_sound_when_agent_done": false
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "agent": {
+                                "play_sound_when_agent_done": false
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -2367,38 +2299,34 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_remove_context_server_source() {
         assert_migrate_settings(
-            &r#"
-            {
-                "context_servers": {
-                    "extension_server": {
-                        "source": "extension",
-                        "settings": {
-                            "foo": "bar"
-                        }
-                    },
-                    "custom_server": {
-                        "source": "custom",
-                        "command": "foo",
-                        "args": ["bar"],
-                        "env": {
-                            "FOO": "BAR"
-                        }
-                    },
+            indoc! {r#"
+                {
+                    "context_servers": {
+                        "extension_server": {
+                            "source": "extension",
+                            "settings": {
+                                "foo": "bar"
+                            }
+                        },
+                        "custom_server": {
+                            "source": "custom",
+                            "command": "foo",
+                            "args": ["bar"],
+                            "env": {
+                                "FOO": "BAR"
+                            }
+                        },
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "context_servers": {
                         "extension_server": {
@@ -2415,9 +2343,7 @@ mod tests {
                         },
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Platform key: settings nested inside "linux" should be migrated
@@ -2425,23 +2351,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
-            &r#"
-            {
-                "linux": {
-                    "context_servers": {
-                        "my_server": {
-                            "source": "extension",
-                            "settings": {
-                                "key": "value"
+            indoc! {r#"
+                {
+                    "linux": {
+                        "context_servers": {
+                            "my_server": {
+                                "source": "extension",
+                                "settings": {
+                                    "key": "value"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "linux": {
                         "context_servers": {
@@ -2453,9 +2377,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -2463,24 +2385,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_11_25::remove_context_server_source,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "context_servers": {
-                            "my_server": {
-                                "source": "custom",
-                                "command": "foo",
-                                "args": ["bar"]
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "context_servers": {
+                                "my_server": {
+                                    "source": "custom",
+                                    "command": "foo",
+                                    "args": ["bar"]
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -2493,72 +2413,60 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_project_panel_open_file_on_paste_migration() {
         assert_migrate_settings(
-            &r#"
-            {
-                "project_panel": {
-                    "open_file_on_paste": true
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "open_file_on_paste": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "project_panel": {
                         "auto_open": { "on_paste": true }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_settings(
-            &r#"
-            {
-                "project_panel": {
-                    "open_file_on_paste": false
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "open_file_on_paste": false
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "project_panel": {
                         "auto_open": { "on_paste": false }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_enable_preview_from_code_navigation_migration() {
         assert_migrate_settings(
-            &r#"
-            {
-                "other_setting_1": 1,
-                "preview_tabs": {
-                    "other_setting_2": 2,
-                    "enable_preview_from_code_navigation": false
+            indoc! {r#"
+                {
+                    "other_setting_1": 1,
+                    "preview_tabs": {
+                        "other_setting_2": 2,
+                        "enable_preview_from_code_navigation": false
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "other_setting_1": 1,
                     "preview_tabs": {
@@ -2566,24 +2474,20 @@ mod tests {
                         "enable_keep_preview_on_code_navigation": false
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_settings(
-            &r#"
-            {
-                "other_setting_1": 1,
-                "preview_tabs": {
-                    "other_setting_2": 2,
-                    "enable_preview_from_code_navigation": true
+            indoc! {r#"
+                {
+                    "other_setting_1": 1,
+                    "preview_tabs": {
+                        "other_setting_2": 2,
+                        "enable_preview_from_code_navigation": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "other_setting_1": 1,
                     "preview_tabs": {
@@ -2591,9 +2495,7 @@ mod tests {
                         "enable_keep_preview_on_code_navigation": true
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -2604,7 +2506,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2613,16 +2515,14 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            &r#"{
-                "auto_indent": true
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
-                "auto_indent": "syntax_aware"
-            }"#
-                .unindent(),
-            ),
+            indoc! {r#"
+                {
+                    "auto_indent": true
+                }"#},
+            Some(indoc! {r#"
+                {
+                    "auto_indent": "syntax_aware"
+                }"#}),
         );
 
         // false should become "none"
@@ -2630,16 +2530,14 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            &r#"{
-                "auto_indent": false
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
-                "auto_indent": "none"
-            }"#
-                .unindent(),
-            ),
+            indoc! {r#"
+                {
+                    "auto_indent": false
+                }"#},
+            Some(indoc! {r#"
+                {
+                    "auto_indent": "none"
+                }"#}),
         );
 
         // Already valid enum values should not change
@@ -2647,10 +2545,10 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            &r#"{
-                "auto_indent": "preserve_indent"
-            }"#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "auto_indent": "preserve_indent"
+                }"#},
             None,
         );
 
@@ -2659,26 +2557,24 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            &r#"{
-                "auto_indent": true,
-                "languages": {
-                    "Python": {
-                        "auto_indent": false
+            indoc! {r#"
+                {
+                    "auto_indent": true,
+                    "languages": {
+                        "Python": {
+                            "auto_indent": false
+                        }
                     }
-                }
-            }"#
-            .unindent(),
-            Some(
-                &r#"{
+                }"#},
+            Some(indoc! {r#"
+                {
                     "auto_indent": "syntax_aware",
                     "languages": {
                         "Python": {
                             "auto_indent": "none"
                         }
                     }
-                }"#
-                .unindent(),
-            ),
+                }"#}),
         );
     }
 
@@ -2688,7 +2584,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2696,93 +2592,80 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": "copilot"
+            indoc! {r#"
+                {
+                    "features": {
+                        "edit_prediction_provider": "copilot"
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "copilot"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": "zed"
-                },
-                "edit_predictions": {
-                    "mode": "eager"
+            indoc! {r#"
+                {
+                    "features": {
+                        "edit_prediction_provider": "zed"
+                    },
+                    "edit_predictions": {
+                        "mode": "eager"
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "zed",
                         "mode": "eager"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": "supermaven"
-                },
-                "edit_predictions": {
-                    "provider": "copilot"
+            indoc! {r#"
+                {
+                    "features": {
+                        "edit_prediction_provider": "supermaven"
+                    },
+                    "edit_predictions": {
+                        "provider": "copilot"
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "copilot"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": "zed"
+            indoc! {r#"
+                {
+                    "edit_predictions": {
+                        "provider": "zed"
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
@@ -2792,23 +2675,19 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": "copilot"
-                },
-                "edit_predictions": true
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            indoc! {r#"
+                {
+                    "features": {
+                        "edit_prediction_provider": "copilot"
+                    },
+                    "edit_predictions": true
+                }
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": true
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Platform key: settings nested inside "macos" should be migrated
@@ -2816,18 +2695,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "macos": {
-                    "features": {
-                        "edit_prediction_provider": "copilot"
+            indoc! {r#"
+                {
+                    "macos": {
+                        "features": {
+                            "edit_prediction_provider": "copilot"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "edit_predictions": {
@@ -2835,9 +2712,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -2845,20 +2720,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "features": {
-                            "edit_prediction_provider": "copilot"
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "features": {
+                                "edit_prediction_provider": "copilot"
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -2868,9 +2741,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
@@ -2878,28 +2749,26 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": "copilot"
-                },
-                "macos": {
+            indoc! {r#"
+                {
                     "features": {
-                        "edit_prediction_provider": "zed"
-                    }
-                },
-                "profiles": {
-                    "work": {
+                        "edit_prediction_provider": "copilot"
+                    },
+                    "macos": {
                         "features": {
-                            "edit_prediction_provider": "supermaven"
+                            "edit_prediction_provider": "zed"
+                        }
+                    },
+                    "profiles": {
+                        "work": {
+                            "features": {
+                                "edit_prediction_provider": "supermaven"
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "copilot"
@@ -2917,9 +2786,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -2929,7 +2796,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -2937,92 +2804,79 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": {
-                        "experimental": "sweep"
+            indoc! {r#"
+                {
+                    "edit_predictions": {
+                        "provider": {
+                            "experimental": "sweep"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "sweep"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": {
-                        "experimental": "mercury"
+            indoc! {r#"
+                {
+                    "edit_predictions": {
+                        "provider": {
+                            "experimental": "mercury"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "mercury"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "features": {
-                    "edit_prediction_provider": {
-                        "experimental": "sweep"
+            indoc! {r#"
+                {
+                    "features": {
+                        "edit_prediction_provider": {
+                            "experimental": "sweep"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "features": {
                         "edit_prediction_provider": "sweep"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": "zed"
+            indoc! {r#"
+                {
+                    "edit_predictions": {
+                        "provider": "zed"
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
@@ -3030,26 +2884,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": {
-                        "experimental": "zeta2"
+            indoc! {r#"
+                {
+                    "edit_predictions": {
+                        "provider": {
+                            "experimental": "zeta2"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "zed"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Platform key: settings nested inside "linux" should be migrated
@@ -3057,20 +2907,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "linux": {
-                    "edit_predictions": {
-                        "provider": {
-                            "experimental": "sweep"
+            indoc! {r#"
+                {
+                    "linux": {
+                        "edit_predictions": {
+                            "provider": {
+                                "experimental": "sweep"
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "linux": {
                         "edit_predictions": {
@@ -3078,9 +2926,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile: settings nested inside profiles should be migrated
@@ -3088,22 +2934,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "dev": {
-                        "edit_predictions": {
-                            "provider": {
-                                "experimental": "mercury"
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "dev": {
+                            "edit_predictions": {
+                                "provider": {
+                                    "experimental": "mercury"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "dev": {
@@ -3113,9 +2957,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Combined: root + platform + profile should all be migrated simultaneously
@@ -3123,34 +2965,32 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            &r#"
-            {
-                "edit_predictions": {
-                    "provider": {
-                        "experimental": "sweep"
-                    }
-                },
-                "linux": {
+            indoc! {r#"
+                {
                     "edit_predictions": {
                         "provider": {
-                            "experimental": "mercury"
+                            "experimental": "sweep"
                         }
-                    }
-                },
-                "profiles": {
-                    "dev": {
+                    },
+                    "linux": {
                         "edit_predictions": {
                             "provider": {
-                                "experimental": "sweep"
+                                "experimental": "mercury"
+                            }
+                        }
+                    },
+                    "profiles": {
+                        "dev": {
+                            "edit_predictions": {
+                                "provider": {
+                                    "experimental": "sweep"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "edit_predictions": {
                         "provider": "sweep"
@@ -3168,9 +3008,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -3181,7 +3019,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"{ }"#.unindent(),
+            indoc! {r#"{ }"#},
             None,
         );
 
@@ -3190,16 +3028,14 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3207,9 +3043,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // always_allow_tool_actions: false -> just remove it
@@ -3217,14 +3051,13 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": false
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": false
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             Some(
                 // The blank line has spaces because the migration preserves the original indentation
                 "{\n    \"agent\": {\n        \n    }\n}\n",
@@ -3236,23 +3069,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true,
-                    "tool_permissions": {
-                        "tools": {
-                            "terminal": {
-                                "always_deny": [{ "pattern": "rm\\s+-rf" }]
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true,
+                        "tool_permissions": {
+                            "tools": {
+                                "terminal": {
+                                    "always_deny": [{ "pattern": "rm\\s+-rf" }]
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3265,9 +3096,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Don't override existing default (and migrate default_mode to default)
@@ -3275,19 +3104,17 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true,
-                    "tool_permissions": {
-                        "default_mode": "confirm"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true,
+                        "tool_permissions": {
+                            "default_mode": "confirm"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3295,9 +3122,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Migrate existing default_mode to default (no always_allow_tool_actions)
@@ -3305,18 +3130,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "default_mode": "allow"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "default_mode": "allow"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3324,9 +3147,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // No migration needed if already using new format with "default"
@@ -3334,16 +3155,15 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "default": "allow"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "default": "allow"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
@@ -3352,23 +3172,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "default_mode": "confirm",
-                        "tools": {
-                            "terminal": {
-                                "default_mode": "allow"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "default_mode": "confirm",
+                            "tools": {
+                                "terminal": {
+                                    "default_mode": "allow"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3381,9 +3199,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // When tool_permissions is null, replace it so always_allow is preserved
@@ -3391,17 +3207,15 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true,
-                    "tool_permissions": null
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true,
+                        "tool_permissions": null
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3409,9 +3223,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Platform-specific agent migration
@@ -3419,18 +3231,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "linux": {
-                    "agent": {
-                        "always_allow_tool_actions": true
+            indoc! {r#"
+                {
+                    "linux": {
+                        "agent": {
+                            "always_allow_tool_actions": true
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "linux": {
                         "agent": {
@@ -3440,9 +3250,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Channel-specific agent migration
@@ -3450,23 +3258,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true
-                },
-                "nightly": {
+            indoc! {r#"
+                {
                     "agent": {
-                        "tool_permissions": {
-                            "default_mode": "confirm"
+                        "always_allow_tool_actions": true
+                    },
+                    "nightly": {
+                        "agent": {
+                            "tool_permissions": {
+                                "default_mode": "confirm"
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3481,9 +3287,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Profile-level migration
@@ -3491,23 +3295,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "profiles": {
-                        "custom": {
-                            "always_allow_tool_actions": true,
-                            "tool_permissions": {
-                                "default_mode": "allow"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "profiles": {
+                            "custom": {
+                                "always_allow_tool_actions": true,
+                                "tool_permissions": {
+                                    "default_mode": "allow"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "profiles": {
@@ -3519,9 +3321,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Platform-specific agent with profiles
@@ -3529,25 +3329,23 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "macos": {
-                    "agent": {
-                        "always_allow_tool_actions": true,
-                        "profiles": {
-                            "strict": {
-                                "tool_permissions": {
-                                    "default_mode": "deny"
+            indoc! {r#"
+                {
+                    "macos": {
+                        "agent": {
+                            "always_allow_tool_actions": true,
+                            "profiles": {
+                                "strict": {
+                                    "tool_permissions": {
+                                        "default_mode": "deny"
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "agent": {
@@ -3564,9 +3362,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Root-level profile with always_allow_tool_actions
@@ -3574,20 +3370,18 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "agent": {
-                            "always_allow_tool_actions": true
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "agent": {
+                                "always_allow_tool_actions": true
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -3599,9 +3393,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Root-level profile with default_mode
@@ -3609,22 +3401,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "agent": {
-                            "tool_permissions": {
-                                "default_mode": "allow"
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "agent": {
+                                "tool_permissions": {
+                                    "default_mode": "allow"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -3636,9 +3426,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Root-level profile + root-level agent both migrated
@@ -3646,25 +3434,23 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true
-                },
-                "profiles": {
-                    "strict": {
-                        "agent": {
-                            "tool_permissions": {
-                                "default_mode": "deny"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true
+                    },
+                    "profiles": {
+                        "strict": {
+                            "agent": {
+                                "tool_permissions": {
+                                    "default_mode": "deny"
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3681,9 +3467,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Non-boolean always_allow_tool_actions (string "true") is left in place
@@ -3692,14 +3476,13 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": "true"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": "true"
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
@@ -3708,14 +3491,13 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": null
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": null
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             Some(&"{\n    \"agent\": {\n        \n    }\n}\n"),
         );
 
@@ -3725,24 +3507,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true,
-                    "tool_permissions": {
-                        "tools": {
-                            "terminal": {
-                                "default_mode": "confirm",
-                                "always_deny": [{ "pattern": "rm\\s+-rf" }]
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true,
+                        "tool_permissions": {
+                            "tools": {
+                                "terminal": {
+                                    "default_mode": "confirm",
+                                    "always_deny": [{ "pattern": "rm\\s+-rf" }]
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3756,9 +3536,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Project-local settings with only default_mode (no always_allow_tool_actions)
@@ -3766,18 +3544,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "default_mode": "deny"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "default_mode": "deny"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3785,9 +3561,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Project-local settings with no agent section at all - no change
@@ -3795,13 +3569,12 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "tab_size": 4,
-                "format_on_save": "on"
-            }
-            "#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "tab_size": 4,
+                    "format_on_save": "on"
+                }
+            "#},
             None,
         );
 
@@ -3810,24 +3583,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true
-                },
-                "agent_servers": {
-                    "claude": {
-                        "default_mode": "plan"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true
                     },
-                    "codex": {
-                        "default_mode": "read-only"
+                    "agent_servers": {
+                        "claude": {
+                            "default_mode": "plan"
+                        },
+                        "codex": {
+                            "default_mode": "read-only"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3843,9 +3614,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // Existing agent_servers are left untouched even with partial entries
@@ -3853,21 +3622,19 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": true
-                },
-                "agent_servers": {
-                    "claude": {
-                        "default_mode": "plan"
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": true
+                    },
+                    "agent_servers": {
+                        "claude": {
+                            "default_mode": "plan"
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -3880,9 +3647,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         // always_allow_tool_actions: false leaves agent_servers untouched
@@ -3890,17 +3655,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            &r#"
-            {
-                "agent": {
-                    "always_allow_tool_actions": false
-                },
-                "agent_servers": {
-                    "claude": {}
+            indoc! {r#"
+                {
+                    "agent": {
+                        "always_allow_tool_actions": false
+                    },
+                    "agent_servers": {
+                        "claude": {}
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             Some(
                 "{\n    \"agent\": {\n        \n    },\n    \"agent_servers\": {\n        \"claude\": {}\n    }\n}\n",
             ),
@@ -4325,18 +4089,17 @@ mod tests {
                 migrations::m_2026_03_23::KEYMAP_PATTERNS,
                 &KEYMAP_QUERY_2026_03_23,
             )],
-            &r#"
-            [
-                {
-                    "context": "Editor && edit_prediction_conflict",
-                    "bindings": {
-                        "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
+            indoc! {r#"
+                [
+                    {
+                        "context": "Editor && edit_prediction_conflict",
+                        "bindings": {
+                            "ctrl-enter": "editor::AcceptEditPrediction" // Example of a modified keybinding
+                        }
                     }
-                }
-            ]
-            "#.unindent(),
-            Some(
-                &r#"
+                ]
+            "#},
+            Some(indoc! {r#"
                 [
                     {
                         "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
@@ -4345,8 +4108,7 @@ mod tests {
                         }
                     }
                 ]
-                "#.unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
@@ -4354,19 +4116,18 @@ mod tests {
                 migrations::m_2026_03_23::KEYMAP_PATTERNS,
                 &KEYMAP_QUERY_2026_03_23,
             )],
-            &r#"
-            [
-                {
-                    "context": "Editor && edit_prediction_conflict && !showing_completions",
-                    "bindings": {
-                        // Here we don't require a modifier unless there's a language server completion
-                        "tab": "editor::AcceptEditPrediction"
+            indoc! {r#"
+                [
+                    {
+                        "context": "Editor && edit_prediction_conflict && !showing_completions",
+                        "bindings": {
+                            // Here we don't require a modifier unless there's a language server completion
+                            "tab": "editor::AcceptEditPrediction"
+                        }
                     }
-                }
-            ]
-            "#.unindent(),
-            Some(
-                &r#"
+                ]
+            "#},
+            Some(indoc! {r#"
                 [
                     {
                         "context": "Editor && (edit_prediction && in_leading_whitespace)",
@@ -4376,8 +4137,7 @@ mod tests {
                         }
                     }
                 ]
-                "#.unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
@@ -4385,19 +4145,17 @@ mod tests {
                 migrations::m_2026_03_23::KEYMAP_PATTERNS,
                 &KEYMAP_QUERY_2026_03_23,
             )],
-            &r#"
-            [
-                {
-                    "context": "Editor && edit_prediction_conflict && showing_completions",
-                    "bindings": {
-                        "tab": "editor::AcceptEditPrediction"
+            indoc! {r#"
+                [
+                    {
+                        "context": "Editor && edit_prediction_conflict && showing_completions",
+                        "bindings": {
+                            "tab": "editor::AcceptEditPrediction"
+                        }
                     }
-                }
-            ]
-            "#
-            .unindent(),
-            Some(
-                &r#"
+                ]
+            "#},
+            Some(indoc! {r#"
                 [
                     {
                         "context": "Editor && (edit_prediction && showing_completions)",
@@ -4406,9 +4164,7 @@ mod tests {
                         }
                     }
                 ]
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
 
         assert_migrate_with_migrations(
@@ -4416,57 +4172,53 @@ mod tests {
                 migrations::m_2026_03_23::KEYMAP_PATTERNS,
                 &KEYMAP_QUERY_2026_03_23,
             )],
-            &r#"
-            [
-                {
-                    "context": "Editor && edit_prediction",
-                    "bindings": {
-                        "tab": "editor::AcceptEditPrediction",
-                        // Optional: This makes the default `alt-l` binding do nothing.
-                        "alt-l": null
-                    }
-                },
-                {
-                    "context": "Editor && edit_prediction_conflict",
-                    "bindings": {
-                        "alt-tab": "editor::AcceptEditPrediction",
-                        // Optional: This makes the default `alt-l` binding do nothing.
-                        "alt-l": null
-                    }
-                },
-            ]
-            "#
-            .unindent(),
-            Some(
-                &r#"
-                    [
-                        {
-                            "context": "Editor && edit_prediction",
-                            "bindings": {
-                                "tab": "editor::AcceptEditPrediction",
-                                // Optional: This makes the default `alt-l` binding do nothing.
-                                "alt-l": null
-                            }
-                        },
-                        {
-                            "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
-                            "bindings": {
-                                "alt-tab": "editor::AcceptEditPrediction",
-                                // Optional: This makes the default `alt-l` binding do nothing.
-                                "alt-l": null
-                            }
-                        },
-                    ]
-                "#
-                .unindent(),
-            ),
+            indoc! {r#"
+                [
+                    {
+                        "context": "Editor && edit_prediction",
+                        "bindings": {
+                            "tab": "editor::AcceptEditPrediction",
+                            // Optional: This makes the default `alt-l` binding do nothing.
+                            "alt-l": null
+                        }
+                    },
+                    {
+                        "context": "Editor && edit_prediction_conflict",
+                        "bindings": {
+                            "alt-tab": "editor::AcceptEditPrediction",
+                            // Optional: This makes the default `alt-l` binding do nothing.
+                            "alt-l": null
+                        }
+                    },
+                ]
+            "#},
+            Some(indoc! {r#"
+                [
+                    {
+                        "context": "Editor && edit_prediction",
+                        "bindings": {
+                            "tab": "editor::AcceptEditPrediction",
+                            // Optional: This makes the default `alt-l` binding do nothing.
+                            "alt-l": null
+                        }
+                    },
+                    {
+                        "context": "Editor && (edit_prediction && (showing_completions || in_leading_whitespace))",
+                        "bindings": {
+                            "alt-tab": "editor::AcceptEditPrediction",
+                            // Optional: This makes the default `alt-l` binding do nothing.
+                            "alt-l": null
+                        }
+                    },
+                ]
+            "#}),
         );
     }
 
     #[test]
     fn test_restructure_profiles_with_settings_key() {
         assert_migrate_settings(
-            &r#"
+            indoc! {r#"
                 {
                     "buffer_font_size": 14,
                     "profiles": {
@@ -4479,10 +4231,8 @@ mod tests {
                         }
                     }
                 }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "buffer_font_size": 14,
                     "profiles": {
@@ -4499,16 +4249,14 @@ mod tests {
                         }
                     }
                 }
-            "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_restructure_profiles_with_settings_key_already_migrated() {
         assert_migrate_settings(
-            &r#"
+            indoc! {r#"
                 {
                     "profiles": {
                         "Presenting": {
@@ -4518,8 +4266,7 @@ mod tests {
                         }
                     }
                 }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -4527,12 +4274,11 @@ mod tests {
     #[test]
     fn test_restructure_profiles_with_settings_key_no_profiles() {
         assert_migrate_settings(
-            &r#"
+            indoc! {r#"
                 {
                     "buffer_font_size": 14
                 }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -4543,22 +4289,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "tools": {
-                            "web_search": {
-                                "allow": true
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "tools": {
+                                "web_search": {
+                                    "allow": true
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -4570,9 +4314,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4582,22 +4324,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "agent": {
-                    "profiles": {
-                        "write": {
-                            "tools": {
-                                "web_search": false
+            indoc! {r#"
+                {
+                    "agent": {
+                        "profiles": {
+                            "write": {
+                                "tools": {
+                                    "web_search": false
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "profiles": {
@@ -4609,9 +4349,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4621,20 +4359,19 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "tools": {
-                            "search_web": {
-                                "allow": true
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "tools": {
+                                "search_web": {
+                                    "allow": true
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -4645,25 +4382,23 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "agent": {
-                    "tool_permissions": {
-                        "tools": {
-                            "web_search": {
-                                "allow": false
-                            },
-                            "search_web": {
-                                "allow": true
+            indoc! {r#"
+                {
+                    "agent": {
+                        "tool_permissions": {
+                            "tools": {
+                                "web_search": {
+                                    "allow": false
+                                },
+                                "search_web": {
+                                    "allow": true
+                                }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "agent": {
                         "tool_permissions": {
@@ -4675,9 +4410,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4687,24 +4420,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "linux": {
-                    "agent": {
-                        "tool_permissions": {
-                            "tools": {
-                                "web_search": {
-                                    "allow": true
+            indoc! {r#"
+                {
+                    "linux": {
+                        "agent": {
+                            "tool_permissions": {
+                                "tools": {
+                                    "web_search": {
+                                        "allow": true
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "linux": {
                         "agent": {
@@ -4718,9 +4449,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4730,24 +4459,22 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "nightly": {
-                    "agent": {
-                        "tool_permissions": {
-                            "tools": {
-                                "web_search": {
-                                    "default": "allow"
+            indoc! {r#"
+                {
+                    "nightly": {
+                        "agent": {
+                            "tool_permissions": {
+                                "tools": {
+                                    "web_search": {
+                                        "default": "allow"
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "nightly": {
                         "agent": {
@@ -4761,9 +4488,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4773,12 +4498,11 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "buffer_font_size": 14
-            }
-            "#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "buffer_font_size": 14
+                }
+            "#},
             None,
         );
     }
@@ -4881,16 +4605,17 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_04_10::rename_web_search_to_search_web,
             )],
-            &r#"
-            {
-                "profiles": {
-                    "Work": {
-                        "settings": {
-                            "agent": {
-                                "tool_permissions": {
-                                    "tools": {
-                                        "web_search": {
-                                            "default": "allow"
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "Work": {
+                            "settings": {
+                                "agent": {
+                                    "tool_permissions": {
+                                        "tools": {
+                                            "web_search": {
+                                                "default": "allow"
+                                            }
                                         }
                                     }
                                 }
@@ -4898,11 +4623,8 @@ mod tests {
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "Work": {
@@ -4920,9 +4642,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -4959,70 +4679,60 @@ mod tests {
     #[test]
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_at_root() {
         assert_migrate_settings(
-            &r#"
-            {
-                "title_bar": {
-                    "show_branch_icon": true,
-                    "show_branch_name": true
+            indoc! {r#"
+                {
+                    "title_bar": {
+                        "show_branch_icon": true,
+                        "show_branch_name": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "title_bar": {
                         "show_branch_status_icon": true,
                         "show_branch_name": true
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_drop_show_branch_icon_false_without_setting_status_icon() {
         assert_migrate_settings(
-            &r#"
-            {
-                "title_bar": {
-                    "show_branch_icon": false,
-                    "show_branch_name": true
+            indoc! {r#"
+                {
+                    "title_bar": {
+                        "show_branch_icon": false,
+                        "show_branch_name": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "title_bar": {
                         "show_branch_name": true
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_in_platform_override() {
         assert_migrate_settings(
-            &r#"
-            {
-                "macos": {
-                    "title_bar": {
-                        "show_branch_icon": true,
-                        "show_branch_name": true
+            indoc! {r#"
+                {
+                    "macos": {
+                        "title_bar": {
+                            "show_branch_icon": true,
+                            "show_branch_name": true
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "title_bar": {
@@ -5031,28 +4741,24 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_in_release_override() {
         assert_migrate_settings(
-            &r#"
-            {
-                "preview": {
-                    "title_bar": {
-                        "show_branch_icon": true,
-                        "show_branch_name": true
+            indoc! {r#"
+                {
+                    "preview": {
+                        "title_bar": {
+                            "show_branch_icon": true,
+                            "show_branch_name": true
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "preview": {
                         "title_bar": {
@@ -5061,30 +4767,26 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_in_profiles() {
         assert_migrate_settings(
-            &r#"
-            {
-                "profiles": {
-                    "work": {
-                        "title_bar": {
-                            "show_branch_icon": true,
-                            "show_branch_name": true
+            indoc! {r#"
+                {
+                    "profiles": {
+                        "work": {
+                            "title_bar": {
+                                "show_branch_icon": true,
+                                "show_branch_name": true
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "profiles": {
                         "work": {
@@ -5097,46 +4799,42 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
     #[test]
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_across_all_scopes() {
         assert_migrate_settings(
-            &r#"
-            {
-                "title_bar": {
-                    "show_branch_icon": true,
-                    "show_branch_name": true
-                },
-                "macos": {
+            indoc! {r#"
+                {
                     "title_bar": {
                         "show_branch_icon": true,
                         "show_branch_name": true
-                    }
-                },
-                "preview": {
-                    "title_bar": {
-                        "show_branch_icon": true,
-                        "show_branch_name": true
-                    }
-                },
-                "profiles": {
-                    "work": {
+                    },
+                    "macos": {
                         "title_bar": {
                             "show_branch_icon": true,
                             "show_branch_name": true
                         }
+                    },
+                    "preview": {
+                        "title_bar": {
+                            "show_branch_icon": true,
+                            "show_branch_name": true
+                        }
+                    },
+                    "profiles": {
+                        "work": {
+                            "title_bar": {
+                                "show_branch_icon": true,
+                                "show_branch_name": true
+                            }
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "title_bar": {
                         "show_branch_status_icon": true,
@@ -5165,9 +4863,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5211,31 +4907,29 @@ mod tests {
     fn test_promote_show_branch_icon_true_to_show_branch_status_icon_no_change_when_already_migrated()
      {
         assert_migrate_settings(
-            &r#"
-            {
-                "title_bar": {
-                    "show_branch_status_icon": true,
-                    "show_branch_name": true
+            indoc! {r#"
+                {
+                    "title_bar": {
+                        "show_branch_status_icon": true,
+                        "show_branch_name": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
         // No title_bar key — should be unchanged
-        assert_migrate_settings(&r#"{ "theme": "One Dark" }"#.unindent(), None);
+        assert_migrate_settings(indoc! {r#"{ "theme": "One Dark" }"#}, None);
 
         // title_bar without show_branch_icon — should be unchanged
         assert_migrate_settings(
-            &r#"
-            {
-                "title_bar": {
-                    "show_branch_name": true
+            indoc! {r#"
+                {
+                    "title_bar": {
+                        "show_branch_name": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -5243,16 +4937,14 @@ mod tests {
     #[test]
     fn test_make_git_gutter_width_an_enum_from_number() {
         assert_migrate_settings(
-            &r#"
-            {
-                "gutter": {
-                    "git_gutter_width": 4.0
+            indoc! {r#"
+                {
+                    "gutter": {
+                        "git_gutter_width": 4.0
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "gutter": {
                         "git_gutter_width": {
@@ -5260,9 +4952,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5270,32 +4960,30 @@ mod tests {
     fn test_make_git_gutter_width_an_enum_no_change_when_already_migrated() {
         // already "default" string — no change
         assert_migrate_settings(
-            &r#"
-            {
-                "gutter": {
-                    "git_gutter_width": "default"
+            indoc! {r#"
+                {
+                    "gutter": {
+                        "git_gutter_width": "default"
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
         // already custom object — no change
         assert_migrate_settings(
-            &r#"
-            {
-                "gutter": {
-                    "git_gutter_width": { "custom": 4.0 }
+            indoc! {r#"
+                {
+                    "gutter": {
+                        "git_gutter_width": { "custom": 4.0 }
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
         // no gutter key — no change
-        assert_migrate_settings(&r#"{ "theme": "One Dark" }"#.unindent(), None);
+        assert_migrate_settings(indoc! {r#"{ "theme": "One Dark" }"#}, None);
     }
 
     #[test]
@@ -5344,22 +5032,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_26::rename_folder_icons_to_folder_indicator,
             )],
-            &r#"
-            {
-                "project_panel": {
-                    "folder_icons": true
-                },
-                "outline_panel": {
-                    "folder_icons": false
-                },
-                "git_panel": {
-                    "folder_icons": true
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "folder_icons": true
+                    },
+                    "outline_panel": {
+                        "folder_icons": false
+                    },
+                    "git_panel": {
+                        "folder_icons": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "project_panel": {
                         "folder_indicator": "icon"
@@ -5371,9 +5057,7 @@ mod tests {
                         "folder_indicator": "icon"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5386,19 +5070,17 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_26::rename_folder_icons_to_folder_indicator,
             )],
-            &r#"
-            {
-                // Keep this comment.
-                "project_panel": {
-                    "file_icons": true,
-                    "folder_icons": false,
-                    "indent_size": 20
+            indoc! {r#"
+                {
+                    // Keep this comment.
+                    "project_panel": {
+                        "file_icons": true,
+                        "folder_icons": false,
+                        "indent_size": 20
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     // Keep this comment.
                     "project_panel": {
@@ -5407,9 +5089,7 @@ mod tests {
                         "indent_size": 20
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5419,18 +5099,16 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_26::rename_folder_icons_to_folder_indicator,
             )],
-            &r#"
-            {
-                "macos": {
-                    "project_panel": {
-                        "folder_icons": false
+            indoc! {r#"
+                {
+                    "macos": {
+                        "project_panel": {
+                            "folder_icons": false
+                        }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "macos": {
                         "project_panel": {
@@ -5438,9 +5116,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5450,25 +5126,21 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_26::rename_folder_icons_to_folder_indicator,
             )],
-            &r#"
-            {
-                "project_panel": {
-                    "folder_icons": true,
-                    "folder_indicator": "both"
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "folder_icons": true,
+                        "folder_indicator": "both"
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "project_panel": {
                         "folder_indicator": "both"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5481,42 +5153,39 @@ mod tests {
         // Already migrated.
         assert_migrate_with_migrations(
             migrations,
-            &r#"
-            {
-                "project_panel": {
-                    "folder_indicator": "both"
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "folder_indicator": "both"
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
         // A non-boolean value is already invalid; leave it rather than guess.
         assert_migrate_with_migrations(
             migrations,
-            &r#"
-            {
-                "project_panel": {
-                    "folder_icons": 3
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "folder_icons": 3
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
 
         // `folder_icons` outside the three panels is not ours to rename.
         assert_migrate_with_migrations(
             migrations,
-            &r#"
-            {
-                "terminal": {
-                    "folder_icons": true
+            indoc! {r#"
+                {
+                    "terminal": {
+                        "folder_icons": true
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -5524,24 +5193,20 @@ mod tests {
     #[test]
     fn test_rename_folder_icons_to_folder_indicator_is_registered() {
         assert_migrate_settings(
-            &r#"
-            {
-                "project_panel": {
-                    "folder_icons": false
+            indoc! {r#"
+                {
+                    "project_panel": {
+                        "folder_icons": false
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "project_panel": {
                         "folder_indicator": "chevron"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5551,27 +5216,25 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_30::nest_markdown_preview_settings,
             )],
-            &r#"
-            {
-                "markdown_preview_font_size": 14,
-                "macos": {
-                    "markdown_preview_font_size": 15
-                },
-                "preview": {
-                    "markdown_preview_font_size": 16
-                },
-                "profiles": {
-                    "work": {
-                        "settings": {
-                            "markdown_preview_font_size": 17
+            indoc! {r#"
+                {
+                    "markdown_preview_font_size": 14,
+                    "macos": {
+                        "markdown_preview_font_size": 15
+                    },
+                    "preview": {
+                        "markdown_preview_font_size": 16
+                    },
+                    "profiles": {
+                        "work": {
+                            "settings": {
+                                "markdown_preview_font_size": 17
+                            }
                         }
                     }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "markdown_preview": {
                         "font_size": 14
@@ -5596,9 +5259,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5608,22 +5269,20 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_30::nest_markdown_preview_settings,
             )],
-            &r#"
-            {
-                "markdown_preview_font_size": 15,
-                "markdown_preview_font_family": "Zed Sans",
-                "markdown_preview_code_font_family": "Zed Mono",
-                "markdown_preview_theme": "One Dark",
-                "markdown_preview": {
-                    "font_size": 18,
-                    "limit_content_width": false,
-                    "max_width": 900
+            indoc! {r#"
+                {
+                    "markdown_preview_font_size": 15,
+                    "markdown_preview_font_family": "Zed Sans",
+                    "markdown_preview_code_font_family": "Zed Mono",
+                    "markdown_preview_theme": "One Dark",
+                    "markdown_preview": {
+                        "font_size": 18,
+                        "limit_content_width": false,
+                        "max_width": 900
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "markdown_preview": {
                         "theme": "One Dark",
@@ -5634,9 +5293,7 @@ mod tests {
                         "max_width": 900
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5646,13 +5303,12 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_30::nest_markdown_preview_settings,
             )],
-            &r#"
-            {
-                "markdown_preview_font_size": 15,
-                "markdown_preview": false
-            }
-            "#
-            .unindent(),
+            indoc! {r#"
+                {
+                    "markdown_preview_font_size": 15,
+                    "markdown_preview": false
+                }
+            "#},
             None,
         );
     }
@@ -5663,19 +5319,17 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_30::nest_markdown_preview_settings,
             )],
-            &r#"
-            {
-                "markdown_preview": null,
-                "markdown_preview_font_size": 15,
-                "preview": {
+            indoc! {r#"
+                {
                     "markdown_preview": null,
-                    "markdown_preview_theme": "One Dark"
+                    "markdown_preview_font_size": 15,
+                    "preview": {
+                        "markdown_preview": null,
+                        "markdown_preview_theme": "One Dark"
+                    }
                 }
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            "#},
+            Some(indoc! {r#"
                 {
                     "markdown_preview": {
                         "font_size": 15
@@ -5686,9 +5340,7 @@ mod tests {
                         }
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 
@@ -5698,15 +5350,14 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_08_30::nest_markdown_preview_settings,
             )],
-            &r#"
-            {
-                "markdown_preview": null,
-                "preview": {
-                    "markdown_preview": null
+            indoc! {r#"
+                {
+                    "markdown_preview": null,
+                    "preview": {
+                        "markdown_preview": null
+                    }
                 }
-            }
-            "#
-            .unindent(),
+            "#},
             None,
         );
     }
@@ -5714,17 +5365,15 @@ mod tests {
     #[test]
     fn test_nest_markdown_preview_settings_is_registered() {
         assert_migrate_settings(
-            &r#"
-            {
-                "markdown_preview_font_size": 15,
-                "markdown_preview_font_family": "Zed Sans",
-                "markdown_preview_code_font_family": "Zed Mono",
-                "markdown_preview_theme": "One Dark"
-            }
-            "#
-            .unindent(),
-            Some(
-                &r#"
+            indoc! {r#"
+                {
+                    "markdown_preview_font_size": 15,
+                    "markdown_preview_font_family": "Zed Sans",
+                    "markdown_preview_code_font_family": "Zed Mono",
+                    "markdown_preview_theme": "One Dark"
+                }
+            "#},
+            Some(indoc! {r#"
                 {
                     "markdown_preview": {
                         "font_size": 15,
@@ -5733,9 +5382,7 @@ mod tests {
                         "theme": "One Dark"
                     }
                 }
-                "#
-                .unindent(),
-            ),
+            "#}),
         );
     }
 }

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -1991,7 +1991,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -2110,7 +2110,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_10_21::make_relative_line_numbers_an_enum,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -2195,7 +2195,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_03_30::make_play_sound_when_agent_done_an_enum,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -2506,7 +2506,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2025_01_27::make_auto_indent_an_enum,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -2584,7 +2584,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_02::move_edit_prediction_provider_to_edit_predictions,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -2796,7 +2796,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_03::migrate_experimental_sweep_mercury,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -3019,7 +3019,7 @@ mod tests {
             &[MigrationType::Json(
                 migrations::m_2026_02_04::migrate_tool_permission_defaults,
             )],
-            indoc! {r#"{ }"#},
+            r#"{ }"#,
             None,
         );
 
@@ -4919,7 +4919,7 @@ mod tests {
         );
 
         // No title_bar key — should be unchanged
-        assert_migrate_settings(indoc! {r#"{ "theme": "One Dark" }"#}, None);
+        assert_migrate_settings(r#"{ "theme": "One Dark" }"#, None);
 
         // title_bar without show_branch_icon — should be unchanged
         assert_migrate_settings(
@@ -4983,7 +4983,7 @@ mod tests {
         );
 
         // no gutter key — no change
-        assert_migrate_settings(indoc! {r#"{ "theme": "One Dark" }"#}, None);
+        assert_migrate_settings(r#"{ "theme": "One Dark" }"#, None);
     }
 
     #[test]


### PR DESCRIPTION
## Objective

Follow-up to #62818.

## Solution

Completed the [fixture cleanup deferred from the original PR](https://github.com/zed-industries/zed/pull/62818#pullrequestreview-4973821021), removing `unindent` from the migrator crate’s dependencies.

## Testing

All original migrator tests pass.

## Self-Review Checklist:

- [x] I’ve reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed’s UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A