### PR TITLE
worktree: Prevent scan requests from starving

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1456,6 +1456,7 @@ struct FakeFsState {
     buffered_events: Vec<PathEvent>,
     metadata_call_count: usize,
     read_dir_call_count: usize,
+    metadata_pauses: std::collections::HashMap<PathBuf, FakeFsMetadataPauseState>,
     path_write_counts: std::collections::HashMap<PathBuf, usize>,
     job_event_subscribers: Arc<Mutex<Vec<JobEventSender>>>,
     trash: Mutex<SlotMap<TrashId, (TrashedEntry, FakeFsEntry)>>,
@@ -1472,6 +1473,35 @@ struct FakeWatches {
     registered_paths: Vec<PathBuf>,
     watch_calls: Vec<PathBuf>,
     event_sink: Option<Box<dyn Fn(notify::Result<notify::Event>) + Send + Sync>>,
+}
+
+#[cfg(feature = "test-support")]
+struct FakeFsMetadataPauseState {
+    started: async_channel::Sender<()>,
+    release: async_channel::Receiver<()>,
+}
+
+#[cfg(feature = "test-support")]
+pub struct FakeFsMetadataPause {
+    started: async_channel::Receiver<()>,
+    release: async_channel::Sender<()>,
+}
+
+#[cfg(feature = "test-support")]
+impl FakeFsMetadataPause {
+    pub async fn wait_until_paused(&self) -> Result<()> {
+        self.started
+            .recv()
+            .await
+            .context("metadata operation ended before pausing")
+    }
+
+    pub async fn release(self) -> Result<()> {
+        self.release
+            .send(())
+            .await
+            .context("metadata operation ended before it was released")
+    }
 }
 
 #[cfg(feature = "test-support")]
@@ -1826,6 +1856,7 @@ impl FakeFs {
             events_paused: false,
             read_dir_call_count: 0,
             metadata_call_count: 0,
+            metadata_pauses: Default::default(),
             path_write_counts: Default::default(),
             job_event_subscribers: Arc::new(Mutex::new(Vec::new())),
             trash: Mutex::new(SlotMap::with_key()),
@@ -2740,6 +2771,23 @@ impl FakeFs {
         self.state.lock().metadata_call_count
     }
 
+    pub fn pause_metadata(&self, path: impl AsRef<Path>) -> FakeFsMetadataPause {
+        let path = normalize_path(path.as_ref());
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        self.state.lock().metadata_pauses.insert(
+            path,
+            FakeFsMetadataPauseState {
+                started: started_tx,
+                release: release_rx,
+            },
+        );
+        FakeFsMetadataPause {
+            started: started_rx,
+            release: release_tx,
+        }
+    }
+
     /// How many write operations have been issued for a specific path.
     pub fn write_count_for_path(&self, path: impl AsRef<Path>) -> usize {
         let path = path.as_ref().to_path_buf();
@@ -3269,8 +3317,25 @@ impl Fs for FakeFs {
     async fn metadata(&self, path: &Path) -> Result<Option<Metadata>> {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
+        let metadata_pause = {
+            let mut state = self.state.lock();
+            state.metadata_call_count += 1;
+            state.metadata_pauses.remove(&path)
+        };
+        if let Some(metadata_pause) = metadata_pause {
+            metadata_pause
+                .started
+                .send(())
+                .await
+                .context("metadata pause observer was dropped")?;
+            metadata_pause
+                .release
+                .recv()
+                .await
+                .context("metadata pause was dropped without being released")?;
+        }
+
         let mut state = self.state.lock();
-        state.metadata_call_count += 1;
         if let Some((mut entry, _)) = state.try_entry(&path, false) {
             let is_symlink = entry.is_symlink();
             if is_symlink {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5287,10 +5287,34 @@ impl BackgroundScanner {
         }
 
         let progress_update_count = AtomicUsize::new(0);
+        // Nothing is sent on this channel; it closes when the last worker drops its
+        // clone, the one completion signal an early worker exit cannot skip.
+        let (scan_complete_tx, scan_complete_rx) = async_channel::bounded::<()>(1);
         self.executor
             .scoped_priority(Priority::Low, |scope| {
+                // Workers only reach their `select_biased!` between directory jobs, so
+                // while they are all inside `scan_dir` none can accept a refresh request.
+                scope.spawn(async {
+                    loop {
+                        select_biased! {
+                            // Before requests, so a backlog cannot outlive the scan.
+                            _ = scan_complete_rx.recv().fuse() => break,
+
+                            request = self.next_scan_request().fuse() => {
+                                let Ok(request) = request else { break };
+                                if !self.process_scan_request(request, true).await {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+
                 for _ in 0..self.executor.num_cpus() {
+                    let scan_complete_tx = scan_complete_tx.clone();
                     scope.spawn(async {
+                        let _scan_complete_tx = scan_complete_tx;
+
                         let mut last_progress_update_count = 0;
                         let progress_update_timer = self.progress_timer(enable_progress_updates).fuse();
                         futures::pin_mut!(progress_update_timer);
@@ -5340,6 +5364,8 @@ impl BackgroundScanner {
                         }
                     });
                 }
+
+                drop(scan_complete_tx);
             })
             .await;
     }

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -2966,6 +2966,101 @@ async fn test_create_file_in_expanded_gitignored_dir(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_load_file_is_not_blocked_by_directory_scan(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.background_executor.set_num_cpus(1);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "first.txt": "first",
+            "second.txt": "second",
+            "blocked": {
+                "child.txt": "child",
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    let metadata_pause = fs.pause_metadata("/root/blocked/child.txt");
+    fs.emit_fs_event("/root/blocked", Some(PathEventKind::Changed));
+    metadata_pause.wait_until_paused().await.unwrap();
+
+    let first_load = tree.update(cx, |tree, cx| tree.load_file(rel_path("first.txt"), cx));
+    let second_load = tree.update(cx, |tree, cx| tree.load_file(rel_path("second.txt"), cx));
+    let (first_file, second_file) = futures::future::join(first_load, second_load).await;
+
+    assert_eq!(first_file.unwrap().text.to_string(), "first");
+    assert_eq!(second_file.unwrap().text.to_string(), "second");
+
+    metadata_pause.release().await.unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+}
+
+#[gpui::test]
+async fn test_drop_worktree_with_blocked_scan_request(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.background_executor.set_num_cpus(1);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "known.txt": "known",
+            "blocked": {
+                "child.txt": "child",
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    let directory_metadata_pause = fs.pause_metadata("/root/blocked/child.txt");
+    fs.emit_fs_event("/root/blocked", Some(PathEventKind::Changed));
+    directory_metadata_pause.wait_until_paused().await.unwrap();
+
+    let request_metadata_pause = fs.pause_metadata("/root/known.txt");
+    let mut refresh = tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .manually_refresh_entries_for_paths(vec![rel_path("known.txt").into()])
+    });
+    request_metadata_pause.wait_until_paused().await.unwrap();
+
+    drop(tree);
+    drop(request_metadata_pause);
+    drop(directory_metadata_pause);
+    refresh.recv().await;
+}
+
+#[gpui::test]
 async fn test_fs_event_for_gitignored_dir_does_not_lose_contents(cx: &mut TestAppContext) {
     // Tests the behavior of our worktree refresh when a directory modification for a gitignored directory
     // is triggered.


### PR DESCRIPTION
# Objective

Opening an already-scanned file can block behind the initial background scan when every scanner worker is busy processing a large directory.

Although scan requests are prioritized by `select_biased!`, workers only check for requests between directory jobs. A single directory job processes all of its children before returning, so a large directory can delay foreground file refreshes.

This redesigns the approach from #63192 without bypassing worktree snapshot synchronization or reusing potentially stale entries.

## Solution

Add a scoped task during `BackgroundScanner::scan_dirs` that remains available to process priority `ScanRequest`s while ordinary workers are inside `scan_dir`.

The task:

- Uses the existing `next_scan_request` coalescing and `process_scan_request` paths.
- Preserves `ScanRequest.done` barriers and snapshot publication.
- Exits when the ordinary directory workers finish. Each worker holds a channel sender, so dropping the final sender closes the channel and signals completion on every worker exit path.
- Prioritizes scan completion over further requests once the active directory scan has finished; remaining requests continue through the scanner's main loop.
- Works with a single scanner CPU without reserving the only ordinary worker.

`LocalWorktree::load_file` remains unchanged and continues to resolve files through `refresh_entry`, preserving entry identity, canonical-path, ignored, hidden, external, and private-file state.

The ordinary scanner worker count is unchanged. The additional low-priority task is normally parked and only adds concurrent work while processing a foreground request.

## Testing

Added deterministic fake-filesystem metadata barriers and regression coverage:

- `test_load_file_is_not_blocked_by_directory_scan`
  - Uses a single-CPU executor.
  - Blocks the sole ordinary scanner worker inside an unrelated directory scan.
  - Queues two already-known file loads.
  - Verifies both loads finish before the unrelated scan is released.
  - Fails on the previous implementation with `Parking forbidden`.
  - Passes across a 50-seed GPUI sweep.
- `test_drop_worktree_with_blocked_scan_request`
  - Verifies dropping the worktree releases a pending refresh while both the ordinary scan and priority request are blocked.
- Both tests verify that the initial and overall scans complete normally.

Validation performed:

- `cargo nextest run -p worktree --no-fail-fast --failure-output immediate-final` — 82 passed
- `cargo nextest run -p fs --no-fail-fast` — 19 passed, 1 skipped
- `./script/clippy -p worktree`
- `cargo fmt --all --check`
- `git diff --check`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed delays when opening files while large worktrees are still being scanned