### PR TITLE
Fix Dock panel buttons when panels are zoomed

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1401,6 +1401,20 @@ impl Render for PanelButtons {
 
         let dock_entity = self.dock.clone();
         let workspace = dock.workspace.clone();
+        // When this dock's active panel is zoomed, `render_dock` skips painting
+        // the Dock's own element (see `Workspace::render_dock`), so its
+        // `focus_handle` has no node in this frame's dispatch tree. Dispatching
+        // an action through it then falls back to the window root, which can
+        // miss `Workspace`'s `on_action` handlers entirely. Route focus through
+        // the zoomed panel's own (painted) handle instead in that case.
+        let zoomed_panel_focus_handle = workspace.upgrade().and_then(|workspace| {
+            if workspace.read(cx).zoomed_position == Some(dock_position) {
+                dock.active_panel()
+                    .map(|panel| panel.activation_focus_handle(cx))
+            } else {
+                None
+            }
+        });
         let mut buttons: Vec<_> = dock
             .panel_entries
             .iter()
@@ -1435,7 +1449,9 @@ impl Render for PanelButtons {
                     (action, icon_tooltip.into())
                 };
 
-                let focus_handle = dock.focus_handle(cx);
+                let focus_handle = zoomed_panel_focus_handle
+                    .clone()
+                    .unwrap_or_else(|| dock.focus_handle(cx));
                 let icon_label = entry.panel.icon_label(window, cx);
 
                 Some(


### PR DESCRIPTION
# Objective

Fixes #64024

Fix the Terminal and other Dock panel buttons so their close/toggle actions continue to work when a panel is zoomed/full-screen.

When a Dock panel such as Terminal is zoomed, the normal Dock is removed from the UI tree while the zoomed panel remains visible. The panel buttons still relied on the normal Dock's UI-tree path to dispatch their actions, causing the close/toggle action to stop working in the zoomed state.

## Solution

Update the panel button action flow to account for both the normal Dock and the zoomed panel state.

When the normal Dock is present in the UI tree, the existing action path is used. When a panel is zoomed and the normal Dock is no longer present in the UI tree, the zoomed state is handled so the toggle action can still reach the Workspace.

This fixes the issue for Terminal and other Dock panels that use the same button behavior while preserving the existing behavior when panels are not zoomed.

## Testing

- Tested locally on Linux.
- Verified the Terminal panel in the normal state.
- Verified the Terminal panel when zoomed/full-screen.
- Verified the close button works correctly while the Terminal panel is zoomed.
- Verified the Agent panel with the same behavior.
- Verified the buttons still work after interacting with other UI elements.
- Verified panels can be opened, closed, zoomed, and reopened normally.
- No additional platform-specific testing was performed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

### Before

When the Terminal panel was zoomed/full-screen, clicking the close button did nothing.


https://github.com/user-attachments/assets/a7cfb0ac-2ef1-46b2-92b7-2c7289ca2a2b



### After

The Terminal panel can now be closed normally while zoomed/full-screen.


https://github.com/user-attachments/assets/b3a87832-a978-4851-8803-b6c0ef80b38f



</details>

---

Release Notes:

- Fixed Terminal and other Dock panel buttons not working correctly when panels are zoomed/full-screen.