### PR TITLE
fix: add Helix ctrl-w t pane transpose

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -551,6 +551,7 @@
       "space w q": "pane::CloseActiveItem",
       "space w r": "pane::SplitRight", // not a helix default
       "space w d": "pane::SplitDown", // not a helix default
+      "space w t": "pane::TransposePaneGroup",
 
       // Space mode
       "space b": "tab_switcher::ToggleAll",
@@ -964,6 +965,8 @@
       "ctrl-w ctrl-g t": "pane::ActivateNextItem",
       "ctrl-w g shift-t": "pane::ActivatePreviousItem",
       "ctrl-w ctrl-g shift-t": "pane::ActivatePreviousItem",
+      "ctrl-w t": "pane::TransposePaneGroup",
+      "ctrl-w ctrl-t": "pane::TransposePaneGroup",
       "ctrl-w w": "workspace::ActivateNextPane",
       "ctrl-w ctrl-w": "workspace::ActivateNextPane",
       "ctrl-w p": "workspace::ActivatePreviousPane",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -246,6 +246,13 @@ split_structs!(
     SplitVertical => "Splits the pane vertically."
 );
 
+/// Transposes the orientation of the active pane's parent split group,
+/// swapping its axis between horizontal and vertical.
+#[derive(Default, Clone, PartialEq, Deserialize, JsonSchema, Action)]
+#[action(namespace = pane)]
+#[serde(deny_unknown_fields)]
+pub struct TransposePaneGroup;
+
 /// Activates the previous item in the pane.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = pane)]

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -290,6 +290,37 @@ impl PaneGroup {
         self.root.invert_pane_axies();
         self.mark_positions(cx);
     }
+
+    pub fn transpose_pane_axis(&mut self, pane: &Entity<Pane>, cx: &mut App) -> bool {
+        if Self::transpose_axis_in_member(&mut self.root, pane) {
+            self.mark_positions(cx);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn transpose_axis_in_member(member: &mut Member, pane: &Entity<Pane>) -> bool {
+        match member {
+            Member::Pane(_) => false,
+            Member::Axis(axis) => {
+                if let Some(child) = axis
+                    .members
+                    .iter_mut()
+                    .find(|child| child.contains_pane(pane))
+                {
+                    return match child {
+                        Member::Pane(_) => {
+                            axis.axis = axis.axis.invert();
+                            true
+                        }
+                        Member::Axis(_) => Self::transpose_axis_in_member(child, pane),
+                    };
+                }
+                false
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5947,6 +5947,12 @@ impl Workspace {
         }
     }
 
+    pub fn transpose_active_pane_group(&mut self, cx: &mut Context<Self>) {
+        if self.center.transpose_pane_axis(&self.active_pane, cx) {
+            cx.notify();
+        }
+    }
+
     pub fn resize_pane(
         &mut self,
         axis: gpui::Axis,
@@ -8185,6 +8191,11 @@ impl Workspace {
             .on_action(cx.listener(|workspace, _: &MovePaneDown, _, cx| {
                 workspace.move_pane_to_border(SplitDirection::Down, cx)
             }))
+            .on_action(
+                cx.listener(|workspace, _: &pane::TransposePaneGroup, _, cx| {
+                    workspace.transpose_active_pane_group(cx)
+                }),
+            )
             .on_action(cx.listener(|this, _: &ToggleLeftDock, window, cx| {
                 this.toggle_dock(DockPosition::Left, window, cx);
             }))
@@ -14555,6 +14566,65 @@ mod tests {
             assert_eq!(*top.flexes.lock(), vec![1.0; top.members.len()]);
             assert_eq!(*nested.flexes.lock(), vec![1.0; nested.members.len()]);
         });
+    }
+
+    #[gpui::test]
+    async fn test_transpose_active_pane_group(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let item = cx.new(|cx| {
+                TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "1.txt", cx)])
+            });
+            workspace.add_item_to_active_pane(Box::new(item), None, true, window, cx);
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                SplitDirection::Down,
+                window,
+                cx,
+            );
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                SplitDirection::Right,
+                window,
+                cx,
+            );
+        });
+
+        fn immediate_parent_axis(workspace: &Workspace) -> Axis {
+            let active = workspace.active_pane().clone();
+            fn find_axis(member: &Member, pane: &Entity<Pane>) -> Option<Axis> {
+                let Member::Axis(axis) = member else {
+                    return None;
+                };
+                let contains = axis.members.iter().any(|child| child.contains_pane(pane));
+                if !contains {
+                    return None;
+                }
+                axis.members.iter().find_map(|child| match child {
+                    Member::Pane(p) if p == pane => Some(axis.axis),
+                    Member::Axis(_) => find_axis(child, pane),
+                    _ => None,
+                })
+            }
+            find_axis(&workspace.center.root, &active)
+                .expect("expected the active pane to be nested in an axis")
+        }
+
+        let before_axis = workspace.read_with(cx, |workspace, _| immediate_parent_axis(workspace));
+        cx.dispatch_action(pane::TransposePaneGroup);
+        let after_axis = workspace.read_with(cx, |workspace, _| immediate_parent_axis(workspace));
+        assert_ne!(before_axis, after_axis);
+
+        cx.dispatch_action(pane::TransposePaneGroup);
+        let restored_axis =
+            workspace.read_with(cx, |workspace, _| immediate_parent_axis(workspace));
+        assert_eq!(restored_axis, before_axis);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

* Add the missing Helix `Ctrl-w t` pane transpose operation.
* Fixes #63995.

## Solution

* Added `pane::TransposePaneGroup` to transpose the active pane's parent split axis.
* Added pane tree logic to find and invert the immediate parent axis of the active pane.
* Wired the action through `Workspace`.
* Added Helix `Ctrl-w t`, `Ctrl-w Ctrl-t`, and `Space-w t` keybindings.
* Added a test covering nested splits and repeated transposition.

## Testing

* `cargo test -p workspace --lib` passed.
* `./script/clippy -p workspace` passed.
* `./script/check-keymaps` passed.
* `cargo build -p zed` passed.
* Manually verified pane transposition in Helix mode.

## Self-Review Checklist

* [x] I've reviewed my own diff for quality, security, and reliability
* [x] Unsafe blocks (if any) have justifying comments
* [x] The content adheres to Zed's UI standards
* [x] Tests cover the new/changed behavior
* [x] Performance impact has been considered and is acceptable

## Showcase

Not applicable. This change does not introduce a visual UI change.

---

Release Notes:

* Fixed missing Helix pane transpose support for `Ctrl-w t`.
