### PR TITLE
workspace: Fix cross-host workspace reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14757,6 +14757,7 @@ dependencies = [
  "remote",
  "remote_connection",
  "remote_server",
+ "rpc",
  "semver",
  "serde_json",
  "settings",

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -67,6 +67,7 @@ release_channel.workspace = true
 remote = { workspace = true, features = ["test-support"] }
 remote_connection = { workspace = true, features = ["test-support"] }
 remote_server.workspace = true
+rpc.workspace = true
 serde_json.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/recent_projects/src/remote_connections.rs
+++ b/crates/recent_projects/src/remote_connections.rs
@@ -516,8 +516,10 @@ mod tests {
     use gpui::{AppContext, TestAppContext};
     use http_client::BlockedHttpClient;
     use node_runtime::NodeRuntime;
+    use project::Project;
     use remote::RemoteClient;
     use remote_server::{HeadlessAppState, HeadlessProject};
+    use rpc::proto;
     use serde_json::json;
     use util::path;
     use workspace::find_existing_workspace;
@@ -604,7 +606,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_reuse_existing_remote_workspace_window(
+    async fn test_find_existing_workspace_does_not_reuse_workspace_from_another_remote(
         cx: &mut TestAppContext,
         server_cx: &mut TestAppContext,
     ) {
@@ -680,9 +682,53 @@ mod tests {
         );
 
         let first_window = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let first_workspace = first_window
+            .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+            .unwrap();
+
+        let (other_opts, other_server_session, other_connect_guard) =
+            RemoteClient::fake_server(cx, server_cx);
+        let ping_handler = server_cx.new(|_| ());
+        other_server_session.add_request_handler::<proto::Ping, _, _, _>(
+            ping_handler.downgrade(),
+            |_, _, _| async { Ok(proto::Ack {}) },
+        );
+        drop(other_connect_guard);
+        let other_remote_client = RemoteClient::connect_mock(other_opts.clone(), cx).await;
+        let other_project = cx.update(|cx| {
+            Project::remote(
+                other_remote_client,
+                app_state.client.clone(),
+                app_state.node_runtime.clone(),
+                app_state.user_store.clone(),
+                app_state.languages.clone(),
+                app_state.fs.clone(),
+                false,
+                cx,
+            )
+        });
+        first_window
+            .update(cx, |multi_workspace, window, cx| {
+                let other_workspace =
+                    cx.new(|cx| Workspace::new(None, other_project, app_state.clone(), window, cx));
+                multi_workspace.add(other_workspace, window, cx);
+            })
+            .unwrap();
+
+        let search_paths = vec![PathBuf::from(path!("/project/src/lib.rs"))];
+        let (found, _) = find_existing_workspace(
+            &search_paths,
+            &workspace::OpenOptions::default(),
+            &SerializedWorkspaceLocation::Remote(other_opts),
+            &mut async_cx,
+        )
+        .await;
+        assert!(
+            found.is_none(),
+            "a matching path on another remote must not satisfy the request"
+        );
 
         // Verify find_existing_workspace discovers the remote workspace.
-        let search_paths = vec![PathBuf::from(path!("/project/src/lib.rs"))];
         let (found, _open_visible) = find_existing_workspace(
             &search_paths,
             &workspace::OpenOptions::default(),
@@ -695,10 +741,14 @@ mod tests {
             found.is_some(),
             "find_existing_workspace should locate the existing remote workspace"
         );
-        let (found_window, _found_workspace) = found.unwrap();
+        let (found_window, found_workspace) = found.unwrap();
         assert_eq!(
             found_window, first_window,
             "find_existing_workspace should return the same window"
+        );
+        assert_eq!(
+            found_workspace, first_workspace,
+            "find_existing_workspace should return the workspace for the requested remote"
         );
 
         // Second open with the same connection options should reuse the window.

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -10258,6 +10258,48 @@ pub fn activate_any_workspace_window(cx: &mut AsyncApp) -> Option<WindowHandle<M
     })
 }
 
+fn workspace_is_at_location(
+    workspace: &Entity<Workspace>,
+    location: &SerializedWorkspaceLocation,
+    cx: &App,
+) -> bool {
+    let WorkspaceLocation::Location(workspace_location, _) =
+        workspace.read(cx).workspace_location(cx)
+    else {
+        return false;
+    };
+
+    match (&workspace_location, location) {
+        (SerializedWorkspaceLocation::Local, SerializedWorkspaceLocation::Local) => true,
+        (
+            SerializedWorkspaceLocation::Remote(workspace_remote),
+            SerializedWorkspaceLocation::Remote(remote),
+        ) => match (workspace_remote, remote) {
+            (RemoteConnectionOptions::Ssh(_), RemoteConnectionOptions::Ssh(_)) => {
+                same_remote_connection_identity(Some(workspace_remote), Some(remote))
+            }
+            (
+                RemoteConnectionOptions::Wsl(workspace_remote),
+                RemoteConnectionOptions::Wsl(remote),
+            ) => {
+                // The WSL username is not consistently populated in the workspace location, so ignore it for now.
+                workspace_remote.distro_name == remote.distro_name
+            }
+            (
+                RemoteConnectionOptions::Docker(workspace_remote),
+                RemoteConnectionOptions::Docker(remote),
+            ) => workspace_remote.container_id == remote.container_id,
+            #[cfg(any(test, feature = "test-support"))]
+            (
+                RemoteConnectionOptions::Mock(workspace_remote),
+                RemoteConnectionOptions::Mock(remote),
+            ) => workspace_remote.id == remote.id,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 pub fn workspace_windows_for_location(
     serialized_location: &SerializedWorkspaceLocation,
     cx: &App,
@@ -10266,43 +10308,10 @@ pub fn workspace_windows_for_location(
         .into_iter()
         .filter_map(|window| window.downcast::<MultiWorkspace>())
         .filter(|multi_workspace| {
-            let same_host = |left: &RemoteConnectionOptions, right: &RemoteConnectionOptions| match (left, right) {
-                (RemoteConnectionOptions::Ssh(a), RemoteConnectionOptions::Ssh(b)) => {
-                    (&a.host, &a.username, &a.port) == (&b.host, &b.username, &b.port)
-                }
-                (RemoteConnectionOptions::Wsl(a), RemoteConnectionOptions::Wsl(b)) => {
-                    // The WSL username is not consistently populated in the workspace location, so ignore it for now.
-                    a.distro_name == b.distro_name
-                }
-                (RemoteConnectionOptions::Docker(a), RemoteConnectionOptions::Docker(b)) => {
-                    a.container_id == b.container_id
-                }
-                #[cfg(any(test, feature = "test-support"))]
-                (RemoteConnectionOptions::Mock(a), RemoteConnectionOptions::Mock(b)) => {
-                    a.id == b.id
-                }
-                _ => false,
-            };
-
             multi_workspace.read(cx).is_ok_and(|multi_workspace| {
-                multi_workspace.workspaces().any(|workspace| {
-                    match workspace.read(cx).workspace_location(cx) {
-                        WorkspaceLocation::Location(location, _) => {
-                            match (&location, serialized_location) {
-                                (
-                                    SerializedWorkspaceLocation::Local,
-                                    SerializedWorkspaceLocation::Local,
-                                ) => true,
-                                (
-                                    SerializedWorkspaceLocation::Remote(a),
-                                    SerializedWorkspaceLocation::Remote(b),
-                                ) => same_host(a, b),
-                                _ => false,
-                            }
-                        }
-                        _ => false,
-                    }
-                })
+                multi_workspace
+                    .workspaces()
+                    .any(|workspace| workspace_is_at_location(workspace, serialized_location, cx))
             })
         })
         .collect()
@@ -10326,6 +10335,10 @@ pub async fn find_existing_workspace(
             for window in workspace_windows_for_location(location, cx) {
                 if let Ok(multi_workspace) = window.read(cx) {
                     for workspace in multi_workspace.workspaces() {
+                        if !workspace_is_at_location(workspace, location, cx) {
+                            continue;
+                        }
+
                         let project = workspace.read(cx).project.read(cx);
                         let m = match open_options.workspace_matching {
                             WorkspaceMatching::None => None,


### PR DESCRIPTION
# Objective

Prevent remote open requests from reusing a retained workspace connected to a different host when both hosts contain the same absolute path.

A window can contain workspaces from multiple locations. Previously, the window qualified for reuse when any retained workspace matched the requested host, but path scoring subsequently considered every workspace in that window. As a result, a workspace from another host could win.

This is a reworked and simplied version of the fix in https://github.com/zed-industries/zed/pull/62561

## Solution

Filter each retained workspace by the requested location before scoring its paths.

Workspace-location matching is centralized while preserving the existing connection semantics:

- SSH matches by host, username, and port.
- WSL matches by distribution name because usernames are not consistently populated.
- Docker matches by container ID.
- Mock connections match by ID.

## Testing

- Added a regression test with two distinct mock remote identities in one window.
- Confirmed the regression test fails with the production fix stashed:
  - `a matching path on another remote must not satisfy the request`
- Confirmed the test passes with the fix:
  - `cargo test -p recent_projects test_find_existing_workspace_does_not_reuse_workspace_from_another_remote --no-fail-fast`
- Confirmed the centralized remote identity tests pass:
  - `cargo test -p remote remote_identity --no-fail-fast`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed remote paths sometimes reusing a workspace connected to a different host.


