### PR TITLE
language_models: Make `reasoning_effort: "none"` opt-in for OpenAI-compatible models

### DIFF
--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -300,7 +300,7 @@ fn chat_completion_max_tokens_parameter(
 }
 
 fn supports_none_reasoning_effort(model: &AvailableModel) -> bool {
-    model.reasoning_effort.is_some()
+    model.capabilities.supports_none_reasoning_effort
 }
 
 fn chat_completion_reasoning_effort(
@@ -574,8 +574,14 @@ mod tests {
         );
 
         request.thinking_allowed = false;
+        assert_eq!(chat_completion_reasoning_effort(&request, &model), None);
+
+        let mut model_with_none_capability = model.clone();
+        model_with_none_capability
+            .capabilities
+            .supports_none_reasoning_effort = true;
         assert_eq!(
-            chat_completion_reasoning_effort(&request, &model),
+            chat_completion_reasoning_effort(&request, &model_with_none_capability),
             Some(open_ai::ReasoningEffort::None)
         );
     }
@@ -711,14 +717,49 @@ mod tests {
     }
 
     #[test]
-    fn configured_reasoning_effort_supports_none_reasoning_effort() {
-        assert!(supports_none_reasoning_effort(&available_model(Some(
-            open_ai::ReasoningEffort::Medium
-        ))));
-        assert!(supports_none_reasoning_effort(&available_model(Some(
-            open_ai::ReasoningEffort::None
-        ))));
-        assert!(!supports_none_reasoning_effort(&available_model(None)));
+    fn model_capabilities_determines_supports_none_reasoning_effort() {
+        let mut model = available_model(Some(open_ai::ReasoningEffort::Medium));
+        assert!(!supports_none_reasoning_effort(&model));
+
+        model.capabilities.supports_none_reasoning_effort = true;
+        assert!(supports_none_reasoning_effort(&model));
+    }
+
+    #[test]
+    fn chat_completion_omits_reasoning_effort_when_thinking_is_disabled_by_default() {
+        let mut model = available_model(Some(open_ai::ReasoningEffort::Medium));
+        model.capabilities.chat_completions = true;
+        let request = LanguageModelRequest {
+            thinking_allowed: false,
+            ..Default::default()
+        };
+        let reasoning_effort = chat_completion_reasoning_effort(&request, &model);
+        assert_eq!(reasoning_effort, None);
+    }
+
+    #[test]
+    fn chat_completion_sends_none_reasoning_effort_when_capability_is_enabled() {
+        let mut model = available_model(Some(open_ai::ReasoningEffort::Medium));
+        model.capabilities.chat_completions = true;
+        model.capabilities.supports_none_reasoning_effort = true;
+        let request = LanguageModelRequest {
+            thinking_allowed: false,
+            ..Default::default()
+        };
+        let reasoning_effort = chat_completion_reasoning_effort(&request, &model);
+        assert_eq!(reasoning_effort, Some(open_ai::ReasoningEffort::None));
+    }
+
+    #[test]
+    fn chat_completion_preserves_explicit_none_configured_effort() {
+        let mut model = available_model(Some(open_ai::ReasoningEffort::None));
+        model.capabilities.chat_completions = true;
+        let request = LanguageModelRequest {
+            thinking_allowed: false,
+            ..Default::default()
+        };
+        let reasoning_effort = chat_completion_reasoning_effort(&request, &model);
+        assert_eq!(reasoning_effort, Some(open_ai::ReasoningEffort::None));
     }
 
     #[test]

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -599,6 +599,7 @@ async fn list_models(
                 chat_completions: true,
                 interleaved_reasoning: false,
                 max_tokens_parameter: false,
+                supports_none_reasoning_effort: false,
             },
         });
     }

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -454,6 +454,8 @@ pub struct OpenAiCompatibleModelCapabilities {
     pub interleaved_reasoning: bool,
     #[serde(default)]
     pub max_tokens_parameter: bool,
+    #[serde(default)]
+    pub supports_none_reasoning_effort: bool,
 }
 
 impl Default for OpenAiCompatibleModelCapabilities {
@@ -466,6 +468,7 @@ impl Default for OpenAiCompatibleModelCapabilities {
             chat_completions: default_true(),
             interleaved_reasoning: false,
             max_tokens_parameter: false,
+            supports_none_reasoning_effort: false,
         }
     }
 }

--- a/crates/settings_ui/src/pages/llm_providers_page.rs
+++ b/crates/settings_ui/src/pages/llm_providers_page.rs
@@ -567,6 +567,7 @@ struct ModelInput {
     supports_thinking: ToggleState,
     interleaved_reasoning: ToggleState,
     max_tokens_parameter: ToggleState,
+    supports_none_reasoning_effort: ToggleState,
 }
 
 impl ModelInput {
@@ -579,6 +580,7 @@ impl ModelInput {
             chat_completions,
             interleaved_reasoning,
             max_tokens_parameter,
+            supports_none_reasoning_effort,
         } = OpenAiCompatibleModelCapabilities::default();
 
         Self {
@@ -601,6 +603,7 @@ impl ModelInput {
             supports_thinking: ToggleState::Unselected,
             interleaved_reasoning: interleaved_reasoning.into(),
             max_tokens_parameter: max_tokens_parameter.into(),
+            supports_none_reasoning_effort: supports_none_reasoning_effort.into(),
         }
     }
 }
