### PR TITLE
cli: add --focus-terminal <PID> to bring the user to a running process's terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -72,6 +72,10 @@ pub enum CliRequest {
     SetOpenBehavior {
         behavior: CliBehaviorSetting,
     },
+    /// Focus the terminal in which the process `pid` runs.
+    FocusTerminal {
+        pid: u32,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -761,6 +761,12 @@ fn run() -> Result<()> {
                     }
                 }
 
+                // A Zed that does not know the request drops the connection without an answer.
+                if args.focus_terminal.is_some() && exit_status.lock().is_none() {
+                    eprintln!("Zed closed the connection without answering: does it support --focus-terminal?");
+                    exit_status.lock().replace(1);
+                }
+
                 Ok(())
             }
         })

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -141,6 +141,13 @@ struct Args {
     /// Generate shell completions for Zed
     #[arg(long, value_names = ["SHELL"])]
     completions: Option<Shell>,
+    /// Focus the terminal tab in which the process with the given PID runs.
+    ///
+    /// The terminal is found by its shell or foreground process: the PID itself or one of its
+    /// ancestors. Lets a program running in a Zed terminal bring the user back to it, e.g. from
+    /// a desktop notification.
+    #[arg(long, value_name = "PID", conflicts_with_all = ["wait", "diff", "paths_with_position"])]
+    focus_terminal: Option<u32>,
     /// Uninstall Zed from user system
     #[cfg(all(
         any(target_os = "linux", target_os = "macos"),
@@ -717,18 +724,22 @@ fn run() -> Result<()> {
                 #[cfg(not(target_os = "windows"))]
                 let wsl = None;
 
-                let open_request = CliRequest::Open {
-                    paths,
-                    urls,
-                    diff_paths,
-                    diff_all: diff_all_mode,
-                    wsl,
-                    wait: args.wait,
-                    open_behavior,
-                    env,
-                    user_data_dir: user_data_dir_for_thread,
-                    dev_container: args.dev_container,
-                    cwd: env::current_dir().ok(),
+                let open_request = if let Some(pid) = args.focus_terminal {
+                    CliRequest::FocusTerminal { pid }
+                } else {
+                    CliRequest::Open {
+                        paths,
+                        urls,
+                        diff_paths,
+                        diff_all: diff_all_mode,
+                        wsl,
+                        wait: args.wait,
+                        open_behavior,
+                        env,
+                        user_data_dir: user_data_dir_for_thread,
+                        dev_container: args.dev_container,
+                        cwd: env::current_dir().ok(),
+                    }
                 };
 
                 tx.send(open_request)?;

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -15,7 +15,7 @@ use futures::future;
 use futures::{FutureExt, StreamExt};
 use git_ui::multi_diff_view::MultiDiffView;
 use git_ui_core::file_diff_view::FileDiffView;
-use gpui::{App, AsyncApp, Global, TaskExt, WindowHandle};
+use gpui::{App, AsyncApp, Entity, Global, TaskExt, WindowHandle};
 use onboarding::FIRST_OPEN;
 use onboarding::show_onboarding_view;
 use recent_projects::{RemoteSettings, navigate_to_positions, open_remote_project};
@@ -25,13 +25,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use ui::SharedString;
 use util::ResultExt;
 use util::debug_panic;
 use util::paths::PathWithPosition;
 use workspace::PathList;
 use workspace::item::ItemHandle;
-use workspace::{AppState, MultiWorkspace, OpenOptions, OpenResult, SerializedWorkspaceLocation};
+use workspace::{
+    AppState, MultiWorkspace, OpenOptions, OpenResult, Pane, SerializedWorkspaceLocation, Workspace,
+};
 
 #[derive(Default, Debug)]
 pub struct OpenRequest {
@@ -675,8 +678,132 @@ pub async fn handle_cli_connection(
                 // resolve_open_behavior
                 debug_panic!("unexpected SetOpenBehavior message");
             }
+            CliRequest::FocusTerminal { pid } => {
+                let status = match cx.update(|cx| focus_terminal_for_pid(pid, cx)) {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        responses
+                            .send(CliResponse::Stderr {
+                                message: format!("{error:#}"),
+                            })
+                            .log_err();
+                        1
+                    }
+                };
+                responses.send(CliResponse::Exit { status }).log_err();
+            }
         }
     }
+}
+
+/// The process `pid` and its ancestors, nearest first.
+fn process_ancestors(pid: u32) -> Vec<sysinfo::Pid> {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+    let mut system = System::new();
+    let mut ancestors = Vec::new();
+    let mut current = Pid::from_u32(pid);
+    while ancestors.len() < 64 {
+        ancestors.push(current);
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[current]),
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        match system.process(current).and_then(|process| process.parent()) {
+            Some(parent) if parent != current => current = parent,
+            _ => break,
+        }
+    }
+    ancestors
+}
+
+/// Where a terminal view lives in a workspace.
+enum TerminalLocation {
+    Center(Entity<TerminalView>),
+    Dock {
+        pane: Entity<Pane>,
+        item_index: usize,
+    },
+}
+
+/// The terminal of `workspace` whose shell or foreground process is one of `pids`.
+fn find_terminal(
+    workspace: &Entity<Workspace>,
+    pids: &[sysinfo::Pid],
+    cx: &App,
+) -> Option<TerminalLocation> {
+    let runs_one_of = |terminal_view: &Entity<TerminalView>| {
+        let terminal = terminal_view.read(cx).terminal().read(cx);
+        terminal.pid().is_some_and(|pid| pids.contains(&pid))
+            || terminal
+                .pid_getter()
+                .is_some_and(|getter| pids.contains(&getter.fallback_pid()))
+    };
+
+    let workspace = workspace.read(cx);
+    if let Some(terminal_panel) = workspace.panel::<TerminalPanel>(cx) {
+        for pane in terminal_panel.read(cx).panes() {
+            let item_index = pane.read(cx).items().enumerate().find_map(|(index, item)| {
+                item.act_as::<TerminalView>(cx)
+                    .filter(runs_one_of)
+                    .map(|_| index)
+            });
+            if let Some(item_index) = item_index {
+                return Some(TerminalLocation::Dock {
+                    pane: pane.clone(),
+                    item_index,
+                });
+            }
+        }
+    }
+    workspace
+        .items_of_type::<TerminalView>(cx)
+        .find(runs_one_of)
+        .map(TerminalLocation::Center)
+}
+
+/// Brings the user to the terminal in which the process `pid` runs: activates its window,
+/// workspace and tab. The terminal is recognized by its shell or foreground process, which is
+/// `pid` or one of its ancestors.
+fn focus_terminal_for_pid(pid: u32, cx: &mut App) -> Result<()> {
+    let pids = process_ancestors(pid);
+    for window in cx.windows() {
+        let Some(multi_workspace) = window.downcast::<MultiWorkspace>() else {
+            continue;
+        };
+        let focused = multi_workspace.update(cx, |multi_workspace, window, cx| {
+            let workspaces: Vec<_> = multi_workspace.workspaces().cloned().collect();
+            for workspace in workspaces {
+                let Some(location) = find_terminal(&workspace, &pids, cx) else {
+                    continue;
+                };
+                window.activate_window();
+                multi_workspace.activate(workspace.clone(), None, window, cx);
+                match location {
+                    TerminalLocation::Center(terminal_view) => {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.activate_item(&terminal_view, true, true, window, cx);
+                        });
+                    }
+                    TerminalLocation::Dock { pane, item_index } => {
+                        pane.update(cx, |pane, cx| {
+                            pane.activate_item(item_index, true, true, window, cx);
+                        });
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.focus_panel::<TerminalPanel>(window, cx);
+                        });
+                    }
+                }
+                return true;
+            }
+            false
+        })?;
+        if focused {
+            return Ok(());
+        }
+    }
+    anyhow::bail!("no terminal is running process {pid}")
 }
 
 /// Resolves the CLI open behavior when no explicit open behavior flag was given.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -104,6 +104,16 @@ zed --diff file1.txt file2.txt
 zed --diff old.rs new.rs --diff old2.rs new2.rs
 ```
 
+### `--focus-terminal <PID>`
+
+Bring the terminal tab in which a process runs to the front: its window, workspace and tab are activated. The terminal is found by its shell or foreground process, which may be the given PID or one of its ancestors. This lets a program running in a Zed terminal call the user back to it, for example when a long task finishes:
+
+```sh
+zed --focus-terminal $$
+```
+
+Exits with status 1 when no open terminal runs the process.
+
 ### `--foreground`
 
 Run Zed in the foreground, keeping the terminal attached. Useful for debugging:


### PR DESCRIPTION
# Objective

A program running in a Zed terminal has no way to call the user back to it. The typical case is a long-running tool (a build, a test run, an AI coding agent) that sends a desktop notification when it needs attention: clicking the notification can focus the Zed window through the window manager, but not the terminal tab the tool runs in, so with several terminals open the user still has to look for it.

Terminal emulators solve this with remote control (kitty's `focus-window --match pid:…`), Zed had nothing comparable.

## Solution

`zed --focus-terminal <PID>`. The CLI sends a new `CliRequest::FocusTerminal { pid }` to the running Zed, which looks through every window and workspace for a terminal whose shell or foreground process is that PID or one of its ancestors (the tool usually runs under a shell, possibly through wrappers), then activates the window, the workspace in the sidebar and the tab, in the terminal panel or in the center. Exit status is 1 with a message on stderr when no open terminal runs the process.

The terminal is recognized by what `Terminal` already knows: the foreground process group of the PTY (`Terminal::pid`) and the shell PID (`ProcessIdGetter::fallback_pid`). The ancestor chain is read with `sysinfo`, which the `zed` crate already depends on.

Documented in `docs/src/reference/cli.md`.

## Testing

- Built in release mode on Linux (Wayland, Hyprland) from the v1.19.2 tag and installed over the stable build; this PR is the same commit cherry-picked onto `main`.
- `zed --focus-terminal 1` against a fresh instance: prints `no terminal is running process 1`, exit status 1.
- The positive path (activating the tab) is being verified with a Claude Code notification hook whose default action runs `zed --focus-terminal $CLAUDE_PID`; the PR stays a draft until that is confirmed.
- Not tested on macOS and Windows. The process-ancestor lookup goes through `sysinfo`, so it is expected to work there; on Windows the PTY has no foreground process group, so only the shell PID matches.

To try it: open a terminal in Zed, run `zed --focus-terminal $$` from another terminal after noting the shell's PID, or from within the Zed terminal itself after switching to another tab: `(sleep 3; zed --focus-terminal $$) &`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added `zed --focus-terminal <PID>` to bring the terminal tab in which a process runs to the front, so tools running in a Zed terminal can call the user back to them (for example from a desktop notification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHkBy8x6Wijh8Then5xhuv
