### PR TITLE
Fix insertion modes for completions without edit ranges

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11603,6 +11603,7 @@ fn process_completion_for_edit(
         let replace_range = &completion.replace_range;
         if let CompletionSource::Lsp {
             insert_range: Some(insert_range),
+            lsp_completion,
             ..
         } = &completion.source
         {
@@ -11641,7 +11642,7 @@ fn process_completion_for_edit(
                                     ..buffer.anchor_after(replace_range.end),
                             );
                             let mut current_needle = text_to_replace.next();
-                            for haystack_ch in completion.label.text.chars() {
+                            for haystack_ch in lsp_completion.label.chars() {
                                 if let Some(needle_ch) = current_needle
                                     && haystack_ch.eq_ignore_ascii_case(&needle_ch)
                                 {
@@ -11664,9 +11665,8 @@ fn process_completion_for_edit(
                                     )
                                     .collect::<String>()
                                     .to_ascii_lowercase();
-                                completion
+                                lsp_completion
                                     .label
-                                    .text
                                     .to_ascii_lowercase()
                                     .ends_with(&text_after_cursor)
                             } else {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20897,6 +20897,357 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_completion_without_text_edit(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions::default()),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    for (initial_state, completion_text, filter_text, expected_states) in [
+        (
+            "test(value1, ˇvalue2)",
+            "value2=",
+            "value2",
+            [
+                "test(value1, value2=ˇvalue2)",
+                "test(value1, value2=ˇ)",
+                "test(value1, value2=ˇ)",
+                "test(value1, value2=ˇvalue2)",
+            ],
+        ),
+        (
+            "test(value1, valˇvalue2)",
+            "value2=",
+            "value2",
+            [
+                "test(value1, value2=ˇvalue2)",
+                "test(value1, value2=ˇ)",
+                "test(value1, value2=ˇvalue2)",
+                "test(value1, value2=ˇvalue2)",
+            ],
+        ),
+        (
+            "ediˇtor",
+            "editor",
+            "edi",
+            ["editorˇtor", "editorˇ", "editorˇ", "editorˇ"],
+        ),
+        (
+            "strˇing",
+            "str",
+            "str",
+            ["strˇing", "strˇ", "strˇing", "strˇing"],
+        ),
+        (
+            "SuˇErr",
+            "SubscriptionError",
+            "Su",
+            [
+                "SubscriptionErrorˇErr",
+                "SubscriptionErrorˇ",
+                "SubscriptionErrorˇ",
+                "SubscriptionErrorˇErr",
+            ],
+        ),
+        (
+            "test(value1, valueˇ)",
+            "value2=",
+            "value",
+            ["test(value1, value2=ˇ)"; 4],
+        ),
+        (
+            "test(value1, ˇ)",
+            "value2=",
+            "v2",
+            ["test(value1, value2=ˇ)"; 4],
+        ),
+        (
+            "test(value1, ˇv2)",
+            "value2=",
+            "v2",
+            [
+                "test(value1, value2=ˇv2)",
+                "test(value1, value2=ˇ)",
+                "test(value1, value2=ˇ)",
+                "test(value1, value2=ˇv2)",
+            ],
+        ),
+        (
+            "test(\"😀\", 𐐀naïˇve)",
+            "𐐀naïve",
+            "𐐀naï",
+            [
+                "test(\"😀\", 𐐀naïveˇve)",
+                "test(\"😀\", 𐐀naïveˇ)",
+                "test(\"😀\", 𐐀naïveˇ)",
+                "test(\"😀\", 𐐀naïveˇ)",
+            ],
+        ),
+        (
+            "test(\n\tˇvalue2\n)",
+            "value2=",
+            "value2",
+            [
+                "test(\n\tvalue2=ˇvalue2\n)",
+                "test(\n\tvalue2=ˇ\n)",
+                "test(\n\tvalue2=ˇ\n)",
+                "test(\n\tvalue2=ˇvalue2\n)",
+            ],
+        ),
+        (
+            "ˇvalue2",
+            "value2=",
+            "value2",
+            ["value2=ˇvalue2", "value2=ˇ", "value2=ˇ", "value2=ˇvalue2"],
+        ),
+        ("valueˇ", "value2=", "value", ["value2=ˇ"; 4]),
+        ("ˇ", "value2=", "v2", ["value2=ˇ"; 4]),
+    ] {
+        for (lsp_insert_mode, expected_state) in [
+            LspInsertMode::Insert,
+            LspInsertMode::Replace,
+            LspInsertMode::ReplaceSubsequence,
+            LspInsertMode::ReplaceSuffix,
+        ]
+        .into_iter()
+        .zip(expected_states)
+        {
+            update_test_language_settings(&mut cx, &|settings| {
+                settings.defaults.completions = Some(CompletionSettingsContent {
+                    lsp_insert_mode: Some(lsp_insert_mode),
+                    words: Some(WordsCompletionMode::Disabled),
+                    ..CompletionSettingsContent::default()
+                });
+            });
+
+            for (insert_text, detail, description, use_filter_text) in [
+                (None, None, None, false),
+                (Some(completion_text), None, None, false),
+                (None, Some("string"), None, false),
+                (Some(completion_text), Some("string"), None, false),
+                (None, None, Some("string"), false),
+                (Some(completion_text), None, Some("string"), false),
+                (Some(completion_text), None, None, true),
+                (Some(completion_text), Some(filter_text), None, true),
+            ] {
+                eprintln!(
+                    "{initial_state:?}, {lsp_insert_mode:?}, {insert_text:?}, {detail:?}, {description:?}, {use_filter_text:?}"
+                );
+                cx.set_state(initial_state);
+                cx.set_request_handler::<lsp::request::Completion, _, _>(
+                    move |_, _, _| async move {
+                        Ok(Some(lsp::CompletionResponse::List(lsp::CompletionList {
+                            is_incomplete: true,
+                            items: vec![lsp::CompletionItem {
+                                label: completion_text.to_string(),
+                                filter_text: use_filter_text.then(|| filter_text.to_string()),
+                                insert_text: insert_text.map(str::to_string),
+                                detail: detail.map(str::to_string),
+                                label_details: description.map(|description| {
+                                    lsp::CompletionItemLabelDetails {
+                                        detail: None,
+                                        description: Some(description.to_string()),
+                                    }
+                                }),
+                                ..lsp::CompletionItem::default()
+                            }],
+                            item_defaults: None,
+                        })))
+                    },
+                );
+                cx.update_editor(|editor, window, cx| {
+                    editor.show_completions(&ShowCompletions, window, cx);
+                });
+                cx.condition(|editor, _| editor.context_menu_visible())
+                    .await;
+                cx.update_editor(|editor, window, cx| {
+                    editor.confirm_completion(&ConfirmCompletion::default(), window, cx)
+                })
+                .expect("completion should be accepted")
+                .await
+                .expect("completion should succeed");
+                cx.assert_editor_state(expected_state);
+            }
+        }
+    }
+}
+
+#[gpui::test]
+async fn test_completion_without_text_edit_after_typing(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.completions = Some(CompletionSettingsContent {
+            lsp_insert_mode: Some(LspInsertMode::Replace),
+            words: Some(WordsCompletionMode::Disabled),
+            ..CompletionSettingsContent::default()
+        });
+    });
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions {
+                resolve_provider: Some(true),
+                ..lsp::CompletionOptions::default()
+            }),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    let requests = Arc::new(AtomicUsize::new(0));
+    cx.set_request_handler::<lsp::request::Completion, _, _>({
+        let requests = requests.clone();
+        move |_, _, _| {
+            requests.fetch_add(1, atomic::Ordering::Release);
+            async move {
+                Ok(Some(lsp::CompletionResponse::Array(vec![
+                    lsp::CompletionItem {
+                        label: "value2=".to_string(),
+                        insert_text: Some("value2=".to_string()),
+                        ..lsp::CompletionItem::default()
+                    },
+                ])))
+            }
+        }
+    });
+    let mut resolved = cx.set_request_handler::<lsp::request::ResolveCompletionItem, _, _>(
+        |_, mut item, _| async move {
+            item.documentation = Some(lsp::Documentation::String("resolved".to_string()));
+            Ok(item)
+        },
+    );
+    cx.set_state("test(value1, ˇvalue2)");
+    cx.update_editor(|editor, window, cx| {
+        editor.show_completions(&ShowCompletions, window, cx);
+    });
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+    resolved.next().await.expect("completion should resolve");
+    cx.run_until_parked();
+
+    cx.simulate_input("v");
+    cx.run_until_parked();
+    cx.simulate_input("a");
+    cx.run_until_parked();
+    assert_eq!(requests.load(atomic::Ordering::Acquire), 1);
+    cx.assert_editor_state("test(value1, vaˇvalue2)");
+    cx.update_editor(|editor, window, cx| {
+        editor.confirm_completion_insert(&ConfirmCompletionInsert, window, cx)
+    })
+    .expect("completion should be accepted")
+    .await
+    .expect("completion should succeed");
+    cx.assert_editor_state("test(value1, value2=ˇvalue2)");
+}
+
+#[gpui::test]
+async fn test_completion_with_explicit_replace_range(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.completions = Some(CompletionSettingsContent {
+            lsp_insert_mode: Some(LspInsertMode::Insert),
+            words: Some(WordsCompletionMode::Disabled),
+            ..CompletionSettingsContent::default()
+        });
+    });
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions::default()),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    for (lsp_insert_mode, expected_pair_state) in [
+        (LspInsertMode::ReplaceSuffix, "test(value1, value2=ˇvalue2)"),
+        (LspInsertMode::Insert, "test(value1, value2=ˇvalue2)"),
+        (LspInsertMode::Replace, "test(value1, value2=ˇ)"),
+        (LspInsertMode::ReplaceSubsequence, "test(value1, value2=ˇ)"),
+    ] {
+        update_test_language_settings(&mut cx, &|settings| {
+            settings.defaults.completions = Some(CompletionSettingsContent {
+                lsp_insert_mode: Some(lsp_insert_mode),
+                words: Some(WordsCompletionMode::Disabled),
+                ..CompletionSettingsContent::default()
+            });
+        });
+        for (use_default_range, use_insert_range) in
+            [(false, true), (true, true), (false, false), (true, false)]
+        {
+            for filter_text in [Some("value2"), None] {
+                eprintln!(
+                    "{lsp_insert_mode:?}, {use_default_range:?}, {use_insert_range:?}, {filter_text:?}"
+                );
+                cx.set_state("test(value1, ˇvalue2)");
+                cx.set_request_handler::<lsp::request::Completion, _, _>(
+                    move |_, _, _| async move {
+                        let insert =
+                            lsp::Range::new(lsp::Position::new(0, 13), lsp::Position::new(0, 13));
+                        let replace =
+                            lsp::Range::new(lsp::Position::new(0, 13), lsp::Position::new(0, 19));
+                        let text_edit = if use_insert_range {
+                            lsp::CompletionTextEdit::InsertAndReplace(lsp::InsertReplaceEdit {
+                                insert,
+                                replace,
+                                new_text: "value2=".to_string(),
+                            })
+                        } else {
+                            lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                                range: replace,
+                                new_text: "value2=".to_string(),
+                            })
+                        };
+                        let edit_range = if use_insert_range {
+                            lsp::CompletionListItemDefaultsEditRange::InsertAndReplace {
+                                insert,
+                                replace,
+                            }
+                        } else {
+                            lsp::CompletionListItemDefaultsEditRange::Range(replace)
+                        };
+                        Ok(Some(lsp::CompletionResponse::List(lsp::CompletionList {
+                            items: vec![lsp::CompletionItem {
+                                label: "value2=".to_string(),
+                                filter_text: filter_text.map(str::to_string),
+                                text_edit: (!use_default_range).then_some(text_edit),
+                                ..lsp::CompletionItem::default()
+                            }],
+                            item_defaults: use_default_range.then(|| {
+                                lsp::CompletionListItemDefaults {
+                                    edit_range: Some(edit_range),
+                                    ..lsp::CompletionListItemDefaults::default()
+                                }
+                            }),
+                            ..lsp::CompletionList::default()
+                        })))
+                    },
+                );
+                cx.update_editor(|editor, window, cx| {
+                    editor.show_completions(&ShowCompletions, window, cx);
+                });
+                cx.condition(|editor, _| editor.context_menu_visible())
+                    .await;
+                cx.update_editor(|editor, window, cx| {
+                    editor.confirm_completion(&ConfirmCompletion::default(), window, cx)
+                })
+                .expect("completion should be accepted")
+                .await
+                .expect("completion should succeed");
+                cx.assert_editor_state(if use_insert_range {
+                    expected_pair_state
+                } else {
+                    "test(value1, value2=ˇ)"
+                });
+            }
+        }
+    }
+}
+
+#[gpui::test]
 async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorLspTestContext::new_rust(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -3324,9 +3324,12 @@ impl LspCommand for GetCompletions {
                             .unwrap_or(&lsp_completion.label)
                             .clone();
 
+                        let insert_range = default_edit_range
+                            .is_none()
+                            .then(|| range.start..snapshot.anchor_after(self.position));
                         ParsedCompletionEdit {
                             replace_range: range,
-                            insert_range: None,
+                            insert_range,
                             new_text: text,
                         }
                     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8297,6 +8297,10 @@ impl LspStore {
             .await
             .context("completion documentation resolve proto request")?;
         let resolved_lsp_completion = serde_json::from_slice(&response.lsp_completion)?;
+        let replace_range = response
+            .old_replace_start
+            .and_then(deserialize_anchor)
+            .zip(response.old_replace_end.and_then(deserialize_anchor));
 
         let documentation = if response.documentation.is_empty() {
             CompletionDocumentation::Undocumented
@@ -8319,11 +8323,13 @@ impl LspStore {
             lsp_defaults: _,
         } = &mut completion.source
         {
-            let completion_insert_range = response
-                .old_insert_start
-                .and_then(deserialize_anchor)
-                .zip(response.old_insert_end.and_then(deserialize_anchor));
-            *insert_range = completion_insert_range.map(|(start, end)| start..end);
+            if replace_range.is_some() {
+                let completion_insert_range = response
+                    .old_insert_start
+                    .and_then(deserialize_anchor)
+                    .zip(response.old_insert_end.and_then(deserialize_anchor));
+                *insert_range = completion_insert_range.map(|(start, end)| start..end);
+            }
 
             if *resolved {
                 return Ok(());
@@ -8336,10 +8342,6 @@ impl LspStore {
             *resolved = true;
         }
 
-        let replace_range = response
-            .old_replace_start
-            .and_then(deserialize_anchor)
-            .zip(response.old_replace_end.and_then(deserialize_anchor));
         if let Some((old_replace_start, old_replace_end)) = replace_range
             && !response.new_text.is_empty()
         {

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -40,7 +40,7 @@ use lsp::{
 };
 use node_runtime::NodeRuntime;
 use project::{
-    LanguageServerLogType, ProgressToken, Project, ProjectPath,
+    CompletionSource, LanguageServerLogType, ProgressToken, Project, ProjectPath,
     agent_server_store::AgentServerCommand,
     image_store,
     lsp_store::log_store::{LanguageServerKind, LanguageServerLogKey, LogStore},
@@ -54,6 +54,7 @@ use settings::{
 };
 use smol::stream::StreamExt;
 use std::{
+    cell::RefCell,
     path::{Path, PathBuf},
     rc::Rc,
     str::FromStr,
@@ -1212,6 +1213,185 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
     buffer.update(cx, |buffer, _| {
         assert_eq!(buffer.text(), "fn two() -> usize { 1 }")
     })
+}
+
+#[gpui::test]
+async fn test_remote_completion_resolve_edit_ranges(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(
+        path!("/code/project"),
+        json!({ "lib.rs": "test(value1, value2)" }),
+    )
+    .await;
+    let (project, headless) = init_test(&fs, cx, server_cx).await;
+    let capabilities = lsp::ServerCapabilities {
+        completion_provider: Some(lsp::CompletionOptions {
+            resolve_provider: Some(true),
+            ..lsp::CompletionOptions::default()
+        }),
+        ..lsp::ServerCapabilities::default()
+    };
+    project.update(cx, |project, _| {
+        project.languages().add(rust_lang());
+        project.languages().register_fake_lsp_adapter(
+            "Rust",
+            FakeLspAdapter {
+                name: "rust-analyzer",
+                capabilities: capabilities.clone(),
+                ..FakeLspAdapter::default()
+            },
+        );
+    });
+    let mut fake_servers = server_cx.update(|cx| {
+        headless.read(cx).languages.register_fake_lsp_server(
+            LanguageServerName(SharedString::from("rust-analyzer")),
+            capabilities,
+            Some(Box::new(|fake_server| {
+                fake_server.set_request_handler::<lsp::request::Completion, _, _>(
+                    |params, _| async move {
+                        assert_eq!(
+                            params.text_document_position.position,
+                            lsp::Position::new(0, 13)
+                        );
+                        Ok(Some(CompletionResponse::Array(vec![lsp::CompletionItem {
+                            label: "value2=".to_string(),
+                            ..lsp::CompletionItem::default()
+                        }])))
+                    },
+                );
+            })),
+        )
+    });
+    let worktree_id = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/code/project"), true, cx)
+        })
+        .await
+        .expect("worktree should open")
+        .0
+        .read_with(cx, |worktree, _| worktree.id());
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_buffer_with_lsp((worktree_id, rel_path("lib.rs")), cx)
+        })
+        .await
+        .expect("buffer should open with LSP");
+    let fake_server = fake_servers.next().await.expect("LSP should start");
+    cx.run_until_parked();
+
+    let explicit_replace_range =
+        lsp::Range::new(lsp::Position::new(0, 12), lsp::Position::new(0, 19));
+    let explicit_insert_range =
+        lsp::Range::new(lsp::Position::new(0, 12), lsp::Position::new(0, 13));
+    let lsp_store = project.read_with(cx, |project, _| project.lsp_store());
+    for (resolved_edit, expected_insert_range, expected_replace_range, expected_text) in [
+        (None, Some(13..13), 13..19, "value2="),
+        (
+            Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                range: explicit_replace_range,
+                new_text: " value2=".to_string(),
+            })),
+            None,
+            12..19,
+            " value2=",
+        ),
+        (
+            Some(lsp::CompletionTextEdit::InsertAndReplace(
+                lsp::InsertReplaceEdit {
+                    insert: explicit_insert_range,
+                    replace: explicit_replace_range,
+                    new_text: " value2=".to_string(),
+                },
+            )),
+            Some(12..13),
+            12..19,
+            " value2=",
+        ),
+    ] {
+        fake_server.set_request_handler::<lsp::request::ResolveCompletionItem, _, _>(
+            move |mut item, _| {
+                let resolved_edit = resolved_edit.clone();
+                async move {
+                    assert_eq!(item.label, "value2=");
+                    item.documentation = Some(lsp::Documentation::String("resolved".to_string()));
+                    item.text_edit = resolved_edit;
+                    Ok(item)
+                }
+            },
+        );
+        let completions = project
+            .update(cx, |project, cx| {
+                project.completions(
+                    &buffer,
+                    13,
+                    CompletionContext {
+                        trigger_kind: CompletionTriggerKind::INVOKED,
+                        trigger_character: None,
+                    },
+                    cx,
+                )
+            })
+            .await
+            .expect("completions should load")
+            .into_iter()
+            .flat_map(|response| response.completions)
+            .collect::<Vec<_>>();
+        assert_eq!(completions.len(), 1);
+        buffer.read_with(cx, |buffer, _| {
+            let completion = completions.first().expect("completion should exist");
+            let CompletionSource::Lsp { insert_range, .. } = &completion.source else {
+                panic!("expected LSP completion");
+            };
+            assert_eq!(
+                *insert_range,
+                Some(buffer.anchor_before(13)..buffer.anchor_after(13))
+            );
+            assert_eq!(
+                completion.replace_range,
+                buffer.anchor_before(13)..buffer.anchor_after(19)
+            );
+        });
+        let completions = Rc::new(RefCell::new(completions.into_boxed_slice()));
+        let did_resolve = lsp_store
+            .update(cx, |lsp_store, cx| {
+                lsp_store.resolve_completions(buffer.clone(), vec![0], completions.clone(), cx)
+            })
+            .await
+            .expect("completion should resolve");
+        assert!(did_resolve);
+        buffer.read_with(cx, |buffer, _| {
+            let completions = completions.borrow();
+            let completion = completions.first().expect("completion should exist");
+            let CompletionSource::Lsp {
+                insert_range,
+                resolved,
+                lsp_completion,
+                ..
+            } = &completion.source
+            else {
+                panic!("expected LSP completion");
+            };
+            assert!(*resolved);
+            assert_eq!(
+                lsp_completion.documentation,
+                Some(lsp::Documentation::String("resolved".to_string()))
+            );
+            assert_eq!(
+                *insert_range,
+                expected_insert_range
+                    .map(|range| buffer.anchor_before(range.start)..buffer.anchor_after(range.end))
+            );
+            assert_eq!(
+                completion.replace_range,
+                buffer.anchor_before(expected_replace_range.start)
+                    ..buffer.anchor_after(expected_replace_range.end)
+            );
+            assert_eq!(completion.new_text, expected_text);
+        });
+    }
 }
 
 #[gpui::test]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/64118

https://github.com/user-attachments/assets/f2152411-6011-4d87-8c8e-d83bed0afbbc

`ty` returns completion text without a `textEdit` or a completion-list default edit range:

```json
{"label":"value2=","insertText":"value2="}
```

The [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) explicitly states:

> The `insertText` is subject to interpretation by the client side.

For the reported example, `ˇ` marks the cursor:

```py
test(value1, ˇvalue2)
```

Previously, Zed inferred only a range covering the existing `value2`.
Without an insert range, completion acceptance bypassed `completions.lsp_insert_mode` and replaced that argument with `value2=`, producing:

```py
test(value1, value2=)
```

The patch also infers an insert range, ending at the cursor rather than the end of the word.
This lets the existing setting choose between inserting before `value2` and replacing it.
When a prefix has already been typed, insertion replaces that prefix while preserving the text after the cursor.

With the unchanged default, `"replace_suffix"`, Zed replaces text after the cursor only when it is a suffix of the completion’s label.
Here, `value2` is not a suffix of `value2=`, so Zed inserts and produces:

```py
test(value1, value2=value2)
```

The suffix and subsequence checks now use the raw LSP `label`, not decorated menu text or `filterText`.
These checks select the edit range; `insertText` still supplies the inserted text in this example.

Release Notes:

- Fixed insertion modes for completions without edit ranges


