### PR TITLE
auto_update: Add title bar feedback when Zed is already up to date

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -476,7 +476,8 @@ impl AutoUpdater {
 
         let check_type = self.update_check_type;
         self.pending_poll.take();
-        self.status = AutoUpdateStatus::Idle;
+        // Passing through `Idle` would read as a completed check.
+        self.status = AutoUpdateStatus::Checking;
         self.poll(check_type, cx);
     }
 

--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -1,25 +1,44 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::anyhow;
 use auto_update::{AutoUpdateStatus, AutoUpdater, UpdateCheckType};
-use gpui::{Empty, Render};
+use gpui::{Empty, Render, Task};
 use semver::Version;
 use ui::{Tooltip, UpdateButton, prelude::*};
+
+const UP_TO_DATE_DISPLAY_DURATION: Duration = Duration::from_secs(4);
 
 pub struct UpdateVersion {
     status: AutoUpdateStatus,
     update_check_type: UpdateCheckType,
     dismissed_status: Option<AutoUpdateStatus>,
+    showing_up_to_date: bool,
+    _up_to_date_timer: Option<Task<()>>,
 }
 
 impl UpdateVersion {
     pub fn new(cx: &mut Context<Self>) -> Self {
         if let Some(auto_updater) = AutoUpdater::get(cx) {
             cx.observe(&auto_updater, |this, auto_update, cx| {
-                let auto_update = auto_update.read(cx);
-                this.status = auto_update.status();
-                this.update_check_type = auto_update.update_check_type();
-                this.dismissed_status = auto_update.dismissed_status();
+                let (status, update_check_type, dismissed_status) = {
+                    let auto_update = auto_update.read(cx);
+                    (
+                        auto_update.status(),
+                        auto_update.update_check_type(),
+                        auto_update.dismissed_status(),
+                    )
+                };
+                let finished_manual_check =
+                    Self::is_up_to_date(&this.status, &status, update_check_type);
+                this.status = status;
+                this.update_check_type = update_check_type;
+                this.dismissed_status = dismissed_status;
+                if finished_manual_check {
+                    this.show_up_to_date(cx);
+                } else if !matches!(this.status, AutoUpdateStatus::Idle) {
+                    this.hide_up_to_date();
+                }
                 cx.notify();
             })
             .detach();
@@ -27,14 +46,47 @@ impl UpdateVersion {
                 status: auto_updater.read(cx).status(),
                 update_check_type: UpdateCheckType::Automatic,
                 dismissed_status: auto_updater.read(cx).dismissed_status(),
+                showing_up_to_date: false,
+                _up_to_date_timer: None,
             }
         } else {
             Self {
                 status: AutoUpdateStatus::Idle,
                 update_check_type: UpdateCheckType::Automatic,
                 dismissed_status: None,
+                showing_up_to_date: false,
+                _up_to_date_timer: None,
             }
         }
+    }
+
+    fn is_up_to_date(
+        previous_status: &AutoUpdateStatus,
+        status: &AutoUpdateStatus,
+        update_check_type: UpdateCheckType,
+    ) -> bool {
+        update_check_type.is_manual()
+            && matches!(previous_status, AutoUpdateStatus::Checking)
+            && matches!(status, AutoUpdateStatus::Idle)
+    }
+
+    fn show_up_to_date(&mut self, cx: &mut Context<Self>) {
+        self.showing_up_to_date = true;
+        self._up_to_date_timer = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(UP_TO_DATE_DISPLAY_DURATION)
+                .await;
+            this.update(cx, |this, cx| {
+                this.hide_up_to_date();
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn hide_up_to_date(&mut self) {
+        self.showing_up_to_date = false;
+        self._up_to_date_timer = None;
     }
 
     pub fn update_simulation(&mut self, cx: &mut Context<Self>) {
@@ -59,6 +111,7 @@ impl UpdateVersion {
         self.status = next_state;
         self.update_check_type = UpdateCheckType::Manual;
         self.dismissed_status = None;
+        self.hide_up_to_date();
         cx.notify()
     }
 
@@ -90,6 +143,9 @@ impl Render for UpdateVersion {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if self.is_dismissed() {
             return Empty.into_any_element();
+        }
+        if self.showing_up_to_date {
+            return UpdateButton::up_to_date().into_any_element();
         }
         match &self.status {
             AutoUpdateStatus::Checking if self.update_check_type.is_manual() => {
@@ -159,6 +215,36 @@ mod tests {
             message,
             "Update to Version: 1.0.0+nightly.14d9a4189f058d8736339b06ff2340101eaea5af"
         );
+    }
+
+    #[test]
+    fn test_is_up_to_date() {
+        assert!(UpdateVersion::is_up_to_date(
+            &AutoUpdateStatus::Checking,
+            &AutoUpdateStatus::Idle,
+            UpdateCheckType::Manual
+        ));
+
+        assert!(!UpdateVersion::is_up_to_date(
+            &AutoUpdateStatus::Checking,
+            &AutoUpdateStatus::Idle,
+            UpdateCheckType::Automatic
+        ));
+
+        assert!(!UpdateVersion::is_up_to_date(
+            &AutoUpdateStatus::Checking,
+            &AutoUpdateStatus::Downloading {
+                version: Version::new(1, 99, 0),
+                progress: None,
+            },
+            UpdateCheckType::Manual
+        ));
+
+        assert!(!UpdateVersion::is_up_to_date(
+            &AutoUpdateStatus::Idle,
+            &AutoUpdateStatus::Idle,
+            UpdateCheckType::Manual
+        ));
     }
 
     #[test]

--- a/crates/ui/src/components/collab/update_button.rs
+++ b/crates/ui/src/components/collab/update_button.rs
@@ -118,6 +118,10 @@ impl UpdateButton {
             .disabled(true)
     }
 
+    pub fn up_to_date() -> Self {
+        Self::new(IconName::Check, "Up to Date").disabled(true)
+    }
+
     pub fn updated(version: impl Into<SharedString>) -> Self {
         Self::new(IconName::Download, "Restart to Update")
             .tooltip(version)
@@ -254,6 +258,7 @@ impl Component for UpdateButton {
                             "Installing",
                             UpdateButton::installing(version).into_any_element(),
                         ),
+                        single_example("Up to Date", UpdateButton::up_to_date().into_any_element()),
                     ],
                 ),
                 example_group_with_title(


### PR DESCRIPTION
# Objective

A manual "check for updates" that finds no newer version left the updater back at `Idle`, so the "Checking for Zed Updates…" indicator in the title bar simply vanished with no confirmation that the check had succeeded.

## Solution

Track that transition in `UpdateVersion` and show an "Up to Date" button in its place for a few seconds. The timer is stored as a task on the view, so it is cancelled when the view is dropped or a new update state arrives.

`restart_after_wake` passed through `Idle` before re-polling, which would read as a completed check; it now stays in `Checking`.

## Testing

- Did you test these changes? If so, how? **Tested by running Zed in preview channel.**
- Are there any parts that need more testing? **No**
- How can other people (reviewers) test your changes? Is there anything specific they need to know?

**Use `ZED_RELEASE_CHANNEL=preview cargo run` to open Zed. Then manually trigger a check within menu `Zed -> Check for Updates`.**

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

**Tested only on MacOS Tahoe**

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

A visual demo of what happens in title_bar when a manual check for updates is triggered.

https://github.com/user-attachments/assets/23b72bf2-6188-4eae-82b9-1c5b70782bb4

---

Release Notes:

- Added confirmation in the title bar when a manual update check finds Zed is already up to date