@@ -929,6 +932,14 @@ fn render_model_capabilities(
                     window,
                     cx,
                 ))
+                .child(render_capability_checkbox(
+                    "supports-none-reasoning-effort",
+                    index,
+                    "Supports reasoning_effort 'none'",
+                    model.supports_none_reasoning_effort,
+                    |model, state| model.supports_none_reasoning_effort = state,
+                    cx,
+                ))
                 .when(model.supports_chat_completions.selected(), |this| {
                     this.child(render_capability_checkbox(
                         "interleaved-reasoning",
@@ -1066,6 +1077,7 @@ struct ModelValues {
     supports_thinking: bool,
     interleaved_reasoning: bool,
     max_tokens_parameter: bool,
+    supports_none_reasoning_effort: bool,
 }
 
 enum ParsedModels {
@@ -1104,6 +1116,7 @@ fn save_llm_provider_form(
                     supports_thinking: model.supports_thinking.selected(),
                     interleaved_reasoning: model.interleaved_reasoning.selected(),
                     max_tokens_parameter: model.max_tokens_parameter.selected(),
+                    supports_none_reasoning_effort: model.supports_none_reasoning_effort.selected(),
                 })
                 .collect(),
         }
@@ -1292,6 +1305,8 @@ fn parse_open_ai_model(
                 && model.supports_chat_completions
                 && model.interleaved_reasoning,
             max_tokens_parameter: model.supports_chat_completions && model.max_tokens_parameter,
+            supports_none_reasoning_effort: model.supports_thinking
+                && model.supports_none_reasoning_effort,
         },
     })
 }

--- a/docs/src/ai/use-api-access.md
+++ b/docs/src/ai/use-api-access.md
@@ -500,6 +500,7 @@ By default, OpenAI-compatible models inherit these capabilities:
 - `chat_completions`: `true`
 - `interleaved_reasoning`: `false`
 - `max_tokens_parameter`: `false`
+- `supports_none_reasoning_effort`: `false`
 
 If a model only works with the Responses API, set `capabilities.chat_completions` to `false`. Zed will use the Responses endpoint for that model.
 
@@ -535,7 +536,7 @@ If the model requires the Responses API for reasoning state, set `capabilities.c
 }
 ```
 
-Valid settings values are `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, and `"max"`. Use `"none"` in `settings.json` when you need to force reasoning off for an endpoint; the provider setup UI exposes the non-`none` values for thinking-capable models. For chat-completions endpoints that should receive prior thinking back in a dedicated `reasoning_content` field, also set `capabilities.interleaved_reasoning` to `true`. If the endpoint expects the output-token limit as `max_tokens` instead of `max_completion_tokens`, set `capabilities.max_tokens_parameter` to `true`.
+Valid settings values are `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, and `"max"`. Use `"none"` in `settings.json` when you need to force reasoning off for an endpoint; the provider setup UI exposes the non-`none` values for thinking-capable models. For chat-completions endpoints that should receive prior thinking back in a dedicated `reasoning_content` field, also set `capabilities.interleaved_reasoning` to `true`. If the endpoint expects the output-token limit as `max_tokens` instead of `max_completion_tokens`, set `capabilities.max_tokens_parameter` to `true`. If your endpoint specifically accepts `"none"` as a reasoning effort when thinking is disabled (such as official OpenAI proxy endpoints), set `capabilities.supports_none_reasoning_effort` to `true`.
 
 For example, a chat-completions endpoint with the maximum OpenAI-style reasoning effort, streamed thinking, and `max_tokens` output limits can be configured as:
 


### PR DESCRIPTION
# Objective

Fix context compaction, thread title generation, and summary failures for OpenAI-compatible models that do not accept `"none"` as a `reasoning_effort` level.

Fixes #60411.

## Solution

- Added a `supports_none_reasoning_effort` capability (defaulting to `false`) to `OpenAiCompatibleModelCapabilities`.
- Updated `supports_none_reasoning_effort()` in `crates/language_models/src/provider/open_ai_compatible.rs` to read from the model capability instead of assuming any model with `reasoning_effort` supports `"none"`.
- When `supports_none_reasoning_effort` is `false` (default), `reasoning_effort` is omitted from the request when thinking is disabled. This allows mandatory-reasoning models (such as Z.ai / Zhipu GLM-5.3, OpenRouter `gpt-oss-20b`) and gateways with strict enum validation (BytePlus, MTPLX, vLLM) to succeed using their default reasoning mode.
- Preserved explicit `"reasoning_effort": "none"` when configured on the model or when `capabilities.supports_none_reasoning_effort` is set to `true`.
- Added UI toggle in `settings_ui` and documented the capability in `docs/src/ai/use-api-access.md`.

## Testing

- `cargo test -p language_models provider::open_ai_compatible::tests --lib` (17 tests passing)
- `cargo check -p settings_content`
- `cargo check -p settings_ui`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed context compaction and thread title failures on OpenAI-compatible providers that do not accept `reasoning_effort: "none"`.