### PR TITLE
ui: Use version_control colors for diff stat labels

### DIFF
--- a/crates/ui/src/components/diff_stat.rs
+++ b/crates/ui/src/components/diff_stat.rs
@@ -44,12 +44,12 @@ impl RenderOnce for DiffStat {
             .gap_1()
             .child(
                 Label::new(format!("+\u{2009}{added}"))
-                    .color(Color::Success)
+                    .color(Color::VersionControlAdded)
                     .size(self.label_size),
             )
             .child(
                 Label::new(format!("\u{2012}\u{2009}{removed}"))
-                    .color(Color::Error)
+                    .color(Color::VersionControlDeleted)
                     .size(self.label_size),
             )
             .when_some(tooltip, |this, tooltip| {


### PR DESCRIPTION
# Objective

Fixes #63806

In the Version Control panel, the `+ N` / `− N` diff counts did not pick up `version_control.added` / `version_control.deleted` from custom themes, even though the status icons next to them did.

`DiffStat` rendered those labels with `Color::Success` / `Color::Error`, which resolve to `theme.status().success` / `theme.status().error`. The version control icons (`GitStatusIcon` in `crates/git_ui/src/git_ui.rs`, plus the title bar) read `colors().version_control_added` / `colors().version_control_deleted` instead. The two are only linked in one direction: in `crates/theme_settings/src/schema.rs`, `version_control.added` falls back to `status.created` when unset, but `status.success` never reads back from `version_control.added`. The defaults also look nearly identical (`success = grass.step_9` vs. the built-in `ADDED_COLOR`), so the mismatch only surfaces once a theme overrides `version_control.added` / `version_control.deleted`.

## Solution

- Swapped `DiffStat` over to the existing `Color::VersionControlAdded` / `Color::VersionControlDeleted` variants, so the counts follow the same semantic colors as the icons.
- Every consumer picks this up automatically: the Git panel's per-entry stats and totals row, branch diff, commit view, git graph, the editor diff header, and agent thread items.
- No public API changes and no new dependencies — both variants already exist and are used in `crates/title_bar/src/title_bar.rs` and `crates/git_ui/src/git_panel.rs`.
- Deliberately left alone: deleted file *names* in the Git panel keep `Color::Disabled`. That is an intentional choice documented in the code ("we don't want a bunch of red labels in the list"), and this change only affects the +/- counts.

## Testing

- Static verification only: confirmed both `Color` variants exist and are already referenced elsewhere, and that `Color` is re-exported by `crates/ui/src/prelude.rs` (so no import change is needed). `git diff` is 2 insertions / 2 deletions in a single file, with no unrelated reformatting.
- I do not have a Rust toolchain on this machine (`rust-toolchain.toml` pins 1.98.1), so `cargo fmt` / `clippy` / `check` were **not** run. The change is a swap between two variants of the same enum, so it is compile-safe by construction, but CI should confirm.
- To verify manually: open the Git panel (with `diff_stats` enabled) using a theme that overrides `version_control.added` / `version_control.deleted`; the `+ N` / `− N` labels should now match the file status icons.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (none introduced)
- [x] The content adheres to Zed's UI standards (it makes panel text consistent with the icons it sits next to)
- [ ] Tests cover the new/changed behavior (no test added — this is a pure theme-color mapping; the `ui` crate has no existing harness for asserting rendered colors)
- [x] Performance impact has been considered and is acceptable
