### PR TITLE
inherit whole word match from buffer search

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -273,7 +273,7 @@ use workspace::{
     TabBarSettings, Toast, ViewId, Workspace, WorkspaceId, WorkspaceSettings,
     item::{ItemBufferKind, ItemHandle, PreviewTabsSettings, SaveOptions},
     notifications::{DetachAndPromptErr, NotificationId, NotifyResultExt, NotifyTaskExt},
-    searchable::SearchEvent,
+    searchable::{SearchEvent, SelectSearchOptions},
 };
 pub use zed_actions::editor::RevealInFileManager;
 use zed_actions::editor::{MoveDown, MoveUp};
@@ -1200,7 +1200,7 @@ pub struct Editor {
     refresh_folding_ranges_task: Task<()>,
     inlay_hints: Option<LspInlayHintData>,
     folding_newlines: Task<()>,
-    select_next_is_case_sensitive: Option<bool>,
+    select_next_options: Option<SelectSearchOptions>,
     pub lookup_key: Option<Box<dyn Any + Send + Sync>>,
     on_local_selections_changed:
         Option<Box<dyn Fn(Point, &mut Window, &mut Context<Self>) + 'static>>,
@@ -2565,7 +2565,7 @@ impl Editor {
             selection_drag_state: SelectionDragState::None,
             folding_newlines: Task::ready(()),
             lookup_key: None,
-            select_next_is_case_sensitive: None,
+            select_next_options: None,
             on_local_selections_changed: None,
             suppress_selection_callback: false,
             applicable_language_settings: HashMap::default(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -12525,6 +12525,18 @@ async fn test_select_next(cx: &mut TestAppContext) {
         e.select_next(&SelectNext::default(), window, cx).unwrap();
     });
     cx.assert_editor_state("«ˇfoo»\n«ˇFOO»\n«ˇFoo»");
+
+    // Enable whole word
+    update_test_editor_settings(&mut cx, &|settings| {
+        let mut search_settings = SearchSettingsContent::default();
+        search_settings.whole_word = Some(true);
+        settings.search = Some(search_settings);
+    });
+
+    cx.set_state("abc\nabc «abcˇ»\ndefabc\nabc");
+    cx.update_editor(|e, window, cx| e.select_next(&SelectNext::default(), window, cx))
+        .unwrap();
+    cx.assert_editor_state("abc\nabc «abcˇ»\ndefabc\n«abcˇ»");
 }
 
 #[gpui::test]

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -59,7 +59,7 @@ use workspace::{
     item::{FollowableItem, Item, ItemBufferKind, ItemEvent, ProjectItem, SaveOptions},
     searchable::{
         Direction, FilteredSearchRange, SearchEvent, SearchToken, SearchableItem,
-        SearchableItemHandle,
+        SearchableItemHandle, SelectSearchOptions,
     },
 };
 use workspace::{
@@ -2121,12 +2121,12 @@ impl SearchableItem for Editor {
         self.expect_bounds_change = self.last_bounds;
     }
 
-    fn set_search_is_case_sensitive(
+    fn set_select_search_options(
         &mut self,
-        case_sensitive: Option<bool>,
+        select_search_options: Option<SelectSearchOptions>,
         _cx: &mut Context<Self>,
     ) {
-        self.select_next_is_case_sensitive = case_sensitive;
+        self.select_next_options = select_search_options;
     }
 }
 

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -541,22 +541,23 @@ impl Editor {
                         .text_for_range(selection.start..selection.end)
                         .collect::<String>();
                     let is_empty = query.is_empty();
-                    let select_state = SelectNextState {
-                        query: self.build_query(&[query.chars().rev().collect::<String>()], cx)?,
-                        wordwise: true,
-                        done: is_empty,
-                    };
+                    let select_state = self.build_select_state(
+                        &[query.chars().rev().collect::<String>()],
+                        cx,
+                        Some(true),
+                        is_empty,
+                    )?;
                     self.select_prev_state = Some(select_state);
                 } else {
                     self.select_prev_state = None;
                 }
             } else if let Some(selected_text) = selected_text {
-                self.select_prev_state = Some(SelectNextState {
-                    query: self
-                        .build_query(&[selected_text.chars().rev().collect::<String>()], cx)?,
-                    wordwise: false,
-                    done: false,
-                });
+                self.select_prev_state = Some(self.build_select_state(
+                    &[selected_text.chars().rev().collect::<String>()],
+                    cx,
+                    None,
+                    false,
+                )?);
                 self.select_previous(action, window, cx)?;
             }
         }
