### PR TITLE
editor: Open locations for jdtls references/implementations code lenses

### DIFF
--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -77,12 +77,7 @@ pub(super) fn try_handle_client_command(
         .read(cx)
         .language_server_adapter_for_id(action.server_id)
         .and_then(|adapter| adapter.adapter.client_command(&command.command, arguments))
-        .or_else(|| match command.command.as_str() {
-            "editor.action.showReferences"
-            | "editor.action.goToLocations"
-            | "editor.action.peekLocations" => Some(ClientCommand::ShowLocations),
-            _ => None,
-        });
+        .or_else(|| well_known_client_command(&command.command));
 
     match client_command {
         Some(ClientCommand::ScheduleTask(task_template)) => {
@@ -92,6 +87,21 @@ pub(super) fn try_handle_client_command(
             try_show_references(arguments, action, editor, window, cx)
         }
         None => false,
+    }
+}
+
+/// Client-side commands that servers written against VS Code embed in code
+/// lenses: the VS Code built-ins, plus the jdtls references and implementations
+/// lenses, which vscode-java implements on the client with the same
+/// `[uri, position, locations]` arguments.
+fn well_known_client_command(command: &str) -> Option<ClientCommand> {
+    match command {
+        "editor.action.showReferences"
+        | "editor.action.goToLocations"
+        | "editor.action.peekLocations"
+        | "java.show.references"
+        | "java.show.implementations" => Some(ClientCommand::ShowLocations),
+        _ => None,
     }
 }
 
@@ -727,12 +737,34 @@ mod tests {
     use multi_buffer::{MultiBufferRow, ToPoint as _};
     use text::Point;
 
-    use super::{CODE_LENS_SEPARATOR, displayed_title};
+    use language::ClientCommand;
+
+    use super::{CODE_LENS_SEPARATOR, displayed_title, well_known_client_command};
     use crate::{
         Editor, LSP_REQUEST_DEBOUNCE_TIMEOUT,
         editor_tests::{init_test, update_test_editor_settings},
         test::editor_lsp_test_context::EditorLspTestContext,
     };
+
+    #[test]
+    fn test_well_known_client_commands() {
+        for command in [
+            "editor.action.showReferences",
+            "editor.action.goToLocations",
+            "editor.action.peekLocations",
+            "java.show.references",
+            "java.show.implementations",
+        ] {
+            assert!(
+                matches!(
+                    well_known_client_command(command),
+                    Some(ClientCommand::ShowLocations)
+                ),
+                "{command} should open the locations list"
+            );
+        }
+        assert!(well_known_client_command("java.action.applyRefactoringCommand").is_none());
+    }
 
     #[gpui::test]
     async fn test_code_lens_blocks(cx: &mut TestAppContext) {


### PR DESCRIPTION
# Objective

Clicking the "N references" / "N implementations" code lenses that [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls) publishes does nothing in Zed.

jdtls attaches the client-side commands `java.show.references` and `java.show.implementations` to those lenses (implemented by vscode-java by opening VS Code's references view). `try_handle_client_command` only maps the VS Code built-in names (`editor.action.showReferences`, `editor.action.goToLocations`, `editor.action.peekLocations`) to `ClientCommand::ShowLocations`, so the click falls through to `workspace/executeCommand`, which jdtls rejects because these commands are not server-side, and the user sees nothing.

## Solution

Move the fallback list into `well_known_client_command` and add the two jdtls command names next to the VS Code built-ins. The arguments have the same `[uri, position, locations]` shape, so `try_show_references` handles them unchanged: one location navigates directly, several open the locations multibuffer. The Java extension cannot do this itself because extension adapters have no `client_command` hook.

## Testing

- Added `test_well_known_client_commands` covering the built-in and jdtls names plus a negative case.
- `cargo fmt`, `cargo check -p editor --tests` and `cargo clippy -p editor --tests -- -D warnings` pass locally (macOS, aarch64).
- Verified on the wire against jdtls 1.54 (as launched by the Java extension) that its resolved references/implementations lenses carry `[uri, position, locations]`, the shape `try_show_references` already handles for the VS Code names.
- I have not run a patched Zed build; reviewers with jdtls can check by opening a Java file with `"code_lens": "on"` and clicking an "N references" lens above a type: before this change nothing happens, after it the locations open.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed clicking the references and implementations code lenses from jdtls (Java) not opening the locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PqanyZWiAWsSeu1mK7Fex
