### PR TITLE
markdown: Add select all and rich text copying in preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14356,7 +14356,7 @@ checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
- "pulldown-cmark-escape",
+ "pulldown-cmark-escape 0.10.1",
  "unicase",
 ]
 
@@ -14368,6 +14368,7 @@ checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
+ "pulldown-cmark-escape 0.11.0",
  "unicase",
 ]
 
@@ -14376,6 +14377,12 @@ name = "pulldown-cmark-escape"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -172,6 +172,7 @@
   {
     "context": "Markdown",
     "bindings": {
+      "ctrl-a": "markdown::SelectAll",
       "copy": "markdown::Copy",
       "ctrl-insert": "markdown::Copy",
       "ctrl-c": "markdown::Copy",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -207,6 +207,7 @@
     "context": "Markdown",
     "use_key_equivalents": true,
     "bindings": {
+      "cmd-a": "markdown::SelectAll",
       "cmd-c": "markdown::Copy",
     },
   },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -172,6 +172,7 @@
     "context": "Markdown",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-a": "markdown::SelectAll",
       "ctrl-c": "markdown::Copy",
     },
   },

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -2536,7 +2536,27 @@ impl ClipboardItem {
             entries: vec![ClipboardEntry::String(ClipboardString {
                 text,
                 metadata: Some(metadata),
+                html: None,
             })],
+        }
+    }
+
+    /// Create a clipboard item with HTML and a plain-text fallback.
+    pub fn new_string_with_html(text: String, html: String) -> Self {
+        Self {
+            entries: vec![ClipboardEntry::String(ClipboardString {
+                text,
+                metadata: None,
+                html: Some(html),
+            })],
+        }
+    }
+
+    /// Returns the HTML representation of a single string entry, if present.
+    pub fn html(&self) -> Option<&str> {
+        match self.entries.as_slice() {
+            [ClipboardEntry::String(string)] => string.html.as_deref(),
+            _ => None,
         }
     }
 
