### PR TITLE
gpui: Allow keybindings to pass keystrokes to macOS

### DIFF
--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use collections::{HashMap, TypeIdHashMap};
 pub use gpui_macros::Action;
-pub use no_action::{NoAction, Unbind, is_no_action, is_unbind};
+pub use no_action::{NoAction, PassToSystem, Unbind, is_no_action, is_pass_to_system, is_unbind};
 use serde_json::json;
 use std::{
     any::{Any, TypeId},
@@ -436,6 +436,17 @@ mod no_action {
         ]
     );
 
+    actions!(
+        zed,
+        [
+            /// Action with special handling which stops dispatching the key event and leaves it
+            /// unhandled, so that the platform's own key handling still gets a chance at it. On
+            /// macOS this lets the main menu's key equivalents run, such as the
+            /// Window > Move & Resize window-tiling shortcuts.
+            PassToSystem
+        ]
+    );
+
     /// Action with special handling which unbinds later bindings for the same keystrokes when they
     /// dispatch the named action, regardless of that action's context.
     ///
@@ -454,5 +465,11 @@ mod no_action {
     /// Returns whether or not this action represents an unbind marker.
     pub fn is_unbind(action: &dyn gpui::Action) -> bool {
         action.as_any().is::<Unbind>()
+    }
+
+    /// Returns whether or not this action represents a request to leave the key event unhandled
+    /// for the platform to act on.
+    pub fn is_pass_to_system(action: &dyn gpui::Action) -> bool {
+        action.as_any().is::<PassToSystem>()
     }
 }

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -634,9 +634,9 @@ mod tests {
 
     use crate::{
         ActionRegistry, App, Bounds, Context, DispatchPhase, DispatchTree, FocusHandle,
-        InputHandler, IntoElement, KeyBinding, KeyContext, Keymap, Pixels, PlatformWindow, Point,
-        Render, Subscription, TestAppContext, UTF16Selection, Unbind, VisualContext,
-        VisualTestContext, Window,
+        InputHandler, InteractiveElement, IntoElement, KeyBinding, KeyContext, KeyDownEvent,
+        Keymap, PassToSystem, Pixels, PlatformInput, PlatformWindow, Point, Render, Subscription,
+        TestAppContext, UTF16Selection, Unbind, VisualContext, VisualTestContext, Window,
     };
 
     actions!(dispatch_test, [TestAction, SecondaryTestAction]);
@@ -908,6 +908,110 @@ mod tests {
         let keybinding = tree.bindings_for_action(&TestAction, &contexts);
 
         assert!(keybinding[0].action.partial_eq(&TestAction))
+    }
+
+    /// Models the macOS window-tiling scenario: a raw key listener (as `TerminalView` has)
+    /// would otherwise consume the keystroke before the platform's own key handling sees it.
+    /// A contextless `zed::PassToSystem` binding outranks the in-context binding and leaves the
+    /// event unhandled.
+    #[crate::test]
+    fn test_pass_to_system_leaves_key_event_unhandled(cx: &mut TestAppContext) {
+        #[derive(Clone)]
+        struct PassToSystemTestView {
+            focus_handle: FocusHandle,
+            action_count: Rc<Cell<usize>>,
+            raw_key_count: Rc<Cell<usize>>,
+        }
+
+        impl Render for PassToSystemTestView {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                crate::div()
+                    .track_focus(&self.focus_handle)
+                    .key_context("Terminal")
+                    .on_action({
+                        let action_count = self.action_count.clone();
+                        move |_: &TestAction, _, cx| {
+                            action_count.set(action_count.get() + 1);
+                            cx.stop_propagation();
+                        }
+                    })
+                    .on_key_down({
+                        // Mirrors `TerminalView::key_down`, which consumes any keystroke it can
+                        // translate into terminal escape bytes.
+                        let raw_key_count = self.raw_key_count.clone();
+                        move |_, _, cx| {
+                            raw_key_count.set(raw_key_count.get() + 1);
+                            cx.stop_propagation();
+                        }
+                    })
+            }
+        }
+
+        cx.update(|cx| {
+            cx.bind_keys([
+                KeyBinding::new("ctrl-alt-left", TestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-alt-up", TestAction, Some("Terminal")),
+                KeyBinding::new("ctrl-alt-left", PassToSystem, None),
+            ]);
+        });
+
+        let (view, cx) = cx.add_window_view(|_, cx| PassToSystemTestView {
+            focus_handle: cx.focus_handle(),
+            action_count: Rc::default(),
+            raw_key_count: Rc::default(),
+        });
+        let (action_count, raw_key_count) = view.update(cx, |view, _| {
+            (view.action_count.clone(), view.raw_key_count.clone())
+        });
+        let focus_handle = view.update(cx, |view, _| view.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+        cx.run_until_parked();
+
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let observed_action = Rc::new(Cell::new(false));
+        let _subscription = cx.update(|_, cx| {
+            let observed = observed.clone();
+            let observed_action = observed_action.clone();
+            cx.observe_keystrokes(move |event, _, _| {
+                observed.borrow_mut().push(event.keystroke.clone());
+                observed_action.set(event.action.is_some());
+            })
+        });
+
+        let propagate = dispatch_key_down(cx, "ctrl-alt-left");
+
+        // Left unhandled: the platform still gets a chance at the key.
+        assert!(propagate);
+        assert_eq!(action_count.get(), 0);
+        assert_eq!(raw_key_count.get(), 0);
+        assert_eq!(observed.borrow().len(), 1);
+        assert!(!observed_action.get());
+
+        // Unbound combinations are unaffected, so the action is strictly opt-in.
+        let propagate = dispatch_key_down(cx, "ctrl-alt-up");
+
+        assert!(!propagate);
+        assert_eq!(action_count.get(), 1);
+        assert_eq!(raw_key_count.get(), 0);
+    }
+
+    fn dispatch_key_down(cx: &mut VisualTestContext, keystroke: &str) -> bool {
+        let keystroke = Keystroke::parse(keystroke).expect("valid keystroke");
+        cx.update(|window, cx| {
+            window
+                .dispatch_event(
+                    PlatformInput::KeyDown(KeyDownEvent {
+                        keystroke,
+                        is_held: false,
+                        prefer_character_input: false,
+                    }),
+                    cx,
+                )
+                .propagate
+        })
     }
 
     #[test]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -22,7 +22,7 @@ use crate::{
     TextInputStateChange, TextRenderingMode, TextStyle, TextStyleRefinement, ThermalState,
     TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance,
     WindowBounds, WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem,
-    point, prelude::*, px, rems, size, transparent_black,
+    is_pass_to_system, point, prelude::*, px, rems, size, transparent_black,
 };
 
 use crate::gestures::{GestureTuning, RecognizedTouchGesture, TouchGestureRecognizer};
@@ -5791,6 +5791,14 @@ impl Window {
 
         if !skip_bindings {
             for binding in match_result.bindings {
+                if is_pass_to_system(binding.action.as_ref()) {
+                    // Leave `propagate_event` set and skip the rest of dispatch, so the platform
+                    // sees the key as unhandled and its own key handling still gets a chance at it
+                    // - on macOS, the main menu's key equivalents.
+                    self.dispatch_keystroke_observers(event, None, match_result.context_stack, cx);
+                    self.pending_input_changed(cx);
+                    return;
+                }
                 self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
                 if !cx.propagate_event {
                     self.dispatch_keystroke_observers(

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -268,6 +268,31 @@ This is useful for preventing Zed from falling back to a default key binding whe
 ]
 ```
 
+### Passing a key to the operating system
+
+If you'd like a keystroke to be left alone entirely, so that the operating system can act on it instead of Zed, bind it to `zed::PassToSystem`. This is different from `null`: a `null` binding only removes lower-precedence bindings, and Zed's own key handling still sees the key. `zed::PassToSystem` stops dispatch outright and reports the key as unhandled.
+
+On macOS this is mainly useful for the window tiling shortcuts under Window > Move & Resize. Those are menu key equivalents, so the frontmost application gets first refusal, and they only reach the menu if Zed declines the key:
+
+```json [keymap]
+[
+  {
+    "bindings": {
+      "ctrl-alt-left": "zed::PassToSystem",
+      "ctrl-alt-right": "zed::PassToSystem"
+    }
+  }
+]
+```
+
+Leaving out the `context` is deliberate. A binding with no context is treated as the deepest context, and user bindings are added after the built-in ones, so this outranks the default bindings in every context at once. That includes `Terminal`, where the terminal would otherwise translate the keystroke into an escape sequence and send it to the shell.
+
+There are some limitations, notably:
+
+- It only works as a complete, single-keystroke binding. Used as the prefix of a multi-key sequence, Zed waits for the rest of the sequence and nothing is passed on.
+- It does not apply to printable input on layouts where a modified key still produces a character, such as AltGr layouts, because text input takes precedence over bindings there.
+- On Linux and Windows there is usually no system-level handling waiting behind an unhandled key, so the binding tends to mean "do nothing" rather than "do something else".
+
 ### Remapping keys
 
 A common request is to be able to map from a single keystroke to a sequence. You can do this with the `workspace::SendKeystrokes` action.
@@ -319,6 +344,8 @@ For example, `ctrl-n` creates a new tab in Zed on Linux. If you want to send `ct
   }
 }
 ```
+
+For the opposite direction, taking a key away from Zed so that the operating system can act on it, see [Passing a key to the operating system](#passing-a-key-to-the-operating-system).
 
 ### Task Key bindings
 


### PR DESCRIPTION
# Objective

Let users reserve keybindings for macOS. Zed currently handles some menu key equivalents before AppKit can invoke commands under Window > Move & Resize. A focused terminal consumes these keystrokes as terminal input.

Related to https://github.com/zed-industries/zed/issues/38037.

## Solution

Add `zed::PassToSystem`, a keybinding action that stops Zed's key dispatch while leaving the event unhandled for the platform. Keystroke observers still receive the raw key without an executed action, so Vim does not add it to macro or dot recordings.

Document contextless bindings, which override focused components such as Terminal.

## Testing

- Manually bound `ctrl-alt-left` and `ctrl-alt-right` to `zed::PassToSystem` on macOS and confirmed both shortcuts move the window while Terminal has focus.
- `cargo test -p gpui key_dispatch::tests --features gpui_platform/runtime_shaders`
- `cargo fmt --all -- --check`
- `cargo build -p zed --features gpui_platform/runtime_shaders`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added a `zed::PassToSystem` keybinding action to let macOS handle configured shortcuts.
