### PR TITLE
gpui_linux: Avoid local XKB files for server keymaps

### DIFF
--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -899,9 +899,13 @@ pub(super) fn is_within_click_distance(a: Point<Pixels>, b: Point<Pixels>) -> bo
     diff.x.abs() <= DOUBLE_CLICK_DISTANCE && diff.y.abs() <= DOUBLE_CLICK_DISTANCE
 }
 
+/// Creates an XKB context for keymaps supplied by Wayland or X11.
+///
+/// Server keymaps are already resolved and need no local keyboard definitions.
+/// Loading default include paths can fail on systems without those files.
 #[cfg(any(feature = "wayland", feature = "x11"))]
 pub(super) fn new_xkb_context() -> anyhow::Result<xkb::Context> {
-    validate_xkb_context(xkb::Context::new(xkb::CONTEXT_NO_FLAGS))
+    validate_xkb_context(xkb::Context::new(xkb::CONTEXT_NO_DEFAULT_INCLUDES))
 }
 
 #[cfg(any(feature = "wayland", feature = "x11"))]

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -2847,7 +2847,9 @@ mod tests {
     }
 
     fn test_keymap_with_variant(layouts: &str, variant: &str) -> xkbc::Keymap {
-        let context = new_xkb_context().expect("test XKB context should initialize");
+        // These fixtures compile layout names from local files, unlike server keymaps.
+        let context = xkbc::Context::new(xkbc::CONTEXT_NO_FLAGS);
+        assert!(!context.get_raw_ptr().is_null());
         xkbc::Keymap::new_from_names(
             &context,
             "",


### PR DESCRIPTION
# Objective

Avoid requiring local XKB keyboard-definition directories when using the resolved keymap supplied by Wayland or X11. If libxkbcommon cannot find any usable default include directory, context creation can fail even though the client already has everything needed to use the server's keyboard map. Wayland can then panic on missing keyboard state when a modifier event arrives.

Closes DELTA-9B

## Solution

Create the shared XKB context with `XKB_CONTEXT_NO_DEFAULT_INCLUDES`. The [libxkbcommon documentation](https://xkbcommon.org/doc/current/group__context.html) explicitly identifies clients retrieving their keymaps from Wayland or X11 as a use case for this flag. [Qt's X11 backend](https://github.com/qt/qtbase/blob/6.8/src/plugins/platforms/xcb/qxcbkeyboard.cpp#L342-L358) uses the same approach.

Keep default include paths in the X11 test fixtures, which compile named layouts from local definitions instead of receiving resolved maps from a server. No fallback layout, platform-error callback API, or changes to other keymap failure handling are included.

## Testing

- Passed `corgi fmt --check -p gpui_linux` and `git diff origin/main...HEAD --check`.
- Reviewed the complete diff: two source files. The author has removed the README review marker.
- Linux build/test execution remains unverified. Earlier `corgi` and `cargo` cross-build attempts on macOS were blocked by missing Linux native dependencies/toolchain (`x86_64-linux-musl-gcc`); no Linux runtime or running Docker daemon is available here.
- No subprocess/environment-manipulating regression test is included. Manual verification is pending:
  - On ordinary Linux, check typing, modifiers/shortcuts, layout switching, and compose/dead keys under both Wayland and X11.
  - Reproduce startup with inaccessible XKB configuration paths in the old build, then verify keyboard input works in the patched build under the same conditions, ideally on the affected NixOS setup.
  - Run the existing `gpui_linux` X11 keyboard tests on Linux to verify the fixture adjustment.

Draft pending Linux validation.

Release Notes:

- Fixed a Linux startup crash when local XKB keyboard-definition files are unavailable.