@@ -2562,7 +2582,7 @@ impl ClipboardItem {
         let mut answer = String::new();
 
         for entry in self.entries.iter() {
-            if let ClipboardEntry::String(ClipboardString { text, metadata: _ }) = entry {
+            if let ClipboardEntry::String(ClipboardString { text, .. }) = entry {
                 answer.push_str(text);
             }
         }
@@ -2883,6 +2903,8 @@ pub struct ClipboardString {
     pub text: String,
     /// Optional metadata associated with this clipboard string.
     pub metadata: Option<String>,
+    /// Optional HTML representation of the text for rich-text destinations.
+    pub html: Option<String>,
 }
 
 impl ClipboardString {
@@ -2891,6 +2913,7 @@ impl ClipboardString {
         Self {
             text,
             metadata: None,
+            html: None,
         }
     }
 
@@ -2932,10 +2955,7 @@ impl ClipboardString {
 
 impl From<String> for ClipboardString {
     fn from(value: String) -> Self {
-        Self {
-            text: value,
-            metadata: None,
-        }
+        Self::new(value)
     }
 }
 

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -1239,6 +1239,7 @@ impl LinuxClient for WaylandClient {
             return;
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
+            let has_html = item.html().is_some();
             state.clipboard.set(item);
             let Some(serial) = state.serial_tracker.selection_serial() else {
                 log::warn!(
@@ -1250,6 +1251,9 @@ impl LinuxClient for WaylandClient {
                 .create_data_source(&state.globals.qh, DataSourceKind::Clipboard);
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
+            }
+            if has_html {
+                data_source.offer("text/html".to_string());
             }
             data_source.offer(state.clipboard.self_mime());
             data_device.set_selection(Some(&data_source), serial.as_raw());

--- a/crates/gpui_linux/src/linux/wayland/clipboard.rs
+++ b/crates/gpui_linux/src/linux/wayland/clipboard.rs
@@ -180,9 +180,18 @@ impl Clipboard {
         self.self_mime.clone()
     }
 
-    pub fn send(&self, _mime_type: String, fd: OwnedFd) {
-        if let Some(text) = self.contents.as_ref().and_then(|contents| contents.text()) {
-            self.send_bytes(fd, text.as_bytes().to_owned());
+    pub fn send(&self, mime_type: String, fd: OwnedFd) {
+        if let Some(contents) = self.contents.as_ref() {
+            let text = if mime_type == "text/html" {
+                contents.html().map(str::to_owned)
+            } else if TEXT_MIME_TYPES.contains(&mime_type.as_str()) {
+                contents.text()
+            } else {
+                None
+            };
+            if let Some(text) = text {
+                self.send_bytes(fd, text.into_bytes());
+            }
         }
     }
 

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -1760,11 +1760,7 @@ impl LinuxClient for X11Client {
         let mut state = self.0.borrow_mut();
         state
             .clipboard
-            .set_text(
-                std::borrow::Cow::Owned(item.text().unwrap_or_default()),
-                clipboard::ClipboardKind::Clipboard,
-                clipboard::WaitConfig::None,
-            )
+            .set_item(&item)
             .context("X11: Failed to write to clipboard (clipboard)")
             .log_with_level(log::Level::Debug);
         state.clipboard_item.replace(item);

--- a/crates/gpui_linux/src/linux/x11/clipboard.rs
+++ b/crates/gpui_linux/src/linux/x11/clipboard.rs
@@ -77,7 +77,7 @@ x11rb::atom_manager! {
         TEXT,
         TEXT_MIME_UNKNOWN: b"text/plain",
 
-        // HTML: b"text/html",
+        HTML: b"text/html",
         // URI_LIST: b"text/uri-list",
 
         PNG__MIME: ImageFormat::mime_type(ImageFormat::Png ).as_bytes(),
@@ -988,6 +988,21 @@ impl Clipboard {
             format: self.inner.atoms.UTF8_STRING,
         }];
         self.inner.write(data, selection, wait)
+    }
+
+    pub(crate) fn set_item(&self, item: &ClipboardItem) -> Result<()> {
+        let mut data = vec![ClipboardData {
+            bytes: item.text().unwrap_or_default().into_bytes(),
+            format: self.inner.atoms.UTF8_STRING,
+        }];
+        if let Some(html) = item.html() {
+            data.push(ClipboardData {
+                bytes: html.as_bytes().to_vec(),
+                format: self.inner.atoms.HTML,
+            });
+        }
+        self.inner
+            .write(data, ClipboardKind::Clipboard, WaitConfig::None)
     }
 
     fn image_format_atom(&self, format: ImageFormat) -> Atom {

--- a/crates/gpui_macos/src/pasteboard.rs
+++ b/crates/gpui_macos/src/pasteboard.rs
@@ -137,7 +137,11 @@ impl Pasteboard {
                     }
                 });
 
-            Some(ClipboardEntry::String(ClipboardString { text, metadata }))
+            Some(ClipboardEntry::String(ClipboardString {
+                text,
+                metadata,
+                html: None,
+            }))
         }
     }
 
@@ -181,6 +185,7 @@ impl Pasteboard {
                     let mut combined = ClipboardString {
                         text: String::new(),
                         metadata: None,
+                        html: None,
                     };
 
                     for entry in item.entries {
@@ -212,6 +217,16 @@ impl Pasteboard {
             );
             self.inner
                 .setData_forType(text_bytes, NSPasteboardTypeString);
+
+            if let Some(html) = string.html.as_ref() {
+                let html_bytes = NSData::dataWithBytes_length_(
+                    nil,
+                    html.as_ptr() as *const c_void,
+                    html.len() as u64,
+                );
+                self.inner
+                    .setData_forType(html_bytes, ns_string("public.html"));
+            }
 
             if let Some(metadata) = string.metadata.as_ref() {
                 let hash_bytes = ClipboardString::text_hash(&string.text).to_be_bytes();
@@ -402,6 +417,29 @@ mod tests {
             pasteboard.read(),
             Some(ClipboardItem::new_string(text_from_other_app.to_string()))
         );
+    }
+
+    #[test]
+    fn test_html_with_plain_text_fallback() {
+        autoreleasepool(|| {
+            let pasteboard = Pasteboard::unique();
+            pasteboard.write(ClipboardItem::new_string_with_html(
+                "Olá 世界".to_string(),
+                "<strong>Olá 世界</strong>".to_string(),
+            ));
+            assert_eq!(
+                pasteboard.read().and_then(|item| item.text()).as_deref(),
+                Some("Olá 世界")
+            );
+            let html = unsafe { pasteboard.data_for_type(ns_string("public.html")) };
+            assert_eq!(
+                html.as_deref(),
+                Some("<strong>Olá 世界</strong>".as_bytes())
+            );
+
+            pasteboard.write(ClipboardItem::new_string("plain".to_string()));
+            assert!(unsafe { pasteboard.data_for_type(ns_string("public.html")) }.is_none());
+        });
     }
 
     #[test]

--- a/crates/gpui_macos/src/pasteboard.rs
+++ b/crates/gpui_macos/src/pasteboard.rs
@@ -431,6 +431,8 @@ mod tests {
                 pasteboard.read().and_then(|item| item.text()).as_deref(),
                 Some("Olá 世界")
             );
+            // SAFETY: The unique pasteboard is alive, and the type NSString remains
+            // valid within this autorelease pool while data_for_type copies its data.
             let html = unsafe { pasteboard.data_for_type(ns_string("public.html")) };
             assert_eq!(
                 html.as_deref(),
@@ -438,6 +440,7 @@ mod tests {
             );
 
             pasteboard.write(ClipboardItem::new_string("plain".to_string()));
+            // SAFETY: The pasteboard and type NSString are still valid in this pool.
             assert!(unsafe { pasteboard.data_for_type(ns_string("public.html")) }.is_none());
         });
     }

--- a/crates/gpui_windows/src/clipboard.rs
+++ b/crates/gpui_windows/src/clipboard.rs
@@ -28,6 +28,8 @@ static CLIPBOARD_HASH_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GPUI internal text hash")));
 static CLIPBOARD_METADATA_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("GPUI internal metadata")));
+static CLIPBOARD_HTML_FORMAT: LazyLock<u32> =
+    LazyLock::new(|| register_clipboard_format(windows::core::w!("HTML Format")));
 static CLIPBOARD_SVG_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("image/svg+xml")));
 static CLIPBOARD_GIF_FORMAT: LazyLock<u32> =
@@ -181,6 +183,13 @@ fn write_string(item: &ClipboardString) -> Result<()> {
     let wide: Vec<u16> = item.text.encode_utf16().chain(Some(0)).collect_vec();
     set_clipboard_bytes(&wide, CF_UNICODETEXT.0 as u32)?;
 
+    if let Some(html) = item.html.as_deref() {
+        set_clipboard_bytes(
+            html_clipboard_format(html).as_bytes(),
+            *CLIPBOARD_HTML_FORMAT,
+        )?;
+    }
+
     if let Some(metadata) = item.metadata.as_ref() {
         let hash_bytes = ClipboardString::text_hash(&item.text).to_ne_bytes();
         set_clipboard_bytes(&hash_bytes, *CLIPBOARD_HASH_FORMAT)?;
@@ -189,6 +198,55 @@ fn write_string(item: &ClipboardString) -> Result<()> {
         set_clipboard_bytes(&wide, *CLIPBOARD_METADATA_FORMAT)?;
     }
     Ok(())
+}
+
+fn html_clipboard_format(fragment: &str) -> String {
+    const PREFIX: &str = "<html><body><!--StartFragment-->";
+    const SUFFIX: &str = "<!--EndFragment--></body></html>";
+    let header = |start_html, end_html, start_fragment, end_fragment| {
+        format!(
+            "Version:0.9\r\nStartHTML:{start_html:010}\r\nEndHTML:{end_html:010}\r\nStartFragment:{start_fragment:010}\r\nEndFragment:{end_fragment:010}\r\n"
+        )
+    };
+    // CF_HTML offsets count UTF-8 bytes from the start of the clipboard payload.
+    let start_html = header(0, 0, 0, 0).len();
+    let start_fragment = start_html + PREFIX.len();
+    let end_fragment = start_fragment + fragment.len();
+    let end_html = end_fragment + SUFFIX.len();
+    format!(
+        "{}{PREFIX}{fragment}{SUFFIX}\0",
+        header(start_html, end_html, start_fragment, end_fragment)
+    )
+}
+
+#[test]
+fn test_html_clipboard_format_offsets() {
+    for fragment in ["", "<p>Hello</p>", "<p>Olá 世界 🌍</p>"] {
+        let payload = html_clipboard_format(fragment);
+        let offset = |name: &str| {
+            payload
+                .lines()
+                .find_map(|line| line.strip_prefix(name))
+                .expect("header should contain offset")
+                .parse::<usize>()
+                .expect("offset should be numeric")
+        };
+        assert_eq!(
+            payload.get(offset("StartFragment:")..offset("EndFragment:")),
+            Some(fragment)
+        );
+        assert_eq!(
+            payload.get(offset("StartHTML:")..offset("EndHTML:")),
+            Some(
+                format!(
+                    "<html><body><!--StartFragment-->{fragment}<!--EndFragment--></body></html>"
+                )
+                .as_str()
+            )
+        );
+        assert_eq!(offset("EndHTML:") + 1, payload.len());
+        assert!(payload.ends_with('\0'));
+    }
 }
 
 fn write_image(item: &Image) -> Result<()> {
@@ -229,7 +287,11 @@ fn convert_to_png(bytes: &[u8], format: ImageFormat) -> Option<Vec<u8>> {
 fn read_string() -> Option<ClipboardEntry> {
     let text = get_clipboard_string(CF_UNICODETEXT.0 as u32)?;
     let metadata = read_clipboard_metadata(&text);
-    Some(ClipboardEntry::String(ClipboardString { text, metadata }))
+    Some(ClipboardEntry::String(ClipboardString {
+        text,
+        metadata,
+        html: None,
+    }))
 }
 
 fn read_clipboard_metadata(text: &str) -> Option<String> {

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -29,7 +29,7 @@ linkify.workspace = true
 log.workspace = true
 markup5ever_rcdom.workspace = true
 mermaid_render = { path = "../mermaid_render" }
-pulldown-cmark.workspace = true
+pulldown-cmark = { workspace = true, features = ["html"] }
 settings.workspace = true
 smallvec.workspace = true
 stacksafe.workspace = true

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -567,7 +567,11 @@ actions!(
         /// Copies the selected text to the clipboard.
         Copy,
         /// Copies the selected text as markdown to the clipboard.
-        CopyAsMarkdown
+        CopyAsMarkdown,
+        /// Copies the selected rendered content as HTML with a plain-text fallback.
+        CopyAsHtml,
+        /// Selects all rendered Markdown content.
+        SelectAll
     ]
 );
 
@@ -1126,6 +1130,40 @@ impl Markdown {
 
     pub fn active_search_highlight(&self) -> Option<usize> {
         self.active_search_highlight
+    }
+
+    pub fn select_all(&mut self, cx: &mut Context<Self>) {
+        self.context_menu_selected_markdown = None;
+        self.context_menu_selected_text = None;
+        self.selection = Selection {
+            start: 0,
+            end: self.source.len(),
+            ..Default::default()
+        };
+        cx.notify();
+    }
+
+    pub fn clipboard_item_as_html(text: String, markdown: &str) -> ClipboardItem {
+        let mut html = String::new();
+        pulldown_cmark::html::push_html(
+            &mut html,
+            pulldown_cmark::Parser::new_ext(markdown, parser::PARSE_OPTIONS),
+        );
+        ClipboardItem::new_string_with_html(text, html)
+    }
+
+    fn copy_as_html(&mut self, text: &RenderedText, cx: &mut Context<Self>) {
+        if !self.has_selection() {
+            return;
+        }
+        let range = self.selection.start..self.selection.end;
+        let markdown = self
+            .parsed_markdown
+            .rebalanced_markdown_for_selection(range.clone());
+        cx.write_to_clipboard(Self::clipboard_item_as_html(
+            text.text_for_range(range),
+            &markdown,
+        ));
     }
 
     fn copy(&self, text: &RenderedText, _: &mut Window, cx: &mut Context<Self>) {
@@ -3345,6 +3383,24 @@ impl Element for MarkdownElement {
             move |_, phase, window, cx| {
                 if phase == DispatchPhase::Bubble {
                     entity.update(cx, move |this, cx| this.copy_as_markdown(window, cx))
+                }
+            }
+        });
+
+        window.on_action(std::any::TypeId::of::<crate::CopyAsHtml>(), {
+            let entity = self.markdown.clone();
+            let text = rendered_markdown.text.clone();
+            move |_, phase, _, cx| {
+                if phase == DispatchPhase::Bubble {
+                    entity.update(cx, |this, cx| this.copy_as_html(&text, cx));
+                }
+            }
+        });
+        window.on_action(std::any::TypeId::of::<crate::SelectAll>(), {
+            let entity = self.markdown.clone();
+            move |_, phase, _, cx| {
+                if phase == DispatchPhase::Bubble {
+                    entity.update(cx, |this, cx| this.select_all(cx));
                 }
             }
         });
@@ -6358,6 +6414,107 @@ mod tests {
             selected_text,
             "Hello world\nThis is a test\nwith multiple lines"
         );
+    }
+
+    #[gpui::test]
+    fn test_select_all_and_copy_as_html(cx: &mut TestAppContext) {
+        ensure_theme_initialized(cx);
+        let source = "# Olá\n\n**bold** and [link](https://example.com)\n\n- one\n- two\n\n```rust\n<&>\n```";
+        let markdown = cx.new(|cx| Markdown::new(source.into(), None, None, cx));
+        cx.run_until_parked();
+        let rendered = render_markdown_entity_in_view(
+            markdown.clone(),
+            MarkdownStyle::default(),
+            None,
+            None,
+            cx,
+        );
+        markdown.update(cx, |markdown, cx| {
+            markdown.select_all(cx);
+            assert_eq!(markdown.selected_source(), Some(source));
+            assert!(!markdown.selection.pending);
+            markdown.copy_as_html(&rendered, cx);
+        });
+        let clipboard = cx
+            .read_from_clipboard()
+            .expect("clipboard should contain HTML");
+        assert_eq!(
+            clipboard.text(),
+            Some(rendered.text_for_range(0..source.len()))
+        );
+        let html = clipboard
+            .html()
+            .expect("HTML representation should be present");
+        assert!(html.contains("<h1>Olá</h1>"));
+        assert!(html.contains("<strong>bold</strong>"));
+        assert!(html.contains("<a href=\"https://example.com\">link</a>"));
+        assert!(html.contains("<li>one</li>"));
+        assert!(html.contains("&lt;&amp;&gt;"));
+
+        markdown.update(cx, |markdown, cx| {
+            let start = source.find("bold").expect("bold is in source");
+            markdown.selection = Selection {
+                start,
+                end: start + 4,
+                ..Default::default()
+            };
+            markdown.copy_as_html(&rendered, cx);
+        });
+        let clipboard = cx
+            .read_from_clipboard()
+            .expect("selection should be copied");
+        assert_eq!(clipboard.text().as_deref(), Some("bold"));
+        assert_eq!(clipboard.html(), Some("<p><strong>bold</strong></p>\n"));
+    }
+
+    #[gpui::test]
+    fn test_select_all_and_copy_actions(cx: &mut TestAppContext) {
+        ensure_theme_initialized(cx);
+        cx.update(|cx| {
+            cx.bind_keys([
+                gpui::KeyBinding::new("ctrl-a", SelectAll, Some("Markdown")),
+                gpui::KeyBinding::new("ctrl-c", Copy, Some("Markdown")),
+            ]);
+        });
+        let source = "# Title\n\n**Hello**, 世界!";
+        let markdown = cx.new(|cx| Markdown::new(source.into(), None, None, cx));
+        cx.run_until_parked();
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            markdown.focus_handle(cx).focus(window, cx);
+            MarkdownTestView {
+                markdown: markdown.clone(),
+                style: MarkdownStyle::default(),
+                code_span_link: None,
+                rendered_text: Rc::default(),
+            }
+        });
+        cx.run_until_parked();
+        cx.simulate_keystrokes("ctrl-a ctrl-c");
+        assert_eq!(
+            cx.read_from_clipboard()
+                .and_then(|item| item.text())
+                .as_deref(),
+            Some("Title\nHello, 世界!")
+        );
+        cx.dispatch_action(CopyAsHtml);
+        assert!(
+            cx.read_from_clipboard()
+                .expect("HTML should be copied")
+                .html()
+                .is_some()
+        );
+        cx.dispatch_action(CopyAsMarkdown);
+        assert_eq!(
+            cx.read_from_clipboard()
+                .and_then(|item| item.text())
+                .as_deref(),
+            Some(source)
+        );
+
+        markdown.update(cx, |markdown, cx| markdown.reset("".into(), cx));
+        cx.run_until_parked();
+        cx.simulate_keystrokes("ctrl-a");
+        markdown.read_with(cx, |markdown, _| assert!(!markdown.has_selection()));
     }
 
     fn nbsp(n: usize) -> String {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -571,7 +571,8 @@ impl MarkdownPreviewView {
                                 (index, focused)
                             });
                         if let Some(selection_start) = selection_start {
-                            let reveal = editor_is_focused || this.focus_handle.is_focused(window);
+                            let reveal =
+                                editor_is_focused || this.focus_handle.contains_focused(window, cx);
                             this.sync_preview_to_source_index(selection_start, reveal, cx);
                             cx.notify();
                         }
@@ -1597,8 +1598,8 @@ fn resolve_project_path_for_preview_image(
 }
 
 impl Focusable for MarkdownPreviewView {
-    fn focus_handle(&self, _: &App) -> FocusHandle {
-        self.focus_handle.clone()
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.markdown.focus_handle(cx)
     }
 }
 
@@ -1755,7 +1756,7 @@ impl Render for MarkdownPreviewView {
             .image_cache(self.image_cache.clone())
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")
-            .track_focus(&self.focus_handle(cx))
+            .track_focus(&self.focus_handle)
             .on_hover(cx.listener(|view, hovered, _window, cx| {
                 if !hovered && view.hovered_url.take().is_some() {
                     cx.notify();
@@ -1795,21 +1796,32 @@ impl Render for MarkdownPreviewView {
                             let content = right_click_menu("markdown-preview-context-menu")
                                 .trigger(move |_, _, _| markdown_element)
                                 .maybe_menu(move |window, cx| {
-                                    let focus = window.focused(cx);
+                                    let focus = markdown.focus_handle(cx);
                                     let markdown = markdown.read(cx);
                                     let context_menu_link = markdown.context_menu_link().cloned();
                                     let selected_text =
                                         markdown.context_menu_selected_text().cloned();
                                     let selected_markdown =
                                         markdown.context_menu_selected_markdown().cloned();
-                                    if context_menu_link.is_none()
-                                        && selected_text.is_none()
-                                        && selected_markdown.is_none()
-                                    {
-                                        return None;
-                                    }
+                                    let html_selection =
+                                        selected_text.clone().zip(selected_markdown.clone());
                                     Some(ContextMenu::build(window, cx, move |menu, _, _cx| {
-                                        menu.when_some(focus, |menu, focus| menu.context(focus))
+                                        menu.context(focus)
+                                            .action("Select All", Box::new(markdown::SelectAll))
+                                            .when_some(html_selection, |menu, (text, markdown)| {
+                                                menu.entry(
+                                                    "Copy as HTML",
+                                                    Some(Box::new(markdown::CopyAsHtml)),
+                                                    move |_, cx| {
+                                                        cx.write_to_clipboard(
+                                                            Markdown::clipboard_item_as_html(
+                                                                text.to_string(),
+                                                                &markdown,
+                                                            ),
+                                                        )
+                                                    },
+                                                )
+                                            })
                                             .when_some(selected_text, |menu, text| {
                                                 menu.entry(
                                                     "Copy",
@@ -3615,6 +3627,40 @@ mod tests {
             .unwrap()
     }
 
+    #[gpui::test]
+    async fn selects_and_copies_rendered_content_when_preview_opens(cx: &mut TestAppContext) {
+        let source = "# Title\n\n**Hello**, 世界!";
+        let (multi_workspace, _) = open_markdown_file(cx, "copy.md", source).await;
+        let preview = open_preview_for_active_editor(cx, &multi_workspace);
+        cx.update(|cx| {
+            cx.bind_keys([
+                gpui::KeyBinding::new("ctrl-a", markdown::SelectAll, Some("Markdown")),
+                gpui::KeyBinding::new("ctrl-c", markdown::Copy, Some("Markdown")),
+            ]);
+        });
+        cx.run_until_parked();
+        cx.simulate_keystrokes(multi_workspace.into(), "ctrl-a ctrl-c");
+        preview.read_with(cx, |preview, cx| {
+            assert_eq!(preview.markdown.read(cx).selected_source(), Some(source));
+        });
+        assert_eq!(
+            cx.read_from_clipboard()
+                .and_then(|item| item.text())
+                .as_deref(),
+            Some("Title\nHello, 世界!")
+        );
+        cx.dispatch_action(multi_workspace.into(), markdown::CopyAsHtml);
+        let clipboard = cx
+            .read_from_clipboard()
+            .expect("rendered content should be copied");
+        assert!(
+            clipboard
+                .html()
+                .expect("HTML should be available")
+                .contains("<strong>Hello</strong>")
+        );
+    }
+
     fn dispatch_close_and_return_to_editor(
         cx: &mut TestAppContext,
         multi_workspace: &WindowHandle<MultiWorkspace>,
@@ -4029,7 +4075,7 @@ mod tests {
                     })
                     .unwrap();
                 assert_eq!(preview.read(cx).active_source_index, Some(source_index));
-                assert!(preview.read(cx).focus_handle.is_focused(window));
+                assert!(preview.focus_handle(cx).is_focused(window));
                 assert!(
                     workspace
                         .read(cx)

--- a/docs/src/languages/markdown.md
+++ b/docs/src/languages/markdown.md
@@ -24,6 +24,23 @@ def fib(n):
 ```
 ````
 
+## Preview and Copying {#preview-and-copying}
+
+Open the rendered preview with {#action markdown::OpenPreview}
+({#kb markdown::OpenPreview}). To open it beside the source, use
+{#action markdown::OpenPreviewToTheSide}.
+
+With the preview focused, use {#action markdown::SelectAll}
+({#kb markdown::SelectAll}) to select the entire document, or drag to select part
+of the rendered text.
+
+Right-click the selection and choose **Copy as HTML** to paste formatted content
+into a rich-text destination, such as a document or email editor. You can also
+run {#action markdown::CopyAsHtml} from the command palette. The clipboard includes
+a plain-text fallback for applications that do not accept HTML.
+
+Use **Copy** for plain text or **Copy as Markdown** for Markdown source.
+
 ## Configuration
 
 ### Format


### PR DESCRIPTION
# Objective

Fixes #61966.

Allow selecting the complete Markdown preview with Ctrl+A on Linux/Windows or Cmd+A on macOS, then copying formatted content into rich-text applications.

Related work: #62706 is an open implementation of HTML copying; #62910 addressed Select All and was closed. This implementation covers both parts of the issue.

## Author context

I had some time to work on the issue I originally reported and implemented a fix.

The code compiled without errors. I then opened a test document in the Markdown preview, pressed Ctrl+A, and selected Copy as HTML from the context menu. Pasting into LibreOffice preserved the formatting as expected.

## Solution

- Add Select All and Copy as HTML actions to Markdown, expose them in the preview context menu, and route focus to the rendered Markdown so keyboard actions work immediately after opening the preview.
- Generate HTML from the selected Markdown, preserving formatting and a plain-text clipboard fallback. Publish native HTML clipboard formats on Linux X11/Wayland, macOS, and Windows.
- Document preview selection and copying, and add regression coverage for selection, keyboard routing, Unicode, formatting, and clipboard serialization.

## Testing

- `cargo test -p markdown --lib`: 160 passed.
- `cargo test -p markdown_preview --lib`: 29 passed.
- `CARGO_BUILD_JOBS=2 ./script/clippy -p markdown -p markdown_preview -p gpui -p gpui_linux`: passed.
- `cargo build -p zed --bin zed`: passed; Juliano tested the running application and reported success.
- Isolated Linux X11 application testing: Select All, context-menu and command-palette Copy as HTML, formatted HTML and Unicode read by a separate clipboard client, plain-text fallback, and ordinary Copy clearing the HTML target. Checked dark/light themes and a resized 720×600 window, including content below the viewport.
- Windows CF_HTML serialization test ran in isolation on Linux and passed. Native Windows and macOS clipboard integration remains untested.
- Changed documentation passed Prettier. The full documentation formatting check reports existing failures in untouched installation, C#, and VS Code migration pages.

To reproduce: open a Markdown preview containing headings, bold text, a link, a table, and Unicode. Focus the preview, select all, choose Copy as HTML, and paste into a rich-text destination. Repeat with a partial selection and with ordinary Copy into a plain-text destination.

High-DPI behavior and large-document performance have not been measured. Implementation and technical verification notes were prepared with AI assistance; human review is pending.

## Self-Review Checklist

- [ ] I've reviewed my own diff for quality, security, and reliability
- [x] Added unsafe blocks have justifying comments
- [ ] The content adheres to all of Zed's UI standards
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable
- [ ] Human author has removed the required README review notice

## Showcase

Dark theme: full preview selection and context-menu actions.

![Selected Markdown preview and Copy as HTML context-menu action](https://raw.githubusercontent.com/jjunho/zed/18a4349bffc5164155b573bb063fefd7c5e63d92/zed-61966-dark-menu.png)

Light theme, resized window: Copy as HTML in the command palette.

![Copy as HTML command in a narrow light-theme window](https://raw.githubusercontent.com/jjunho/zed/18a4349bffc5164155b573bb063fefd7c5e63d92/zed-61966-light-palette.png)

Release Notes:

- Added Select All (Ctrl+A on Linux/Windows, Cmd+A on macOS) and Copy as HTML to Markdown previews for copying formatted content into rich-text applications.