@@ -2284,21 +2285,15 @@ impl Editor {
                         .text_for_range(selection.start..selection.end)
                         .collect::<String>();
                     let is_empty = query.is_empty();
-                    let select_state = SelectNextState {
-                        query: self.build_query(&[query], cx)?,
-                        wordwise: true,
-                        done: is_empty,
-                    };
+                    let select_state =
+                        self.build_select_state(&[query], cx, Some(true), is_empty)?;
                     self.select_next_state = Some(select_state);
                 } else {
                     self.select_next_state = None;
                 }
             } else if let Some(selected_text) = selected_text {
-                self.select_next_state = Some(SelectNextState {
-                    query: self.build_query(&[selected_text], cx)?,
-                    wordwise: false,
-                    done: false,
-                });
+                self.select_next_state =
+                    Some(self.build_select_state(&[selected_text], cx, None, false)?);
                 self.select_next_match_internal(
                     display_map,
                     replace_newest,
@@ -2311,18 +2306,43 @@ impl Editor {
         Ok(())
     }
 
-    fn build_query<I, P>(&self, patterns: I, cx: &Context<Self>) -> Result<AhoCorasick, BuildError>
+    fn build_query<I, P>(
+        &self,
+        patterns: I,
+        case_sensitive: bool,
+    ) -> Result<AhoCorasick, BuildError>
     where
         I: IntoIterator<Item = P>,
         P: AsRef<[u8]>,
     {
-        let case_sensitive = self
-            .select_next_is_case_sensitive
-            .unwrap_or_else(|| EditorSettings::get_global(cx).search.case_sensitive);
-
         let mut builder = AhoCorasickBuilder::new();
         builder.ascii_case_insensitive(!case_sensitive);
         builder.build(patterns)
+    }
+
+    fn build_select_state<I, P>(
+        &self,
+        patterns: I,
+        cx: &mut Context<Self>,
+        wordwise: Option<bool>,
+        done: bool,
+    ) -> Result<SelectNextState, BuildError>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<[u8]>,
+    {
+        let search_options = self.select_next_options.unwrap_or_else(|| {
+            let search_settings = EditorSettings::get_global(cx).search;
+            SelectSearchOptions {
+                case_sensitive: search_settings.case_sensitive,
+                whole_word: search_settings.whole_word,
+            }
+        });
+        Ok(SelectNextState {
+            query: self.build_query(patterns, search_options.case_sensitive)?,
+            wordwise: wordwise.unwrap_or(search_options.whole_word),
+            done,
+        })
     }
 
     fn find_syntax_node_boundary(

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -41,7 +41,7 @@ use workspace::{
     item::{ItemBufferKind, ItemHandle},
     searchable::{
         Direction, FilteredSearchRange, SearchEvent, SearchToken, SearchableItemHandle,
-        WeakSearchableItemHandle,
+        SelectSearchOptions, WeakSearchableItemHandle,
     },
 };
 
@@ -823,7 +823,7 @@ impl BufferSearchBar {
         self.dismissed = true;
         cx.emit(Event::Dismissed);
         self.query_error = None;
-        self.sync_select_next_case_sensitivity(cx);
+        self.sync_select_search_options(cx);
 
         for searchable_item in self.searchable_items_with_matches.keys() {
             if let Some(searchable_item) =
@@ -877,7 +877,7 @@ impl BufferSearchBar {
             }
             self.search_suggested(seed_query_override, window, cx);
             self.smartcase(window, cx);
-            self.sync_select_next_case_sensitivity(cx);
+            self.sync_select_search_options(cx);
             self.replace_enabled |= deploy.replace_enabled;
             self.selection_search_enabled =
                 self.selection_search_enabled
@@ -1210,7 +1210,7 @@ impl BufferSearchBar {
         self.default_options = self.search_options;
         drop(self.update_matches(false, false, window, cx));
         self.adjust_query_regex_language(cx);
-        self.sync_select_next_case_sensitivity(cx);
+        self.sync_select_search_options(cx);
         cx.notify();
     }
 
@@ -1245,7 +1245,7 @@ impl BufferSearchBar {
     pub fn set_search_options(&mut self, search_options: SearchOptions, cx: &mut Context<Self>) {
         self.search_options = search_options;
         self.adjust_query_regex_language(cx);
-        self.sync_select_next_case_sensitivity(cx);
+        self.sync_select_search_options(cx);
         cx.notify();
     }
 
@@ -1849,21 +1849,24 @@ impl BufferSearchBar {
         }
     }
 
-    /// Updates the searchable item's case sensitivity option to match the
-    /// search bar's current case sensitivity setting. This ensures that
+    /// Updates the searchable item's search options to match the
+    /// search bar's current settings. This ensures that
     /// editor's `select_next`/ `select_previous` operations respect the buffer
     /// search bar's search options.
     ///
-    /// Clears the case sensitivity when the search bar is dismissed so that
+    /// Clears them when the search bar is dismissed so that
     /// only the editor's settings are respected.
-    fn sync_select_next_case_sensitivity(&self, cx: &mut Context<Self>) {
-        let case_sensitive = match self.dismissed {
+    fn sync_select_search_options(&self, cx: &mut Context<Self>) {
+        let search_options = match self.dismissed {
             true => None,
-            false => Some(self.search_options.contains(SearchOptions::CASE_SENSITIVE)),
+            false => Some(SelectSearchOptions {
+                case_sensitive: self.search_options.contains(SearchOptions::CASE_SENSITIVE),
+                whole_word: self.search_options.contains(SearchOptions::WHOLE_WORD),
+            }),
         };
 
         if let Some(active_searchable_item) = self.active_searchable_item.as_ref() {
-            active_searchable_item.set_search_is_case_sensitive(case_sensitive, cx);
+            active_searchable_item.set_select_search_options(search_options, cx);
         }
     }
 }

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -70,6 +70,12 @@ pub enum FilteredSearchRange {
     Default,
 }
 
+#[derive(Copy, Clone)]
+pub struct SelectSearchOptions {
+    pub case_sensitive: bool,
+    pub whole_word: bool,
+}
+
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
     type Match: Any + Sync + Send + Clone;
 
@@ -205,7 +211,8 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<usize>;
-    fn set_search_is_case_sensitive(&mut self, _: Option<bool>, _: &mut Context<Self>) {}
+    fn set_select_search_options(&mut self, _: Option<SelectSearchOptions>, _: &mut Context<Self>) {
+    }
 }
 
 pub trait SearchableItemHandle: ItemHandle {
@@ -303,7 +310,7 @@ pub trait SearchableItemHandle: ItemHandle {
         cx: &mut App,
     );
 
-    fn set_search_is_case_sensitive(&self, is_case_sensitive: Option<bool>, cx: &mut App);
+    fn set_select_search_options(&self, search_options: Option<SelectSearchOptions>, cx: &mut App);
 }
 
 impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
@@ -507,9 +514,9 @@ impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
             this.toggle_filtered_search_ranges(enabled, window, cx)
         });
     }
-    fn set_search_is_case_sensitive(&self, enabled: Option<bool>, cx: &mut App) {
+    fn set_select_search_options(&self, search_options: Option<SelectSearchOptions>, cx: &mut App) {
         self.update(cx, |this, cx| {
-            this.set_search_is_case_sensitive(enabled, cx)
+            this.set_select_search_options(search_options, cx)
         });
     }
 }


### PR DESCRIPTION
# Objective

Make `editor: select next` / `editor: select previous` more powerful and conform to VSCode behaviour
Partial fix for #15415

## Solution

As a first step (and a way to familiarize myself with the codebase) i had it inherit "whole word" from `BufferSearch`, additionally to "case sensitive", which it already does.
Note that like before, this only applies while `BufferSearch` is deployed

## Testing

Manually tested and added test case in `test_select_next`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved `editor: select next` and `editor: select previous` to inherit whole word from buffer search
