### PR TITLE
gpui_linux: Discard stale Wayland file drag reads

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -370,14 +370,14 @@ pub(crate) struct WaylandClientState {
     ime_enabled: Option<bool>,
 }
 
-pub struct DragState {
-    data_offer: Option<wl_data_offer::WlDataOffer>,
-    window: Option<WaylandWindowStatePtr>,
+struct DragState<DataOffer = wl_data_offer::WlDataOffer, Window = WaylandWindowStatePtr> {
+    data_offer: Option<DataOffer>,
+    window: Option<Window>,
     position: Point<Pixels>,
     uri_read_generation: u64,
 }
 
-impl DragState {
+impl<DataOffer, Window> DragState<DataOffer, Window> {
     fn begin_uri_read(&mut self) -> u64 {
         self.invalidate_uri_read();
         self.uri_read_generation
@@ -389,6 +389,75 @@ impl DragState {
 
     fn is_uri_read_current(&self, generation: u64) -> bool {
         self.uri_read_generation == generation
+    }
+}
+
+trait FileDragDataOffer {
+    fn finish(&self);
+    fn destroy(&self);
+}
+
+impl FileDragDataOffer for wl_data_offer::WlDataOffer {
+    fn finish(&self) {
+        wl_data_offer::WlDataOffer::finish(self);
+    }
+
+    fn destroy(&self) {
+        wl_data_offer::WlDataOffer::destroy(self);
+    }
+}
+
+impl<DataOffer, Window> DragState<DataOffer, Window>
+where
+    DataOffer: FileDragDataOffer + Clone,
+    Window: Clone,
+{
+    fn handle_leave(&mut self) -> Option<(Window, PlatformInput)> {
+        self.invalidate_uri_read();
+        let window = self.window.clone()?;
+        let data_offer = self.data_offer.clone()?;
+        data_offer.destroy();
+        self.data_offer = None;
+        self.window = None;
+        Some((window, PlatformInput::FileDrop(FileDropEvent::Exited {})))
+    }
+
+    fn handle_drop(&mut self) -> Option<(Window, PlatformInput)> {
+        self.invalidate_uri_read();
+        let window = self.window.clone()?;
+        let data_offer = self.data_offer.clone()?;
+        data_offer.finish();
+        data_offer.destroy();
+        self.data_offer = None;
+        self.window = None;
+        Some((
+            window,
+            PlatformInput::FileDrop(FileDropEvent::Submit {
+                position: self.position,
+            }),
+        ))
+    }
+
+    fn complete_uri_read(
+        &mut self,
+        generation: u64,
+        data_offer: DataOffer,
+        window: Window,
+        position: Point<Pixels>,
+        paths: gpui::ExternalPaths,
+    ) -> Option<(Window, PlatformInput)> {
+        if !self.is_uri_read_current(generation) {
+            data_offer.destroy();
+            return None;
+        }
+
+        self.data_offer = Some(data_offer);
+        self.window = Some(window.clone());
+        self.position = position;
+        Some((
+            window,
+            PlatformInput::FileDrop(FileDropEvent::Entered { position, paths }),
+        ))
     }
 }
 
@@ -2667,23 +2736,20 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                                 data_offer.destroy();
                                 return;
                             }
-                            let input = PlatformInput::FileDrop(FileDropEvent::Entered {
-                                position,
-                                paths: gpui::ExternalPaths(paths),
-                            });
-
                             let client = this.get_client();
                             let mut state = client.borrow_mut();
-                            if !state.drag.is_uri_read_current(uri_read_generation) {
-                                data_offer.destroy();
-                                return;
-                            }
-                            state.drag.data_offer = Some(data_offer);
-                            state.drag.window = Some(drag_window.clone());
-                            state.drag.position = position;
+                            let input = state.drag.complete_uri_read(
+                                uri_read_generation,
+                                data_offer,
+                                drag_window,
+                                position,
+                                gpui::ExternalPaths(paths),
+                            );
 
                             drop(state);
-                            drag_window.handle_input(input);
+                            if let Some((drag_window, input)) = input {
+                                drag_window.handle_input(input);
+                            }
                         })
                         .detach();
                 }
