### PR TITLE
gpui: List only available font families in suggestions

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -84,15 +84,11 @@ impl TextSystem {
         }
     }
 
-    /// Get a list of all available font names from the operating system.
+    /// Get sorted, unique font family names available to the platform text system.
+    ///
+    /// Includes fonts registered with [`Self::add_fonts`].
     pub fn all_font_names(&self) -> Vec<String> {
         let mut names = self.platform_text_system.all_font_names();
-        names.extend(
-            self.fallback_font_stack
-                .iter()
-                .map(|font| font.family.to_string()),
-        );
-        names.push(".SystemUIFont".to_string());
         names.sort_unstable();
         names.dedup();
         names

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -1041,6 +1041,26 @@ fn check_is_known_emoji_font(postscript_name: &str) -> bool {
 mod tests {
     use super::*;
 
+    #[test]
+    fn all_font_names_tracks_available_families() -> Result<()> {
+        let text_system = gpui::TextSystem::new(Arc::new(
+            CosmicTextSystem::new_without_system_fonts("IBM Plex Sans"),
+        ));
+        assert!(text_system.all_font_names().is_empty());
+
+        text_system.add_fonts(vec![Cow::Borrowed(include_bytes!(
+            "../../../assets/fonts/lilex/Lilex-Regular.ttf"
+        ))])?;
+        assert_eq!(text_system.all_font_names(), ["Lilex"]);
+
+        text_system.add_fonts(vec![
+            Cow::Borrowed(IBM_PLEX),
+            Cow::Borrowed(include_bytes!("../../../assets/fonts/lilex/Lilex-Bold.ttf")),
+        ])?;
+        assert_eq!(text_system.all_font_names(), ["IBM Plex Sans", "Lilex"]);
+        Ok(())
+    }
+
     fn fid(i: usize) -> FontId {
         FontId(i)
     }


### PR DESCRIPTION
## Summary

Make GPUI's font suggestions reflect the platform text system's actual font inventory, including fonts loaded by the application, rather than appending hardcoded fallback candidates.

The appended names could be unavailable on the current platform.

The downside of this is that virtual aliases such as `.SystemUIFont`, `.ZedMono`, and `.ZedSans` are no longer injected into suggestions; existing settings using those aliases still resolve as before, they just won't be shown in the settings UI anymore.

Release Notes:

- Fixed font suggestions listing unavailable fallback fonts and internal font aliases.
