### PR TITLE
debugger: Fix CodeLLDB schema validation for build-inferred configurations

### DIFF
--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -280,7 +280,10 @@ impl DebugAdapter for CodeLldbDebugAdapter {
                     "default": false
                 }
             },
-            "required": ["request"],
+            "anyOf": [
+                { "required": ["request"] },
+                { "required": ["build"] }
+            ]
             "allOf": [
                 {
                     "if": {

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -287,6 +287,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
             "allOf": [
                 {
                     "if": {
+                        "required": ["request"],
                         "properties": {
                             "request": {
                                 "enum": ["launch"]
@@ -306,6 +307,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
                 },
                 {
                     "if": {
+                        "required": ["request"],
                         "properties": {
                             "request": {
                                 "enum": ["attach"]


### PR DESCRIPTION
## Summary

Fix the false CodeLLDB schema warnings reported in the linked issue.

- Allow configurations with `build` to omit `request`.
- Apply launch/attach target checks only when `request` is present, preserving target requirements for explicit requests even when `build` is provided.

No debugger runtime behavior changes.

Closes #64132

## Release Notes

- Fixed false missing-property warnings for CodeLLDB debug configurations using build-based target inference.