@@ -2700,37 +2766,18 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                 drag_window.handle_input(input);
             }
             wl_data_device::Event::Leave => {
-                state.drag.invalidate_uri_read();
-                let Some(drag_window) = state.drag.window.clone() else {
-                    return;
-                };
-                let data_offer = state.drag.data_offer.clone().unwrap();
-                data_offer.destroy();
-
-                state.drag.data_offer = None;
-                state.drag.window = None;
-
-                let input = PlatformInput::FileDrop(FileDropEvent::Exited {});
+                let input = state.drag.handle_leave();
                 drop(state);
-                drag_window.handle_input(input);
+                if let Some((drag_window, input)) = input {
+                    drag_window.handle_input(input);
+                }
             }
             wl_data_device::Event::Drop => {
-                state.drag.invalidate_uri_read();
-                let Some(drag_window) = state.drag.window.clone() else {
-                    return;
-                };
-                let data_offer = state.drag.data_offer.clone().unwrap();
-                data_offer.finish();
-                data_offer.destroy();
-
-                state.drag.data_offer = None;
-                state.drag.window = None;
-
-                let input = PlatformInput::FileDrop(FileDropEvent::Submit {
-                    position: state.drag.position,
-                });
+                let input = state.drag.handle_drop();
                 drop(state);
-                drag_window.handle_input(input);
+                if let Some((drag_window, input)) = input {
+                    drag_window.handle_input(input);
+                }
             }
             _ => {}
         }
@@ -2933,24 +2980,131 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn invalidates_stale_drag_uri_reads() {
-        let mut drag = DragState {
+    #[derive(Clone)]
+    struct FakeDataOffer {
+        name: &'static str,
+        finished: Rc<Cell<bool>>,
+        destroyed: Rc<Cell<bool>>,
+    }
+
+    impl FakeDataOffer {
+        fn new(name: &'static str) -> Self {
+            Self {
+                name,
+                finished: Rc::new(Cell::new(false)),
+                destroyed: Rc::new(Cell::new(false)),
+            }
+        }
+    }
+
+    impl FileDragDataOffer for FakeDataOffer {
+        fn finish(&self) {
+            self.finished.set(true);
+        }
+
+        fn destroy(&self) {
+            self.destroyed.set(true);
+        }
+    }
+
+    fn drag_state() -> DragState<FakeDataOffer, &'static str> {
+        DragState {
             data_offer: None,
             window: None,
             position: Point::default(),
             uri_read_generation: 0,
-        };
+        }
+    }
 
-        let first_generation = drag.begin_uri_read();
-        assert!(drag.is_uri_read_current(first_generation));
+    fn complete_drag_uri_read(
+        drag: &mut DragState<FakeDataOffer, &'static str>,
+        generation: u64,
+        data_offer: FakeDataOffer,
+        window: &'static str,
+    ) -> Option<(&'static str, PlatformInput)> {
+        drag.complete_uri_read(
+            generation,
+            data_offer,
+            window,
+            Point::default(),
+            gpui::ExternalPaths(SmallVec::from_vec(vec![PathBuf::from("/tmp/file")])),
+        )
+    }
 
