### PR TITLE
agent_ui: Improve model and configuration option search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "fs",
  "futures 0.3.34",
  "fuzzy",
+ "fuzzy_nucleo",
  "git",
  "git_ui_core",
  "gpui",

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -57,6 +57,7 @@ file_icons.workspace = true
 fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
+fuzzy_nucleo.workspace = true
 git.workspace = true
 gpui.workspace = true
 gpui_tokio.workspace = true

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -6,7 +6,7 @@ use agent_servers::AgentServer;
 
 use collections::HashSet;
 use fs::Fs;
-use fuzzy::StringMatchCandidate;
+use fuzzy_nucleo::StringMatchCandidate;
 use gpui::{
     App, BackgroundExecutor, Context, DismissEvent, Entity, Subscription, Task, Window, prelude::*,
 };
@@ -1037,15 +1037,26 @@ async fn fuzzy_search_options(
     let candidates = options
         .iter()
         .enumerate()
-        .map(|(ix, opt)| StringMatchCandidate::new(ix, &opt.name))
+        .map(|(index, option)| {
+            StringMatchCandidate::new(
+                index,
+                format!(
+                    "{} {} {} {}",
+                    option.name,
+                    option.group.as_deref().unwrap_or_default(),
+                    option.description.as_deref().unwrap_or_default(),
+                    option.value.0,
+                ),
+            )
+        })
         .collect::<Vec<_>>();
 
-    let mut matches = fuzzy::match_strings(
+    let mut matches = fuzzy_nucleo::match_strings_async(
         &candidates,
         query,
-        false,
-        true,
-        100,
+        fuzzy_nucleo::Case::Ignore,
+        fuzzy_nucleo::LengthPenalty::On,
+        options.len(),
         &Default::default(),
         executor,
     )
@@ -1104,6 +1115,62 @@ mod tests {
     use parking_lot::Mutex;
     use project::{AgentId, Project};
     use std::{any::Any, cell::RefCell};
+
+    fn option_names(options: Vec<ConfigOptionValue>) -> Vec<String> {
+        options.into_iter().map(|option| option.name).collect()
+    }
+
+    #[gpui::test]
+    async fn config_option_search_matches_all_searchable_fields(executor: BackgroundExecutor) {
+        let options = vec![
+            ConfigOptionValue {
+                value: acp::SessionConfigValueId::new("openai/gpt-5.6-sol"),
+                name: "GPT-5.6 Sol".to_string(),
+                description: Some("Flagship reasoning model".to_string()),
+                group: Some("OpenAI".to_string()),
+            },
+            ConfigOptionValue {
+                value: acp::SessionConfigValueId::new("anthropic/claude-sonnet-4"),
+                name: "Claude Sonnet 4".to_string(),
+                description: None,
+                group: Some("Anthropic".to_string()),
+            },
+        ];
+
+        for query in [
+            "GPT 5.6",
+            "GPT-5.6",
+            "gpt5.6 sol",
+            "openai",
+            "openai/gpt-5.6-sol",
+            "flagship",
+        ] {
+            assert_eq!(
+                option_names(fuzzy_search_options(options.clone(), query, executor.clone()).await),
+                ["GPT-5.6 Sol"],
+                "query {query:?} should match the GPT model",
+            );
+        }
+    }
+
+    #[gpui::test]
+    async fn config_option_search_returns_more_than_one_hundred_matches(
+        executor: BackgroundExecutor,
+    ) {
+        let options = (0..101)
+            .map(|index| ConfigOptionValue {
+                value: acp::SessionConfigValueId::new(format!("model-{index}")),
+                name: format!("Model {index}"),
+                description: None,
+                group: None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            fuzzy_search_options(options, "model", executor).await.len(),
+            101
+        );
+    }
 
     #[gpui::test]
     fn cycling_config_option_saves_selected_value_as_default(cx: &mut TestAppContext) {

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -7,7 +7,7 @@ use acp_thread::{
 use anyhow::Result;
 use collections::{HashSet, IndexMap};
 use futures::FutureExt;
-use fuzzy::{StringMatchCandidate, match_strings};
+use fuzzy_nucleo::StringMatchCandidate;
 use gpui::{
     Action, AsyncWindowContext, BackgroundExecutor, DismissEvent, FocusHandle, Subscription, Task,
     TaskExt, WeakEntity,
@@ -441,20 +441,30 @@ async fn fuzzy_search(
 ) -> AgentModelList {
     async fn fuzzy_search_list(
         model_list: Vec<AgentModelInfo>,
+        group_name: Option<SharedString>,
         query: &str,
         executor: BackgroundExecutor,
     ) -> Vec<AgentModelInfo> {
         let candidates = model_list
             .iter()
             .enumerate()
-            .map(|(ix, model)| StringMatchCandidate::new(ix, model.name.as_ref()))
+            .map(|(index, model)| {
+                StringMatchCandidate::new(
+                    index,
+                    format!(
+                        "{} {}",
+                        model.name,
+                        group_name.as_deref().unwrap_or_default()
+                    ),
+                )
+            })
             .collect::<Vec<_>>();
-        let mut matches = match_strings(
+        let mut matches = fuzzy_nucleo::match_strings_async(
             &candidates,
             query,
-            false,
-            true,
-            100,
+            fuzzy_nucleo::Case::Ignore,
+            fuzzy_nucleo::LengthPenalty::On,
+            model_list.len(),
             &Default::default(),
             executor,
         )
@@ -473,12 +483,12 @@ async fn fuzzy_search(
 
     match model_list {
         AgentModelList::Flat(model_list) => {
-            AgentModelList::Flat(fuzzy_search_list(model_list, &query, executor).await)
+            AgentModelList::Flat(fuzzy_search_list(model_list, None, &query, executor).await)
         }
         AgentModelList::Grouped(index_map) => {
             let groups =
                 futures::future::join_all(index_map.into_iter().map(|(group_name, models)| {
-                    fuzzy_search_list(models, &query, executor.clone())
+                    fuzzy_search_list(models, Some(group_name.0.clone()), &query, executor.clone())
                         .map(|results| (group_name, results))
                 }))
                 .await;
@@ -698,6 +708,16 @@ mod tests {
         // Fuzzy search - test with specific model name
         let results = fuzzy_search(models.clone(), "mistral".into(), cx.executor()).await;
         assert_models_eq(results, vec![("ollama", vec!["mistral"])]);
+
+        let models = create_model_list(vec![
+            ("OpenAI", vec!["GPT-5.6 Sol"]),
+            ("Anthropic", vec!["Claude Sonnet 4"]),
+        ]);
+        let results = fuzzy_search(models.clone(), "GPT 5.6".into(), cx.executor()).await;
+        assert_models_eq(results, vec![("OpenAI", vec!["GPT-5.6 Sol"])]);
+
+        let results = fuzzy_search(models, "openai".into(), cx.executor()).await;
+        assert_models_eq(results, vec![("OpenAI", vec!["GPT-5.6 Sol"])]);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective
Fixes #64144. 

Improve search in agent model and configuration option pickers.

Previously, searches could fail when punctuation differed between the query and model name, such as `GPT 5.6` versus `GPT-5.6`. Configuration options also could not be found by provider/group, description, or value identifier, and results were limited to 100 entries.

## Solution

Use the existing `fuzzy_nucleo` matcher for agent model and configuration option searches.

Include relevant metadata in each search candidate:

- Model name and provider/group
- Configuration option name, group, description, and value identifier

Return all matching configuration options while preserving their existing ordering when scores are equal.

## Testing

- Added and ran automated tests with the following:
	- Searches with punctuation differences, such as `GPT 5.6`
	- Searches by provider/group
	- Searches across configuration option names, descriptions, groups, and identifiers
	- Searches returning more than 100 configuration options
	- Existing fuzzy-match ordering behavior

Additionally compiled the app with `cargo run`, launched OpenCode agent in ACP mode, and searched `GPT 5.6`, which produces `OpenAI/GPT-5.6 Sol` and `OpenRouter/GPT-5.6 Sol`. See video below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/04c1a59e-8454-49f8-af6c-47e1107f9416

---

Release Notes:

- Improves fuzzy searching for agent model and configuration option pickers across Zed Agent and third-party ACP-compatible agents.