-        let second_generation = drag.begin_uri_read();
-        assert!(!drag.is_uri_read_current(first_generation));
-        assert!(drag.is_uri_read_current(second_generation));
+    fn record_entered(
+        input: Option<(&'static str, PlatformInput)>,
+        entered_windows: &mut Vec<&'static str>,
+    ) {
+        if let Some((window, PlatformInput::FileDrop(FileDropEvent::Entered { .. }))) = input {
+            entered_windows.push(window);
+        }
+    }
 
-        drag.invalidate_uri_read();
-        assert!(!drag.is_uri_read_current(second_generation));
+    #[test]
+    fn leave_discards_pending_drag_uri_read() {
+        let mut drag = drag_state();
+        let data_offer = FakeDataOffer::new("A");
+        let generation = drag.begin_uri_read();
+        let mut entered_windows = Vec::new();
+
+        record_entered(drag.handle_leave(), &mut entered_windows);
+        record_entered(
+            complete_drag_uri_read(&mut drag, generation, data_offer.clone(), "window A"),
+            &mut entered_windows,
+        );
+
+        assert!(entered_windows.is_empty());
+        assert!(data_offer.destroyed.get());
+        assert!(drag.data_offer.is_none());
+        assert!(drag.window.is_none());
+    }
+
+    #[test]
+    fn drop_then_leave_discards_pending_drag_uri_read() {
+        let mut drag = drag_state();
+        let data_offer = FakeDataOffer::new("A");
+        let generation = drag.begin_uri_read();
+        let mut entered_windows = Vec::new();
+
+        record_entered(drag.handle_drop(), &mut entered_windows);
+        assert_ne!(drag.uri_read_generation, generation);
+        record_entered(drag.handle_leave(), &mut entered_windows);
+        record_entered(
+            complete_drag_uri_read(&mut drag, generation, data_offer.clone(), "window A"),
+            &mut entered_windows,
+        );
+
+        assert!(entered_windows.is_empty());
+        assert!(!data_offer.finished.get());
+        assert!(data_offer.destroyed.get());
+        assert!(drag.data_offer.is_none());
+        assert!(drag.window.is_none());
+    }
+
+    #[test]
+    fn stale_completion_preserves_newer_drag_destination() {
+        let mut drag = drag_state();
+        let data_offer_a = FakeDataOffer::new("A");
+        let generation_a = drag.begin_uri_read();
+        let mut entered_windows = Vec::new();
+        record_entered(drag.handle_leave(), &mut entered_windows);
+
+        let data_offer_b = FakeDataOffer::new("B");
+        let generation_b = drag.begin_uri_read();
+        record_entered(
+            complete_drag_uri_read(&mut drag, generation_b, data_offer_b.clone(), "window B"),
+            &mut entered_windows,
+        );
+        record_entered(
+            complete_drag_uri_read(&mut drag, generation_a, data_offer_a.clone(), "window A"),
+            &mut entered_windows,
+        );
+
+        assert_eq!(entered_windows, ["window B"]);
+        assert!(data_offer_a.destroyed.get());
+        assert!(!data_offer_b.destroyed.get());
+        assert_eq!(drag.data_offer.as_ref().map(|offer| offer.name), Some("B"));
+        assert_eq!(drag.window, Some("window B"));
     }
 
     #[derive(Default)]

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -374,6 +374,22 @@ pub struct DragState {
     data_offer: Option<wl_data_offer::WlDataOffer>,
     window: Option<WaylandWindowStatePtr>,
     position: Point<Pixels>,
+    uri_read_generation: u64,
+}
+
+impl DragState {
+    fn begin_uri_read(&mut self) -> u64 {
+        self.invalidate_uri_read();
+        self.uri_read_generation
+    }
+
+    fn invalidate_uri_read(&mut self) {
+        self.uri_read_generation = self.uri_read_generation.wrapping_add(1);
+    }
+
+    fn is_uri_read_current(&self, generation: u64) -> bool {
+        self.uri_read_generation == generation
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -929,6 +945,7 @@ impl WaylandClient {
                 data_offer: None,
                 window: None,
                 position: Point::default(),
+                uri_read_generation: 0,
             },
             external_drag: None,
             click: ClickState {
@@ -2601,6 +2618,7 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                     let Some(drag_window) = get_window(&mut state, &surface.id()) else {
                         return;
                     };
+                    let uri_read_generation = state.drag.begin_uri_read();
 
                     const ACTIONS: DndAction = DndAction::Copy;
                     data_offer.set_actions(ACTIONS, ACTIONS);
@@ -2649,7 +2667,6 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                                 data_offer.destroy();
                                 return;
                             }
-
                             let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                                 position,
                                 paths: gpui::ExternalPaths(paths),
@@ -2657,6 +2674,10 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
 
                             let client = this.get_client();
                             let mut state = client.borrow_mut();
+                            if !state.drag.is_uri_read_current(uri_read_generation) {
+                                data_offer.destroy();
+                                return;
+                            }
                             state.drag.data_offer = Some(data_offer);
                             state.drag.window = Some(drag_window.clone());
                             state.drag.position = position;
@@ -2679,6 +2700,7 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                 drag_window.handle_input(input);
             }
             wl_data_device::Event::Leave => {
+                state.drag.invalidate_uri_read();
                 let Some(drag_window) = state.drag.window.clone() else {
                     return;
                 };
@@ -2693,6 +2715,7 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                 drag_window.handle_input(input);
             }
             wl_data_device::Event::Drop => {
+                state.drag.invalidate_uri_read();
                 let Some(drag_window) = state.drag.window.clone() else {
                     return;
                 };
@@ -2909,6 +2932,26 @@ mod tests {
     use std::cell::Cell;
 
     use super::*;
+
+    #[test]
+    fn invalidates_stale_drag_uri_reads() {
+        let mut drag = DragState {
+            data_offer: None,
+            window: None,
+            position: Point::default(),
+            uri_read_generation: 0,
+        };
+
+        let first_generation = drag.begin_uri_read();
+        assert!(drag.is_uri_read_current(first_generation));
+
+        let second_generation = drag.begin_uri_read();
+        assert!(!drag.is_uri_read_current(first_generation));
+        assert!(drag.is_uri_read_current(second_generation));
+
+        drag.invalidate_uri_read();
+        assert!(!drag.is_uri_read_current(second_generation));
+    }
 
     #[derive(Default)]
     struct FakeImeCursorRectangleSink {


### PR DESCRIPTION
## Objective

Prevent canceled external file drags on Linux Wayland from becoming active again after the native drag session has already left the Zed window.

This is a rare timing-sensitive race. When it occurs, the stale external drag remains active inside GPUI. Ordinary mouse movement then behaves like drag movement throughout Zed, and a later unrelated click can drop or copy the previously dragged file into the project panel.

The issue was observed on Fedora 44 with GNOME Wayland, with the drag originating in GNOME Files.

## Cause

The Wayland destination path reads the drag's `text/uri-list` payload asynchronously.

Before this change, `state.drag.window` and `state.drag.data_offer` were installed only after that asynchronous read completed. If `wl_data_device::Event::Leave` arrived first, it found no installed destination and returned. The detached read could then complete and dispatch a stale `FileDropEvent::Entered` after the native drag had already ended.

Rapidly entering and leaving Zed could also create multiple overlapping URI reads whose stale completions replaced one another.

With a temporary delay added to make the timing deterministic, the failing sequence was:

```text
entered: offer=81
left: active_offer=None, had_window=false
paths ready: offer=81
installing destination: offer=81, previous_offer=None
```

Two overlapping stale completions produced:

```text
installing destination: offer=80,
    previous_offer=Some(offer=81),
    had_window=true
```

The temporary delay and diagnostics are not included in this PR.

## Solution

Associate each asynchronous drag URI read with a monotonically increasing generation.

- A new `Enter` begins a new generation and invalidates an older pending read.
- `Leave` invalidates the current pending read.
- `Drop` invalidates the current pending read.
- Before installing the destination and dispatching `FileDropEvent::Entered`, the asynchronous task verifies that its generation is still current.
- Stale completions destroy their data offer and return without creating an active GPUI drag.

Normal drags whose URI reads complete before a terminal event continue through the existing path unchanged.

## Testing

- Added a unit test covering:
  - A newer drag invalidating an older URI read.
  - A terminal drag event invalidating the current URI read.
- Reproduced the race deterministically with a temporary two-second delay before destination installation.
- Verified that stale completions are discarded with the fix and no longer cause ordinary mouse movement or clicks to act on the old file.
- Ran:

```text
cargo test -p gpui_linux invalidates_stale_drag_uri_reads
cargo check -p gpui_linux
cargo build -p zed
git diff --check
```

Release Notes:

- Fixed canceled external file drags on Linux Wayland sometimes remaining active and causing later clicks to copy the dragged file.
